### PR TITLE
NOJIRA-Fix_wrong_channel_hangup

### DIFF
--- a/bin-ai-manager/pkg/aicallhandler/process.go
+++ b/bin-ai-manager/pkg/aicallhandler/process.go
@@ -56,10 +56,12 @@ func (h *aicallHandler) ProcessPause(ctx context.Context, ac *aicall.AIcall) (*a
 	})
 
 	// stop the transcribe
-	_, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, ac.TranscribeID)
-	if err != nil {
-		// failed to stop the transcribe but we keep move
-		log.Errorf("Could not stops the transcribe. err: %v", err)
+	if ac.TranscribeID != uuid.Nil {
+		_, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, ac.TranscribeID)
+		if err != nil {
+			// failed to stop the transcribe but we keep move
+			log.Errorf("Could not stops the transcribe. err: %v", err)
+		}
 	}
 
 	res, err := h.UpdateStatusPausing(ctx, ac.ID)
@@ -71,26 +73,28 @@ func (h *aicallHandler) ProcessPause(ctx context.Context, ac *aicall.AIcall) (*a
 }
 
 // ProcessEnd ends a aicall process
-func (h *aicallHandler) ProcessEnd(ctx context.Context, cb *aicall.AIcall) (*aicall.AIcall, error) {
+func (h *aicallHandler) ProcessEnd(ctx context.Context, ac *aicall.AIcall) (*aicall.AIcall, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":      "ProcessEnd",
-		"aicall_id": cb.ID,
+		"aicall_id": ac.ID,
 	})
 
 	// stop the transcribe
-	_, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, cb.TranscribeID)
-	if err != nil {
-		// failed to stop the transcribe but we keep move
-		log.Errorf("Could not stops the transcribe. err: %v", err)
+	if ac.TranscribeID != uuid.Nil {
+		_, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, ac.TranscribeID)
+		if err != nil {
+			// failed to stop the transcribe but we keep move
+			log.Errorf("Could not stops the transcribe. err: %v", err)
+		}
 	}
 
-	res, err := h.UpdateStatusEnd(ctx, cb.ID)
+	res, err := h.UpdateStatusEnd(ctx, ac.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not end the aicall")
 	}
 
 	// destroy the confbridge
-	tmp, err := h.reqHandler.CallV1ConfbridgeDelete(ctx, cb.ConfbridgeID)
+	tmp, err := h.reqHandler.CallV1ConfbridgeDelete(ctx, ac.ConfbridgeID)
 	if err != nil {
 		// we couldn't delete the confbridge here.
 		// but we don't return any error here because it doesn't affect to the activeflow execution.

--- a/bin-ai-manager/pkg/aicallhandler/process.go
+++ b/bin-ai-manager/pkg/aicallhandler/process.go
@@ -60,7 +60,7 @@ func (h *aicallHandler) ProcessPause(ctx context.Context, ac *aicall.AIcall) (*a
 		_, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, ac.TranscribeID)
 		if err != nil {
 			// failed to stop the transcribe but we keep move
-			log.Errorf("Could not stops the transcribe. err: %v", err)
+			log.Errorf("Could not stop the transcribe. err: %v", err)
 		}
 	}
 
@@ -84,7 +84,7 @@ func (h *aicallHandler) ProcessEnd(ctx context.Context, ac *aicall.AIcall) (*aic
 		_, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, ac.TranscribeID)
 		if err != nil {
 			// failed to stop the transcribe but we keep move
-			log.Errorf("Could not stops the transcribe. err: %v", err)
+			log.Errorf("Could not stop the transcribe. err: %v", err)
 		}
 	}
 

--- a/bin-ai-manager/pkg/dbhandler/aicall.go
+++ b/bin-ai-manager/pkg/dbhandler/aicall.go
@@ -318,14 +318,14 @@ func (h *handler) aicallUpdateStatus(ctx context.Context, id uuid.UUID, transcri
 		update ai_aicalls set
 			status = ?,
 			transcribe_id = ?,
-			 tm_update = ?
+			tm_update = ?
 		where
 			id = ?
 		`
 
 	_, err := h.db.Exec(q, status, transcribeID.Bytes(), h.utilHandler.TimeGetCurTime(), id.Bytes())
 	if err != nil {
-		return errors.Wrapf(err, "could not execute. AIcallUpdateStatusPausing")
+		return errors.Wrapf(err, "could not execute. aicallUpdateStatus")
 	}
 
 	// update the cache

--- a/bin-ai-manager/pkg/summaryhandler/service_test.go
+++ b/bin-ai-manager/pkg/summaryhandler/service_test.go
@@ -115,7 +115,7 @@ func Test_ServiceStart_referencetype_call(t *testing.T) {
 				tmtranscribe.ReferenceTypeCall,
 				tt.referenceID,
 				tt.language,
-				tmtranscribe.DirectionBoth,
+				tmtranscribe.DirectionIn,
 				gomock.Any(),
 			).Return(&tmtranscribe.Transcribe{}, nil)
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)

--- a/bin-ai-manager/pkg/summaryhandler/service_test.go
+++ b/bin-ai-manager/pkg/summaryhandler/service_test.go
@@ -115,7 +115,7 @@ func Test_ServiceStart_referencetype_call(t *testing.T) {
 				tmtranscribe.ReferenceTypeCall,
 				tt.referenceID,
 				tt.language,
-				tmtranscribe.DirectionIn,
+				tmtranscribe.DirectionBoth,
 				gomock.Any(),
 			).Return(&tmtranscribe.Transcribe{}, nil)
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)

--- a/bin-ai-manager/pkg/summaryhandler/start.go
+++ b/bin-ai-manager/pkg/summaryhandler/start.go
@@ -90,7 +90,7 @@ func (h *summaryHandler) startReferenceTypeCall(
 		tmtranscribe.ReferenceTypeCall,
 		referenceID,
 		language,
-		tmtranscribe.DirectionIn,
+		tmtranscribe.DirectionBoth,
 		5000,
 	)
 	if err != nil {

--- a/bin-ai-manager/pkg/summaryhandler/start.go
+++ b/bin-ai-manager/pkg/summaryhandler/start.go
@@ -90,7 +90,7 @@ func (h *summaryHandler) startReferenceTypeCall(
 		tmtranscribe.ReferenceTypeCall,
 		referenceID,
 		language,
-		tmtranscribe.DirectionBoth,
+		tmtranscribe.DirectionIn,
 		5000,
 	)
 	if err != nil {
@@ -152,7 +152,7 @@ func (h *summaryHandler) startReferenceTypeConference(
 		tmtranscribe.ReferenceTypeConfbridge,
 		cf.ConfbridgeID,
 		language,
-		tmtranscribe.DirectionBoth,
+		tmtranscribe.DirectionIn,
 		5000,
 	)
 	if err != nil {

--- a/bin-ai-manager/pkg/summaryhandler/start_test.go
+++ b/bin-ai-manager/pkg/summaryhandler/start_test.go
@@ -114,7 +114,7 @@ func Test_startReferenceTypeCall(t *testing.T) {
 				tmtranscribe.ReferenceTypeCall,
 				tt.referenceID,
 				tt.language,
-				tmtranscribe.DirectionIn,
+				tmtranscribe.DirectionBoth,
 				5000,
 			).Return(tt.responseTranscribe, nil)
 

--- a/bin-ai-manager/pkg/summaryhandler/start_test.go
+++ b/bin-ai-manager/pkg/summaryhandler/start_test.go
@@ -114,7 +114,7 @@ func Test_startReferenceTypeCall(t *testing.T) {
 				tmtranscribe.ReferenceTypeCall,
 				tt.referenceID,
 				tt.language,
-				tmtranscribe.DirectionBoth,
+				tmtranscribe.DirectionIn,
 				5000,
 			).Return(tt.responseTranscribe, nil)
 
@@ -226,7 +226,7 @@ func Test_startReferenceTypeConference(t *testing.T) {
 				tmtranscribe.ReferenceTypeConfbridge,
 				tt.responseConference.ConfbridgeID,
 				tt.language,
-				tmtranscribe.DirectionBoth,
+				tmtranscribe.DirectionIn,
 				5000,
 			).Return(tt.responseTranscribe, nil)
 

--- a/bin-call-manager/go.sum
+++ b/bin-call-manager/go.sum
@@ -401,6 +401,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/bin-call-manager/pkg/callhandler/hangup.go
+++ b/bin-call-manager/pkg/callhandler/hangup.go
@@ -31,6 +31,7 @@ func (h *callHandler) Hangup(ctx context.Context, cn *channel.Channel) (*call.Ca
 		return nil, errors.Wrap(err, "could not get call info from the db")
 	}
 	log = log.WithField("call", c)
+	log.Debugf("Hanging up the call. call_id: %s, channel_id: %s", c.ID, cn.ID)
 
 	// remove the call bridge
 	if errDestroy := h.bridgeHandler.Destroy(ctx, c.BridgeID); errDestroy != nil {

--- a/bin-call-manager/pkg/channelhandler/hangup.go
+++ b/bin-call-manager/pkg/channelhandler/hangup.go
@@ -64,6 +64,7 @@ func (h *channelHandler) HangingUpWithAsteriskID(ctx context.Context, asteriskID
 		"channel_id":  id,
 		"cause":       cause,
 	})
+	log.Debugf("Hanging up channel with asteriskID: %s, channelID: %s, cause: %d", asteriskID, id, cause)
 
 	if errHangup := h.reqHandler.AstChannelHangup(ctx, asteriskID, id, cause, 0); errHangup != nil {
 		if strings.Contains(errHangup.Error(), "404") {

--- a/bin-call-manager/pkg/externalmediahandler/stop.go
+++ b/bin-call-manager/pkg/externalmediahandler/stop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-call-manager/models/ari"
@@ -27,9 +28,8 @@ func (h *externalMediaHandler) Stop(ctx context.Context, externalMediaID uuid.UU
 	}
 
 	// hangup the external media channel
-	if errHangup := h.reqHandler.AstChannelHangup(ctx, res.AsteriskID, res.ChannelID, ari.ChannelCauseNormalClearing, 0); errHangup != nil {
-		log.Errorf("Could not hangup the external media channel. err: %v", errHangup)
-		return nil, fmt.Errorf("could not hangup the external media channel")
+	if errHangup := h.channelHandler.HangingUpWithAsteriskID(ctx, res.AsteriskID, res.ChannelID, ari.ChannelCauseNormalClearing); errHangup != nil {
+		return nil, errors.Wrapf(errHangup, "could not hangup the external media channel")
 	}
 
 	// delete external media info

--- a/bin-call-manager/pkg/externalmediahandler/stop_test.go
+++ b/bin-call-manager/pkg/externalmediahandler/stop_test.go
@@ -13,6 +13,7 @@ import (
 
 	"monorepo/bin-call-manager/models/ari"
 	"monorepo/bin-call-manager/models/externalmedia"
+	"monorepo/bin-call-manager/pkg/channelhandler"
 	"monorepo/bin-call-manager/pkg/dbhandler"
 )
 
@@ -51,17 +52,20 @@ func Test_Stop(t *testing.T) {
 			mockUtil := utilhandler.NewMockUtilHandler(mc)
 			mockReq := requesthandler.NewMockRequestHandler(mc)
 			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockChannel := channelhandler.NewMockChannelHandler(mc)
 
 			h := &externalMediaHandler{
 				utilHandler: mockUtil,
 				reqHandler:  mockReq,
 				db:          mockDB,
+
+				channelHandler: mockChannel,
 			}
 
 			ctx := context.Background()
 
 			mockDB.EXPECT().ExternalMediaGet(ctx, tt.externalMediaID).Return(tt.responseExternalMedia, nil)
-			mockReq.EXPECT().AstChannelHangup(ctx, tt.responseExternalMedia.AsteriskID, tt.responseExternalMedia.ChannelID, ari.ChannelCauseNormalClearing, 0).Return(nil)
+			mockChannel.EXPECT().HangingUpWithAsteriskID(ctx, tt.responseExternalMedia.AsteriskID, tt.responseExternalMedia.ChannelID, ari.ChannelCauseNormalClearing).Return(nil)
 			mockDB.EXPECT().ExternalMediaDelete(ctx, tt.externalMediaID).Return(nil)
 
 			res, err := h.Stop(ctx, tt.externalMediaID)

--- a/bin-call-manager/pkg/recordinghandler/stop.go
+++ b/bin-call-manager/pkg/recordinghandler/stop.go
@@ -158,7 +158,7 @@ func (h *recordingHandler) stopReferenceTypeCall(ctx context.Context, r *recordi
 	for _, channelID := range r.ChannelIDs {
 		// hangup the channel
 		log.WithField("channel_id", channelID).Debugf("Hanging up the recording channel. channel_id: %s", channelID)
-		if errHangup := h.reqHandler.AstChannelHangup(ctx, r.AsteriskID, channelID, ari.ChannelCauseNormalClearing, 0); errHangup != nil {
+		if errHangup := h.channelHandler.HangingUpWithAsteriskID(ctx, r.AsteriskID, channelID, ari.ChannelCauseNormalClearing); errHangup != nil {
 			log.Errorf("Could not hangup the recording channel. err: %v", errHangup)
 		}
 	}

--- a/bin-call-manager/pkg/recordinghandler/stop_test.go
+++ b/bin-call-manager/pkg/recordinghandler/stop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"monorepo/bin-call-manager/models/ari"
 	"monorepo/bin-call-manager/models/recording"
+	"monorepo/bin-call-manager/pkg/channelhandler"
 	"monorepo/bin-call-manager/pkg/dbhandler"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
@@ -213,19 +214,22 @@ func Test_Stop_referenceTypeCall(t *testing.T) {
 			mockReq := requesthandler.NewMockRequestHandler(mc)
 			mockDB := dbhandler.NewMockDBHandler(mc)
 			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockChannel := channelhandler.NewMockChannelHandler(mc)
 
 			h := &recordingHandler{
 				utilHandler:   mockUtil,
 				reqHandler:    mockReq,
 				db:            mockDB,
 				notifyHandler: mockNotify,
+
+				channelHandler: mockChannel,
 			}
 
 			ctx := context.Background()
 
 			mockDB.EXPECT().RecordingGet(ctx, tt.id).Return(tt.responseRecording, nil)
 			for _, channelID := range tt.responseRecording.ChannelIDs {
-				mockReq.EXPECT().AstChannelHangup(ctx, tt.responseRecording.AsteriskID, channelID, ari.ChannelCauseNormalClearing, 0).Return(nil)
+				mockChannel.EXPECT().HangingUpWithAsteriskID(ctx, tt.responseRecording.AsteriskID, channelID, ari.ChannelCauseNormalClearing).Return(nil)
 			}
 			mockDB.EXPECT().RecordingSetStatus(ctx, tt.id, recording.StatusStopping).Return(nil)
 			mockDB.EXPECT().RecordingGet(ctx, tt.id).Return(tt.responseRecording, nil)

--- a/bin-transcribe-manager/go.mod
+++ b/bin-transcribe-manager/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
+	github.com/stretchr/testify v1.10.0
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984
 	monorepo/bin-flow-manager v0.0.0-20240403034140-ce82222fe7f4
 )
@@ -114,6 +115,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
 	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -129,12 +131,14 @@ require (
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/sagikazarmark/locafero v0.9.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.8.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect

--- a/bin-transcribe-manager/go.sum
+++ b/bin-transcribe-manager/go.sum
@@ -450,7 +450,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -710,6 +709,8 @@ github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqj
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/bin-transcribe-manager/go.sum
+++ b/bin-transcribe-manager/go.sum
@@ -450,6 +450,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/bin-transcribe-manager/pkg/listenhandler/v1_transcribes.go
+++ b/bin-transcribe-manager/pkg/listenhandler/v1_transcribes.go
@@ -167,12 +167,10 @@ func (h *listenHandler) processV1TranscribesIDDelete(ctx context.Context, m *soc
 
 // processV1TranscribesIDStopPost handles /v1/transcribes/<id>/stop POST request
 func (h *listenHandler) processV1TranscribesIDStopPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
-	log := logrus.WithFields(
-		logrus.Fields{
-			"handler": "processV1TranscribesIDStopPost",
-			"request": m,
-		},
-	)
+	log := logrus.WithFields(logrus.Fields{
+		"handler": "processV1TranscribesIDStopPost",
+		"request": m,
+	})
 
 	uriItems := strings.Split(m.URI, "/")
 	if len(uriItems) < 4 {

--- a/bin-transcribe-manager/pkg/listenhandler/v1_transcribes.go
+++ b/bin-transcribe-manager/pkg/listenhandler/v1_transcribes.go
@@ -183,7 +183,7 @@ func (h *listenHandler) processV1TranscribesIDStopPost(ctx context.Context, m *s
 
 	tr, err := h.transcribeHandler.Stop(ctx, id)
 	if err != nil {
-		log.Errorf("Could not update the conference. err: %v", err)
+		log.Errorf("Could not stop the transcribe. err: %v", err)
 		return simpleResponse(400), nil
 	}
 

--- a/bin-transcribe-manager/pkg/streaminghandler/audiosocket.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/audiosocket.go
@@ -32,7 +32,7 @@ func (h *streamingHandler) audiosocketGetNextMedia(conn net.Conn) (audiosocket.M
 
 	if m.Kind() != audiosocket.KindSlin {
 		if m.Kind() == audiosocket.KindHangup {
-			return nil, fmt.Errorf("received hangup. message_len: %d, kind: %v", m.ContentLength(), m.Kind())
+			return nil, fmt.Errorf("received hangup. message_len: %d, kind: %v", len(m), m.Kind())
 		}
 
 		return nil, nil

--- a/bin-transcribe-manager/pkg/streaminghandler/audiosocket.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/audiosocket.go
@@ -32,7 +32,7 @@ func (h *streamingHandler) audiosocketGetNextMedia(conn net.Conn) (audiosocket.M
 
 	if m.Kind() != audiosocket.KindSlin {
 		if m.Kind() == audiosocket.KindHangup {
-			return nil, fmt.Errorf("received hangup. message_len: %d, kind: %v", len(m), m.Kind())
+			return nil, fmt.Errorf("received hangup. content_len: %d, kind: %v", m.ContentLength(), m.Kind())
 		}
 
 		return nil, nil

--- a/bin-transcribe-manager/pkg/streaminghandler/audiosocket.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/audiosocket.go
@@ -32,7 +32,7 @@ func (h *streamingHandler) audiosocketGetNextMedia(conn net.Conn) (audiosocket.M
 
 	if m.Kind() != audiosocket.KindSlin {
 		if m.Kind() == audiosocket.KindHangup {
-			return nil, fmt.Errorf("received hangup")
+			return nil, fmt.Errorf("received hangup. message_len: %d, kind: %v", m.ContentLength(), m.Kind())
 		}
 
 		return nil, nil

--- a/bin-transcribe-manager/pkg/streaminghandler/main.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/main.go
@@ -64,6 +64,8 @@ const (
 
 const (
 	defaultKeepAliveInterval = 10 * time.Second // 10 seconds
+	defaultMaxRetryAttempts  = 3
+	defaultInitialBackoff    = 100 * time.Millisecond // 100 milliseconds
 )
 
 type streamingHandler struct {

--- a/bin-transcribe-manager/pkg/streaminghandler/main.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"log"
 	"sync"
+	"time"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -59,6 +60,10 @@ const (
 	defaultAWSRegion     = "eu-central-1"
 	defaultAWSEncoding   = transcribestreamingservice.MediaEncodingPcm
 	defaultAWSSampleRate = 8000
+)
+
+const (
+	defaultKeepAliveInterval = 10 * time.Second // 10 seconds
 )
 
 type streamingHandler struct {

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -50,7 +50,7 @@ func (h *streamingHandler) runStart(conn net.Conn) {
 	// Get streamingID
 	streamingID, err := h.audiosocketGetStreamingID(conn)
 	if err != nil {
-		log.Errorf("Could not get mediaID: %v", err)
+		log.Errorf("Could not get streaming ID. err: %v", err)
 		return
 	}
 	log = log.WithField("streaming_id", streamingID)

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -38,6 +38,7 @@ func (h *streamingHandler) runStart(conn net.Conn) {
 	log := logrus.WithFields(logrus.Fields{
 		"func": "runStart",
 	})
+	defer conn.Close()
 
 	// get streamingID
 	streamingID, err := h.audiosocketGetStreamingID(conn)

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -81,20 +81,18 @@ func (h *streamingHandler) startKeepAlive(conn net.Conn) {
 	ticker := time.NewTicker(10 * time.Second) // Send keep alive every 10 seconds
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-ticker.C:
-			// Create AudioSocket keepalive message
-			// Header: type (0x10) + length (0x0000)
-			keepAliveMessage := []byte{0x10, 0x00, 0x00}
+	// Use for range to iterate over ticker.C
+	for range ticker.C {
+		// Create AudioSocket keepalive message
+		// Header: type (0x10) + length (0x0000)
+		keepAliveMessage := []byte{0x10, 0x00, 0x00}
 
-			// Send message
-			_, err := conn.Write(keepAliveMessage)
-			if err != nil {
-				log.Errorf("Failed to send keep alive message. err: %v", err)
-				return
-			}
-			log.Debug("Keep alive message sent")
+		// Send message
+		_, err := conn.Write(keepAliveMessage)
+		if err != nil {
+			log.Errorf("Failed to send keep alive message. err: %v", err)
+			return
 		}
+		log.Debug("Keep alive message sent")
 	}
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -53,9 +53,9 @@ func (h *streamingHandler) runStart(conn net.Conn) {
 		log.Errorf("Could not get mediaID: %v", err)
 		return
 	}
+	log = log.WithField("streaming_id", streamingID)
 	log.Debugf("Found streaming id: %s", streamingID)
 
-	// Fetch streaming information
 	st, err := h.Get(ctx, streamingID)
 	if err != nil {
 		log.Errorf("Could not get streaming: %v", err)
@@ -63,13 +63,11 @@ func (h *streamingHandler) runStart(conn net.Conn) {
 	}
 	log.WithField("streaming", st).Debugf("Streaming info retrieved. streaming_id: %s", st.ID)
 
-	// Define handlers
 	handlers := []func(*streaming.Streaming, net.Conn) error{
 		h.gcpRun,
 		h.awsRun,
 	}
 
-	// Execute handlers
 	for _, handler := range handlers {
 		if errRun := handler(st, conn); errRun != nil {
 			log.Errorf("Handler execution failed: %v", errRun)
@@ -104,62 +102,3 @@ func (h *streamingHandler) startKeepAlive(ctx context.Context, conn net.Conn) {
 		}
 	}
 }
-
-// func (h *streamingHandler) runStart(conn net.Conn) {
-// 	log := logrus.WithFields(logrus.Fields{
-// 		"func": "runStart",
-// 	})
-// 	defer conn.Close()
-
-// 	// get streamingID
-// 	streamingID, err := h.audiosocketGetStreamingID(conn)
-// 	if err != nil {
-// 		log.Errorf("Could not get mediaID. err: %v", err)
-// 		return
-// 	}
-// 	log.Debugf("Found streaming id. streaming_id: %s", streamingID)
-
-// 	st, err := h.Get(context.Background(), streamingID)
-// 	if err != nil {
-// 		log.Errorf("Could not get streaming. err: %v", err)
-// 		return
-// 	}
-// 	log.WithField("streaming", st).Debugf("Found streaming info. streaming_id: %s", st.ID)
-
-// 	handlers := []func(*streaming.Streaming, net.Conn) error{
-// 		h.gcpRun,
-// 		h.awsRun,
-// 	}
-
-// 	// Start Keep Alive after successful handler execution
-// 	go h.startKeepAlive(conn)
-
-// 	for _, handler := range handlers {
-// 		if errRun := handler(st, conn); errRun == nil {
-// 			return
-// 		} else {
-// 			log.Errorf("Could not run the handler. err: %v", errRun)
-// 		}
-// 	}
-// }
-
-// func (h *streamingHandler) startKeepAlive(conn net.Conn) {
-// 	log := logrus.WithFields(logrus.Fields{
-// 		"func": "startKeepAlive",
-// 	})
-
-// 	ticker := time.NewTicker(10 * time.Second) // Send keep alive every 10 seconds
-// 	defer ticker.Stop()
-
-// 	for range ticker.C {
-// 		// Create AudioSocket keepalive message
-// 		// Header: type (0x10) + length (0x0000)
-// 		keepAliveMessage := []byte{0x10, 0x00, 0x00}
-
-// 		_, err := conn.Write(keepAliveMessage)
-// 		if err != nil {
-// 			log.Debugf("Failed to send keep alive message. err: %v", err)
-// 			return
-// 		}
-// 	}
-// }

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -45,7 +45,7 @@ func (h *streamingHandler) runStart(conn net.Conn) {
 	}()
 
 	// Start keep-alive in a separate goroutine
-	go h.startKeepAlive(ctx, conn)
+	go h.runKeepAlive(ctx, conn, defaultKeepAliveInterval)
 
 	// Get streamingID
 	streamingID, err := h.audiosocketGetStreamingID(conn)
@@ -79,10 +79,10 @@ func (h *streamingHandler) runStart(conn net.Conn) {
 	log.Warn("No handler executed successfully")
 }
 
-func (h *streamingHandler) startKeepAlive(ctx context.Context, conn net.Conn) {
-	log := logrus.WithField("func", "startKeepAlive")
+func (h *streamingHandler) runKeepAlive(ctx context.Context, conn net.Conn, interval time.Duration) {
+	log := logrus.WithField("func", "runKeepAlive")
 
-	ticker := time.NewTicker(10 * time.Second) // Send keep alive every 10 seconds
+	ticker := time.NewTicker(interval) // Use configurable interval
 	defer ticker.Stop()
 
 	for {

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -90,9 +90,8 @@ func (h *streamingHandler) startKeepAlive(conn net.Conn) {
 		// Send message
 		_, err := conn.Write(keepAliveMessage)
 		if err != nil {
-			log.Errorf("Failed to send keep alive message. err: %v", err)
+			log.Debugf("Failed to send keep alive message. err: %v", err)
 			return
 		}
-		log.Debug("Keep alive message sent")
 	}
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/run_test.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run_test.go
@@ -1,0 +1,90 @@
+package streaminghandler
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockConn is a mock implementation of the net.Conn interface
+type MockConn struct {
+	mock.Mock
+}
+
+func (m *MockConn) Write(b []byte) (int, error) {
+	args := m.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockConn) Close() error {
+	return m.Called().Error(0)
+}
+
+func (m *MockConn) Read(b []byte) (int, error) {
+	args := m.Called(b)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockConn) LocalAddr() net.Addr {
+	return m.Called().Get(0).(net.Addr)
+}
+
+func (m *MockConn) RemoteAddr() net.Addr {
+	return m.Called().Get(0).(net.Addr)
+}
+
+func (m *MockConn) SetDeadline(t time.Time) error {
+	return m.Called(t).Error(0)
+}
+
+func (m *MockConn) SetReadDeadline(t time.Time) error {
+	return m.Called(t).Error(0)
+}
+
+func (m *MockConn) SetWriteDeadline(t time.Time) error {
+	return m.Called(t).Error(0)
+}
+
+func Test_runKeepAlive(t *testing.T) {
+	tests := []struct {
+		name          string
+		expectWrites  int
+		cancelAfterMs int
+		intervalMs    int
+	}{
+		{
+			name:          "normal",
+			expectWrites:  3,
+			cancelAfterMs: 1050,
+			intervalMs:    300,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mockConn := new(MockConn)
+			mockConn.On("Write", []byte{0x10, 0x00, 0x00}).Return(3, nil)
+
+			ctx, cancel := context.WithCancel(context.Background())
+
+			defer func() {
+				cancel()
+				mockConn.AssertExpectations(t)
+			}()
+
+			go func() {
+				time.Sleep(time.Duration(tt.cancelAfterMs) * time.Millisecond)
+				cancel()
+			}()
+
+			handler := &streamingHandler{}
+			handler.runKeepAlive(ctx, mockConn, time.Duration(tt.intervalMs)*time.Millisecond)
+
+			mockConn.AssertNumberOfCalls(t, "Write", tt.expectWrites)
+		})
+	}
+}

--- a/bin-transcribe-manager/pkg/streaminghandler/run_test.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -50,16 +51,19 @@ func (m *MockConn) SetWriteDeadline(t time.Time) error {
 
 func Test_runKeepAlive(t *testing.T) {
 	tests := []struct {
-		name          string
+		name        string
+		interval    time.Duration
+		streamingID uuid.UUID
+
 		expectWrites  int
 		cancelAfterMs int
-		intervalMs    int
 	}{
 		{
 			name:          "normal",
+			interval:      300 * time.Millisecond,
+			streamingID:   uuid.FromStringOrNil("eee08956-3bd7-11f0-b6f0-9fd777b76ce0"),
 			expectWrites:  3,
 			cancelAfterMs: 1050,
-			intervalMs:    300,
 		},
 	}
 
@@ -82,7 +86,7 @@ func Test_runKeepAlive(t *testing.T) {
 			}()
 
 			handler := &streamingHandler{}
-			handler.runKeepAlive(ctx, mockConn, time.Duration(tt.intervalMs)*time.Millisecond)
+			handler.runKeepAlive(ctx, mockConn, tt.interval, tt.streamingID)
 
 			mockConn.AssertNumberOfCalls(t, "Write", tt.expectWrites)
 		})


### PR DESCRIPTION
* bin-call-manager: Replacing direct calls to AstChannelHangup with the new channelhandler.HangingUpWithAsteriskID in the call manager and external media handler.
* bin-call-manager: Updating unit tests and dependency management to support the new hangup logic.
* bin-ai-manager: Enhancing logging messages and error wrapping for better diagnostics across streaming, call, and AI call handlers.
* bin-transcribe-manager: Implement runKeepAlive in streamingHandler (with configurable interval and tests) and define defaultKeepAliveInterval.
* bin-transcribe-manager: Adjust summary handler to use DirectionIn instead of DirectionBoth, and refine error messages/log statements.
 