### PR TITLE
VOIP-1086-Fix_wrong_silence_play

### DIFF
--- a/bin-call-manager/pkg/arieventhandler/ari_playback.go
+++ b/bin-call-manager/pkg/arieventhandler/ari_playback.go
@@ -81,7 +81,7 @@ func (h *eventHandler) EventHandlerPlaybackFinished(ctx context.Context, evt int
 		}
 
 		if br.TMDelete < dbhandler.DefaultTimeStamp {
-			log.Infof("The channel already hungup. channel_id: %s", br.ID)
+			log.Infof("The bridge already deleted. bridge_id: %s", br.ID)
 			return nil
 		}
 
@@ -91,30 +91,4 @@ func (h *eventHandler) EventHandlerPlaybackFinished(ctx context.Context, evt int
 		return fmt.Errorf("unsupported target resource: %s", targetResource)
 
 	}
-
-	// channelID := parts[1]
-
-	// channelID := e.Playback.TargetURI[len("channel:"):]
-	// cn, err := h.channelHandler.UpdatePlaybackID(ctx, channelID, "")
-	// if err != nil {
-	// 	log.Errorf("Could not update the channel's playback id. channel_id: %s, err: %v", channelID, err)
-	// 	// we've failed to set the plabyback id, but the playback is working.
-	// 	// we don't return the error here.
-	// }
-
-	// if cn.TMEnd < dbhandler.DefaultTimeStamp {
-	// 	log.Infof("The channel already hungup. channel_id: %s", cn.ID)
-	// 	return nil
-	// }
-
-	// switch {
-	// case strings.HasPrefix(e.Playback.ID, playback.IDPrefixCall):
-	// 	return h.callHandler.ARIPlaybackFinished(ctx, cn, e)
-
-	// case strings.HasPrefix(e.Playback.ID, playback.IDPrefixExternalMedia):
-	// 	return h.externalmediaHandler.ARIPlaybackFinished(ctx, cn, e)
-
-	// default:
-	// 	return fmt.Errorf("could not find playback id prefix. playback_id: %s", e.Playback.ID)
-	// }
 }

--- a/bin-call-manager/pkg/arieventhandler/ari_playback.go
+++ b/bin-call-manager/pkg/arieventhandler/ari_playback.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	ari "monorepo/bin-call-manager/models/ari"
-	"monorepo/bin-call-manager/models/playback"
 	"monorepo/bin-call-manager/pkg/dbhandler"
 )
 
@@ -49,32 +48,73 @@ func (h *eventHandler) EventHandlerPlaybackFinished(ctx context.Context, evt int
 		"event": e,
 	})
 
-	if !strings.HasPrefix(e.Playback.TargetURI, "channel:") {
+	// Extract the string after the first ':' from TargetURI
+	parts := strings.SplitN(e.Playback.TargetURI, ":", 2)
+	if len(parts) < 2 {
 		// no channel info
 		return nil
 	}
 
-	channelID := e.Playback.TargetURI[len("channel:"):]
-	cn, err := h.channelHandler.UpdatePlaybackID(ctx, channelID, "")
-	if err != nil {
-		log.Errorf("Could not update the channel's playback id. channel_id: %s, err: %v", channelID, err)
-		// we've failed to set the plabyback id, but the playback is working.
-		// we don't return the error here.
-	}
+	targetResource := parts[0]
+	targetID := parts[1]
+	switch targetResource {
+	case "channel":
+		cn, err := h.channelHandler.UpdatePlaybackID(ctx, targetID, "")
+		if err != nil {
+			log.Errorf("Could not update the channel's playback id. channel_id: %s, err: %v", targetID, err)
+			// we've failed to set the plabyback id, but the playback is working.
+			// we don't return the error here.
+		}
 
-	if cn.TMEnd < dbhandler.DefaultTimeStamp {
-		log.Infof("The channel already hungup. channel_id: %s", cn.ID)
-		return nil
-	}
+		if cn.TMEnd < dbhandler.DefaultTimeStamp {
+			log.Infof("The channel already hungup. channel_id: %s", cn.ID)
+			return nil
+		}
 
-	switch {
-	case strings.HasPrefix(e.Playback.ID, playback.IDPrefixCall):
 		return h.callHandler.ARIPlaybackFinished(ctx, cn, e)
 
-	case strings.HasPrefix(e.Playback.ID, playback.IDPrefixExternalMedia):
-		return h.externalmediaHandler.ARIPlaybackFinished(ctx, cn, e)
+	case "bridge":
+		br, err := h.bridgeHandler.Get(ctx, targetID)
+		if err != nil {
+			log.Errorf("Could not get bridge info. err: %v", err)
+			return err
+		}
+
+		if br.TMDelete < dbhandler.DefaultTimeStamp {
+			log.Infof("The channel already hungup. channel_id: %s", br.ID)
+			return nil
+		}
+
+		return h.externalmediaHandler.ARIPlaybackFinished(ctx, br, e)
 
 	default:
-		return fmt.Errorf("could not find playback id prefix. playback_id: %s", e.Playback.ID)
+		return fmt.Errorf("unsupported target resource: %s", targetResource)
+
 	}
+
+	// channelID := parts[1]
+
+	// channelID := e.Playback.TargetURI[len("channel:"):]
+	// cn, err := h.channelHandler.UpdatePlaybackID(ctx, channelID, "")
+	// if err != nil {
+	// 	log.Errorf("Could not update the channel's playback id. channel_id: %s, err: %v", channelID, err)
+	// 	// we've failed to set the plabyback id, but the playback is working.
+	// 	// we don't return the error here.
+	// }
+
+	// if cn.TMEnd < dbhandler.DefaultTimeStamp {
+	// 	log.Infof("The channel already hungup. channel_id: %s", cn.ID)
+	// 	return nil
+	// }
+
+	// switch {
+	// case strings.HasPrefix(e.Playback.ID, playback.IDPrefixCall):
+	// 	return h.callHandler.ARIPlaybackFinished(ctx, cn, e)
+
+	// case strings.HasPrefix(e.Playback.ID, playback.IDPrefixExternalMedia):
+	// 	return h.externalmediaHandler.ARIPlaybackFinished(ctx, cn, e)
+
+	// default:
+	// 	return fmt.Errorf("could not find playback id prefix. playback_id: %s", e.Playback.ID)
+	// }
 }

--- a/bin-call-manager/pkg/externalmediahandler/main.go
+++ b/bin-call-manager/pkg/externalmediahandler/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"monorepo/bin-call-manager/models/ari"
-	"monorepo/bin-call-manager/models/channel"
+	"monorepo/bin-call-manager/models/bridge"
 	"monorepo/bin-call-manager/models/externalmedia"
 	"monorepo/bin-call-manager/pkg/bridgehandler"
 	"monorepo/bin-call-manager/pkg/channelhandler"
@@ -38,7 +38,7 @@ type ExternalMediaHandler interface {
 	) (*externalmedia.ExternalMedia, error)
 	Stop(ctx context.Context, externalMediaID uuid.UUID) (*externalmedia.ExternalMedia, error)
 
-	ARIPlaybackFinished(ctx context.Context, cn *channel.Channel, e *ari.PlaybackFinished) error
+	ARIPlaybackFinished(ctx context.Context, cn *bridge.Bridge, e *ari.PlaybackFinished) error
 }
 
 // list of channel variables

--- a/bin-call-manager/pkg/externalmediahandler/mock_main.go
+++ b/bin-call-manager/pkg/externalmediahandler/mock_main.go
@@ -12,7 +12,7 @@ package externalmediahandler
 import (
 	context "context"
 	ari "monorepo/bin-call-manager/models/ari"
-	channel "monorepo/bin-call-manager/models/channel"
+	bridge "monorepo/bin-call-manager/models/bridge"
 	externalmedia "monorepo/bin-call-manager/models/externalmedia"
 	reflect "reflect"
 
@@ -45,7 +45,7 @@ func (m *MockExternalMediaHandler) EXPECT() *MockExternalMediaHandlerMockRecorde
 }
 
 // ARIPlaybackFinished mocks base method.
-func (m *MockExternalMediaHandler) ARIPlaybackFinished(ctx context.Context, cn *channel.Channel, e *ari.PlaybackFinished) error {
+func (m *MockExternalMediaHandler) ARIPlaybackFinished(ctx context.Context, cn *bridge.Bridge, e *ari.PlaybackFinished) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ARIPlaybackFinished", ctx, cn, e)
 	ret0, _ := ret[0].(error)

--- a/bin-call-manager/pkg/externalmediahandler/playback.go
+++ b/bin-call-manager/pkg/externalmediahandler/playback.go
@@ -32,9 +32,9 @@ func (h *externalMediaHandler) ARIPlaybackFinished(ctx context.Context, br *brid
 	}
 
 	if errPlay := h.bridgeHandler.Play(ctx, br.ID, e.Playback.ID, []string{defaultSilencePlaybackMedia}, "", 0, 0); errPlay != nil {
-		return errors.Wrapf(errPlay, "could not start silence playback for channel_id: %s", br.ID)
+		return errors.Wrapf(errPlay, "could not start silence playback for bridge. bridge_id: %s", br.ID)
 	}
-	log.Debugf("Started silence playback for the channel. channel_id: %s", br.ID)
+	log.Debugf("Started silence playback for the bridge. bridge_id: %s", br.ID)
 
 	return nil
 }

--- a/bin-call-manager/pkg/externalmediahandler/playback.go
+++ b/bin-call-manager/pkg/externalmediahandler/playback.go
@@ -3,7 +3,7 @@ package externalmediahandler
 import (
 	"context"
 	"monorepo/bin-call-manager/models/ari"
-	"monorepo/bin-call-manager/models/channel"
+	"monorepo/bin-call-manager/models/bridge"
 	"monorepo/bin-call-manager/models/externalmedia"
 	"monorepo/bin-call-manager/models/playback"
 	"strings"
@@ -13,10 +13,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (h *externalMediaHandler) ARIPlaybackFinished(ctx context.Context, cn *channel.Channel, e *ari.PlaybackFinished) error {
+func (h *externalMediaHandler) ARIPlaybackFinished(ctx context.Context, br *bridge.Bridge, e *ari.PlaybackFinished) error {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "ARIPlaybackFinished",
-		"channel": cn,
+		"channel": br,
 		"event":   e,
 	})
 
@@ -31,10 +31,10 @@ func (h *externalMediaHandler) ARIPlaybackFinished(ctx context.Context, cn *chan
 		return nil
 	}
 
-	if errPlay := h.channelHandler.Play(ctx, cn.ID, e.Playback.ID, []string{defaultSilencePlaybackMedia}, "", 0, 0); errPlay != nil {
-		return errors.Wrapf(errPlay, "could not start silence playback for channel_id: %s", cn.ID)
+	if errPlay := h.bridgeHandler.Play(ctx, br.ID, e.Playback.ID, []string{defaultSilencePlaybackMedia}, "", 0, 0); errPlay != nil {
+		return errors.Wrapf(errPlay, "could not start silence playback for channel_id: %s", br.ID)
 	}
-	log.Debugf("Started silence playback for the channel. channel_id: %s", cn.ID)
+	log.Debugf("Started silence playback for the channel. channel_id: %s", br.ID)
 
 	return nil
 }

--- a/bin-call-manager/pkg/externalmediahandler/start.go
+++ b/bin-call-manager/pkg/externalmediahandler/start.go
@@ -112,8 +112,10 @@ func (h *externalMediaHandler) startReferenceTypeCall(
 	log.WithField("snoop_channel", tmp).Debugf("Created a new snoop channel. channel_id: %s", tmp.ID)
 
 	// start silence playback
+	// we are playing a silence playback to the call's callbridge.
+	// because if we play the silence playback to the call's channel, it blocks other media play on the call's channel.
 	playbackID := fmt.Sprintf("%s%s", playback.IDPrefixExternalMedia, id.String())
-	if errPlay := h.channelHandler.Play(ctx, ch.ID, playbackID, []string{defaultSilencePlaybackMedia}, "", 0, 0); errPlay != nil {
+	if errPlay := h.bridgeHandler.Play(ctx, c.BridgeID, playbackID, []string{defaultSilencePlaybackMedia}, "", 0, 0); errPlay != nil {
 		return nil, errors.Wrapf(errPlay, "could not start silence playback for channel_id: %s", ch.ID)
 	}
 	log.WithField("playback_id", playbackID).Debugf("Started silence playback for the channel. channel_id: %s", ch.ID)

--- a/bin-call-manager/pkg/externalmediahandler/start_test.go
+++ b/bin-call-manager/pkg/externalmediahandler/start_test.go
@@ -71,6 +71,7 @@ func Test_Start_startReferenceTypeCall(t *testing.T) {
 				},
 				// AsteriskID: "42:01:0a:a4:00:05",
 				ChannelID: "8066017c-02fb-11ec-ba6c-c320820accf1",
+				BridgeID:  "51bf770e-7f1b-11f0-ac50-971ccbe0a7ba",
 			},
 			responseChannel: &channel.Channel{
 				AsteriskID: "42:01:0a:a4:00:05",
@@ -134,7 +135,7 @@ func Test_Start_startReferenceTypeCall(t *testing.T) {
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDSnoopID)
 			mockChannel.EXPECT().StartSnoop(ctx, tt.responseCall.ChannelID, gomock.Any(), gomock.Any(), channel.SnoopDirection(tt.directionListen), channel.SnoopDirection(tt.directionSpeak)).Return(&channel.Channel{}, nil)
 
-			mockChannel.EXPECT().Play(ctx, tt.responseCall.ChannelID, tt.expectPlaybackID, []string{defaultSilencePlaybackMedia}, "", 0, 0).Return(nil)
+			mockBridge.EXPECT().Play(ctx, tt.responseCall.BridgeID, tt.expectPlaybackID, []string{defaultSilencePlaybackMedia}, "", 0, 0).Return(nil)
 
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDChannelID)
 			mockChannel.EXPECT().StartExternalMedia(ctx, tt.responseChannel.AsteriskID, gomock.Any(), tt.externalHost, string(tt.encapsulation), string(tt.transport), tt.connectionType, tt.format, string(tt.directionListen), tt.expectChannelData, gomock.Any()).Return(&channel.Channel{}, nil)

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -107,8 +107,6 @@ func (h *streamingHandler) runKeepAlive(ctx context.Context, conn net.Conn, inte
 				log.Errorf("Failed to send keep alive message after retries: %v", errRetry)
 				return
 			}
-
-			log.Debugf("Keep-alive message sent successfully. streaming_id: %s", streamingID)
 		}
 	}
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/run.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/run.go
@@ -107,6 +107,8 @@ func (h *streamingHandler) runKeepAlive(ctx context.Context, conn net.Conn, inte
 				log.Errorf("Failed to send keep alive message after retries: %v", errRetry)
 				return
 			}
+
+			log.Debugf("Keep-alive message sent successfully. streaming_id: %s", streamingID)
 		}
 	}
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/start.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/start.go
@@ -20,6 +20,7 @@ func (h *streamingHandler) Start(ctx context.Context, customerID uuid.UUID, tran
 		"transcribe_id":  transcribeID,
 		"reference_type": referenceType,
 		"reference_id":   referenceID,
+		"language":       language,
 		"direction":      direction,
 	})
 

--- a/bin-transcribe-manager/pkg/transcribehandler/start.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start.go
@@ -144,6 +144,7 @@ func (h *transcribeHandler) startLive(
 	// create transcribe id
 	id := h.utilHandler.UUIDCreate()
 	log = log.WithField("transcribe_id", id)
+	log.Debugf("Starting live transcribe. transcribe_id: %s", id)
 
 	directions := []transcript.Direction{transcript.Direction(direction)}
 	if direction == transcribe.DirectionBoth {


### PR DESCRIPTION
* bin-call-manager: Modified silence playback to target bridges instead of channels to prevent blocking other media
* bin-call-manager: Updated event handling to support both channel and bridge-based playback events
* bin-call-manager: Added logging improvements for better debugging
