### PR TITLE
NOJIRA_Add_aicall_terminate

### DIFF
--- a/bin-ai-manager/go.mod
+++ b/bin-ai-manager/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/sashabaranov/go-openai v1.41.1
+	github.com/sashabaranov/go-openai v1.41.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/smotes/purse v1.0.1
 	github.com/spf13/pflag v1.0.10

--- a/bin-ai-manager/go.sum
+++ b/bin-ai-manager/go.sum
@@ -644,8 +644,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
-github.com/sashabaranov/go-openai v1.41.1 h1:zf5tM+GuxpyiyD9XZg8nCqu52eYFQg9OOew0gnIuDy4=
-github.com/sashabaranov/go-openai v1.41.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
+github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/bin-ai-manager/models/aicall/event.go
+++ b/bin-ai-manager/models/aicall/event.go
@@ -6,5 +6,6 @@ const (
 	EventTypeStatusProgressing  string = "aicall_status_progressing"  // the aicall status is progressing
 	EventTypeStatusPausing      string = "aicall_status_pausing"      // the aicall status is pausing
 	EventTypeStatusResuming     string = "aicall_status_resuming"     // the aicall status is resuming
-	EventTypeStatusEnd          string = "aicall_status_end"          // the aicall status is end
+	EventTypeStatusFinishing    string = "aicall_status_finishing"    // the aicall status is finishing
+	EventTypeStatusFinished     string = "aicall_status_finished"     // the aicall status is finished
 )

--- a/bin-ai-manager/models/aicall/main.go
+++ b/bin-ai-manager/models/aicall/main.go
@@ -57,8 +57,8 @@ const (
 	StatusProgressing Status = "progressing"
 	StatusPausing     Status = "pausing"
 	StatusResuming    Status = "resuming"
-	StatusFinish      Status = "finish" // the call is finished, but the resources may not be released yet.
-	StatusEnd         Status = "end"
+	StatusFinishing   Status = "finishing" // the call is being finished.
+	StatusFinished    Status = "finished"
 )
 
 // Gender define

--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -208,7 +208,7 @@ func (h *aicallHandler) UpdateStatusFinishing(ctx context.Context, id uuid.UUID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get updated aicall info. aicall_id: %s", id)
 	}
-	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusFinished, res)
+	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusFinishing, res)
 
 	return res, nil
 }

--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -197,10 +197,26 @@ func (h *aicallHandler) UpdateStatusResuming(ctx context.Context, id uuid.UUID, 
 	return res, nil
 }
 
-// UpdateStatusEnd updates the status to end
-func (h *aicallHandler) UpdateStatusEnd(ctx context.Context, id uuid.UUID) (*aicall.AIcall, error) {
+// UpdateStatusFinishing updates the status to finishing
+func (h *aicallHandler) UpdateStatusFinishing(ctx context.Context, id uuid.UUID) (*aicall.AIcall, error) {
 
-	if errUpdate := h.db.AIcallUpdateStatusEnd(ctx, id); errUpdate != nil {
+	if errUpdate := h.db.AIcallUpdateStatusFinishing(ctx, id); errUpdate != nil {
+		return nil, errors.Wrapf(errUpdate, "could not update the status to finishing. aicall_id: %s", id)
+	}
+
+	res, err := h.Get(ctx, id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get updated aicall info. aicall_id: %s", id)
+	}
+	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusFinished, res)
+
+	return res, nil
+}
+
+// UpdateStatusFinished updates the status to end
+func (h *aicallHandler) UpdateStatusFinished(ctx context.Context, id uuid.UUID) (*aicall.AIcall, error) {
+
+	if errUpdate := h.db.AIcallUpdateStatusFinished(ctx, id); errUpdate != nil {
 		return nil, errors.Wrapf(errUpdate, "could not update the status to end. aicall_id: %s", id)
 	}
 
@@ -208,7 +224,7 @@ func (h *aicallHandler) UpdateStatusEnd(ctx context.Context, id uuid.UUID) (*aic
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get updated aicall info. aicall_id: %s", id)
 	}
-	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusEnd, res)
+	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusFinished, res)
 
 	return res, nil
 }

--- a/bin-ai-manager/pkg/aicallhandler/db_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/db_test.go
@@ -406,11 +406,11 @@ func Test_UpdateStatusEnd(t *testing.T) {
 
 			ctx := context.Background()
 
-			mockDB.EXPECT().AIcallUpdateStatusEnd(ctx, tt.id).Return(nil)
+			mockDB.EXPECT().AIcallUpdateStatusFinished(ctx, tt.id).Return(nil)
 			mockDB.EXPECT().AIcallGet(ctx, tt.id).Return(tt.responseAIcall, nil)
-			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseAIcall.CustomerID, aicall.EventTypeStatusEnd, tt.responseAIcall)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseAIcall.CustomerID, aicall.EventTypeStatusFinished, tt.responseAIcall)
 
-			res, err := h.UpdateStatusEnd(ctx, tt.id)
+			res, err := h.UpdateStatusFinished(ctx, tt.id)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-ai-manager/pkg/aicallhandler/main.go
+++ b/bin-ai-manager/pkg/aicallhandler/main.go
@@ -46,6 +46,7 @@ type AIcallHandler interface {
 
 	ProcessStart(ctx context.Context, cb *aicall.AIcall) (*aicall.AIcall, error)
 	ProcessPause(ctx context.Context, ac *aicall.AIcall) (*aicall.AIcall, error)
+	ProcessTerminating(ctx context.Context, id uuid.UUID) (*aicall.AIcall, error)
 	ProcessEnd(ctx context.Context, cb *aicall.AIcall) (*aicall.AIcall, error)
 
 	Start(

--- a/bin-ai-manager/pkg/aicallhandler/mock_main.go
+++ b/bin-ai-manager/pkg/aicallhandler/mock_main.go
@@ -259,6 +259,21 @@ func (mr *MockAIcallHandlerMockRecorder) ProcessStart(ctx, cb any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessStart", reflect.TypeOf((*MockAIcallHandler)(nil).ProcessStart), ctx, cb)
 }
 
+// ProcessTerminating mocks base method.
+func (m *MockAIcallHandler) ProcessTerminating(ctx context.Context, id uuid.UUID) (*aicall.AIcall, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessTerminating", ctx, id)
+	ret0, _ := ret[0].(*aicall.AIcall)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ProcessTerminating indicates an expected call of ProcessTerminating.
+func (mr *MockAIcallHandlerMockRecorder) ProcessTerminating(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessTerminating", reflect.TypeOf((*MockAIcallHandler)(nil).ProcessTerminating), ctx, id)
+}
+
 // ServiceStart mocks base method.
 func (m *MockAIcallHandler) ServiceStart(ctx context.Context, aiID, activeflowID uuid.UUID, referenceType aicall.ReferenceType, referenceID uuid.UUID, gender aicall.Gender, language string, resuming bool) (*service.Service, error) {
 	m.ctrl.T.Helper()

--- a/bin-ai-manager/pkg/aicallhandler/process.go
+++ b/bin-ai-manager/pkg/aicallhandler/process.go
@@ -88,7 +88,7 @@ func (h *aicallHandler) ProcessEnd(ctx context.Context, ac *aicall.AIcall) (*aic
 		}
 	}
 
-	res, err := h.UpdateStatusEnd(ctx, ac.ID)
+	res, err := h.UpdateStatusFinished(ctx, ac.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not end the aicall")
 	}
@@ -101,6 +101,16 @@ func (h *aicallHandler) ProcessEnd(ctx context.Context, ac *aicall.AIcall) (*aic
 		log.Errorf("Could not delete the confbridge. err: %v", err)
 	}
 	log.WithField("confbridge", tmp).Debugf("Destroyed the confbridge. confbridge_id: %s", tmp.ID)
+
+	return res, nil
+}
+
+// ProcessTerminating starts the aicall terminating process.
+func (h *aicallHandler) ProcessTerminating(ctx context.Context, id uuid.UUID) (*aicall.AIcall, error) {
+	res, err := h.UpdateStatusFinishing(ctx, id)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not terminating the aicall")
+	}
 
 	return res, nil
 }

--- a/bin-ai-manager/pkg/aicallhandler/process_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/process_test.go
@@ -151,10 +151,10 @@ func Test_ProcessEnd(t *testing.T) {
 			ctx := context.Background()
 
 			mockReq.EXPECT().TranscribeV1TranscribeStop(ctx, tt.aicall.TranscribeID).Return(&tmtranscribe.Transcribe{}, nil)
-			mockDB.EXPECT().AIcallUpdateStatusEnd(ctx, tt.aicall.ID).Return(nil)
+			mockDB.EXPECT().AIcallUpdateStatusFinished(ctx, tt.aicall.ID).Return(nil)
 			mockDB.EXPECT().AIcallGet(ctx, tt.aicall.ID).Return(tt.aicall, nil)
 			mockReq.EXPECT().CallV1ConfbridgeDelete(ctx, tt.aicall.ConfbridgeID).Return(&cmconfbridge.Confbridge{}, nil)
-			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.aicall.CustomerID, aicall.EventTypeStatusEnd, tt.aicall)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.aicall.CustomerID, aicall.EventTypeStatusFinished, tt.aicall)
 
 			res, err := h.ProcessEnd(ctx, tt.aicall)
 			if err != nil {

--- a/bin-ai-manager/pkg/dbhandler/aicall.go
+++ b/bin-ai-manager/pkg/dbhandler/aicall.go
@@ -413,7 +413,7 @@ func (h *handler) AIcallUpdateStatusResuming(ctx context.Context, id uuid.UUID, 
 	return nil
 }
 
-// AIcallUpdateStAIcallUpdateStatusFinishingatusPausing updates the aicall's status to finishing
+// AIcallUpdateStatusFinishing updates the aicall's status to finishing
 func (h *handler) AIcallUpdateStatusFinishing(ctx context.Context, id uuid.UUID) error {
 	return h.aicallUpdateStatus(ctx, id, uuid.Nil, aicall.StatusFinishing)
 }

--- a/bin-ai-manager/pkg/dbhandler/aicall.go
+++ b/bin-ai-manager/pkg/dbhandler/aicall.go
@@ -413,8 +413,13 @@ func (h *handler) AIcallUpdateStatusResuming(ctx context.Context, id uuid.UUID, 
 	return nil
 }
 
-// AIcallUpdateStatusEnd updates the aicall's status to end
-func (h *handler) AIcallUpdateStatusEnd(ctx context.Context, id uuid.UUID) error {
+// AIcallUpdateStAIcallUpdateStatusFinishingatusPausing updates the aicall's status to finishing
+func (h *handler) AIcallUpdateStatusFinishing(ctx context.Context, id uuid.UUID) error {
+	return h.aicallUpdateStatus(ctx, id, uuid.Nil, aicall.StatusFinishing)
+}
+
+// AIcallUpdateStatusFinished updates the aicall's status to end
+func (h *handler) AIcallUpdateStatusFinished(ctx context.Context, id uuid.UUID) error {
 	//prepare
 	q := `
 	update ai_aicalls set
@@ -427,9 +432,9 @@ func (h *handler) AIcallUpdateStatusEnd(ctx context.Context, id uuid.UUID) error
 	`
 
 	ts := h.utilHandler.TimeGetCurTime()
-	_, err := h.db.Exec(q, aicall.StatusEnd, uuid.Nil.Bytes(), ts, ts, id.Bytes())
+	_, err := h.db.Exec(q, aicall.StatusFinished, uuid.Nil.Bytes(), ts, ts, id.Bytes())
 	if err != nil {
-		return fmt.Errorf("could not execute. AIcallUpdateStatusEnd. err: %v", err)
+		return fmt.Errorf("could not execute. AIcallUpdateStatusFinished. err: %v", err)
 	}
 
 	// update the cache

--- a/bin-ai-manager/pkg/dbhandler/aicall_test.go
+++ b/bin-ai-manager/pkg/dbhandler/aicall_test.go
@@ -483,7 +483,7 @@ func Test_AIcallUpdateStatusEnd(t *testing.T) {
 				},
 				AIEngineData: map[string]any{},
 				TranscribeID: uuid.Nil,
-				Status:       aicall.StatusEnd,
+				Status:       aicall.StatusFinished,
 				TMEnd:        "2023-01-03 21:35:02.809",
 				TMCreate:     "2023-01-03 21:35:02.809",
 				TMUpdate:     "2023-01-03 21:35:02.809",
@@ -516,7 +516,7 @@ func Test_AIcallUpdateStatusEnd(t *testing.T) {
 
 			mockUtil.EXPECT().TimeGetCurTime().Return(tt.responseCurTime)
 			mockCache.EXPECT().AIcallSet(ctx, gomock.Any())
-			if err := h.AIcallUpdateStatusEnd(ctx, tt.id); err != nil {
+			if err := h.AIcallUpdateStatusFinished(ctx, tt.id); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 

--- a/bin-ai-manager/pkg/dbhandler/main.go
+++ b/bin-ai-manager/pkg/dbhandler/main.go
@@ -36,7 +36,8 @@ type DBHandler interface {
 	AIcallUpdateStatusPausing(ctx context.Context, id uuid.UUID) error
 	AIcallUpdateStatusProgressing(ctx context.Context, id uuid.UUID, transcribeID uuid.UUID) error
 	AIcallUpdateStatusResuming(ctx context.Context, id uuid.UUID, confbridgeID uuid.UUID) error
-	AIcallUpdateStatusEnd(ctx context.Context, id uuid.UUID) error
+	AIcallUpdateStatusFinishing(ctx context.Context, id uuid.UUID) error
+	AIcallUpdateStatusFinished(ctx context.Context, id uuid.UUID) error
 
 	MessageCreate(ctx context.Context, c *message.Message) error
 	MessageGet(ctx context.Context, id uuid.UUID) (*message.Message, error)

--- a/bin-ai-manager/pkg/dbhandler/mock_main.go
+++ b/bin-ai-manager/pkg/dbhandler/mock_main.go
@@ -220,18 +220,32 @@ func (mr *MockDBHandlerMockRecorder) AIcallGets(ctx, size, token, filters any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallGets", reflect.TypeOf((*MockDBHandler)(nil).AIcallGets), ctx, size, token, filters)
 }
 
-// AIcallUpdateStatusEnd mocks base method.
-func (m *MockDBHandler) AIcallUpdateStatusEnd(ctx context.Context, id uuid.UUID) error {
+// AIcallUpdateStatusFinished mocks base method.
+func (m *MockDBHandler) AIcallUpdateStatusFinished(ctx context.Context, id uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AIcallUpdateStatusEnd", ctx, id)
+	ret := m.ctrl.Call(m, "AIcallUpdateStatusFinished", ctx, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AIcallUpdateStatusEnd indicates an expected call of AIcallUpdateStatusEnd.
-func (mr *MockDBHandlerMockRecorder) AIcallUpdateStatusEnd(ctx, id any) *gomock.Call {
+// AIcallUpdateStatusFinished indicates an expected call of AIcallUpdateStatusFinished.
+func (mr *MockDBHandlerMockRecorder) AIcallUpdateStatusFinished(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallUpdateStatusEnd", reflect.TypeOf((*MockDBHandler)(nil).AIcallUpdateStatusEnd), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallUpdateStatusFinished", reflect.TypeOf((*MockDBHandler)(nil).AIcallUpdateStatusFinished), ctx, id)
+}
+
+// AIcallUpdateStatusFinishing mocks base method.
+func (m *MockDBHandler) AIcallUpdateStatusFinishing(ctx context.Context, id uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AIcallUpdateStatusFinishing", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AIcallUpdateStatusFinishing indicates an expected call of AIcallUpdateStatusFinishing.
+func (mr *MockDBHandlerMockRecorder) AIcallUpdateStatusFinishing(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallUpdateStatusFinishing", reflect.TypeOf((*MockDBHandler)(nil).AIcallUpdateStatusFinishing), ctx, id)
 }
 
 // AIcallUpdateStatusPausing mocks base method.

--- a/bin-ai-manager/pkg/listenhandler/main.go
+++ b/bin-ai-manager/pkg/listenhandler/main.go
@@ -57,9 +57,10 @@ var (
 	regV1AIsID  = regexp.MustCompile("/v1/ais/" + regUUID + "$")
 
 	// aicalls
-	regV1AIcallsGet = regexp.MustCompile(`/v1/aicalls\?`)
-	regV1AIcalls    = regexp.MustCompile(`/v1/aicalls$`)
-	regV1AIcallsID  = regexp.MustCompile("/v1/aicalls/" + regUUID + "$")
+	regV1AIcallsGet         = regexp.MustCompile(`/v1/aicalls\?`)
+	regV1AIcalls            = regexp.MustCompile(`/v1/aicalls$`)
+	regV1AIcallsID          = regexp.MustCompile("/v1/aicalls/" + regUUID + "$")
+	regV1AIcallsIDTerminate = regexp.MustCompile("/v1/aicalls/" + regUUID + "/terminate$")
 
 	// messages
 	regV1MessagesGet = regexp.MustCompile(`/v1/messages\?`)
@@ -237,6 +238,11 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1AIcallsID.MatchString(m.URI) && m.Method == sock.RequestMethodDelete:
 		response, err = h.processV1AIcallsIDDelete(ctx, m)
 		requestType = "/v1/aicalls/<aicall-id>"
+
+	// POST /aicalls/<aicall-id>/terminate
+	case regV1AIcallsIDTerminate.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1AIcallsIDTerminatePost(ctx, m)
+		requestType = "/v1/aicalls/<aicall-id>/terminate"
 
 	///////////////
 	// messages

--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
@@ -165,3 +165,38 @@ func (h *listenHandler) processV1AIcallsIDDelete(ctx context.Context, m *sock.Re
 
 	return res, nil
 }
+
+// processV1AIcallsPost handles POST /v1/aicalls/<aicall-id>/terminate request
+func (h *listenHandler) processV1AIcallsIDTerminatePost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"handler": "processV1AIcallsIDTerminatePost",
+		"request": m,
+	})
+
+	uriItems := strings.Split(m.URI, "/")
+	if len(uriItems) < 4 {
+		log.Errorf("Wrong uri item count. uri_items: %d", len(uriItems))
+		return simpleResponse(400), nil
+	}
+	id := uuid.FromStringOrNil(uriItems[3])
+
+	tmp, err := h.aicallHandler.ProcessTerminating(ctx, id)
+	if err != nil {
+		log.Errorf("Could not terminate aicall. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	data, err := json.Marshal(tmp)
+	if err != nil {
+		log.Errorf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		return simpleResponse(500), nil
+	}
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}

--- a/bin-ai-manager/pkg/messagehandler/send.go
+++ b/bin-ai-manager/pkg/messagehandler/send.go
@@ -31,7 +31,7 @@ func (h *messageHandler) Send(ctx context.Context, aicallID uuid.UUID, role mess
 		return nil, errors.Wrapf(err, "could not get the aicall correctly")
 	}
 
-	if cc.Status == aicall.StatusEnd {
+	if cc.Status == aicall.StatusFinished {
 		return nil, errors.New("aicall is already ended")
 	}
 

--- a/bin-ai-manager/pkg/messagehandler/streaming_send.go
+++ b/bin-ai-manager/pkg/messagehandler/streaming_send.go
@@ -32,7 +32,7 @@ func (h *messageHandler) StreamingSend(ctx context.Context, aicallID uuid.UUID, 
 		return nil, errors.Wrapf(err, "could not get the aicall correctly")
 	}
 
-	if cc.Status == aicall.StatusEnd {
+	if cc.Status == aicall.StatusFinished {
 		return nil, errors.New("aicall is already ended")
 	} else if cc.ReferenceType != aicall.ReferenceTypeCall {
 		return nil, fmt.Errorf("unsupported reference type: %s", cc.ReferenceType)

--- a/bin-common-handler/pkg/requesthandler/ai_aicalls.go
+++ b/bin-common-handler/pkg/requesthandler/ai_aicalls.go
@@ -88,11 +88,30 @@ func (r *requestHandler) AIV1AIcallGet(ctx context.Context, aicallID uuid.UUID) 
 
 // AIV1AIcallDelete sends a request to ai-manager
 // to deleting a aicall.
-// it returns deleted conference if it succeed.
+// it returns deleted aicall if it succeed.
 func (r *requestHandler) AIV1AIcallDelete(ctx context.Context, aicallID uuid.UUID) (*amaicall.AIcall, error) {
 	uri := fmt.Sprintf("/v1/aicalls/%s", aicallID)
 
 	tmp, err := r.sendRequestAI(ctx, uri, sock.RequestMethodDelete, "ai/aicalls/<aicall-id>", requestTimeoutDefault, 0, ContentTypeNone, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res amaicall.AIcall
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
+// AIV1AIcallTerminate sends a request to ai-manager
+// to terminate an aicall.
+// it returns aicall if it succeed.
+func (r *requestHandler) AIV1AIcallTerminate(ctx context.Context, aicallID uuid.UUID) (*amaicall.AIcall, error) {
+	uri := fmt.Sprintf("/v1/aicalls/%s/terminate", aicallID)
+
+	tmp, err := r.sendRequestAI(ctx, uri, sock.RequestMethodPost, "ai/aicalls/<aicall-id>/terminate", requestTimeoutDefault, 0, ContentTypeNone, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -195,6 +195,7 @@ type RequestHandler interface {
 	AIV1AIcallGets(ctx context.Context, pageToken string, pageSize uint64, filters map[string]string) ([]amaicall.AIcall, error)
 	AIV1AIcallGet(ctx context.Context, aicallID uuid.UUID) (*amaicall.AIcall, error)
 	AIV1AIcallDelete(ctx context.Context, aicallID uuid.UUID) (*amaicall.AIcall, error)
+	AIV1AIcallTerminate(ctx context.Context, aicallID uuid.UUID) (*amaicall.AIcall, error)
 
 	// ai-manager message
 	AIV1MessageGetsByAIcallID(ctx context.Context, aicallID uuid.UUID, pageToken string, pageSize uint64, filters map[string]string) ([]cbmessage.Message, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -242,6 +242,21 @@ func (mr *MockRequestHandlerMockRecorder) AIV1AIcallStart(ctx, activeflowID, aiI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIV1AIcallStart", reflect.TypeOf((*MockRequestHandler)(nil).AIV1AIcallStart), ctx, activeflowID, aiID, referenceType, referenceID, gender, language)
 }
 
+// AIV1AIcallTerminate mocks base method.
+func (m *MockRequestHandler) AIV1AIcallTerminate(ctx context.Context, aicallID uuid.UUID) (*aicall.AIcall, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AIV1AIcallTerminate", ctx, aicallID)
+	ret0, _ := ret[0].(*aicall.AIcall)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AIV1AIcallTerminate indicates an expected call of AIV1AIcallTerminate.
+func (mr *MockRequestHandlerMockRecorder) AIV1AIcallTerminate(ctx, aicallID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIV1AIcallTerminate", reflect.TypeOf((*MockRequestHandler)(nil).AIV1AIcallTerminate), ctx, aicallID)
+}
+
 // AIV1MessageDelete mocks base method.
 func (m *MockRequestHandler) AIV1MessageDelete(ctx context.Context, messageID uuid.UUID) (*message.Message, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* bin-ai-manager, bin-common-handler: Introduces new AIV1AIcallTerminate method in request handler interfaces with corresponding mock implementations.
* bin-ai-manager: Adds new AI call statuses StatusFinishing and StatusFinished to replace the previous StatusEnd.
* all: Updates existing code to use the new status names and adds termination workflow support
