### PR TITLE
VOIP-1128-Change_column_utf8mb4

### DIFF
--- a/bin-dbscheme-bin-manager/bin-manager/main/versions/f46d9c5c4438_ai_messages_alter_column_content.py
+++ b/bin-dbscheme-bin-manager/bin-manager/main/versions/f46d9c5c4438_ai_messages_alter_column_content.py
@@ -21,7 +21,8 @@ def upgrade():
         ALTER TABLE ai_messages 
         MODIFY COLUMN content TEXT 
         CHARACTER SET utf8mb4 
-        COLLATE utf8mb4_general_ci;""")
+        COLLATE utf8mb4_general_ci;
+    """)
 
 
 def downgrade():


### PR DESCRIPTION
* bin-dbscheme-bin-manager: Updates the content column character set from utf8mb3 to utf8mb4 with utf8mb4_general_ci collation
* bin-dbscheme-bin-manager: Provides a downgrade path to revert to utf8mb3 if needed
