### PR TITLE
NOJIRA-Fix_unregister_error

### DIFF
--- a/bin-pipecat-manager/scripts/pipecat/tools.py
+++ b/bin-pipecat-manager/scripts/pipecat/tools.py
@@ -367,7 +367,6 @@ def tool_unregister(llm_service):
             llm_service.unregister_function(tool_name)
         except KeyError:
             logger.debug(f"Tool '{tool_name}' was not registered or already removed.")
-            pass
         except Exception as e:
             logger.warning(f"Error while unregistering tool '{tool_name}': {e}")
 


### PR DESCRIPTION
* bin-pipecat-manager: Added try-except blocks around llm_service.unregister_function() calls
* bin-pipecat-manager: Handles KeyError exceptions with debug logging for expected scenarios
* bin-pipecat-manager: Catches general exceptions with warning-level logging for unexpected errors
