### PR TITLE
NOJIRA-Add_asterisk_proxy_kubernetes_disabled

### DIFF
--- a/voip-asterisk-proxy/cmd/asterisk-proxy/init.go
+++ b/voip-asterisk-proxy/cmd/asterisk-proxy/init.go
@@ -88,6 +88,8 @@ func initVariable() {
 	pflag.String("recording_asterisk_directory", defaultRecordingAsteriskDirectory, "recording directory of the Asterisk server")
 	pflag.String("recording_bucket_directory", defaultRecordingBucketDirectory, "recording directory of the bucket")
 
+	pflag.Bool("kubernetes_disabled", false, "Disable Kubernetes integration")
+
 	pflag.Parse()
 
 	// ari_address
@@ -321,6 +323,16 @@ func initVariable() {
 	}
 	recordingBucketDirectory = viper.GetString("recording_bucket_directory")
 
+	// kubernetes_disabled
+	if errFlag := viper.BindPFlag("kubernetes_disabled", pflag.Lookup("kubernetes_disabled")); errFlag != nil {
+		log.Errorf("Error binding flag: %v", errFlag)
+		panic(errFlag)
+	}
+	if errEnv := viper.BindEnv("kubernetes_disabled", "KUBERNETES_DISABLED"); errEnv != nil {
+		log.Errorf("Error binding env: %v", errEnv)
+		panic(errEnv)
+	}
+	kubernetesDisabled = viper.GetBool("kubernetes_disabled")
 }
 
 // initLog inits log settings.

--- a/voip-asterisk-proxy/cmd/asterisk-proxy/main.go
+++ b/voip-asterisk-proxy/cmd/asterisk-proxy/main.go
@@ -56,6 +56,8 @@ var (
 	recordingBucketName        = ""
 	recordingAsteriskDirectory = ""
 	recordingBucketDirectory   = ""
+
+	kubernetesDisabled = false
 )
 
 const (
@@ -91,9 +93,12 @@ func main() {
 		return
 	}
 
-	if errSet := setProxyInfoAnnotation(asteriskID); errSet != nil {
-		log.Errorf("Could not initiate proxy info annotation handler. err: %v", errSet)
-		return
+	if !kubernetesDisabled {
+		log.Infof("Kubernetes integration is enabled. Attempting to set pod annotation.")
+		if errSet := setProxyInfoAnnotation(asteriskID); errSet != nil {
+			log.Errorf("Could not initiate proxy info annotation handler. err: %v", errSet)
+			return
+		}
 	}
 
 	// create rabbitmq listen requet queue names

--- a/voip-asterisk-proxy/pkg/eventhandler/ari_handler.go
+++ b/voip-asterisk-proxy/pkg/eventhandler/ari_handler.go
@@ -23,7 +23,9 @@ func (h *eventHandler) eventARIRun() error {
 
 			continue
 		}
-		defer h.ariSock.Close()
+		defer func() {
+			_ = h.ariSock.Close()
+		}()
 
 		// receive ARI events
 		for {

--- a/voip-asterisk-proxy/pkg/eventhandler/ari_handler_test.go
+++ b/voip-asterisk-proxy/pkg/eventhandler/ari_handler_test.go
@@ -31,7 +31,10 @@ func echo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
+
 	for {
 		mt, message, err := c.ReadMessage()
 		if err != nil {

--- a/voip-asterisk-proxy/pkg/listenhandler/ari_handler.go
+++ b/voip-asterisk-proxy/pkg/listenhandler/ari_handler.go
@@ -37,7 +37,7 @@ func (h *listenHandler) ariSendRequestToAsterisk(m *sock.Request) (int, []byte, 
 	}
 
 	res, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if err != nil {
 		return 0, nil, err
 	}

--- a/voip-asterisk-proxy/pkg/listenhandler/ari_handler_test.go
+++ b/voip-asterisk-proxy/pkg/listenhandler/ari_handler_test.go
@@ -63,7 +63,7 @@ func Test_ariSendRequestToAsterisk(t *testing.T) {
 
 			// setup dummy server
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprintf(w, "%s", tt.response)
+				_, _ = fmt.Fprintf(w, "%s", tt.response)
 			}))
 			defer ts.Close()
 

--- a/voip-asterisk-proxy/pkg/servicehandler/recording.go
+++ b/voip-asterisk-proxy/pkg/servicehandler/recording.go
@@ -39,7 +39,9 @@ func (h *serviceHandler) recordingFileUpload(ctx context.Context, filename strin
 	if err != nil {
 		return errors.Wrapf(err, "failed to open source file. source_filepath: %s", sourceFilepath)
 	}
-	defer sourceFile.Close()
+	defer func() {
+		_ = sourceFile.Close()
+	}()
 
 	destinationFilepath := fmt.Sprintf("%s/%s", h.recordingBucketDirectory, filename)
 	wc := h.client.Bucket(h.recordingBucketName).Object(destinationFilepath).NewWriter(ctx)


### PR DESCRIPTION
* voip-asterisk-proxy: Adds a new kubernetes_disabled flag that allows the service to run without Kubernetes pod annotations
* voip-asterisk-proxy: Updates error handling to explicitly ignore errors from Close() operations using _ = Close() pattern in defer statements
* voip-asterisk-proxy: Adds informative logging when Kubernetes integration is enabled