### PR TITLE
NOJIRA-Implement_talk_manager_request_models_pattern

### DIFF
--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -724,7 +724,7 @@ type ServiceHandler interface {
 	// service_agent talk message
 	ServiceAgentTalkMessageGet(ctx context.Context, a *amagent.Agent, messageID uuid.UUID) (*tkmessage.WebhookMessage, error)
 	ServiceAgentTalkMessageList(ctx context.Context, a *amagent.Agent, chatID uuid.UUID, size uint64, token string) ([]*tkmessage.WebhookMessage, error)
-	ServiceAgentTalkMessageCreate(ctx context.Context, a *amagent.Agent, chatID uuid.UUID, parentID *uuid.UUID, msgType tkmessage.Type, text string) (*tkmessage.WebhookMessage, error)
+	ServiceAgentTalkMessageCreate(ctx context.Context, a *amagent.Agent, chatID uuid.UUID, parentID *uuid.UUID, msgType tkmessage.Type, text string, medias []tkmessage.Media) (*tkmessage.WebhookMessage, error)
 	ServiceAgentTalkMessageDelete(ctx context.Context, a *amagent.Agent, messageID uuid.UUID) (*tkmessage.WebhookMessage, error)
 	ServiceAgentTalkMessageReactionCreate(ctx context.Context, a *amagent.Agent, messageID uuid.UUID, emoji string) (*tkmessage.WebhookMessage, error)
 

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -3731,18 +3731,18 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentTalkChatUpdate(ctx, a, tal
 }
 
 // ServiceAgentTalkMessageCreate mocks base method.
-func (m *MockServiceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *agent.Agent, chatID uuid.UUID, parentID *uuid.UUID, msgType message2.Type, text string) (*message2.WebhookMessage, error) {
+func (m *MockServiceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *agent.Agent, chatID uuid.UUID, parentID *uuid.UUID, msgType message2.Type, text string, medias []message2.Media) (*message2.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceAgentTalkMessageCreate", ctx, a, chatID, parentID, msgType, text)
+	ret := m.ctrl.Call(m, "ServiceAgentTalkMessageCreate", ctx, a, chatID, parentID, msgType, text, medias)
 	ret0, _ := ret[0].(*message2.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ServiceAgentTalkMessageCreate indicates an expected call of ServiceAgentTalkMessageCreate.
-func (mr *MockServiceHandlerMockRecorder) ServiceAgentTalkMessageCreate(ctx, a, chatID, parentID, msgType, text any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentTalkMessageCreate(ctx, a, chatID, parentID, msgType, text, medias any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTalkMessageCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTalkMessageCreate), ctx, a, chatID, parentID, msgType, text)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTalkMessageCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTalkMessageCreate), ctx, a, chatID, parentID, msgType, text, medias)
 }
 
 // ServiceAgentTalkMessageDelete mocks base method.

--- a/bin-api-manager/pkg/servicehandler/serviceagent_talk.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_talk.go
@@ -215,14 +215,14 @@ func (h *serviceHandler) ServiceAgentTalkMessageList(ctx context.Context, a *ama
 }
 
 // ServiceAgentTalkMessageCreate creates a new message
-func (h *serviceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *amagent.Agent, chatID uuid.UUID, parentID *uuid.UUID, msgType tkmessage.Type, text string) (*tkmessage.WebhookMessage, error) {
+func (h *serviceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *amagent.Agent, chatID uuid.UUID, parentID *uuid.UUID, msgType tkmessage.Type, text string, medias []tkmessage.Media) (*tkmessage.WebhookMessage, error) {
 	// Check permission
 	if !h.isParticipantOfTalk(ctx, a.ID, chatID) {
 		return nil, fmt.Errorf("agent is not a participant of this talk")
 	}
 
 	// Create message via RPC
-	tmp, err := h.reqHandler.TalkV1MessageCreate(ctx, chatID, parentID, "agent", a.ID, msgType, text)
+	tmp, err := h.reqHandler.TalkV1MessageCreate(ctx, chatID, parentID, "agent", a.ID, msgType, text, medias)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not create message.")
 	}

--- a/bin-api-manager/server/service_agents_talk.go
+++ b/bin-api-manager/server/service_agents_talk.go
@@ -463,7 +463,26 @@ func (h *server) PostServiceAgentsTalkMessages(c *gin.Context) {
 	// Convert type (req.Type is non-pointer, required field)
 	msgType := tkmessage.Type(req.Type)
 
-	res, err := h.serviceHandler.ServiceAgentTalkMessageCreate(c.Request.Context(), &a, chatID, parentID, msgType, req.Text)
+	// Convert medias
+	var medias []tkmessage.Media
+	if req.Medias != nil {
+		for _, m := range *req.Medias {
+			media := tkmessage.Media{}
+			if m.Type != nil {
+				media.Type = tkmessage.MediaType(*m.Type)
+			}
+			if m.FileId != nil {
+				media.FileID = uuid.FromStringOrNil(*m.FileId)
+			}
+			if m.LinkUrl != nil {
+				media.LinkURL = *m.LinkUrl
+			}
+			// Note: Address and Agent fields require deeper conversion if needed
+			medias = append(medias, media)
+		}
+	}
+
+	res, err := h.serviceHandler.ServiceAgentTalkMessageCreate(c.Request.Context(), &a, chatID, parentID, msgType, req.Text, medias)
 	if err != nil {
 		log.Errorf("Could not create message. err: %v", err)
 		c.AbortWithStatus(400)

--- a/bin-api-manager/server/service_agents_talk_test.go
+++ b/bin-api-manager/server/service_agents_talk_test.go
@@ -765,6 +765,7 @@ func Test_talkMessagesPOST(t *testing.T) {
 		expectParentID *uuid.UUID
 		expectType     tkmessage.Type
 		expectText     string
+		expectMedias   []tkmessage.Media
 	}{
 		{
 			name: "normal",
@@ -796,6 +797,7 @@ func Test_talkMessagesPOST(t *testing.T) {
 			expectParentID: nil,
 			expectType:     tkmessage.TypeNormal,
 			expectText:     "Hello",
+			expectMedias:   nil,
 		},
 	}
 
@@ -820,7 +822,7 @@ func Test_talkMessagesPOST(t *testing.T) {
 			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBufferString(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().ServiceAgentTalkMessageCreate(req.Context(), &tt.agent, tt.expectChatID, tt.expectParentID, tt.expectType, tt.expectText).Return(tt.responseMessage, nil)
+			mockSvc.EXPECT().ServiceAgentTalkMessageCreate(req.Context(), &tt.agent, tt.expectChatID, tt.expectParentID, tt.expectType, tt.expectText, tt.expectMedias).Return(tt.responseMessage, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -1149,7 +1149,7 @@ type RequestHandler interface {
 
 	// talk-manager message
 	TalkV1MessageGet(ctx context.Context, messageID uuid.UUID) (*talkmessage.Message, error)
-	TalkV1MessageCreate(ctx context.Context, chatID uuid.UUID, parentID *uuid.UUID, ownerType string, ownerID uuid.UUID, msgType talkmessage.Type, text string) (*talkmessage.Message, error)
+	TalkV1MessageCreate(ctx context.Context, chatID uuid.UUID, parentID *uuid.UUID, ownerType string, ownerID uuid.UUID, msgType talkmessage.Type, text string, medias []talkmessage.Media) (*talkmessage.Message, error)
 	TalkV1MessageDelete(ctx context.Context, messageID uuid.UUID) (*talkmessage.Message, error)
 	TalkV1MessageList(ctx context.Context, pageToken string, pageSize uint64) ([]*talkmessage.Message, error)
 	TalkV1MessageListWithFilters(ctx context.Context, filters map[string]any, pageToken string, pageSize uint64) ([]*talkmessage.Message, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -5557,18 +5557,18 @@ func (mr *MockRequestHandlerMockRecorder) TalkV1ChatUpdate(ctx, chatID, name, de
 }
 
 // TalkV1MessageCreate mocks base method.
-func (m *MockRequestHandler) TalkV1MessageCreate(ctx context.Context, chatID uuid.UUID, parentID *uuid.UUID, ownerType string, ownerID uuid.UUID, msgType message3.Type, text string) (*message3.Message, error) {
+func (m *MockRequestHandler) TalkV1MessageCreate(ctx context.Context, chatID uuid.UUID, parentID *uuid.UUID, ownerType string, ownerID uuid.UUID, msgType message3.Type, text string, medias []message3.Media) (*message3.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TalkV1MessageCreate", ctx, chatID, parentID, ownerType, ownerID, msgType, text)
+	ret := m.ctrl.Call(m, "TalkV1MessageCreate", ctx, chatID, parentID, ownerType, ownerID, msgType, text, medias)
 	ret0, _ := ret[0].(*message3.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TalkV1MessageCreate indicates an expected call of TalkV1MessageCreate.
-func (mr *MockRequestHandlerMockRecorder) TalkV1MessageCreate(ctx, chatID, parentID, ownerType, ownerID, msgType, text any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) TalkV1MessageCreate(ctx, chatID, parentID, ownerType, ownerID, msgType, text, medias any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TalkV1MessageCreate", reflect.TypeOf((*MockRequestHandler)(nil).TalkV1MessageCreate), ctx, chatID, parentID, ownerType, ownerID, msgType, text)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TalkV1MessageCreate", reflect.TypeOf((*MockRequestHandler)(nil).TalkV1MessageCreate), ctx, chatID, parentID, ownerType, ownerID, msgType, text, medias)
 }
 
 // TalkV1MessageDelete mocks base method.

--- a/bin-common-handler/pkg/requesthandler/talk_messages.go
+++ b/bin-common-handler/pkg/requesthandler/talk_messages.go
@@ -7,6 +7,7 @@ import (
 
 	"monorepo/bin-common-handler/models/sock"
 	talkmessage "monorepo/bin-talk-manager/models/message"
+	tmrequest "monorepo/bin-talk-manager/pkg/listenhandler/models/request"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -42,22 +43,25 @@ func (r *requestHandler) TalkV1MessageCreate(
 	ownerID uuid.UUID,
 	msgType talkmessage.Type,
 	text string,
+	medias []talkmessage.Media,
 ) (*talkmessage.Message, error) {
 	uri := "/v1/messages"
 
-	data := map[string]any{
-		"chat_id":    chatID.String(),
-		"owner_type": ownerType,
-		"owner_id":   ownerID.String(),
-		"type":       string(msgType),
-		"text":       text,
+	req := tmrequest.V1DataMessagesPost{
+		ChatID:    chatID.String(),
+		OwnerType: ownerType,
+		OwnerID:   ownerID.String(),
+		Type:      string(msgType),
+		Text:      text,
+		Medias:    medias,
 	}
 
 	if parentID != nil {
-		data["parent_id"] = parentID.String()
+		parentIDStr := parentID.String()
+		req.ParentID = &parentIDStr
 	}
 
-	m, err := json.Marshal(data)
+	m, err := json.Marshal(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not marshal request")
 	}
@@ -158,13 +162,13 @@ func (r *requestHandler) TalkV1MessageReactionCreate(
 ) (*talkmessage.Message, error) {
 	uri := fmt.Sprintf("/v1/messages/%s/reactions", messageID.String())
 
-	data := map[string]any{
-		"owner_type": ownerType,
-		"owner_id":   ownerID.String(),
-		"emoji":      emoji,
+	req := tmrequest.V1DataMessagesIDReactionsPost{
+		OwnerType: ownerType,
+		OwnerID:   ownerID.String(),
+		Reaction:  emoji,
 	}
 
-	m, err := json.Marshal(data)
+	m, err := json.Marshal(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not marshal request")
 	}

--- a/bin-common-handler/pkg/requesthandler/talk_messages_test.go
+++ b/bin-common-handler/pkg/requesthandler/talk_messages_test.go
@@ -102,6 +102,7 @@ func Test_TalkV1MessageCreate(t *testing.T) {
 		ownerID   uuid.UUID
 		msgType   talkmessage.Type
 		text      string
+		medias    []talkmessage.Media
 
 		expectQueue string
 
@@ -117,6 +118,7 @@ func Test_TalkV1MessageCreate(t *testing.T) {
 			ownerID:   uuid.FromStringOrNil("660e8400-e29b-41d4-a716-446655440000"),
 			msgType:   talkmessage.TypeNormal,
 			text:      "Hello",
+			medias:    []talkmessage.Media{},
 
 			expectQueue: "bin-manager.talk-manager.request",
 
@@ -150,6 +152,7 @@ func Test_TalkV1MessageCreate(t *testing.T) {
 			ownerID:   uuid.FromStringOrNil("660e8400-e29b-41d4-a716-446655440000"),
 			msgType:   talkmessage.TypeNormal,
 			text:      "Reply",
+			medias:    []talkmessage.Media{},
 
 			expectQueue: "bin-manager.talk-manager.request",
 
@@ -191,7 +194,7 @@ func Test_TalkV1MessageCreate(t *testing.T) {
 
 			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectQueue, gomock.Any()).Return(tt.response, nil)
 
-			res, err := reqHandler.TalkV1MessageCreate(ctx, tt.chatID, tt.parentID, tt.ownerType, tt.ownerID, tt.msgType, tt.text)
+			res, err := reqHandler.TalkV1MessageCreate(ctx, tt.chatID, tt.parentID, tt.ownerType, tt.ownerID, tt.msgType, tt.text, tt.medias)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-talk-manager/pkg/listenhandler/models/request/chats.go
+++ b/bin-talk-manager/pkg/listenhandler/models/request/chats.go
@@ -1,0 +1,24 @@
+package request
+
+// V1DataChatsParticipant represents a participant in a chat creation request
+type V1DataChatsParticipant struct {
+	OwnerType string `json:"owner_type"`
+	OwnerID   string `json:"owner_id"`
+}
+
+// V1DataChatsPost represents the request body for POST /v1/chats
+type V1DataChatsPost struct {
+	CustomerID   string                   `json:"customer_id"`
+	Type         string                   `json:"type"`
+	Name         string                   `json:"name"`
+	Detail       string                   `json:"detail"`
+	CreatorType  string                   `json:"creator_type"`
+	CreatorID    string                   `json:"creator_id"`
+	Participants []V1DataChatsParticipant `json:"participants"`
+}
+
+// V1DataChatsIDPut represents the request body for PUT /v1/chats/{id}
+type V1DataChatsIDPut struct {
+	Name   *string `json:"name"`
+	Detail *string `json:"detail"`
+}

--- a/bin-talk-manager/pkg/listenhandler/models/request/main.go
+++ b/bin-talk-manager/pkg/listenhandler/models/request/main.go
@@ -1,0 +1,5 @@
+package request
+
+// Package request contains request data structures for the talk-manager API.
+// These structs are shared between listenhandler and requesthandler to ensure
+// type safety and consistency across inter-service communication.

--- a/bin-talk-manager/pkg/listenhandler/models/request/messages.go
+++ b/bin-talk-manager/pkg/listenhandler/models/request/messages.go
@@ -1,0 +1,14 @@
+package request
+
+import "monorepo/bin-talk-manager/models/message"
+
+// V1DataMessagesPost represents the request body for POST /v1/messages
+type V1DataMessagesPost struct {
+	ChatID    string          `json:"chat_id"`
+	ParentID  *string         `json:"parent_id,omitempty"`
+	OwnerType string          `json:"owner_type"`
+	OwnerID   string          `json:"owner_id"`
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	Medias    []message.Media `json:"medias"`
+}

--- a/bin-talk-manager/pkg/listenhandler/models/request/participants.go
+++ b/bin-talk-manager/pkg/listenhandler/models/request/participants.go
@@ -1,0 +1,8 @@
+package request
+
+// V1DataChatsIDParticipantsPost represents the request body for POST /v1/chats/{id}/participants
+type V1DataChatsIDParticipantsPost struct {
+	CustomerID string `json:"customer_id"`
+	OwnerType  string `json:"owner_type"`
+	OwnerID    string `json:"owner_id"`
+}

--- a/bin-talk-manager/pkg/listenhandler/models/request/reactions.go
+++ b/bin-talk-manager/pkg/listenhandler/models/request/reactions.go
@@ -1,0 +1,9 @@
+package request
+
+// V1DataMessagesIDReactionsPost represents the request body for POST /v1/messages/{id}/reactions
+// Also used for DELETE /v1/messages/{id}/reactions
+type V1DataMessagesIDReactionsPost struct {
+	OwnerType string `json:"owner_type"`
+	OwnerID   string `json:"owner_id"`
+	Reaction  string `json:"reaction"`
+}

--- a/bin-talk-manager/pkg/listenhandler/v1_chats.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats.go
@@ -13,21 +13,11 @@ import (
 	commonutil "monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-talk-manager/models/chat"
 	"monorepo/bin-talk-manager/models/participant"
+	"monorepo/bin-talk-manager/pkg/listenhandler/models/request"
 )
 
 func (h *listenHandler) v1ChatsPost(ctx context.Context, m commonsock.Request) (*commonsock.Response, error) {
-	var req struct {
-		CustomerID   string `json:"customer_id"`
-		Type         string `json:"type"`
-		Name         string `json:"name"`
-		Detail       string `json:"detail"`
-		CreatorType  string `json:"creator_type"`
-		CreatorID    string `json:"creator_id"`
-		Participants []struct {
-			OwnerType string `json:"owner_type"`
-			OwnerID   string `json:"owner_id"`
-		} `json:"participants"`
-	}
+	var req request.V1DataChatsPost
 
 	err := json.Unmarshal(m.Data, &req)
 	if err != nil {
@@ -131,10 +121,7 @@ func (h *listenHandler) v1ChatsIDPut(ctx context.Context, m commonsock.Request) 
 	matches := regV1ChatsID.FindStringSubmatch(m.URI)
 	chatID := uuid.FromStringOrNil(matches[1])
 
-	var req struct {
-		Name   *string `json:"name"`
-		Detail *string `json:"detail"`
-	}
+	var req request.V1DataChatsIDPut
 
 	err := json.Unmarshal(m.Data, &req)
 	if err != nil {

--- a/bin-talk-manager/pkg/listenhandler/v1_chats_participants.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats_participants.go
@@ -8,17 +8,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	commonsock "monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-talk-manager/pkg/listenhandler/models/request"
 )
 
 func (h *listenHandler) v1ChatsIDParticipantsPost(ctx context.Context, m commonsock.Request) (*commonsock.Response, error) {
 	matches := regV1ChatsIDParticipants.FindStringSubmatch(m.URI)
 	chatID := uuid.FromStringOrNil(matches[1])
 
-	var req struct {
-		CustomerID string `json:"customer_id"`
-		OwnerType  string `json:"owner_type"`
-		OwnerID    string `json:"owner_id"`
-	}
+	var req request.V1DataChatsIDParticipantsPost
 
 	err := json.Unmarshal(m.Data, &req)
 	if err != nil {

--- a/bin-talk-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_messages.go
@@ -12,19 +12,12 @@ import (
 	commonsock "monorepo/bin-common-handler/models/sock"
 	commonutil "monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-talk-manager/models/message"
+	"monorepo/bin-talk-manager/pkg/listenhandler/models/request"
 	"monorepo/bin-talk-manager/pkg/messagehandler"
 )
 
 func (h *listenHandler) v1MessagesPost(ctx context.Context, m commonsock.Request) (*commonsock.Response, error) {
-	var req struct {
-		ChatID    string          `json:"chat_id"`
-		ParentID  *string         `json:"parent_id,omitempty"`
-		OwnerType string          `json:"owner_type"`
-		OwnerID   string          `json:"owner_id"`
-		Type      string          `json:"type"`
-		Text      string          `json:"text"`
-		Medias    []message.Media `json:"medias"`
-	}
+	var req request.V1DataMessagesPost
 
 	err := json.Unmarshal(m.Data, &req)
 	if err != nil {

--- a/bin-talk-manager/pkg/listenhandler/v1_reactions.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_reactions.go
@@ -8,17 +8,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	commonsock "monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-talk-manager/pkg/listenhandler/models/request"
 )
 
 func (h *listenHandler) v1MessagesIDReactionsPost(ctx context.Context, m commonsock.Request) (*commonsock.Response, error) {
 	matches := regV1MessagesIDReactions.FindStringSubmatch(m.URI)
 	messageID := uuid.FromStringOrNil(matches[1])
 
-	var req struct {
-		OwnerType string `json:"owner_type"`
-		OwnerID   string `json:"owner_id"`
-		Reaction  string `json:"reaction"`
-	}
+	var req request.V1DataMessagesIDReactionsPost
 
 	err := json.Unmarshal(m.Data, &req)
 	if err != nil {
@@ -49,11 +46,7 @@ func (h *listenHandler) v1MessagesIDReactionsDelete(ctx context.Context, m commo
 	matches := regV1MessagesIDReactions.FindStringSubmatch(m.URI)
 	messageID := uuid.FromStringOrNil(matches[1])
 
-	var req struct {
-		OwnerType string `json:"owner_type"`
-		OwnerID   string `json:"owner_id"`
-		Reaction  string `json:"reaction"`
-	}
+	var req request.V1DataMessagesIDReactionsPost
 
 	err := json.Unmarshal(m.Data, &req)
 	if err != nil {


### PR DESCRIPTION
Implement the standard monorepo request models pattern for bin-talk-manager, centralizing request struct definitions and adding medias support to message creation.

- bin-talk-manager: Create pkg/listenhandler/models/request/ directory with typed request structs
- bin-talk-manager: Add V1DataMessagesPost with proper Medias []message.Media field
- bin-talk-manager: Add V1DataMessagesIDReactionsPost, V1DataChatsPost, V1DataChatsIDPut structs
- bin-talk-manager: Add V1DataChatsIDParticipantsPost struct
- bin-talk-manager: Update listenhandler to use typed request structs instead of inline structs
- bin-common-handler: Update TalkV1MessageCreate to accept medias parameter
- bin-common-handler: Use typed tmrequest structs instead of map[string]any
- bin-api-manager: Update ServiceAgentTalkMessageCreate to accept and pass medias
- bin-api-manager: Convert OpenAPI TalkManagerMedia to tkmessage.Media in server handler