### PR TITLE
NOJIRA-Fix_service_agent_file_upload_default_name

### DIFF
--- a/bin-api-manager/server/service_agents_files.go
+++ b/bin-api-manager/server/service_agents_files.go
@@ -38,7 +38,7 @@ func (h *server) PostServiceAgentsFiles(c *gin.Context) {
 	}
 	log.WithField("file", header).Debugf("Checking uploaded file header. filename: %s", header.Filename)
 
-	res, err := h.serviceHandler.ServiceAgentFileCreate(c.Request.Context(), &a, f, "", "", header.Filename)
+	res, err := h.serviceHandler.ServiceAgentFileCreate(c.Request.Context(), &a, f, header.Filename, "Uploaded by agent", header.Filename)
 	if err != nil {
 		log.Errorf("Could not upload the file. err: %v", err)
 		c.AbortWithStatus(400)

--- a/bin-api-manager/server/service_agents_files_test.go
+++ b/bin-api-manager/server/service_agents_files_test.go
@@ -161,7 +161,7 @@ func Test_PostServiceAgentsFiles(t *testing.T) {
 			req, _ := http.NewRequest("POST", tt.reqQuery, body)
 			req.Header.Add("Content-Type", writer.FormDataContentType())
 
-			mockSvc.EXPECT().ServiceAgentFileCreate(req.Context(), &tt.agent, gomock.Any(), "", "", tt.filename).Return(tt.responseFile, nil)
+			mockSvc.EXPECT().ServiceAgentFileCreate(req.Context(), &tt.agent, gomock.Any(), tt.filename, "Uploaded by agent", tt.filename).Return(tt.responseFile, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {


### PR DESCRIPTION
Set default name and detail for files uploaded via service agent API endpoint.

- bin-api-manager: Use filename as default name instead of empty string
- bin-api-manager: Set detail to "Uploaded by agent" for service agent uploads
- bin-api-manager: Update test expectations to match new default values