### PR TITLE
NOJIRA-Fix_talk_manager_webhook_and_reaction_field

### DIFF
--- a/bin-common-handler/pkg/requesthandler/talk_messages.go
+++ b/bin-common-handler/pkg/requesthandler/talk_messages.go
@@ -165,7 +165,7 @@ func (r *requestHandler) TalkV1MessageReactionCreate(
 	req := tmrequest.V1DataMessagesIDReactionsPost{
 		OwnerType: ownerType,
 		OwnerID:   ownerID.String(),
-		Reaction:  emoji,
+		Emoji:     emoji,
 	}
 
 	m, err := json.Marshal(req)

--- a/bin-talk-manager/models/message/message.go
+++ b/bin-talk-manager/models/message/message.go
@@ -94,7 +94,7 @@ func (m *Message) ConvertWebhookMessage() (*WebhookMessage, error) {
 	}, nil
 }
 
-// CreateWebhookEvent generates WebhookEvent JSON
+// CreateWebhookEvent generates WebhookEvent JSON from Message
 func (m *Message) CreateWebhookEvent() ([]byte, error) {
 	e, err := m.ConvertWebhookMessage()
 	if err != nil {

--- a/bin-talk-manager/pkg/listenhandler/models/request/reactions.go
+++ b/bin-talk-manager/pkg/listenhandler/models/request/reactions.go
@@ -5,5 +5,5 @@ package request
 type V1DataMessagesIDReactionsPost struct {
 	OwnerType string `json:"owner_type"`
 	OwnerID   string `json:"owner_id"`
-	Reaction  string `json:"reaction"`
+	Emoji     string `json:"emoji"`
 }

--- a/bin-talk-manager/pkg/listenhandler/v1_reactions.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_reactions.go
@@ -28,7 +28,7 @@ func (h *listenHandler) v1MessagesIDReactionsPost(ctx context.Context, m commons
 		return simpleResponse(400), nil
 	}
 
-	msg, err := h.reactionHandler.ReactionAdd(ctx, messageID, req.Reaction, req.OwnerType, ownerID)
+	msg, err := h.reactionHandler.ReactionAdd(ctx, messageID, req.Emoji, req.OwnerType, ownerID)
 	if err != nil {
 		logrus.Errorf("Failed to add reaction: %v", err)
 		return simpleResponse(500), nil
@@ -59,7 +59,7 @@ func (h *listenHandler) v1MessagesIDReactionsDelete(ctx context.Context, m commo
 		return simpleResponse(400), nil
 	}
 
-	msg, err := h.reactionHandler.ReactionRemove(ctx, messageID, req.Reaction, req.OwnerType, ownerID)
+	msg, err := h.reactionHandler.ReactionRemove(ctx, messageID, req.Emoji, req.OwnerType, ownerID)
 	if err != nil {
 		logrus.Errorf("Failed to remove reaction: %v", err)
 		return simpleResponse(500), nil

--- a/bin-talk-manager/pkg/listenhandler/v1_reactions_test.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_reactions_test.go
@@ -34,7 +34,7 @@ func Test_processV1MessagesIDReactionsPost(t *testing.T) {
 				URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798/reactions",
 				Method:   sock.RequestMethodPost,
 				DataType: "application/json",
-				Data:     []byte(`{"owner_type":"agent","owner_id":"7fcd7990-42eb-11ed-9fa6-b4cd93af9796","reaction":"👍"}`),
+				Data:     []byte(`{"owner_type":"agent","owner_id":"7fcd7990-42eb-11ed-9fa6-b4cd93af9796","emoji":"👍"}`),
 			},
 
 			messageID: uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798"),
@@ -71,7 +71,7 @@ func Test_processV1MessagesIDReactionsPost(t *testing.T) {
 				URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798/reactions",
 				Method:   sock.RequestMethodPost,
 				DataType: "application/json",
-				Data:     []byte(`{"owner_type":"customer","owner_id":"8ede8b40-86ef-11ed-d4fb-e9e028af9801","reaction":"❤️"}`),
+				Data:     []byte(`{"owner_type":"customer","owner_id":"8ede8b40-86ef-11ed-d4fb-e9e028af9801","emoji":"❤️"}`),
 			},
 
 			messageID: uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798"),
@@ -160,7 +160,7 @@ func Test_processV1MessagesIDReactionsPost_error(t *testing.T) {
 				URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798/reactions",
 				Method:   sock.RequestMethodPost,
 				DataType: "application/json",
-				Data:     []byte(`{"owner_type":"agent","owner_id":"","reaction":"👍"}`),
+				Data:     []byte(`{"owner_type":"agent","owner_id":"","emoji":"👍"}`),
 			},
 			messageID: uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798"),
 			expectRes: &sock.Response{
@@ -215,7 +215,7 @@ func Test_processV1MessagesIDReactionsDelete(t *testing.T) {
 				URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798/reactions",
 				Method:   sock.RequestMethodDelete,
 				DataType: "application/json",
-				Data:     []byte(`{"owner_type":"agent","owner_id":"7fcd7990-42eb-11ed-9fa6-b4cd93af9796","reaction":"👍"}`),
+				Data:     []byte(`{"owner_type":"agent","owner_id":"7fcd7990-42eb-11ed-9fa6-b4cd93af9796","emoji":"👍"}`),
 			},
 
 			messageID: uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798"),
@@ -252,7 +252,7 @@ func Test_processV1MessagesIDReactionsDelete(t *testing.T) {
 				URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798/reactions",
 				Method:   sock.RequestMethodDelete,
 				DataType: "application/json",
-				Data:     []byte(`{"owner_type":"customer","owner_id":"8ede8b40-86ef-11ed-d4fb-e9e028af9801","reaction":"❤️"}`),
+				Data:     []byte(`{"owner_type":"customer","owner_id":"8ede8b40-86ef-11ed-d4fb-e9e028af9801","emoji":"❤️"}`),
 			},
 
 			messageID: uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798"),
@@ -341,7 +341,7 @@ func Test_processV1MessagesIDReactionsDelete_error(t *testing.T) {
 				URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798/reactions",
 				Method:   sock.RequestMethodDelete,
 				DataType: "application/json",
-				Data:     []byte(`{"owner_type":"agent","owner_id":"","reaction":"👍"}`),
+				Data:     []byte(`{"owner_type":"agent","owner_id":"","emoji":"👍"}`),
 			},
 			messageID: uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798"),
 			expectRes: &sock.Response{


### PR DESCRIPTION
Fix two production errors in bin-talk-manager:

1. JSON unmarshal error for medias field:
   - PublishWebhookEvent was passing *Message (Medias string) but api-manager expected *WebhookMessage (Medias []Media)
   - Added conversion from Message to WebhookMessage before publishing

2. Reaction emoji field name mismatch:
   - listenhandler expected "reaction" but api-manager sends "emoji"
   - Changed field name to "emoji" in request struct

- bin-talk-manager: Convert Message to WebhookMessage before webhook publishing
- bin-talk-manager: Add CreateWebhookEvent method to WebhookMessage struct
- bin-talk-manager: Change reaction field from "reaction" to "emoji"
- bin-talk-manager: Update tests to use gomock.Any() for webhook data