### PR TITLE
NOJIRA-Add_project_domain_config_to_common_handler

### DIFF
--- a/bin-call-manager/k8s/deployment.yml
+++ b/bin-call-manager/k8s/deployment.yml
@@ -52,6 +52,10 @@ spec:
               value: ${HOMER_AUTH_TOKEN}
             - name: HOMER_WHITELIST
               value: ${HOMER_WHITELIST}
+            - name: PROJECT_BASE_DOMAIN
+              value: "voipbin.net"
+            - name: PROJECT_BUCKET_NAME
+              value: "voipbin-voip-media-bucket-europe-west4"
           ports:
             - name: metrics
               protocol: "TCP"

--- a/bin-call-manager/models/common/domain.go
+++ b/bin-call-manager/models/common/domain.go
@@ -5,14 +5,16 @@ import (
 	"strings"
 
 	"github.com/gofrs/uuid"
+
+	"monorepo/bin-common-handler/pkg/projectconfig"
 )
 
-// list of domain defines
-const (
-	DomainConference      = "conference.voipbin.net"
-	DomainPSTN            = "pstn.voipbin.net"
-	DomainTrunkSuffix     = ".trunk.voipbin.net"
-	DomainRegistrarSuffix = ".registrar.voipbin.net"
+// Domain variables initialized once from project config
+var (
+	DomainConference      = projectconfig.Get().DomainConference
+	DomainPSTN            = projectconfig.Get().DomainPSTN
+	DomainTrunkSuffix     = projectconfig.Get().DomainTrunkSuffix
+	DomainRegistrarSuffix = projectconfig.Get().DomainRegistrarSuffix
 )
 
 // ParseSIPURI parses the sip uri.

--- a/bin-call-manager/pkg/callhandler/outgoing_call.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call.go
@@ -557,7 +557,7 @@ func setChannelVariablesCallerID(variables map[string]string, c *call.Call) {
 	if c.Destination.Type == commonaddress.TypeTel && c.Source.Target == "anonymous" {
 		// we can't verify the caller's id. setting the default anonymous caller id
 		variables["CALLERID(pres)"] = "prohib"
-		variables["PJSIP_HEADER(add,P-Asserted-Identity)"] = "\"Anonymous\" <sip:+821100000001@pstn.voipbin.net>"
+		variables["PJSIP_HEADER(add,P-Asserted-Identity)"] = fmt.Sprintf("\"Anonymous\" <sip:+821100000001@%s>", common.DomainPSTN)
 		variables["PJSIP_HEADER(add,Privacy)"] = "id"
 
 		return

--- a/bin-call-manager/pkg/recordinghandler/main.go
+++ b/bin-call-manager/pkg/recordinghandler/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/projectconfig"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
@@ -44,9 +45,11 @@ type RecordingHandler interface {
 const (
 	ContextRecording = "call-record"
 
-	defaultDirectory  = "recording"
-	defaultBucketName = "voipbin-voip-media-bucket-europe-west4"
+	defaultDirectory = "recording"
 )
+
+// defaultBucketName initialized once from project config
+var defaultBucketName = projectconfig.Get().ProjectBucketName
 
 // list of variables
 const (

--- a/bin-common-handler/pkg/projectconfig/main.go
+++ b/bin-common-handler/pkg/projectconfig/main.go
@@ -1,0 +1,68 @@
+package projectconfig
+
+import (
+	"os"
+	"sync"
+)
+
+// Default values
+const (
+	defaultBaseDomain = "voipbin.net"
+	defaultBucketName = "voipbin-voip-media-bucket-europe-west4"
+)
+
+var (
+	config *ProjectConfig
+	once   sync.Once
+)
+
+// ProjectConfig holds project-wide configuration values
+type ProjectConfig struct {
+	// ProjectBaseDomain is the base domain for the project (e.g., "voipbin.net", "example.com")
+	ProjectBaseDomain string
+
+	// SIP Domains (derived from ProjectBaseDomain)
+	DomainConference      string // conference.{base}
+	DomainPSTN            string // pstn.{base}
+	DomainTrunkSuffix     string // .trunk.{base}
+	DomainRegistrarSuffix string // .registrar.{base}
+
+	// Storage
+	ProjectBucketName string
+}
+
+// Get returns the singleton ProjectConfig instance.
+// Configuration is loaded from environment variables on first call.
+func Get() *ProjectConfig {
+	once.Do(func() {
+		config = load()
+	})
+	return config
+}
+
+// load reads environment variables and returns a new ProjectConfig
+func load() *ProjectConfig {
+	baseDomain := getEnv("PROJECT_BASE_DOMAIN", defaultBaseDomain)
+	bucketName := getEnv("PROJECT_BUCKET_NAME", defaultBucketName)
+
+	return &ProjectConfig{
+		ProjectBaseDomain: baseDomain,
+
+		// SIP domains derived from base domain
+		DomainConference:      "conference." + baseDomain,
+		DomainPSTN:            "pstn." + baseDomain,
+		DomainTrunkSuffix:     ".trunk." + baseDomain,
+		DomainRegistrarSuffix: ".registrar." + baseDomain,
+
+		// Storage
+		ProjectBucketName: bucketName,
+	}
+}
+
+// getEnv returns the value of an environment variable or a default value if not set
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/bin-common-handler/pkg/projectconfig/main_test.go
+++ b/bin-common-handler/pkg/projectconfig/main_test.go
@@ -1,0 +1,153 @@
+package projectconfig
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_getEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          string
+		defaultValue string
+		envValue     string
+		setEnv       bool
+		expected     string
+	}{
+		{
+			name:         "returns default when env not set",
+			key:          "TEST_GETENV_UNSET",
+			defaultValue: "default_value",
+			setEnv:       false,
+			expected:     "default_value",
+		},
+		{
+			name:         "returns env value when set",
+			key:          "TEST_GETENV_SET",
+			defaultValue: "default_value",
+			envValue:     "env_value",
+			setEnv:       true,
+			expected:     "env_value",
+		},
+		{
+			name:         "returns default when env is empty string",
+			key:          "TEST_GETENV_EMPTY",
+			defaultValue: "default_value",
+			envValue:     "",
+			setEnv:       true,
+			expected:     "default_value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up before test
+			_ = os.Unsetenv(tt.key)
+
+			if tt.setEnv {
+				t.Setenv(tt.key, tt.envValue)
+			}
+
+			result := getEnv(tt.key, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("getEnv() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_load(t *testing.T) {
+	tests := []struct {
+		name                     string
+		envBaseDomain            string
+		envBucketName            string
+		expectedBaseDomain       string
+		expectedDomainConference string
+		expectedDomainPSTN       string
+		expectedDomainTrunk      string
+		expectedDomainRegistrar  string
+		expectedBucketName       string
+	}{
+		{
+			name:                     "uses defaults when no env vars set",
+			envBaseDomain:            "",
+			envBucketName:            "",
+			expectedBaseDomain:       "voipbin.net",
+			expectedDomainConference: "conference.voipbin.net",
+			expectedDomainPSTN:       "pstn.voipbin.net",
+			expectedDomainTrunk:      ".trunk.voipbin.net",
+			expectedDomainRegistrar:  ".registrar.voipbin.net",
+			expectedBucketName:       "voipbin-voip-media-bucket-europe-west4",
+		},
+		{
+			name:                     "uses custom domain when env var set",
+			envBaseDomain:            "example.com",
+			envBucketName:            "",
+			expectedBaseDomain:       "example.com",
+			expectedDomainConference: "conference.example.com",
+			expectedDomainPSTN:       "pstn.example.com",
+			expectedDomainTrunk:      ".trunk.example.com",
+			expectedDomainRegistrar:  ".registrar.example.com",
+			expectedBucketName:       "voipbin-voip-media-bucket-europe-west4",
+		},
+		{
+			name:                     "uses custom bucket when env var set",
+			envBaseDomain:            "",
+			envBucketName:            "custom-bucket-name",
+			expectedBaseDomain:       "voipbin.net",
+			expectedDomainConference: "conference.voipbin.net",
+			expectedDomainPSTN:       "pstn.voipbin.net",
+			expectedDomainTrunk:      ".trunk.voipbin.net",
+			expectedDomainRegistrar:  ".registrar.voipbin.net",
+			expectedBucketName:       "custom-bucket-name",
+		},
+		{
+			name:                     "uses all custom values when both env vars set",
+			envBaseDomain:            "localhost",
+			envBucketName:            "local-bucket",
+			expectedBaseDomain:       "localhost",
+			expectedDomainConference: "conference.localhost",
+			expectedDomainPSTN:       "pstn.localhost",
+			expectedDomainTrunk:      ".trunk.localhost",
+			expectedDomainRegistrar:  ".registrar.localhost",
+			expectedBucketName:       "local-bucket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up before test
+			_ = os.Unsetenv("PROJECT_BASE_DOMAIN")
+			_ = os.Unsetenv("PROJECT_BUCKET_NAME")
+
+			if tt.envBaseDomain != "" {
+				t.Setenv("PROJECT_BASE_DOMAIN", tt.envBaseDomain)
+			}
+
+			if tt.envBucketName != "" {
+				t.Setenv("PROJECT_BUCKET_NAME", tt.envBucketName)
+			}
+
+			result := load()
+
+			if result.ProjectBaseDomain != tt.expectedBaseDomain {
+				t.Errorf("ProjectBaseDomain = %v, want %v", result.ProjectBaseDomain, tt.expectedBaseDomain)
+			}
+			if result.DomainConference != tt.expectedDomainConference {
+				t.Errorf("DomainConference = %v, want %v", result.DomainConference, tt.expectedDomainConference)
+			}
+			if result.DomainPSTN != tt.expectedDomainPSTN {
+				t.Errorf("DomainPSTN = %v, want %v", result.DomainPSTN, tt.expectedDomainPSTN)
+			}
+			if result.DomainTrunkSuffix != tt.expectedDomainTrunk {
+				t.Errorf("DomainTrunkSuffix = %v, want %v", result.DomainTrunkSuffix, tt.expectedDomainTrunk)
+			}
+			if result.DomainRegistrarSuffix != tt.expectedDomainRegistrar {
+				t.Errorf("DomainRegistrarSuffix = %v, want %v", result.DomainRegistrarSuffix, tt.expectedDomainRegistrar)
+			}
+			if result.ProjectBucketName != tt.expectedBucketName {
+				t.Errorf("ProjectBucketName = %v, want %v", result.ProjectBucketName, tt.expectedBucketName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add centralized project configuration for domain and bucket settings.

- bin-common-handler: Add projectconfig package for PROJECT_BASE_DOMAIN and PROJECT_BUCKET_NAME
- bin-call-manager: Replace hardcoded domain constants with projectconfig variables
- bin-call-manager: Update P-Asserted-Identity header to use configurable PSTN domain
- bin-call-manager: Update recording handler to use configurable bucket name
- bin-call-manager: Add PROJECT_BASE_DOMAIN and PROJECT_BUCKET_NAME to k8s deployment