### PR TITLE
NOJIRA-Add-quick-win-documentation-and-openapi-ci

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -459,8 +459,13 @@ workflows:
             - bin-number-manager-build
             - release-approval
 
+  bin-openapi-manager:
+    when: << pipeline.parameters.run-bin-openapi-manager >>
+    jobs:
+      - bin-openapi-manager-validate
+
   bin-outdial-manager:
-    when: 
+    when:
       or: [<< pipeline.parameters.run-bin-outdial-manager >>, << pipeline.parameters.run-bin-common-handler >>]
     jobs:
       - bin-outdial-manager-test
@@ -1103,6 +1108,33 @@ jobs:
           project-repository: bin-number-manager
           source-directory: bin-number-manager
           image-name: number-manager
+
+  # bin-openapi-manager
+  bin-openapi-manager-validate:
+    docker: *go_image
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            cd bin-openapi-manager
+            go mod download
+            go mod vendor
+      - run:
+          name: Validate OpenAPI spec syntax
+          command: |
+            cd bin-openapi-manager
+            go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+            oapi-codegen -config configs/config_model/config.generate.yaml openapi/openapi.yaml > /dev/null
+      - run:
+          name: Verify generated models match committed
+          command: |
+            cd bin-openapi-manager
+            go generate ./...
+            if ! git diff --exit-code gens/models/gen.go; then
+              echo "ERROR: Generated models differ from committed. Run 'go generate ./...' and commit changes."
+              exit 1
+            fi
 
   # bin-outdial-manager
   bin-outdial-manager-test:

--- a/docs/claude-md-template.md
+++ b/docs/claude-md-template.md
@@ -1,0 +1,269 @@
+# CLAUDE.md Service Template
+
+> **Purpose:** Standardized template for service-specific CLAUDE.md files. Copy this template when creating documentation for a new service.
+
+## Required Sections
+
+Every service CLAUDE.md should include these 10 sections:
+
+1. Overview
+2. Architecture
+3. Request Routing (API endpoints)
+4. Event Subscriptions
+5. Common Commands
+6. Monorepo Context
+7. Testing Patterns
+8. Key Implementation Details
+9. Configuration
+10. Prometheus Metrics
+
+---
+
+## Template
+
+Copy everything below this line into your service's `CLAUDE.md`:
+
+---
+
+```markdown
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`bin-<service>-manager` is [brief description of service purpose]. It [main responsibilities].
+
+**Key Concepts:**
+- **Concept1**: Brief explanation
+- **Concept2**: Brief explanation
+- **Concept3**: Brief explanation
+
+## Architecture
+
+### Service Communication Pattern
+
+This service uses **RabbitMQ for event-driven RPC communication**:
+- **ListenHandler** (`pkg/listenhandler/`): Consumes RPC requests from queue `bin-manager.<service>-manager.request`
+- **SubscribeHandler** (`pkg/subscribehandler/`): Subscribes to events from other services
+- **NotifyHandler**: Publishes events to `bin-manager.<service>-manager.event` exchange
+
+### Core Components
+
+```
+cmd/<service>-manager/main.go
+    ├── Database (MySQL)
+    ├── Cache (Redis via pkg/cachehandler) [if applicable]
+    └── run()
+        ├── pkg/dbhandler (MySQL operations)
+        ├── Domain Handlers:
+        │   ├── pkg/<domain>handler (Business logic)
+        │   └── [additional handlers]
+        ├── runSubscribe() -> pkg/subscribehandler
+        └── runRequestListen() -> pkg/listenhandler
+```
+
+**Layer Responsibilities:**
+- `models/`: Data structures
+- `pkg/*handler/`: Domain-specific business logic
+- `pkg/dbhandler/`: Database operations (Squirrel query builder)
+- `pkg/listenhandler/`: RabbitMQ RPC request routing
+- `pkg/subscribehandler/`: Event consumption [if applicable]
+
+## Request Routing
+
+ListenHandler routes requests using regex patterns matching REST-like URIs:
+
+**Resource API (`/v1/<resources>/*`)**:
+- `POST /v1/<resources>` - Create resource
+- `GET /v1/<resources>?<filters>` - List resources (pagination)
+- `GET /v1/<resources>/<uuid>` - Get resource details
+- `POST /v1/<resources>/<uuid>` - Update resource
+- `DELETE /v1/<resources>/<uuid>` - Delete resource
+
+[Add additional endpoints as needed]
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to these RabbitMQ queues:
+- **bin-manager.<other>-manager.event**: [What events and why]
+
+Processes events including:
+- **EventType1**: What it does
+- **EventType2**: What it does
+
+[If no subscriptions, write: "This service does not subscribe to external events."]
+
+## Common Commands
+
+### Build
+```bash
+# Build from service directory
+go build -o bin/<service>-manager ./cmd/<service>-manager
+
+# Build with vendor
+export GOPRIVATE="gitlab.com/voipbin"
+go mod vendor
+go build ./cmd/...
+```
+
+### Test
+```bash
+# Run all tests with coverage
+go test -coverprofile cp.out -v $(go list ./...)
+go tool cover -func=cp.out
+
+# Run tests for specific package
+go test -v ./pkg/<domain>handler/...
+```
+
+### Generate Mocks
+```bash
+go generate ./...
+```
+
+### Lint
+```bash
+golangci-lint run -v --timeout 5m
+```
+
+### Run Locally
+```bash
+DATABASE_DSN="user:pass@tcp(127.0.0.1:3306)/bin_manager" \
+RABBITMQ_ADDRESS="amqp://guest:guest@localhost:5672" \
+[additional env vars] \
+./bin/<service>-manager
+```
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared handlers (sockhandler, requesthandler, notifyhandler)
+- [List other dependencies]
+
+**Important**: Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces generated in same package as interface definition
+- Table-driven tests with struct slices
+- Context passed to all handler methods
+- Tests co-located with implementation: `<package>/<feature>_test.go`
+
+Example test structure:
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Important Pattern 1
+Brief explanation of key implementation detail.
+
+### Important Pattern 2
+Brief explanation of another key detail.
+
+### Database Operations
+- Uses Squirrel query builder
+- Soft deletes with `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records)
+- UUID fields require `,uuid` db tag
+
+[Add 3-5 key implementation details specific to this service]
+
+## Configuration
+
+Uses **Viper + pflag** pattern (see `cmd/<service>-manager/init.go`):
+
+| Flag/Env | Description | Default |
+|----------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+| [service-specific configs] | | |
+
+## Prometheus Metrics
+
+Service exposes metrics on configured endpoint (default `:2112/metrics`):
+- `<service>_manager_receive_request_process_time` - Histogram of RPC request processing time
+- `<service>_manager_subscribe_event_process_time` - Histogram of event processing time [if applicable]
+- [service-specific metrics]
+```
+
+---
+
+## Section Guidelines
+
+### Overview
+- 2-3 sentences describing what the service does
+- List 3-5 key concepts/entities the service manages
+- Keep it high-level
+
+### Architecture
+- Show the component hierarchy
+- Explain layer responsibilities
+- Include ASCII diagram of component structure
+
+### Request Routing
+- List ALL endpoints handled by ListenHandler
+- Group by resource type
+- Include HTTP method and URI pattern
+
+### Event Subscriptions
+- List queues the service subscribes to
+- Explain what events are processed
+- Say "none" if service doesn't subscribe
+
+### Common Commands
+- Build, test, generate, lint commands
+- Local run command with environment variables
+- Keep it copy-paste ready
+
+### Monorepo Context
+- List dependencies from go.mod replace directives
+- Highlight shared handler usage
+
+### Testing Patterns
+- Show example test structure
+- Mention mock generation
+- Reference table-driven test pattern
+
+### Key Implementation Details
+- 3-5 service-specific patterns
+- Database patterns if unique
+- Cache strategies
+- Business logic rules
+
+### Configuration
+- Table of all config flags
+- Include environment variable names
+- Mark required vs optional
+
+### Prometheus Metrics
+- List all exposed metrics
+- Include metric type (counter, histogram, gauge)
+- Describe labels
+
+## See Also
+
+- [Code Quality Standards](code-quality-standards.md) - Logging, naming conventions
+- [Common Workflows](common-workflows.md) - Adding endpoints, handlers
+- [RabbitMQ Queues Reference](rabbitmq-queues-reference.md) - Queue naming
+- [Error Handling Patterns](error-handling-patterns.md) - Error responses

--- a/docs/database-patterns-checklist.md
+++ b/docs/database-patterns-checklist.md
@@ -1,0 +1,334 @@
+# Database Patterns Checklist
+
+> **Quick Reference:** Essential database patterns and gotchas to verify when working with models and database operations.
+
+## Pre-Commit Checklist
+
+Use this checklist when adding or modifying database models:
+
+### Model Definition
+
+- [ ] All `uuid.UUID` fields have `,uuid` db tag
+- [ ] Soft delete field: `TMDelete string \`db:"tm_delete"\``
+- [ ] All fields have appropriate `db:"column_name"` tags
+- [ ] JSON tags match API expectations
+
+### Database Operations
+
+- [ ] Use Squirrel query builder (not raw SQL)
+- [ ] Active record check: `WHERE tm_delete = ?` with `DefaultTimeStamp`
+- [ ] UUID fields converted to binary for MySQL
+
+## Critical: UUID Field Tags
+
+**ALWAYS add `,uuid` to uuid.UUID fields:**
+
+```go
+// CORRECT
+type Call struct {
+    ID           uuid.UUID `json:"id" db:"id,uuid"`
+    CustomerID   uuid.UUID `json:"customer_id" db:"customer_id,uuid"`
+    FlowID       uuid.UUID `json:"flow_id" db:"flow_id,uuid"`
+    Name         string    `json:"name" db:"name"`
+    TMCreate     string    `json:"tm_create" db:"tm_create"`
+    TMUpdate     string    `json:"tm_update" db:"tm_update"`
+    TMDelete     string    `json:"tm_delete" db:"tm_delete"`
+}
+
+// WRONG - Missing ,uuid tag
+type Call struct {
+    ID           uuid.UUID `json:"id" db:"id"`           // BUG: queries will fail
+    CustomerID   uuid.UUID `json:"customer_id" db:"customer_id"` // BUG
+}
+```
+
+### Why This Matters
+
+1. `commondatabasehandler.PrepareFields()` needs `,uuid` to convert UUID → binary
+2. Without it, UUIDs are passed as strings → no database matches
+3. Results in silent failures: list endpoints return empty arrays
+
+### Symptoms of Missing UUID Tag
+
+- GET with filters returns `[]` when data exists
+- POST works but GET by ID fails
+- No errors in logs, just empty results
+
+## Soft Delete Pattern
+
+All tables use soft deletes with `tm_delete` timestamp:
+
+```go
+// Active records have this timestamp
+const DefaultTimeStamp = "9999-01-01 00:00:00.000000"
+
+// Querying active records
+query := sq.Select("*").
+    From("call_calls").
+    Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp})
+
+// Soft delete
+query := sq.Update("call_calls").
+    Set("tm_delete", time.Now().Format("2006-01-02 15:04:05.000000")).
+    Where(sq.Eq{"id": id})
+```
+
+## Squirrel Query Builder
+
+### SELECT
+
+```go
+query := sq.Select(
+    "id",
+    "customer_id",
+    "name",
+    "tm_create",
+).From("call_calls").
+    Where(sq.Eq{"id": id}).
+    Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp})
+
+sql, args, err := query.ToSql()
+```
+
+### INSERT
+
+```go
+query := sq.Insert("call_calls").
+    Columns("id", "customer_id", "name", "tm_create", "tm_update", "tm_delete").
+    Values(
+        id.Bytes(),
+        customerID.Bytes(),
+        name,
+        now,
+        now,
+        databasehandler.DefaultTimeStamp,
+    )
+```
+
+### UPDATE
+
+```go
+query := sq.Update("call_calls").
+    Set("name", newName).
+    Set("tm_update", time.Now().Format("2006-01-02 15:04:05.000000")).
+    Where(sq.Eq{"id": id.Bytes()}).
+    Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp})
+```
+
+### DELETE (Soft)
+
+```go
+query := sq.Update("call_calls").
+    Set("tm_delete", time.Now().Format("2006-01-02 15:04:05.000000")).
+    Where(sq.Eq{"id": id.Bytes()})
+```
+
+## Filter Handling
+
+### Using ApplyFields
+
+```go
+// From bin-common-handler/pkg/databasehandler/
+filters := map[string]any{
+    "customer_id": customerID,  // uuid.UUID
+    "status":      "active",    // string
+}
+
+query := sq.Select("*").From("call_calls")
+query = databasehandler.ApplyFields(query, filters)
+```
+
+### Manual Filter Application
+
+```go
+query := sq.Select("*").From("call_calls")
+
+if customerID, ok := filters["customer_id"].(uuid.UUID); ok {
+    query = query.Where(sq.Eq{"customer_id": customerID.Bytes()})
+}
+
+if status, ok := filters["status"].(string); ok {
+    query = query.Where(sq.Eq{"status": status})
+}
+```
+
+## Pagination Pattern
+
+```go
+const (
+    DefaultPageSize = 100
+    MaxPageSize     = 1000
+)
+
+func (h *dbHandler) List(ctx context.Context, size, token int, filters map[string]any) ([]*Model, error) {
+    if size <= 0 || size > MaxPageSize {
+        size = DefaultPageSize
+    }
+
+    query := sq.Select("*").
+        From("table_name").
+        Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp}).
+        OrderBy("tm_create DESC").
+        Limit(uint64(size)).
+        Offset(uint64(token))
+
+    query = databasehandler.ApplyFields(query, filters)
+    // ...
+}
+```
+
+## Timestamp Format
+
+```go
+// Standard format for MySQL DATETIME(6)
+const TimeFormat = "2006-01-02 15:04:05.000000"
+
+now := time.Now().Format(TimeFormat)
+```
+
+## Common Database Queries
+
+### Get by ID
+
+```go
+func (h *dbHandler) Get(ctx context.Context, id uuid.UUID) (*Model, error) {
+    query := sq.Select("*").
+        From("table_name").
+        Where(sq.Eq{"id": id.Bytes()}).
+        Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp})
+
+    sql, args, err := query.ToSql()
+    if err != nil {
+        return nil, errors.Wrap(err, "could not build query")
+    }
+
+    row := h.db.QueryRowContext(ctx, sql, args...)
+    // scan row...
+}
+```
+
+### Check Existence
+
+```go
+func (h *dbHandler) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+    query := sq.Select("COUNT(*)").
+        From("table_name").
+        Where(sq.Eq{"id": id.Bytes()}).
+        Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp})
+
+    var count int
+    // execute and scan count
+    return count > 0, nil
+}
+```
+
+### Get by Unique Field
+
+```go
+func (h *dbHandler) GetByName(ctx context.Context, customerID uuid.UUID, name string) (*Model, error) {
+    query := sq.Select("*").
+        From("table_name").
+        Where(sq.Eq{"customer_id": customerID.Bytes()}).
+        Where(sq.Eq{"name": name}).
+        Where(sq.Eq{"tm_delete": databasehandler.DefaultTimeStamp})
+    // ...
+}
+```
+
+## Scanning Results
+
+### Single Row
+
+```go
+var m Model
+err := row.Scan(
+    &m.ID,
+    &m.CustomerID,
+    &m.Name,
+    &m.TMCreate,
+    &m.TMUpdate,
+    &m.TMDelete,
+)
+```
+
+### Multiple Rows
+
+```go
+rows, err := h.db.QueryContext(ctx, sql, args...)
+if err != nil {
+    return nil, err
+}
+defer rows.Close()
+
+var results []*Model
+for rows.Next() {
+    var m Model
+    if err := rows.Scan(&m.ID, &m.Name); err != nil {
+        return nil, err
+    }
+    results = append(results, &m)
+}
+
+if err := rows.Err(); err != nil {
+    return nil, err
+}
+return results, nil
+```
+
+## Transaction Pattern
+
+```go
+func (h *dbHandler) CreateWithRelated(ctx context.Context, model *Model) error {
+    tx, err := h.db.BeginTx(ctx, nil)
+    if err != nil {
+        return errors.Wrap(err, "could not begin transaction")
+    }
+    defer tx.Rollback()
+
+    // Insert main record
+    if err := h.insertModel(ctx, tx, model); err != nil {
+        return err
+    }
+
+    // Insert related records
+    if err := h.insertRelated(ctx, tx, model.ID, model.Related); err != nil {
+        return err
+    }
+
+    return tx.Commit()
+}
+```
+
+## Debugging Database Issues
+
+### Enable Query Logging
+
+```go
+sql, args, _ := query.ToSql()
+log.WithFields(log.Fields{
+    "sql":  sql,
+    "args": args,
+}).Debug("Executing query")
+```
+
+### Check UUID Conversion
+
+```go
+// Verify UUID is being converted to bytes
+id := uuid.FromStringOrNil("...")
+log.Printf("UUID bytes: %v", id.Bytes())
+```
+
+### Verify Soft Delete Filter
+
+```go
+// Ensure tm_delete check is present
+log.Printf("Query: %s", sql)
+// Should contain: tm_delete = '9999-01-01 00:00:00.000000'
+```
+
+## See Also
+
+- [Code Quality Standards](code-quality-standards.md#uuid-fields-and-db-tags) - UUID gotcha details
+- [Common Workflows](common-workflows.md) - Adding new models
+- `bin-common-handler/pkg/databasehandler/` - Utility functions

--- a/docs/error-handling-patterns.md
+++ b/docs/error-handling-patterns.md
@@ -1,0 +1,302 @@
+# Error Handling Patterns
+
+> **Quick Reference:** Standard error handling patterns used across all services in the monorepo.
+
+## Overview
+
+This document describes the three error handling layers in the monorepo:
+
+1. **RabbitMQ RPC Layer** - Status codes in `sock.Response`
+2. **Service Logic Layer** - Error wrapping and propagation
+3. **API Gateway Layer** - HTTP responses in bin-api-manager
+
+## Layer 1: RabbitMQ RPC Responses
+
+All internal service communication uses `sock.Response` with HTTP-style status codes.
+
+### Standard Status Codes
+
+| Code | Meaning | When to Use |
+|------|---------|-------------|
+| 200 | OK | Successful operation |
+| 201 | Created | Resource successfully created |
+| 204 | No Content | Successful delete or update with no body |
+| 400 | Bad Request | Invalid request data, validation failure |
+| 401 | Unauthorized | Missing or invalid authentication |
+| 403 | Forbidden | Valid auth but insufficient permissions |
+| 404 | Not Found | Resource does not exist |
+| 409 | Conflict | Resource already exists or state conflict |
+| 500 | Internal Error | Unexpected server error |
+
+### Response Pattern
+
+```go
+// bin-common-handler/models/sock/message.go
+type Response struct {
+    StatusCode int         `json:"status_code"`
+    DataType   string      `json:"data_type"`
+    Data       interface{} `json:"data"`
+}
+
+// Simple response helper (used in listenhandler)
+func simpleResponse(code int) *sock.Response {
+    return &sock.Response{
+        StatusCode: code,
+    }
+}
+```
+
+### ListenHandler Examples
+
+```go
+// From bin-call-manager/pkg/listenhandler/
+
+// 404 - Resource not found
+func (h *listenHandler) processV1CallsID(m *sock.Request) (*sock.Response, error) {
+    res, err := h.callHandler.Get(ctx, callID)
+    if err != nil {
+        return simpleResponse(404), nil  // Call not found
+    }
+    return &sock.Response{StatusCode: 200, Data: res}, nil
+}
+
+// 400 - Invalid request
+func (h *listenHandler) processV1Calls(m *sock.Request) (*sock.Response, error) {
+    var req call.CreateRequest
+    if err := json.Unmarshal(m.Data, &req); err != nil {
+        return simpleResponse(400), nil  // Bad request format
+    }
+    // ...
+}
+
+// 500 - Internal error
+func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) {
+    res, err := h.callHandler.Create(ctx, &req)
+    if err != nil {
+        log.Errorf("Failed to create call: %v", err)
+        return simpleResponse(500), nil  // Internal error
+    }
+    return &sock.Response{StatusCode: 200, Data: res}, nil
+}
+```
+
+## Layer 2: Service Logic Errors
+
+Business logic handlers use Go's standard error handling with wrapping.
+
+### Error Wrapping Pattern
+
+Use `errors.Wrapf` from `github.com/pkg/errors` for context:
+
+```go
+import "github.com/pkg/errors"
+
+func (h *callHandler) Get(ctx context.Context, id uuid.UUID) (*call.Call, error) {
+    res, err := h.dbHandler.CallGet(ctx, id)
+    if err != nil {
+        return nil, errors.Wrapf(err, "could not get call. id: %s", id)
+    }
+    return res, nil
+}
+```
+
+### Error Checking Patterns
+
+```go
+// Check for specific error conditions
+if res == nil {
+    return nil, fmt.Errorf("call not found. id: %s", id)
+}
+
+// Check response status from other services
+resp, err := h.reqHandler.FlowV1FlowGet(ctx, flowID)
+if err != nil {
+    return nil, errors.Wrapf(err, "could not get flow info")
+}
+if resp.StatusCode != 200 {
+    return nil, fmt.Errorf("wrong status from flow-manager. status: %d", resp.StatusCode)
+}
+```
+
+### Logging Before Return
+
+Always log errors with context before returning:
+
+```go
+func (h *handler) DoSomething(ctx context.Context, id uuid.UUID) error {
+    log := logrus.WithFields(logrus.Fields{
+        "func": "DoSomething",
+        "id":   id,
+    })
+
+    res, err := h.dbHandler.Get(ctx, id)
+    if err != nil {
+        log.Errorf("Could not get resource: %v", err)
+        return errors.Wrapf(err, "could not get resource")
+    }
+
+    return nil
+}
+```
+
+## Layer 3: API Gateway Responses
+
+The bin-api-manager translates internal responses to HTTP responses.
+
+### Gin Framework Pattern
+
+```go
+// From bin-api-manager/lib/service/
+
+// Success response
+c.JSON(200, res.Data)
+
+// Error response
+c.AbortWithStatus(400)
+c.AbortWithStatusJSON(404, gin.H{"error": "resource not found"})
+
+// Authentication failure
+c.AbortWithStatus(401)
+```
+
+### Response Translation
+
+```go
+func (h *handler) handleGet(c *gin.Context) {
+    // Make RPC call
+    resp, err := h.reqHandler.CallV1CallGet(ctx, callID)
+    if err != nil {
+        log.Errorf("RPC call failed: %v", err)
+        c.AbortWithStatus(500)
+        return
+    }
+
+    // Translate status code
+    if resp.StatusCode != 200 {
+        c.AbortWithStatus(resp.StatusCode)
+        return
+    }
+
+    c.JSON(200, resp.Data)
+}
+```
+
+## Common Error Scenarios
+
+### Validation Errors (400)
+
+```go
+// Request validation
+if req.Name == "" {
+    return simpleResponse(400), nil
+}
+
+// UUID parsing
+id, err := uuid.FromString(idStr)
+if err != nil {
+    return simpleResponse(400), nil
+}
+```
+
+### Not Found (404)
+
+```go
+res, err := h.dbHandler.Get(ctx, id)
+if err != nil || res == nil {
+    return simpleResponse(404), nil
+}
+```
+
+### Conflict (409)
+
+```go
+// Check for duplicate
+existing, _ := h.dbHandler.GetByName(ctx, req.Name)
+if existing != nil {
+    return simpleResponse(409), nil
+}
+```
+
+### Permission Denied (403)
+
+```go
+// Check ownership
+if res.CustomerID != customerID {
+    return simpleResponse(403), nil
+}
+```
+
+## Error Messages
+
+### Do's
+
+- Include relevant IDs: `"could not get call. id: %s"`
+- Include status codes: `"wrong status. status: %d"`
+- Use past tense for failures: `"could not create resource"`
+
+### Don'ts
+
+- Don't expose internal details to API clients
+- Don't log sensitive data (passwords, tokens)
+- Don't use panic for expected errors
+
+## Database Error Handling
+
+```go
+// Check for no rows
+res, err := h.db.Query(ctx, query)
+if err == sql.ErrNoRows {
+    return nil, nil  // Not found, not an error
+}
+if err != nil {
+    return nil, errors.Wrapf(err, "database query failed")
+}
+
+// Soft delete check (active records have tm_delete = "9999-01-01...")
+// Handled automatically by dbhandler WHERE clauses
+```
+
+## Event Handler Errors
+
+For SubscribeHandler event processing, errors are logged but don't stop processing:
+
+```go
+func (h *subscribeHandler) processEvent(e *sock.Event) error {
+    log := logrus.WithFields(logrus.Fields{
+        "func":  "processEvent",
+        "type":  e.Type,
+    })
+
+    if err := h.handleEvent(ctx, e); err != nil {
+        log.Errorf("Failed to process event: %v", err)
+        // Return nil to acknowledge message (don't requeue)
+        return nil
+    }
+
+    return nil
+}
+```
+
+## Testing Error Paths
+
+```go
+func Test_Get_NotFound(t *testing.T) {
+    mc := gomock.NewController(t)
+    defer mc.Finish()
+
+    mockDB := NewMockDBHandler(mc)
+    mockDB.EXPECT().Get(gomock.Any(), testID).Return(nil, sql.ErrNoRows)
+
+    h := NewHandler(mockDB)
+    res, err := h.Get(context.Background(), testID)
+
+    assert.Nil(t, res)
+    assert.Error(t, err)
+}
+```
+
+## See Also
+
+- [Code Quality Standards](code-quality-standards.md) - Logging patterns
+- [Common Workflows](common-workflows.md) - Adding endpoints
+- `bin-common-handler/models/sock/message.go` - Response structure

--- a/docs/rabbitmq-queues-reference.md
+++ b/docs/rabbitmq-queues-reference.md
@@ -1,0 +1,319 @@
+# RabbitMQ Queue Reference
+
+> **Source of Truth:** `bin-common-handler/models/outline/queuename.go`
+
+## Overview
+
+All services in the monorepo communicate via RabbitMQ using a consistent queue naming pattern. This document provides a complete reference for all queue names and their purposes.
+
+## Queue Naming Pattern
+
+Every service follows this naming convention:
+
+```
+bin-manager.<service-name>.event       # Service publishes events here
+bin-manager.<service-name>.request     # Service receives RPC requests here
+bin-manager.<service-name>.subscribe   # Service subscribes to events here
+```
+
+### Special Queues
+
+| Queue | Purpose |
+|-------|---------|
+| `bin-manager.delay` | Delayed message delivery (scheduled tasks) |
+| `asterisk.all.event` | Asterisk ARI events (channel/bridge state changes) |
+
+## Complete Queue Reference
+
+### AI Manager
+```go
+QueueNameAIEvent     = "bin-manager.ai-manager.event"
+QueueNameAIRequest   = "bin-manager.ai-manager.request"
+QueueNameAISubscribe = "bin-manager.ai-manager.subscribe"
+```
+
+### Agent Manager
+```go
+QueueNameAgentEvent     = "bin-manager.agent-manager.event"
+QueueNameAgentRequest   = "bin-manager.agent-manager.request"
+QueueNameAgentSubscribe = "bin-manager.agent-manager.subscribe"
+```
+
+### API Manager
+```go
+QueueNameAPIEvent     = "bin-manager.api-manager.event"
+QueueNameAPIRequest   = "bin-manager.api-manager.request"
+QueueNameAPISubscribe = "bin-manager.api-manager.subscribe"
+```
+
+### Billing Manager
+```go
+QueueNameBillingEvent     = "bin-manager.billing-manager.event"
+QueueNameBillingRequest   = "bin-manager.billing-manager.request"
+QueueNameBillingSubscribe = "bin-manager.billing-manager.subscribe"
+```
+
+### Call Manager
+```go
+QueueNameCallEvent     = "bin-manager.call-manager.event"
+QueueNameCallRequest   = "bin-manager.call-manager.request"
+QueueNameCallSubscribe = "bin-manager.call-manager.subscribe"
+```
+
+### Campaign Manager
+```go
+QueueNameCampaignEvent     = "bin-manager.campaign-manager.event"
+QueueNameCampaignRequest   = "bin-manager.campaign-manager.request"
+QueueNameCampaignSubscribe = "bin-manager.campaign-manager.subscribe"
+```
+
+### Chat Manager
+```go
+QueueNameChatEvent     = "bin-manager.chat-manager.event"
+QueueNameChatRequest   = "bin-manager.chat-manager.request"
+QueueNameChatSubscribe = "bin-manager.chat-manager.subscribe"
+```
+
+### Conference Manager
+```go
+QueueNameConferenceEvent     = "bin-manager.conference-manager.event"
+QueueNameConferenceRequest   = "bin-manager.conference-manager.request"
+QueueNameConferenceSubscribe = "bin-manager.conference-manager.subscribe"
+```
+
+### Conversation Manager
+```go
+QueueNameConversationEvent     = "bin-manager.conversation-manager.event"
+QueueNameConversationRequest   = "bin-manager.conversation-manager.request"
+QueueNameConversationSubscribe = "bin-manager.conversation-manager.subscribe"
+```
+
+### Customer Manager
+```go
+QueueNameCustomerEvent     = "bin-manager.customer-manager.event"
+QueueNameCustomerRequest   = "bin-manager.customer-manager.request"
+QueueNameCustomerSubscribe = "bin-manager.customer-manager.subscribe"
+```
+
+### Email Manager
+```go
+QueueNameEmailEvent     = "bin-manager.email-manager.event"
+QueueNameEmailRequest   = "bin-manager.email-manager.request"
+QueueNameEmailSubscribe = "bin-manager.email-manager.subscribe"
+```
+
+### Flow Manager
+```go
+QueueNameFlowEvent     = "bin-manager.flow-manager.event"
+QueueNameFlowRequest   = "bin-manager.flow-manager.request"
+QueueNameFlowSubscribe = "bin-manager.flow-manager.subscribe"
+```
+
+### Message Manager
+```go
+QueueNameMessageEvent     = "bin-manager.message-manager.event"
+QueueNameMessageRequest   = "bin-manager.message-manager.request"
+QueueNameMessageSubscribe = "bin-manager.message-manager.subscribe"
+```
+
+### Number Manager
+```go
+QueueNameNumberEvent     = "bin-manager.number-manager.event"
+QueueNameNumberRequest   = "bin-manager.number-manager.request"
+QueueNameNumberSubscribe = "bin-manager.number-manager.subscribe"
+```
+
+### Outdial Manager
+```go
+QueueNameOutdialEvent     = "bin-manager.outdial-manager.event"
+QueueNameOutdialRequest   = "bin-manager.outdial-manager.request"
+QueueNameOutdialSubscribe = "bin-manager.outdial-manager.subscribe"
+```
+
+### Pipecat Manager
+```go
+QueueNamePipecatEvent     = "bin-manager.pipecat-manager.event"
+QueueNamePipecatRequest   = "bin-manager.pipecat-manager.request"
+QueueNamePipecatSubscribe = "bin-manager.pipecat-manager.subscribe"
+```
+
+### Queue Manager
+```go
+QueueNameQueueEvent     = "bin-manager.queue-manager.event"
+QueueNameQueueRequest   = "bin-manager.queue-manager.request"
+QueueNameQueueSubscribe = "bin-manager.queue-manager.subscribe"
+```
+
+### Registrar Manager
+```go
+QueueNameRegistrarEvent     = "bin-manager.registrar-manager.event"
+QueueNameRegistrarRequest   = "bin-manager.registrar-manager.request"
+QueueNameRegistrarSubscribe = "bin-manager.registrar-manager.subscribe"
+```
+
+### Route Manager
+```go
+QueueNameRouteEvent     = "bin-manager.route-manager.event"
+QueueNameRouteRequest   = "bin-manager.route-manager.request"
+QueueNameRouteSubscribe = "bin-manager.route-manager.subscribe"
+```
+
+### Sentinel Manager
+```go
+QueueNameSentinelEvent     = "bin-manager.sentinel-manager.event"
+QueueNameSentinelRequest   = "bin-manager.sentinel-manager.request"
+QueueNameSentinelSubscribe = "bin-manager.sentinel-manager.subscribe"
+```
+
+### Storage Manager
+```go
+QueueNameStorageEvent     = "bin-manager.storage-manager.event"
+QueueNameStorageRequest   = "bin-manager.storage-manager.request"
+QueueNameStorageSubscribe = "bin-manager.storage-manager.subscribe"
+```
+
+### Tag Manager
+```go
+QueueNameTagEvent     = "bin-manager.tag-manager.event"
+QueueNameTagRequest   = "bin-manager.tag-manager.request"
+QueueNameTagSubscribe = "bin-manager.tag-manager.subscribe"
+```
+
+### Talk Manager
+```go
+QueueNameTalkEvent     = "bin-manager.talk-manager.event"
+QueueNameTalkRequest   = "bin-manager.talk-manager.request"
+QueueNameTalkSubscribe = "bin-manager.talk-manager.subscribe"
+```
+
+### Transcribe Manager
+```go
+QueueNameTranscribeEvent     = "bin-manager.transcribe-manager.event"
+QueueNameTranscribeRequest   = "bin-manager.transcribe-manager.request"
+QueueNameTranscribeSubscribe = "bin-manager.transcribe-manager.subscribe"
+```
+
+### Transfer Manager
+```go
+QueueNameTransferEvent     = "bin-manager.transfer-manager.event"
+QueueNameTransferRequest   = "bin-manager.transfer-manager.request"
+QueueNameTransferSubscribe = "bin-manager.transfer-manager.subscribe"
+```
+
+### TTS Manager
+```go
+QueueNameTTSEvent     = "bin-manager.tts-manager.event"
+QueueNameTTSRequest   = "bin-manager.tts-manager.request"
+QueueNameTTSSubscribe = "bin-manager.tts-manager.subscribe"
+```
+
+### User Manager
+```go
+QueueNameUserEvent     = "bin-manager.user-manager.event"
+QueueNameUserRequest   = "bin-manager.user-manager.request"
+QueueNameUserSubscribe = "bin-manager.user-manager.subscribe"
+```
+
+### Webhook Manager
+```go
+QueueNameWebhookEvent     = "bin-manager.webhook-manager.event"
+QueueNameWebhookRequest   = "bin-manager.webhook-manager.request"
+QueueNameWebhookSubscribe = "bin-manager.webhook-manager.subscribe"
+```
+
+## Usage Examples
+
+### ListenHandler (Receiving Requests)
+
+```go
+// In pkg/listenhandler/main.go
+func (h *listenHandler) Run(queue, exchangeDelay string) error {
+    // queue = "bin-manager.call-manager.request"
+    if err := h.sockHandler.QueueCreate(queue, "normal"); err != nil {
+        return fmt.Errorf("could not declare the queue: %v", err)
+    }
+
+    go h.sockHandler.ConsumeRPC(ctx, queue, serviceName, false, false, false, 10, h.processRequest)
+    return nil
+}
+```
+
+### NotifyHandler (Publishing Events)
+
+```go
+// Publishing an event
+h.notifyHandler.PublishEvent(ctx, outline.QueueNameCallEvent, call.EventCallCreated, callData)
+```
+
+### SubscribeHandler (Subscribing to Events)
+
+```go
+// In pkg/subscribehandler/main.go
+func (h *subscribeHandler) Run() error {
+    // Subscribe to customer events
+    h.sockHandler.QueueBind(string(outline.QueueNameCallSubscribe), string(outline.QueueNameCustomerEvent))
+
+    // Subscribe to flow events
+    h.sockHandler.QueueBind(string(outline.QueueNameCallSubscribe), string(outline.QueueNameFlowEvent))
+
+    go h.sockHandler.ConsumeEvent(ctx, string(outline.QueueNameCallSubscribe), serviceName, h.processEvent)
+    return nil
+}
+```
+
+### RequestHandler (Making RPC Calls)
+
+```go
+// Making a request to another service
+resp, err := h.reqHandler.CallV1CallGet(ctx, callID)
+// Internally sends to: bin-manager.call-manager.request
+```
+
+## Queue Types
+
+### Normal Queues
+- Durable, survive broker restarts
+- Used for request/response and persistent events
+- Created with `QueueCreate(queue, "normal")`
+
+### Volatile Queues
+- Auto-delete when unused
+- Used for temporary subscriptions
+- Created with `QueueCreate(queue, "volatile")`
+
+## Message Format
+
+### Request (sock.Request)
+```go
+type Request struct {
+    URI       string      `json:"uri"`        // e.g., "/v1/calls/{uuid}"
+    Method    string      `json:"method"`     // GET, POST, PUT, DELETE
+    Publisher string      `json:"publisher"`  // Source service name
+    Data      interface{} `json:"data"`       // Request payload
+}
+```
+
+### Response (sock.Response)
+```go
+type Response struct {
+    StatusCode int         `json:"status_code"` // HTTP-style status code
+    DataType   string      `json:"data_type"`   // Response type identifier
+    Data       interface{} `json:"data"`        // Response payload
+}
+```
+
+### Event (sock.Event)
+```go
+type Event struct {
+    Type      string      `json:"type"`      // Event type (e.g., "call.created")
+    Publisher string      `json:"publisher"` // Source service name
+    Data      interface{} `json:"data"`      // Event payload
+}
+```
+
+## See Also
+
+- [Architecture Deep Dive](architecture-deep-dive.md) - Service communication patterns
+- [Common Workflows](common-workflows.md) - Adding new endpoints
+- `bin-common-handler/pkg/requesthandler/` - RPC request implementations
+- `bin-common-handler/pkg/notifyhandler/` - Event publishing implementations

--- a/docs/test-utilities-guide.md
+++ b/docs/test-utilities-guide.md
@@ -1,0 +1,350 @@
+# Test Utilities Guide
+
+> **Quick Reference:** How to use testing utilities from `bin-common-handler` and write effective tests.
+
+## Overview
+
+The monorepo provides comprehensive testing utilities in `bin-common-handler`. This guide shows how to use them effectively to improve test coverage across services.
+
+## Mock Generation
+
+### Standard Pattern
+
+Every handler interface uses mockgen:
+
+```go
+// In main.go
+//go:generate mockgen -package packagename -destination ./mock_main.go -source main.go -build_flags=-mod=mod
+
+type Handler interface {
+    Get(ctx context.Context, id uuid.UUID) (*Model, error)
+    Create(ctx context.Context, req *CreateRequest) (*Model, error)
+    Delete(ctx context.Context, id uuid.UUID) error
+}
+```
+
+### Generating Mocks
+
+```bash
+# Generate all mocks in a service
+cd bin-<service-name>
+go generate ./...
+
+# Generate mocks for specific package
+go generate ./pkg/callhandler
+```
+
+### Using Mocks
+
+```go
+func TestGet(t *testing.T) {
+    mc := gomock.NewController(t)
+    defer mc.Finish()
+
+    mockDB := NewMockDBHandler(mc)
+    mockCache := NewMockCacheHandler(mc)
+
+    // Set expectations
+    mockDB.EXPECT().
+        Get(gomock.Any(), testID).
+        Return(expectedResult, nil)
+
+    h := NewHandler(mockDB, mockCache)
+    result, err := h.Get(context.Background(), testID)
+
+    assert.NoError(t, err)
+    assert.Equal(t, expectedResult, result)
+}
+```
+
+## Table-Driven Tests
+
+### Standard Pattern
+
+```go
+func Test_List(t *testing.T) {
+    tests := []struct {
+        name       string
+        filters    map[string]any
+        dbResponse []*Model
+        dbError    error
+        expectRes  []*Model
+        expectErr  bool
+    }{
+        {
+            name:       "empty filters returns all",
+            filters:    map[string]any{},
+            dbResponse: []*Model{{ID: uuid1}, {ID: uuid2}},
+            expectRes:  []*Model{{ID: uuid1}, {ID: uuid2}},
+        },
+        {
+            name:       "with customer_id filter",
+            filters:    map[string]any{"customer_id": customerID},
+            dbResponse: []*Model{{ID: uuid1}},
+            expectRes:  []*Model{{ID: uuid1}},
+        },
+        {
+            name:      "database error",
+            filters:   map[string]any{},
+            dbError:   errors.New("connection failed"),
+            expectErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            mc := gomock.NewController(t)
+            defer mc.Finish()
+
+            mockDB := NewMockDBHandler(mc)
+            mockDB.EXPECT().
+                List(gomock.Any(), tt.filters).
+                Return(tt.dbResponse, tt.dbError)
+
+            h := NewHandler(mockDB)
+            result, err := h.List(context.Background(), tt.filters)
+
+            if tt.expectErr {
+                assert.Error(t, err)
+                return
+            }
+            assert.NoError(t, err)
+            assert.Equal(t, tt.expectRes, result)
+        })
+    }
+}
+```
+
+## Database Handler Testing
+
+### Using PrepareFields and ApplyFields
+
+The `databasehandler` package in `bin-common-handler` provides utilities for dynamic field handling:
+
+```go
+// From bin-common-handler/pkg/databasehandler/mapping.go
+
+// PrepareFields extracts non-zero fields from a struct for INSERT/UPDATE
+fields, values := databasehandler.PrepareFields(model)
+
+// ApplyFields adds WHERE conditions based on filters
+query = databasehandler.ApplyFields(query, filters)
+```
+
+### Testing Database Operations
+
+```go
+func Test_DBHandler_Get(t *testing.T) {
+    // Setup test database (or mock)
+    db, mock, err := sqlmock.New()
+    require.NoError(t, err)
+    defer db.Close()
+
+    // Set expectations
+    rows := sqlmock.NewRows([]string{"id", "name", "customer_id"}).
+        AddRow(testID.Bytes(), "test", customerID.Bytes())
+
+    mock.ExpectQuery("SELECT").
+        WithArgs(testID.Bytes()).
+        WillReturnRows(rows)
+
+    h := NewDBHandler(db)
+    result, err := h.Get(context.Background(), testID)
+
+    assert.NoError(t, err)
+    assert.Equal(t, "test", result.Name)
+}
+```
+
+## RequestHandler Test Examples
+
+The `bin-common-handler/pkg/requesthandler/` contains 40+ test files showing how to test RPC calls:
+
+### Pattern from requesthandler Tests
+
+```go
+// From bin-common-handler/pkg/requesthandler/call_test.go
+func Test_CallV1CallGet(t *testing.T) {
+    tests := []struct {
+        name         string
+        callID       uuid.UUID
+        mockResponse *sock.Response
+        mockError    error
+        expectRes    *call.Call
+        expectErr    bool
+    }{
+        {
+            name:   "success",
+            callID: testCallID,
+            mockResponse: &sock.Response{
+                StatusCode: 200,
+                Data:       expectedCall,
+            },
+            expectRes: expectedCall,
+        },
+        {
+            name:   "not found",
+            callID: testCallID,
+            mockResponse: &sock.Response{
+                StatusCode: 404,
+            },
+            expectErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            mc := gomock.NewController(t)
+            defer mc.Finish()
+
+            mockSock := sockhandler.NewMockSockHandler(mc)
+            mockSock.EXPECT().
+                RequestPublish(gomock.Any(), gomock.Any()).
+                Return(tt.mockResponse, tt.mockError)
+
+            h := NewRequestHandler(mockSock)
+            result, err := h.CallV1CallGet(context.Background(), tt.callID)
+
+            if tt.expectErr {
+                assert.Error(t, err)
+                return
+            }
+            assert.NoError(t, err)
+            assert.Equal(t, tt.expectRes, result)
+        })
+    }
+}
+```
+
+## NotifyHandler Testing
+
+### Testing Event Publishing
+
+```go
+func Test_PublishEvent(t *testing.T) {
+    mc := gomock.NewController(t)
+    defer mc.Finish()
+
+    mockSock := sockhandler.NewMockSockHandler(mc)
+    mockSock.EXPECT().
+        Publish(
+            gomock.Any(),                              // context
+            string(outline.QueueNameCallEvent),        // queue
+            gomock.Any(),                              // event data
+        ).
+        Return(nil)
+
+    h := NewNotifyHandler(mockSock)
+    err := h.PublishEvent(context.Background(), outline.QueueNameCallEvent, "call.created", callData)
+
+    assert.NoError(t, err)
+}
+```
+
+## UUID Testing Helpers
+
+```go
+// Create test UUIDs
+var (
+    testID       = uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001")
+    testID2      = uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002")
+    customerID   = uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440010")
+)
+
+// Or generate fresh UUIDs
+func generateTestID() uuid.UUID {
+    return uuid.Must(uuid.NewV4())
+}
+```
+
+## Context Testing
+
+Always pass context in tests:
+
+```go
+func TestWithContext(t *testing.T) {
+    ctx := context.Background()
+
+    // Or with timeout
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+
+    result, err := h.Get(ctx, testID)
+    // ...
+}
+```
+
+## Common Test Assertions
+
+```go
+import (
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// Basic assertions
+assert.NoError(t, err)
+assert.Error(t, err)
+assert.Nil(t, result)
+assert.NotNil(t, result)
+assert.Equal(t, expected, actual)
+assert.True(t, condition)
+
+// Require stops test on failure (use for setup)
+require.NoError(t, err)
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+go test ./...
+
+# Run with verbose output
+go test -v ./...
+
+# Run with coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+go tool cover -func=coverage.out
+
+# Run specific test
+go test -v ./pkg/callhandler -run Test_Get
+
+# Run tests matching pattern
+go test -v ./... -run "Test_.*Create"
+
+# Clear test cache (important after bin-common-handler changes)
+go clean -testcache
+go test ./...
+```
+
+## Test File Organization
+
+```
+pkg/callhandler/
+├── main.go           # Interface definition + go:generate
+├── mock_main.go      # Generated mocks
+├── call.go           # Implementation
+├── call_test.go      # Tests for call.go
+├── db.go             # Database operations
+└── db_test.go        # Tests for db.go
+```
+
+## Checklist for New Tests
+
+- [ ] Use table-driven tests for multiple scenarios
+- [ ] Test success path first
+- [ ] Test error paths (not found, validation, db errors)
+- [ ] Mock external dependencies
+- [ ] Use meaningful test names
+- [ ] Pass context.Background() to all handler calls
+- [ ] Use gomock.NewController with defer mc.Finish()
+- [ ] Test edge cases (nil, empty, max values)
+
+## See Also
+
+- [Code Quality Standards](code-quality-standards.md) - Testing patterns
+- [Development Guide](development-guide.md) - Build and test commands
+- `bin-common-handler/pkg/requesthandler/*_test.go` - 40+ test examples
+- `bin-common-handler/pkg/databasehandler/mapping_test.go` - DB utility tests


### PR DESCRIPTION
Add documentation quick wins and OpenAPI validation to CI pipeline.

- docs: Add RabbitMQ queue reference with all 31 service queues
- docs: Add error handling patterns guide for 3 error layers
- docs: Add test utilities guide for bin-common-handler usage
- docs: Add database patterns checklist with UUID tag gotcha
- docs: Add CLAUDE.md service template with 10 required sections
- .circleci: Add bin-openapi-manager workflow with validation job
- .circleci: Add schema drift detection (generated vs committed check)