### PR TITLE
NOJIRA-Fix-config-binding-for-env-vars

### DIFF
--- a/bin-billing-manager/cmd/billing-manager/main.go
+++ b/bin-billing-manager/cmd/billing-manager/main.go
@@ -67,6 +67,9 @@ func runDaemon() error {
 	signal.Notify(chSigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go signalHandler()
 
+	// init prometheus
+	config.InitPrometheus()
+
 	// connect to database
 	sqlDB, err := commondatabasehandler.Connect(config.Get().DatabaseDSN)
 	if err != nil {

--- a/bin-billing-manager/internal/config/main.go
+++ b/bin-billing-manager/internal/config/main.go
@@ -3,7 +3,6 @@ package config
 import (
 	"net/http"
 	"sync"
-	"time"
 
 	joonix "github.com/joonix/log"
 	"github.com/pkg/errors"
@@ -32,11 +31,9 @@ type Config struct {
 
 func Bootstrap(cmd *cobra.Command) error {
 	initLog()
-	initSignal()
 	if errBind := bindConfig(cmd); errBind != nil {
 		return errors.Wrapf(errBind, "could not bind config")
 	}
-	initPrometheus()
 
 	return nil
 }
@@ -47,13 +44,13 @@ func bindConfig(cmd *cobra.Command) error {
 	viper.AutomaticEnv()
 	f := cmd.PersistentFlags()
 
-	f.String("rabbitmq_address", "amqp://guest:guest@localhost:5672", "RabbitMQ server address")
-	f.String("prometheus_endpoint", "/metrics", "Prometheus metrics endpoint")
-	f.String("prometheus_listen_address", ":2112", "Prometheus listen address")
-	f.String("database_dsn", "testid:testpassword@tcp(127.0.0.1:3306)/test", "Database connection DSN")
-	f.String("redis_address", "127.0.0.1:6379", "Redis server address")
+	f.String("rabbitmq_address", "", "RabbitMQ server address")
+	f.String("prometheus_endpoint", "", "Prometheus metrics endpoint")
+	f.String("prometheus_listen_address", "", "Prometheus listen address")
+	f.String("database_dsn", "", "Database connection DSN")
+	f.String("redis_address", "", "Redis server address")
 	f.String("redis_password", "", "Redis password")
-	f.Int("redis_database", 1, "Redis database index")
+	f.Int("redis_database", 0, "Redis database index")
 
 	bindings := map[string]string{
 		"rabbitmq_address":          "RABBITMQ_ADDRESS",
@@ -105,24 +102,22 @@ func initLog() {
 	logrus.SetLevel(logrus.DebugLevel)
 }
 
-func initSignal() {
-	// Signal handler is now managed in main.go
-}
+// InitPrometheus initializes Prometheus metrics server.
+// Must be called AFTER LoadGlobalConfig().
+func InitPrometheus() {
+	cfg := Get()
 
-func initPrometheus() {
-	endpoint := viper.GetString("prometheus_endpoint")
-	listen := viper.GetString("prometheus_listen_address")
+	// Skip Prometheus initialization if endpoint or listen address is not configured
+	if cfg.PrometheusEndpoint == "" || cfg.PrometheusListenAddress == "" {
+		logrus.Debug("Prometheus metrics server disabled (endpoint or listen address not configured)")
+		return
+	}
 
-	http.Handle(endpoint, promhttp.Handler())
+	http.Handle(cfg.PrometheusEndpoint, promhttp.Handler())
 	go func() {
-		for {
-			err := http.ListenAndServe(listen, nil)
-			if err != nil {
-				logrus.Errorf("Could not start prometheus listener")
-				time.Sleep(time.Second * 1)
-				continue
-			}
-			break
+		logrus.Infof("Prometheus metrics server starting on %s%s", cfg.PrometheusListenAddress, cfg.PrometheusEndpoint)
+		if err := http.ListenAndServe(cfg.PrometheusListenAddress, nil); err != nil {
+			logrus.Errorf("Prometheus server error: %v", err)
 		}
 	}()
 }

--- a/bin-email-manager/cmd/email-manager/main.go
+++ b/bin-email-manager/cmd/email-manager/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
@@ -18,7 +16,6 @@ import (
 	"monorepo/bin-email-manager/pkg/emailhandler"
 
 	_ "github.com/go-sql-driver/mysql"
-	joonix "github.com/joonix/log"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -28,50 +25,38 @@ import (
 	"monorepo/bin-email-manager/pkg/listenhandler"
 )
 
-const serviceName = commonoutline.ServiceNameFlowManager
+const serviceName = commonoutline.ServiceNameEmailManager
 
 // channels
 var chSigs = make(chan os.Signal, 1)
 var chDone = make(chan bool, 1)
 
-var rootCmd = &cobra.Command{
-	Use:   "email-manager",
-	Short: "Email Manager Service",
-	Long:  `Email Manager handles email sending and management for the VoIPbin platform.`,
-	Run:   runService,
-}
-
-func init() {
-	// Define flags
-	rootCmd.Flags().String("database_dsn", "testid:testpassword@tcp(127.0.0.1:3306)/test", "Data Source Name for database connection (e.g., user:password@tcp(localhost:3306)/dbname)")
-	rootCmd.Flags().String("prometheus_endpoint", "/metrics", "URL for the Prometheus metrics endpoint")
-	rootCmd.Flags().String("prometheus_listen_address", ":2112", "Address for Prometheus to listen on (e.g., localhost:8080)")
-	rootCmd.Flags().String("rabbitmq_address", "amqp://guest:guest@localhost:5672", "Address of the RabbitMQ server (e.g., amqp://guest:guest@localhost:5672)")
-	rootCmd.Flags().String("redis_address", "127.0.0.1:6379", "Address of the Redis server (e.g., localhost:6379)")
-	rootCmd.Flags().String("redis_password", "", "Password for authenticating with the Redis server (if required)")
-	rootCmd.Flags().Int("redis_database", 1, "Redis database index to use (default is 1)")
-	rootCmd.Flags().String("sendgrid_api_key", "", "API key for Sendgrid")
-	rootCmd.Flags().String("mailgun_api_key", "", "API key for Mailgun")
-
-	// Initialize configuration
-	config.InitConfig(rootCmd)
-
-	// Initialize logging
-	initLog()
-
-	// Initialize signal handler
-	initSignal()
-}
-
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		logrus.Errorf("Failed to execute command: %v", err)
+	rootCmd := &cobra.Command{
+		Use:   "email-manager",
+		Short: "Email Manager Service",
+		Long:  `Email Manager handles email sending and management for the VoIPbin platform.`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			config.LoadGlobalConfig()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runService()
+		},
+	}
+
+	if errBind := config.Bootstrap(rootCmd); errBind != nil {
+		logrus.Fatalf("Failed to bootstrap config: %v", errBind)
+	}
+
+	if errExecute := rootCmd.Execute(); errExecute != nil {
+		logrus.Errorf("Command execution failed: %v", errExecute)
 		os.Exit(1)
 	}
 }
 
-func runService(cmd *cobra.Command, args []string) {
-	fmt.Printf("Hello world!\n")
+func runService() error {
+	initSignal()
 
 	cfg := config.Get()
 
@@ -81,19 +66,15 @@ func runService(cmd *cobra.Command, args []string) {
 	// create dbhandler
 	dbHandler, err := createDBHandler(cfg)
 	if err != nil {
-		logrus.Errorf("Could not connect to the database or failed to initiate the cachehandler. err: ")
-		return
+		logrus.Errorf("Could not connect to the database or failed to initiate the cachehandler. err: %v", err)
+		return err
 	}
 
 	// run the service
 	run(dbHandler, cfg)
 	<-chDone
-}
-
-// initLog inits log settings.
-func initLog() {
-	logrus.SetFormatter(joonix.NewFormatter())
-	logrus.SetLevel(logrus.DebugLevel)
+	logrus.Info("Email-manager stopped safely.")
+	return nil
 }
 
 // initSignal inits signal settings.
@@ -104,16 +85,17 @@ func initSignal() {
 
 // initProm inits prometheus settings
 func initProm(endpoint, listen string) {
+	// Skip Prometheus initialization if endpoint or listen address is not configured
+	if endpoint == "" || listen == "" {
+		logrus.Debug("Prometheus metrics server disabled (endpoint or listen address not configured)")
+		return
+	}
+
 	http.Handle(endpoint, promhttp.Handler())
 	go func() {
-		for {
-			err := http.ListenAndServe(listen, nil)
-			if err != nil {
-				logrus.Errorf("Could not start prometheus listener")
-				time.Sleep(time.Second * 1)
-				continue
-			}
-			break
+		logrus.Infof("Prometheus metrics server starting on %s%s", listen, endpoint)
+		if err := http.ListenAndServe(listen, nil); err != nil {
+			logrus.Errorf("Prometheus server error: %v", err)
 		}
 	}()
 }
@@ -156,7 +138,7 @@ func run(dbHandler dbhandler.DBHandler, cfg *config.Config) {
 
 	// create handlers
 	reqHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
-	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameFlowEvent, serviceName)
+	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameEmailEvent, serviceName)
 
 	emailHandler := emailhandler.NewEmailHandler(dbHandler, reqHandler, notifyHandler, cfg.SendgridAPIKey, cfg.MailgunAPIKey)
 

--- a/bin-email-manager/internal/config/config.go
+++ b/bin-email-manager/internal/config/config.go
@@ -43,8 +43,8 @@ func bindConfig(cmd *cobra.Command) error {
 	f := cmd.PersistentFlags()
 
 	f.String("rabbitmq_address", "", "RabbitMQ server address")
-	f.String("prometheus_endpoint", "/metrics", "Prometheus metrics endpoint")
-	f.String("prometheus_listen_address", ":2112", "Prometheus listen address")
+	f.String("prometheus_endpoint", "", "Prometheus metrics endpoint")
+	f.String("prometheus_listen_address", "", "Prometheus listen address")
 	f.String("database_dsn", "", "Database connection DSN")
 	f.String("redis_address", "", "Redis server address")
 	f.String("redis_password", "", "Redis password")

--- a/bin-pipecat-manager/cmd/pipecat-manager/main.go
+++ b/bin-pipecat-manager/cmd/pipecat-manager/main.go
@@ -42,6 +42,10 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "pipecat-manager",
 		Short: "Voipbin Pipecat Manager Daemon",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			config.LoadGlobalConfig()
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDaemon()
 		},


### PR DESCRIPTION
Fix configuration binding to properly read environment variables and command-line flags at runtime.

- bin-ai-manager: Use empty flag defaults instead of hardcoded values
- bin-ai-manager: Update InitPrometheus to handle empty config gracefully
- bin-billing-manager: Move InitPrometheus call after config is loaded
- bin-billing-manager: Use empty flag defaults instead of hardcoded values
- bin-email-manager: Refactor main.go to use Bootstrap/LoadGlobalConfig pattern
- bin-email-manager: Add PersistentPreRunE for proper config loading timing
- bin-email-manager: Use empty flag defaults in config bindings
- bin-message-manager: Refactor main.go to use Bootstrap/LoadGlobalConfig pattern
- bin-message-manager: Add PersistentPreRunE for proper config loading timing
- bin-pipecat-manager: Add PersistentPreRunE for config loading after flag parsing
- bin-pipecat-manager: Refactor Bootstrap to separate binding from loading
- bin-pipecat-manager: Use empty flag defaults instead of hardcoded values