### PR TITLE
NOJIRA-Add-discord-merge-notification

### DIFF
--- a/.github/workflows/discord-merge-notify.yml
+++ b/.github/workflows/discord-merge-notify.yml
@@ -1,0 +1,42 @@
+name: Discord Merge Notification
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"🔀 PR Merged to main\",
+                \"color\": 5763719,
+                \"fields\": [
+                  {
+                    \"name\": \"Title\",
+                    \"value\": \"${{ github.event.pull_request.title }}\",
+                    \"inline\": false
+                  },
+                  {
+                    \"name\": \"Author\",
+                    \"value\": \"${{ github.event.pull_request.user.login }}\",
+                    \"inline\": true
+                  },
+                  {
+                    \"name\": \"Link\",
+                    \"value\": \"${{ github.event.pull_request.html_url }}\",
+                    \"inline\": false
+                  }
+                ]
+              }]
+            }" \
+            "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
Add GitHub Action workflow to send Discord notifications when pull requests are merged to main. This enables the team to receive real-time updates in Discord    
when code changes land.                                                                                                                                          
                                                                                                                                                               
- github-workflows: Add discord-merge-notify.yml workflow triggered on PR merge to main                                                                          
- github-workflows: Send Discord embed with PR title, author, and link via webhook                                                                               