### PR TITLE
NOJIRA-Improve-password-reset-success-message

### DIFF
--- a/bin-api-manager/lib/service/auth.go
+++ b/bin-api-manager/lib/service/auth.go
@@ -214,9 +214,14 @@ const passwordResetHTML = `<!DOCTYPE html>
       body: JSON.stringify({ token: token, password: password })
     }).then(function(resp) {
       if (resp.ok) {
-        msgEl.textContent = 'Password updated successfully. You can now log in with your new password.';
-        msgEl.className = 'message success';
-        document.getElementById('resetForm').style.display = 'none';
+        var container = document.querySelector('.container');
+        while (container.firstChild) { container.removeChild(container.firstChild); }
+        var h1 = document.createElement('h1');
+        h1.textContent = 'Password Updated';
+        var p = document.createElement('p');
+        p.textContent = 'Your password has been changed successfully.';
+        container.appendChild(h1);
+        container.appendChild(p);
       } else {
         msgEl.textContent = 'Invalid or expired reset link. Please request a new one.';
         msgEl.className = 'message error';

--- a/bin-api-manager/server/auth.go
+++ b/bin-api-manager/server/auth.go
@@ -171,9 +171,14 @@ const passwordResetHTML = `<!DOCTYPE html>
       body: JSON.stringify({ token: token, password: password })
     }).then(function(resp) {
       if (resp.ok) {
-        msgEl.textContent = 'Password updated successfully. You can now log in with your new password.';
-        msgEl.className = 'message success';
-        document.getElementById('resetForm').style.display = 'none';
+        var container = document.querySelector('.container');
+        while (container.firstChild) { container.removeChild(container.firstChild); }
+        var h1 = document.createElement('h1');
+        h1.textContent = 'Password Updated';
+        var p = document.createElement('p');
+        p.textContent = 'Your password has been changed successfully.';
+        container.appendChild(h1);
+        container.appendChild(p);
       } else {
         msgEl.textContent = 'Invalid or expired reset link. Please request a new one.';
         msgEl.className = 'message error';


### PR DESCRIPTION
Improve password reset page to show a clean success state after the password
has been changed, instead of keeping the stale "Reset Password / Enter your
new password below" heading visible.

- bin-api-manager: Replace entire container content with "Password Updated" heading and confirmation message on successful reset