### PR TITLE
NOJIRA-Fix-agent-address-update-not-found-error

### DIFF
--- a/bin-agent-manager/pkg/agenthandler/agent.go
+++ b/bin-agent-manager/pkg/agenthandler/agent.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"monorepo/bin-agent-manager/internal/config"
+	"monorepo/bin-agent-manager/pkg/dbhandler"
 	commonaddress "monorepo/bin-common-handler/models/address"
 
 	"github.com/gofrs/uuid"
@@ -367,7 +368,7 @@ func (h *agentHandler) UpdateAddresses(ctx context.Context, id uuid.UUID, addres
 
 		// check if the address is already assigned to the other agent
 		ag, err := h.GetByCustomerIDAndAddress(ctx, a.CustomerID, &address)
-		if err != nil {
+		if err != nil && err != dbhandler.ErrNotFound {
 			log.Errorf("Could not get agent info of the address. err: %v", err)
 			return nil, errors.Wrap(err, "could not get agent info of the address")
 		}

--- a/bin-agent-manager/pkg/agenthandler/agent_test.go
+++ b/bin-agent-manager/pkg/agenthandler/agent_test.go
@@ -816,7 +816,7 @@ func Test_UpdateAddresses(t *testing.T) {
 					mockReq.EXPECT().RegistrarV1ExtensionGet(ctx, uuid.FromStringOrNil(addr.Target)).Return(tt.responseExtension, nil)
 				}
 
-				mockDB.EXPECT().AgentGetByCustomerIDAndAddress(ctx, tt.responseAgent.CustomerID, &addr).Return(nil, nil)
+				mockDB.EXPECT().AgentGetByCustomerIDAndAddress(ctx, tt.responseAgent.CustomerID, &addr).Return(nil, dbhandler.ErrNotFound)
 			}
 			mockDB.EXPECT().AgentSetAddresses(ctx, tt.id, tt.addresses).Return(nil)
 			mockDB.EXPECT().AgentGet(ctx, tt.id).Return(tt.responseAgent, nil)


### PR DESCRIPTION
Fix agent address update failing with "record not found" when assigning
new addresses that don't belong to any other agent.

The UpdateAddresses method checks if an address is already assigned to
another agent by calling GetByCustomerIDAndAddress. When no agent has
that address, the DB layer returns ErrNotFound. The code was treating
this expected case as an error instead of the happy path (no conflict).

- bin-agent-manager: Handle ErrNotFound as non-error when checking address conflicts in UpdateAddresses
- bin-agent-manager: Update test to use ErrNotFound for realistic DB behavior