### PR TITLE
NOJIRA-Fix-race-conditions-in-common-handler

### DIFF
--- a/bin-common-handler/pkg/notifyhandler/publish_test.go
+++ b/bin-common-handler/pkg/notifyhandler/publish_test.go
@@ -3,6 +3,7 @@ package notifyhandler
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -262,5 +263,88 @@ func Test_PublishEventRaw(t *testing.T) {
 
 			time.Sleep(time.Millisecond * 1000)
 		})
+	}
+}
+
+func Test_publishToClickHouse_NilClient(t *testing.T) {
+	// When chClient has no value stored (zero Value), publishToClickHouse should return immediately.
+	h := &notifyHandler{
+		publisher: testPublisher,
+	}
+	// chClient is zero-value atomic.Value (Load() returns nil)
+
+	// Should not panic or block
+	h.publishToClickHouse("test_event", "application/json", []byte(`{"key":"value"}`))
+}
+
+func Test_publishToClickHouse_WrongType(t *testing.T) {
+	// When chClient stores a non-clickhouse.Conn value, the type assertion should fail
+	// and publishToClickHouse should return safely.
+	h := &notifyHandler{
+		publisher: testPublisher,
+	}
+	h.chClient.Store("not-a-clickhouse-conn")
+
+	// Should not panic — type assertion guard catches this
+	h.publishToClickHouse("test_event", "application/json", []byte(`{"key":"value"}`))
+}
+
+func Test_publishEvent_SkipsClickHouseWhenClientNil(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &notifyHandler{
+		sockHandler: mockSock,
+		queueNotify: commonoutline.QueueNameCallEvent,
+		publisher:   testPublisher,
+	}
+	// chClient is zero-value (nil) — ClickHouse path should be skipped
+
+	mockSock.EXPECT().EventPublish(string(h.queueNotify), "", gomock.Any()).Return(nil)
+
+	err := h.publishEvent("test_event", "application/json", []byte(`{"key":"value"}`), 3, 0)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	// Give a moment for any unexpected goroutine (there should be none)
+	time.Sleep(100 * time.Millisecond)
+}
+
+func Test_chClient_ConcurrentStoreLoad(t *testing.T) {
+	// Verify that concurrent Store and Load on chClient do not cause a data race.
+	// This test is meaningful when run with -race flag.
+	h := &notifyHandler{
+		publisher: testPublisher,
+	}
+
+	var wg sync.WaitGroup
+
+	// Writer goroutine: stores values
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			h.chClient.Store("dummy-value")
+		}
+	}()
+
+	// Reader goroutine: loads values
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = h.chClient.Load()
+		}
+	}()
+
+	wg.Wait()
+
+	// After all writes, Load should return the stored value
+	val := h.chClient.Load()
+	if val == nil {
+		t.Error("Expected chClient to have a value after concurrent stores")
 	}
 }

--- a/bin-rag-manager/go.mod
+++ b/bin-rag-manager/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	go.uber.org/mock v0.6.0
 	go.yaml.in/yaml/v3 v3.0.4
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
 )
@@ -89,7 +90,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.32.0 // indirect


### PR DESCRIPTION
Fix two data race conditions in bin-common-handler's rabbitmqhandler and
notifyhandler packages, and add comprehensive tests for the fixes.

- bin-common-handler: Fix race on rabbitmqhandler closed field by changing from bool to atomic.Bool
- bin-common-handler: Fix race on notifyhandler chClient field by changing from clickhouse.Conn to atomic.Value with type assertion guard
- bin-common-handler: Add rabbitmqhandler tests for reconnector exit on channel close and closed flag
- bin-common-handler: Add rabbitmqhandler tests for atomic safety and closed-before-close ordering
- bin-common-handler: Add notifyhandler tests for chClient nil guard, wrong type assertion, and concurrent access
- bin-rag-manager: Tidy go.mod from verification workflow