### PR TITLE
NOJIRA-Add-billing-control-update-plan-type

### DIFF
--- a/bin-billing-manager/pkg/accounthandler/account.go
+++ b/bin-billing-manager/pkg/accounthandler/account.go
@@ -45,6 +45,23 @@ func (h *accountHandler) UpdateBasicInfo(ctx context.Context, id uuid.UUID, name
 	return res, nil
 }
 
+// UpdatePlanType updates the account's plan type
+func (h *accountHandler) UpdatePlanType(ctx context.Context, id uuid.UUID, planType account.PlanType) (*account.Account, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "UpdatePlanType",
+		"id":        id,
+		"plan_type": planType,
+	})
+
+	res, err := h.dbUpdatePlanType(ctx, id, planType)
+	if err != nil {
+		log.Errorf("Could not update the account plan type. err: %v", err)
+		return nil, errors.Wrap(err, "could not update the account plan type")
+	}
+
+	return res, nil
+}
+
 // UpdatePaymentInfo updates the account's basic info
 func (h *accountHandler) UpdatePaymentInfo(ctx context.Context, id uuid.UUID, paymentType account.PaymentType, paymentMethod account.PaymentMethod) (*account.Account, error) {
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-billing-manager/pkg/accounthandler/db.go
+++ b/bin-billing-manager/pkg/accounthandler/db.go
@@ -231,6 +231,32 @@ func (h *accountHandler) dbUpdateBasicInfo(ctx context.Context, id uuid.UUID, na
 	return res, nil
 }
 
+// dbUpdatePlanType updates the account's plan type
+func (h *accountHandler) dbUpdatePlanType(ctx context.Context, id uuid.UUID, planType account.PlanType) (*account.Account, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "dbUpdatePlanType",
+		"id":        id,
+		"plan_type": planType,
+	})
+
+	fields := map[account.Field]any{
+		account.FieldPlanType: planType,
+	}
+
+	if errUpdate := h.db.AccountUpdate(ctx, id, fields); errUpdate != nil {
+		log.Errorf("Could not update the account plan type. err: %v", errUpdate)
+		return nil, errors.Wrap(errUpdate, "could not update the account plan type")
+	}
+
+	res, err := h.Get(ctx, id)
+	if err != nil {
+		log.Errorf("Could not get updated account. err: %v", err)
+		return nil, errors.Wrap(err, "could not get updated account")
+	}
+
+	return res, nil
+}
+
 // dbUpdatePaymentInfo updates the account's payment info
 func (h *accountHandler) dbUpdatePaymentInfo(ctx context.Context, id uuid.UUID, paymentType account.PaymentType, paymentMethod account.PaymentMethod) (*account.Account, error) {
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-billing-manager/pkg/accounthandler/main.go
+++ b/bin-billing-manager/pkg/accounthandler/main.go
@@ -30,6 +30,7 @@ type AccountHandler interface {
 	AddBalance(ctx context.Context, accountID uuid.UUID, balance float32) (*account.Account, error)
 	UpdateBasicInfo(ctx context.Context, id uuid.UUID, name string, detail string) (*account.Account, error)
 	UpdatePaymentInfo(ctx context.Context, id uuid.UUID, paymentType account.PaymentType, paymentMethod account.PaymentMethod) (*account.Account, error)
+	UpdatePlanType(ctx context.Context, id uuid.UUID, planType account.PlanType) (*account.Account, error)
 
 	Delete(ctx context.Context, id uuid.UUID) (*account.Account, error)
 

--- a/bin-billing-manager/pkg/accounthandler/mock_main.go
+++ b/bin-billing-manager/pkg/accounthandler/mock_main.go
@@ -252,3 +252,18 @@ func (mr *MockAccountHandlerMockRecorder) UpdatePaymentInfo(ctx, id, paymentType
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePaymentInfo", reflect.TypeOf((*MockAccountHandler)(nil).UpdatePaymentInfo), ctx, id, paymentType, paymentMethod)
 }
+
+// UpdatePlanType mocks base method.
+func (m *MockAccountHandler) UpdatePlanType(ctx context.Context, id uuid.UUID, planType account.PlanType) (*account.Account, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdatePlanType", ctx, id, planType)
+	ret0, _ := ret[0].(*account.Account)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdatePlanType indicates an expected call of UpdatePlanType.
+func (mr *MockAccountHandlerMockRecorder) UpdatePlanType(ctx, id, planType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePlanType", reflect.TypeOf((*MockAccountHandler)(nil).UpdatePlanType), ctx, id, planType)
+}

--- a/docs/plans/2026-02-10-billing-control-update-plan-type-design.md
+++ b/docs/plans/2026-02-10-billing-control-update-plan-type-design.md
@@ -1,0 +1,49 @@
+# Design: Add update-plan-type Command to billing-control
+
+## Problem
+
+The billing-control CLI tool has no command to change an account's plan tier (PlanType).
+Currently, plan types can only be changed by directly updating the database. Admins need
+a safe, consistent way to change account tiers via the existing CLI tool.
+
+## Approach
+
+Add an `update-plan-type` subcommand to the `billing-control account` command group,
+following the same pattern as the existing `update` and `update-payment-info` commands.
+
+### Usage
+
+```bash
+billing-control account update-plan-type --id <account-uuid> --plan-type <free|basic|professional|unlimited>
+```
+
+Returns the updated account as JSON.
+
+### Changes
+
+**1. AccountHandler interface** (`pkg/accounthandler/main.go`)
+- Add `UpdatePlanType(ctx context.Context, id uuid.UUID, planType account.PlanType) (*account.Account, error)`
+
+**2. AccountHandler implementation** (`pkg/accounthandler/account.go`)
+- Add `UpdatePlanType` method that delegates to `dbUpdatePlanType`
+
+**3. DB helper** (`pkg/accounthandler/db.go`)
+- Add `dbUpdatePlanType` that builds `{FieldPlanType: planType}` field map and calls `h.db.AccountUpdate`
+
+**4. CLI command** (`cmd/billing-control/main.go`)
+- Add `cmdAccountUpdatePlanType()` with `--id` and `--plan-type` flags
+- Add `runAccountUpdatePlanType()` that validates plan-type against known constants before calling handler
+- Register under `cmdAccount`
+
+**5. Mock regeneration**
+- Run `go generate ./...` to update mock for the new interface method
+
+### Validation
+
+The CLI validates `--plan-type` against the four known values: `free`, `basic`, `professional`, `unlimited`.
+Invalid values are rejected before calling the handler.
+
+### No validation on downgrade
+
+Per user requirement, this is a direct admin override with no resource-count validation.
+The admin is responsible for ensuring the tier change is appropriate.


### PR DESCRIPTION
Add update-plan-type command to billing-control CLI for changing account
plan tiers (free, basic, professional, unlimited).

- bin-billing-manager: Add UpdatePlanType to AccountHandler interface
- bin-billing-manager: Add dbUpdatePlanType using FieldPlanType field map
- bin-billing-manager: Add update-plan-type CLI command with plan type validation
- bin-billing-manager: Regenerate accounthandler mock
- docs: Add design document for billing-control update-plan-type