### PR TITLE
NOJIRA-Fix-migration-chain

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/fc1a2b3d4e5f_number_add_type_column.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/fc1a2b3d4e5f_number_add_type_column.py
@@ -1,7 +1,7 @@
 """number_add_type_column
 
 Revision ID: fc1a2b3d4e5f
-Revises: fb5b8d1359c9
+Revises: d4e5f6a7b8c9
 Create Date: 2026-02-10 12:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'fc1a2b3d4e5f'
-down_revision = 'fb5b8d1359c9'
+down_revision = 'd4e5f6a7b8c9'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Fix Alembic multiple heads error caused by the virtual number migration
(fc1a2b3d4e5f) and billing accounts migration (c3a7f1b2d8e4) both pointing
to the same parent revision (fb5b8d1359c9).

- bin-dbscheme-manager: Update number_add_type_column down_revision from fb5b8d1359c9 to d4e5f6a7b8c9