### PR TITLE
NOJIRA-Add-customer-manager-metrics

### DIFF
--- a/bin-customer-manager/pkg/accesskeyhandler/db.go
+++ b/bin-customer-manager/pkg/accesskeyhandler/db.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-customer-manager/models/accesskey"
+	"monorepo/bin-customer-manager/pkg/metricshandler"
 )
 
 // List returns list of accesskeys
@@ -121,6 +122,7 @@ func (h *accesskeyHandler) Create(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, accesskey.EventTypeAccesskeyCreated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(accesskey.EventTypeAccesskeyCreated).Inc()
 
 	return res, nil
 }
@@ -160,6 +162,7 @@ func (h *accesskeyHandler) Delete(ctx context.Context, id uuid.UUID) (*accesskey
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, accesskey.EventTypeAccesskeyDeleted, res)
+	metricshandler.EventPublishTotal.WithLabelValues(accesskey.EventTypeAccesskeyDeleted).Inc()
 
 	return res, nil
 }
@@ -196,6 +199,7 @@ func (h *accesskeyHandler) UpdateBasicInfo(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, accesskey.EventTypeAccesskeyUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(accesskey.EventTypeAccesskeyUpdated).Inc()
 
 	return res, nil
 }

--- a/bin-customer-manager/pkg/customerhandler/db.go
+++ b/bin-customer-manager/pkg/customerhandler/db.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-customer-manager/models/customer"
+	"monorepo/bin-customer-manager/pkg/metricshandler"
 )
 
 // List returns list of customers
@@ -97,6 +98,7 @@ func (h *customerHandler) Create(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerCreated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerCreated).Inc()
 
 	return res, nil
 }
@@ -124,6 +126,7 @@ func (h *customerHandler) dbDelete(ctx context.Context, id uuid.UUID) (*customer
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerDeleted, res)
+	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerDeleted).Inc()
 
 	return res, nil
 }
@@ -171,6 +174,7 @@ func (h *customerHandler) UpdateBasicInfo(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerUpdated).Inc()
 
 	return res, nil
 }
@@ -201,6 +205,7 @@ func (h *customerHandler) UpdateBillingAccountID(ctx context.Context, id uuid.UU
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerUpdated).Inc()
 
 	return res, nil
 }

--- a/bin-customer-manager/pkg/customerhandler/signup.go
+++ b/bin-customer-manager/pkg/customerhandler/signup.go
@@ -10,6 +10,7 @@ import (
 	commonaddress "monorepo/bin-common-handler/models/address"
 	"monorepo/bin-customer-manager/internal/config"
 	"monorepo/bin-customer-manager/models/customer"
+	"monorepo/bin-customer-manager/pkg/metricshandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -40,6 +41,7 @@ func (h *customerHandler) Signup(
 	// validate email
 	if !h.validateCreate(ctx, email) {
 		log.Errorf("Email validation failed. email: %s", email)
+		metricshandler.SignupTotal.WithLabelValues("validation_failed").Inc()
 		return nil, fmt.Errorf("the email is not available")
 	}
 
@@ -64,12 +66,14 @@ func (h *customerHandler) Signup(
 
 	if err := h.db.CustomerCreate(ctx, u); err != nil {
 		log.Errorf("Could not create customer. err: %v", err)
+		metricshandler.SignupTotal.WithLabelValues("error").Inc()
 		return nil, err
 	}
 
 	res, err := h.db.CustomerGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get created customer. err: %v", err)
+		metricshandler.SignupTotal.WithLabelValues("error").Inc()
 		return nil, err
 	}
 	log.WithField("customer", res).Debugf("Created unverified customer. customer_id: %s", res.ID)
@@ -78,6 +82,7 @@ func (h *customerHandler) Signup(
 	tokenBytes := make([]byte, emailVerifyTokenLen)
 	if _, err := rand.Read(tokenBytes); err != nil {
 		log.Errorf("Could not generate random token. err: %v", err)
+		metricshandler.SignupTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("could not generate verification token")
 	}
 	token := hex.EncodeToString(tokenBytes)
@@ -85,6 +90,7 @@ func (h *customerHandler) Signup(
 	// store token in Redis
 	if err := h.cache.EmailVerifyTokenSet(ctx, token, id, emailVerifyTokenTTL); err != nil {
 		log.Errorf("Could not store verification token. err: %v", err)
+		metricshandler.SignupTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("could not store verification token")
 	}
 
@@ -95,6 +101,8 @@ func (h *customerHandler) Signup(
 	}
 
 	// do NOT publish customer_created event — wait for email verification
+
+	metricshandler.SignupTotal.WithLabelValues("success").Inc()
 
 	return res, nil
 }
@@ -110,6 +118,7 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 	customerID, err := h.cache.EmailVerifyTokenGet(ctx, token)
 	if err != nil {
 		log.Errorf("Could not get verification token. err: %v", err)
+		metricshandler.EmailVerificationTotal.WithLabelValues("invalid_token").Inc()
 		return nil, fmt.Errorf("verification token expired or invalid")
 	}
 	log.Debugf("Found verification token. customer_id: %s", customerID)
@@ -118,12 +127,14 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 	c, err := h.db.CustomerGet(ctx, customerID)
 	if err != nil {
 		log.Errorf("Could not get customer. err: %v", err)
+		metricshandler.EmailVerificationTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("customer not found")
 	}
 	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.EmailVerified {
 		log.Infof("Customer already verified. customer_id: %s", c.ID)
+		metricshandler.EmailVerificationTotal.WithLabelValues("already_verified").Inc()
 		return c, nil
 	}
 
@@ -133,6 +144,7 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 	}
 	if err := h.db.CustomerUpdate(ctx, customerID, fields); err != nil {
 		log.Errorf("Could not update customer. err: %v", err)
+		metricshandler.EmailVerificationTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("could not verify customer")
 	}
 
@@ -146,12 +158,16 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 	res, err := h.db.CustomerGet(ctx, customerID)
 	if err != nil {
 		log.Errorf("Could not get updated customer. err: %v", err)
+		metricshandler.EmailVerificationTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("could not get verified customer")
 	}
 	log.WithField("customer", res).Debugf("Customer verified. customer_id: %s", res.ID)
 
 	// publish customer_created event — triggers default agent creation + welcome email
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerCreated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerCreated).Inc()
+
+	metricshandler.EmailVerificationTotal.WithLabelValues("success").Inc()
 
 	return res, nil
 }
@@ -182,6 +198,13 @@ func (h *customerHandler) sendVerificationEmail(ctx context.Context, email strin
 		},
 	}
 
+	start := time.Now()
+	rpcStatus := "error"
+	defer func() {
+		metricshandler.RPCCallDuration.WithLabelValues("email-manager", "email_send").Observe(float64(time.Since(start).Milliseconds()))
+		metricshandler.RPCCallTotal.WithLabelValues("email-manager", "email_send", rpcStatus).Inc()
+	}()
+
 	if _, err := h.reqHandler.EmailV1EmailSend(
 		ctx,
 		uuid.Nil,
@@ -194,6 +217,8 @@ func (h *customerHandler) sendVerificationEmail(ctx context.Context, email strin
 		log.Errorf("Could not send verification email. err: %v", err)
 		return err
 	}
+
+	rpcStatus = "success"
 
 	log.Debugf("Sent verification email. email: %s", email)
 	return nil

--- a/bin-customer-manager/pkg/metricshandler/main.go
+++ b/bin-customer-manager/pkg/metricshandler/main.go
@@ -1,0 +1,116 @@
+package metricshandler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricsNamespace = "customer_manager"
+
+var (
+	// ReceivedRequestProcessTime tracks RPC request processing time.
+	ReceivedRequestProcessTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "receive_request_process_time",
+			Help:      "Process time of received request",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"type", "method"},
+	)
+
+	// DBOperationDuration tracks database operation latency in milliseconds.
+	DBOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "db_operation_duration",
+			Help:      "Duration of database operations in milliseconds",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"operation", "entity"},
+	)
+
+	// DBOperationTotal counts database operations by outcome.
+	DBOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "db_operation_total",
+			Help:      "Total number of database operations",
+		},
+		[]string{"operation", "entity", "status"},
+	)
+
+	// CacheOperationTotal counts cache operations by result (hit/miss).
+	CacheOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "cache_operation_total",
+			Help:      "Total number of cache operations",
+		},
+		[]string{"operation", "entity", "result"},
+	)
+
+	// EventPublishTotal counts published events by type.
+	EventPublishTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "event_publish_total",
+			Help:      "Total number of published events",
+		},
+		[]string{"type"},
+	)
+
+	// RPCCallDuration tracks cross-service RPC call latency in milliseconds.
+	RPCCallDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "rpc_call_duration",
+			Help:      "Duration of cross-service RPC calls in milliseconds",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"service", "method"},
+	)
+
+	// RPCCallTotal counts cross-service RPC calls by outcome.
+	RPCCallTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "rpc_call_total",
+			Help:      "Total number of cross-service RPC calls",
+		},
+		[]string{"service", "method", "status"},
+	)
+
+	// SignupTotal counts customer signup attempts by outcome.
+	SignupTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "signup_total",
+			Help:      "Total number of customer signup attempts",
+		},
+		[]string{"status"},
+	)
+
+	// EmailVerificationTotal counts email verification attempts by outcome.
+	EmailVerificationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "email_verification_total",
+			Help:      "Total number of email verification attempts",
+		},
+		[]string{"status"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		ReceivedRequestProcessTime,
+		DBOperationDuration,
+		DBOperationTotal,
+		CacheOperationTotal,
+		EventPublishTotal,
+		RPCCallDuration,
+		RPCCallTotal,
+		SignupTotal,
+		EmailVerificationTotal,
+	)
+}


### PR DESCRIPTION
Add comprehensive Prometheus metrics for the customer-manager service. Previously
the service only had a single request processing time histogram. This adds 8 new
metrics covering database operations, cache performance, cross-service RPC calls,
event publishing, and business-specific signup/verification flows.

- bin-customer-manager: Add centralized metricshandler package with 9 Prometheus metrics
- bin-customer-manager: Instrument all DB operations with duration histograms and counters using defer pattern
- bin-customer-manager: Add cache hit/miss counters for customer and accesskey lookups
- bin-customer-manager: Track cross-service RPC calls to billing-manager, agent-manager, and email-manager
- bin-customer-manager: Add event publish counters for all customer and accesskey lifecycle events
- bin-customer-manager: Add signup and email verification flow counters with granular status labels
- bin-customer-manager: Consolidate metric namespace by moving ReceivedRequestProcessTime to metricshandler