### PR TITLE
NOJIRA-Add-agent-manager-metrics

### DIFF
--- a/bin-agent-manager/pkg/agenthandler/db.go
+++ b/bin-agent-manager/pkg/agenthandler/db.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-agent-manager/pkg/metricshandler"
 )
 
 // dbList returns agents
@@ -100,6 +101,7 @@ func (h *agentHandler) dbCreate(ctx context.Context, customerID uuid.UUID, usern
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentCreated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentCreated)).Inc()
 
 	log.WithField("agent", res).Debug("Created a new agent.")
 
@@ -125,6 +127,7 @@ func (h *agentHandler) dbDelete(ctx context.Context, id uuid.UUID) (*agent.Agent
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentDeleted, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentDeleted)).Inc()
 
 	return res, nil
 }
@@ -172,6 +175,7 @@ func (h *agentHandler) dbUpdateInfo(ctx context.Context, id uuid.UUID, name stri
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -201,6 +205,7 @@ func (h *agentHandler) dbUpdatePassword(ctx context.Context, id uuid.UUID, passw
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -225,6 +230,7 @@ func (h *agentHandler) dbUpdatePermission(ctx context.Context, id uuid.UUID, per
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -249,6 +255,7 @@ func (h *agentHandler) dbUpdateTagIDs(ctx context.Context, id uuid.UUID, tagIDs 
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -272,6 +279,7 @@ func (h *agentHandler) dbUpdateAddresses(ctx context.Context, id uuid.UUID, addr
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -296,6 +304,7 @@ func (h *agentHandler) dbUpdateStatus(ctx context.Context, id uuid.UUID, status 
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentStatusUpdated, res)
+	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentStatusUpdated)).Inc()
 
 	return res, nil
 }

--- a/bin-agent-manager/pkg/metricshandler/main.go
+++ b/bin-agent-manager/pkg/metricshandler/main.go
@@ -1,0 +1,128 @@
+package metricshandler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricsNamespace = "agent_manager"
+
+var (
+	// ReceivedRequestProcessTime tracks RPC request processing time.
+	ReceivedRequestProcessTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "receive_request_process_time",
+			Help:      "Process time of received request",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"type", "method"},
+	)
+
+	// ReceivedSubscribeEventProcessTime tracks subscribe event processing time.
+	ReceivedSubscribeEventProcessTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "receive_subscribe_event_process_time",
+			Help:      "Process time of received subscribe event",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"publisher", "type"},
+	)
+
+	// DBOperationDuration tracks database operation latency in milliseconds.
+	DBOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "db_operation_duration",
+			Help:      "Duration of database operations in milliseconds",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"operation", "entity"},
+	)
+
+	// DBOperationTotal counts database operations by outcome.
+	DBOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "db_operation_total",
+			Help:      "Total number of database operations",
+		},
+		[]string{"operation", "entity", "status"},
+	)
+
+	// CacheOperationTotal counts cache operations by result (hit/miss).
+	CacheOperationTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "cache_operation_total",
+			Help:      "Total number of cache operations",
+		},
+		[]string{"operation", "entity", "result"},
+	)
+
+	// EventPublishTotal counts published events by type.
+	EventPublishTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "event_publish_total",
+			Help:      "Total number of published events",
+		},
+		[]string{"type"},
+	)
+
+	// RPCCallDuration tracks cross-service RPC call latency in milliseconds.
+	RPCCallDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "rpc_call_duration",
+			Help:      "Duration of cross-service RPC calls in milliseconds",
+			Buckets:   []float64{50, 100, 500, 1000, 3000},
+		},
+		[]string{"service", "method"},
+	)
+
+	// RPCCallTotal counts cross-service RPC calls by outcome.
+	RPCCallTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "rpc_call_total",
+			Help:      "Total number of cross-service RPC calls",
+		},
+		[]string{"service", "method", "status"},
+	)
+
+	// LoginTotal counts agent login attempts by outcome.
+	LoginTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "login_total",
+			Help:      "Total number of agent login attempts",
+		},
+		[]string{"status"},
+	)
+
+	// PasswordResetTotal counts password reset attempts by outcome.
+	PasswordResetTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "password_reset_total",
+			Help:      "Total number of password reset attempts",
+		},
+		[]string{"status"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		ReceivedRequestProcessTime,
+		ReceivedSubscribeEventProcessTime,
+		DBOperationDuration,
+		DBOperationTotal,
+		CacheOperationTotal,
+		EventPublishTotal,
+		RPCCallDuration,
+		RPCCallTotal,
+		LoginTotal,
+		PasswordResetTotal,
+	)
+}


### PR DESCRIPTION
Add comprehensive Prometheus metrics instrumentation to the agent-manager service,
following the same pattern established in customer-manager.

- bin-agent-manager: Create centralized metricshandler package with 10 metric definitions
- bin-agent-manager: Move existing request/event process time metrics from listenhandler and subscribehandler to metricshandler
- bin-agent-manager: Add DB operation duration and count metrics with defer pattern for agent CRUD operations
- bin-agent-manager: Add cache hit/miss metrics for agent lookups in AgentGet
- bin-agent-manager: Add event publish counters for agent_created, agent_deleted, agent_updated, agent_status_updated
- bin-agent-manager: Add RPC call duration and count metrics for customer-manager, registrar-manager, email-manager
- bin-agent-manager: Add login attempt counter (success/failure)
- bin-agent-manager: Add password reset attempt counter (success/failure)