### PR TITLE
NOJIRA-Fix-alembic-migration-down-revision

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/e1f2a3b4c5d6_add_table_registrar_directs.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/e1f2a3b4c5d6_add_table_registrar_directs.py
@@ -1,7 +1,7 @@
 """add_table_registrar_directs
 
 Revision ID: e1f2a3b4c5d6
-Revises: d4e5f6a7b8c9
+Revises: fc1a2b3d4e5f
 Create Date: 2026-02-11 12:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'e1f2a3b4c5d6'
-down_revision = 'd4e5f6a7b8c9'
+down_revision = 'fc1a2b3d4e5f'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Fix Alembic multiple heads error by correcting down_revision in registrar_directs
migration from d4e5f6a7b8c9 to fc1a2b3d4e5f.

- bin-dbscheme-manager: Fix down_revision in e1f2a3b4c5d6_add_table_registrar_directs to chain after fc1a2b3d4e5f instead of d4e5f6a7b8c9