### PR TITLE
NOJIRA-Fix-duplicate-prometheus-metric-registration

### DIFF
--- a/bin-agent-manager/pkg/agenthandler/agent.go
+++ b/bin-agent-manager/pkg/agenthandler/agent.go
@@ -552,7 +552,6 @@ func (h *agentHandler) PasswordReset(ctx context.Context, token string, password
 		return nil
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return nil
 }

--- a/bin-agent-manager/pkg/agenthandler/db.go
+++ b/bin-agent-manager/pkg/agenthandler/db.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-agent-manager/models/agent"
-	"monorepo/bin-agent-manager/pkg/metricshandler"
 )
 
 // dbList returns agents
@@ -101,7 +100,6 @@ func (h *agentHandler) dbCreate(ctx context.Context, customerID uuid.UUID, usern
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentCreated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentCreated)).Inc()
 
 	log.WithField("agent", res).Debug("Created a new agent.")
 
@@ -127,7 +125,6 @@ func (h *agentHandler) dbDelete(ctx context.Context, id uuid.UUID) (*agent.Agent
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentDeleted, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentDeleted)).Inc()
 
 	return res, nil
 }
@@ -175,7 +172,6 @@ func (h *agentHandler) dbUpdateInfo(ctx context.Context, id uuid.UUID, name stri
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -205,7 +201,6 @@ func (h *agentHandler) dbUpdatePassword(ctx context.Context, id uuid.UUID, passw
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -230,7 +225,6 @@ func (h *agentHandler) dbUpdatePermission(ctx context.Context, id uuid.UUID, per
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -255,7 +249,6 @@ func (h *agentHandler) dbUpdateTagIDs(ctx context.Context, id uuid.UUID, tagIDs 
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -279,7 +272,6 @@ func (h *agentHandler) dbUpdateAddresses(ctx context.Context, id uuid.UUID, addr
 		return nil, err
 	}
 	h.notifyHandler.PublishEvent(ctx, agent.EventTypeAgentUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentUpdated)).Inc()
 
 	return res, nil
 }
@@ -304,7 +296,6 @@ func (h *agentHandler) dbUpdateStatus(ctx context.Context, id uuid.UUID, status 
 		return nil, err
 	}
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, agent.EventTypeAgentStatusUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(string(agent.EventTypeAgentStatusUpdated)).Inc()
 
 	return res, nil
 }

--- a/bin-agent-manager/pkg/metricshandler/main.go
+++ b/bin-agent-manager/pkg/metricshandler/main.go
@@ -60,16 +60,6 @@ var (
 		[]string{"operation", "entity", "result"},
 	)
 
-	// EventPublishTotal counts published events by type.
-	EventPublishTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Name:      "event_publish_total",
-			Help:      "Total number of published events",
-		},
-		[]string{"type"},
-	)
-
 	// RPCCallDuration tracks cross-service RPC call latency in milliseconds.
 	RPCCallDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -119,7 +109,6 @@ func init() {
 		DBOperationDuration,
 		DBOperationTotal,
 		CacheOperationTotal,
-		EventPublishTotal,
 		RPCCallDuration,
 		RPCCallTotal,
 		LoginTotal,

--- a/bin-customer-manager/pkg/accesskeyhandler/db.go
+++ b/bin-customer-manager/pkg/accesskeyhandler/db.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-customer-manager/models/accesskey"
-	"monorepo/bin-customer-manager/pkg/metricshandler"
 )
 
 // List returns list of accesskeys
@@ -122,7 +121,6 @@ func (h *accesskeyHandler) Create(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, accesskey.EventTypeAccesskeyCreated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(accesskey.EventTypeAccesskeyCreated).Inc()
 
 	return res, nil
 }
@@ -162,7 +160,6 @@ func (h *accesskeyHandler) Delete(ctx context.Context, id uuid.UUID) (*accesskey
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, accesskey.EventTypeAccesskeyDeleted, res)
-	metricshandler.EventPublishTotal.WithLabelValues(accesskey.EventTypeAccesskeyDeleted).Inc()
 
 	return res, nil
 }
@@ -199,7 +196,6 @@ func (h *accesskeyHandler) UpdateBasicInfo(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, accesskey.EventTypeAccesskeyUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(accesskey.EventTypeAccesskeyUpdated).Inc()
 
 	return res, nil
 }

--- a/bin-customer-manager/pkg/customerhandler/db.go
+++ b/bin-customer-manager/pkg/customerhandler/db.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-customer-manager/models/customer"
-	"monorepo/bin-customer-manager/pkg/metricshandler"
 )
 
 // List returns list of customers
@@ -98,7 +97,6 @@ func (h *customerHandler) Create(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerCreated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerCreated).Inc()
 
 	return res, nil
 }
@@ -126,7 +124,6 @@ func (h *customerHandler) dbDelete(ctx context.Context, id uuid.UUID) (*customer
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerDeleted, res)
-	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerDeleted).Inc()
 
 	return res, nil
 }
@@ -174,7 +171,6 @@ func (h *customerHandler) UpdateBasicInfo(
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerUpdated).Inc()
 
 	return res, nil
 }
@@ -205,7 +201,6 @@ func (h *customerHandler) UpdateBillingAccountID(ctx context.Context, id uuid.UU
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerUpdated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerUpdated).Inc()
 
 	return res, nil
 }

--- a/bin-customer-manager/pkg/customerhandler/signup.go
+++ b/bin-customer-manager/pkg/customerhandler/signup.go
@@ -165,7 +165,6 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 
 	// publish customer_created event — triggers default agent creation + welcome email
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerCreated, res)
-	metricshandler.EventPublishTotal.WithLabelValues(customer.EventTypeCustomerCreated).Inc()
 
 	metricshandler.EmailVerificationTotal.WithLabelValues("success").Inc()
 

--- a/bin-customer-manager/pkg/metricshandler/main.go
+++ b/bin-customer-manager/pkg/metricshandler/main.go
@@ -49,16 +49,6 @@ var (
 		[]string{"operation", "entity", "result"},
 	)
 
-	// EventPublishTotal counts published events by type.
-	EventPublishTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Name:      "event_publish_total",
-			Help:      "Total number of published events",
-		},
-		[]string{"type"},
-	)
-
 	// RPCCallDuration tracks cross-service RPC call latency in milliseconds.
 	RPCCallDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -107,7 +97,6 @@ func init() {
 		DBOperationDuration,
 		DBOperationTotal,
 		CacheOperationTotal,
-		EventPublishTotal,
 		RPCCallDuration,
 		RPCCallTotal,
 		SignupTotal,


### PR DESCRIPTION
Remove duplicate EventPublishTotal Prometheus metric from agent-manager and
customer-manager metricshandler packages. The metric conflicts with the shared
requesthandler in bin-common-handler which already registers event_publish_total
with different labels and help text, causing a panic at startup (CrashLoopBackOff
in production).

- bin-agent-manager: Remove EventPublishTotal definition and all usages in agenthandler
- bin-customer-manager: Remove EventPublishTotal definition and all usages in accesskeyhandler and customerhandler
- docs: Add Prometheus metric name conflict gotcha to CLAUDE.md to prevent recurrence