### PR TITLE
NOJIRA-Add-type-field-to-number-response

### DIFF
--- a/bin-number-manager/models/number/webhook.go
+++ b/bin-number-manager/models/number/webhook.go
@@ -14,6 +14,7 @@ type WebhookMessage struct {
 	commonidentity.Identity
 
 	Number string `json:"number"`
+	Type   Type   `json:"type"`
 
 	CallFlowID    uuid.UUID `json:"call_flow_id"`
 	MessageFlowID uuid.UUID `json:"message_flow_id"`
@@ -40,6 +41,7 @@ func (h *Number) ConvertWebhookMessage() *WebhookMessage {
 		Identity: h.Identity,
 
 		Number: h.Number,
+		Type:   h.Type,
 
 		CallFlowID:    h.CallFlowID,
 		MessageFlowID: h.MessageFlowID,


### PR DESCRIPTION
Add missing type field to number API response. The WebhookMessage struct
was not including the type field (normal/virtual), causing it to be
omitted from external API responses despite being defined in the OpenAPI spec.

- bin-number-manager: Add Type field to WebhookMessage struct
- bin-number-manager: Include Type in ConvertWebhookMessage conversion