### PR TITLE
NOJIRA-Add-flow-manager-metrics-and-grafana-dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,16 @@ Key points:
 - Shared MySQL database, Redis cache, RabbitMQ broker
 - Kubernetes deployment on GCP GKE
 
+## Grafana Dashboards
+
+**All Grafana dashboard JSON provisioning files MUST be placed in `monitoring/grafana/dashboards/`.**
+
+- File naming: `<service-name>.json` (e.g., `flow-manager.json`, `call-manager.json`)
+- One dashboard per service
+- Dashboards are importable JSON files (Grafana provisioning format)
+
+**Why:** Centralized location makes dashboards discoverable and maintainable as the number of services with dashboards grows.
+
 ## API Design Principles
 
 ### Atomic API Responses

--- a/bin-flow-manager/pkg/activeflowhandler/db.go
+++ b/bin-flow-manager/pkg/activeflowhandler/db.go
@@ -102,6 +102,10 @@ func (h *activeflowHandler) Create(
 
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, activeflow.EventTypeActiveflowCreated, res)
 
+	// metrics
+	promActiveflowCreatedTotal.WithLabelValues(string(referenceType)).Inc()
+	promActiveflowRunning.WithLabelValues(string(referenceType)).Inc()
+
 	return res, nil
 }
 

--- a/bin-flow-manager/pkg/activeflowhandler/main.go
+++ b/bin-flow-manager/pkg/activeflowhandler/main.go
@@ -123,10 +123,113 @@ var (
 		},
 		[]string{"type"},
 	)
+
+	promActiveflowCreatedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "activeflow_created_total",
+			Help:      "Total number of activeflows created",
+		},
+		[]string{"reference_type"},
+	)
+
+	promActiveflowEndedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "activeflow_ended_total",
+			Help:      "Total number of activeflows ended",
+		},
+		[]string{"reference_type"},
+	)
+
+	// promActiveflowRunning tracks in-process activeflows only.
+	// It resets to 0 on service restart and does not reflect database state.
+	promActiveflowRunning = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "activeflow_running",
+			Help:      "Number of currently running activeflows",
+		},
+		[]string{"reference_type"},
+	)
+
+	promActionExecutedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "action_executed_total",
+			Help:      "Total number of actions executed",
+		},
+		[]string{"type"},
+	)
+
+	// promActionErrorTotal tracks only fatal action errors that stop the flow.
+	// Non-critical actions (email_send, webhook_send, conversation_send, etc.)
+	// swallow errors and continue the flow, so they are not counted here.
+	promActionErrorTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "action_error_total",
+			Help:      "Total number of action execution errors that stopped the flow",
+		},
+		[]string{"type"},
+	)
+
+	promActiveflowDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "activeflow_duration_seconds",
+			Help:      "Total duration of activeflow from creation to end",
+			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 30, 60, 120, 300, 600},
+		},
+		[]string{"reference_type"},
+	)
+
+	promActionDispatchTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "action_dispatch_total",
+			Help:      "Total number of actions dispatched to external services",
+		},
+		[]string{"target", "type"},
+	)
+
+	promActiveflowExecuteIterations = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "activeflow_execute_iterations",
+			Help:      "Number of action iterations per execute loop",
+			Buckets:   []float64{1, 2, 5, 10, 20, 50, 100, 200, 500, 1000},
+		},
+		[]string{"reference_type"},
+	)
 )
+
+// actionDispatchTarget maps action types to the service they dispatch to.
+var actionDispatchTarget = map[action.Type]string{
+	action.TypeAISummary:          "ai-manager",
+	action.TypeAITalk:             "ai-manager",
+	action.TypeAITask:             "ai-manager",
+	action.TypeConferenceJoin:     "conference-manager",
+	action.TypeConnect:            "call-manager",
+	action.TypeConversationSend:   "conversation-manager",
+	action.TypeEmailSend:          "email-manager",
+	action.TypeMessageSend:        "message-manager",
+	action.TypeQueueJoin:          "queue-manager",
+	action.TypeTranscribeRecording: "transcribe-manager",
+	action.TypeTranscribeStart:    "transcribe-manager",
+	action.TypeWebhookSend:        "webhook-manager",
+}
 
 func init() {
 	prometheus.MustRegister(
 		promActionExecuteDuration,
+		promActiveflowCreatedTotal,
+		promActiveflowEndedTotal,
+		promActiveflowRunning,
+		promActionExecutedTotal,
+		promActionErrorTotal,
+		promActiveflowDurationSeconds,
+		promActionDispatchTotal,
+		promActiveflowExecuteIterations,
 	)
 }

--- a/bin-flow-manager/pkg/listenhandler/main.go
+++ b/bin-flow-manager/pkg/listenhandler/main.go
@@ -86,11 +86,21 @@ var (
 		},
 		[]string{"type", "method"},
 	)
+
+	promFlowCRUDTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "flow_crud_total",
+			Help:      "Total number of flow template CRUD operations",
+		},
+		[]string{"operation"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(
 		promReceivedRequestProcessTime,
+		promFlowCRUDTotal,
 	)
 }
 

--- a/bin-flow-manager/pkg/listenhandler/v1_flows.go
+++ b/bin-flow-manager/pkg/listenhandler/v1_flows.go
@@ -80,6 +80,7 @@ func (h *listenHandler) v1FlowsIDPut(ctx context.Context, m *sock.Request) (*soc
 		log.Errorf("Could not update the flow info. err: %v", err)
 		return nil, err
 	}
+	promFlowCRUDTotal.WithLabelValues("update").Inc()
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
@@ -116,6 +117,7 @@ func (h *listenHandler) v1FlowsIDDelete(ctx context.Context, m *sock.Request) (*
 	if err != nil {
 		return nil, err
 	}
+	promFlowCRUDTotal.WithLabelValues("delete").Inc()
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
@@ -161,6 +163,7 @@ func (h *listenHandler) v1FlowsPost(ctx context.Context, m *sock.Request) (*sock
 		log.Errorf("Could not create anew flow. err: %v", err)
 		return nil, err
 	}
+	promFlowCRUDTotal.WithLabelValues("create").Inc()
 
 	data, err := json.Marshal(tmp)
 	if err != nil {

--- a/docs/plans/2026-02-11-flow-manager-metrics-design.md
+++ b/docs/plans/2026-02-11-flow-manager-metrics-design.md
@@ -1,0 +1,180 @@
+# Flow Manager Metrics & Grafana Dashboard Design
+
+## Problem Statement
+
+Flow-manager currently has only 4 metrics (2 service-specific, 2 shared from bin-common-handler).
+These cover basic request/response timing but miss the flow execution engine, activeflow lifecycle,
+action throughput, error breakdown, and service dependency visibility. There is also no Grafana
+dashboard to visualize any of these.
+
+## Goals
+
+1. Add 9 new Prometheus metrics covering operational health and business insight
+2. Create a Grafana dashboard JSON provisioning file with 16 panels across 5 rows
+3. No customer_id labels (keep cardinality low)
+
+## Existing Metrics (4)
+
+| Metric | Type | Labels | Location |
+|--------|------|--------|----------|
+| `flow_manager_action_exeucte_duration` | Histogram | `type` | activeflowhandler/main.go |
+| `flow_manager_receive_request_process_time` | Histogram | `type`, `method` | listenhandler/main.go |
+| `flow_manager_request_process_time` (shared) | Histogram | `target`, `resource`, `method` | bin-common-handler requesthandler |
+| `flow_manager_event_publish_total` (shared) | Counter | `event_type` | bin-common-handler requesthandler |
+
+## New Metrics (9)
+
+### Operational Health
+
+| # | Metric Name | Type | Labels | Purpose | Instrumentation Point |
+|---|-------------|------|--------|---------|----------------------|
+| 1 | `activeflow_created_total` | Counter | `reference_type` | Track activeflow creation rate | `activeflowhandler.Create()` |
+| 2 | `activeflow_ended_total` | Counter | `reference_type` | Track activeflow termination rate | `activeflowhandler.Stop()` |
+| 3 | `activeflow_running` | Gauge | `reference_type` | Currently running activeflows | Inc in Create(), Dec in Stop() |
+| 4 | `action_executed_total` | Counter | `type` | Action throughput by type | `executeAction()` |
+| 5 | `action_error_total` | Counter | `type` | Fatal action errors that stop the flow | `executeAction()` on error |
+| 6 | `activeflow_duration_seconds` | Histogram | `reference_type` | Total activeflow lifetime | `activeflowhandler.Stop()` |
+
+### Business Insight
+
+| # | Metric Name | Type | Labels | Purpose | Instrumentation Point |
+|---|-------------|------|--------|---------|----------------------|
+| 7 | `action_dispatch_total` | Counter | `target`, `type` | Actions dispatched to external services | `executeAction()` for non-flow actions |
+| 8 | `activeflow_execute_iterations` | Histogram | `reference_type` | Actions per execute loop iteration | `ExecuteNextAction()` loop exit |
+| 9 | `flow_crud_total` | Counter | `operation` | Flow template CRUD ops | listenhandler CRUD endpoints |
+
+### Metric Details
+
+**Namespace:** `flow_manager` (all metrics)
+
+**Histogram Buckets:**
+- `activeflow_duration_seconds`: [0.1, 0.5, 1, 5, 10, 30, 60, 120, 300, 600] (100ms to 10min)
+- `activeflow_execute_iterations`: [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000]
+
+**`activeflow_ended_total`:** The `reason` label was dropped during implementation because
+all stop paths go through a single `Stop()` method, making it non-trivial to distinguish the cause
+without changing the interface. The `reference_type` label is sufficient for operational monitoring.
+
+**`action_error_total`:** Only tracks fatal errors that stop the flow. Non-critical actions
+(email_send, webhook_send, conversation_send, etc.) swallow errors and continue the flow,
+so they are not counted.
+
+**`flow_crud_total` operation values:**
+- `create`, `update`, `delete`
+
+### Collision Check
+
+None of these metric names conflict with the shared metrics from
+`bin-common-handler/pkg/requesthandler/main.go` (`request_process_time`, `event_publish_total`).
+
+## Implementation Plan
+
+### File Changes
+
+**1. `bin-flow-manager/pkg/activeflowhandler/main.go`** — Register new metrics
+
+Add metric variables alongside the existing `actionExecuteDuration`:
+- `activeflowCreatedTotal` (CounterVec)
+- `activeflowEndedTotal` (CounterVec)
+- `activeflowRunning` (GaugeVec)
+- `actionExecutedTotal` (CounterVec)
+- `actionErrorTotal` (CounterVec)
+- `activeflowDurationSeconds` (HistogramVec)
+- `actionDispatchTotal` (CounterVec)
+- `activeflowExecuteIterations` (HistogramVec)
+
+Register them in the `init()` function or alongside the existing `prometheus.MustRegister` calls.
+
+**2. `bin-flow-manager/pkg/activeflowhandler/activeflow.go`** — Instrument Create/Stop
+
+In `Create()`:
+- Increment `activeflowCreatedTotal` with reference_type label
+- Increment `activeflowRunning` gauge
+
+In `Stop()`:
+- Increment `activeflowEndedTotal` with reference_type and reason labels
+- Decrement `activeflowRunning` gauge
+- Observe `activeflowDurationSeconds` (compute from TMCreate to now)
+
+**3. `bin-flow-manager/pkg/activeflowhandler/execute.go`** — Instrument execution loop
+
+In `executeAction()`:
+- Increment `actionExecutedTotal` with type label
+- On error: increment `actionErrorTotal` with type label
+- For non-flow actions (dispatched to other services): increment `actionDispatchTotal` with target and type labels
+
+In `ExecuteNextAction()`:
+- Count loop iterations, observe `activeflowExecuteIterations` at loop exit
+
+**4. `bin-flow-manager/pkg/listenhandler/` (v1_flow*.go files)** — Instrument CRUD
+
+In flow create/update/delete handlers:
+- Increment `flowCRUDTotal` with operation label
+
+Register `flowCRUDTotal` metric in `listenhandler/main.go`.
+
+**5. `monitoring/grafana/dashboards/flow-manager.json`** — Grafana dashboard
+
+New file with the dashboard JSON provisioning definition. This establishes the standard
+location for all Grafana dashboards in the monorepo: `monitoring/grafana/dashboards/<service-name>.json`.
+
+### Grafana Dashboard Layout
+
+**Dashboard Title:** "Flow Manager"
+**Refresh:** 30s
+**Time Range:** Last 1 hour
+
+#### Row 1 — Overview (4 stat panels)
+
+| Panel | Type | Query |
+|-------|------|-------|
+| Active Flows | Stat | `sum(flow_manager_activeflow_running)` |
+| Activeflows Created/min | Stat | `sum(rate(flow_manager_activeflow_created_total[5m])) * 60` |
+| Actions Executed/min | Stat | `sum(rate(flow_manager_action_executed_total[5m])) * 60` |
+| Action Error Rate % | Stat | `sum(rate(flow_manager_action_error_total[5m])) / sum(rate(flow_manager_action_executed_total[5m])) * 100` |
+
+#### Row 2 — Activeflow Lifecycle (3 panels)
+
+| Panel | Type | Query |
+|-------|------|-------|
+| Activeflows Created (by ref type) | Time Series | `sum by (reference_type) (rate(flow_manager_activeflow_created_total[5m]))` |
+| Activeflows Ended (by ref type) | Time Series | `sum by (reference_type) (rate(flow_manager_activeflow_ended_total[5m]))` |
+| Activeflow Duration (p50/p95/p99) | Time Series | `histogram_quantile(0.5/0.95/0.99, sum by (le) (rate(flow_manager_activeflow_duration_seconds_bucket[5m])))` |
+
+#### Row 3 — Action Performance (3 panels)
+
+| Panel | Type | Query |
+|-------|------|-------|
+| Action Execution Rate (by type) | Time Series | `sum by (type) (rate(flow_manager_action_executed_total[5m]))` |
+| Action Duration p95 (by type) | Time Series | `histogram_quantile(0.95, sum by (le, type) (rate(flow_manager_action_exeucte_duration_bucket[5m])))` |
+| Action Errors (by type) | Time Series | `sum by (type) (rate(flow_manager_action_error_total[5m]))` |
+
+#### Row 4 — Service Dependencies (3 panels)
+
+| Panel | Type | Query |
+|-------|------|-------|
+| Dispatches to External Services | Time Series | `sum by (target) (rate(flow_manager_action_dispatch_total[5m]))` |
+| Outbound RPC Latency p95 | Time Series | `histogram_quantile(0.95, sum by (le, target) (rate(flow_manager_request_process_time_bucket[5m])))` |
+| Execute Loop Iterations (p50/p95) | Time Series | `histogram_quantile(0.5/0.95, sum by (le) (rate(flow_manager_activeflow_execute_iterations_bucket[5m])))` |
+
+#### Row 5 — API & Flow Templates (3 panels)
+
+| Panel | Type | Query |
+|-------|------|-------|
+| Request Processing Time p95 | Time Series | `histogram_quantile(0.95, sum by (le, type) (rate(flow_manager_receive_request_process_time_bucket[5m])))` |
+| Flow CRUD Operations | Time Series | `sum by (operation) (rate(flow_manager_flow_crud_total[5m]))` |
+| Events Published | Time Series | `sum by (event_type) (rate(flow_manager_event_publish_total[5m]))` |
+
+## Testing
+
+- Unit tests for metric registration (verify no panics on duplicate registration)
+- Verify metrics appear on `/metrics` endpoint after service startup
+- Run `go test ./...` and `golangci-lint run -v --timeout 5m` for bin-flow-manager
+
+## Risks / Notes
+
+- The existing metric `action_exeucte_duration` has a typo ("exeucte" instead of "execute").
+  We will NOT rename it to avoid breaking existing dashboards/alerts. New metrics use correct spelling.
+- The `activeflow_running` gauge may drift if the service restarts with activeflows still in the database.
+  This is acceptable — the gauge tracks in-process activeflows, not database state.
+- All new metric names are verified to not conflict with bin-common-handler shared metrics.

--- a/monitoring/grafana/dashboards/flow-manager.json
+++ b/monitoring/grafana/dashboards/flow-manager.json
@@ -1,0 +1,1312 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(flow_manager_activeflow_running)",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Flows",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(flow_manager_activeflow_created_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "Activeflows Created/min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(flow_manager_action_executed_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "Actions Executed/min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(flow_manager_action_error_total[5m])) / sum(rate(flow_manager_action_executed_total[5m])) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Action Error Rate %",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Activeflow Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (reference_type) (rate(flow_manager_activeflow_created_total[5m]))",
+          "legendFormat": "{{reference_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Activeflows Created",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (reference_type) (rate(flow_manager_activeflow_ended_total[5m]))",
+          "legendFormat": "{{reference_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Activeflows Ended",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(flow_manager_activeflow_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(flow_manager_activeflow_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(flow_manager_activeflow_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Activeflow Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Action Performance",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (type) (rate(flow_manager_action_executed_total[5m]))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Action Execution Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(flow_manager_action_exeucte_duration_bucket[5m])))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Action Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (type) (rate(flow_manager_action_error_total[5m]))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Action Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Service Dependencies",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (target) (rate(flow_manager_action_dispatch_total[5m]))",
+          "legendFormat": "{{target}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Dispatches to External Services",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, target) (rate(flow_manager_request_process_time_bucket[5m])))",
+          "legendFormat": "{{target}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Outbound RPC Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(flow_manager_activeflow_execute_iterations_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(flow_manager_activeflow_execute_iterations_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "Execute Loop Iterations",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 18,
+      "panels": [],
+      "title": "API & Flow Templates",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(flow_manager_receive_request_process_time_bucket[5m])))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Processing Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (operation) (rate(flow_manager_flow_crud_total[5m]))",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Flow CRUD Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (event_type) (rate(flow_manager_event_publish_total[5m]))",
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Published",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "flow-manager",
+    "voipbin"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Flow Manager",
+  "uid": "flow-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add 9 new Prometheus metrics and a Grafana dashboard for flow-manager
to provide operational health and business insight observability.

- bin-flow-manager: Add activeflow lifecycle metrics (created, ended, running gauge, duration)
- bin-flow-manager: Add action execution metrics (executed total, error total, dispatch total)
- bin-flow-manager: Add activeflow execute iterations histogram for loop depth tracking
- bin-flow-manager: Add flow CRUD operations counter in listenhandler
- bin-flow-manager: Instrument Create(), Stop(), executeAction(), ExecuteNextAction()
- monitoring: Add Grafana dashboard JSON provisioning file with 16 panels across 5 rows
- monitoring: Establish monitoring/grafana/dashboards/ as standard dashboard location
- docs: Add design document for flow-manager metrics
- docs: Add Grafana dashboards convention to root CLAUDE.md