### PR TITLE
NOJIRA-Add-tts-manager-metrics-and-grafana-dashboard

### DIFF
--- a/bin-tts-manager/models/streaming/streaming.go
+++ b/bin-tts-manager/models/streaming/streaming.go
@@ -1,9 +1,11 @@
 package streaming
 
 import (
-	commonidentity "monorepo/bin-common-handler/models/identity"
 	"net"
 	"sync"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
 
 	"github.com/gofrs/uuid"
 )
@@ -27,7 +29,8 @@ type Streaming struct {
 	VendorName   VendorName `json:"-"` // Vendor of the service (e.g., gcp, aws)
 	VendorConfig any        `json:"-"`
 
-	ConnAst net.Conn `json:"-"` // Connection to the Asterisk for the streaming
+	ConnAst   net.Conn  `json:"-"` // Connection to the Asterisk for the streaming
+	CreatedAt time.Time `json:"-"` // Timestamp of when the streaming was created (for metrics)
 }
 
 // // Direction represents the direction of the streaming in a call.

--- a/bin-tts-manager/pkg/streaminghandler/say.go
+++ b/bin-tts-manager/pkg/streaminghandler/say.go
@@ -17,6 +17,8 @@ func (h *streamingHandler) SayInit(ctx context.Context, id uuid.UUID, messageID 
 		"streaming_id": id,
 	})
 
+	promStreamingMessageTotal.Inc()
+
 	res, err := h.UpdateMessageID(ctx, id, messageID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not update message ID. streaming_id: %s, message_id: %s", id, messageID)

--- a/bin-tts-manager/pkg/streaminghandler/start.go
+++ b/bin-tts-manager/pkg/streaminghandler/start.go
@@ -57,6 +57,7 @@ func (h *streamingHandler) Start(
 	)
 	if err != nil {
 		log.Errorf("Could not create external media. err: %v", err)
+		promStreamingErrorTotal.WithLabelValues("unknown").Inc()
 		return nil, err
 	}
 	log.WithField("external_media", em).Debugf("Started external media. external_media_id: %s, host_addr: %s, media_ip: %s, media_port: %d", em.ID, h.listenAddress, em.LocalIP, em.LocalPort)

--- a/bin-tts-manager/pkg/streaminghandler/streaming_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/streaming_test.go
@@ -93,7 +93,7 @@ func Test_Create(t *testing.T) {
 				t.Errorf("Wrong match. expected: ok, got: %v", err)
 			}
 
-			mockNotify.EXPECT().PublishEvent(ctx, streaming.EventTypeStreamingDeleted, tt.expectRes)
+			mockNotify.EXPECT().PublishEvent(ctx, streaming.EventTypeStreamingDeleted, gomock.Any())
 			h.Delete(ctx, tt.responseID)
 			resDelete, err := h.Get(ctx, tt.responseID)
 			if err == nil {

--- a/bin-tts-manager/pkg/ttshandler/main.go
+++ b/bin-tts-manager/pkg/ttshandler/main.go
@@ -43,11 +43,45 @@ var (
 		},
 		[]string{},
 	)
+
+	// speech_request_total counts batch TTS requests by result (cache_hit, created, error).
+	promSpeechRequestTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "speech_request_total",
+			Help:      "Total number of batch TTS speech requests by result.",
+		},
+		[]string{"result"},
+	)
+
+	// speech_create_duration_seconds measures end-to-end audio creation latency (cache misses only).
+	promSpeechCreateDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "speech_create_duration_seconds",
+			Help:      "Duration of batch TTS audio creation in seconds (cache misses only).",
+			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{},
+	)
+
+	// speech_language_total counts batch TTS requests by language and gender.
+	promSpeechLanguageTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "speech_language_total",
+			Help:      "Total number of batch TTS requests by language and gender.",
+		},
+		[]string{"language", "gender"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(
 		promHashProcessTime,
+		promSpeechRequestTotal,
+		promSpeechCreateDurationSeconds,
+		promSpeechLanguageTotal,
 	)
 }
 

--- a/docs/plans/2026-02-11-tts-manager-metrics-design.md
+++ b/docs/plans/2026-02-11-tts-manager-metrics-design.md
@@ -1,0 +1,68 @@
+# TTS Manager Metrics and Grafana Dashboard Design
+
+## Problem Statement
+
+The tts-manager service handles two modes of text-to-speech: batch TTS (GCP/AWS with file caching) and real-time streaming (ElevenLabs WebSocket). Currently, it has only basic infrastructure metrics (`hash_process_time`, `receive_request_process_time`) and no visibility into speech synthesis performance, streaming session lifecycle, or cache effectiveness.
+
+## Approach
+
+Add 10 new Prometheus metrics covering both batch TTS and streaming operations, plus a Grafana dashboard for visualization. Same approach as the flow-manager metrics work: operational health + business insight, no customer_id labels, JSON provisioning file.
+
+## Metrics
+
+### Batch TTS (ttshandler)
+
+| Metric | Type | Labels | Location |
+|--------|------|--------|----------|
+| `speech_request_total` | Counter | `result` (cache_hit/created/error) | ttshandler/tts.go Create() |
+| `speech_create_duration_seconds` | Histogram | none | ttshandler/tts.go Create() (cache misses only) |
+| `speech_language_total` | Counter | `language`, `gender` | ttshandler/tts.go Create() |
+
+### Streaming (streaminghandler)
+
+| Metric | Type | Labels | Location |
+|--------|------|--------|----------|
+| `streaming_created_total` | Counter | `vendor` | streaminghandler/streaming.go Create() |
+| `streaming_ended_total` | Counter | `vendor` | streaminghandler/streaming.go Delete() |
+| `streaming_active` | Gauge | `vendor` | streaminghandler/streaming.go Create()/Delete() |
+| `streaming_duration_seconds` | Histogram | `vendor` | streaminghandler/streaming.go Delete() |
+| `streaming_message_total` | Counter | none | streaminghandler/say.go SayInit() |
+| `streaming_error_total` | Counter | `vendor` | streaminghandler/stop.go Stop(), start.go Start() |
+| `streaming_language_total` | Counter | `language`, `gender` | streaminghandler/streaming.go Create() |
+
+### Notes
+
+- `streaming_active` gauge resets to 0 on service restart and does not reflect persistent state.
+- `streaming_created_total` uses `vendor=unknown` at creation time because the vendor is not yet determined until the streamer is initialized.
+- `speech_create_duration_seconds` only measures cache misses (actual audio creation latency).
+- Added `CreatedAt` field to the `streaming.Streaming` model to track session duration.
+
+## Grafana Dashboard
+
+Location: `monitoring/grafana/dashboards/tts-manager.json`
+
+### Layout: 4 rows, 13 panels
+
+| Row | Title | Panels |
+|-----|-------|--------|
+| 1 | Overview | Active Streams, Speech Requests/min, Cache Hit Rate %, Streaming Errors/min |
+| 2 | Batch TTS | Speech Requests by Result, Speech Create Duration p95, Language Usage |
+| 3 | Streaming Sessions | Sessions Created, Duration p50/p95, Errors |
+| 4 | Throughput & API | Messages/min, Request Processing Time p95, Events Published |
+
+### Existing metrics reused in dashboard
+- `tts_manager_receive_request_process_time` (from listenhandler)
+- `tts_manager_event_publish_total` (from requesthandler/bin-common-handler)
+
+## Files Changed
+
+- `bin-tts-manager/models/streaming/streaming.go` — Added `CreatedAt` field
+- `bin-tts-manager/pkg/ttshandler/main.go` — Registered 3 new metrics
+- `bin-tts-manager/pkg/ttshandler/tts.go` — Instrumented Create()
+- `bin-tts-manager/pkg/streaminghandler/main.go` — Registered 7 new metrics
+- `bin-tts-manager/pkg/streaminghandler/streaming.go` — Instrumented Create() and Delete()
+- `bin-tts-manager/pkg/streaminghandler/start.go` — Instrumented Start() error path
+- `bin-tts-manager/pkg/streaminghandler/stop.go` — Instrumented Stop() with error tracking
+- `bin-tts-manager/pkg/streaminghandler/say.go` — Instrumented SayInit()
+- `bin-tts-manager/pkg/streaminghandler/streaming_test.go` — Updated test for dynamic CreatedAt
+- `monitoring/grafana/dashboards/tts-manager.json` — New Grafana dashboard

--- a/monitoring/grafana/dashboards/tts-manager.json
+++ b/monitoring/grafana/dashboards/tts-manager.json
@@ -1,0 +1,1063 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(tts_manager_streaming_active)",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Streams",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(tts_manager_speech_request_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "Speech Requests/min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(tts_manager_speech_request_total{result=\"cache_hit\"}[5m])) / sum(rate(tts_manager_speech_request_total[5m])) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate %",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(tts_manager_streaming_error_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "Streaming Errors/min",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Batch TTS",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(tts_manager_speech_request_total[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Speech Requests by Result",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tts_manager_speech_create_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Speech Create Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (language, gender) (rate(tts_manager_speech_language_total[5m]))",
+          "legendFormat": "{{language}} ({{gender}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Language Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Streaming Sessions",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (vendor) (rate(tts_manager_streaming_created_total[5m]))",
+          "legendFormat": "{{vendor}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Streaming Sessions Created",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(tts_manager_streaming_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(tts_manager_streaming_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "Streaming Duration p50/p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (vendor) (rate(tts_manager_streaming_error_total[5m]))",
+          "legendFormat": "{{vendor}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Streaming Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Throughput and API",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(tts_manager_streaming_message_total[5m])) * 60",
+          "legendFormat": "messages/min",
+          "refId": "A"
+        }
+      ],
+      "title": "Messages/min",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(tts_manager_receive_request_process_time_bucket[5m])))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Processing Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (event_type) (rate(tts_manager_event_publish_total[5m]))",
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Published",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "tts-manager",
+    "voipbin"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "TTS Manager",
+  "uid": "tts-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add 10 new Prometheus metrics and a Grafana dashboard for the tts-manager
service covering both batch TTS and real-time streaming operations.

- bin-tts-manager: Add 3 batch TTS metrics (speech_request_total, speech_create_duration_seconds, speech_language_total)
- bin-tts-manager: Add 7 streaming metrics (streaming_created_total, streaming_ended_total, streaming_active, streaming_duration_seconds, streaming_message_total, streaming_error_total, streaming_language_total)
- bin-tts-manager: Add CreatedAt field to streaming model for duration tracking
- bin-tts-manager: Instrument ttshandler Create() with cache hit/miss/error tracking
- bin-tts-manager: Instrument streaminghandler Create/Delete/Stop/SayInit with metrics
- bin-tts-manager: Update streaming test for dynamic CreatedAt field
- monitoring: Add tts-manager Grafana dashboard with 4 rows and 13 panels
- docs: Add tts-manager metrics design document