### PR TITLE
NOJIRA-Fix-extension-update-direct-fields

### DIFF
--- a/bin-api-manager/pkg/servicehandler/extension.go
+++ b/bin-api-manager/pkg/servicehandler/extension.go
@@ -162,7 +162,7 @@ func (h *serviceHandler) ExtensionList(ctx context.Context, a *amagent.Agent, si
 
 // ExtesnionUpdate updates the extension info.
 // It returns updated extension if it succeed.
-func (h *serviceHandler) ExtensionUpdate(ctx context.Context, a *amagent.Agent, id uuid.UUID, name, detail, password string) (*rmextension.WebhookMessage, error) {
+func (h *serviceHandler) ExtensionUpdate(ctx context.Context, a *amagent.Agent, id uuid.UUID, name, detail, password string, direct *bool, directRegenerate *bool) (*rmextension.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":         "ExtensionUpdate",
 		"customer_id":  a.CustomerID,
@@ -181,7 +181,7 @@ func (h *serviceHandler) ExtensionUpdate(ctx context.Context, a *amagent.Agent, 
 		return nil, fmt.Errorf("user has no permission")
 	}
 
-	tmp, err := h.reqHandler.RegistrarV1ExtensionUpdate(ctx, id, name, detail, password)
+	tmp, err := h.reqHandler.RegistrarV1ExtensionUpdate(ctx, id, name, detail, password, direct, directRegenerate)
 	if err != nil {
 		logrus.Errorf("Could not update the domain. err: %v", err)
 		return nil, err

--- a/bin-api-manager/pkg/servicehandler/extension_test.go
+++ b/bin-api-manager/pkg/servicehandler/extension_test.go
@@ -92,16 +92,22 @@ func Test_ExtensionCreate(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func Test_ExtensionUpdate(t *testing.T) {
 
 	type test struct {
 		name  string
 		agent *amagent.Agent
 
-		id       uuid.UUID
-		extName  string
-		detail   string
-		password string
+		id               uuid.UUID
+		extName          string
+		detail           string
+		password         string
+		direct           *bool
+		directRegenerate *bool
 
 		responseExtension *rmextension.Extension
 		expectRes         *rmextension.WebhookMessage
@@ -122,6 +128,8 @@ func Test_ExtensionUpdate(t *testing.T) {
 			"update name",
 			"update detail",
 			"update password",
+			nil,
+			nil,
 
 			&rmextension.Extension{
 				Identity: commonidentity.Identity{
@@ -145,7 +153,176 @@ func Test_ExtensionUpdate(t *testing.T) {
 				Extension: "test",
 				Password:  "update password",
 				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
-				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z")},
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+		},
+		{
+			"with direct true",
+			&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+
+			uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+			"update name",
+			"update detail",
+			"update password",
+			boolPtr(true),
+			nil,
+
+			&rmextension.Extension{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+			&rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+		},
+		{
+			"with direct false",
+			&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+
+			uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+			"update name",
+			"update detail",
+			"update password",
+			boolPtr(false),
+			nil,
+
+			&rmextension.Extension{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+			&rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+		},
+		{
+			"with direct_regenerate",
+			&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+
+			uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+			"update name",
+			"update detail",
+			"update password",
+			nil,
+			boolPtr(true),
+
+			&rmextension.Extension{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+			&rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+		},
+		{
+			"with all optional fields",
+			&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+
+			uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+			"update name",
+			"update detail",
+			"update password",
+			boolPtr(true),
+			boolPtr(true),
+
+			&rmextension.Extension{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
+			&rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50c1e4ca-6fa5-11eb-8a12-67425d88ba43"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Name:      "update name",
+				Detail:    "update detail",
+				Extension: "test",
+				Password:  "update password",
+				TMCreate:  timePtr("2020-09-20T03:23:20.995000Z"),
+				TMUpdate:  timePtr("2020-09-20T03:23:23.995000Z"),
+			},
 		},
 	}
 
@@ -164,8 +341,8 @@ func Test_ExtensionUpdate(t *testing.T) {
 			ctx := context.Background()
 
 			mockReq.EXPECT().RegistrarV1ExtensionGet(ctx, tt.id).Return(tt.responseExtension, nil)
-			mockReq.EXPECT().RegistrarV1ExtensionUpdate(ctx, tt.id, tt.extName, tt.detail, tt.password).Return(tt.responseExtension, nil)
-			res, err := h.ExtensionUpdate(ctx, tt.agent, tt.id, tt.extName, tt.detail, tt.password)
+			mockReq.EXPECT().RegistrarV1ExtensionUpdate(ctx, tt.id, tt.extName, tt.detail, tt.password, tt.direct, tt.directRegenerate).Return(tt.responseExtension, nil)
+			res, err := h.ExtensionUpdate(ctx, tt.agent, tt.id, tt.extName, tt.detail, tt.password, tt.direct, tt.directRegenerate)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -479,7 +479,7 @@ type ServiceHandler interface {
 	ExtensionDelete(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*rmextension.WebhookMessage, error)
 	ExtensionGet(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*rmextension.WebhookMessage, error)
 	ExtensionList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmextension.WebhookMessage, error)
-	ExtensionUpdate(ctx context.Context, a *amagent.Agent, id uuid.UUID, name, detail, password string) (*rmextension.WebhookMessage, error)
+	ExtensionUpdate(ctx context.Context, a *amagent.Agent, id uuid.UUID, name, detail, password string, direct *bool, directRegenerate *bool) (*rmextension.WebhookMessage, error)
 
 	// email handlers
 	EmailSend(

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -2124,18 +2124,18 @@ func (mr *MockServiceHandlerMockRecorder) ExtensionList(ctx, a, size, token any)
 }
 
 // ExtensionUpdate mocks base method.
-func (m *MockServiceHandler) ExtensionUpdate(ctx context.Context, a *agent.Agent, id uuid.UUID, name, detail, password string) (*extension.WebhookMessage, error) {
+func (m *MockServiceHandler) ExtensionUpdate(ctx context.Context, a *agent.Agent, id uuid.UUID, name, detail, password string, direct, directRegenerate *bool) (*extension.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtensionUpdate", ctx, a, id, name, detail, password)
+	ret := m.ctrl.Call(m, "ExtensionUpdate", ctx, a, id, name, detail, password, direct, directRegenerate)
 	ret0, _ := ret[0].(*extension.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExtensionUpdate indicates an expected call of ExtensionUpdate.
-func (mr *MockServiceHandlerMockRecorder) ExtensionUpdate(ctx, a, id, name, detail, password any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ExtensionUpdate(ctx, a, id, name, detail, password, direct, directRegenerate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtensionUpdate", reflect.TypeOf((*MockServiceHandler)(nil).ExtensionUpdate), ctx, a, id, name, detail, password)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtensionUpdate", reflect.TypeOf((*MockServiceHandler)(nil).ExtensionUpdate), ctx, a, id, name, detail, password, direct, directRegenerate)
 }
 
 // FlowCreate mocks base method.

--- a/bin-api-manager/server/extensions.go
+++ b/bin-api-manager/server/extensions.go
@@ -157,7 +157,7 @@ func (h *server) PutExtensionsId(c *gin.Context, id string) {
 		return
 	}
 
-	res, err := h.serviceHandler.ExtensionUpdate(c.Request.Context(), &a, target, req.Name, req.Detail, req.Password)
+	res, err := h.serviceHandler.ExtensionUpdate(c.Request.Context(), &a, target, req.Name, req.Detail, req.Password, req.Direct, req.DirectRegenerate)
 	if err != nil {
 		log.Errorf("Could not update the extension. err: %v", err)
 		c.AbortWithStatus(400)

--- a/bin-api-manager/server/extensions_test.go
+++ b/bin-api-manager/server/extensions_test.go
@@ -242,6 +242,10 @@ func Test_ExtensionsIDGET(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func TestExtensionsIDPUT(t *testing.T) {
 
 	type test struct {
@@ -253,11 +257,13 @@ func TestExtensionsIDPUT(t *testing.T) {
 
 		responseExtension *rmextension.WebhookMessage
 
-		extensionID    uuid.UUID
-		expectName     string
-		expectDetail   string
-		expectPassword string
-		expectRes      string
+		extensionID            uuid.UUID
+		expectName             string
+		expectDetail           string
+		expectPassword         string
+		expectDirect           *bool
+		expectDirectRegenerate *bool
+		expectRes              string
 	}
 
 	tests := []test{
@@ -278,11 +284,113 @@ func TestExtensionsIDPUT(t *testing.T) {
 				},
 			},
 
-			extensionID:    uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
-			expectName:     "test name",
-			expectDetail:   "test detail",
-			expectPassword: "update password",
-			expectRes:      `{"id":"67492c7a-6fb0-11eb-8b3f-d7eb268910df","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","extension":"","domain_name":"","username":"","password":"","direct_hash":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+			extensionID:            uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+			expectName:             "test name",
+			expectDetail:           "test detail",
+			expectPassword:         "update password",
+			expectDirect:           nil,
+			expectDirectRegenerate: nil,
+			expectRes:              `{"id":"67492c7a-6fb0-11eb-8b3f-d7eb268910df","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","extension":"","domain_name":"","username":"","password":"","direct_hash":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			name: "with direct true",
+			agent: amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			},
+
+			reqQuery: "/extensions/67492c7a-6fb0-11eb-8b3f-d7eb268910df",
+			reqBody:  []byte(`{"name":"test name","detail":"test detail","password":"update password","direct":true}`),
+
+			responseExtension: &rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+				},
+			},
+
+			extensionID:            uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+			expectName:             "test name",
+			expectDetail:           "test detail",
+			expectPassword:         "update password",
+			expectDirect:           boolPtr(true),
+			expectDirectRegenerate: nil,
+			expectRes:              `{"id":"67492c7a-6fb0-11eb-8b3f-d7eb268910df","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","extension":"","domain_name":"","username":"","password":"","direct_hash":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			name: "with direct false",
+			agent: amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			},
+
+			reqQuery: "/extensions/67492c7a-6fb0-11eb-8b3f-d7eb268910df",
+			reqBody:  []byte(`{"name":"test name","detail":"test detail","password":"update password","direct":false}`),
+
+			responseExtension: &rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+				},
+			},
+
+			extensionID:            uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+			expectName:             "test name",
+			expectDetail:           "test detail",
+			expectPassword:         "update password",
+			expectDirect:           boolPtr(false),
+			expectDirectRegenerate: nil,
+			expectRes:              `{"id":"67492c7a-6fb0-11eb-8b3f-d7eb268910df","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","extension":"","domain_name":"","username":"","password":"","direct_hash":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			name: "with direct_regenerate",
+			agent: amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			},
+
+			reqQuery: "/extensions/67492c7a-6fb0-11eb-8b3f-d7eb268910df",
+			reqBody:  []byte(`{"name":"test name","detail":"test detail","password":"update password","direct_regenerate":true}`),
+
+			responseExtension: &rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+				},
+			},
+
+			extensionID:            uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+			expectName:             "test name",
+			expectDetail:           "test detail",
+			expectPassword:         "update password",
+			expectDirect:           nil,
+			expectDirectRegenerate: boolPtr(true),
+			expectRes:              `{"id":"67492c7a-6fb0-11eb-8b3f-d7eb268910df","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","extension":"","domain_name":"","username":"","password":"","direct_hash":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			name: "with all fields",
+			agent: amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			},
+
+			reqQuery: "/extensions/67492c7a-6fb0-11eb-8b3f-d7eb268910df",
+			reqBody:  []byte(`{"name":"test name","detail":"test detail","password":"update password","direct":true,"direct_regenerate":true}`),
+
+			responseExtension: &rmextension.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+				},
+			},
+
+			extensionID:            uuid.FromStringOrNil("67492c7a-6fb0-11eb-8b3f-d7eb268910df"),
+			expectName:             "test name",
+			expectDetail:           "test detail",
+			expectPassword:         "update password",
+			expectDirect:           boolPtr(true),
+			expectDirectRegenerate: boolPtr(true),
+			expectRes:              `{"id":"67492c7a-6fb0-11eb-8b3f-d7eb268910df","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","extension":"","domain_name":"","username":"","password":"","direct_hash":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -308,7 +416,7 @@ func TestExtensionsIDPUT(t *testing.T) {
 			req, _ := http.NewRequest("PUT", "/extensions/"+tt.extensionID.String(), bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().ExtensionUpdate(req.Context(), &tt.agent, tt.extensionID, tt.expectName, tt.expectDetail, tt.expectPassword).Return(tt.responseExtension, nil)
+			mockSvc.EXPECT().ExtensionUpdate(req.Context(), &tt.agent, tt.extensionID, tt.expectName, tt.expectDetail, tt.expectPassword, tt.expectDirect, tt.expectDirectRegenerate).Return(tt.responseExtension, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -1077,7 +1077,7 @@ type RequestHandler interface {
 	RegistrarV1ExtensionDelete(ctx context.Context, extensionID uuid.UUID) (*rmextension.Extension, error)
 	RegistrarV1ExtensionGet(ctx context.Context, extensionID uuid.UUID) (*rmextension.Extension, error)
 	RegistrarV1ExtensionList(ctx context.Context, pageToken string, pageSize uint64, filters map[rmextension.Field]any) ([]rmextension.Extension, error)
-	RegistrarV1ExtensionUpdate(ctx context.Context, id uuid.UUID, name, detail, password string) (*rmextension.Extension, error)
+	RegistrarV1ExtensionUpdate(ctx context.Context, id uuid.UUID, name, detail, password string, direct *bool, directRegenerate *bool) (*rmextension.Extension, error)
 	RegistrarV1ExtensionCountByCustomerID(ctx context.Context, customerID uuid.UUID) (int, error)
 	RegistrarV1ExtensionGetByDirectHash(ctx context.Context, hash string) (*rmextension.Extension, error)
 

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -4976,18 +4976,18 @@ func (mr *MockRequestHandlerMockRecorder) RegistrarV1ExtensionList(ctx, pageToke
 }
 
 // RegistrarV1ExtensionUpdate mocks base method.
-func (m *MockRequestHandler) RegistrarV1ExtensionUpdate(ctx context.Context, id uuid.UUID, name, detail, password string) (*extension.Extension, error) {
+func (m *MockRequestHandler) RegistrarV1ExtensionUpdate(ctx context.Context, id uuid.UUID, name, detail, password string, direct, directRegenerate *bool) (*extension.Extension, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegistrarV1ExtensionUpdate", ctx, id, name, detail, password)
+	ret := m.ctrl.Call(m, "RegistrarV1ExtensionUpdate", ctx, id, name, detail, password, direct, directRegenerate)
 	ret0, _ := ret[0].(*extension.Extension)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RegistrarV1ExtensionUpdate indicates an expected call of RegistrarV1ExtensionUpdate.
-func (mr *MockRequestHandlerMockRecorder) RegistrarV1ExtensionUpdate(ctx, id, name, detail, password any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) RegistrarV1ExtensionUpdate(ctx, id, name, detail, password, direct, directRegenerate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistrarV1ExtensionUpdate", reflect.TypeOf((*MockRequestHandler)(nil).RegistrarV1ExtensionUpdate), ctx, id, name, detail, password)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegistrarV1ExtensionUpdate", reflect.TypeOf((*MockRequestHandler)(nil).RegistrarV1ExtensionUpdate), ctx, id, name, detail, password, direct, directRegenerate)
 }
 
 // RegistrarV1TrunkCountByCustomerID mocks base method.

--- a/bin-common-handler/pkg/requesthandler/registrar_extensions.go
+++ b/bin-common-handler/pkg/requesthandler/registrar_extensions.go
@@ -95,13 +95,15 @@ func (r *requestHandler) RegistrarV1ExtensionDelete(ctx context.Context, extensi
 // RegistrarV1ExtensionUpdate sends a request to registrar-manager
 // to update the detail extension info.
 // it returns updated extension info if it succeed.
-func (r *requestHandler) RegistrarV1ExtensionUpdate(ctx context.Context, id uuid.UUID, name string, detail string, password string) (*rmextension.Extension, error) {
+func (r *requestHandler) RegistrarV1ExtensionUpdate(ctx context.Context, id uuid.UUID, name string, detail string, password string, direct *bool, directRegenerate *bool) (*rmextension.Extension, error) {
 	uri := fmt.Sprintf("/v1/extensions/%s", id)
 
 	data := &rmrequest.V1DataExtensionsIDPut{
-		Name:     name,
-		Detail:   detail,
-		Password: password,
+		Name:             name,
+		Detail:           detail,
+		Password:         password,
+		Direct:           direct,
+		DirectRegenerate: directRegenerate,
 	}
 
 	m, err := json.Marshal(data)

--- a/bin-common-handler/pkg/requesthandler/registrar_extensions_test.go
+++ b/bin-common-handler/pkg/requesthandler/registrar_extensions_test.go
@@ -92,15 +92,21 @@ func Test_RegistrarExtensionCreate(t *testing.T) {
 	}
 }
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func Test_RegistrarExtensionUpdate(t *testing.T) {
 
 	tests := []struct {
 		name string
 
-		id            uuid.UUID
-		extensionName string
-		detail        string
-		password      string
+		id               uuid.UUID
+		extensionName    string
+		detail           string
+		password         string
+		direct           *bool
+		directRegenerate *bool
 
 		response *sock.Response
 
@@ -115,6 +121,8 @@ func Test_RegistrarExtensionUpdate(t *testing.T) {
 			"update name",
 			"update detail",
 			"update password",
+			nil,
+			nil,
 
 			&sock.Response{
 				StatusCode: 200,
@@ -127,6 +135,134 @@ func Test_RegistrarExtensionUpdate(t *testing.T) {
 				Method:   sock.RequestMethodPut,
 				DataType: ContentTypeJSON,
 				Data:     []byte(`{"name":"update name","detail":"update detail","password":"update password"}`),
+			},
+			&rmextension.Extension{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+					CustomerID: uuid.FromStringOrNil("324cf776-7ff0-11ec-a0ea-e30825a4224f"),
+				},
+				Name:     "update name",
+				Detail:   "update detail",
+				Password: "update password",
+			},
+		},
+		{
+			"with direct true",
+
+			uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+			"update name",
+			"update detail",
+			"update password",
+			boolPtr(true),
+			nil,
+
+			&sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"0be5298a-6f9f-11eb-bb77-f71f5b5f95f7","customer_id":"324cf776-7ff0-11ec-a0ea-e30825a4224f","name":"update name","detail":"update detail","password":"update password"}`),
+			},
+			"bin-manager.registrar-manager.request",
+			&sock.Request{
+				URI:      "/v1/extensions/0be5298a-6f9f-11eb-bb77-f71f5b5f95f7",
+				Method:   sock.RequestMethodPut,
+				DataType: ContentTypeJSON,
+				Data:     []byte(`{"name":"update name","detail":"update detail","password":"update password","direct":true}`),
+			},
+			&rmextension.Extension{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+					CustomerID: uuid.FromStringOrNil("324cf776-7ff0-11ec-a0ea-e30825a4224f"),
+				},
+				Name:     "update name",
+				Detail:   "update detail",
+				Password: "update password",
+			},
+		},
+		{
+			"with direct false",
+
+			uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+			"update name",
+			"update detail",
+			"update password",
+			boolPtr(false),
+			nil,
+
+			&sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"0be5298a-6f9f-11eb-bb77-f71f5b5f95f7","customer_id":"324cf776-7ff0-11ec-a0ea-e30825a4224f","name":"update name","detail":"update detail","password":"update password"}`),
+			},
+			"bin-manager.registrar-manager.request",
+			&sock.Request{
+				URI:      "/v1/extensions/0be5298a-6f9f-11eb-bb77-f71f5b5f95f7",
+				Method:   sock.RequestMethodPut,
+				DataType: ContentTypeJSON,
+				Data:     []byte(`{"name":"update name","detail":"update detail","password":"update password","direct":false}`),
+			},
+			&rmextension.Extension{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+					CustomerID: uuid.FromStringOrNil("324cf776-7ff0-11ec-a0ea-e30825a4224f"),
+				},
+				Name:     "update name",
+				Detail:   "update detail",
+				Password: "update password",
+			},
+		},
+		{
+			"with direct_regenerate true",
+
+			uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+			"update name",
+			"update detail",
+			"update password",
+			nil,
+			boolPtr(true),
+
+			&sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"0be5298a-6f9f-11eb-bb77-f71f5b5f95f7","customer_id":"324cf776-7ff0-11ec-a0ea-e30825a4224f","name":"update name","detail":"update detail","password":"update password"}`),
+			},
+			"bin-manager.registrar-manager.request",
+			&sock.Request{
+				URI:      "/v1/extensions/0be5298a-6f9f-11eb-bb77-f71f5b5f95f7",
+				Method:   sock.RequestMethodPut,
+				DataType: ContentTypeJSON,
+				Data:     []byte(`{"name":"update name","detail":"update detail","password":"update password","direct_regenerate":true}`),
+			},
+			&rmextension.Extension{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+					CustomerID: uuid.FromStringOrNil("324cf776-7ff0-11ec-a0ea-e30825a4224f"),
+				},
+				Name:     "update name",
+				Detail:   "update detail",
+				Password: "update password",
+			},
+		},
+		{
+			"with all optional fields",
+
+			uuid.FromStringOrNil("0be5298a-6f9f-11eb-bb77-f71f5b5f95f7"),
+			"update name",
+			"update detail",
+			"update password",
+			boolPtr(true),
+			boolPtr(true),
+
+			&sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"0be5298a-6f9f-11eb-bb77-f71f5b5f95f7","customer_id":"324cf776-7ff0-11ec-a0ea-e30825a4224f","name":"update name","detail":"update detail","password":"update password"}`),
+			},
+			"bin-manager.registrar-manager.request",
+			&sock.Request{
+				URI:      "/v1/extensions/0be5298a-6f9f-11eb-bb77-f71f5b5f95f7",
+				Method:   sock.RequestMethodPut,
+				DataType: ContentTypeJSON,
+				Data:     []byte(`{"name":"update name","detail":"update detail","password":"update password","direct":true,"direct_regenerate":true}`),
 			},
 			&rmextension.Extension{
 				Identity: identity.Identity{
@@ -153,7 +289,7 @@ func Test_RegistrarExtensionUpdate(t *testing.T) {
 			ctx := context.Background()
 			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
 
-			res, err := reqHandler.RegistrarV1ExtensionUpdate(ctx, tt.id, tt.extensionName, tt.detail, tt.password)
+			res, err := reqHandler.RegistrarV1ExtensionUpdate(ctx, tt.id, tt.extensionName, tt.detail, tt.password, tt.direct, tt.directRegenerate)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}


### PR DESCRIPTION
Fix PUT /extensions/{id} silently dropping direct and direct_regenerate fields,
and add comprehensive test coverage for extension and agent PUT endpoints.

The API accepted these fields in the request body (defined in OpenAPI spec and
parsed by api-manager), but they were never forwarded to registrar-manager. Clients
sending {"direct": true} got a 200 OK but direct was never actually enabled. The
registrar-manager already supports these fields — the bug was purely in the
api-manager forwarding chain.

- bin-common-handler: Add direct and directRegenerate params to RegistrarV1ExtensionUpdate interface and implementation
- bin-api-manager: Add direct and directRegenerate params to ExtensionUpdate interface and implementation
- bin-api-manager: Pass req.Direct and req.DirectRegenerate from server handler to servicehandler
- bin-common-handler: Add test cases for direct true, false, direct_regenerate, and all fields combined
- bin-api-manager: Add matching test cases in servicehandler and server extension tests
- bin-api-manager: Add new Test_PutAgentsId HTTP handler test for previously missing coverage