### PR TITLE
NOJIRA-Add-call-manager-metrics-and-grafana-dashboard

### DIFF
--- a/bin-call-manager/pkg/callhandler/main.go
+++ b/bin-call-manager/pkg/callhandler/main.go
@@ -261,6 +261,17 @@ var (
 		},
 		[]string{"type"},
 	)
+
+	// call_duration_seconds measures total call duration from creation to hangup.
+	promCallDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "call_duration_seconds",
+			Help:      "Duration of calls in seconds from creation to hangup.",
+			Buckets:   []float64{1, 5, 10, 30, 60, 300, 600, 1800, 3600},
+		},
+		[]string{"direction", "type"},
+	)
 )
 
 func init() {
@@ -270,6 +281,7 @@ func init() {
 		promCallActionTotal,
 		promCallActionProcessTime,
 		promConferenceLeaveTotal,
+		promCallDurationSeconds,
 	)
 }
 

--- a/bin-call-manager/pkg/confbridgehandler/db.go
+++ b/bin-call-manager/pkg/confbridgehandler/db.go
@@ -3,6 +3,7 @@ package confbridgehandler
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -261,6 +262,9 @@ func (h *confbridgeHandler) UpdateStatus(ctx context.Context, id uuid.UUID, stat
 
 	case confbridge.StatusTerminated:
 		promConfbridgeCloseTotal.Inc()
+		if res.TMCreate != nil {
+			promConfbridgeDurationSeconds.WithLabelValues(string(res.Type)).Observe(time.Since(*res.TMCreate).Seconds())
+		}
 		h.notifyHandler.PublishEvent(ctx, confbridge.EventTypeConfbridgeTerminated, res)
 	}
 

--- a/bin-call-manager/pkg/confbridgehandler/main.go
+++ b/bin-call-manager/pkg/confbridgehandler/main.go
@@ -127,6 +127,17 @@ var (
 			Help:      "Total number of joined calls to the confbridge with type.",
 		},
 	)
+
+	// confbridge_duration_seconds measures total confbridge duration from creation to termination.
+	promConfbridgeDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "confbridge_duration_seconds",
+			Help:      "Duration of conference bridges in seconds from creation to termination.",
+			Buckets:   []float64{1, 5, 10, 30, 60, 300, 600, 1800, 3600},
+		},
+		[]string{"type"},
+	)
 )
 
 func init() {
@@ -134,6 +145,7 @@ func init() {
 		promConfbridgeCreateTotal,
 		promConfbridgeCloseTotal,
 		promConfbridgeJoinTotal,
+		promConfbridgeDurationSeconds,
 	)
 }
 

--- a/bin-call-manager/pkg/externalmediahandler/main.go
+++ b/bin-call-manager/pkg/externalmediahandler/main.go
@@ -5,11 +5,15 @@ package externalmediahandler
 import (
 	"context"
 
+	"monorepo/bin-call-manager/models/common"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"monorepo/bin-call-manager/models/ari"
 	"monorepo/bin-call-manager/models/bridge"
@@ -55,6 +59,37 @@ const (
 	defaultDirection            = "both" //
 	defaultSilencePlaybackMedia = "sound:silence_slin16_8000_1m"
 )
+
+var (
+	metricsNamespace = commonoutline.GetMetricNameSpace(common.Servicename)
+
+	// external_media_start_total counts external media starts by reference type and encapsulation.
+	promExternalMediaStartTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "external_media_start_total",
+			Help:      "Total number of external media starts by reference type and encapsulation.",
+		},
+		[]string{"reference_type", "encapsulation"},
+	)
+
+	// external_media_stop_total counts external media stops by reference type.
+	promExternalMediaStopTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "external_media_stop_total",
+			Help:      "Total number of external media stops by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promExternalMediaStartTotal,
+		promExternalMediaStopTotal,
+	)
+}
 
 type externalMediaHandler struct {
 	utilHandler   utilhandler.UtilHandler

--- a/bin-call-manager/pkg/externalmediahandler/start.go
+++ b/bin-call-manager/pkg/externalmediahandler/start.go
@@ -41,6 +41,8 @@ func (h *externalMediaHandler) Start(
 		id = h.utilHandler.UUIDCreate()
 	}
 
+	promExternalMediaStartTotal.WithLabelValues(string(referenceType), string(encapsulation)).Inc()
+
 	switch referenceType {
 	case externalmedia.ReferenceTypeCall:
 		return h.startReferenceTypeCall(ctx, id, referenceID, externalHost, encapsulation, transport, format, directionListen, directionSpeak)

--- a/bin-call-manager/pkg/externalmediahandler/stop.go
+++ b/bin-call-manager/pkg/externalmediahandler/stop.go
@@ -24,6 +24,7 @@ func (h *externalMediaHandler) Stop(ctx context.Context, externalMediaID uuid.UU
 	if err != nil {
 		return nil, fmt.Errorf("could not update external media status: %w", err)
 	}
+	promExternalMediaStopTotal.WithLabelValues(string(res.ReferenceType)).Inc()
 
 	// hangup the external media channel
 	if errHangup := h.channelHandler.HangingUpWithAsteriskID(ctx, res.AsteriskID, res.ChannelID, ari.ChannelCauseNormalClearing); errHangup != nil {

--- a/bin-call-manager/pkg/recordinghandler/main.go
+++ b/bin-call-manager/pkg/recordinghandler/main.go
@@ -6,12 +6,16 @@ import (
 	"context"
 	"fmt"
 
+	"monorepo/bin-call-manager/models/common"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-call-manager/pkg/projectconfig"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"monorepo/bin-call-manager/models/recording"
 	"monorepo/bin-call-manager/pkg/bridgehandler"
@@ -62,6 +66,37 @@ const (
 	variableRecordingRecordingName = "voipbin.recording.recording_name"
 	variableRecordingFilenames     = "voipbin.recording.filenames"
 )
+
+var (
+	metricsNamespace = commonoutline.GetMetricNameSpace(common.Servicename)
+
+	// recording_start_total counts recording starts by reference type.
+	promRecordingStartTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "recording_start_total",
+			Help:      "Total number of recording starts by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+
+	// recording_end_total counts recording completions by reference type.
+	promRecordingEndTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "recording_end_total",
+			Help:      "Total number of recording completions by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promRecordingStartTotal,
+		promRecordingEndTotal,
+	)
+}
 
 // recordingHandler structure for service handle
 type recordingHandler struct {

--- a/bin-call-manager/pkg/recordinghandler/start.go
+++ b/bin-call-manager/pkg/recordinghandler/start.go
@@ -23,6 +23,8 @@ func (h *recordingHandler) Start(
 	onEndFlowID uuid.UUID,
 ) (*recording.Recording, error) {
 
+	promRecordingStartTotal.WithLabelValues(string(referenceType)).Inc()
+
 	switch referenceType {
 	case recording.ReferenceTypeCall:
 		return h.recordingReferenceTypeCall(ctx, activeflowID, referenceID, format, endOfSilence, endOfKey, duration, onEndFlowID)

--- a/bin-call-manager/pkg/recordinghandler/stop.go
+++ b/bin-call-manager/pkg/recordinghandler/stop.go
@@ -30,6 +30,7 @@ func (h *recordingHandler) Stopped(ctx context.Context, id uuid.UUID) (*recordin
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not get recording info")
 	}
+	promRecordingEndTotal.WithLabelValues(string(res.ReferenceType)).Inc()
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, recording.EventTypeRecordingFinished, res)
 
 	// store the recording

--- a/docs/plans/2026-02-12-call-manager-metrics-design.md
+++ b/docs/plans/2026-02-12-call-manager-metrics-design.md
@@ -1,0 +1,74 @@
+# Call Manager Metrics and Grafana Dashboard Design
+
+## Problem Statement
+
+The call-manager service is the core telephony operations hub handling calls, channels, conference bridges, recordings, and external media. It already has 15 existing custom metrics but is missing duration histograms, recording metrics, and external media metrics. It also has no Grafana dashboard for visualization.
+
+## Approach
+
+Add 6 new Prometheus metrics to fill the gaps in existing instrumentation, plus a comprehensive Grafana dashboard that visualizes both existing and new metrics. Same approach as flow-manager and tts-manager: operational health + business insight, no customer_id labels, JSON provisioning file.
+
+## Existing Metrics (15)
+
+| Metric | Type | Labels | Handler |
+|--------|------|--------|---------|
+| `call_create_total` | Counter | direction, type | callhandler |
+| `call_hangup_total` | Counter | direction, type, reason | callhandler |
+| `call_action_total` | Counter | type | callhandler |
+| `call_action_process_time` | Histogram | type | callhandler |
+| `conference_leave_total` | Counter | type | callhandler |
+| `channel_create_total` | Counter | direction, tech | channelhandler |
+| `channel_hangup_total` | Counter | direction, type, reason | channelhandler |
+| `channel_transport_direction_total` | Counter | transport, direction | channelhandler |
+| `confbridge_create_total` | Counter | none | confbridgehandler |
+| `confbridge_close_total` | Counter | none | confbridgehandler |
+| `confbridge_join_total` | Counter | none | confbridgehandler |
+| `bridge_create_total` | Counter | reference_type | bridgehandler |
+| `bridge_destroy_total` | Counter | reference_type | bridgehandler |
+| `groupcall_create_total` | Counter | none | groupcallhandler |
+| `subscribe_event_process_time` | Histogram | publisher, type | subscribehandler |
+
+## New Metrics (6)
+
+| Metric | Type | Labels | Location |
+|--------|------|--------|----------|
+| `call_duration_seconds` | Histogram | direction, type | callhandler/db.go UpdateHangupInfo() |
+| `confbridge_duration_seconds` | Histogram | type | confbridgehandler/db.go UpdateStatus() |
+| `recording_start_total` | Counter | reference_type | recordinghandler/start.go Start() |
+| `recording_end_total` | Counter | reference_type | recordinghandler/stop.go Stopped() |
+| `external_media_start_total` | Counter | reference_type, encapsulation | externalmediahandler/start.go Start() |
+| `external_media_stop_total` | Counter | reference_type | externalmediahandler/stop.go Stop() |
+
+### Notes
+
+- `call_duration_seconds` uses TMCreate and TMHangup timestamps from the call model (database-persisted).
+- `confbridge_duration_seconds` uses TMCreate from the confbridge model, measured at StatusTerminated.
+- Recording and external media metrics are simple counters since these operations are initiated by other services.
+
+## Grafana Dashboard
+
+Location: `monitoring/grafana/dashboards/call-manager.json`
+
+### Layout: 5 rows, 18 panels
+
+| Row | Title | Panels |
+|-----|-------|--------|
+| 1 | Overview | Calls/min, Active Channels, Conference Bridges/min, ARI Events/min |
+| 2 | Calls | Created by Direction, Hangup by Reason, Duration p50/p95, Actions |
+| 3 | Conference & Recording | Confbridge Created/Closed, Confbridge Duration, Recording Start/End, External Media |
+| 4 | Channels & Infrastructure | Channels by Tech, Groupcall Created, Bridge Create/Destroy |
+| 5 | API & Events | Request Processing Time p95, ARI Event Processing Time p95, Events Published |
+
+## Files Changed
+
+- `bin-call-manager/pkg/callhandler/main.go` — Added `call_duration_seconds` histogram
+- `bin-call-manager/pkg/callhandler/db.go` — Instrumented UpdateHangupInfo() with duration tracking
+- `bin-call-manager/pkg/confbridgehandler/main.go` — Added `confbridge_duration_seconds` histogram
+- `bin-call-manager/pkg/confbridgehandler/db.go` — Instrumented UpdateStatus() with duration tracking
+- `bin-call-manager/pkg/recordinghandler/main.go` — Added `recording_start_total` and `recording_end_total` counters
+- `bin-call-manager/pkg/recordinghandler/start.go` — Instrumented Start()
+- `bin-call-manager/pkg/recordinghandler/stop.go` — Instrumented Stopped()
+- `bin-call-manager/pkg/externalmediahandler/main.go` — Added `external_media_start_total` and `external_media_stop_total` counters
+- `bin-call-manager/pkg/externalmediahandler/start.go` — Instrumented Start()
+- `bin-call-manager/pkg/externalmediahandler/stop.go` — Instrumented Stop()
+- `monitoring/grafana/dashboards/call-manager.json` — New Grafana dashboard (5 rows, 18 panels)

--- a/monitoring/grafana/dashboards/call-manager.json
+++ b/monitoring/grafana/dashboards/call-manager.json
@@ -1,0 +1,1470 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(call_manager_call_create_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "Calls/min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(call_manager_channel_create_total[5m])) - sum(rate(call_manager_channel_hangup_total[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Channels",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(call_manager_confbridge_create_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "Conference Bridges/min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(call_manager_ari_event_listen_total[5m])) * 60",
+          "refId": "A"
+        }
+      ],
+      "title": "ARI Events/min",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Calls",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (direction) (rate(call_manager_call_create_total[5m]))",
+          "legendFormat": "{{direction}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Calls Created by Direction",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(call_manager_call_hangup_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Calls Hangup by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le, direction) (rate(call_manager_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{direction}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, direction) (rate(call_manager_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{direction}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Call Duration p50/p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (type) (rate(call_manager_call_action_total[5m]))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Call Actions",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Conference & Recording",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 15
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(call_manager_confbridge_create_total[5m]))",
+          "legendFormat": "created",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(call_manager_confbridge_close_total[5m]))",
+          "legendFormat": "closed",
+          "refId": "B"
+        }
+      ],
+      "title": "Confbridge Created/Closed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 15
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(call_manager_confbridge_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(call_manager_confbridge_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "Confbridge Duration p50/p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 15
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (reference_type) (rate(call_manager_recording_start_total[5m]))",
+          "legendFormat": "start {{reference_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (reference_type) (rate(call_manager_recording_end_total[5m]))",
+          "legendFormat": "end {{reference_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Recording Start/End",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 15
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (reference_type) (rate(call_manager_external_media_start_total[5m]))",
+          "legendFormat": "start {{reference_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (reference_type) (rate(call_manager_external_media_stop_total[5m]))",
+          "legendFormat": "stop {{reference_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "External Media Start/Stop",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Channels & Infrastructure",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (tech) (rate(call_manager_channel_create_total[5m]))",
+          "legendFormat": "{{tech}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Channels by Tech",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(call_manager_groupcall_create_total[5m]))",
+          "legendFormat": "groupcall created",
+          "refId": "A"
+        }
+      ],
+      "title": "Groupcall Created",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (reference_type) (rate(call_manager_bridge_create_total[5m]))",
+          "legendFormat": "create {{reference_type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (reference_type) (rate(call_manager_bridge_destroy_total[5m]))",
+          "legendFormat": "destroy {{reference_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Bridge Create/Destroy",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 20,
+      "panels": [],
+      "title": "API & Events",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(call_manager_receive_request_process_time_bucket[5m])))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Processing Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(call_manager_ari_event_listen_process_time_bucket[5m])))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "ARI Event Processing Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "expr": "sum by (event_type) (rate(call_manager_event_publish_total[5m]))",
+          "legendFormat": "{{event_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Published",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "call-manager",
+    "voipbin"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Call Manager",
+  "uid": "call-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add 6 new Prometheus metrics and a comprehensive Grafana dashboard for the call-manager service, complementing the 15 existing metrics already in place.

New metrics fill gaps in duration tracking, recording, and external media instrumentation:
- call_duration_seconds histogram (direction, type)
- confbridge_duration_seconds histogram (type)
- recording_start_total counter (reference_type)
- recording_end_total counter (reference_type)
- external_media_start_total counter (reference_type, encapsulation)
- external_media_stop_total counter (reference_type)

The Grafana dashboard (5 rows, 18 panels) visualizes both existing and new metrics covering calls, conferences, recordings, channels, and event processing.

- bin-call-manager: Add call_duration_seconds histogram to callhandler
- bin-call-manager: Instrument UpdateHangupInfo() with duration tracking
- bin-call-manager: Add confbridge_duration_seconds histogram to confbridgehandler
- bin-call-manager: Instrument confbridge UpdateStatus() with duration at termination
- bin-call-manager: Add recording_start_total and recording_end_total counters
- bin-call-manager: Instrument recording Start() and Stopped() methods
- bin-call-manager: Add external_media_start_total and external_media_stop_total counters
- bin-call-manager: Instrument external media Start() and Stop() methods
- monitoring: Add call-manager Grafana dashboard with 5 rows and 18 panels
- docs: Add call-manager metrics design document