### PR TITLE
NOJIRA-Add-ai-manager-metrics-and-grafana-dashboard

### DIFF
--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -2,6 +2,7 @@ package aicallhandler
 
 import (
 	"context"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -187,6 +188,10 @@ func (h *aicallHandler) UpdateStatus(ctx context.Context, id uuid.UUID, status a
 	case aicall.StatusTerminating:
 		h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusTerminating, res)
 	case aicall.StatusTerminated:
+		promAIcallEndTotal.WithLabelValues(string(res.ReferenceType)).Inc()
+		if res.TMCreate != nil {
+			promAIcallDurationSeconds.WithLabelValues(string(res.ReferenceType)).Observe(time.Since(*res.TMCreate).Seconds())
+		}
 		h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, aicall.EventTypeStatusTerminated, res)
 	}
 

--- a/bin-ai-manager/pkg/aicallhandler/main.go
+++ b/bin-ai-manager/pkg/aicallhandler/main.go
@@ -135,6 +135,23 @@ var (
 		},
 		[]string{"reference_type"},
 	)
+	promAIcallEndTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "aicall_end_total",
+			Help:      "Total number of terminated aicalls by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+	promAIcallDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "aicall_duration_seconds",
+			Help:      "Duration of aicalls in seconds from creation to termination.",
+			Buckets:   []float64{1, 5, 10, 30, 60, 300, 600, 1800, 3600},
+		},
+		[]string{"reference_type"},
+	)
 	promAIcallInitProcessTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
@@ -157,13 +174,24 @@ var (
 		},
 		[]string{"engine_type"},
 	)
+	promAIcallToolExecuteTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "aicall_tool_execute_total",
+			Help:      "Total number of tool executions by tool name.",
+		},
+		[]string{"tool_name"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(
 		promAIcallCreateTotal,
+		promAIcallEndTotal,
+		promAIcallDurationSeconds,
 		promAIcallInitProcessTime,
 		promAIcallMessageProcessTime,
+		promAIcallToolExecuteTotal,
 	)
 }
 

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -53,6 +53,8 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		message.FunctionCallNameStopService:       h.toolHandleServiceStop,
 	}
 
+	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()
+
 	var tmpMessageContent *messageContent
 	if fn, exists := mapFunctions[tool.Function.Name]; exists {
 		tmpMessageContent = fn(ctx, c, tool)

--- a/bin-ai-manager/pkg/summaryhandler/db.go
+++ b/bin-ai-manager/pkg/summaryhandler/db.go
@@ -54,6 +54,10 @@ func (h *summaryHandler) Create(
 		return nil, errors.Wrapf(errSet, "could not set the variable")
 	}
 
+	if res.Status == summary.StatusDone {
+		promSummaryDoneTotal.WithLabelValues(string(res.ReferenceType)).Inc()
+	}
+
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, summary.EventTypeCreated, res)
 	return res, nil
 }
@@ -148,6 +152,7 @@ func (h *summaryHandler) UpdateStatusDone(ctx context.Context, id uuid.UUID, con
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get updated summary")
 	}
+	promSummaryDoneTotal.WithLabelValues(string(res.ReferenceType)).Inc()
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, summary.EventTypeUpdated, res)
 
 	return res, nil

--- a/bin-ai-manager/pkg/summaryhandler/main.go
+++ b/bin-ai-manager/pkg/summaryhandler/main.go
@@ -15,6 +15,7 @@ import (
 	cfconference "monorepo/bin-conference-manager/models/conference"
 
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sashabaranov/go-openai"
 )
 
@@ -53,6 +54,37 @@ type summaryHandler struct {
 	db            dbhandler.DBHandler
 
 	engineOpenaiHandler engine_openai_handler.EngineOpenaiHandler
+}
+
+var (
+	metricsNamespace = "ai_manager"
+
+	// summary_start_total counts summary starts by reference type.
+	promSummaryStartTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "summary_start_total",
+			Help:      "Total number of summary starts by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+
+	// summary_done_total counts summary completions by reference type.
+	promSummaryDoneTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "summary_done_total",
+			Help:      "Total number of summary completions by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promSummaryStartTotal,
+		promSummaryDoneTotal,
+	)
 }
 
 func NewSummaryHandler(

--- a/bin-ai-manager/pkg/summaryhandler/start.go
+++ b/bin-ai-manager/pkg/summaryhandler/start.go
@@ -32,6 +32,8 @@ func (h *summaryHandler) Start(
 		return tmp, nil
 	}
 
+	promSummaryStartTotal.WithLabelValues(string(referenceType)).Inc()
+
 	switch referenceType {
 	case summary.ReferenceTypeTranscribe:
 		return h.startReferenceTypeTranscribe(ctx, customerID, activeflowID, onEndFlowID, referenceID, language)

--- a/docs/plans/2026-02-12-ai-manager-metrics-design.md
+++ b/docs/plans/2026-02-12-ai-manager-metrics-design.md
@@ -1,0 +1,60 @@
+# AI Manager Metrics and Grafana Dashboard Design
+
+## Problem Statement
+
+The ai-manager service orchestrates AI-powered conversations, managing AIcall sessions, LLM message processing, tool execution, and summary generation. It has 6 existing custom metrics but is missing session lifecycle metrics (end/duration), tool execution tracking, and summary metrics. It also has no Grafana dashboard.
+
+## Approach
+
+Add 5 new Prometheus metrics to fill gaps in session lifecycle, tool execution, and summary tracking. Create a Grafana dashboard (5 rows, 17 panels) visualizing both existing and new metrics.
+
+## Existing Metrics (6)
+
+| Metric | Type | Labels | Handler |
+|--------|------|--------|---------|
+| `ai_create_total` | Counter | engine_type | aihandler |
+| `aicall_create_total` | Counter | reference_type | aicallhandler |
+| `aicall_init_process_time` | Histogram | engine_type | aicallhandler |
+| `aicall_message_process_time` | Histogram | engine_type | aicallhandler |
+| `message_create_total` | Counter | engine_type | messagehandler |
+| `message_process_time` | Histogram | engine_type | messagehandler |
+
+## New Metrics (5)
+
+| Metric | Type | Labels | Location |
+|--------|------|--------|----------|
+| `aicall_end_total` | Counter | reference_type | aicallhandler/db.go UpdateStatus() at StatusTerminated |
+| `aicall_duration_seconds` | Histogram | reference_type | aicallhandler/db.go UpdateStatus() at StatusTerminated |
+| `aicall_tool_execute_total` | Counter | tool_name | aicallhandler/tool.go ToolHandle() |
+| `summary_start_total` | Counter | reference_type | summaryhandler/start.go Start() |
+| `summary_done_total` | Counter | reference_type | summaryhandler/db.go UpdateStatusDone() and Create() with StatusDone |
+
+### Notes
+
+- `aicall_duration_seconds` uses TMCreate from the AIcall model, measured at StatusTerminated transition.
+- `summary_done_total` fires both in UpdateStatusDone() (for call/conference async completions) and in Create() when status is directly set to Done (for transcribe/recording synchronous completions).
+- Tool execution counter tracks all tool names including connect_call, send_email, send_message, stop_service, etc.
+
+## Grafana Dashboard
+
+Location: `monitoring/grafana/dashboards/ai-manager.json`
+
+### Layout: 5 rows, 17 panels
+
+| Row | Title | Panels |
+|-----|-------|--------|
+| 1 | Overview | AIcalls/min, Messages/min, Tool Executions/min, Summaries/min |
+| 2 | AIcalls | Created by Reference Type, Ended by Reference Type, Duration p50/p95, Init Time p95 |
+| 3 | Messages & Tools | Messages by Engine Type, Message Process Time p95, Tool Executions by Tool Name, AIcall Message Process Time p95 |
+| 4 | Summaries & AI Config | Summary Starts, Summary Completions, AI Configs by Engine Type |
+| 5 | API & Events | Request Processing Time p95, Event Processing Time p95 |
+
+## Files Changed
+
+- `bin-ai-manager/pkg/aicallhandler/main.go` — Added `aicall_end_total`, `aicall_duration_seconds`, `aicall_tool_execute_total`
+- `bin-ai-manager/pkg/aicallhandler/db.go` — Instrumented UpdateStatus() at StatusTerminated with end counter and duration
+- `bin-ai-manager/pkg/aicallhandler/tool.go` — Instrumented ToolHandle() with tool execution counter
+- `bin-ai-manager/pkg/summaryhandler/main.go` — Added `summary_start_total` and `summary_done_total` counters
+- `bin-ai-manager/pkg/summaryhandler/start.go` — Instrumented Start()
+- `bin-ai-manager/pkg/summaryhandler/db.go` — Instrumented UpdateStatusDone() and Create()
+- `monitoring/grafana/dashboards/ai-manager.json` — New Grafana dashboard (5 rows, 17 panels)

--- a/monitoring/grafana/dashboards/ai-manager.json
+++ b/monitoring/grafana/dashboards/ai-manager.json
@@ -1,0 +1,594 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(ai_manager_aicall_create_total[5m])) * 60",
+          "legendFormat": "AIcalls/min"
+        }
+      ],
+      "title": "AIcalls / min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(ai_manager_message_create_total[5m])) * 60",
+          "legendFormat": "Messages/min"
+        }
+      ],
+      "title": "Messages / min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(ai_manager_aicall_tool_execute_total[5m])) * 60",
+          "legendFormat": "Tool Executions/min"
+        }
+      ],
+      "title": "Tool Executions / min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(ai_manager_summary_start_total[5m])) * 60",
+          "legendFormat": "Summaries/min"
+        }
+      ],
+      "title": "Summaries / min",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 101,
+      "title": "AIcalls",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (reference_type) (rate(ai_manager_aicall_create_total[5m])) * 60",
+          "legendFormat": "{{reference_type}}"
+        }
+      ],
+      "title": "AIcalls Created by Reference Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (reference_type) (rate(ai_manager_aicall_end_total[5m])) * 60",
+          "legendFormat": "{{reference_type}}"
+        }
+      ],
+      "title": "AIcalls Ended by Reference Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.50, sum by (le, reference_type) (rate(ai_manager_aicall_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{reference_type}}"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, reference_type) (rate(ai_manager_aicall_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{reference_type}}"
+        }
+      ],
+      "title": "AIcall Duration p50 / p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "id": 8,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, engine_type) (rate(ai_manager_aicall_init_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{engine_type}}"
+        }
+      ],
+      "title": "AIcall Init Time p95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "id": 102,
+      "title": "Messages & Tools",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 17 },
+      "id": 9,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (engine_type) (rate(ai_manager_message_create_total[5m])) * 60",
+          "legendFormat": "{{engine_type}}"
+        }
+      ],
+      "title": "Messages by Engine Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 17 },
+      "id": 10,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, engine_type) (rate(ai_manager_message_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{engine_type}}"
+        }
+      ],
+      "title": "Message Process Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 17 },
+      "id": 11,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (tool_name) (rate(ai_manager_aicall_tool_execute_total[5m])) * 60",
+          "legendFormat": "{{tool_name}}"
+        }
+      ],
+      "title": "Tool Executions by Tool Name",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 17 },
+      "id": 12,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, engine_type) (rate(ai_manager_aicall_message_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{engine_type}}"
+        }
+      ],
+      "title": "AIcall Message Process Time p95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+      "id": 103,
+      "title": "Summaries & AI Config",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 26 },
+      "id": 13,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (reference_type) (rate(ai_manager_summary_start_total[5m])) * 60",
+          "legendFormat": "{{reference_type}}"
+        }
+      ],
+      "title": "Summary Starts by Reference Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 26 },
+      "id": 14,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (reference_type) (rate(ai_manager_summary_done_total[5m])) * 60",
+          "legendFormat": "{{reference_type}}"
+        }
+      ],
+      "title": "Summary Completions by Reference Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 26 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (engine_type) (rate(ai_manager_ai_create_total[5m])) * 60",
+          "legendFormat": "{{engine_type}}"
+        }
+      ],
+      "title": "AI Configs Created by Engine Type",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 104,
+      "title": "API & Events",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 16,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(ai_manager_receive_request_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{type}}"
+        }
+      ],
+      "title": "Request Processing Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 17,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, publisher) (rate(ai_manager_subscribe_event_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{publisher}}"
+        }
+      ],
+      "title": "Event Processing Time p95",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["ai-manager", "voipbin"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AI Manager",
+  "uid": "ai-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add 5 new Prometheus metrics and a comprehensive Grafana dashboard for the ai-manager service, complementing the 6 existing custom metrics.

New metrics cover AIcall lifecycle, tool execution, and summary tracking:
- aicall_end_total counter (reference_type)
- aicall_duration_seconds histogram (reference_type)
- aicall_tool_execute_total counter (tool_name)
- summary_start_total counter (reference_type)
- summary_done_total counter (reference_type)

- bin-ai-manager: Add aicall_end_total, aicall_duration_seconds, aicall_tool_execute_total metrics
- bin-ai-manager: Instrument UpdateStatus() at StatusTerminated with end counter and duration tracking
- bin-ai-manager: Instrument ToolHandle() with tool execution counter
- bin-ai-manager: Add summary_start_total and summary_done_total counters
- bin-ai-manager: Instrument summary Start() and UpdateStatusDone()
- monitoring: Add ai-manager Grafana dashboard with 5 rows and 17 panels
- docs: Add ai-manager metrics design document