### PR TITLE
NOJIRA-Add-billing-manager-metrics-and-grafana-dashboard

### DIFF
--- a/bin-billing-manager/pkg/accounthandler/balance.go
+++ b/bin-billing-manager/pkg/accounthandler/balance.go
@@ -86,9 +86,11 @@ func (h *accountHandler) IsValidBalance(ctx context.Context, accountID uuid.UUID
 	}
 
 	if a.Balance > expectCost {
+		promAccountBalanceCheckTotal.WithLabelValues("valid").Inc()
 		return true, nil
 	}
 	log.Infof("The account has not enough balance. expect_cost: %f, balance: %f", expectCost, a.Balance)
 
+	promAccountBalanceCheckTotal.WithLabelValues("invalid").Inc()
 	return false, nil
 }

--- a/bin-billing-manager/pkg/accounthandler/main.go
+++ b/bin-billing-manager/pkg/accounthandler/main.go
@@ -60,7 +60,24 @@ var (
 			Help:      "Total number of created account.",
 		},
 	)
+
+	// account_balance_check_total tracks balance validation outcomes.
+	promAccountBalanceCheckTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "account_balance_check_total",
+			Help:      "Total number of balance validation checks by result.",
+		},
+		[]string{"result"},
+	)
 )
+
+func init() {
+	prometheus.MustRegister(
+		promAccountCreateTotal,
+		promAccountBalanceCheckTotal,
+	)
+}
 
 // NewAccountHandler returns a new AccountHandler
 func NewAccountHandler(reqHandler requesthandler.RequestHandler, db dbhandler.DBHandler, notifyHandler notifyhandler.NotifyHandler) AccountHandler {

--- a/bin-billing-manager/pkg/billinghandler/db.go
+++ b/bin-billing-manager/pkg/billinghandler/db.go
@@ -145,6 +145,9 @@ func (h *billingHandler) UpdateStatusEnd(ctx context.Context, id uuid.UUID, bill
 	}
 
 	promBillingEndTotal.WithLabelValues(string(res.ReferenceType)).Inc()
+	if res.TMBillingStart != nil && res.TMBillingEnd != nil {
+		promBillingDurationSeconds.WithLabelValues(string(res.ReferenceType)).Observe(res.TMBillingEnd.Sub(*res.TMBillingStart).Seconds())
+	}
 
 	return res, nil
 }

--- a/bin-billing-manager/pkg/billinghandler/main.go
+++ b/bin-billing-manager/pkg/billinghandler/main.go
@@ -75,7 +75,26 @@ var (
 		},
 		[]string{"reference_type"},
 	)
+
+	// billing_duration_seconds tracks billing duration from start to end by reference type.
+	promBillingDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "billing_duration_seconds",
+			Help:      "Duration of billing records in seconds from start to end.",
+			Buckets:   []float64{1, 5, 10, 30, 60, 300, 600, 1800, 3600},
+		},
+		[]string{"reference_type"},
+	)
 )
+
+func init() {
+	prometheus.MustRegister(
+		promBillingCreateTotal,
+		promBillingEndTotal,
+		promBillingDurationSeconds,
+	)
+}
 
 // NewBillingHandler create a new BillingHandler
 func NewBillingHandler(

--- a/docs/plans/2026-02-12-billing-manager-metrics-design.md
+++ b/docs/plans/2026-02-12-billing-manager-metrics-design.md
@@ -1,0 +1,51 @@
+# Billing Manager Metrics and Grafana Dashboard Design
+
+## Problem Statement
+
+The billing-manager service handles billing records, account balances, and payment validation. It had 5 registered metrics plus 2 unregistered ones (billing_create_total, billing_end_total, account_create_total were defined but never called prometheus.MustRegister). It also lacked duration tracking and balance validation metrics, with no Grafana dashboard.
+
+## Approach
+
+Fix 3 unregistered metrics, add 2 new metrics (billing duration, balance check outcomes), and create a Grafana dashboard (5 rows, 15 panels) visualizing billing operations, failed events, accounts, and API performance.
+
+## Existing Metrics (Fixed: 3 were unregistered)
+
+| Metric | Type | Labels | Handler | Status |
+|--------|------|--------|---------|--------|
+| `billing_create_total` | Counter | reference_type | billinghandler | Fixed (was unregistered) |
+| `billing_end_total` | Counter | reference_type | billinghandler | Fixed (was unregistered) |
+| `account_create_total` | Counter | none | accounthandler | Fixed (was unregistered) |
+| `failed_event_save_total` | Counter | event_type, publisher | failedeventhandler | OK |
+| `failed_event_retry_total` | Counter | result | failedeventhandler | OK |
+| `failed_event_exhausted_total` | Counter | event_type | failedeventhandler | OK |
+| `receive_request_process_time` | Histogram | type, method | listenhandler | OK |
+| `receive_subscribe_event_process_time` | Histogram | publisher, type | subscribehandler | OK |
+
+## New Metrics (2)
+
+| Metric | Type | Labels | Location |
+|--------|------|--------|----------|
+| `billing_duration_seconds` | Histogram | reference_type | billinghandler/db.go UpdateStatusEnd() |
+| `account_balance_check_total` | Counter | result | accounthandler/balance.go IsValidBalance() |
+
+## Grafana Dashboard
+
+Location: `monitoring/grafana/dashboards/billing-manager.json`
+
+### Layout: 5 rows, 15 panels
+
+| Row | Title | Panels |
+|-----|-------|--------|
+| 1 | Overview | Billings Created/min, Billings Ended/min, Failed Events/min, Balance Check Failures/min |
+| 2 | Billing Records | Created by Type, Ended by Type, Duration p50/p95, Balance Check Results |
+| 3 | Failed Events & Retry | Failed Events by Type, Retry Results, Exhausted by Type |
+| 4 | Accounts | Account Creates/min, Balance Check Totals |
+| 5 | API & Events | Request Processing Time p95, Event Processing Time p95 |
+
+## Files Changed
+
+- `bin-billing-manager/pkg/billinghandler/main.go` — Added billing_duration_seconds, registered existing metrics with MustRegister
+- `bin-billing-manager/pkg/billinghandler/db.go` — Instrumented UpdateStatusEnd() with duration tracking
+- `bin-billing-manager/pkg/accounthandler/main.go` — Added account_balance_check_total, registered existing account_create_total with MustRegister
+- `bin-billing-manager/pkg/accounthandler/balance.go` — Instrumented IsValidBalance() with balance check counter
+- `monitoring/grafana/dashboards/billing-manager.json` — New Grafana dashboard (5 rows, 15 panels)

--- a/monitoring/grafana/dashboards/billing-manager.json
+++ b/monitoring/grafana/dashboards/billing-manager.json
@@ -1,0 +1,540 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(billing_manager_billing_create_total[5m])) * 60",
+          "legendFormat": "Billings/min"
+        }
+      ],
+      "title": "Billings Created / min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(billing_manager_billing_end_total[5m])) * 60",
+          "legendFormat": "Billings Ended/min"
+        }
+      ],
+      "title": "Billings Ended / min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(billing_manager_failed_event_save_total[5m])) * 60",
+          "legendFormat": "Failed Events/min"
+        }
+      ],
+      "title": "Failed Events / min",
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum(rate(billing_manager_account_balance_check_total{result=\"invalid\"}[5m])) * 60",
+          "legendFormat": "Invalid Checks/min"
+        }
+      ],
+      "title": "Balance Check Failures / min",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 101,
+      "title": "Billing Records",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "id": 5,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (reference_type) (rate(billing_manager_billing_create_total[5m])) * 60",
+          "legendFormat": "{{reference_type}}"
+        }
+      ],
+      "title": "Billings Created by Reference Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (reference_type) (rate(billing_manager_billing_end_total[5m])) * 60",
+          "legendFormat": "{{reference_type}}"
+        }
+      ],
+      "title": "Billings Ended by Reference Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.50, sum by (le, reference_type) (rate(billing_manager_billing_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{reference_type}}"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, reference_type) (rate(billing_manager_billing_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{reference_type}}"
+        }
+      ],
+      "title": "Billing Duration p50 / p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "id": 8,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (result) (rate(billing_manager_account_balance_check_total[5m])) * 60",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "title": "Balance Check Results",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "id": 102,
+      "title": "Failed Events & Retry",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 17 },
+      "id": 9,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (event_type) (rate(billing_manager_failed_event_save_total[5m])) * 60",
+          "legendFormat": "{{event_type}}"
+        }
+      ],
+      "title": "Failed Events by Event Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 17 },
+      "id": 10,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (result) (rate(billing_manager_failed_event_retry_total[5m])) * 60",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "title": "Failed Event Retry Results",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 17 },
+      "id": 11,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (event_type) (rate(billing_manager_failed_event_exhausted_total[5m])) * 60",
+          "legendFormat": "{{event_type}}"
+        }
+      ],
+      "title": "Failed Events Exhausted by Type",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+      "id": 103,
+      "title": "Accounts",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "id": 12,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(billing_manager_account_create_total[5m]) * 60",
+          "legendFormat": "accounts/min"
+        }
+      ],
+      "title": "Account Creates / min",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "id": 13,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "sum by (result) (billing_manager_account_balance_check_total)",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "title": "Balance Check Totals (Cumulative)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 104,
+      "title": "API & Events",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 14,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(billing_manager_receive_request_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{type}}"
+        }
+      ],
+      "title": "Request Processing Time p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": false,
+            "stacking": { "mode": "none" }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.95, sum by (le, publisher) (rate(billing_manager_receive_subscribe_event_process_time_bucket[5m])))",
+          "legendFormat": "p95 {{publisher}}"
+        }
+      ],
+      "title": "Event Processing Time p95",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["billing-manager", "voipbin"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Billing Manager",
+  "uid": "billing-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add 2 new Prometheus metrics, fix 3 unregistered metrics, and create a Grafana dashboard for the billing-manager service.

Fixes: billing_create_total, billing_end_total, and account_create_total were defined but never registered with prometheus.MustRegister, meaning they were silently not exported.

New metrics add billing duration tracking and balance validation outcomes:
- billing_duration_seconds histogram (reference_type)
- account_balance_check_total counter (result: valid/invalid)

- bin-billing-manager: Register previously unregistered billing_create_total and billing_end_total metrics
- bin-billing-manager: Register previously unregistered account_create_total metric
- bin-billing-manager: Add billing_duration_seconds histogram for billing duration tracking
- bin-billing-manager: Add account_balance_check_total counter for balance validation outcomes
- bin-billing-manager: Instrument UpdateStatusEnd() with duration tracking
- bin-billing-manager: Instrument IsValidBalance() with balance check counter
- monitoring: Add billing-manager Grafana dashboard with 5 rows and 15 panels
- docs: Add billing-manager metrics design document