### PR TITLE
NOJIRA-Add-queue-manager-metrics-and-grafana-dashboard

### DIFF
--- a/bin-queue-manager/pkg/queuecallhandler/db.go
+++ b/bin-queue-manager/pkg/queuecallhandler/db.go
@@ -117,6 +117,7 @@ func (h *queuecallHandler) Create(
 		log.Errorf("Could not get created queuecall. err: %v", err)
 		return nil, err
 	}
+	promQueuecallCreateTotal.Inc()
 	h.notifyhandler.PublishWebhookEvent(ctx, res.CustomerID, queuecall.EventTypeQueuecallCreated, res)
 
 	if errSet := h.setVariables(ctx, q, res); errSet != nil {
@@ -206,6 +207,7 @@ func (h *queuecallHandler) UpdateStatusService(ctx context.Context, qc *queuecal
 		log.Errorf("Could not get updated queuecall. err: %v", err)
 		return nil, err
 	}
+	promQueuecallWaitingDurationSeconds.Observe(duration.Seconds())
 	h.notifyhandler.PublishWebhookEvent(ctx, res.CustomerID, queuecall.EventTypeQueuecallServiced, res)
 
 	_, err = h.queueHandler.AddServiceQueuecallID(ctx, res.QueueID, res.ID)
@@ -244,6 +246,7 @@ func (h *queuecallHandler) UpdateStatusAbandoned(ctx context.Context, qc *queuec
 		log.Errorf("Could not get updated queuecall. err: %v", err)
 		return nil, err
 	}
+	promQueuecallAbandonedTotal.Inc()
 	h.notifyhandler.PublishWebhookEvent(ctx, res.CustomerID, queuecall.EventTypeQueuecallAbandoned, res)
 
 	// remove the queuecall from the queue.
@@ -291,6 +294,7 @@ func (h *queuecallHandler) UpdateStatusDone(ctx context.Context, qc *queuecall.Q
 		log.Errorf("Could not get updated queuecall. err: %v", err)
 		return nil, err
 	}
+	promQueuecallDoneTotal.Inc()
 	h.notifyhandler.PublishWebhookEvent(ctx, res.CustomerID, queuecall.EventTypeQueuecallDone, res)
 
 	// remove the queuecall from the queue.

--- a/bin-queue-manager/pkg/queuecallhandler/main.go
+++ b/bin-queue-manager/pkg/queuecallhandler/main.go
@@ -14,6 +14,7 @@ import (
 	cucustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	commonservice "monorepo/bin-common-handler/models/service"
@@ -22,6 +23,52 @@ import (
 	"monorepo/bin-queue-manager/pkg/dbhandler"
 	"monorepo/bin-queue-manager/pkg/queuehandler"
 )
+
+var (
+	metricsNamespace = "queue_manager"
+
+	promQueuecallCreateTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "queuecall_create_total",
+			Help:      "Total number of queuecalls created.",
+		},
+	)
+
+	promQueuecallDoneTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "queuecall_done_total",
+			Help:      "Total number of queuecalls completed successfully.",
+		},
+	)
+
+	promQueuecallAbandonedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "queuecall_abandoned_total",
+			Help:      "Total number of queuecalls abandoned.",
+		},
+	)
+
+	promQueuecallWaitingDurationSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "queuecall_waiting_duration_seconds",
+			Help:      "Duration of queuecall waiting time in seconds before service.",
+			Buckets:   []float64{1, 5, 10, 30, 60, 120, 300, 600},
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promQueuecallCreateTotal,
+		promQueuecallDoneTotal,
+		promQueuecallAbandonedTotal,
+		promQueuecallWaitingDurationSeconds,
+	)
+}
 
 const (
 	defaultHealthCheckMaxRetryCount = 2

--- a/docs/plans/2026-02-12-queue-manager-metrics-design.md
+++ b/docs/plans/2026-02-12-queue-manager-metrics-design.md
@@ -1,0 +1,50 @@
+# Queue Manager Metrics & Grafana Dashboard Design
+
+## Date: 2026-02-12
+
+## Problem Statement
+
+The queue-manager service had no custom Prometheus metrics or Grafana dashboard, limiting visibility into queuecall lifecycle, wait times, abandonment rates, and overall queue performance.
+
+## Approach
+
+Add 4 new Prometheus metrics to the queuecallhandler package and create a Grafana dashboard with 5 rows and 14 panels.
+
+## New Metrics
+
+| Metric | Type | Location | Description |
+|--------|------|----------|-------------|
+| `queue_manager_queuecall_create_total` | Counter | queuecallhandler | Total queuecalls created |
+| `queue_manager_queuecall_done_total` | Counter | queuecallhandler | Total queuecalls completed successfully |
+| `queue_manager_queuecall_abandoned_total` | Counter | queuecallhandler | Total queuecalls abandoned |
+| `queue_manager_queuecall_waiting_duration_seconds` | Histogram | queuecallhandler | Wait time before service (buckets: 1,5,10,30,60,120,300,600) |
+
+## Shared Metrics (from bin-common-handler/requesthandler)
+
+- `queue_manager_request_process_time` — RPC request processing duration
+- `queue_manager_event_publish_total` — Published events by type
+
+## Instrumentation Points
+
+- **Create()** in `db.go` — increments `queuecall_create_total` after successful creation
+- **UpdateStatusService()** in `db.go` — observes `queuecall_waiting_duration_seconds` with duration from TMCreate to now
+- **UpdateStatusDone()** in `db.go` — increments `queuecall_done_total`
+- **UpdateStatusAbandoned()** in `db.go` — increments `queuecall_abandoned_total`
+
+## Grafana Dashboard
+
+File: `monitoring/grafana/dashboards/queue-manager.json`
+
+### Rows & Panels
+
+1. **Overview** (4 stat panels) — Total created, done, abandoned, avg waiting duration
+2. **Queuecall Lifecycle** (4 panels) — Create rate, done vs abandoned rate, success rate, abandonment rate
+3. **Waiting Duration** (3 panels) — Average wait, percentiles (p50/p90/p99), histogram distribution
+4. **API & RPC Performance** (2 panels) — RPC processing time percentiles, request rate
+5. **Events** (1 panel) — Event publish rate by type
+
+## Files Changed
+
+- `bin-queue-manager/pkg/queuecallhandler/main.go` — Added prometheus import, 4 metric variables, init() registration
+- `bin-queue-manager/pkg/queuecallhandler/db.go` — Instrumented Create, UpdateStatusService, UpdateStatusDone, UpdateStatusAbandoned
+- `monitoring/grafana/dashboards/queue-manager.json` — New dashboard (5 rows, 14 panels)

--- a/monitoring/grafana/dashboards/queue-manager.json
+++ b/monitoring/grafana/dashboards/queue-manager.json
@@ -1,0 +1,603 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Queuecalls Created (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "queue_manager_queuecall_create_total",
+          "legendFormat": "Created"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Queuecalls Done (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "queue_manager_queuecall_done_total",
+          "legendFormat": "Done"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Queuecalls Abandoned (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "queue_manager_queuecall_abandoned_total",
+          "legendFormat": "Abandoned"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 120 }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Avg Waiting Duration",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_waiting_duration_seconds_sum[5m]) / rate(queue_manager_queuecall_waiting_duration_seconds_count[5m])",
+          "legendFormat": "Avg Wait"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 200,
+      "title": "Queuecall Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "queuecalls/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Queuecall Create Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_create_total[5m])",
+          "legendFormat": "Create Rate"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "queuecalls/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Queuecall Done vs Abandoned Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_done_total[5m])",
+          "legendFormat": "Done Rate"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_abandoned_total[5m])",
+          "legendFormat": "Abandoned Rate"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "%"
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 7,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "min"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Queuecall Success Rate (Done / (Done + Abandoned))",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_done_total[5m]) / (rate(queue_manager_queuecall_done_total[5m]) + rate(queue_manager_queuecall_abandoned_total[5m]))",
+          "legendFormat": "Success Rate"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "%"
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 8,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Abandonment Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_abandoned_total[5m]) / (rate(queue_manager_queuecall_done_total[5m]) + rate(queue_manager_queuecall_abandoned_total[5m]))",
+          "legendFormat": "Abandonment Rate"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 300,
+      "title": "Waiting Duration",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "seconds"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 9,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Avg Waiting Duration (5m)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_queuecall_waiting_duration_seconds_sum[5m]) / rate(queue_manager_queuecall_waiting_duration_seconds_count[5m])",
+          "legendFormat": "Avg Wait"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "spanNulls": true,
+            "axisLabel": "seconds"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 10,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Waiting Duration Percentiles",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.50, rate(queue_manager_queuecall_waiting_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.90, rate(queue_manager_queuecall_waiting_duration_seconds_bucket[5m]))",
+          "legendFormat": "p90"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.99, rate(queue_manager_queuecall_waiting_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 0,
+            "fillOpacity": 50,
+            "spanNulls": true,
+            "drawStyle": "bars",
+            "axisLabel": "count"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
+      "id": 11,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Waiting Duration Distribution (Histogram Buckets)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"1\"}[1h])",
+          "legendFormat": "≤1s"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"5\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"1\"}[1h])",
+          "legendFormat": "1-5s"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"10\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"5\"}[1h])",
+          "legendFormat": "5-10s"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"30\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"10\"}[1h])",
+          "legendFormat": "10-30s"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"60\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"30\"}[1h])",
+          "legendFormat": "30-60s"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"120\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"60\"}[1h])",
+          "legendFormat": "1-2m"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"300\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"120\"}[1h])",
+          "legendFormat": "2-5m"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"+Inf\"}[1h]) - increase(queue_manager_queuecall_waiting_duration_seconds_bucket{le=\"300\"}[1h])",
+          "legendFormat": ">5m"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "id": 400,
+      "title": "API & RPC Performance",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "seconds"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 42 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "RPC Request Processing Time (p50 / p90 / p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.50, rate(queue_manager_request_process_time_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.90, rate(queue_manager_request_process_time_bucket[5m]))",
+          "legendFormat": "p90"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.99, rate(queue_manager_request_process_time_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "req/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 42 },
+      "id": 13,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "RPC Request Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_request_process_time_count[5m])",
+          "legendFormat": "Request Rate"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "id": 500,
+      "title": "Events",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "events/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
+      "id": 14,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Event Publish Rate by Type",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(queue_manager_event_publish_total[5m])",
+          "legendFormat": "{{ type }}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["queue-manager", "voipbin"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Queue Manager",
+  "uid": "queue-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add Prometheus metrics and Grafana dashboard for the queue-manager service to provide visibility into queuecall lifecycle, wait times, and abandonment rates.

- bin-queue-manager: Add queuecall_create_total counter for tracking new queuecalls
- bin-queue-manager: Add queuecall_done_total counter for successfully completed queuecalls
- bin-queue-manager: Add queuecall_abandoned_total counter for abandoned queuecalls
- bin-queue-manager: Add queuecall_waiting_duration_seconds histogram for wait time tracking
- bin-queue-manager: Instrument Create, UpdateStatusService, UpdateStatusDone, UpdateStatusAbandoned
- monitoring: Add Grafana dashboard with 5 rows and 14 panels covering overview stats, lifecycle rates, waiting duration percentiles, RPC performance, and events
- docs: Add queue-manager metrics design document