### PR TITLE
NOJIRA-Add-campaign-manager-metrics-and-grafana-dashboard

### DIFF
--- a/bin-campaign-manager/pkg/campaigncallhandler/campaigncall.go
+++ b/bin-campaign-manager/pkg/campaigncallhandler/campaigncall.go
@@ -74,6 +74,7 @@ func (h *campaigncallHandler) Create(
 		log.Errorf("Could not get created campaigncall. err: %v", err)
 		return nil, err
 	}
+	promCampaigncallCreateTotal.WithLabelValues(string(referenceType)).Inc()
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, campaigncall.EventTypeCampaigncallCreated, res)
 
 	// set the outdial target status to progressing

--- a/bin-campaign-manager/pkg/campaigncallhandler/main.go
+++ b/bin-campaign-manager/pkg/campaigncallhandler/main.go
@@ -13,10 +13,40 @@ import (
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"monorepo/bin-campaign-manager/models/campaigncall"
 	"monorepo/bin-campaign-manager/pkg/dbhandler"
 )
+
+var (
+	metricsNamespace = "campaign_manager"
+
+	promCampaigncallCreateTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaigncall_create_total",
+			Help:      "Total number of campaigncalls created by reference type.",
+		},
+		[]string{"reference_type"},
+	)
+
+	promCampaigncallDoneTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaigncall_done_total",
+			Help:      "Total number of campaigncalls completed by result.",
+		},
+		[]string{"result"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promCampaigncallCreateTotal,
+		promCampaigncallDoneTotal,
+	)
+}
 
 // campaigncallHandler defines
 type campaigncallHandler struct {

--- a/bin-campaign-manager/pkg/campaigncallhandler/status.go
+++ b/bin-campaign-manager/pkg/campaigncallhandler/status.go
@@ -27,6 +27,7 @@ func (h *campaigncallHandler) Done(ctx context.Context, id uuid.UUID, result cam
 		log.Errorf("Could not update the campaigncall status to done. err: %v", err)
 		return nil, err
 	}
+	promCampaigncallDoneTotal.WithLabelValues(string(result)).Inc()
 
 	// calculate omoutdialtarget status
 	otStatus, err := calcDialtargetStatus(result)

--- a/bin-campaign-manager/pkg/campaignhandler/campaign.go
+++ b/bin-campaign-manager/pkg/campaignhandler/campaign.go
@@ -93,6 +93,7 @@ func (h *campaignHandler) Create(
 		log.Errorf("Could not get created campaign. err: %v", err)
 		return nil, err
 	}
+	promCampaignCreateTotal.Inc()
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, campaign.EventTypeCampaignCreated, res)
 
 	log.WithField("campaign", res).Debugf("Created a new campaign. campaign_id: %s", res.ID)

--- a/bin-campaign-manager/pkg/campaignhandler/execute.go
+++ b/bin-campaign-manager/pkg/campaignhandler/execute.go
@@ -27,6 +27,8 @@ func (h *campaignHandler) Execute(ctx context.Context, id uuid.UUID) {
 		"campaign_id": id,
 	})
 
+	promCampaignExecuteTotal.Inc()
+
 	// get campaign
 	c, err := h.Get(ctx, id)
 	if err != nil {

--- a/bin-campaign-manager/pkg/campaignhandler/main.go
+++ b/bin-campaign-manager/pkg/campaignhandler/main.go
@@ -12,12 +12,58 @@ import (
 	fmaction "monorepo/bin-flow-manager/models/action"
 
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"monorepo/bin-campaign-manager/models/campaign"
 	"monorepo/bin-campaign-manager/pkg/campaigncallhandler"
 	"monorepo/bin-campaign-manager/pkg/dbhandler"
 	"monorepo/bin-campaign-manager/pkg/outplanhandler"
 )
+
+var (
+	metricsNamespace = "campaign_manager"
+
+	promCampaignCreateTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaign_create_total",
+			Help:      "Total number of campaigns created.",
+		},
+	)
+
+	promCampaignStatusRunTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaign_status_run_total",
+			Help:      "Total number of campaigns set to run status.",
+		},
+	)
+
+	promCampaignStatusStopTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaign_status_stop_total",
+			Help:      "Total number of campaigns stopped.",
+		},
+	)
+
+	promCampaignExecuteTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaign_execute_total",
+			Help:      "Total number of campaign execution loops.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promCampaignCreateTotal,
+		promCampaignStatusRunTotal,
+		promCampaignStatusStopTotal,
+		promCampaignExecuteTotal,
+	)
+}
 
 // campaignHandler defines
 type campaignHandler struct {

--- a/bin-campaign-manager/pkg/campaignhandler/status_run.go
+++ b/bin-campaign-manager/pkg/campaignhandler/status_run.go
@@ -55,6 +55,7 @@ func (h *campaignHandler) campaignRun(ctx context.Context, id uuid.UUID) (*campa
 		log.Errorf("Could not get updated campaign info. err: %v", err)
 		return nil, err
 	}
+	promCampaignStatusRunTotal.Inc()
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, campaign.EventTypeCampaignStatusRun, res)
 
 	// execute campaign handle with 1 second delay

--- a/bin-campaign-manager/pkg/campaignhandler/status_stop.go
+++ b/bin-campaign-manager/pkg/campaignhandler/status_stop.go
@@ -119,6 +119,7 @@ func (h *campaignHandler) campaignStopNow(ctx context.Context, id uuid.UUID) (*c
 		log.Errorf("Could not get updated campaign info. err: %v", err)
 		return nil, err
 	}
+	promCampaignStatusStopTotal.Inc()
 	h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, campaign.EventTypeCampaignStatusStop, res)
 
 	return res, nil

--- a/docs/plans/2026-02-12-campaign-manager-metrics-design.md
+++ b/docs/plans/2026-02-12-campaign-manager-metrics-design.md
@@ -1,0 +1,67 @@
+# Campaign Manager Metrics & Grafana Dashboard Design
+
+## Date: 2026-02-12
+
+## Problem Statement
+
+The campaign-manager service had no custom Prometheus metrics or Grafana dashboard, limiting visibility into campaign lifecycle, campaigncall outcomes, and execution loop activity.
+
+## Approach
+
+Add 6 new Prometheus metrics across campaignhandler and campaigncallhandler packages, and create a Grafana dashboard with 5 rows and 13 panels.
+
+## New Metrics
+
+### campaignhandler
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `campaign_manager_campaign_create_total` | Counter | Total campaigns created |
+| `campaign_manager_campaign_status_run_total` | Counter | Total campaigns set to run status |
+| `campaign_manager_campaign_status_stop_total` | Counter | Total campaigns stopped |
+| `campaign_manager_campaign_execute_total` | Counter | Total campaign execution loops |
+
+### campaigncallhandler
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `campaign_manager_campaigncall_create_total` | CounterVec | reference_type | Total campaigncalls created by type (call/flow) |
+| `campaign_manager_campaigncall_done_total` | CounterVec | result | Total campaigncalls completed by result (success/fail) |
+
+## Shared Metrics (from bin-common-handler/requesthandler)
+
+- `campaign_manager_request_process_time` — RPC request processing duration
+- `campaign_manager_event_publish_total` — Published events by type
+
+## Instrumentation Points
+
+- **campaignhandler/campaign.go Create()** — increments `campaign_create_total`
+- **campaignhandler/status_run.go campaignRun()** — increments `campaign_status_run_total`
+- **campaignhandler/status_stop.go campaignStopNow()** — increments `campaign_status_stop_total`
+- **campaignhandler/execute.go Execute()** — increments `campaign_execute_total`
+- **campaigncallhandler/campaigncall.go Create()** — increments `campaigncall_create_total` with reference_type label
+- **campaigncallhandler/status.go Done()** — increments `campaigncall_done_total` with result label
+
+## Grafana Dashboard
+
+File: `monitoring/grafana/dashboards/campaign-manager.json`
+
+### Rows & Panels
+
+1. **Overview** (4 stat panels) — Campaigns created, started, stopped, execute loops
+2. **Campaign Lifecycle** (3 panels) — Create rate, run vs stop rate, execute loop rate
+3. **Campaigncall Lifecycle** (3 panels) — Create rate by reference type, done rate by result, success rate
+4. **API & RPC Performance** (2 panels) — RPC processing time percentiles, request rate
+5. **Events** (1 panel) — Event publish rate by type
+
+## Files Changed
+
+- `bin-campaign-manager/pkg/campaignhandler/main.go` — Added prometheus import, 4 metric vars, init()
+- `bin-campaign-manager/pkg/campaignhandler/campaign.go` — Instrumented Create()
+- `bin-campaign-manager/pkg/campaignhandler/status_run.go` — Instrumented campaignRun()
+- `bin-campaign-manager/pkg/campaignhandler/status_stop.go` — Instrumented campaignStopNow()
+- `bin-campaign-manager/pkg/campaignhandler/execute.go` — Instrumented Execute()
+- `bin-campaign-manager/pkg/campaigncallhandler/main.go` — Added prometheus import, 2 metric vars, init()
+- `bin-campaign-manager/pkg/campaigncallhandler/campaigncall.go` — Instrumented Create()
+- `bin-campaign-manager/pkg/campaigncallhandler/status.go` — Instrumented Done()
+- `monitoring/grafana/dashboards/campaign-manager.json` — New dashboard

--- a/monitoring/grafana/dashboards/campaign-manager.json
+++ b/monitoring/grafana/dashboards/campaign-manager.json
@@ -1,0 +1,525 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Campaigns Created (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "campaign_manager_campaign_create_total",
+          "legendFormat": "Created"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Campaigns Started (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "campaign_manager_campaign_status_run_total",
+          "legendFormat": "Started"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Campaigns Stopped (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "campaign_manager_campaign_status_stop_total",
+          "legendFormat": "Stopped"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      },
+      "title": "Execute Loops (total)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "campaign_manager_campaign_execute_total",
+          "legendFormat": "Executions"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 200,
+      "title": "Campaign Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "campaigns/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Campaign Create Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaign_create_total[5m])",
+          "legendFormat": "Create Rate"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "campaigns/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Campaign Run vs Stop Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaign_status_run_total[5m])",
+          "legendFormat": "Run Rate"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaign_status_stop_total[5m])",
+          "legendFormat": "Stop Rate"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "loops/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 7,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Campaign Execute Loop Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaign_execute_total[5m])",
+          "legendFormat": "Execute Rate"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 300,
+      "title": "Campaigncall Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "calls/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 8,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Campaigncall Create Rate by Reference Type",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaigncall_create_total[5m])",
+          "legendFormat": "{{ reference_type }}"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "calls/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 9,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Campaigncall Done Rate by Result",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaigncall_done_total[5m])",
+          "legendFormat": "{{ result }}"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "%"
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
+      "id": 10,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "min"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Campaigncall Success Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_campaigncall_done_total{result=\"success\"}[5m]) / (rate(campaign_manager_campaigncall_done_total{result=\"success\"}[5m]) + rate(campaign_manager_campaigncall_done_total{result=\"fail\"}[5m]))",
+          "legendFormat": "Success Rate"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "id": 400,
+      "title": "API & RPC Performance",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "seconds"
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 42 },
+      "id": 11,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "RPC Request Processing Time (p50 / p90 / p99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.50, rate(campaign_manager_request_process_time_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.90, rate(campaign_manager_request_process_time_bucket[5m]))",
+          "legendFormat": "p90"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "histogram_quantile(0.99, rate(campaign_manager_request_process_time_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "req/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 42 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "RPC Request Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_request_process_time_count[5m])",
+          "legendFormat": "Request Rate"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 50 },
+      "id": 500,
+      "title": "Events",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "axisLabel": "events/sec"
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
+      "id": 13,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] },
+        "tooltip": { "mode": "multi" }
+      },
+      "title": "Event Publish Rate by Type",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "rate(campaign_manager_event_publish_total[5m])",
+          "legendFormat": "{{ type }}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["campaign-manager", "voipbin"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Campaign Manager",
+  "uid": "campaign-manager",
+  "version": 1
+}


### PR DESCRIPTION
Add Prometheus metrics and Grafana dashboard for the campaign-manager service to provide visibility into campaign lifecycle, campaigncall outcomes, and execution loop activity.

- bin-campaign-manager: Add campaign_create_total, campaign_status_run_total, campaign_status_stop_total, campaign_execute_total counters
- bin-campaign-manager: Add campaigncall_create_total (by reference_type) and campaigncall_done_total (by result) counters
- bin-campaign-manager: Instrument campaign Create, Run, Stop, Execute and campaigncall Create, Done
- monitoring: Add Grafana dashboard with 5 rows and 13 panels covering overview stats, campaign lifecycle, campaigncall lifecycle, RPC performance, and events
- docs: Add campaign-manager metrics design document