### PR TITLE
NOJIRA-Fix-empty-string-time-parsing-in-message-scanner

### DIFF
--- a/bin-common-handler/pkg/databasehandler/mapping.go
+++ b/bin-common-handler/pkg/databasehandler/mapping.go
@@ -429,6 +429,11 @@ func (t *scanTarget) copyPrimitive() error {
 
 // copyTimePtr parses a datetime string and sets it as *time.Time
 func (t *scanTarget) copyTimePtr(s string) error {
+	// Empty string means no value — leave the field as nil
+	if s == "" {
+		return nil
+	}
+
 	// Convert MySQL format to ISO 8601 if needed
 	isoStr := convertMySQLTimestampToISO8601(s)
 


### PR DESCRIPTION
Handle empty string in copyTimePtr to prevent database scan failures when
*time.Time columns or JSON-embedded time fields contain "" instead of NULL.

- bin-common-handler: Add empty string guard in copyTimePtr to return nil instead of failing all 10 parse attempts
- bin-common-handler: Add unit tests for copyTimePtr covering empty string, valid timestamps, and invalid input