### PR TITLE
NOJIRA-Add-billing-manager-handler-tests

### DIFF
--- a/bin-billing-manager/pkg/accounthandler/balance_test.go
+++ b/bin-billing-manager/pkg/accounthandler/balance_test.go
@@ -2,7 +2,9 @@ package accounthandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
@@ -74,6 +76,17 @@ func Test_IsValidBalanceByCustomerID(t *testing.T) {
 			},
 			expectRes: true,
 		},
+		{
+			name: "customer not found error",
+
+			customerID:  uuid.FromStringOrNil("b1c1d1e1-1111-11ee-86c6-111111111111"),
+			billingType: billing.ReferenceTypeCall,
+			count:       1,
+
+			responseCustomer: nil,
+			responseAccount:  nil,
+			expectRes:        false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -93,6 +106,16 @@ func Test_IsValidBalanceByCustomerID(t *testing.T) {
 				reqHandler:    mockReq,
 			}
 			ctx := context.Background()
+
+			if tt.name == "customer not found error" {
+				mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(nil, fmt.Errorf("customer not found"))
+
+				_, err := h.IsValidBalanceByCustomerID(ctx, tt.customerID, tt.billingType, tt.country, tt.count)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
 
 			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(tt.responseCustomer, nil)
 			mockDB.EXPECT().AccountGet(ctx, tt.responseCustomer.BillingAccountID).Return(tt.responseAccount, nil)
@@ -121,7 +144,10 @@ func Test_IsValidBalance(t *testing.T) {
 
 		responseAccount *account.Account
 		expectRes       bool
+		expectErr       bool
 	}
+
+	tmDelete := time.Now()
 
 	tests := []test{
 		{
@@ -156,6 +182,119 @@ func Test_IsValidBalance(t *testing.T) {
 			},
 			expectRes: true,
 		},
+		{
+			name: "deleted account returns false",
+
+			accountID:   uuid.FromStringOrNil("a1b1c1d1-1111-11ee-86c6-111111111111"),
+			billingType: billing.ReferenceTypeCall,
+			count:       1,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a1b1c1d1-1111-11ee-86c6-111111111111"),
+				},
+				Balance:  10.0,
+				TMDelete: &tmDelete,
+			},
+			expectRes: false,
+		},
+		{
+			name: "insufficient balance for call",
+
+			accountID:   uuid.FromStringOrNil("a2b2c2d2-2222-11ee-86c6-222222222222"),
+			billingType: billing.ReferenceTypeCall,
+			count:       1,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a2b2c2d2-2222-11ee-86c6-222222222222"),
+				},
+				Balance:  0.01,
+				TMDelete: nil,
+			},
+			expectRes: false,
+		},
+		{
+			name: "insufficient balance for number",
+
+			accountID:   uuid.FromStringOrNil("a3b3c3d3-3333-11ee-86c6-333333333333"),
+			billingType: billing.ReferenceTypeNumber,
+			count:       1,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a3b3c3d3-3333-11ee-86c6-333333333333"),
+				},
+				Balance:  4.99,
+				TMDelete: nil,
+			},
+			expectRes: false,
+		},
+		{
+			name: "call_extension always valid regardless of balance",
+
+			accountID:   uuid.FromStringOrNil("a4b4c4d4-4444-11ee-86c6-444444444444"),
+			billingType: billing.ReferenceTypeCallExtension,
+			count:       1,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a4b4c4d4-4444-11ee-86c6-444444444444"),
+				},
+				Balance:  0,
+				TMDelete: nil,
+			},
+			expectRes: true,
+		},
+		{
+			name: "sms with enough balance",
+
+			accountID:   uuid.FromStringOrNil("a5b5c5d5-5555-11ee-86c6-555555555555"),
+			billingType: billing.ReferenceTypeSMS,
+			count:       1,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a5b5c5d5-5555-11ee-86c6-555555555555"),
+				},
+				Balance:  1.0,
+				TMDelete: nil,
+			},
+			expectRes: true,
+		},
+		{
+			name: "count less than 1 normalized to 1",
+
+			accountID:   uuid.FromStringOrNil("a6b6c6d6-6666-11ee-86c6-666666666666"),
+			billingType: billing.ReferenceTypeCall,
+			count:       0,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a6b6c6d6-6666-11ee-86c6-666666666666"),
+				},
+				Balance:  10.0,
+				TMDelete: nil,
+			},
+			expectRes: true,
+		},
+		{
+			name: "unsupported billing type returns error",
+
+			accountID:   uuid.FromStringOrNil("a7b7c7d7-7777-11ee-86c6-777777777777"),
+			billingType: billing.ReferenceType("unknown"),
+			count:       1,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a7b7c7d7-7777-11ee-86c6-777777777777"),
+				},
+				Balance:  10.0,
+				TMDelete: nil,
+			},
+			expectRes: false,
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +318,13 @@ func Test_IsValidBalance(t *testing.T) {
 			mockDB.EXPECT().AccountGet(ctx, tt.accountID).Return(tt.responseAccount, nil)
 
 			res, err := h.IsValidBalance(ctx, tt.accountID, tt.billingType, tt.country, tt.count)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
+
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-billing-manager/pkg/accounthandler/event_test.go
+++ b/bin-billing-manager/pkg/accounthandler/event_test.go
@@ -2,6 +2,7 @@ package accounthandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"monorepo/bin-billing-manager/models/account"
@@ -160,6 +161,211 @@ func Test_EventCUCustomerCreated(t *testing.T) {
 
 			if err := h.EventCUCustomerCreated(ctx, tt.customer); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EventCUCustomerCreated_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		customer *cucustomer.Customer
+
+		responseUUID    uuid.UUID
+		responseAccount *account.Account
+	}
+
+	tests := []test{
+		{
+			name: "create account error",
+
+			customer: &cucustomer.Customer{
+				ID: uuid.FromStringOrNil("d1e1f101-c9eb-11ef-b340-4f193897195f"),
+			},
+
+			responseUUID:    uuid.FromStringOrNil("d1e1f101-c9eb-11ef-b340-4f193897195f"),
+			responseAccount: nil,
+		},
+		{
+			name: "update customer error",
+
+			customer: &cucustomer.Customer{
+				ID: uuid.FromStringOrNil("d2e2f202-c9eb-11ef-b341-5f294898296g"),
+			},
+
+			responseUUID: uuid.FromStringOrNil("d2e2f202-c9eb-11ef-b341-5f294898296g"),
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("d2e2f202-c9eb-11ef-b341-5f294898296g"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+
+			h := accountHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+			}
+			ctx := context.Background()
+
+			if tt.name == "create account error" {
+				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+				mockDB.EXPECT().AccountCreate(ctx, gomock.Any()).Return(nil)
+				mockDB.EXPECT().AccountGet(ctx, tt.responseUUID).Return(nil, fmt.Errorf("get failed after create"))
+
+				err := h.EventCUCustomerCreated(ctx, tt.customer)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
+
+			if tt.name == "update customer error" {
+				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+				mockDB.EXPECT().AccountCreate(ctx, gomock.Any()).Return(nil)
+				mockDB.EXPECT().AccountGet(ctx, tt.responseUUID).Return(tt.responseAccount, nil)
+				mockNotify.EXPECT().PublishEvent(ctx, account.EventTypeAccountCreated, tt.responseAccount)
+				mockReq.EXPECT().CustomerV1CustomerUpdateBillingAccountID(ctx, tt.customer.ID, tt.responseAccount.ID).Return(nil, fmt.Errorf("update failed"))
+
+				err := h.EventCUCustomerCreated(ctx, tt.customer)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+			}
+		})
+	}
+}
+
+func Test_EventCUCustomerDeleted_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		customerID uuid.UUID
+		customer   *cucustomer.Customer
+
+		expectFilters map[account.Field]any
+	}
+
+	tests := []test{
+		{
+			name: "list error",
+
+			customerID: uuid.FromStringOrNil("e3f3a313-0e69-11ee-b842-4ff4e11b8ac0"),
+			customer: &cucustomer.Customer{
+				ID: uuid.FromStringOrNil("e3f3a313-0e69-11ee-b842-4ff4e11b8ac0"),
+			},
+
+			expectFilters: map[account.Field]any{
+				account.FieldCustomerID: uuid.FromStringOrNil("e3f3a313-0e69-11ee-b842-4ff4e11b8ac0"),
+				account.FieldDeleted:    false,
+			},
+		},
+		{
+			name: "empty accounts",
+
+			customerID: uuid.FromStringOrNil("e4f4b424-0e69-11ee-b843-5005f22c9bd1"),
+			customer: &cucustomer.Customer{
+				ID: uuid.FromStringOrNil("e4f4b424-0e69-11ee-b843-5005f22c9bd1"),
+			},
+
+			expectFilters: map[account.Field]any{
+				account.FieldCustomerID: uuid.FromStringOrNil("e4f4b424-0e69-11ee-b843-5005f22c9bd1"),
+				account.FieldDeleted:    false,
+			},
+		},
+		{
+			name: "delete error continues",
+
+			customerID: uuid.FromStringOrNil("e5f5c535-0e69-11ee-b844-6116033dace2"),
+			customer: &cucustomer.Customer{
+				ID: uuid.FromStringOrNil("e5f5c535-0e69-11ee-b844-6116033dace2"),
+			},
+
+			expectFilters: map[account.Field]any{
+				account.FieldCustomerID: uuid.FromStringOrNil("e5f5c535-0e69-11ee-b844-6116033dace2"),
+				account.FieldDeleted:    false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			h := accountHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			if tt.name == "list error" {
+				mockDB.EXPECT().AccountList(ctx, uint64(1000), "", tt.expectFilters).Return(nil, fmt.Errorf("list failed"))
+
+				err := h.EventCUCustomerDeleted(ctx, tt.customer)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
+
+			if tt.name == "empty accounts" {
+				mockDB.EXPECT().AccountList(ctx, uint64(1000), "", tt.expectFilters).Return([]*account.Account{}, nil)
+
+				err := h.EventCUCustomerDeleted(ctx, tt.customer)
+				if err != nil {
+					t.Errorf("Wrong match. expect: ok, got: %v", err)
+				}
+				return
+			}
+
+			if tt.name == "delete error continues" {
+				accounts := []*account.Account{
+					{
+						Identity: commonidentity.Identity{
+							ID: uuid.FromStringOrNil("f6060d46-0e69-11ee-b845-7227144ebdf3"),
+						},
+					},
+					{
+						Identity: commonidentity.Identity{
+							ID: uuid.FromStringOrNil("f7071e57-0e69-11ee-b846-8338255fceg4"),
+						},
+					},
+				}
+
+				mockDB.EXPECT().AccountList(ctx, uint64(1000), "", tt.expectFilters).Return(accounts, nil)
+
+				// First delete fails
+				mockDB.EXPECT().AccountDelete(ctx, accounts[0].ID).Return(fmt.Errorf("delete failed"))
+
+				// Second delete succeeds
+				mockDB.EXPECT().AccountDelete(ctx, accounts[1].ID).Return(nil)
+				mockDB.EXPECT().AccountGet(ctx, accounts[1].ID).Return(accounts[1], nil)
+
+				err := h.EventCUCustomerDeleted(ctx, tt.customer)
+				if err != nil {
+					t.Errorf("Wrong match. expect: ok, got: %v", err)
+				}
 			}
 		})
 	}

--- a/bin-billing-manager/pkg/accounthandler/resource_limit_test.go
+++ b/bin-billing-manager/pkg/accounthandler/resource_limit_test.go
@@ -2,6 +2,7 @@ package accounthandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
+	cmcustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -129,6 +131,36 @@ func Test_IsValidResourceLimit(t *testing.T) {
 			expectRes:       false,
 			expectErr:       true,
 		},
+		{
+			name: "db get error",
+
+			accountID:    uuid.FromStringOrNil("a1b2c3d4-0006-0001-0001-000000000001"),
+			resourceType: account.ResourceTypeAgent,
+
+			responseAccount: nil,
+
+			expectCountCall: false,
+			expectRes:       false,
+			expectErr:       true,
+		},
+		{
+			name: "resource count error",
+
+			accountID:    uuid.FromStringOrNil("a1b2c3d4-0007-0001-0001-000000000001"),
+			resourceType: account.ResourceTypeAgent,
+
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("a1b2c3d4-0007-0001-0001-000000000001"),
+					CustomerID: uuid.FromStringOrNil("a1b2c3d4-0007-0001-0001-000000000002"),
+				},
+				PlanType: account.PlanTypeFree,
+			},
+
+			expectCountCall: false,
+			expectRes:       false,
+			expectErr:       true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -149,7 +181,27 @@ func Test_IsValidResourceLimit(t *testing.T) {
 			}
 			ctx := context.Background()
 
+			if tt.name == "db get error" {
+				mockDB.EXPECT().AccountGet(ctx, tt.accountID).Return(nil, fmt.Errorf("database error"))
+
+				_, err := h.IsValidResourceLimit(ctx, tt.accountID, tt.resourceType)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
+
 			mockDB.EXPECT().AccountGet(ctx, tt.accountID).Return(tt.responseAccount, nil)
+
+			if tt.name == "resource count error" {
+				mockReq.EXPECT().AgentV1AgentCountByCustomerID(ctx, tt.responseAccount.CustomerID).Return(0, fmt.Errorf("count error"))
+
+				_, err := h.IsValidResourceLimit(ctx, tt.accountID, tt.resourceType)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
 
 			if tt.expectCountCall {
 				mockReq.EXPECT().AgentV1AgentCountByCustomerID(ctx, tt.responseAccount.CustomerID).Return(tt.responseCount, nil)
@@ -232,6 +284,13 @@ func Test_getResourceCount(t *testing.T) {
 			responseCount: 2,
 			expectRes:     2,
 		},
+		{
+			name:          "virtual_number",
+			customerID:    customerID,
+			resourceType:  account.ResourceTypeVirtualNumber,
+			responseCount: 3,
+			expectRes:     3,
+		},
 	}
 
 	for _, tt := range tests {
@@ -265,6 +324,8 @@ func Test_getResourceCount(t *testing.T) {
 				mockReq.EXPECT().FlowV1FlowCountByCustomerID(ctx, tt.customerID).Return(tt.responseCount, nil)
 			case account.ResourceTypeConference:
 				mockReq.EXPECT().ConferenceV1ConferenceCountByCustomerID(ctx, tt.customerID).Return(tt.responseCount, nil)
+			case account.ResourceTypeVirtualNumber:
+				mockReq.EXPECT().NumberV1VirtualNumberCountByCustomerID(ctx, tt.customerID).Return(tt.responseCount, nil)
 			}
 
 			res, err := h.getResourceCount(ctx, tt.customerID, tt.resourceType)
@@ -300,5 +361,118 @@ func Test_getResourceCount_unsupported(t *testing.T) {
 	_, err := h.getResourceCount(ctx, customerID, account.ResourceType("unsupported"))
 	if err == nil {
 		t.Errorf("Wrong match. expect: error, got: nil")
+	}
+}
+
+func Test_IsValidResourceLimitByCustomerID(t *testing.T) {
+
+	type test struct {
+		name string
+
+		customerID   uuid.UUID
+		resourceType account.ResourceType
+
+		responseCustomer *cmcustomer.Customer
+		responseAccount  *account.Account
+		responseCount    int
+
+		expectCountCall bool
+		expectRes       bool
+		expectErr       bool
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+
+			customerID:   uuid.FromStringOrNil("c1d1e1f1-0001-0001-0001-000000000001"),
+			resourceType: account.ResourceTypeAgent,
+
+			responseCustomer: &cmcustomer.Customer{
+				ID:               uuid.FromStringOrNil("c1d1e1f1-0001-0001-0001-000000000001"),
+				BillingAccountID: uuid.FromStringOrNil("c1d1e1f1-0001-0001-0001-000000000002"),
+			},
+			responseAccount: &account.Account{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c1d1e1f1-0001-0001-0001-000000000002"),
+					CustomerID: uuid.FromStringOrNil("c1d1e1f1-0001-0001-0001-000000000001"),
+				},
+				PlanType: account.PlanTypeFree,
+			},
+			responseCount: 3,
+
+			expectCountCall: true,
+			expectRes:       true,
+			expectErr:       false,
+		},
+		{
+			name: "customer not found error",
+
+			customerID:   uuid.FromStringOrNil("c2d2e2f2-0002-0001-0001-000000000001"),
+			resourceType: account.ResourceTypeAgent,
+
+			responseCustomer: nil,
+			responseAccount:  nil,
+
+			expectCountCall: false,
+			expectRes:       false,
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+
+			h := accountHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+			}
+			ctx := context.Background()
+
+			if tt.name == "customer not found error" {
+				mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(nil, fmt.Errorf("customer not found"))
+
+				_, err := h.IsValidResourceLimitByCustomerID(ctx, tt.customerID, tt.resourceType)
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
+
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(tt.responseCustomer, nil)
+			// GetByCustomerID calls AccountGet
+			mockDB.EXPECT().AccountGet(ctx, tt.responseCustomer.BillingAccountID).Return(tt.responseAccount, nil)
+			// IsValidResourceLimit calls h.Get which calls AccountGet again
+			mockDB.EXPECT().AccountGet(ctx, tt.responseAccount.ID).Return(tt.responseAccount, nil)
+
+			if tt.expectCountCall {
+				mockReq.EXPECT().AgentV1AgentCountByCustomerID(ctx, tt.responseAccount.CustomerID).Return(tt.responseCount, nil)
+			}
+
+			res, err := h.IsValidResourceLimitByCustomerID(ctx, tt.customerID, tt.resourceType)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %v, got: %v", tt.expectRes, res)
+			}
+		})
 	}
 }

--- a/bin-billing-manager/pkg/billinghandler/db_test.go
+++ b/bin-billing-manager/pkg/billinghandler/db_test.go
@@ -2,6 +2,7 @@ package billinghandler
 
 import (
 	"context"
+	"fmt"
 	reflect "reflect"
 	"testing"
 	"time"
@@ -355,6 +356,426 @@ func Test_UpdateStatusEnd(t *testing.T) {
 
 			if reflect.DeepEqual(tt.responseBilling, res) == false {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.responseBilling, res)
+			}
+		})
+	}
+}
+
+func Test_Create_db_create_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		customerID     uuid.UUID
+		accountID      uuid.UUID
+		referenceType  billing.ReferenceType
+		referenceID    uuid.UUID
+		costPerUnit    float32
+		tmBillingStart *time.Time
+
+		responseUUID uuid.UUID
+
+		expectBilling *billing.Billing
+	}
+
+	tmBillingStart := time.Date(2023, 6, 8, 3, 22, 17, 995000000, time.UTC)
+
+	tests := []test{
+		{
+			name: "db create error",
+
+			customerID:     uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001"),
+			accountID:      uuid.FromStringOrNil("22222222-0000-0000-0000-000000000001"),
+			referenceType:  billing.ReferenceTypeCall,
+			referenceID:    uuid.FromStringOrNil("33333333-0000-0000-0000-000000000001"),
+			costPerUnit:    billing.DefaultCostPerUnitReferenceTypeCall,
+			tmBillingStart: &tmBillingStart,
+
+			responseUUID: uuid.FromStringOrNil("44444444-0000-0000-0000-000000000001"),
+
+			expectBilling: &billing.Billing{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("44444444-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001"),
+				},
+				AccountID:      uuid.FromStringOrNil("22222222-0000-0000-0000-000000000001"),
+				Status:         billing.StatusProgressing,
+				ReferenceType:  billing.ReferenceTypeCall,
+				ReferenceID:    uuid.FromStringOrNil("33333333-0000-0000-0000-000000000001"),
+				CostPerUnit:    billing.DefaultCostPerUnitReferenceTypeCall,
+				CostTotal:      0,
+				TMBillingStart: &tmBillingStart,
+				TMBillingEnd:   nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+			mockDB.EXPECT().BillingCreate(ctx, tt.expectBilling).Return(fmt.Errorf("db connection lost"))
+
+			_, err := h.Create(ctx, tt.customerID, tt.accountID, tt.referenceType, tt.referenceID, tt.costPerUnit, tt.tmBillingStart)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
+			}
+		})
+	}
+}
+
+func Test_Create_db_get_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		customerID     uuid.UUID
+		accountID      uuid.UUID
+		referenceType  billing.ReferenceType
+		referenceID    uuid.UUID
+		costPerUnit    float32
+		tmBillingStart *time.Time
+
+		responseUUID uuid.UUID
+
+		expectBilling *billing.Billing
+	}
+
+	tmBillingStart := time.Date(2023, 6, 8, 3, 22, 17, 995000000, time.UTC)
+
+	tests := []test{
+		{
+			name: "db get error after create",
+
+			customerID:     uuid.FromStringOrNil("55555555-0000-0000-0000-000000000001"),
+			accountID:      uuid.FromStringOrNil("66666666-0000-0000-0000-000000000001"),
+			referenceType:  billing.ReferenceTypeCall,
+			referenceID:    uuid.FromStringOrNil("77777777-0000-0000-0000-000000000001"),
+			costPerUnit:    billing.DefaultCostPerUnitReferenceTypeCall,
+			tmBillingStart: &tmBillingStart,
+
+			responseUUID: uuid.FromStringOrNil("88888888-0000-0000-0000-000000000001"),
+
+			expectBilling: &billing.Billing{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("88888888-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("55555555-0000-0000-0000-000000000001"),
+				},
+				AccountID:      uuid.FromStringOrNil("66666666-0000-0000-0000-000000000001"),
+				Status:         billing.StatusProgressing,
+				ReferenceType:  billing.ReferenceTypeCall,
+				ReferenceID:    uuid.FromStringOrNil("77777777-0000-0000-0000-000000000001"),
+				CostPerUnit:    billing.DefaultCostPerUnitReferenceTypeCall,
+				CostTotal:      0,
+				TMBillingStart: &tmBillingStart,
+				TMBillingEnd:   nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+			mockDB.EXPECT().BillingCreate(ctx, tt.expectBilling).Return(nil)
+			mockDB.EXPECT().BillingGet(ctx, tt.responseUUID).Return(nil, fmt.Errorf("connection timeout"))
+
+			_, err := h.Create(ctx, tt.customerID, tt.accountID, tt.referenceType, tt.referenceID, tt.costPerUnit, tt.tmBillingStart)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
+			}
+		})
+	}
+}
+
+func Test_Get_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		id uuid.UUID
+	}
+
+	tests := []test{
+		{
+			name: "db error",
+
+			id: uuid.FromStringOrNil("99999999-0000-0000-0000-000000000001"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			mockAccount := accounthandler.NewMockAccountHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+
+				accountHandler: mockAccount,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().BillingGet(ctx, tt.id).Return(nil, fmt.Errorf("connection timeout"))
+
+			_, err := h.Get(ctx, tt.id)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
+			}
+		})
+	}
+}
+
+func Test_GetByReferenceID_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		referenceID uuid.UUID
+
+		responseBilling *billing.Billing
+	}
+
+	tests := []test{
+		{
+			name: "db error",
+
+			referenceID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000001"),
+		},
+		{
+			name: "wrong reference type",
+
+			referenceID: uuid.FromStringOrNil("bbbbbbbb-0000-0000-0000-000000000001"),
+
+			responseBilling: &billing.Billing{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("cccccccc-0000-0000-0000-000000000001"),
+				},
+				ReferenceType: billing.ReferenceTypeSMS,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			mockAccount := accounthandler.NewMockAccountHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+
+				accountHandler: mockAccount,
+			}
+			ctx := context.Background()
+
+			if tt.responseBilling == nil {
+				mockDB.EXPECT().BillingGetByReferenceID(ctx, tt.referenceID).Return(nil, fmt.Errorf("connection timeout"))
+			} else {
+				mockDB.EXPECT().BillingGetByReferenceID(ctx, tt.referenceID).Return(tt.responseBilling, nil)
+			}
+
+			_, err := h.GetByReferenceID(ctx, tt.referenceID)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
+			}
+		})
+	}
+}
+
+func Test_List_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		size    uint64
+		token   string
+		filters map[billing.Field]any
+	}
+
+	tests := []test{
+		{
+			name: "db error",
+
+			size:  10,
+			token: "2023-06-08T03:22:17.995000Z",
+			filters: map[billing.Field]any{
+				billing.FieldCustomerID: uuid.FromStringOrNil("dddddddd-0000-0000-0000-000000000001"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			mockAccount := accounthandler.NewMockAccountHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+
+				accountHandler: mockAccount,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().BillingList(ctx, tt.size, tt.token, tt.filters).Return(nil, fmt.Errorf("connection timeout"))
+
+			_, err := h.List(ctx, tt.size, tt.token, tt.filters)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
+			}
+		})
+	}
+}
+
+func Test_UpdateStatusEnd_set_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		id              uuid.UUID
+		billingDuration float32
+		tmBillingEnd    *time.Time
+	}
+
+	tmBillingEnd := time.Date(2023, 6, 9, 3, 22, 17, 995000000, time.UTC)
+
+	tests := []test{
+		{
+			name: "set status error",
+
+			id:              uuid.FromStringOrNil("eeeeeeee-0000-0000-0000-000000000001"),
+			billingDuration: 10.32,
+			tmBillingEnd:    &tmBillingEnd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			mockAccount := accounthandler.NewMockAccountHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+
+				accountHandler: mockAccount,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().BillingSetStatusEnd(ctx, tt.id, tt.billingDuration, tt.tmBillingEnd).Return(fmt.Errorf("connection timeout"))
+
+			_, err := h.UpdateStatusEnd(ctx, tt.id, tt.billingDuration, tt.tmBillingEnd)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
+			}
+		})
+	}
+}
+
+func Test_UpdateStatusEnd_get_error(t *testing.T) {
+
+	type test struct {
+		name string
+
+		id              uuid.UUID
+		billingDuration float32
+		tmBillingEnd    *time.Time
+	}
+
+	tmBillingEnd := time.Date(2023, 6, 9, 3, 22, 17, 995000000, time.UTC)
+
+	tests := []test{
+		{
+			name: "get error after set",
+
+			id:              uuid.FromStringOrNil("ffffffff-0000-0000-0000-000000000001"),
+			billingDuration: 10.32,
+			tmBillingEnd:    &tmBillingEnd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			mockAccount := accounthandler.NewMockAccountHandler(mc)
+
+			h := billingHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+
+				accountHandler: mockAccount,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().BillingSetStatusEnd(ctx, tt.id, tt.billingDuration, tt.tmBillingEnd).Return(nil)
+			mockDB.EXPECT().BillingGet(ctx, tt.id).Return(nil, fmt.Errorf("connection timeout"))
+
+			_, err := h.UpdateStatusEnd(ctx, tt.id, tt.billingDuration, tt.tmBillingEnd)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: nil")
 			}
 		})
 	}


### PR DESCRIPTION
Add comprehensive test coverage for billing-manager business logic handlers
covering error paths, edge cases, and previously untested methods. Increases
handler test cases from ~49 to ~104 across accounthandler, billinghandler,
and credithandler.

- bin-billing-manager: Add accounthandler tests for UpdatePaymentInfo, UpdatePlanType, IsValidResourceLimitByCustomerID
- bin-billing-manager: Add accounthandler error path tests for Get, GetByCustomerID, List, SubtractBalance, AddBalance, Delete, Create
- bin-billing-manager: Add accounthandler IsValidBalance tests for all billing types, insufficient balance, deleted account, count normalization
- bin-billing-manager: Add accounthandler IsValidResourceLimit tests for DB errors, resource count errors, virtual_number type
- bin-billing-manager: Add accounthandler event tests for create/update errors, empty lists, partial deletion failures
- bin-billing-manager: Add billinghandler BillingStart tests for idempotency retry, unsupported type, account not found, create error
- bin-billing-manager: Add billinghandler BillingEnd tests for nil timestamps, unsupported type, SetStatusEnd/Get errors
- bin-billing-manager: Add billinghandler CRUD error path tests for Create, Get, GetByReferenceID, List, UpdateStatusEnd
- bin-billing-manager: Add billinghandler event tests for nil tmHangup, billing not found, empty targets, error on first target
- bin-billing-manager: Add credithandler ProcessAll test for mid-pagination AccountList error