### PR TITLE
NOJIRA-Add-tts-provider-fallback

### DIFF
--- a/bin-api-manager/docsdev/source/call_media.rst
+++ b/bin-api-manager/docsdev/source/call_media.rst
@@ -373,11 +373,26 @@ TTS converts text to spoken audio:
 
     TTS Providers:
 
-    Google Cloud TTS:
+    Google Cloud TTS (default):
     +------------------------------------------+
     | Voices: 200+ in 40+ languages            |
     | Quality: Neural and Standard             |
     | SSML: Supported                          |
+    +------------------------------------------+
+
+    AWS Polly:
+    +------------------------------------------+
+    | Voices: 60+ in 30+ languages             |
+    | Quality: Neural and Standard             |
+    | SSML: Supported                          |
+    +------------------------------------------+
+
+    Provider Fallback:
+    +------------------------------------------+
+    | If the selected provider fails, the      |
+    | system falls back to the alternative     |
+    | provider with the default voice for the  |
+    | language.                                |
     +------------------------------------------+
 
     TTS Action Example:

--- a/bin-api-manager/docsdev/source/flow_struct_action.rst
+++ b/bin-api-manager/docsdev/source/flow_struct_action.rst
@@ -1164,8 +1164,8 @@ Parameters
 
 * text: Text to speech. SSML(https://cloud.google.com/text-to-speech/docs/ssml) supported.
 * language: Specifies the language. The value may contain a lowercase, two-letter language code (for example, en), or the language code and uppercase country/region (for example, en-US).
-* provider: TTS provider. Optional. ``gcp`` (Google Cloud TTS) or ``aws`` (AWS Polly). If omitted, the system uses the default provider.
-* voice_id: Provider-specific voice identifier. Optional. For example, ``en-US-Wavenet-D`` (GCP) or ``Joanna`` (AWS).
+* provider: TTS provider. Optional. ``gcp`` (Google Cloud TTS) or ``aws`` (AWS Polly). If omitted, defaults to GCP. If the selected provider fails, the system automatically falls back to the alternative provider with the default voice for the language.
+* voice_id: Provider-specific voice identifier. Optional. For example, ``en-US-Wavenet-D`` (GCP) or ``Joanna`` (AWS). On fallback, the voice_id is reset to the alternative provider's default voice.
 * digits_handle: See detail :ref:`here <flow-struct-action-talk-digits_handle>`.
 
 .. _flow-struct-action-talk-digits_handle:

--- a/bin-openapi-manager/openapi/paths/calls/id_talk.yaml
+++ b/bin-openapi-manager/openapi/paths/calls/id_talk.yaml
@@ -21,10 +21,10 @@ post:
               type: string
             provider:
               type: string
-              description: TTS provider to use (gcp or aws). If empty, auto-selects GCP first then AWS fallback.
+              description: TTS provider to use (gcp or aws). If empty, defaults to GCP. If the selected provider fails, the system falls back to the alternative provider with the default voice for the language.
             voice_id:
               type: string
-              description: Provider-specific voice ID. If empty, uses the default voice for the given language.
+              description: Provider-specific voice ID. If empty, uses the default voice for the given language. On fallback, the voice_id is reset to the alternative provider's default.
   responses:
     '200':
       description: The result of the talk action.

--- a/bin-tts-manager/pkg/audiohandler/audio.go
+++ b/bin-tts-manager/pkg/audiohandler/audio.go
@@ -23,24 +23,6 @@ func (h *audioHandler) AudioCreate(ctx context.Context, callID uuid.UUID, text s
 	case tts.ProviderAWS:
 		return h.awsAudioCreate(ctx, callID, text, lang, voiceID, filepath)
 
-	case "":
-		// no provider specified — try GCP first, fall back to AWS.
-		// GCP is preferred because it auto-selects a voice when the language is not in our default map.
-		gcpErr := h.gcpAudioCreate(ctx, callID, text, lang, voiceID, filepath)
-		if gcpErr == nil {
-			return nil
-		}
-		log.WithError(gcpErr).Warn("GCP audio provider failed, trying AWS")
-
-		awsErr := h.awsAudioCreate(ctx, callID, text, lang, voiceID, filepath)
-		if awsErr == nil {
-			return nil
-		}
-		log.WithError(awsErr).Warn("AWS audio provider failed")
-
-		log.Error("All audio providers failed")
-		return fmt.Errorf("all audio providers failed. gcp: %v, aws: %v", gcpErr, awsErr)
-
 	default:
 		return fmt.Errorf("unsupported provider: %s", provider)
 	}

--- a/bin-tts-manager/pkg/audiohandler/audio_test.go
+++ b/bin-tts-manager/pkg/audiohandler/audio_test.go
@@ -1,0 +1,39 @@
+package audiohandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-tts-manager/models/tts"
+)
+
+func Test_AudioCreate_unsupportedProvider(t *testing.T) {
+	h := &audioHandler{}
+	ctx := context.Background()
+	callID := uuid.FromStringOrNil("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+	tests := []struct {
+		name     string
+		provider tts.Provider
+	}{
+		{
+			name:     "empty provider returns error",
+			provider: "",
+		},
+		{
+			name:     "unknown provider returns error",
+			provider: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := h.AudioCreate(ctx, callID, "<speak>hello</speak>", "en-US", tt.provider, "", "/tmp/test.wav")
+			if err == nil {
+				t.Errorf("expected error for provider %q, got nil", tt.provider)
+			}
+		})
+	}
+}

--- a/bin-tts-manager/pkg/ttshandler/main.go
+++ b/bin-tts-manager/pkg/ttshandler/main.go
@@ -74,6 +74,16 @@ var (
 		},
 		[]string{"language", "provider"},
 	)
+
+	// speech_fallback_total counts how often fallback to an alternative provider occurs.
+	promSpeechFallbackTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "speech_fallback_total",
+			Help:      "Total number of batch TTS fallbacks by original provider.",
+		},
+		[]string{"from_provider"},
+	)
 )
 
 func init() {
@@ -82,6 +92,7 @@ func init() {
 		promSpeechRequestTotal,
 		promSpeechCreateDurationSeconds,
 		promSpeechLanguageTotal,
+		promSpeechFallbackTotal,
 	)
 }
 

--- a/bin-tts-manager/pkg/ttshandler/tts_test.go
+++ b/bin-tts-manager/pkg/ttshandler/tts_test.go
@@ -2,6 +2,7 @@ package ttshandler
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -12,6 +13,61 @@ import (
 	"monorepo/bin-tts-manager/pkg/audiohandler"
 	"monorepo/bin-tts-manager/pkg/buckethandler"
 )
+
+func Test_buildAttempts(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider tts.Provider
+		voiceID  string
+		expect   []providerAttempt
+	}{
+		{
+			name:     "gcp provider",
+			provider: tts.ProviderGCP,
+			voiceID:  "en-US-Wavenet-F",
+			expect: []providerAttempt{
+				{provider: tts.ProviderGCP, voiceID: "en-US-Wavenet-F"},
+				{provider: tts.ProviderAWS, voiceID: ""},
+			},
+		},
+		{
+			name:     "aws provider",
+			provider: tts.ProviderAWS,
+			voiceID:  "Joanna",
+			expect: []providerAttempt{
+				{provider: tts.ProviderAWS, voiceID: "Joanna"},
+				{provider: tts.ProviderGCP, voiceID: ""},
+			},
+		},
+		{
+			name:     "empty provider defaults to gcp first",
+			provider: "",
+			voiceID:  "en-US-Wavenet-F",
+			expect: []providerAttempt{
+				{provider: tts.ProviderGCP, voiceID: "en-US-Wavenet-F"},
+				{provider: tts.ProviderAWS, voiceID: ""},
+			},
+		},
+		{
+			name:     "empty provider with empty voice_id",
+			provider: "",
+			voiceID:  "",
+			expect: []providerAttempt{
+				{provider: tts.ProviderGCP, voiceID: ""},
+				{provider: tts.ProviderAWS, voiceID: ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildAttempts(tt.provider, tt.voiceID)
+			if !reflect.DeepEqual(got, tt.expect) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expect, got)
+			}
+		})
+	}
+}
 
 func Test_Create(t *testing.T) {
 
@@ -24,18 +80,28 @@ func Test_Create(t *testing.T) {
 		provider tts.Provider
 		voiceID  string
 
-		cacheHit bool
+		// normalizedText is what normalizeText returns. When empty, defaults to text (assumed already valid SSML).
+		normalizedText string
 
-		responseFilePath      string
-		responseMediaFilepath string
+		// primary attempt
+		primaryCacheHit  bool
+		primaryCreateErr error
+		primaryFilePath  string
+		primaryMediaPath string
 
-		expectFilename string
-		expectRes      *tts.TTS
+		// fallback attempt (only used when primary fails and is not cache hit)
+		fallbackCacheHit  bool
+		fallbackCreateErr error
+		fallbackFilePath  string
+		fallbackMediaPath string
+
+		expectRes *tts.TTS
+		expectErr bool
 	}
 
 	tests := []test{
 		{
-			name: "normal",
+			name: "primary succeeds (no fallback)",
 
 			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
 			text:     "<speak>Hello world</speak>",
@@ -43,10 +109,9 @@ func Test_Create(t *testing.T) {
 			provider: tts.ProviderGCP,
 			voiceID:  "en-US-Wavenet-F",
 
-			responseFilePath:      "/shared-data/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
-			responseMediaFilepath: "http://10-96-0-112.bin-manager.pod.cluster.local/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
+			primaryFilePath:  "/shared-data/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
+			primaryMediaPath: "http://10-96-0-112.bin-manager.pod.cluster.local/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
 
-			expectFilename: "d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
 			expectRes: &tts.TTS{
 				Provider:      tts.ProviderGCP,
 				VoiceID:       "en-US-Wavenet-F",
@@ -56,7 +121,7 @@ func Test_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "cache hit skips audio creation",
+			name: "primary cache hit skips audio creation",
 
 			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
 			text:     "<speak>Hello world</speak>",
@@ -64,18 +129,177 @@ func Test_Create(t *testing.T) {
 			provider: tts.ProviderGCP,
 			voiceID:  "en-US-Wavenet-F",
 
-			cacheHit: true,
+			primaryCacheHit:  true,
+			primaryFilePath:  "/shared-data/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
+			primaryMediaPath: "http://10-96-0-112.bin-manager.pod.cluster.local/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
 
-			responseFilePath:      "/shared-data/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
-			responseMediaFilepath: "http://10-96-0-112.bin-manager.pod.cluster.local/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
-
-			expectFilename: "d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
 			expectRes: &tts.TTS{
 				Provider:      tts.ProviderGCP,
 				VoiceID:       "en-US-Wavenet-F",
 				Text:          "<speak>Hello world</speak>",
 				Language:      "en-US",
 				MediaFilepath: "http://10-96-0-112.bin-manager.pod.cluster.local/d27dff3751181a10e4fc7f216a936c9c3f33c339.wav",
+			},
+		},
+		{
+			name: "primary fails fallback cache hit",
+
+			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:     "<speak>Hello world</speak>",
+			language: "en-US",
+			provider: tts.ProviderGCP,
+			voiceID:  "en-US-Wavenet-F",
+
+			primaryCreateErr: fmt.Errorf("gcp error"),
+			primaryFilePath:  "/shared-data/primary.wav",
+			primaryMediaPath: "http://host/primary.wav",
+
+			fallbackCacheHit:  true,
+			fallbackFilePath:  "/shared-data/fallback.wav",
+			fallbackMediaPath: "http://host/fallback.wav",
+
+			expectRes: &tts.TTS{
+				Provider:      tts.ProviderAWS,
+				VoiceID:       "",
+				Text:          "<speak>Hello world</speak>",
+				Language:      "en-US",
+				MediaFilepath: "http://host/fallback.wav",
+			},
+		},
+		{
+			name: "primary fails fallback audio creation succeeds",
+
+			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:     "<speak>Hello world</speak>",
+			language: "en-US",
+			provider: tts.ProviderGCP,
+			voiceID:  "en-US-Wavenet-F",
+
+			primaryCreateErr: fmt.Errorf("gcp error"),
+			primaryFilePath:  "/shared-data/primary.wav",
+			primaryMediaPath: "http://host/primary.wav",
+
+			fallbackFilePath:  "/shared-data/fallback.wav",
+			fallbackMediaPath: "http://host/fallback.wav",
+
+			expectRes: &tts.TTS{
+				Provider:      tts.ProviderAWS,
+				VoiceID:       "",
+				Text:          "<speak>Hello world</speak>",
+				Language:      "en-US",
+				MediaFilepath: "http://host/fallback.wav",
+			},
+		},
+		{
+			name: "both providers fail",
+
+			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:     "<speak>Hello world</speak>",
+			language: "en-US",
+			provider: tts.ProviderGCP,
+			voiceID:  "en-US-Wavenet-F",
+
+			primaryCreateErr: fmt.Errorf("gcp error"),
+			primaryFilePath:  "/shared-data/primary.wav",
+			primaryMediaPath: "http://host/primary.wav",
+
+			fallbackCreateErr: fmt.Errorf("aws error"),
+			fallbackFilePath:  "/shared-data/fallback.wav",
+			fallbackMediaPath: "http://host/fallback.wav",
+
+			expectErr: true,
+		},
+		{
+			name: "empty provider resolves to gcp first then aws",
+
+			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:     "<speak>Hello world</speak>",
+			language: "en-US",
+			provider: "",
+			voiceID:  "en-US-Wavenet-F",
+
+			primaryCreateErr: fmt.Errorf("gcp error"),
+			primaryFilePath:  "/shared-data/primary.wav",
+			primaryMediaPath: "http://host/primary.wav",
+
+			fallbackFilePath:  "/shared-data/fallback.wav",
+			fallbackMediaPath: "http://host/fallback.wav",
+
+			expectRes: &tts.TTS{
+				Provider:      tts.ProviderAWS,
+				VoiceID:       "",
+				Text:          "<speak>Hello world</speak>",
+				Language:      "en-US",
+				MediaFilepath: "http://host/fallback.wav",
+			},
+		},
+		{
+			name: "aws provider falls back to gcp",
+
+			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:     "<speak>Hello world</speak>",
+			language: "en-US",
+			provider: tts.ProviderAWS,
+			voiceID:  "Joanna",
+
+			primaryCreateErr: fmt.Errorf("aws error"),
+			primaryFilePath:  "/shared-data/primary.wav",
+			primaryMediaPath: "http://host/primary.wav",
+
+			fallbackFilePath:  "/shared-data/fallback.wav",
+			fallbackMediaPath: "http://host/fallback.wav",
+
+			expectRes: &tts.TTS{
+				Provider:      tts.ProviderGCP,
+				VoiceID:       "",
+				Text:          "<speak>Hello world</speak>",
+				Language:      "en-US",
+				MediaFilepath: "http://host/fallback.wav",
+			},
+		},
+		{
+			name: "plain text is normalized before cache key computation",
+
+			callID:         uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:           "Hello world",
+			normalizedText: "<speak>Hello world</speak>",
+			language:       "en-US",
+			provider:       tts.ProviderGCP,
+			voiceID:        "en-US-Wavenet-F",
+
+			primaryFilePath:  "/shared-data/normalized.wav",
+			primaryMediaPath: "http://host/normalized.wav",
+
+			expectRes: &tts.TTS{
+				Provider:      tts.ProviderGCP,
+				VoiceID:       "en-US-Wavenet-F",
+				Text:          "<speak>Hello world</speak>",
+				Language:      "en-US",
+				MediaFilepath: "http://host/normalized.wav",
+			},
+		},
+		{
+			name: "empty provider and empty voice_id both attempts use defaults",
+
+			callID:   uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"),
+			text:     "<speak>Hello world</speak>",
+			language: "en-US",
+			provider: "",
+			voiceID:  "",
+
+			primaryCreateErr: fmt.Errorf("gcp error"),
+			primaryFilePath:  "/shared-data/primary.wav",
+			primaryMediaPath: "http://host/primary.wav",
+
+			fallbackFilePath:  "/shared-data/fallback.wav",
+			fallbackMediaPath: "http://host/fallback.wav",
+
+			expectRes: &tts.TTS{
+				Provider:      tts.ProviderAWS,
+				VoiceID:       "",
+				Text:          "<speak>Hello world</speak>",
+				Language:      "en-US",
+				MediaFilepath: "http://host/fallback.wav",
 			},
 		},
 	}
@@ -94,22 +318,83 @@ func Test_Create(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			mockBucket.EXPECT().OSGetFilepath(ctx, tt.expectFilename).Return(tt.responseFilePath)
-			mockBucket.EXPECT().OSGetMediaFilepath(ctx, tt.expectFilename).Return(tt.responseMediaFilepath)
-			mockBucket.EXPECT().OSFileExist(ctx, tt.responseFilePath).Return(tt.cacheHit)
-			if !tt.cacheHit {
-				mockAudio.EXPECT().AudioCreate(ctx, tt.callID, tt.text, tt.language, tt.provider, tt.voiceID, tt.responseFilePath).Return(nil)
+			// resolve normalized text: if not specified, text is already valid SSML
+			normalizedText := tt.normalizedText
+			if normalizedText == "" {
+				normalizedText = tt.text
+			}
+
+			// determine the attempts that will be made
+			attempts := buildAttempts(tt.provider, tt.voiceID)
+
+			// set up expectations for primary attempt
+			primary := attempts[0]
+			primaryFilename := h.filenameHashGenerator(normalizedText, tt.language, primary.provider, primary.voiceID)
+
+			mockBucket.EXPECT().OSGetFilepath(ctx, primaryFilename).Return(tt.primaryFilePath)
+			mockBucket.EXPECT().OSGetMediaFilepath(ctx, primaryFilename).Return(tt.primaryMediaPath)
+			mockBucket.EXPECT().OSFileExist(ctx, tt.primaryFilePath).Return(tt.primaryCacheHit)
+
+			if !tt.primaryCacheHit {
+				mockAudio.EXPECT().AudioCreate(ctx, tt.callID, normalizedText, tt.language, primary.provider, primary.voiceID, tt.primaryFilePath).Return(tt.primaryCreateErr)
+
+				// if primary failed, set up fallback expectations
+				if tt.primaryCreateErr != nil && len(attempts) > 1 {
+					fallback := attempts[1]
+					fallbackFilename := h.filenameHashGenerator(normalizedText, tt.language, fallback.provider, fallback.voiceID)
+
+					mockBucket.EXPECT().OSGetFilepath(ctx, fallbackFilename).Return(tt.fallbackFilePath)
+					mockBucket.EXPECT().OSGetMediaFilepath(ctx, fallbackFilename).Return(tt.fallbackMediaPath)
+					mockBucket.EXPECT().OSFileExist(ctx, tt.fallbackFilePath).Return(tt.fallbackCacheHit)
+
+					if !tt.fallbackCacheHit {
+						mockAudio.EXPECT().AudioCreate(ctx, tt.callID, normalizedText, tt.language, fallback.provider, fallback.voiceID, tt.fallbackFilePath).Return(tt.fallbackCreateErr)
+					}
+				}
 			}
 
 			res, err := h.Create(ctx, tt.callID, tt.text, tt.language, tt.provider, tt.voiceID)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error, got nil")
+				}
+				return
+			}
+
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
+				return
 			}
 
 			if !reflect.DeepEqual(res, tt.expectRes) {
-				t.Errorf("Wrong match.\nexpect: %s\ngot: %s", tt.expectRes, res)
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_Create_normalizationFailure(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockAudio := audiohandler.NewMockAudioHandler(mc)
+	mockBucket := buckethandler.NewMockBucketHandler(mc)
+
+	h := &ttsHandler{
+		audioHandler:  mockAudio,
+		bucketHandler: mockBucket,
+	}
+	ctx := context.Background()
+
+	// invalid XML that can't be normalized: unclosed tag without valid wrapping
+	invalidText := "<speak><break"
+
+	res, err := h.Create(ctx, uuid.FromStringOrNil("c1a8bfe6-9214-11ec-a013-1bbdbd87fc23"), invalidText, "en-US", tts.ProviderGCP, "en-US-Wavenet-F")
+	if err == nil {
+		t.Errorf("Expected normalization error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result on normalization failure, got: %v", res)
 	}
 }
 

--- a/docs/plans/2026-02-13-tts-provider-fallback-design.md
+++ b/docs/plans/2026-02-13-tts-provider-fallback-design.md
@@ -1,0 +1,101 @@
+# TTS Provider Fallback Design
+
+## Problem
+
+When an explicit TTS provider is specified (e.g., `provider="gcp"`) and it fails, the request fails entirely with no recovery. Additionally, when no provider is specified and GCP fails, the fallback to AWS passes through the original `voice_id`, which may be a GCP-specific voice that is meaningless to AWS.
+
+## Approach
+
+Move fallback orchestration from `AudioCreate` (audiohandler) up to `Create` (ttshandler), where caching already lives. This ensures each provider attempt gets its own correct cache key and the returned TTS result accurately reflects the provider that produced the audio.
+
+### Fallback Rules
+
+| Request | First attempt | Fallback |
+|---------|--------------|----------|
+| `provider="gcp"` | GCP with given `voice_id` | AWS with empty `voice_id` (AWS default for language) |
+| `provider="aws"` | AWS with given `voice_id` | GCP with empty `voice_id` (GCP auto-selects) |
+| `provider=""` | GCP with given `voice_id` | AWS with empty `voice_id` (reset, not passthrough) |
+
+On fallback, `voice_id` is always reset to empty. Each provider uses its own default voice selection logic for the language.
+
+### Cache Behavior
+
+Each provider attempt computes its own cache key: `SHA1(text + lang + provider + voiceID)`. This means:
+
+- Primary attempt cache key: `hash(text, lang, "gcp", "en-US-Wavenet-D")`
+- Fallback attempt cache key: `hash(text, lang, "aws", "")`
+
+Each is cached independently. A cached GCP result is never confused with an AWS result. Fallback results are cached for reuse on subsequent identical fallback scenarios.
+
+**Migration note:** Existing cache entries created with `provider=""` used `hash(text, lang, "", voiceID)`. After this change, the same request resolves to `hash(text, lang, "gcp", voiceID)`. Old cache entries become orphaned (one-time cache miss). This is acceptable since the files are regenerated on next request.
+
+### TTS Result
+
+The returned `tts.TTS` struct reflects the **actual** provider and voiceID that produced the audio, not the original request. This ensures callers receive accurate metadata about the generated audio.
+
+### Prometheus Metrics
+
+- `promSpeechLanguageTotal` tracks the **actual** provider that succeeded (not the original request).
+- Add a new `promSpeechFallbackTotal` counter with label `from_provider` to track how often fallbacks occur and from which provider.
+
+## Changes
+
+### `bin-tts-manager/pkg/ttshandler/tts.go` — `Create()`
+
+Refactor to orchestrate fallback with per-attempt caching:
+
+```
+1. Normalize text (once, before the attempt loop)
+
+2. Build provider attempt list:
+   - provider="gcp"  → [{gcp, voiceID}, {aws, ""}]
+   - provider="aws"  → [{aws, voiceID}, {gcp, ""}]
+   - provider=""     → [{gcp, voiceID}, {aws, ""}]
+
+3. For each attempt:
+   a. Compute cache key: filenameHashGenerator(text, lang, attempt.provider, attempt.voiceID)
+   b. Get filepath and mediaFilepath from bucket handler
+   c. Check if file exists (cache hit) → return TTS result with attempt.provider/attempt.voiceID
+   d. Call AudioCreate(attempt.provider, attempt.voiceID) → if success → return TTS result
+   e. Log failure, if not last attempt increment promSpeechFallbackTotal, continue
+
+4. All attempts failed → return combined error
+```
+
+A concrete attempt struct for clarity:
+
+```go
+type providerAttempt struct {
+    provider tts.Provider
+    voiceID  string
+}
+```
+
+### `bin-tts-manager/pkg/audiohandler/audio.go` — `AudioCreate()`
+
+Simplify to single-provider dispatch only (no fallback logic):
+
+```go
+switch provider {
+case tts.ProviderGCP:  return h.gcpAudioCreate(...)
+case tts.ProviderAWS:  return h.awsAudioCreate(...)
+default:               return fmt.Errorf("unsupported provider: %s", provider)
+}
+```
+
+The empty provider case (`""`) is removed — it is now handled by `ttshandler.Create()`.
+
+### Test Updates
+
+- **`ttshandler/tts_test.go`**: Add test cases for:
+  - Primary succeeds (no fallback)
+  - Primary fails, fallback cache hit
+  - Primary fails, fallback audio creation succeeds
+  - Both providers fail (combined error)
+  - Empty provider resolves to GCP first
+- **`audiohandler/audio_test.go`**: Update to reflect simplified `AudioCreate` — empty provider now returns error.
+- Existing `aws_test.go` and `gcp_test.go` tests remain valid.
+
+## Services Affected
+
+Only `bin-tts-manager`. No changes to call-manager, flow-manager, or any other service. The RPC interface (`TTSV1SpeecheCreate`) remains unchanged.


### PR DESCRIPTION
Add TTS provider fallback so that when the primary provider fails, the system
automatically retries with the alternative provider using default voice for
the language.

- bin-tts-manager: Move fallback orchestration from audiohandler to ttshandler for per-attempt caching
- bin-tts-manager: Simplify audiohandler.AudioCreate to single-provider dispatch (no more implicit fallback)
- bin-tts-manager: Add providerAttempt struct and buildAttempts() for fallback sequencing
- bin-tts-manager: Add promSpeechFallbackTotal Prometheus metric with from_provider label
- bin-tts-manager: Add comprehensive tests for ttshandler fallback (9 cases) and audiohandler dispatch
- bin-openapi-manager: Update calls/{id}/talk endpoint descriptions for provider fallback behavior
- bin-api-manager: Update call_media.rst with AWS Polly provider section and fallback documentation
- bin-api-manager: Update flow_struct_action.rst Talk action parameter descriptions for fallback
- docs: Add TTS provider fallback design document