### PR TITLE
NOJIRA-Test-coverage-sentinel-manager

### DIFF
--- a/bin-sentinel-manager/internal/config/config_test.go
+++ b/bin-sentinel-manager/internal/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func TestGet(t *testing.T) {
@@ -115,6 +118,273 @@ func TestInitConfig(t *testing.T) {
 			}
 			if res.RabbitMQAddress != tt.rabbitmqAddress {
 				t.Errorf("Wrong RabbitMQAddress. expect: %s, got: %s", tt.rabbitmqAddress, res.RabbitMQAddress)
+			}
+		})
+	}
+}
+
+func TestBootstrap(t *testing.T) {
+	tests := []struct {
+		name string
+
+		expectErr bool
+	}{
+		{
+			name: "bootstrap_with_default_flags",
+
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper to clean state
+			viper.Reset()
+
+			cmd := &cobra.Command{}
+
+			err := Bootstrap(cmd)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify flags were created
+			if cmd.PersistentFlags().Lookup("rabbitmq_address") == nil {
+				t.Errorf("Expected rabbitmq_address flag to be registered")
+			}
+			if cmd.PersistentFlags().Lookup("prometheus_endpoint") == nil {
+				t.Errorf("Expected prometheus_endpoint flag to be registered")
+			}
+			if cmd.PersistentFlags().Lookup("prometheus_listen_address") == nil {
+				t.Errorf("Expected prometheus_listen_address flag to be registered")
+			}
+		})
+	}
+}
+
+func TestBootstrapWithEnv(t *testing.T) {
+	tests := []struct {
+		name string
+
+		envVars map[string]string
+
+		expectErr bool
+	}{
+		{
+			name: "bootstrap_reads_env_vars",
+
+			envVars: map[string]string{
+				"RABBITMQ_ADDRESS":          "amqp://test:test@test:5672",
+				"PROMETHEUS_ENDPOINT":       "/test-metrics",
+				"PROMETHEUS_LISTEN_ADDRESS": ":9999",
+			},
+
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper to clean state
+			viper.Reset()
+
+			// Set environment variables
+			for k, v := range tt.envVars {
+				if err := os.Setenv(k, v); err != nil {
+					t.Fatalf("Failed to set env var %s: %v", k, err)
+				}
+				defer func(key string) {
+					if err := os.Unsetenv(key); err != nil {
+						t.Logf("Failed to unset env var %s: %v", key, err)
+					}
+				}(k)
+			}
+
+			cmd := &cobra.Command{}
+
+			err := Bootstrap(cmd)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify bindings work by checking viper can read the env vars
+			if viper.GetString("rabbitmq_address") != tt.envVars["RABBITMQ_ADDRESS"] {
+				t.Errorf("Wrong rabbitmq_address. expect: %s, got: %s", tt.envVars["RABBITMQ_ADDRESS"], viper.GetString("rabbitmq_address"))
+			}
+		})
+	}
+}
+
+func TestLoadGlobalConfig(t *testing.T) {
+	tests := []struct {
+		name string
+
+		viperValues map[string]string
+		expectCfg   Config
+	}{
+		{
+			name: "loads_config_from_viper",
+
+			viperValues: map[string]string{
+				"prometheus_endpoint":       "/test-metrics",
+				"prometheus_listen_address": ":8888",
+				"rabbitmq_address":          "amqp://test:test@localhost:5672",
+			},
+			expectCfg: Config{
+				PrometheusEndpoint:      "/test-metrics",
+				PrometheusListenAddress: ":8888",
+				RabbitMQAddress:         "amqp://test:test@localhost:5672",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper and once to clean state
+			viper.Reset()
+			once = sync.Once{}
+			cfg = Config{}
+
+			// Set viper values
+			for k, v := range tt.viperValues {
+				viper.Set(k, v)
+			}
+
+			LoadGlobalConfig()
+
+			res := Get()
+			if res.PrometheusEndpoint != tt.expectCfg.PrometheusEndpoint {
+				t.Errorf("Wrong PrometheusEndpoint. expect: %s, got: %s", tt.expectCfg.PrometheusEndpoint, res.PrometheusEndpoint)
+			}
+			if res.PrometheusListenAddress != tt.expectCfg.PrometheusListenAddress {
+				t.Errorf("Wrong PrometheusListenAddress. expect: %s, got: %s", tt.expectCfg.PrometheusListenAddress, res.PrometheusListenAddress)
+			}
+			if res.RabbitMQAddress != tt.expectCfg.RabbitMQAddress {
+				t.Errorf("Wrong RabbitMQAddress. expect: %s, got: %s", tt.expectCfg.RabbitMQAddress, res.RabbitMQAddress)
+			}
+		})
+	}
+}
+
+func TestLoadGlobalConfigOnlyOnce(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "loads_config_only_once",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper and once to clean state
+			viper.Reset()
+			once = sync.Once{}
+			cfg = Config{}
+
+			// Set initial viper values
+			viper.Set("prometheus_endpoint", "/first")
+			viper.Set("prometheus_listen_address", ":1111")
+			viper.Set("rabbitmq_address", "amqp://first")
+
+			LoadGlobalConfig()
+
+			firstCfg := Get()
+
+			// Change viper values
+			viper.Set("prometheus_endpoint", "/second")
+			viper.Set("prometheus_listen_address", ":2222")
+			viper.Set("rabbitmq_address", "amqp://second")
+
+			// Call LoadGlobalConfig again - should not change cfg
+			LoadGlobalConfig()
+
+			secondCfg := Get()
+
+			// Verify config did not change (once.Do ensures it runs only once)
+			if firstCfg.PrometheusEndpoint != secondCfg.PrometheusEndpoint {
+				t.Errorf("Config should not change after second LoadGlobalConfig call")
+			}
+			if secondCfg.PrometheusEndpoint != "/first" {
+				t.Errorf("Expected PrometheusEndpoint to be '/first', got: %s", secondCfg.PrometheusEndpoint)
+			}
+		})
+	}
+}
+
+func TestInitConfigWithMissingFlags(t *testing.T) {
+	tests := []struct {
+		name string
+
+		skipFlag  string
+		expectErr bool
+	}{
+		{
+			name: "error_when_prometheus_endpoint_flag_missing",
+
+			skipFlag:  "prometheus_endpoint",
+			expectErr: true,
+		},
+		{
+			name: "error_when_prometheus_listen_address_flag_missing",
+
+			skipFlag:  "prometheus_listen_address",
+			expectErr: true,
+		},
+		{
+			name: "error_when_rabbitmq_address_flag_missing",
+
+			skipFlag:  "rabbitmq_address",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+
+			cmd := &cobra.Command{}
+
+			// Add flags except the one we're testing
+			if tt.skipFlag != "prometheus_endpoint" {
+				cmd.Flags().String("prometheus_endpoint", "/metrics", "")
+			}
+			if tt.skipFlag != "prometheus_listen_address" {
+				cmd.Flags().String("prometheus_listen_address", ":2112", "")
+			}
+			if tt.skipFlag != "rabbitmq_address" {
+				cmd.Flags().String("rabbitmq_address", "amqp://guest:guest@localhost:5672", "")
+			}
+
+			err := InitConfig(cmd)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
 			}
 		})
 	}

--- a/bin-sentinel-manager/models/pod/event_test.go
+++ b/bin-sentinel-manager/models/pod/event_test.go
@@ -1,0 +1,65 @@
+package pod
+
+import (
+	"testing"
+)
+
+func TestEventTypeConstants(t *testing.T) {
+	tests := []struct {
+		name string
+
+		eventType     string
+		expectedValue string
+	}{
+		{
+			name: "pod_added_event_type",
+
+			eventType:     EventTypePodAdded,
+			expectedValue: "pod_added",
+		},
+		{
+			name: "pod_updated_event_type",
+
+			eventType:     EventTypePodUpdated,
+			expectedValue: "pod_updated",
+		},
+		{
+			name: "pod_deleted_event_type",
+
+			eventType:     EventTypePodDeleted,
+			expectedValue: "pod_deleted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.eventType != tt.expectedValue {
+				t.Errorf("Wrong event type. expect: %s, got: %s", tt.expectedValue, tt.eventType)
+			}
+		})
+	}
+}
+
+func TestEventTypeUniqueness(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "all_event_types_are_unique",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventTypes := map[string]bool{
+				EventTypePodAdded:   true,
+				EventTypePodUpdated: true,
+				EventTypePodDeleted: true,
+			}
+
+			if len(eventTypes) != 3 {
+				t.Errorf("Expected 3 unique event types, got: %d", len(eventTypes))
+			}
+		})
+	}
+}

--- a/bin-sentinel-manager/models/pod/main_test.go
+++ b/bin-sentinel-manager/models/pod/main_test.go
@@ -1,0 +1,40 @@
+package pod
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodStruct(t *testing.T) {
+	tests := []struct {
+		name string
+
+		pod Pod
+	}{
+		{
+			name: "creates_pod_with_corev1_pod",
+
+			pod: Pod{
+				Pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.pod.Name != "test-pod" {
+				t.Errorf("Wrong pod name. expect: test-pod, got: %s", tt.pod.Name)
+			}
+			if tt.pod.Namespace != "default" {
+				t.Errorf("Wrong pod namespace. expect: default, got: %s", tt.pod.Namespace)
+			}
+		})
+	}
+}

--- a/bin-sentinel-manager/pkg/monitoringhandler/main_test.go
+++ b/bin-sentinel-manager/pkg/monitoringhandler/main_test.go
@@ -36,3 +36,106 @@ func TestNewMonitoringHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestNewMonitoringHandlerWithNilDependencies(t *testing.T) {
+	tests := []struct {
+		name string
+
+		reqHandler    requesthandler.RequestHandler
+		notifyHandler notifyhandler.NotifyHandler
+		utilHandler   utilhandler.UtilHandler
+	}{
+		{
+			name: "creates_handler_with_nil_request_handler",
+
+			reqHandler:    nil,
+			notifyHandler: notifyhandler.NewMockNotifyHandler(gomock.NewController(t)),
+			utilHandler:   utilhandler.NewMockUtilHandler(gomock.NewController(t)),
+		},
+		{
+			name: "creates_handler_with_nil_notify_handler",
+
+			reqHandler:    requesthandler.NewMockRequestHandler(gomock.NewController(t)),
+			notifyHandler: nil,
+			utilHandler:   utilhandler.NewMockUtilHandler(gomock.NewController(t)),
+		},
+		{
+			name: "creates_handler_with_nil_util_handler",
+
+			reqHandler:    requesthandler.NewMockRequestHandler(gomock.NewController(t)),
+			notifyHandler: notifyhandler.NewMockNotifyHandler(gomock.NewController(t)),
+			utilHandler:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This test verifies that NewMonitoringHandler doesn't panic with nil dependencies
+			// In production, nil dependencies would cause issues, but the constructor should not panic
+			h := NewMonitoringHandler(tt.reqHandler, tt.notifyHandler, tt.utilHandler)
+
+			if h == nil {
+				t.Errorf("Expected non-nil handler even with nil dependencies, got nil")
+			}
+		})
+	}
+}
+
+func TestConstants(t *testing.T) {
+	tests := []struct {
+		name string
+
+		constant      string
+		expectedValue string
+	}{
+		{
+			name: "namespace_voip_constant",
+
+			constant:      namespaceVOIP,
+			expectedValue: "voip",
+		},
+		{
+			name: "namespace_bin_constant",
+
+			constant:      namespaceBIN,
+			expectedValue: "bin",
+		},
+		{
+			name: "label_app_asterisk_call_constant",
+
+			constant:      lableAppAsteriskCall,
+			expectedValue: "asterisk-call",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constant != tt.expectedValue {
+				t.Errorf("Wrong constant value. expect: %s, got: %s", tt.expectedValue, tt.constant)
+			}
+		})
+	}
+}
+
+func TestPrometheusMetrics(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "prometheus_metrics_are_initialized",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Verify metrics are not nil (they should be initialized in init())
+			if promPodStateChangeCounter == nil {
+				t.Errorf("Expected promPodStateChangeCounter to be initialized, got nil")
+			}
+
+			if metricsNamespace == "" {
+				t.Errorf("Expected metricsNamespace to be non-empty, got empty string")
+			}
+		})
+	}
+}

--- a/bin-sentinel-manager/pkg/monitoringhandler/run_test.go
+++ b/bin-sentinel-manager/pkg/monitoringhandler/run_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-sentinel-manager/models/pod"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
@@ -32,6 +34,40 @@ func Test_runPodUpdated(t *testing.T) {
 					Annotations: map[string]string{
 						"asterisk-id": "00:11:22:33:44:55",
 					},
+				},
+			},
+		},
+		{
+			name: "pod_with_different_namespace",
+
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: namespaceBIN,
+					Labels: map[string]string{
+						"app": "test-app",
+					},
+				},
+			},
+		},
+		{
+			name: "pod_without_labels",
+
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-label-pod",
+					Namespace: namespaceVOIP,
+				},
+			},
+		},
+		{
+			name: "pod_with_empty_labels",
+
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-label-pod",
+					Namespace: namespaceVOIP,
+					Labels:    map[string]string{},
 				},
 			},
 		},
@@ -86,6 +122,49 @@ func Test_runPodDeleted(t *testing.T) {
 
 			expectedAsteriskID: "00:11:22:33:44:55",
 		},
+		{
+			name: "pod_with_different_app_label",
+
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-67890",
+					Namespace: namespaceBIN,
+					Labels: map[string]string{
+						"app": "different-app",
+					},
+				},
+			},
+
+			expectedAsteriskID: "",
+		},
+		{
+			name: "pod_without_labels",
+
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-label-pod",
+					Namespace: namespaceVOIP,
+				},
+			},
+
+			expectedAsteriskID: "",
+		},
+		{
+			name: "pod_with_empty_annotations",
+
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-annotation-pod",
+					Namespace: namespaceVOIP,
+					Labels: map[string]string{
+						"app": lableAppAsteriskCall,
+					},
+					Annotations: map[string]string{},
+				},
+			},
+
+			expectedAsteriskID: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -105,6 +184,116 @@ func Test_runPodDeleted(t *testing.T) {
 			mockNotify.EXPECT().PublishEvent(ctx, pod.EventTypePodDeleted, tt.pod)
 			if errRun := h.runPodDeleted(ctx, tt.pod); errRun != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", errRun)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name string
+
+		selectors map[string][]string
+		expectErr bool
+	}{
+		{
+			name: "fails_outside_kubernetes_cluster",
+
+			selectors: map[string][]string{
+				"default": {"app=test"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "fails_with_empty_selectors",
+
+			selectors: map[string][]string{},
+			expectErr: true,
+		},
+		{
+			name: "fails_with_nil_selectors",
+
+			selectors: nil,
+			expectErr: true,
+		},
+		{
+			name: "fails_with_multiple_namespaces",
+
+			selectors: map[string][]string{
+				"voip": {"app=asterisk-call"},
+				"bin":  {"app=test-app"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+			h := NewMonitoringHandler(mockReq, mockNotify, mockUtil)
+
+			// Create a context with timeout to avoid hanging
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			err := h.Run(ctx, tt.selectors)
+
+			// When not running in a Kubernetes cluster, Run should return an error
+			// because rest.InClusterConfig() will fail
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error when running outside Kubernetes cluster, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRunContextCancellation(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "handles_context_cancellation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+			h := NewMonitoringHandler(mockReq, mockNotify, mockUtil)
+
+			// Create a context that's already cancelled
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // Cancel immediately
+
+			selectors := map[string][]string{
+				"default": {"app=test"},
+			}
+
+			// This should fail quickly because we're not in a cluster
+			// and context is already cancelled
+			err := h.Run(ctx, selectors)
+
+			// Should return an error (in-cluster config failure, not context cancellation)
+			if err == nil {
+				t.Errorf("Expected error when running outside Kubernetes cluster")
 			}
 		})
 	}


### PR DESCRIPTION
Increase test coverage for bin-sentinel-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-sentinel-manager: Add unit tests for improved package-level coverage