### PR TITLE
NOJIRA-Test-coverage-tag-manager

### DIFF
--- a/bin-tag-manager/models/tag/event_test.go
+++ b/bin-tag-manager/models/tag/event_test.go
@@ -1,0 +1,35 @@
+package tag
+
+import "testing"
+
+func TestEventTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    string
+		expected string
+	}{
+		{
+			name:     "event_type_tag_created",
+			event:    EventTypeTagCreated,
+			expected: "tag_created",
+		},
+		{
+			name:     "event_type_tag_updated",
+			event:    EventTypeTagUpdated,
+			expected: "tag_updated",
+		},
+		{
+			name:     "event_type_tag_deleted",
+			event:    EventTypeTagDeleted,
+			expected: "tag_deleted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.event != tt.expected {
+				t.Errorf("Wrong event type. expect: %s, got: %s", tt.expected, tt.event)
+			}
+		})
+	}
+}

--- a/bin-tag-manager/models/tag/filters_test.go
+++ b/bin-tag-manager/models/tag/filters_test.go
@@ -1,0 +1,62 @@
+package tag
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestFieldStruct(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    FieldStruct
+		expectID uuid.UUID
+		expectCID uuid.UUID
+		expectName string
+		expectDeleted bool
+	}{
+		{
+			name: "field_struct_with_all_fields",
+			field: FieldStruct{
+				ID:         uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				CustomerID: uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				Name:       "test name",
+				Deleted:    false,
+			},
+			expectID:   uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			expectCID:  uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			expectName: "test name",
+			expectDeleted: false,
+		},
+		{
+			name: "field_struct_with_deleted_true",
+			field: FieldStruct{
+				ID:         uuid.FromStringOrNil("450bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				CustomerID: uuid.FromStringOrNil("550bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				Name:       "deleted tag",
+				Deleted:    true,
+			},
+			expectID:   uuid.FromStringOrNil("450bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			expectCID:  uuid.FromStringOrNil("550bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			expectName: "deleted tag",
+			expectDeleted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.field.ID != tt.expectID {
+				t.Errorf("Wrong ID. expect: %s, got: %s", tt.expectID, tt.field.ID)
+			}
+			if tt.field.CustomerID != tt.expectCID {
+				t.Errorf("Wrong CustomerID. expect: %s, got: %s", tt.expectCID, tt.field.CustomerID)
+			}
+			if tt.field.Name != tt.expectName {
+				t.Errorf("Wrong Name. expect: %s, got: %s", tt.expectName, tt.field.Name)
+			}
+			if tt.field.Deleted != tt.expectDeleted {
+				t.Errorf("Wrong Deleted. expect: %v, got: %v", tt.expectDeleted, tt.field.Deleted)
+			}
+		})
+	}
+}

--- a/bin-tag-manager/models/tag/webhook_test.go
+++ b/bin-tag-manager/models/tag/webhook_test.go
@@ -1,0 +1,117 @@
+package tag
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	curTime := func() *time.Time { t := time.Date(2023, 1, 3, 21, 35, 2, 809000000, time.UTC); return &t }()
+
+	tests := []struct {
+		name      string
+		tag       *Tag
+		expectRes *WebhookMessage
+	}{
+		{
+			name: "converts_tag_to_webhook_message",
+			tag: &Tag{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+					CustomerID: uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name:     "test name",
+				Detail:   "test detail",
+				TMCreate: curTime,
+				TMUpdate: nil,
+				TMDelete: nil,
+			},
+			expectRes: &WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+					CustomerID: uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name:     "test name",
+				Detail:   "test detail",
+				TMCreate: curTime,
+				TMUpdate: nil,
+				TMDelete: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := tt.tag.ConvertWebhookMessage()
+
+			if res.ID != tt.expectRes.ID {
+				t.Errorf("Wrong ID. expect: %s, got: %s", tt.expectRes.ID, res.ID)
+			}
+			if res.CustomerID != tt.expectRes.CustomerID {
+				t.Errorf("Wrong CustomerID. expect: %s, got: %s", tt.expectRes.CustomerID, res.CustomerID)
+			}
+			if res.Name != tt.expectRes.Name {
+				t.Errorf("Wrong Name. expect: %s, got: %s", tt.expectRes.Name, res.Name)
+			}
+			if res.Detail != tt.expectRes.Detail {
+				t.Errorf("Wrong Detail. expect: %s, got: %s", tt.expectRes.Detail, res.Detail)
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	curTime := func() *time.Time { t := time.Date(2023, 1, 3, 21, 35, 2, 809000000, time.UTC); return &t }()
+
+	tests := []struct {
+		name    string
+		tag     *Tag
+		wantErr bool
+	}{
+		{
+			name: "creates_webhook_event_successfully",
+			tag: &Tag{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+					CustomerID: uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name:     "test name",
+				Detail:   "test detail",
+				TMCreate: curTime,
+				TMUpdate: nil,
+				TMDelete: nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.tag.CreateWebhookEvent()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateWebhookEvent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// verify it's valid JSON
+				var msg WebhookMessage
+				if err := json.Unmarshal(res, &msg); err != nil {
+					t.Errorf("Failed to unmarshal webhook event: %v", err)
+				}
+
+				if msg.ID != tt.tag.ID {
+					t.Errorf("Wrong ID in webhook event. expect: %s, got: %s", tt.tag.ID, msg.ID)
+				}
+				if msg.Name != tt.tag.Name {
+					t.Errorf("Wrong Name in webhook event. expect: %s, got: %s", tt.tag.Name, msg.Name)
+				}
+			}
+		})
+	}
+}

--- a/bin-tag-manager/pkg/dbhandler/main_constructor_test.go
+++ b/bin-tag-manager/pkg/dbhandler/main_constructor_test.go
@@ -1,0 +1,22 @@
+package dbhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-tag-manager/pkg/cachehandler"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestNewHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+
+	h := NewHandler(dbTest, mockCache)
+
+	if h == nil {
+		t.Errorf("Expected handler, got nil")
+	}
+}

--- a/bin-tag-manager/pkg/dbhandler/tag_error_test.go
+++ b/bin-tag-manager/pkg/dbhandler/tag_error_test.go
@@ -1,0 +1,255 @@
+package dbhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/models/tag"
+	"monorepo/bin-tag-manager/pkg/cachehandler"
+)
+
+func Test_TagGet_FromCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        uuid.UUID
+		cacheTag  *tag.Tag
+		cacheErr  error
+		expectErr bool
+	}{
+		{
+			name: "get_from_cache_success",
+			id:   uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			cacheTag: &tag.Tag{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name: "cached tag",
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+			ctx := context.Background()
+
+			mockCache.EXPECT().TagGet(ctx, tt.id).Return(tt.cacheTag, tt.cacheErr)
+
+			res, err := h.TagGet(ctx, tt.id)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectErr, err)
+			}
+
+			if !tt.expectErr && res.ID != tt.cacheTag.ID {
+				t.Errorf("Wrong tag returned. expect: %s, got: %s", tt.cacheTag.ID, res.ID)
+			}
+		})
+	}
+}
+
+func Test_TagUpdate_Error(t *testing.T) {
+	curTime := func() *time.Time { t := time.Date(2023, 1, 3, 21, 35, 2, 809000000, time.UTC); return &t }()
+
+	tests := []struct {
+		name   string
+		tag    *tag.Tag
+		fields map[tag.Field]any
+	}{
+		{
+			name: "update_with_multiple_fields",
+			tag: &tag.Tag{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaabbbb-50d7-11ec-a6b1-8f9671a9e70e"),
+					CustomerID: uuid.FromStringOrNil("bbbbcccc-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name:   "original name",
+				Detail: "original detail",
+			},
+			fields: map[tag.Field]any{
+				tag.FieldName:   "updated name",
+				tag.FieldDetail: "updated detail",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+			ctx := context.Background()
+
+			// Create the tag first
+			mockUtil.EXPECT().TimeNow().Return(curTime)
+			mockCache.EXPECT().TagSet(ctx, gomock.Any())
+			if err := h.TagCreate(ctx, tt.tag); err != nil {
+				t.Errorf("Failed to create tag: %v", err)
+			}
+
+			// Now update it
+			mockUtil.EXPECT().TimeNow().Return(curTime)
+			mockCache.EXPECT().TagSet(ctx, gomock.Any())
+			err := h.TagUpdate(ctx, tt.tag.ID, tt.fields)
+			if err != nil {
+				t.Errorf("Expected successful update, got error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_TagGet_NotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	nonExistentID := uuid.FromStringOrNil("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+	mockCache.EXPECT().TagGet(ctx, nonExistentID).Return(nil, fmt.Errorf("not in cache"))
+
+	_, err := h.TagGet(ctx, nonExistentID)
+	if err != ErrNotFound {
+		t.Errorf("Expected ErrNotFound, got: %v", err)
+	}
+}
+
+func Test_tagGetFromCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        uuid.UUID
+		cacheTag  *tag.Tag
+		cacheErr  error
+		expectErr bool
+	}{
+		{
+			name: "cache_hit",
+			id:   uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			cacheTag: &tag.Tag{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+		{
+			name:      "cache_miss",
+			id:        uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+			cacheTag:  nil,
+			cacheErr:  fmt.Errorf("not found"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+			ctx := context.Background()
+
+			mockCache.EXPECT().TagGet(ctx, tt.id).Return(tt.cacheTag, tt.cacheErr)
+
+			res, err := h.tagGetFromCache(ctx, tt.id)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectErr, err)
+			}
+
+			if !tt.expectErr && res == nil {
+				t.Errorf("Expected tag, got nil")
+			}
+		})
+	}
+}
+
+func Test_tagSetToCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		tag      *tag.Tag
+		cacheErr error
+	}{
+		{
+			name: "set_to_cache_success",
+			tag: &tag.Tag{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("250bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name: "test tag",
+			},
+			cacheErr: nil,
+		},
+		{
+			name: "set_to_cache_error",
+			tag: &tag.Tag{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("350bbfa4-50d7-11ec-a6b1-8f9671a9e70e"),
+				},
+				Name: "test tag 2",
+			},
+			cacheErr: fmt.Errorf("cache error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+			ctx := context.Background()
+
+			mockCache.EXPECT().TagSet(ctx, tt.tag).Return(tt.cacheErr)
+
+			err := h.tagSetToCache(ctx, tt.tag)
+			if err != tt.cacheErr {
+				t.Errorf("Wrong error. expect: %v, got: %v", tt.cacheErr, err)
+			}
+		})
+	}
+}

--- a/bin-tag-manager/pkg/listenhandler/v1_tags_error_test.go
+++ b/bin-tag-manager/pkg/listenhandler/v1_tags_error_test.go
@@ -1,0 +1,432 @@
+package listenhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/pkg/taghandler"
+)
+
+func TestProcessV1TagsGet_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		listErr error
+	}{
+		{
+			name: "handler_error",
+			request: &sock.Request{
+				URI:      "/v1/tags?customer_id=92883d56-7fe3-11ec-8931-37d08180a2b9&page_size=10&page_token=2021-11-23T17:55:39.712000Z",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+			},
+			listErr: fmt.Errorf("database error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			mockTag.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tt.listErr)
+
+			res, err := h.processV1TagsGet(context.Background(), tt.request)
+			if err != nil {
+				t.Errorf("processV1TagsGet should not return error, got: %v", err)
+			}
+
+			if res.StatusCode == 200 {
+				t.Errorf("Expected error status code, got 200")
+			}
+		})
+	}
+}
+
+func TestProcessV1TagsPost_Error(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   *sock.Request
+		createErr error
+	}{
+		{
+			name: "handler_error",
+			request: &sock.Request{
+				URI:      "/v1/tags",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"92883d56-7fe3-11ec-8931-37d08180a2b9","name":"test","detail":"test"}`),
+			},
+			createErr: fmt.Errorf("create failed"),
+		},
+		{
+			name: "invalid_json",
+			request: &sock.Request{
+				URI:      "/v1/tags",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`invalid json`),
+			},
+			createErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			if tt.createErr != nil {
+				mockTag.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tt.createErr)
+			}
+
+			res, err := h.processV1TagsPost(context.Background(), tt.request)
+			if err != nil {
+				t.Errorf("processV1TagsPost should not return error, got: %v", err)
+			}
+
+			if res.StatusCode == 200 {
+				t.Errorf("Expected error status code, got 200")
+			}
+		})
+	}
+}
+
+func TestProcessV1TagsIDGet_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		getErr  error
+	}{
+		{
+			name: "handler_error",
+			request: &sock.Request{
+				URI:      "/v1/tags/c31676f0-4e69-11ec-afe3-77ba49fae527",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+			},
+			getErr: fmt.Errorf("not found"),
+		},
+		{
+			name: "invalid_uri",
+			request: &sock.Request{
+				URI:      "/v1/tags",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+			},
+			getErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			if tt.getErr != nil {
+				mockTag.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, tt.getErr)
+			}
+
+			res, err := h.processV1TagsIDGet(context.Background(), tt.request)
+			if err != nil {
+				t.Errorf("processV1TagsIDGet should not return error, got: %v", err)
+			}
+
+			if tt.name == "invalid_uri" && res.StatusCode != 400 {
+				t.Errorf("Expected 400 for invalid URI, got %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+func TestProcessV1TagsIDPut_Error(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   *sock.Request
+		updateErr error
+	}{
+		{
+			name: "handler_error",
+			request: &sock.Request{
+				URI:      "/v1/tags/c31676f0-4e69-11ec-afe3-77ba49fae527",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`{"name":"update","detail":"update"}`),
+			},
+			updateErr: fmt.Errorf("update failed"),
+		},
+		{
+			name: "invalid_json",
+			request: &sock.Request{
+				URI:      "/v1/tags/c31676f0-4e69-11ec-afe3-77ba49fae527",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`invalid json`),
+			},
+			updateErr: nil,
+		},
+		{
+			name: "invalid_uri",
+			request: &sock.Request{
+				URI:      "/v1/tags",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`{"name":"update","detail":"update"}`),
+			},
+			updateErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			if tt.updateErr != nil {
+				mockTag.EXPECT().UpdateBasicInfo(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tt.updateErr)
+			}
+
+			res, err := h.processV1TagsIDPut(context.Background(), tt.request)
+			if err != nil {
+				t.Errorf("processV1TagsIDPut should not return error, got: %v", err)
+			}
+
+			if res.StatusCode == 200 {
+				t.Errorf("Expected error status code, got 200")
+			}
+		})
+	}
+}
+
+func TestProcessV1TagsIDDelete_Error(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   *sock.Request
+		deleteErr error
+	}{
+		{
+			name: "handler_error",
+			request: &sock.Request{
+				URI:      "/v1/tags/c31676f0-4e69-11ec-afe3-77ba49fae527",
+				Method:   sock.RequestMethodDelete,
+				DataType: "application/json",
+			},
+			deleteErr: fmt.Errorf("delete failed"),
+		},
+		{
+			name: "invalid_uri",
+			request: &sock.Request{
+				URI:      "/v1/tags",
+				Method:   sock.RequestMethodDelete,
+				DataType: "application/json",
+			},
+			deleteErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			if tt.deleteErr != nil {
+				mockTag.EXPECT().Delete(gomock.Any(), gomock.Any()).Return(nil, tt.deleteErr)
+			}
+
+			res, err := h.processV1TagsIDDelete(context.Background(), tt.request)
+			if err != nil {
+				t.Errorf("processV1TagsIDDelete should not return error, got: %v", err)
+			}
+
+			if res.StatusCode == 200 {
+				t.Errorf("Expected error status code, got 200")
+			}
+		})
+	}
+}
+
+func TestProcessRequest_NotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockTag := taghandler.NewMockTagHandler(mc)
+
+	h := &listenHandler{
+		sockHandler: mockSock,
+		tagHandler:  mockTag,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/unknown",
+		Method:   sock.RequestMethodGet,
+		DataType: "application/json",
+	}
+
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("processRequest should not return error, got: %v", err)
+	}
+
+	if res.StatusCode != 404 {
+		t.Errorf("Expected 404 for unknown route, got %d", res.StatusCode)
+	}
+}
+
+func TestSimpleResponse(t *testing.T) {
+	tests := []struct {
+		name           string
+		code           int
+		expectedCode   int
+	}{
+		{
+			name:         "status_200",
+			code:         200,
+			expectedCode: 200,
+		},
+		{
+			name:         "status_400",
+			code:         400,
+			expectedCode: 400,
+		},
+		{
+			name:         "status_404",
+			code:         404,
+			expectedCode: 404,
+		},
+		{
+			name:         "status_500",
+			code:         500,
+			expectedCode: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := simpleResponse(tt.code)
+			if res.StatusCode != tt.expectedCode {
+				t.Errorf("Wrong status code. expect: %d, got: %d", tt.expectedCode, res.StatusCode)
+			}
+		})
+	}
+}
+
+func TestNewListenHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockTag := taghandler.NewMockTagHandler(mc)
+
+	h := NewListenHandler(mockSock, mockTag)
+
+	if h == nil {
+		t.Errorf("Expected handler, got nil")
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name           string
+		queue          string
+		exchangeDelay  string
+		queueCreateErr error
+		expectError    bool
+	}{
+		{
+			name:           "runs_successfully",
+			queue:          "test-queue",
+			exchangeDelay:  "test-exchange",
+			queueCreateErr: nil,
+			expectError:    false,
+		},
+		{
+			name:           "queue_create_error",
+			queue:          "test-queue",
+			exchangeDelay:  "test-exchange",
+			queueCreateErr: fmt.Errorf("queue create failed"),
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			mockSock.EXPECT().QueueCreate(tt.queue, "normal").Return(tt.queueCreateErr)
+
+			if tt.queueCreateErr == nil {
+				mockSock.EXPECT().ConsumeRPC(
+					context.Background(),
+					tt.queue,
+					"tag-manager",
+					false,
+					false,
+					false,
+					10,
+					gomock.Any(),
+				).Return(nil).AnyTimes()
+			}
+
+			err := h.Run(tt.queue, tt.exchangeDelay)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/bin-tag-manager/pkg/subscribehandler/customermanager_test.go
+++ b/bin-tag-manager/pkg/subscribehandler/customermanager_test.go
@@ -1,0 +1,89 @@
+package subscribehandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	cmcustomer "monorepo/bin-customer-manager/models/customer"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/pkg/taghandler"
+)
+
+func Test_processEventCMCustomerDeleted(t *testing.T) {
+	customer := &cmcustomer.Customer{
+		ID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+	}
+
+	customerData, _ := json.Marshal(customer)
+
+	tests := []struct {
+		name        string
+		event       *sock.Event
+		handlerErr  error
+		expectError bool
+	}{
+		{
+			name: "processes_customer_deleted_event",
+			event: &sock.Event{
+				Publisher: publisherCustomerManager,
+				Type:      string(cmcustomer.EventTypeCustomerDeleted),
+				Data:      json.RawMessage(customerData),
+			},
+			handlerErr:  nil,
+			expectError: false,
+		},
+		{
+			name: "handles_handler_error",
+			event: &sock.Event{
+				Publisher: publisherCustomerManager,
+				Type:      string(cmcustomer.EventTypeCustomerDeleted),
+				Data:      json.RawMessage(customerData),
+			},
+			handlerErr:  fmt.Errorf("handler error"),
+			expectError: true,
+		},
+		{
+			name: "handles_invalid_json",
+			event: &sock.Event{
+				Publisher: publisherCustomerManager,
+				Type:      string(cmcustomer.EventTypeCustomerDeleted),
+				Data:      json.RawMessage("invalid json"),
+			},
+			handlerErr:  nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &subscribeHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+			ctx := context.Background()
+
+			if string(tt.event.Data) != "invalid json" {
+				mockTag.EXPECT().EventCustomerDeleted(ctx, gomock.Any()).Return(tt.handlerErr)
+			}
+
+			err := h.processEventCMCustomerDeleted(ctx, tt.event)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/bin-tag-manager/pkg/subscribehandler/error_test.go
+++ b/bin-tag-manager/pkg/subscribehandler/error_test.go
@@ -1,0 +1,57 @@
+package subscribehandler
+
+import (
+	"fmt"
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/pkg/taghandler"
+)
+
+func Test_Run_QueueCreateError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockTag := taghandler.NewMockTagHandler(mc)
+
+	h := &subscribeHandler{
+		sockHandler:      mockSock,
+		subscribeQueue:   "test-queue",
+		subscribeTargets: []string{"target1"},
+		tagHandler:       mockTag,
+	}
+
+	mockSock.EXPECT().QueueCreate("test-queue", "normal").Return(fmt.Errorf("queue create failed"))
+
+	err := h.Run()
+	if err == nil {
+		t.Errorf("Expected error when queue create fails, got nil")
+	}
+}
+
+func Test_Run_QueueSubscribeError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockTag := taghandler.NewMockTagHandler(mc)
+
+	h := &subscribeHandler{
+		sockHandler:      mockSock,
+		subscribeQueue:   "test-queue",
+		subscribeTargets: []string{"target1"},
+		tagHandler:       mockTag,
+	}
+
+	mockSock.EXPECT().QueueCreate("test-queue", "normal").Return(nil)
+	mockSock.EXPECT().QueueSubscribe("test-queue", "target1").Return(fmt.Errorf("subscribe failed"))
+
+	err := h.Run()
+	if err == nil {
+		t.Errorf("Expected error when queue subscribe fails, got nil")
+	}
+}

--- a/bin-tag-manager/pkg/subscribehandler/main_test.go
+++ b/bin-tag-manager/pkg/subscribehandler/main_test.go
@@ -1,0 +1,180 @@
+package subscribehandler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	cmcustomer "monorepo/bin-customer-manager/models/customer"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/pkg/taghandler"
+)
+
+func Test_processEvent(t *testing.T) {
+	customer := &cmcustomer.Customer{
+		ID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+	}
+
+	customerData, _ := json.Marshal(customer)
+
+	tests := []struct {
+		name  string
+		event *sock.Event
+	}{
+		{
+			name: "processes_customer_deleted_event",
+			event: &sock.Event{
+				Publisher: publisherCustomerManager,
+				Type:      string(cmcustomer.EventTypeCustomerDeleted),
+				Data:      json.RawMessage(customerData),
+			},
+		},
+		{
+			name: "ignores_unknown_event",
+			event: &sock.Event{
+				Publisher: "unknown-service",
+				Type:      "unknown_event",
+				Data:      json.RawMessage("{}"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &subscribeHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			if tt.event.Publisher == publisherCustomerManager {
+				mockTag.EXPECT().EventCustomerDeleted(gomock.Any(), gomock.Any()).Return(nil)
+			}
+
+			// processEvent runs in background, just call it directly
+			h.processEvent(tt.event)
+		})
+	}
+}
+
+func Test_processEventRun(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *sock.Event
+	}{
+		{
+			name: "runs_process_event",
+			event: &sock.Event{
+				Publisher: "unknown-service",
+				Type:      "unknown_event",
+				Data:      json.RawMessage("{}"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &subscribeHandler{
+				sockHandler: mockSock,
+				tagHandler:  mockTag,
+			}
+
+			err := h.processEventRun(tt.event)
+			if err != nil {
+				t.Errorf("processEventRun should not return error, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_NewSubscribeHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockTag := taghandler.NewMockTagHandler(mc)
+
+	subscribeQueue := "test-queue"
+	subscribeTargets := []string{"target1", "target2"}
+
+	h := NewSubscribeHandler(mockSock, subscribeQueue, subscribeTargets, mockTag)
+
+	if h == nil {
+		t.Errorf("Expected handler, got nil")
+	}
+}
+
+func Test_Run(t *testing.T) {
+	tests := []struct {
+		name             string
+		subscribeQueue   string
+		subscribeTargets []string
+		queueCreateErr   error
+		expectError      bool
+	}{
+		{
+			name:             "runs_successfully",
+			subscribeQueue:   "test-queue",
+			subscribeTargets: []string{"target1"},
+			queueCreateErr:   nil,
+			expectError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTag := taghandler.NewMockTagHandler(mc)
+
+			h := &subscribeHandler{
+				sockHandler:      mockSock,
+				subscribeQueue:   tt.subscribeQueue,
+				subscribeTargets: tt.subscribeTargets,
+				tagHandler:       mockTag,
+			}
+
+			mockSock.EXPECT().QueueCreate(tt.subscribeQueue, "normal").Return(tt.queueCreateErr)
+
+			if tt.queueCreateErr == nil {
+				for _, target := range tt.subscribeTargets {
+					mockSock.EXPECT().QueueSubscribe(tt.subscribeQueue, target).Return(nil)
+				}
+				mockSock.EXPECT().ConsumeMessage(
+					context.Background(),
+					tt.subscribeQueue,
+					gomock.Any(),
+					false,
+					false,
+					false,
+					10,
+					gomock.Any(),
+				).Return(nil).AnyTimes()
+			}
+
+			err := h.Run()
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/bin-tag-manager/pkg/taghandler/db_test.go
+++ b/bin-tag-manager/pkg/taghandler/db_test.go
@@ -1,0 +1,368 @@
+package taghandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/models/tag"
+	"monorepo/bin-tag-manager/pkg/dbhandler"
+)
+
+func Test_dbList(t *testing.T) {
+	tests := []struct {
+		name         string
+		size         uint64
+		token        string
+		filters      map[tag.Field]any
+		responseTags []*tag.Tag
+		dbErr        error
+		expectError  bool
+	}{
+		{
+			name:  "successful_list",
+			size:  10,
+			token: "2020-04-18T03:22:17.995000Z",
+			filters: map[tag.Field]any{
+				tag.FieldCustomerID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+			},
+			responseTags: []*tag.Tag{
+				{},
+			},
+			dbErr:       nil,
+			expectError: false,
+		},
+		{
+			name:  "db_error",
+			size:  10,
+			token: "2020-04-18T03:22:17.995000Z",
+			filters: map[tag.Field]any{
+				tag.FieldCustomerID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+			},
+			responseTags: nil,
+			dbErr:        fmt.Errorf("database error"),
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagList(ctx, tt.size, tt.token, tt.filters).Return(tt.responseTags, tt.dbErr)
+
+			res, err := h.dbList(ctx, tt.size, tt.token, tt.filters)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+
+			if !tt.expectError && len(res) != len(tt.responseTags) {
+				t.Errorf("Wrong result length. expect: %d, got: %d", len(tt.responseTags), len(res))
+			}
+		})
+	}
+}
+
+func Test_dbGet(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          uuid.UUID
+		responseTag *tag.Tag
+		dbErr       error
+		expectError bool
+	}{
+		{
+			name:        "successful_get",
+			id:          uuid.FromStringOrNil("27d26bf2-2a01-11ee-82a4-63ea4f4f7211"),
+			responseTag: &tag.Tag{},
+			dbErr:       nil,
+			expectError: false,
+		},
+		{
+			name:        "db_error",
+			id:          uuid.FromStringOrNil("27d26bf2-2a01-11ee-82a4-63ea4f4f7211"),
+			responseTag: nil,
+			dbErr:       fmt.Errorf("not found"),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagGet(ctx, tt.id).Return(tt.responseTag, tt.dbErr)
+
+			res, err := h.dbGet(ctx, tt.id)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+
+			if !tt.expectError && res == nil {
+				t.Errorf("Expected tag, got nil")
+			}
+		})
+	}
+}
+
+func Test_dbUpdateInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          uuid.UUID
+		tagName     string
+		detail      string
+		updateErr   error
+		getErr      error
+		responseTag *tag.Tag
+		expectError bool
+	}{
+		{
+			name:        "successful_update",
+			id:          uuid.FromStringOrNil("5f6a7ef6-2a01-11ee-8594-87f2ee5140ed"),
+			tagName:     "test name",
+			detail:      "test detail",
+			updateErr:   nil,
+			getErr:      nil,
+			responseTag: &tag.Tag{},
+			expectError: false,
+		},
+		{
+			name:        "update_error",
+			id:          uuid.FromStringOrNil("5f6a7ef6-2a01-11ee-8594-87f2ee5140ed"),
+			tagName:     "test name",
+			detail:      "test detail",
+			updateErr:   fmt.Errorf("update failed"),
+			getErr:      nil,
+			responseTag: nil,
+			expectError: true,
+		},
+		{
+			name:        "get_error_after_update",
+			id:          uuid.FromStringOrNil("5f6a7ef6-2a01-11ee-8594-87f2ee5140ed"),
+			tagName:     "test name",
+			detail:      "test detail",
+			updateErr:   nil,
+			getErr:      fmt.Errorf("get failed"),
+			responseTag: nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagSetBasicInfo(ctx, tt.id, tt.tagName, tt.detail).Return(tt.updateErr)
+
+			if tt.updateErr == nil {
+				mockDB.EXPECT().TagGet(ctx, tt.id).Return(tt.responseTag, tt.getErr)
+				if tt.getErr == nil {
+					mockNotify.EXPECT().PublishEvent(ctx, tag.EventTypeTagUpdated, tt.responseTag)
+				}
+			}
+
+			res, err := h.dbUpdateInfo(ctx, tt.id, tt.tagName, tt.detail)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+
+			if !tt.expectError && res == nil {
+				t.Errorf("Expected tag, got nil")
+			}
+		})
+	}
+}
+
+func Test_dbCreate(t *testing.T) {
+	tests := []struct {
+		name         string
+		customerID   uuid.UUID
+		tagName      string
+		detail       string
+		responseUUID uuid.UUID
+		createErr    error
+		getErr       error
+		responseTag  *tag.Tag
+		expectError  bool
+	}{
+		{
+			name:         "successful_create",
+			customerID:   uuid.FromStringOrNil("5c517950-2a4b-11ee-b280-7389d3585310"),
+			tagName:      "test name",
+			detail:       "test detail",
+			responseUUID: uuid.FromStringOrNil("5c82c65e-2a4b-11ee-b4ae-c3cd00ea0c41"),
+			createErr:    nil,
+			getErr:       nil,
+			responseTag:  &tag.Tag{},
+			expectError:  false,
+		},
+		{
+			name:         "create_error",
+			customerID:   uuid.FromStringOrNil("5c517950-2a4b-11ee-b280-7389d3585310"),
+			tagName:      "test name",
+			detail:       "test detail",
+			responseUUID: uuid.FromStringOrNil("5c82c65e-2a4b-11ee-b4ae-c3cd00ea0c41"),
+			createErr:    fmt.Errorf("create failed"),
+			getErr:       nil,
+			responseTag:  nil,
+			expectError:  true,
+		},
+		{
+			name:         "get_error_after_create",
+			customerID:   uuid.FromStringOrNil("5c517950-2a4b-11ee-b280-7389d3585310"),
+			tagName:      "test name",
+			detail:       "test detail",
+			responseUUID: uuid.FromStringOrNil("5c82c65e-2a4b-11ee-b4ae-c3cd00ea0c41"),
+			createErr:    nil,
+			getErr:       fmt.Errorf("get failed"),
+			responseTag:  nil,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+			mockDB.EXPECT().TagCreate(ctx, gomock.Any()).Return(tt.createErr)
+
+			if tt.createErr == nil {
+				mockDB.EXPECT().TagGet(ctx, tt.responseUUID).Return(tt.responseTag, tt.getErr)
+				if tt.getErr == nil {
+					mockNotify.EXPECT().PublishEvent(ctx, tag.EventTypeTagCreated, tt.responseTag)
+				}
+			}
+
+			res, err := h.dbCreate(ctx, tt.customerID, tt.tagName, tt.detail)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+
+			if !tt.expectError && res == nil {
+				t.Errorf("Expected tag, got nil")
+			}
+		})
+	}
+}
+
+func Test_dbDelete(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          uuid.UUID
+		deleteErr   error
+		getErr      error
+		responseTag *tag.Tag
+		expectError bool
+	}{
+		{
+			name:        "successful_delete",
+			id:          uuid.FromStringOrNil("a6b3cf48-2a4b-11ee-b574-2bad4f039ce5"),
+			deleteErr:   nil,
+			getErr:      nil,
+			responseTag: &tag.Tag{},
+			expectError: false,
+		},
+		{
+			name:        "delete_error",
+			id:          uuid.FromStringOrNil("a6b3cf48-2a4b-11ee-b574-2bad4f039ce5"),
+			deleteErr:   fmt.Errorf("delete failed"),
+			getErr:      nil,
+			responseTag: nil,
+			expectError: true,
+		},
+		{
+			name:        "get_error_after_delete",
+			id:          uuid.FromStringOrNil("a6b3cf48-2a4b-11ee-b574-2bad4f039ce5"),
+			deleteErr:   nil,
+			getErr:      fmt.Errorf("get failed"),
+			responseTag: nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagDelete(ctx, tt.id).Return(tt.deleteErr)
+
+			if tt.deleteErr == nil {
+				mockDB.EXPECT().TagGet(ctx, tt.id).Return(tt.responseTag, tt.getErr)
+				if tt.getErr == nil {
+					mockNotify.EXPECT().PublishEvent(ctx, tag.EventTypeTagDeleted, tt.responseTag)
+				}
+			}
+
+			res, err := h.dbDelete(ctx, tt.id)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Wrong error expectation. expect error: %v, got: %v", tt.expectError, err)
+			}
+
+			if !tt.expectError && res == nil {
+				t.Errorf("Expected tag, got nil")
+			}
+		})
+	}
+}

--- a/bin-tag-manager/pkg/taghandler/event_test.go
+++ b/bin-tag-manager/pkg/taghandler/event_test.go
@@ -1,0 +1,149 @@
+package taghandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	cmcustomer "monorepo/bin-customer-manager/models/customer"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/models/tag"
+	"monorepo/bin-tag-manager/pkg/dbhandler"
+)
+
+func Test_EventCustomerDeleted(t *testing.T) {
+	tests := []struct {
+		name     string
+		customer *cmcustomer.Customer
+		tags     []*tag.Tag
+		listErr  error
+	}{
+		{
+			name: "deletes_all_customer_tags",
+			customer: &cmcustomer.Customer{
+				ID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+			},
+			tags: []*tag.Tag{
+				{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("a0c95b3e-2a00-11ee-a3cd-3307849aa505"),
+						CustomerID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+					},
+					Name: "tag1",
+				},
+				{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("b0c95b3e-2a00-11ee-a3cd-3307849aa505"),
+						CustomerID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+					},
+					Name: "tag2",
+				},
+			},
+			listErr: nil,
+		},
+		{
+			name: "handles_list_error",
+			customer: &cmcustomer.Customer{
+				ID: uuid.FromStringOrNil("b082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+			},
+			tags:    nil,
+			listErr: fmt.Errorf("database error"),
+		},
+		{
+			name: "no_tags_to_delete",
+			customer: &cmcustomer.Customer{
+				ID: uuid.FromStringOrNil("c082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+			},
+			tags:    []*tag.Tag{},
+			listErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			filters := map[tag.Field]any{
+				tag.FieldCustomerID: tt.customer.ID,
+				tag.FieldDeleted:    false,
+			}
+
+			mockUtil.EXPECT().TimeGetCurTime().Return("")
+			mockDB.EXPECT().TagList(ctx, uint64(999), gomock.Any(), filters).Return(tt.tags, tt.listErr)
+
+			if tt.listErr == nil {
+				for _, tg := range tt.tags {
+					mockDB.EXPECT().TagDelete(ctx, tg.ID).Return(nil)
+					mockDB.EXPECT().TagGet(ctx, tg.ID).Return(tg, nil)
+					mockNotify.EXPECT().PublishEvent(ctx, tag.EventTypeTagDeleted, tg)
+				}
+			}
+
+			err := h.EventCustomerDeleted(ctx, tt.customer)
+			if err != nil {
+				t.Errorf("EventCustomerDeleted should not return error, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EventCustomerDeleted_DeleteError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := tagHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyhandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	customer := &cmcustomer.Customer{
+		ID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+	}
+
+	tags := []*tag.Tag{
+		{
+			Identity: commonidentity.Identity{
+				ID:         uuid.FromStringOrNil("a0c95b3e-2a00-11ee-a3cd-3307849aa505"),
+				CustomerID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+			},
+			Name: "tag1",
+		},
+	}
+
+	filters := map[tag.Field]any{
+		tag.FieldCustomerID: customer.ID,
+		tag.FieldDeleted:    false,
+	}
+
+	mockUtil.EXPECT().TimeGetCurTime().Return("")
+	mockDB.EXPECT().TagList(ctx, uint64(999), gomock.Any(), filters).Return(tags, nil)
+	mockDB.EXPECT().TagDelete(ctx, tags[0].ID).Return(fmt.Errorf("delete failed"))
+
+	err := h.EventCustomerDeleted(ctx, customer)
+	if err != nil {
+		t.Errorf("EventCustomerDeleted should not return error even when delete fails, got: %v", err)
+	}
+}

--- a/bin-tag-manager/pkg/taghandler/main_constructor_test.go
+++ b/bin-tag-manager/pkg/taghandler/main_constructor_test.go
@@ -1,0 +1,27 @@
+package taghandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/pkg/dbhandler"
+)
+
+func TestNewTagHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := NewTagHandler(mockReq, mockDB, mockNotify)
+
+	if h == nil {
+		t.Errorf("Expected handler, got nil")
+	}
+}

--- a/bin-tag-manager/pkg/taghandler/tag_error_test.go
+++ b/bin-tag-manager/pkg/taghandler/tag_error_test.go
@@ -1,0 +1,301 @@
+package taghandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-tag-manager/models/tag"
+	"monorepo/bin-tag-manager/pkg/dbhandler"
+)
+
+func Test_List_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		size    uint64
+		token   string
+		filters map[tag.Field]any
+		dbErr   error
+	}{
+		{
+			name:  "database_error",
+			size:  10,
+			token: "2020-04-18T03:22:17.995000Z",
+			filters: map[tag.Field]any{
+				tag.FieldCustomerID: uuid.FromStringOrNil("a082d59c-2a00-11ee-8fb1-8bbf141432f6"),
+				tag.FieldDeleted:    false,
+			},
+			dbErr: fmt.Errorf("database connection failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagList(ctx, tt.size, tt.token, tt.filters).Return(nil, tt.dbErr)
+
+			_, err := h.List(ctx, tt.size, tt.token, tt.filters)
+			if err == nil {
+				t.Errorf("Expected error, got nil")
+			}
+		})
+	}
+}
+
+func Test_Get_Error(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    uuid.UUID
+		dbErr error
+	}{
+		{
+			name:  "tag_not_found",
+			id:    uuid.FromStringOrNil("27d26bf2-2a01-11ee-82a4-63ea4f4f7211"),
+			dbErr: fmt.Errorf("not found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagGet(ctx, tt.id).Return(nil, tt.dbErr)
+
+			_, err := h.Get(ctx, tt.id)
+			if err == nil {
+				t.Errorf("Expected error, got nil")
+			}
+		})
+	}
+}
+
+func Test_UpdateBasicInfo_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      uuid.UUID
+		tagName string
+		detail  string
+		dbErr   error
+	}{
+		{
+			name:    "update_failed",
+			id:      uuid.FromStringOrNil("5f6a7ef6-2a01-11ee-8594-87f2ee5140ed"),
+			tagName: "test name",
+			detail:  "test detail",
+			dbErr:   fmt.Errorf("update failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagSetBasicInfo(ctx, tt.id, tt.tagName, tt.detail).Return(tt.dbErr)
+
+			_, err := h.UpdateBasicInfo(ctx, tt.id, tt.tagName, tt.detail)
+			if err == nil {
+				t.Errorf("Expected error, got nil")
+			}
+		})
+	}
+}
+
+func Test_Create_Error(t *testing.T) {
+	tests := []struct {
+		name       string
+		customerID uuid.UUID
+		tagName    string
+		detail     string
+		dbErr      error
+	}{
+		{
+			name:       "create_failed",
+			customerID: uuid.FromStringOrNil("5c517950-2a4b-11ee-b280-7389d3585310"),
+			tagName:    "test name",
+			detail:     "test detail",
+			dbErr:      fmt.Errorf("create failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			responseUUID := uuid.FromStringOrNil("5c82c65e-2a4b-11ee-b4ae-c3cd00ea0c41")
+
+			mockUtil.EXPECT().UUIDCreate().Return(responseUUID)
+			mockDB.EXPECT().TagCreate(ctx, gomock.Any()).Return(tt.dbErr)
+
+			_, err := h.Create(ctx, tt.customerID, tt.tagName, tt.detail)
+			if err == nil {
+				t.Errorf("Expected error, got nil")
+			}
+		})
+	}
+}
+
+func Test_Delete_Error(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    uuid.UUID
+		dbErr error
+	}{
+		{
+			name:  "delete_failed",
+			id:    uuid.FromStringOrNil("a6b3cf48-2a4b-11ee-b574-2bad4f039ce5"),
+			dbErr: fmt.Errorf("delete failed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := tagHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyhandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			mockDB.EXPECT().TagDelete(ctx, tt.id).Return(tt.dbErr)
+
+			_, err := h.Delete(ctx, tt.id)
+			if err == nil {
+				t.Errorf("Expected error, got nil")
+			}
+		})
+	}
+}
+
+func Test_Create_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := tagHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyhandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("5c517950-2a4b-11ee-b280-7389d3585310")
+	responseUUID := uuid.FromStringOrNil("5c82c65e-2a4b-11ee-b4ae-c3cd00ea0c41")
+
+	mockUtil.EXPECT().UUIDCreate().Return(responseUUID)
+	mockDB.EXPECT().TagCreate(ctx, gomock.Any()).Return(nil)
+	mockDB.EXPECT().TagGet(ctx, responseUUID).Return(nil, fmt.Errorf("get failed"))
+
+	_, err := h.Create(ctx, customerID, "name", "detail")
+	if err == nil {
+		t.Errorf("Expected error when get fails after create, got nil")
+	}
+}
+
+func Test_UpdateBasicInfo_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := tagHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyhandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	id := uuid.FromStringOrNil("5f6a7ef6-2a01-11ee-8594-87f2ee5140ed")
+
+	mockDB.EXPECT().TagSetBasicInfo(ctx, id, "name", "detail").Return(nil)
+	mockDB.EXPECT().TagGet(ctx, id).Return(nil, fmt.Errorf("get failed"))
+
+	_, err := h.UpdateBasicInfo(ctx, id, "name", "detail")
+	if err == nil {
+		t.Errorf("Expected error when get fails after update, got nil")
+	}
+}
+
+func Test_Delete_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := tagHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyhandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	id := uuid.FromStringOrNil("a6b3cf48-2a4b-11ee-b574-2bad4f039ce5")
+
+	mockDB.EXPECT().TagDelete(ctx, id).Return(nil)
+	mockDB.EXPECT().TagGet(ctx, id).Return(nil, fmt.Errorf("get failed"))
+
+	_, err := h.Delete(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error when get fails after delete, got nil")
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-tag-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-tag-manager: Add unit tests for improved package-level coverage