### PR TITLE
NOJIRA-Test-coverage-timeline-manager

### DIFF
--- a/bin-timeline-manager/pkg/eventhandler/event_test.go
+++ b/bin-timeline-manager/pkg/eventhandler/event_test.go
@@ -27,6 +27,11 @@ func TestNewEventHandler(t *testing.T) {
 	}
 }
 
+func TestEventHandler_Interface(t *testing.T) {
+	// Ensure eventHandler implements EventHandler interface
+	var _ EventHandler = (*eventHandler)(nil)
+}
+
 func TestList_Validation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/bin-timeline-manager/pkg/listenhandler/main_test.go
+++ b/bin-timeline-manager/pkg/listenhandler/main_test.go
@@ -14,6 +14,7 @@ import (
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-timeline-manager/models/event"
+	"monorepo/bin-timeline-manager/models/sipmessage"
 	"monorepo/bin-timeline-manager/pkg/eventhandler"
 	"monorepo/bin-timeline-manager/pkg/listenhandler/models/request"
 	"monorepo/bin-timeline-manager/pkg/listenhandler/models/response"
@@ -347,4 +348,572 @@ func TestV1EventsPost_NilData(t *testing.T) {
 	if resp.StatusCode != 400 {
 		t.Errorf("v1EventsPost() StatusCode = %d, want 400", resp.StatusCode)
 	}
+}
+
+func TestV1SIPAnalysisPost_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPAnalysisPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	expectedResp := &sipmessage.SIPAnalysisResponse{
+		SIPMessages: []*sipmessage.SIPMessage{
+			{Method: "INVITE", SrcIP: "203.0.113.1", DstIP: "10.96.4.18"},
+		},
+	}
+
+	mockSIP.EXPECT().GetSIPAnalysis(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).Return(expectedResp, nil)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPAnalysisPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPAnalysisPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("v1SIPAnalysisPost() StatusCode = %d, want 200", resp.StatusCode)
+	}
+
+	if resp.DataType != "application/json" {
+		t.Errorf("v1SIPAnalysisPost() DataType = %q, want %q", resp.DataType, "application/json")
+	}
+}
+
+func TestV1SIPAnalysisPost_InvalidJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   []byte("invalid json"),
+	}
+
+	resp, err := handler.v1SIPAnalysisPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPAnalysisPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 400 {
+		t.Errorf("v1SIPAnalysisPost() StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1SIPAnalysisPost_InvalidFromTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPAnalysisPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "invalid-time",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPAnalysisPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPAnalysisPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 400 {
+		t.Errorf("v1SIPAnalysisPost() StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1SIPAnalysisPost_InvalidToTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPAnalysisPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "invalid-time",
+	}
+	reqData, _ := json.Marshal(req)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPAnalysisPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPAnalysisPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 400 {
+		t.Errorf("v1SIPAnalysisPost() StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1SIPAnalysisPost_HandlerError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPAnalysisPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockSIP.EXPECT().GetSIPAnalysis(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).Return(nil, errors.New("handler error"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPAnalysisPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPAnalysisPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 500 {
+		t.Errorf("v1SIPAnalysisPost() StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestV1SIPPcapPost_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPPcapPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	expectedPcap := []byte("pcap data")
+	mockSIP.EXPECT().GetPcap(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).Return(expectedPcap, nil)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPPcapPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPPcapPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("v1SIPPcapPost() StatusCode = %d, want 200", resp.StatusCode)
+	}
+
+	if resp.DataType != "application/json" {
+		t.Errorf("v1SIPPcapPost() DataType = %q, want %q", resp.DataType, "application/json")
+	}
+
+	// Verify response contains base64-encoded data
+	var result map[string]string
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal response: %v", err)
+	}
+	if _, ok := result["data"]; !ok {
+		t.Error("Response missing 'data' field")
+	}
+}
+
+func TestV1SIPPcapPost_InvalidJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   []byte("invalid json"),
+	}
+
+	resp, err := handler.v1SIPPcapPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPPcapPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 400 {
+		t.Errorf("v1SIPPcapPost() StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1SIPPcapPost_InvalidFromTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPPcapPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "invalid-time",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPPcapPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPPcapPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 400 {
+		t.Errorf("v1SIPPcapPost() StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1SIPPcapPost_InvalidToTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPPcapPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "invalid-time",
+	}
+	reqData, _ := json.Marshal(req)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPPcapPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPPcapPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 400 {
+		t.Errorf("v1SIPPcapPost() StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1SIPPcapPost_HandlerError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPPcapPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockSIP.EXPECT().GetPcap(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).Return(nil, errors.New("pcap fetch failed"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPPcapPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPPcapPost() error = %v", err)
+	}
+
+	if resp.StatusCode != 500 {
+		t.Errorf("v1SIPPcapPost() StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_V1SIPAnalysisPost(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPAnalysisPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	expectedResp := &sipmessage.SIPAnalysisResponse{
+		SIPMessages: []*sipmessage.SIPMessage{},
+	}
+
+	mockSIP.EXPECT().GetSIPAnalysis(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).Return(expectedResp, nil)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.processRequest(sockReq)
+	if err != nil {
+		t.Fatalf("processRequest() error = %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("processRequest() StatusCode = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_V1SIPPcapPost(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPPcapPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockSIP.EXPECT().GetPcap(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).Return([]byte("pcap"), nil)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.processRequest(sockReq)
+	if err != nil {
+		t.Fatalf("processRequest() error = %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("processRequest() StatusCode = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestRegexPatterns_SIPAnalysis(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		matches bool
+	}{
+		{name: "exact match", uri: "/v1/sip/analysis", matches: true},
+		{name: "with query params", uri: "/v1/sip/analysis?param=1", matches: false},
+		{name: "with trailing slash", uri: "/v1/sip/analysis/", matches: false},
+		{name: "different path", uri: "/v1/sip/other", matches: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := regV1SIPAnalysis.MatchString(tt.uri)
+			if result != tt.matches {
+				t.Errorf("regV1SIPAnalysis.MatchString(%q) = %v, want %v", tt.uri, result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestRegexPatterns_SIPPcap(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		matches bool
+	}{
+		{name: "exact match", uri: "/v1/sip/pcap", matches: true},
+		{name: "with query params", uri: "/v1/sip/pcap?param=1", matches: false},
+		{name: "with trailing slash", uri: "/v1/sip/pcap/", matches: false},
+		{name: "different path", uri: "/v1/sip/other", matches: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := regV1SIPPcap.MatchString(tt.uri)
+			if result != tt.matches {
+				t.Errorf("regV1SIPPcap.MatchString(%q) = %v, want %v", tt.uri, result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestListenHandler_Interface(t *testing.T) {
+	// Ensure listenHandler implements ListenHandler interface
+	var _ ListenHandler = (*listenHandler)(nil)
+}
+
+func TestProcessRequest_HandlerReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	testID := uuid.Must(uuid.NewV4())
+	req := &request.V1DataEventsPost{
+		Publisher:  commonoutline.ServiceName("flow-manager"),
+		ResourceID: testID,
+		Events:     []string{"activeflow_*"},
+		PageSize:   10,
+	}
+	reqData, _ := json.Marshal(req)
+
+	// Handler returns error - v1EventsPost returns 500, then processRequest catches and converts to 400
+	mockEvent.EXPECT().
+		List(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("database error"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/events",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.processRequest(sockReq)
+	// processRequest handles errors internally and returns 400 when handler returns non-nil error
+	if err != nil {
+		t.Fatalf("processRequest() error = %v", err)
+	}
+
+	// processRequest sets status to 400 when err is returned from v1EventsPost
+	// but v1EventsPost returns 500 for handler errors, so processRequest wraps and converts
+	if resp.StatusCode != 500 {
+		t.Errorf("processRequest() StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestRun_ConsumeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := NewListenHandler(mockSock, mockEvent, mockSIP)
+
+	mockSock.EXPECT().
+		QueueCreate("test-queue", "normal").
+		Return(nil)
+
+	// ConsumeRPC returns error in goroutine (just verify it doesn't crash)
+	mockSock.EXPECT().
+		ConsumeRPC(gomock.Any(), "test-queue", "timeline-manager", false, false, false, 10, gomock.Any()).
+		Return(errors.New("consume error"))
+
+	err := handler.Run("test-queue")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Give goroutine time to execute (coverage will be counted)
+	time.Sleep(50 * time.Millisecond)
 }

--- a/bin-timeline-manager/pkg/siphandler/main_test.go
+++ b/bin-timeline-manager/pkg/siphandler/main_test.go
@@ -1,16 +1,70 @@
 package siphandler
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-timeline-manager/models/sipmessage"
 	"monorepo/bin-timeline-manager/pkg/homerhandler"
 )
+
+func TestNewSIPHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHomer := homerhandler.NewMockHomerHandler(ctrl)
+	handler := NewSIPHandler(mockHomer)
+
+	if handler == nil {
+		t.Error("NewSIPHandler() returned nil")
+	}
+}
+
+func TestSIPHandler_Interface(t *testing.T) {
+	// Ensure sipHandler implements SIPHandler interface
+	var _ SIPHandler = (*sipHandler)(nil)
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		wantPri bool
+	}{
+		{name: "10.x.x.x private", ip: "10.0.0.1", wantPri: true},
+		{name: "10.x.x.x boundary", ip: "10.255.255.255", wantPri: true},
+		{name: "172.16-31.x.x private", ip: "172.16.0.1", wantPri: true},
+		{name: "172.31.x.x private", ip: "172.31.255.255", wantPri: true},
+		{name: "192.168.x.x private", ip: "192.168.1.1", wantPri: true},
+		{name: "192.168.x.x boundary", ip: "192.168.255.255", wantPri: true},
+		{name: "public IP", ip: "8.8.8.8", wantPri: false},
+		{name: "public IP 2", ip: "203.0.113.1", wantPri: false},
+		{name: "172.15.x.x not private", ip: "172.15.0.1", wantPri: false},
+		{name: "172.32.x.x not private", ip: "172.32.0.1", wantPri: false},
+		{name: "11.x.x.x not private", ip: "11.0.0.1", wantPri: false},
+		{name: "invalid IP", ip: "invalid", wantPri: false},
+		{name: "empty string", ip: "", wantPri: false},
+		{name: "localhost", ip: "127.0.0.1", wantPri: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isPrivateIP(tt.ip)
+			if result != tt.wantPri {
+				t.Errorf("isPrivateIP(%q) = %v, want %v", tt.ip, result, tt.wantPri)
+			}
+		})
+	}
+}
 
 func TestGetSIPAnalysis(t *testing.T) {
 	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -142,5 +196,781 @@ func TestGetSIPAnalysis(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetPcap(t *testing.T) {
+	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	toTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	// Helper to create a minimal valid PCAP
+	createPcap := func(srcIP, dstIP string) []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+		// Create a simple UDP/SIP packet
+		eth := &layers.Ethernet{
+			SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip := &layers.IPv4{
+			Version:  4,
+			SrcIP:    []byte(srcIP),
+			DstIP:    []byte(dstIP),
+			Protocol: layers.IPProtocolUDP,
+		}
+		udp := &layers.UDP{
+			SrcPort: 5060,
+			DstPort: 5060,
+		}
+		_ = udp.SetNetworkLayerForChecksum(ip)
+
+		payload := []byte("INVITE sip:test SIP/2.0")
+		packetBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{ComputeChecksums: true}
+		_ = gopacket.SerializeLayers(packetBuf, opts, eth, ip, udp, gopacket.Payload(payload))
+		packetData := packetBuf.Bytes()
+
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		_ = writer.WritePacket(ci, packetData)
+
+		return buf.Bytes()
+	}
+
+	tests := []struct {
+		name          string
+		sipCallID     string
+		sipPcapData   []byte
+		sipPcapErr    error
+		rtcpPcapData  []byte
+		rtcpPcapErr   error
+		wantErr       bool
+		wantEmpty     bool
+	}{
+		{
+			name:        "SIP PCAP error returns error",
+			sipCallID:   "call-1",
+			sipPcapErr:  fmt.Errorf("pcap fetch failed"),
+			wantErr:     true,
+		},
+		{
+			name:        "empty SIP PCAP returns empty",
+			sipCallID:   "call-1",
+			sipPcapData: []byte{},
+			wantEmpty:   true,
+		},
+		{
+			name:         "SIP PCAP only success",
+			sipCallID:    "call-1",
+			sipPcapData:  createPcap("\x0a\x00\x00\x01", "\xcb\x00\x71\x01"), // 10.0.0.1 -> 203.0.113.1
+			rtcpPcapErr:  fmt.Errorf("rtcp unavailable"),
+			wantErr:      false,
+		},
+		{
+			name:         "SIP and RTCP PCAP merge success",
+			sipCallID:    "call-1",
+			sipPcapData:  createPcap("\x0a\x00\x00\x01", "\xcb\x00\x71\x01"), // 10.0.0.1 -> 203.0.113.1
+			rtcpPcapData: createPcap("\xcb\x00\x71\x01", "\x0a\x00\x00\x01"), // 203.0.113.1 -> 10.0.0.1
+			wantErr:      false,
+		},
+		{
+			name:         "RTCP PCAP empty falls back to SIP only",
+			sipCallID:    "call-1",
+			sipPcapData:  createPcap("\x0a\x00\x00\x01", "\xcb\x00\x71\x01"),
+			rtcpPcapData: []byte{},
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockHomer := homerhandler.NewMockHomerHandler(mc)
+			mockHomer.EXPECT().GetPcap(gomock.Any(), tt.sipCallID, fromTime, toTime).Return(tt.sipPcapData, tt.sipPcapErr)
+
+			if tt.sipPcapErr == nil && len(tt.sipPcapData) > 0 {
+				mockHomer.EXPECT().GetRTCPPcap(gomock.Any(), tt.sipCallID, fromTime, toTime).Return(tt.rtcpPcapData, tt.rtcpPcapErr)
+			}
+
+			h := NewSIPHandler(mockHomer)
+
+			result, err := h.GetPcap(context.Background(), tt.sipCallID, fromTime, toTime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantEmpty {
+				if len(result) != 0 {
+					t.Errorf("expected empty result, got %d bytes", len(result))
+				}
+			} else {
+				if len(result) == 0 {
+					t.Error("expected non-empty result, got empty")
+				}
+			}
+		})
+	}
+}
+
+func TestMergePcaps(t *testing.T) {
+	// Helper to create a PCAP with a single packet at a specific timestamp
+	createTimestampedPcap := func(ts time.Time) []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+		eth := &layers.Ethernet{
+			SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip := &layers.IPv4{
+			Version:  4,
+			SrcIP:    []byte{10, 0, 0, 1},
+			DstIP:    []byte{10, 0, 0, 2},
+			Protocol: layers.IPProtocolUDP,
+		}
+		udp := &layers.UDP{SrcPort: 5060, DstPort: 5060}
+		_ = udp.SetNetworkLayerForChecksum(ip)
+
+		packetBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{ComputeChecksums: true}
+		_ = gopacket.SerializeLayers(packetBuf, opts, eth, ip, udp, gopacket.Payload([]byte("test")))
+		packetData := packetBuf.Bytes()
+
+		ci := gopacket.CaptureInfo{
+			Timestamp:     ts,
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		_ = writer.WritePacket(ci, packetData)
+
+		return buf.Bytes()
+	}
+
+	t.Run("merge sorts by timestamp", func(t *testing.T) {
+		ts1 := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+		ts2 := time.Date(2026, 1, 1, 0, 0, 2, 0, time.UTC)
+
+		pcap1 := createTimestampedPcap(ts1)
+		pcap2 := createTimestampedPcap(ts2)
+
+		merged, err := mergePcaps(pcap1, pcap2)
+		if err != nil {
+			t.Fatalf("mergePcaps() error = %v", err)
+		}
+
+		// Verify merged PCAP has 2 packets
+		reader, err := pcapgo.NewReader(bytes.NewReader(merged))
+		if err != nil {
+			t.Fatalf("failed to read merged PCAP: %v", err)
+		}
+
+		count := 0
+		for {
+			_, _, err := reader.ReadPacketData()
+			if err != nil {
+				break
+			}
+			count++
+		}
+
+		if count != 2 {
+			t.Errorf("merged PCAP has %d packets, want 2", count)
+		}
+	})
+
+	t.Run("invalid pcap1 returns error", func(t *testing.T) {
+		_, err := mergePcaps([]byte("invalid"), createTimestampedPcap(time.Now()))
+		if err == nil {
+			t.Error("expected error for invalid pcap1, got nil")
+		}
+	})
+
+	t.Run("invalid pcap2 returns error", func(t *testing.T) {
+		_, err := mergePcaps(createTimestampedPcap(time.Now()), []byte("invalid"))
+		if err == nil {
+			t.Error("expected error for invalid pcap2, got nil")
+		}
+	})
+}
+
+func TestFilterInternalPackets(t *testing.T) {
+	// Helper to create a PCAP with specific src/dst IPs
+	createPcapWithIPs := func(srcIP, dstIP string) []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+		eth := &layers.Ethernet{
+			SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip := &layers.IPv4{
+			Version:  4,
+			SrcIP:    []byte(srcIP),
+			DstIP:    []byte(dstIP),
+			Protocol: layers.IPProtocolUDP,
+		}
+		udp := &layers.UDP{SrcPort: 5060, DstPort: 5060}
+		_ = udp.SetNetworkLayerForChecksum(ip)
+
+		packetBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{ComputeChecksums: true}
+		_ = gopacket.SerializeLayers(packetBuf, opts, eth, ip, udp, gopacket.Payload([]byte("test")))
+		packetData := packetBuf.Bytes()
+
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		_ = writer.WritePacket(ci, packetData)
+
+		return buf.Bytes()
+	}
+
+	tests := []struct {
+		name      string
+		srcIP     string
+		dstIP     string
+		wantKept  bool
+	}{
+		{name: "internal to internal filtered", srcIP: "\x0a\x00\x00\x01", dstIP: "\x0a\x00\x00\x02", wantKept: false},
+		{name: "internal to external kept", srcIP: "\x0a\x00\x00\x01", dstIP: "\xcb\x00\x71\x01", wantKept: true},
+		{name: "external to internal kept", srcIP: "\xcb\x00\x71\x01", dstIP: "\x0a\x00\x00\x01", wantKept: true},
+		{name: "external to external kept", srcIP: "\xcb\x00\x71\x01", dstIP: "\xcb\x00\x71\x02", wantKept: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcap := createPcapWithIPs(tt.srcIP, tt.dstIP)
+			filtered, err := filterInternalPackets(pcap)
+			if err != nil {
+				t.Fatalf("filterInternalPackets() error = %v", err)
+			}
+
+			reader, err := pcapgo.NewReader(bytes.NewReader(filtered))
+			if err != nil {
+				t.Fatalf("failed to read filtered PCAP: %v", err)
+			}
+
+			count := 0
+			for {
+				_, _, err := reader.ReadPacketData()
+				if err != nil {
+					break
+				}
+				count++
+			}
+
+			if tt.wantKept && count != 1 {
+				t.Errorf("expected packet to be kept, but got %d packets", count)
+			}
+			if !tt.wantKept && count != 0 {
+				t.Errorf("expected packet to be filtered, but got %d packets", count)
+			}
+		})
+	}
+
+	t.Run("invalid PCAP returns error", func(t *testing.T) {
+		_, err := filterInternalPackets([]byte("invalid pcap"))
+		if err == nil {
+			t.Error("expected error for invalid PCAP, got nil")
+		}
+	})
+}
+
+func TestGetPcap_EmptyRTCP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	toTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	// Helper to create a minimal valid PCAP
+	createPcap := func() []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+		eth := &layers.Ethernet{
+			SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip := &layers.IPv4{
+			Version:  4,
+			SrcIP:    []byte{10, 0, 0, 1},
+			DstIP:    []byte{203, 0, 113, 1},
+			Protocol: layers.IPProtocolUDP,
+		}
+		udp := &layers.UDP{SrcPort: 5060, DstPort: 5060}
+		_ = udp.SetNetworkLayerForChecksum(ip)
+
+		packetBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{ComputeChecksums: true}
+		_ = gopacket.SerializeLayers(packetBuf, opts, eth, ip, udp, gopacket.Payload([]byte("test")))
+		packetData := packetBuf.Bytes()
+
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		_ = writer.WritePacket(ci, packetData)
+
+		return buf.Bytes()
+	}
+
+	mockHomer := homerhandler.NewMockHomerHandler(ctrl)
+	sipPcap := createPcap()
+	mockHomer.EXPECT().GetPcap(gomock.Any(), "call-1", fromTime, toTime).Return(sipPcap, nil)
+	mockHomer.EXPECT().GetRTCPPcap(gomock.Any(), "call-1", fromTime, toTime).Return([]byte{}, nil)
+
+	h := NewSIPHandler(mockHomer)
+
+	result, err := h.GetPcap(context.Background(), "call-1", fromTime, toTime)
+	if err != nil {
+		t.Fatalf("GetPcap() error = %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected non-empty result")
+	}
+}
+
+func TestGetPcap_MergeError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	toTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	// Create a valid SIP PCAP
+	createPcap := func() []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+		return buf.Bytes()
+	}
+
+	mockHomer := homerhandler.NewMockHomerHandler(ctrl)
+	sipPcap := createPcap()
+	invalidRTCP := []byte("invalid pcap")
+	mockHomer.EXPECT().GetPcap(gomock.Any(), "call-1", fromTime, toTime).Return(sipPcap, nil)
+	mockHomer.EXPECT().GetRTCPPcap(gomock.Any(), "call-1", fromTime, toTime).Return(invalidRTCP, nil)
+
+	h := NewSIPHandler(mockHomer)
+
+	result, err := h.GetPcap(context.Background(), "call-1", fromTime, toTime)
+	if err != nil {
+		t.Fatalf("GetPcap() error = %v", err)
+	}
+	// Should fall back to SIP only when merge fails
+	if len(result) == 0 {
+		t.Error("expected fallback to SIP pcap")
+	}
+}
+
+func TestFilterInternalPackets_IPv6(t *testing.T) {
+	// Create a PCAP with IPv6 packets
+	var buf bytes.Buffer
+	writer := pcapgo.NewWriter(&buf)
+	_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	ipv6 := &layers.IPv6{
+		Version:    6,
+		SrcIP:      []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+		DstIP:      []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+		NextHeader: layers.IPProtocolUDP,
+	}
+	udp := &layers.UDP{SrcPort: 5060, DstPort: 5060}
+	_ = udp.SetNetworkLayerForChecksum(ipv6)
+
+	packetBuf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{ComputeChecksums: true}
+	_ = gopacket.SerializeLayers(packetBuf, opts, eth, ipv6, udp, gopacket.Payload([]byte("test")))
+	packetData := packetBuf.Bytes()
+
+	ci := gopacket.CaptureInfo{
+		Timestamp:     time.Now(),
+		CaptureLength: len(packetData),
+		Length:        len(packetData),
+	}
+	_ = writer.WritePacket(ci, packetData)
+
+	pcap := buf.Bytes()
+
+	filtered, err := filterInternalPackets(pcap)
+	if err != nil {
+		t.Fatalf("filterInternalPackets() error = %v", err)
+	}
+
+	// IPv6 packets should be kept (not in private IPv4 ranges)
+	reader, err := pcapgo.NewReader(bytes.NewReader(filtered))
+	if err != nil {
+		t.Fatalf("failed to read filtered PCAP: %v", err)
+	}
+
+	count := 0
+	for {
+		_, _, err := reader.ReadPacketData()
+		if err != nil {
+			break
+		}
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 IPv6 packet to be kept, got %d", count)
+	}
+}
+
+func TestFilterInternalPackets_NoIPLayer(t *testing.T) {
+	// Create a PCAP with a packet that has no IP layer
+	var buf bytes.Buffer
+	writer := pcapgo.NewWriter(&buf)
+	_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+	eth := &layers.Ethernet{
+		SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+		DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+		EthernetType: layers.EthernetTypeARP,
+	}
+
+	packetBuf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{}
+	_ = gopacket.SerializeLayers(packetBuf, opts, eth, gopacket.Payload([]byte("arp payload")))
+	packetData := packetBuf.Bytes()
+
+	ci := gopacket.CaptureInfo{
+		Timestamp:     time.Now(),
+		CaptureLength: len(packetData),
+		Length:        len(packetData),
+	}
+	_ = writer.WritePacket(ci, packetData)
+
+	pcap := buf.Bytes()
+
+	filtered, err := filterInternalPackets(pcap)
+	if err != nil {
+		t.Fatalf("filterInternalPackets() error = %v", err)
+	}
+
+	// Packets without IP layer should be kept
+	reader, err := pcapgo.NewReader(bytes.NewReader(filtered))
+	if err != nil {
+		t.Fatalf("failed to read filtered PCAP: %v", err)
+	}
+
+	count := 0
+	for {
+		_, _, err := reader.ReadPacketData()
+		if err != nil {
+			break
+		}
+		count++
+	}
+
+	if count != 1 {
+		t.Errorf("expected 1 non-IP packet to be kept, got %d", count)
+	}
+}
+
+func TestMergePcaps_LinkTypeMismatch(t *testing.T) {
+	// Create two PCAPs with different link types
+	createPcapWithLinkType := func(linkType layers.LinkType) []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, linkType)
+		return buf.Bytes()
+	}
+
+	pcap1 := createPcapWithLinkType(layers.LinkTypeEthernet)
+	pcap2 := createPcapWithLinkType(layers.LinkTypeRaw)
+
+	_, err := mergePcaps(pcap1, pcap2)
+	if err == nil {
+		t.Error("expected error for link type mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "link type mismatch") {
+		t.Errorf("expected link type mismatch error, got: %v", err)
+	}
+}
+
+func TestGetPcap_FilterError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	toTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	mockHomer := homerhandler.NewMockHomerHandler(ctrl)
+	// Return invalid PCAP data that will fail filtering
+	invalidPcap := []byte("invalid pcap data")
+	mockHomer.EXPECT().GetPcap(gomock.Any(), "call-1", fromTime, toTime).Return(invalidPcap, nil)
+	mockHomer.EXPECT().GetRTCPPcap(gomock.Any(), "call-1", fromTime, toTime).Return([]byte{}, nil)
+
+	h := NewSIPHandler(mockHomer)
+
+	result, err := h.GetPcap(context.Background(), "call-1", fromTime, toTime)
+	if err != nil {
+		t.Fatalf("GetPcap() error = %v", err)
+	}
+	// Should return unfiltered data when filtering fails
+	if !bytes.Equal(result, invalidPcap) {
+		t.Error("expected unfiltered data when filter fails")
+	}
+}
+
+func TestGetSIPAnalysis_NilMessages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	toTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	mockHomer := homerhandler.NewMockHomerHandler(ctrl)
+	mockHomer.EXPECT().GetSIPMessages(gomock.Any(), "call-1", fromTime, toTime).Return(nil, nil)
+
+	h := NewSIPHandler(mockHomer)
+
+	resp, err := h.GetSIPAnalysis(context.Background(), "call-1", fromTime, toTime)
+	if err != nil {
+		t.Fatalf("GetSIPAnalysis() error = %v", err)
+	}
+
+	if resp.SIPMessages == nil {
+		t.Error("expected non-nil SIPMessages slice")
+	}
+	if len(resp.SIPMessages) != 0 {
+		t.Errorf("expected empty SIPMessages, got %d", len(resp.SIPMessages))
+	}
+}
+
+func TestGetPcap_MergeSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fromTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	toTime := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+
+	// Create valid PCAPs
+	createPcap := func(srcIP, dstIP string) []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+		eth := &layers.Ethernet{
+			SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip := &layers.IPv4{
+			Version:  4,
+			SrcIP:    []byte(srcIP),
+			DstIP:    []byte(dstIP),
+			Protocol: layers.IPProtocolUDP,
+		}
+		udp := &layers.UDP{SrcPort: 5060, DstPort: 5060}
+		_ = udp.SetNetworkLayerForChecksum(ip)
+
+		packetBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{ComputeChecksums: true}
+		_ = gopacket.SerializeLayers(packetBuf, opts, eth, ip, udp, gopacket.Payload([]byte("test")))
+		packetData := packetBuf.Bytes()
+
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		_ = writer.WritePacket(ci, packetData)
+
+		return buf.Bytes()
+	}
+
+	mockHomer := homerhandler.NewMockHomerHandler(ctrl)
+	sipPcap := createPcap("\x0a\x00\x00\x01", "\xcb\x00\x71\x01")
+	rtcpPcap := createPcap("\xcb\x00\x71\x01", "\x0a\x00\x00\x01")
+	mockHomer.EXPECT().GetPcap(gomock.Any(), "call-1", fromTime, toTime).Return(sipPcap, nil)
+	mockHomer.EXPECT().GetRTCPPcap(gomock.Any(), "call-1", fromTime, toTime).Return(rtcpPcap, nil)
+
+	h := NewSIPHandler(mockHomer)
+
+	result, err := h.GetPcap(context.Background(), "call-1", fromTime, toTime)
+	if err != nil {
+		t.Fatalf("GetPcap() error = %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected merged result")
+	}
+
+	// Verify merged PCAP has packets
+	reader, err := pcapgo.NewReader(bytes.NewReader(result))
+	if err != nil {
+		t.Fatalf("failed to read merged PCAP: %v", err)
+	}
+
+	count := 0
+	for {
+		_, _, err := reader.ReadPacketData()
+		if err != nil {
+			break
+		}
+		count++
+	}
+
+	if count == 0 {
+		t.Error("expected at least one packet in merged PCAP")
+	}
+}
+
+func TestIsPrivateIP_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		wantPri bool
+	}{
+		{name: "10.0.0.0 start of range", ip: "10.0.0.0", wantPri: true},
+		{name: "172.16.0.0 start of range", ip: "172.16.0.0", wantPri: true},
+		{name: "192.168.0.0 start of range", ip: "192.168.0.0", wantPri: true},
+		{name: "9.255.255.255 not private", ip: "9.255.255.255", wantPri: false},
+		{name: "11.0.0.0 not private", ip: "11.0.0.0", wantPri: false},
+		{name: "172.15.255.255 not private", ip: "172.15.255.255", wantPri: false},
+		{name: "172.32.0.0 not private", ip: "172.32.0.0", wantPri: false},
+		{name: "192.167.255.255 not private", ip: "192.167.255.255", wantPri: false},
+		{name: "192.169.0.0 not private", ip: "192.169.0.0", wantPri: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isPrivateIP(tt.ip)
+			if result != tt.wantPri {
+				t.Errorf("isPrivateIP(%q) = %v, want %v", tt.ip, result, tt.wantPri)
+			}
+		})
+	}
+}
+
+func TestMergePcaps_EmptyPcaps(t *testing.T) {
+	// Test merging two empty PCAPs (only headers)
+	createEmptyPcap := func() []byte {
+		var buf bytes.Buffer
+		writer := pcapgo.NewWriter(&buf)
+		_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+		return buf.Bytes()
+	}
+
+	pcap1 := createEmptyPcap()
+	pcap2 := createEmptyPcap()
+
+	merged, err := mergePcaps(pcap1, pcap2)
+	if err != nil {
+		t.Fatalf("mergePcaps() error = %v", err)
+	}
+
+	// Should have valid PCAP header but no packets
+	reader, err := pcapgo.NewReader(bytes.NewReader(merged))
+	if err != nil {
+		t.Fatalf("failed to read merged PCAP: %v", err)
+	}
+
+	count := 0
+	for {
+		_, _, err := reader.ReadPacketData()
+		if err != nil {
+			break
+		}
+		count++
+	}
+
+	if count != 0 {
+		t.Errorf("expected 0 packets in merged empty PCAPs, got %d", count)
+	}
+}
+
+func TestFilterInternalPackets_Mixed(t *testing.T) {
+	// Test PCAP with mix of internal-internal, internal-external, and external-external
+	var buf bytes.Buffer
+	writer := pcapgo.NewWriter(&buf)
+	_ = writer.WriteFileHeader(65536, layers.LinkTypeEthernet)
+
+	addPacket := func(srcIP, dstIP string) {
+		eth := &layers.Ethernet{
+			SrcMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			DstMAC:       []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+			EthernetType: layers.EthernetTypeIPv4,
+		}
+		ip := &layers.IPv4{
+			Version:  4,
+			SrcIP:    []byte(srcIP),
+			DstIP:    []byte(dstIP),
+			Protocol: layers.IPProtocolUDP,
+		}
+		udp := &layers.UDP{SrcPort: 5060, DstPort: 5060}
+		_ = udp.SetNetworkLayerForChecksum(ip)
+
+		packetBuf := gopacket.NewSerializeBuffer()
+		opts := gopacket.SerializeOptions{ComputeChecksums: true}
+		_ = gopacket.SerializeLayers(packetBuf, opts, eth, ip, udp, gopacket.Payload([]byte("test")))
+		packetData := packetBuf.Bytes()
+
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Now(),
+			CaptureLength: len(packetData),
+			Length:        len(packetData),
+		}
+		_ = writer.WritePacket(ci, packetData)
+	}
+
+	// Add 3 packets: internal-internal, internal-external, external-external
+	addPacket("\x0a\x00\x00\x01", "\x0a\x00\x00\x02")    // internal-internal (filtered)
+	addPacket("\x0a\x00\x00\x01", "\xcb\x00\x71\x01")    // internal-external (kept)
+	addPacket("\xcb\x00\x71\x01", "\xcb\x00\x71\x02")    // external-external (kept)
+
+	pcap := buf.Bytes()
+
+	filtered, err := filterInternalPackets(pcap)
+	if err != nil {
+		t.Fatalf("filterInternalPackets() error = %v", err)
+	}
+
+	reader, err := pcapgo.NewReader(bytes.NewReader(filtered))
+	if err != nil {
+		t.Fatalf("failed to read filtered PCAP: %v", err)
+	}
+
+	count := 0
+	for {
+		_, _, err := reader.ReadPacketData()
+		if err != nil {
+			break
+		}
+		count++
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 packets after filtering, got %d", count)
 	}
 }


### PR DESCRIPTION
Increase test coverage for bin-timeline-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-timeline-manager: Add unit tests for improved package-level coverage