### PR TITLE
NOJIRA-Test-coverage-email-manager

### DIFF
--- a/bin-email-manager/internal/config/config_test.go
+++ b/bin-email-manager/internal/config/config_test.go
@@ -107,3 +107,90 @@ func TestInitConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestBootstrap(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "bootstrap_initializes_config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{}
+
+			err := Bootstrap(rootCmd)
+
+			if err != nil {
+				t.Errorf("Unexpected error from Bootstrap: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadGlobalConfig(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "loads_global_config_once",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset for test isolation
+			once = sync.Once{}
+			globalConfig = Config{}
+
+			// Set environment variables for testing
+			t.Setenv("RABBITMQ_ADDRESS", "amqp://test-rabbitmq:5672")
+			t.Setenv("DATABASE_DSN", "test-db-dsn")
+			t.Setenv("REDIS_ADDRESS", "test-redis:6379")
+
+			// Call LoadGlobalConfig
+			LoadGlobalConfig()
+
+			// Call again to test sync.Once
+			LoadGlobalConfig()
+
+			// Verify config loaded
+			cfg := Get()
+			if cfg.RabbitMQAddress != "amqp://test-rabbitmq:5672" {
+				t.Errorf("Wrong RabbitMQAddress. expect: amqp://test-rabbitmq:5672, got: %s", cfg.RabbitMQAddress)
+			}
+		})
+	}
+}
+
+func TestRegisterFlags(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "registers_flags_successfully",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{}
+
+			// This should not panic
+			RegisterFlags(rootCmd)
+
+			// Verify flags are registered
+			flag := rootCmd.PersistentFlags().Lookup("rabbitmq_address")
+			if flag == nil {
+				t.Errorf("Expected rabbitmq_address flag to be registered")
+			}
+
+			flag = rootCmd.PersistentFlags().Lookup("database_dsn")
+			if flag == nil {
+				t.Errorf("Expected database_dsn flag to be registered")
+			}
+		})
+	}
+}

--- a/bin-email-manager/pkg/dbhandler/emails_test.go
+++ b/bin-email-manager/pkg/dbhandler/emails_test.go
@@ -371,3 +371,419 @@ func Test_EmailUpdateProviderReferenceID(t *testing.T) {
 		})
 	}
 }
+
+func Test_EmailGet_NotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		id   uuid.UUID
+	}{
+		{
+			name: "returns_error_when_not_found",
+			id:   uuid.FromStringOrNil("00000000-0000-0000-0000-000000000000"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().EmailGet(ctx, tt.id).Return(nil, fmt.Errorf("not found"))
+
+			_, err := h.EmailGet(ctx, tt.id)
+			if err == nil {
+				t.Errorf("Expected error when email not found")
+			}
+		})
+	}
+}
+
+func Test_EmailList_WithEmptyResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		size    uint64
+		filters map[email.Field]any
+	}{
+		{
+			name:  "returns_empty_or_small_list_when_filtered",
+			token: "",
+			size:  10,
+			filters: map[email.Field]any{
+				email.FieldCustomerID: uuid.FromStringOrNil("99999999-9999-9999-9999-999999999999"),
+				email.FieldDeleted:    false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockUtil.EXPECT().TimeGetCurTime().Return(utilhandler.TimeGetCurTime())
+
+			res, err := h.EmailList(ctx, tt.token, tt.size, tt.filters)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if res == nil {
+				t.Errorf("Expected non-nil result")
+			}
+
+			// Just verify the list is returned, don't check the exact count
+			// since other tests might have created data
+		})
+	}
+}
+
+func Test_EmailUpdate_WithMultipleFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		email  *email.Email
+		fields map[email.Field]any
+	}{
+		{
+			name: "updates_multiple_fields",
+			email: &email.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111"),
+					CustomerID: uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222"),
+				},
+				Status:  email.StatusInitiated,
+				Subject: "Original Subject",
+			},
+			fields: map[email.Field]any{
+				email.FieldStatus:  email.StatusDelivered,
+				email.FieldSubject: "Updated Subject",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			// Create the email first
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(ctx, gomock.Any())
+			if err := h.EmailCreate(ctx, tt.email); err != nil {
+				t.Fatalf("Failed to create email: %v", err)
+			}
+
+			// Update the email
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(gomock.Any(), gomock.Any()).Return(nil)
+			if err := h.EmailUpdate(ctx, tt.email.ID, tt.fields); err != nil {
+				t.Errorf("Unexpected error from EmailUpdate: %v", err)
+			}
+
+			// Verify the update
+			mockCache.EXPECT().EmailGet(ctx, tt.email.ID).Return(nil, fmt.Errorf("not in cache"))
+			mockCache.EXPECT().EmailSet(gomock.Any(), gomock.Any()).Return(nil)
+			res, err := h.EmailGet(ctx, tt.email.ID)
+			if err != nil {
+				t.Fatalf("Failed to get email: %v", err)
+			}
+
+			if res.Status != email.StatusDelivered {
+				t.Errorf("Wrong Status. expect: %s, got: %s", email.StatusDelivered, res.Status)
+			}
+			if res.Subject != "Updated Subject" {
+				t.Errorf("Wrong Subject. expect: Updated Subject, got: %s", res.Subject)
+			}
+		})
+	}
+}
+
+func Test_NewHandler(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "creates_new_handler",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := NewHandler(dbTest, mockCache)
+
+			if h == nil {
+				t.Errorf("Expected non-nil handler")
+			}
+		})
+	}
+}
+
+func Test_EmailGetFromCache_Success(t *testing.T) {
+	tests := []struct {
+		name  string
+		email *email.Email
+	}{
+		{
+			name: "gets_email_from_cache",
+			email: &email.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333"),
+					CustomerID: uuid.FromStringOrNil("44444444-4444-4444-4444-444444444444"),
+				},
+				Status: email.StatusDelivered,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			// Return the email from cache
+			mockCache.EXPECT().EmailGet(ctx, tt.email.ID).Return(tt.email, nil)
+
+			res, err := h.EmailGet(ctx, tt.email.ID)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if res.ID != tt.email.ID {
+				t.Errorf("Wrong ID. expect: %s, got: %s", tt.email.ID, res.ID)
+			}
+		})
+	}
+}
+
+func Test_EmailCreate_CacheFails(t *testing.T) {
+	tests := []struct {
+		name  string
+		email *email.Email
+	}{
+		{
+			name: "succeeds_even_when_cache_fails",
+			email: &email.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("55555555-5555-5555-5555-555555555555"),
+					CustomerID: uuid.FromStringOrNil("66666666-6666-6666-6666-666666666666"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(ctx, gomock.Any()).Return(fmt.Errorf("cache error"))
+
+			// Should succeed even if cache fails
+			err := h.EmailCreate(ctx, tt.email)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EmailUpdate_CacheFails(t *testing.T) {
+	tests := []struct {
+		name   string
+		email  *email.Email
+		fields map[email.Field]any
+	}{
+		{
+			name: "succeeds_even_when_cache_update_fails",
+			email: &email.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("77777777-7777-7777-7777-777777777777"),
+					CustomerID: uuid.FromStringOrNil("88888888-8888-8888-8888-888888888888"),
+				},
+				Status: email.StatusInitiated,
+			},
+			fields: map[email.Field]any{
+				email.FieldStatus: email.StatusDelivered,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			// Create the email
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(ctx, gomock.Any())
+			if err := h.EmailCreate(ctx, tt.email); err != nil {
+				t.Fatalf("Failed to create email: %v", err)
+			}
+
+			// Update with cache failing
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(gomock.Any(), gomock.Any()).Return(fmt.Errorf("cache error"))
+
+			err := h.EmailUpdate(ctx, tt.email.ID, tt.fields)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EmailDelete_CacheFails(t *testing.T) {
+	tests := []struct {
+		name  string
+		email *email.Email
+	}{
+		{
+			name: "succeeds_even_when_cache_fails_on_delete",
+			email: &email.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+					CustomerID: uuid.FromStringOrNil("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			// Create the email
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(ctx, gomock.Any())
+			if err := h.EmailCreate(ctx, tt.email); err != nil {
+				t.Fatalf("Failed to create email: %v", err)
+			}
+
+			// Delete with cache failing
+			mockUtil.EXPECT().TimeNow().Return(utilhandler.TimeNow())
+			mockCache.EXPECT().EmailSet(gomock.Any(), gomock.Any()).Return(fmt.Errorf("cache error"))
+
+			err := h.EmailDelete(ctx, tt.email.ID)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EmailList_WithToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		size  uint64
+	}{
+		{
+			name:  "lists_emails_with_custom_token",
+			token: "2025-01-01 00:00:00.000000",
+			size:  5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				util:  mockUtil,
+				db:    dbTest,
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			res, err := h.EmailList(ctx, tt.token, tt.size, map[email.Field]any{})
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if res == nil {
+				t.Errorf("Expected non-nil result")
+			}
+		})
+	}
+}

--- a/bin-email-manager/pkg/emailhandler/main_test.go
+++ b/bin-email-manager/pkg/emailhandler/main_test.go
@@ -1,0 +1,47 @@
+package emailhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-email-manager/pkg/dbhandler"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewEmailHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		sendgridAPIKey string
+		mailgunAPIKey  string
+	}{
+		{
+			name:           "creates_new_email_handler",
+			sendgridAPIKey: "test-sendgrid-key",
+			mailgunAPIKey:  "test-mailgun-key",
+		},
+		{
+			name:           "creates_with_empty_keys",
+			sendgridAPIKey: "",
+			mailgunAPIKey:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			h := NewEmailHandler(mockDB, mockReq, mockNotify, tt.sendgridAPIKey, tt.mailgunAPIKey)
+
+			if h == nil {
+				t.Errorf("Expected non-nil handler")
+			}
+		})
+	}
+}

--- a/bin-email-manager/pkg/emailhandler/util_test.go
+++ b/bin-email-manager/pkg/emailhandler/util_test.go
@@ -1,0 +1,155 @@
+package emailhandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDownload(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse string
+		serverStatus   int
+		expectError    bool
+	}{
+		{
+			name:           "successfully_downloads_file",
+			serverResponse: "test file content",
+			serverStatus:   http.StatusOK,
+			expectError:    false,
+		},
+		{
+			name:           "fails_on_non_200_status",
+			serverResponse: "error",
+			serverStatus:   http.StatusNotFound,
+			expectError:    true,
+		},
+		{
+			name:           "downloads_empty_file",
+			serverResponse: "",
+			serverStatus:   http.StatusOK,
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.serverStatus)
+				_, _ = w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			result, err := download(ctx, server.URL)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if string(result) != tt.serverResponse {
+					t.Errorf("Wrong content. expect: %s, got: %s", tt.serverResponse, string(result))
+				}
+			}
+		})
+	}
+}
+
+func TestDownloadToBase64(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse string
+		serverStatus   int
+		expectError    bool
+	}{
+		{
+			name:           "successfully_converts_to_base64",
+			serverResponse: "test content",
+			serverStatus:   http.StatusOK,
+			expectError:    false,
+		},
+		{
+			name:           "fails_on_download_error",
+			serverResponse: "error",
+			serverStatus:   http.StatusInternalServerError,
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.serverStatus)
+				_, _ = w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			result, err := downloadToBase64(ctx, server.URL)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if len(result) == 0 {
+					t.Errorf("Expected non-empty base64 string")
+				}
+			}
+		})
+	}
+}
+
+func TestDownload_FileSizeLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentSize int
+		expectError bool
+	}{
+		{
+			name:        "handles_large_file",
+			contentSize: 1024 * 1024, // 1 MB
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server with large response
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				content := strings.Repeat("a", tt.contentSize)
+				_, _ = w.Write([]byte(content))
+			}))
+			defer server.Close()
+
+			ctx := context.Background()
+			result, err := download(ctx, server.URL)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for large file")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if len(result) != tt.contentSize {
+					t.Errorf("Wrong content size. expect: %d, got: %d", tt.contentSize, len(result))
+				}
+			}
+		})
+	}
+}

--- a/bin-email-manager/pkg/listenhandler/main_test.go
+++ b/bin-email-manager/pkg/listenhandler/main_test.go
@@ -1,0 +1,70 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/sockhandler"
+	"monorepo/bin-email-manager/pkg/emailhandler"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewListenHandler(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "creates_new_listen_handler",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockEmail := emailhandler.NewMockEmailHandler(mc)
+
+			h := NewListenHandler(mockSock, mockEmail)
+
+			if h == nil {
+				t.Errorf("Expected non-nil handler")
+			}
+		})
+	}
+}
+
+func TestSimpleResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{
+			name:       "creates_response_with_200",
+			statusCode: 200,
+		},
+		{
+			name:       "creates_response_with_404",
+			statusCode: 404,
+		},
+		{
+			name:       "creates_response_with_500",
+			statusCode: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := simpleResponse(tt.statusCode)
+
+			if resp == nil {
+				t.Errorf("Expected non-nil response")
+			}
+
+			if resp.StatusCode != tt.statusCode {
+				t.Errorf("Wrong status code. expect: %d, got: %d", tt.statusCode, resp.StatusCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-email-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-email-manager: Add unit tests for improved package-level coverage