### PR TITLE
NOJIRA-Test-coverage-customer-manager

### DIFF
--- a/bin-customer-manager/models/accesskey/filters_test.go
+++ b/bin-customer-manager/models/accesskey/filters_test.go
@@ -1,0 +1,36 @@
+package accesskey
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestFieldStruct(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+
+	fs := FieldStruct{
+		ID:         id,
+		CustomerID: customerID,
+		Name:       "test-name",
+		Token:      "test-token",
+		Deleted:    false,
+	}
+
+	if fs.ID != id {
+		t.Errorf("FieldStruct.ID = %v, expected %v", fs.ID, id)
+	}
+	if fs.CustomerID != customerID {
+		t.Errorf("FieldStruct.CustomerID = %v, expected %v", fs.CustomerID, customerID)
+	}
+	if fs.Name != "test-name" {
+		t.Errorf("FieldStruct.Name = %v, expected %v", fs.Name, "test-name")
+	}
+	if fs.Token != "test-token" {
+		t.Errorf("FieldStruct.Token = %v, expected %v", fs.Token, "test-token")
+	}
+	if fs.Deleted != false {
+		t.Errorf("FieldStruct.Deleted = %v, expected %v", fs.Deleted, false)
+	}
+}

--- a/bin-customer-manager/models/accesskey/webhook_test.go
+++ b/bin-customer-manager/models/accesskey/webhook_test.go
@@ -61,3 +61,36 @@ func Test_ConvertWebhookMessage(t *testing.T) {
 		})
 	}
 }
+
+func Test_CreateWebhookEvent(t *testing.T) {
+	tmCreate := time.Date(2020, 4, 18, 3, 22, 17, 995000000, time.UTC)
+
+	tests := []struct {
+		name string
+		data Accesskey
+	}{
+		{
+			name: "normal",
+			data: Accesskey{
+				ID:         uuid.FromStringOrNil("4f6c0cb2-a756-11ef-a880-0b6b35a9a9b8"),
+				CustomerID: uuid.FromStringOrNil("5014f0a2-a756-11ef-9589-e3afd497d2dd"),
+				Name:       "test name",
+				Detail:     "test detail",
+				Token:      "test_token",
+				TMCreate:   &tmCreate,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.data.CreateWebhookEvent()
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res == nil {
+				t.Errorf("Wrong match. expect: webhook event, got: nil")
+			}
+		})
+	}
+}

--- a/bin-customer-manager/models/customer/field_test.go
+++ b/bin-customer-manager/models/customer/field_test.go
@@ -19,6 +19,7 @@ func TestFieldConstants(t *testing.T) {
 		{"field_webhook_method", FieldWebhookMethod, "webhook_method"},
 		{"field_webhook_uri", FieldWebhookURI, "webhook_uri"},
 		{"field_billing_account_id", FieldBillingAccountID, "billing_account_id"},
+		{"field_email_verified", FieldEmailVerified, "email_verified"},
 		{"field_tm_create", FieldTMCreate, "tm_create"},
 		{"field_tm_update", FieldTMUpdate, "tm_update"},
 		{"field_tm_delete", FieldTMDelete, "tm_delete"},

--- a/bin-customer-manager/models/customer/filters_test.go
+++ b/bin-customer-manager/models/customer/filters_test.go
@@ -1,0 +1,40 @@
+package customer
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestFieldStruct(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	billingAccountID := uuid.Must(uuid.NewV4())
+
+	fs := FieldStruct{
+		ID:               id,
+		Name:             "test-name",
+		Email:            "test@example.com",
+		PhoneNumber:      "+1234567890",
+		BillingAccountID: billingAccountID,
+		Deleted:          false,
+	}
+
+	if fs.ID != id {
+		t.Errorf("FieldStruct.ID = %v, expected %v", fs.ID, id)
+	}
+	if fs.Name != "test-name" {
+		t.Errorf("FieldStruct.Name = %v, expected %v", fs.Name, "test-name")
+	}
+	if fs.Email != "test@example.com" {
+		t.Errorf("FieldStruct.Email = %v, expected %v", fs.Email, "test@example.com")
+	}
+	if fs.PhoneNumber != "+1234567890" {
+		t.Errorf("FieldStruct.PhoneNumber = %v, expected %v", fs.PhoneNumber, "+1234567890")
+	}
+	if fs.BillingAccountID != billingAccountID {
+		t.Errorf("FieldStruct.BillingAccountID = %v, expected %v", fs.BillingAccountID, billingAccountID)
+	}
+	if fs.Deleted != false {
+		t.Errorf("FieldStruct.Deleted = %v, expected %v", fs.Deleted, false)
+	}
+}

--- a/bin-customer-manager/models/customer/webhook_test.go
+++ b/bin-customer-manager/models/customer/webhook_test.go
@@ -66,3 +66,39 @@ func Test_ConvertWebhookMessage(t *testing.T) {
 		})
 	}
 }
+
+func Test_CreateWebhookEvent(t *testing.T) {
+	tmCreate := time.Date(2020, 4, 18, 3, 22, 17, 995000000, time.UTC)
+
+	tests := []struct {
+		name     string
+		customer Customer
+	}{
+		{
+			name: "normal",
+			customer: Customer{
+				ID:            uuid.FromStringOrNil("81133fc8-4a01-11ee-8dbf-4bbf6dd46254"),
+				Name:          "test name",
+				Detail:        "test detail",
+				Email:         "test@test.com",
+				PhoneNumber:   "+821100000001",
+				Address:       "Copenhagen, Denmark",
+				WebhookMethod: WebhookMethodPost,
+				WebhookURI:    "test.com",
+				TMCreate:      &tmCreate,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.customer.CreateWebhookEvent()
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res == nil {
+				t.Errorf("Wrong match. expect: webhook event, got: nil")
+			}
+		})
+	}
+}

--- a/bin-customer-manager/pkg/accesskeyhandler/main_test.go
+++ b/bin-customer-manager/pkg/accesskeyhandler/main_test.go
@@ -1,0 +1,31 @@
+package accesskeyhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewAccesskeyHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := NewAccesskeyHandler(mockReq, mockDB, mockNotify)
+	if h == nil {
+		t.Error("NewAccesskeyHandler returned nil")
+	}
+}
+
+func TestDefaultLenToken(t *testing.T) {
+	if defaultLenToken != 16 {
+		t.Errorf("defaultLenToken = %d, expected 16", defaultLenToken)
+	}
+}

--- a/bin-customer-manager/pkg/customerhandler/cleanup_test.go
+++ b/bin-customer-manager/pkg/customerhandler/cleanup_test.go
@@ -1,0 +1,15 @@
+package customerhandler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanupConstants(t *testing.T) {
+	if cleanupInterval != 15*time.Minute {
+		t.Errorf("cleanupInterval = %v, expected %v", cleanupInterval, 15*time.Minute)
+	}
+	if unverifiedMaxAge != time.Hour {
+		t.Errorf("unverifiedMaxAge = %v, expected %v", unverifiedMaxAge, time.Hour)
+	}
+}

--- a/bin-customer-manager/pkg/customerhandler/main_test.go
+++ b/bin-customer-manager/pkg/customerhandler/main_test.go
@@ -1,0 +1,27 @@
+package customerhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-customer-manager/pkg/cachehandler"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewCustomerHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := NewCustomerHandler(mockReq, mockDB, mockCache, mockNotify)
+	if h == nil {
+		t.Error("NewCustomerHandler returned nil")
+	}
+}

--- a/bin-customer-manager/pkg/listenhandler/main_test.go
+++ b/bin-customer-manager/pkg/listenhandler/main_test.go
@@ -1,0 +1,80 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+	"monorepo/bin-customer-manager/pkg/accesskeyhandler"
+	"monorepo/bin-customer-manager/pkg/customerhandler"
+
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewListenHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCustomer := customerhandler.NewMockCustomerHandler(mc)
+	mockAccesskey := accesskeyhandler.NewMockAccesskeyHandler(mc)
+
+	h := NewListenHandler(mockSock, mockReq, mockCustomer, mockAccesskey)
+	if h == nil {
+		t.Error("NewListenHandler returned nil")
+	}
+}
+
+func TestSimpleResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"200", 200},
+		{"404", 404},
+		{"500", 500},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := simpleResponse(tt.statusCode)
+			if res.StatusCode != tt.statusCode {
+				t.Errorf("simpleResponse(%d).StatusCode = %d, expected %d", tt.statusCode, res.StatusCode, tt.statusCode)
+			}
+		})
+	}
+}
+
+func Test_processRequest_NotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCustomer := customerhandler.NewMockCustomerHandler(mc)
+	mockAccesskey := accesskeyhandler.NewMockAccesskeyHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:      mockSock,
+		reqHandler:       mockReq,
+		customerHandler:  mockCustomer,
+		accesskeyHandler: mockAccesskey,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/unknown",
+		Method:   sock.RequestMethodGet,
+		DataType: "application/json",
+	}
+
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("processRequest returned error: %v", err)
+	}
+
+	if res.StatusCode != 404 {
+		t.Errorf("processRequest returned status %d, expected 404", res.StatusCode)
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-customer-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-customer-manager: Add unit tests for improved package-level coverage