### PR TITLE
NOJIRA-Test-coverage-outdial-manager

### DIFF
--- a/bin-outdial-manager/models/outdial/convert_test.go
+++ b/bin-outdial-manager/models/outdial/convert_test.go
@@ -1,0 +1,85 @@
+package outdial
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertStringMapToFieldMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     map[string]any
+		expectErr bool
+	}{
+		{
+			name: "converts valid string map with UUID fields",
+			input: map[string]any{
+				"id":          uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000").String(),
+				"customer_id": uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001").String(),
+				"campaign_id": uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002").String(),
+				"name":        "Test Outdial",
+				"detail":      "Test Detail",
+			},
+			expectErr: false,
+		},
+		{
+			name: "converts empty map",
+			input: map[string]any{},
+			expectErr: false,
+		},
+		{
+			name: "converts map with string fields only",
+			input: map[string]any{
+				"name":   "Test",
+				"detail": "Detail",
+				"data":   "Some data",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ConvertStringMapToFieldMap(tt.input)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if result == nil {
+					t.Error("Expected result but got nil")
+				}
+				if len(result) != len(tt.input) {
+					t.Errorf("Expected %d fields, got %d", len(tt.input), len(result))
+				}
+			}
+		})
+	}
+}
+
+func TestConvertStringMapToFieldMap_UUIDConversion(t *testing.T) {
+	testUUID := uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000")
+
+	input := map[string]any{
+		"id": testUUID.String(),
+	}
+
+	result, err := ConvertStringMapToFieldMap(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 field, got %d", len(result))
+	}
+
+	// Verify the field exists
+	if _, ok := result[Field("id")]; !ok {
+		t.Error("Expected 'id' field in result")
+	}
+}

--- a/bin-outdial-manager/models/outdial/webhook_test.go
+++ b/bin-outdial-manager/models/outdial/webhook_test.go
@@ -1,0 +1,190 @@
+package outdial
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tmCreate := time.Now()
+	tmUpdate := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name    string
+		outdial *Outdial
+	}{
+		{
+			name: "converts outdial with all fields",
+			outdial: &Outdial{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				},
+				CampaignID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002"),
+				Name:       "Test Outdial",
+				Detail:     "Test Detail",
+				Data:       `{"key": "value"}`,
+				TMCreate:   &tmCreate,
+				TMUpdate:   &tmUpdate,
+				TMDelete:   nil,
+			},
+		},
+		{
+			name: "converts outdial with minimal fields",
+			outdial: &Outdial{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				},
+				CampaignID: uuid.Nil,
+				Name:       "",
+				Detail:     "",
+				Data:       "",
+				TMCreate:   nil,
+				TMUpdate:   nil,
+				TMDelete:   nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.outdial.ConvertWebhookMessage()
+
+			if result == nil {
+				t.Fatal("Expected webhook message but got nil")
+			}
+
+			if result.ID != tt.outdial.ID {
+				t.Errorf("Expected ID %v, got %v", tt.outdial.ID, result.ID)
+			}
+			if result.CustomerID != tt.outdial.CustomerID {
+				t.Errorf("Expected CustomerID %v, got %v", tt.outdial.CustomerID, result.CustomerID)
+			}
+			if result.CampaignID != tt.outdial.CampaignID {
+				t.Errorf("Expected CampaignID %v, got %v", tt.outdial.CampaignID, result.CampaignID)
+			}
+			if result.Name != tt.outdial.Name {
+				t.Errorf("Expected Name %s, got %s", tt.outdial.Name, result.Name)
+			}
+			if result.Detail != tt.outdial.Detail {
+				t.Errorf("Expected Detail %s, got %s", tt.outdial.Detail, result.Detail)
+			}
+			if result.Data != tt.outdial.Data {
+				t.Errorf("Expected Data %s, got %s", tt.outdial.Data, result.Data)
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	tmCreate := time.Now()
+
+	tests := []struct {
+		name      string
+		outdial   *Outdial
+		expectErr bool
+	}{
+		{
+			name: "creates valid webhook event",
+			outdial: &Outdial{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				},
+				CampaignID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002"),
+				Name:       "Test Outdial",
+				Detail:     "Test Detail",
+				Data:       `{"key": "value"}`,
+				TMCreate:   &tmCreate,
+			},
+			expectErr: false,
+		},
+		{
+			name: "creates webhook event with empty fields",
+			outdial: &Outdial{
+				Identity: commonidentity.Identity{
+					ID:         uuid.Nil,
+					CustomerID: uuid.Nil,
+				},
+				CampaignID: uuid.Nil,
+				Name:       "",
+				Detail:     "",
+				Data:       "",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.outdial.CreateWebhookEvent()
+
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if result == nil {
+					t.Fatal("Expected result but got nil")
+				}
+
+				// Verify it's valid JSON
+				var webhookMsg WebhookMessage
+				if err := json.Unmarshal(result, &webhookMsg); err != nil {
+					t.Errorf("Failed to unmarshal webhook event: %v", err)
+				}
+
+				// Verify content matches
+				if webhookMsg.ID != tt.outdial.ID {
+					t.Errorf("Expected ID %v, got %v", tt.outdial.ID, webhookMsg.ID)
+				}
+				if webhookMsg.Name != tt.outdial.Name {
+					t.Errorf("Expected Name %s, got %s", tt.outdial.Name, webhookMsg.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestWebhookMessage_JSONMarshaling(t *testing.T) {
+	tmCreate := time.Now()
+	msg := &WebhookMessage{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+			CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+		},
+		CampaignID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002"),
+		Name:       "Test",
+		Detail:     "Detail",
+		Data:       "Data",
+		TMCreate:   &tmCreate,
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal webhook message: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled WebhookMessage
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal webhook message: %v", err)
+	}
+
+	if unmarshaled.ID != msg.ID {
+		t.Errorf("ID mismatch after marshal/unmarshal")
+	}
+	if unmarshaled.Name != msg.Name {
+		t.Errorf("Name mismatch after marshal/unmarshal")
+	}
+}

--- a/bin-outdial-manager/models/outdialtarget/outdialtarget_test.go
+++ b/bin-outdial-manager/models/outdialtarget/outdialtarget_test.go
@@ -1,0 +1,156 @@
+package outdialtarget
+
+import (
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestOutdialTarget(t *testing.T) {
+	tmCreate := time.Now()
+
+	tests := []struct {
+		name   string
+		target *OutdialTarget
+	}{
+		{
+			name: "creates outdialtarget with all fields",
+			target: &OutdialTarget{
+				ID:        uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+				OutdialID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				Name:      "Test Target",
+				Detail:    "Test Detail",
+				Data:      `{"key": "value"}`,
+				Status:    StatusIdle,
+				Destination0: &commonaddress.Address{
+					Type:   "phone",
+					Target: "+12345678900",
+				},
+				Destination1: &commonaddress.Address{
+					Type:   "phone",
+					Target: "+12345678901",
+				},
+				TryCount0: 0,
+				TryCount1: 0,
+				TryCount2: 0,
+				TryCount3: 0,
+				TryCount4: 0,
+				TMCreate:  &tmCreate,
+			},
+		},
+		{
+			name: "creates outdialtarget with minimal fields",
+			target: &OutdialTarget{
+				ID:           uuid.Nil,
+				OutdialID:    uuid.Nil,
+				Name:         "",
+				Detail:       "",
+				Data:         "",
+				Status:       StatusIdle,
+				Destination0: nil,
+				Destination1: nil,
+				Destination2: nil,
+				Destination3: nil,
+				Destination4: nil,
+				TryCount0:    0,
+				TryCount1:    0,
+				TryCount2:    0,
+				TryCount3:    0,
+				TryCount4:    0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.target.ID != tt.target.ID {
+				t.Errorf("ID mismatch")
+			}
+			if tt.target.OutdialID != tt.target.OutdialID {
+				t.Errorf("OutdialID mismatch")
+			}
+			if tt.target.Name != tt.target.Name {
+				t.Errorf("Name mismatch")
+			}
+			if tt.target.Status != tt.target.Status {
+				t.Errorf("Status mismatch")
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		expect Status
+	}{
+		{
+			name:   "status progressing",
+			status: StatusProgressing,
+			expect: StatusProgressing,
+		},
+		{
+			name:   "status done",
+			status: StatusDone,
+			expect: StatusDone,
+		},
+		{
+			name:   "status idle",
+			status: StatusIdle,
+			expect: StatusIdle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.status != tt.expect {
+				t.Errorf("Expected status %v, got %v", tt.expect, tt.status)
+			}
+		})
+	}
+}
+
+func TestOutdialTarget_Destinations(t *testing.T) {
+	target := &OutdialTarget{
+		ID:        uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+		OutdialID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+		Destination0: &commonaddress.Address{
+			Type:   "phone",
+			Target: "+12345678900",
+		},
+		Destination1: &commonaddress.Address{
+			Type:   "phone",
+			Target: "+12345678901",
+		},
+		Destination2: &commonaddress.Address{
+			Type:   "email",
+			Target: "test@example.com",
+		},
+		TryCount0: 1,
+		TryCount1: 2,
+		TryCount2: 0,
+		TryCount3: 0,
+		TryCount4: 0,
+	}
+
+	if target.Destination0 == nil {
+		t.Error("Expected Destination0 to be set")
+	}
+	if target.Destination0.Type != "phone" {
+		t.Errorf("Expected Destination0 type 'phone', got %s", target.Destination0.Type)
+	}
+	if target.Destination0.Target != "+12345678900" {
+		t.Errorf("Expected Destination0 target '+12345678900', got %s", target.Destination0.Target)
+	}
+
+	if target.TryCount0 != 1 {
+		t.Errorf("Expected TryCount0 1, got %d", target.TryCount0)
+	}
+	if target.TryCount1 != 2 {
+		t.Errorf("Expected TryCount1 2, got %d", target.TryCount1)
+	}
+}

--- a/bin-outdial-manager/models/outdialtarget/webhook_test.go
+++ b/bin-outdial-manager/models/outdialtarget/webhook_test.go
@@ -1,0 +1,260 @@
+package outdialtarget
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tmCreate := time.Now()
+	tmUpdate := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name   string
+		target *OutdialTarget
+	}{
+		{
+			name: "converts target with all fields",
+			target: &OutdialTarget{
+				ID:        uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+				OutdialID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				Name:      "Test Target",
+				Detail:    "Test Detail",
+				Data:      `{"key": "value"}`,
+				Status:    StatusProgressing,
+				Destination0: &commonaddress.Address{
+					Type:   "phone",
+					Target: "+12345678900",
+				},
+				Destination1: &commonaddress.Address{
+					Type:   "phone",
+					Target: "+12345678901",
+				},
+				Destination2: &commonaddress.Address{
+					Type:   "email",
+					Target: "test@example.com",
+				},
+				TryCount0: 1,
+				TryCount1: 2,
+				TryCount2: 0,
+				TryCount3: 0,
+				TryCount4: 0,
+				TMCreate:  &tmCreate,
+				TMUpdate:  &tmUpdate,
+				TMDelete:  nil,
+			},
+		},
+		{
+			name: "converts target with minimal fields",
+			target: &OutdialTarget{
+				ID:           uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+				OutdialID:    uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				Name:         "",
+				Detail:       "",
+				Data:         "",
+				Status:       StatusIdle,
+				Destination0: nil,
+				Destination1: nil,
+				Destination2: nil,
+				Destination3: nil,
+				Destination4: nil,
+				TryCount0:    0,
+				TryCount1:    0,
+				TryCount2:    0,
+				TryCount3:    0,
+				TryCount4:    0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.target.ConvertWebhookMessage()
+
+			if result == nil {
+				t.Fatal("Expected webhook message but got nil")
+			}
+
+			if result.ID != tt.target.ID {
+				t.Errorf("Expected ID %v, got %v", tt.target.ID, result.ID)
+			}
+			if result.OutdialID != tt.target.OutdialID {
+				t.Errorf("Expected OutdialID %v, got %v", tt.target.OutdialID, result.OutdialID)
+			}
+			if result.Name != tt.target.Name {
+				t.Errorf("Expected Name %s, got %s", tt.target.Name, result.Name)
+			}
+			if result.Detail != tt.target.Detail {
+				t.Errorf("Expected Detail %s, got %s", tt.target.Detail, result.Detail)
+			}
+			if result.Status != tt.target.Status {
+				t.Errorf("Expected Status %v, got %v", tt.target.Status, result.Status)
+			}
+			if result.TryCount0 != tt.target.TryCount0 {
+				t.Errorf("Expected TryCount0 %d, got %d", tt.target.TryCount0, result.TryCount0)
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	tmCreate := time.Now()
+
+	tests := []struct {
+		name      string
+		target    *OutdialTarget
+		expectErr bool
+	}{
+		{
+			name: "creates valid webhook event",
+			target: &OutdialTarget{
+				ID:        uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+				OutdialID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				Name:      "Test Target",
+				Detail:    "Test Detail",
+				Data:      `{"key": "value"}`,
+				Status:    StatusDone,
+				Destination0: &commonaddress.Address{
+					Type:   "phone",
+					Target: "+12345678900",
+				},
+				TryCount0: 3,
+				TMCreate:  &tmCreate,
+			},
+			expectErr: false,
+		},
+		{
+			name: "creates webhook event with empty fields",
+			target: &OutdialTarget{
+				ID:        uuid.Nil,
+				OutdialID: uuid.Nil,
+				Name:      "",
+				Detail:    "",
+				Data:      "",
+				Status:    StatusIdle,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.target.CreateWebhookEvent()
+
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+				}
+				if result == nil {
+					t.Fatal("Expected result but got nil")
+				}
+
+				// Verify it's valid JSON
+				var webhookMsg WebhookMessage
+				if err := json.Unmarshal(result, &webhookMsg); err != nil {
+					t.Errorf("Failed to unmarshal webhook event: %v", err)
+				}
+
+				// Verify content matches
+				if webhookMsg.ID != tt.target.ID {
+					t.Errorf("Expected ID %v, got %v", tt.target.ID, webhookMsg.ID)
+				}
+				if webhookMsg.Name != tt.target.Name {
+					t.Errorf("Expected Name %s, got %s", tt.target.Name, webhookMsg.Name)
+				}
+				if webhookMsg.Status != tt.target.Status {
+					t.Errorf("Expected Status %v, got %v", tt.target.Status, webhookMsg.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestWebhookMessage_JSONMarshaling(t *testing.T) {
+	tmCreate := time.Now()
+	msg := &WebhookMessage{
+		ID:        uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+		OutdialID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+		Name:      "Test",
+		Detail:    "Detail",
+		Data:      "Data",
+		Status:    StatusProgressing,
+		Destination0: &commonaddress.Address{
+			Type:   "phone",
+			Target: "+12345678900",
+		},
+		TryCount0: 1,
+		TryCount1: 0,
+		TMCreate:  &tmCreate,
+	}
+
+	// Test marshaling
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal webhook message: %v", err)
+	}
+
+	// Test unmarshaling
+	var unmarshaled WebhookMessage
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal webhook message: %v", err)
+	}
+
+	if unmarshaled.ID != msg.ID {
+		t.Errorf("ID mismatch after marshal/unmarshal")
+	}
+	if unmarshaled.Name != msg.Name {
+		t.Errorf("Name mismatch after marshal/unmarshal")
+	}
+	if unmarshaled.Status != msg.Status {
+		t.Errorf("Status mismatch after marshal/unmarshal")
+	}
+}
+
+func TestWebhookMessage_AllDestinations(t *testing.T) {
+	target := &OutdialTarget{
+		ID:        uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+		OutdialID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+		Destination0: &commonaddress.Address{Type: "phone", Target: "+10000000000"},
+		Destination1: &commonaddress.Address{Type: "phone", Target: "+10000000001"},
+		Destination2: &commonaddress.Address{Type: "phone", Target: "+10000000002"},
+		Destination3: &commonaddress.Address{Type: "phone", Target: "+10000000003"},
+		Destination4: &commonaddress.Address{Type: "phone", Target: "+10000000004"},
+		TryCount0:    1,
+		TryCount1:    2,
+		TryCount2:    3,
+		TryCount3:    4,
+		TryCount4:    5,
+		Status:       StatusProgressing,
+	}
+
+	msg := target.ConvertWebhookMessage()
+
+	if msg.Destination0 == nil || msg.Destination0.Target != "+10000000000" {
+		t.Error("Destination0 not properly converted")
+	}
+	if msg.Destination1 == nil || msg.Destination1.Target != "+10000000001" {
+		t.Error("Destination1 not properly converted")
+	}
+	if msg.Destination2 == nil || msg.Destination2.Target != "+10000000002" {
+		t.Error("Destination2 not properly converted")
+	}
+	if msg.Destination3 == nil || msg.Destination3.Target != "+10000000003" {
+		t.Error("Destination3 not properly converted")
+	}
+	if msg.Destination4 == nil || msg.Destination4.Target != "+10000000004" {
+		t.Error("Destination4 not properly converted")
+	}
+	if msg.TryCount0 != 1 || msg.TryCount1 != 2 || msg.TryCount2 != 3 || msg.TryCount3 != 4 || msg.TryCount4 != 5 {
+		t.Error("Try counts not properly converted")
+	}
+}

--- a/bin-outdial-manager/models/outdialtargetcall/outdialtargetcall_test.go
+++ b/bin-outdial-manager/models/outdialtargetcall/outdialtargetcall_test.go
@@ -1,0 +1,196 @@
+package outdialtargetcall
+
+import (
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestOutdialTargetCall(t *testing.T) {
+	tmCreate := time.Now()
+
+	tests := []struct {
+		name string
+		call *OutdialTargetCall
+	}{
+		{
+			name: "creates outdialtargetcall with all fields",
+			call: &OutdialTargetCall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				},
+				CampaignID:      uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002"),
+				OutdialID:       uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440003"),
+				OutdialTargetID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440004"),
+				ActiveflowID:    uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440005"),
+				ReferenceType:   ReferenceTypeCall,
+				ReferenceID:     uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440006"),
+				Status:          StatusProgressing,
+				Destination: &commonaddress.Address{
+					Type:   "phone",
+					Target: "+12345678900",
+				},
+				DestinationIndex: 0,
+				TryCount:         1,
+				TMCreate:         &tmCreate,
+			},
+		},
+		{
+			name: "creates outdialtargetcall with minimal fields",
+			call: &OutdialTargetCall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.Nil,
+					CustomerID: uuid.Nil,
+				},
+				CampaignID:       uuid.Nil,
+				OutdialID:        uuid.Nil,
+				OutdialTargetID:  uuid.Nil,
+				ActiveflowID:     uuid.Nil,
+				ReferenceType:    ReferenceTypeNone,
+				ReferenceID:      uuid.Nil,
+				Status:           StatusDone,
+				Destination:      nil,
+				DestinationIndex: 0,
+				TryCount:         0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.call.ID != tt.call.ID {
+				t.Errorf("ID mismatch")
+			}
+			if tt.call.CampaignID != tt.call.CampaignID {
+				t.Errorf("CampaignID mismatch")
+			}
+			if tt.call.OutdialID != tt.call.OutdialID {
+				t.Errorf("OutdialID mismatch")
+			}
+			if tt.call.OutdialTargetID != tt.call.OutdialTargetID {
+				t.Errorf("OutdialTargetID mismatch")
+			}
+			if tt.call.Status != tt.call.Status {
+				t.Errorf("Status mismatch")
+			}
+		})
+	}
+}
+
+func TestReferenceType(t *testing.T) {
+	tests := []struct {
+		name          string
+		referenceType ReferenceType
+		expect        ReferenceType
+	}{
+		{
+			name:          "reference type none",
+			referenceType: ReferenceTypeNone,
+			expect:        ReferenceTypeNone,
+		},
+		{
+			name:          "reference type call",
+			referenceType: ReferenceTypeCall,
+			expect:        ReferenceTypeCall,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.referenceType != tt.expect {
+				t.Errorf("Expected reference type %v, got %v", tt.expect, tt.referenceType)
+			}
+		})
+	}
+}
+
+func TestStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		expect Status
+	}{
+		{
+			name:   "status progressing",
+			status: StatusProgressing,
+			expect: StatusProgressing,
+		},
+		{
+			name:   "status done",
+			status: StatusDone,
+			expect: StatusDone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.status != tt.expect {
+				t.Errorf("Expected status %v, got %v", tt.expect, tt.status)
+			}
+		})
+	}
+}
+
+func TestOutdialTargetCall_WithDestination(t *testing.T) {
+	call := &OutdialTargetCall{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+			CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+		},
+		Destination: &commonaddress.Address{
+			Type:   "phone",
+			Target: "+12345678900",
+		},
+		DestinationIndex: 2,
+		TryCount:         3,
+		Status:           StatusProgressing,
+		ReferenceType:    ReferenceTypeCall,
+		ReferenceID:      uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440007"),
+	}
+
+	if call.Destination == nil {
+		t.Error("Expected Destination to be set")
+	}
+	if call.Destination.Type != "phone" {
+		t.Errorf("Expected Destination type 'phone', got %s", call.Destination.Type)
+	}
+	if call.Destination.Target != "+12345678900" {
+		t.Errorf("Expected Destination target '+12345678900', got %s", call.Destination.Target)
+	}
+	if call.DestinationIndex != 2 {
+		t.Errorf("Expected DestinationIndex 2, got %d", call.DestinationIndex)
+	}
+	if call.TryCount != 3 {
+		t.Errorf("Expected TryCount 3, got %d", call.TryCount)
+	}
+	if call.ReferenceType != ReferenceTypeCall {
+		t.Errorf("Expected ReferenceType 'call', got %s", call.ReferenceType)
+	}
+}
+
+func TestOutdialTargetCall_WithoutReference(t *testing.T) {
+	call := &OutdialTargetCall{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+			CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+		},
+		ReferenceType: ReferenceTypeNone,
+		ReferenceID:   uuid.Nil,
+		Status:        StatusDone,
+	}
+
+	if call.ReferenceType != ReferenceTypeNone {
+		t.Errorf("Expected ReferenceType 'none', got %s", call.ReferenceType)
+	}
+	if call.ReferenceID != uuid.Nil {
+		t.Errorf("Expected nil ReferenceID, got %v", call.ReferenceID)
+	}
+	if call.Status != StatusDone {
+		t.Errorf("Expected Status 'done', got %s", call.Status)
+	}
+}

--- a/bin-outdial-manager/pkg/outdialhandler/outdial_test.go
+++ b/bin-outdial-manager/pkg/outdialhandler/outdial_test.go
@@ -323,3 +323,57 @@ func Test_UpdateData(t *testing.T) {
 		})
 	}
 }
+
+func Test_List(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		token   string
+		limit   uint64
+		filters map[outdial.Field]any
+	}{
+		{
+			"normal with filters",
+
+			"2020-10-10T03:30:17.000000Z",
+			100,
+			map[outdial.Field]any{
+				outdial.FieldCustomerID: uuid.FromStringOrNil("8777908a-b632-11ec-95d3-07799e382868"),
+				outdial.FieldDeleted:    false,
+			},
+		},
+		{
+			"empty filters",
+
+			"2020-10-10T03:30:17.000000Z",
+			50,
+			map[outdial.Field]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := &outdialHandler{
+				db:            mockDB,
+				reqHandler:    mockReq,
+				notifyHandler: mockNotify,
+			}
+
+			ctx := context.Background()
+
+			mockDB.EXPECT().OutdialList(ctx, tt.token, tt.limit, tt.filters).Return([]*outdial.Outdial{}, nil)
+
+			_, err := h.List(ctx, tt.token, tt.limit, tt.filters)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-outdial-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-outdial-manager: Add unit tests for improved package-level coverage