### PR TITLE
NOJIRA-Test-coverage-route-manager

### DIFF
--- a/bin-route-manager/models/provider/webhook_test.go
+++ b/bin-route-manager/models/provider/webhook_test.go
@@ -1,0 +1,153 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *Provider
+		want     *WebhookMessage
+	}{
+		{
+			name: "all fields populated",
+			provider: &Provider{
+				ID:          uuid.FromStringOrNil("12345678-1234-1234-1234-123456789abc"),
+				Type:        TypeSIP,
+				Hostname:    "sip.example.com",
+				TechPrefix:  "+1",
+				TechPostfix: ";user=phone",
+				TechHeaders: map[string]string{
+					"X-Custom": "value",
+				},
+				Name:     "Test Provider",
+				Detail:   "Test provider detail",
+				TMCreate: timePtr(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+				TMUpdate: timePtr(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+				TMDelete: nil,
+			},
+			want: &WebhookMessage{
+				ID:          uuid.FromStringOrNil("12345678-1234-1234-1234-123456789abc"),
+				Type:        TypeSIP,
+				Hostname:    "sip.example.com",
+				TechPrefix:  "+1",
+				TechPostfix: ";user=phone",
+				TechHeaders: map[string]string{
+					"X-Custom": "value",
+				},
+				Name:     "Test Provider",
+				Detail:   "Test provider detail",
+				TMCreate: timePtr(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+				TMUpdate: timePtr(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+				TMDelete: nil,
+			},
+		},
+		{
+			name: "minimal fields",
+			provider: &Provider{
+				ID:       uuid.FromStringOrNil("87654321-4321-4321-4321-cba987654321"),
+				Type:     TypeSIP,
+				Hostname: "sip.minimal.com",
+			},
+			want: &WebhookMessage{
+				ID:       uuid.FromStringOrNil("87654321-4321-4321-4321-cba987654321"),
+				Type:     TypeSIP,
+				Hostname: "sip.minimal.com",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.provider.ConvertWebhookMessage()
+			if got.ID != tt.want.ID {
+				t.Errorf("ID = %v, want %v", got.ID, tt.want.ID)
+			}
+			if got.Type != tt.want.Type {
+				t.Errorf("Type = %v, want %v", got.Type, tt.want.Type)
+			}
+			if got.Hostname != tt.want.Hostname {
+				t.Errorf("Hostname = %v, want %v", got.Hostname, tt.want.Hostname)
+			}
+			if got.TechPrefix != tt.want.TechPrefix {
+				t.Errorf("TechPrefix = %v, want %v", got.TechPrefix, tt.want.TechPrefix)
+			}
+			if got.TechPostfix != tt.want.TechPostfix {
+				t.Errorf("TechPostfix = %v, want %v", got.TechPostfix, tt.want.TechPostfix)
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.Detail != tt.want.Detail {
+				t.Errorf("Detail = %v, want %v", got.Detail, tt.want.Detail)
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *Provider
+		wantErr  bool
+	}{
+		{
+			name: "valid provider",
+			provider: &Provider{
+				ID:          uuid.FromStringOrNil("12345678-1234-1234-1234-123456789abc"),
+				Type:        TypeSIP,
+				Hostname:    "sip.example.com",
+				TechPrefix:  "+1",
+				TechPostfix: ";user=phone",
+				TechHeaders: map[string]string{
+					"X-Custom": "value",
+				},
+				Name:   "Test Provider",
+				Detail: "Test provider detail",
+			},
+			wantErr: false,
+		},
+		{
+			name: "minimal provider",
+			provider: &Provider{
+				ID:       uuid.FromStringOrNil("87654321-4321-4321-4321-cba987654321"),
+				Type:     TypeSIP,
+				Hostname: "sip.minimal.com",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.provider.CreateWebhookEvent()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateWebhookEvent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) == 0 {
+					t.Errorf("CreateWebhookEvent() returned empty byte slice")
+				}
+				// Verify it's valid JSON
+				var result WebhookMessage
+				if err := json.Unmarshal(got, &result); err != nil {
+					t.Errorf("CreateWebhookEvent() returned invalid JSON: %v", err)
+				}
+				// Verify ID matches
+				if result.ID != tt.provider.ID {
+					t.Errorf("CreateWebhookEvent() ID = %v, want %v", result.ID, tt.provider.ID)
+				}
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/bin-route-manager/models/route/webhook_test.go
+++ b/bin-route-manager/models/route/webhook_test.go
@@ -1,0 +1,144 @@
+package route
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *Route
+		want  *WebhookMessage
+	}{
+		{
+			name: "all fields populated",
+			route: &Route{
+				ID:         uuid.FromStringOrNil("12345678-1234-1234-1234-123456789abc"),
+				CustomerID: uuid.FromStringOrNil("87654321-4321-4321-4321-cba987654321"),
+				Name:       "Test Route",
+				Detail:     "Test route detail",
+				ProviderID: uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555"),
+				Priority:   1,
+				Target:     TargetAll,
+				TMCreate:   timePtr(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+				TMUpdate:   timePtr(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+				TMDelete:   nil,
+			},
+			want: &WebhookMessage{
+				ID:         uuid.FromStringOrNil("12345678-1234-1234-1234-123456789abc"),
+				CustomerID: uuid.FromStringOrNil("87654321-4321-4321-4321-cba987654321"),
+				Name:       "Test Route",
+				Detail:     "Test route detail",
+				ProviderID: uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555"),
+				Priority:   1,
+				Target:     TargetAll,
+				TMCreate:   timePtr(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+				TMUpdate:   timePtr(time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)),
+				TMDelete:   nil,
+			},
+		},
+		{
+			name: "minimal fields",
+			route: &Route{
+				ID:         uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+				CustomerID: uuid.FromStringOrNil("ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"),
+				ProviderID: uuid.FromStringOrNil("99999999-8888-7777-6666-555555555555"),
+			},
+			want: &WebhookMessage{
+				ID:         uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+				CustomerID: uuid.FromStringOrNil("ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"),
+				ProviderID: uuid.FromStringOrNil("99999999-8888-7777-6666-555555555555"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.route.ConvertWebhookMessage()
+			if got.ID != tt.want.ID {
+				t.Errorf("ID = %v, want %v", got.ID, tt.want.ID)
+			}
+			if got.CustomerID != tt.want.CustomerID {
+				t.Errorf("CustomerID = %v, want %v", got.CustomerID, tt.want.CustomerID)
+			}
+			if got.ProviderID != tt.want.ProviderID {
+				t.Errorf("ProviderID = %v, want %v", got.ProviderID, tt.want.ProviderID)
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.Detail != tt.want.Detail {
+				t.Errorf("Detail = %v, want %v", got.Detail, tt.want.Detail)
+			}
+			if got.Priority != tt.want.Priority {
+				t.Errorf("Priority = %v, want %v", got.Priority, tt.want.Priority)
+			}
+			if got.Target != tt.want.Target {
+				t.Errorf("Target = %v, want %v", got.Target, tt.want.Target)
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		route   *Route
+		wantErr bool
+	}{
+		{
+			name: "valid route",
+			route: &Route{
+				ID:         uuid.FromStringOrNil("12345678-1234-1234-1234-123456789abc"),
+				CustomerID: uuid.FromStringOrNil("87654321-4321-4321-4321-cba987654321"),
+				Name:       "Test Route",
+				Detail:     "Test route detail",
+				ProviderID: uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555"),
+				Priority:   1,
+				Target:     TargetAll,
+			},
+			wantErr: false,
+		},
+		{
+			name: "minimal route",
+			route: &Route{
+				ID:         uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+				CustomerID: uuid.FromStringOrNil("ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"),
+				ProviderID: uuid.FromStringOrNil("99999999-8888-7777-6666-555555555555"),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.route.CreateWebhookEvent()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateWebhookEvent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) == 0 {
+					t.Errorf("CreateWebhookEvent() returned empty byte slice")
+				}
+				// Verify it's valid JSON
+				var result WebhookMessage
+				if err := json.Unmarshal(got, &result); err != nil {
+					t.Errorf("CreateWebhookEvent() returned invalid JSON: %v", err)
+				}
+				// Verify ID matches
+				if result.ID != tt.route.ID {
+					t.Errorf("CreateWebhookEvent() ID = %v, want %v", result.ID, tt.route.ID)
+				}
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/bin-route-manager/pkg/providerhandler/provider_test.go
+++ b/bin-route-manager/pkg/providerhandler/provider_test.go
@@ -2,10 +2,12 @@ package providerhandler
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -303,5 +305,220 @@ func Test_Update(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.responseProvider, res)
 			}
 		})
+	}
+}
+
+func Test_Get_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("207afa0a-454a-11ed-9538-03743d74de6a")
+
+	mockDB.EXPECT().ProviderGet(ctx, id).Return(nil, fmt.Errorf("database error"))
+
+	res, err := h.Get(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Create_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+
+	mockDB.EXPECT().ProviderCreate(ctx, gomock.Any()).Return(fmt.Errorf("database error"))
+
+	res, err := h.Create(ctx, provider.TypeSIP, "test.com", "", "", nil, "name", "detail")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_List_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	filters := map[provider.Field]any{}
+
+	mockDB.EXPECT().ProviderList(ctx, "", uint64(10), filters).Return(nil, fmt.Errorf("database error"))
+
+	res, err := h.List(ctx, "", 10)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Delete_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("35ff4a68-454d-11ed-bf33-cbf62afa54f0")
+
+	mockDB.EXPECT().ProviderDelete(ctx, id).Return(fmt.Errorf("database error"))
+
+	res, err := h.Delete(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Update_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("eab70c18-4618-11ed-857f-234c1cd0b634")
+
+	mockDB.EXPECT().ProviderUpdate(ctx, id, gomock.Any()).Return(fmt.Errorf("database error"))
+
+	res, err := h.Update(ctx, id, provider.TypeSIP, "test.com", "", "", nil, "name", "detail")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Create_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+
+	mockDB.EXPECT().ProviderCreate(ctx, gomock.Any()).Return(nil)
+	mockDB.EXPECT().ProviderGet(ctx, gomock.Any()).Return(nil, fmt.Errorf("get error"))
+
+	res, err := h.Create(ctx, provider.TypeSIP, "test.com", "", "", nil, "name", "detail")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Delete_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("35ff4a68-454d-11ed-bf33-cbf62afa54f0")
+
+	mockDB.EXPECT().ProviderDelete(ctx, id).Return(nil)
+	mockDB.EXPECT().ProviderGet(ctx, id).Return(nil, fmt.Errorf("get error"))
+
+	res, err := h.Delete(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Update_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &providerHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("eab70c18-4618-11ed-857f-234c1cd0b634")
+
+	mockDB.EXPECT().ProviderUpdate(ctx, id, gomock.Any()).Return(nil)
+	mockDB.EXPECT().ProviderGet(ctx, id).Return(nil, fmt.Errorf("get error"))
+
+	res, err := h.Update(ctx, id, provider.TypeSIP, "test.com", "", "", nil, "name", "detail")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_NewProviderHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := NewProviderHandler(mockDB, mockReq, mockNotify)
+	if h == nil {
+		t.Errorf("Expected handler to be created, got nil")
 	}
 }

--- a/bin-route-manager/pkg/routehandler/route_test.go
+++ b/bin-route-manager/pkg/routehandler/route_test.go
@@ -2,10 +2,12 @@ package routehandler
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -427,5 +429,294 @@ func Test_Update(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.responseRoute, res)
 			}
 		})
+	}
+}
+
+func Test_Get_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("a5ca3dc4-4658-11ed-8ecc-e35285c03d5c")
+
+	mockDB.EXPECT().RouteGet(ctx, id).Return(nil, fmt.Errorf("database error"))
+
+	res, err := h.Get(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Create_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	customerID := uuid.FromStringOrNil("502369f4-4662-11ed-8f0a-aff10c31ed97")
+	providerID := uuid.FromStringOrNil("505e0a96-4662-11ed-90ea-6b19829a782d")
+
+	mockDB.EXPECT().RouteCreate(ctx, gomock.Any()).Return(fmt.Errorf("database error"))
+
+	res, err := h.Create(ctx, customerID, "name", "detail", providerID, 1, "+82")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_ListByCustomerID_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	customerID := uuid.FromStringOrNil("b4ff0a22-4662-11ed-bba2-dfe5060382ff")
+	filters := map[route.Field]any{
+		route.FieldCustomerID: customerID,
+	}
+
+	mockDB.EXPECT().RouteList(ctx, "", uint64(10), filters).Return(nil, fmt.Errorf("database error"))
+
+	res, err := h.ListByCustomerID(ctx, customerID, "", 10)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_ListByTarget_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	customerID := uuid.FromStringOrNil("dea3392a-4662-11ed-a613-efc9ea475e11")
+
+	filtersTarget := map[route.Field]any{
+		route.FieldCustomerID: customerID,
+		route.FieldTarget:     "+82",
+	}
+
+	mockDB.EXPECT().RouteList(ctx, "", uint64(1000), filtersTarget).Return(nil, fmt.Errorf("database error"))
+
+	res, err := h.ListByTarget(ctx, customerID, "+82")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Delete_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("52c2a598-4663-11ed-b6a2-93dcd490c49c")
+
+	mockDB.EXPECT().RouteDelete(ctx, id).Return(fmt.Errorf("database error"))
+
+	res, err := h.Delete(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Update_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("76eec186-4663-11ed-b7b4-57471964d4f5")
+	providerID := uuid.FromStringOrNil("771ba87c-4663-11ed-bc0e-2ba6cb69d485")
+
+	mockDB.EXPECT().RouteUpdate(ctx, id, gomock.Any()).Return(fmt.Errorf("database error"))
+
+	res, err := h.Update(ctx, id, "name", "detail", providerID, 1, "+82")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Create_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	customerID := uuid.FromStringOrNil("502369f4-4662-11ed-8f0a-aff10c31ed97")
+	providerID := uuid.FromStringOrNil("505e0a96-4662-11ed-90ea-6b19829a782d")
+
+	mockDB.EXPECT().RouteCreate(ctx, gomock.Any()).Return(nil)
+	mockDB.EXPECT().RouteGet(ctx, gomock.Any()).Return(nil, fmt.Errorf("get error"))
+
+	res, err := h.Create(ctx, customerID, "name", "detail", providerID, 1, "+82")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Delete_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("52c2a598-4663-11ed-b6a2-93dcd490c49c")
+
+	mockDB.EXPECT().RouteDelete(ctx, id).Return(nil)
+	mockDB.EXPECT().RouteGet(ctx, id).Return(nil, fmt.Errorf("get error"))
+
+	res, err := h.Delete(ctx, id)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_Update_GetError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	id := uuid.FromStringOrNil("76eec186-4663-11ed-b7b4-57471964d4f5")
+	providerID := uuid.FromStringOrNil("771ba87c-4663-11ed-bc0e-2ba6cb69d485")
+
+	mockDB.EXPECT().RouteUpdate(ctx, id, gomock.Any()).Return(nil)
+	mockDB.EXPECT().RouteGet(ctx, id).Return(nil, fmt.Errorf("get error"))
+
+	res, err := h.Update(ctx, id, "name", "detail", providerID, 1, "+82")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if res != nil {
+		t.Errorf("Expected nil result, got %v", res)
+	}
+}
+
+func Test_ListByTarget_AllRoutesError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &routeHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+
+	ctx := context.Background()
+	customerID := uuid.FromStringOrNil("dea3392a-4662-11ed-a613-efc9ea475e11")
+
+	filtersTarget := map[route.Field]any{
+		route.FieldCustomerID: customerID,
+		route.FieldTarget:     "+82",
+	}
+	filtersAll := map[route.Field]any{
+		route.FieldCustomerID: customerID,
+		route.FieldTarget:     route.TargetAll,
+	}
+
+	mockDB.EXPECT().RouteList(ctx, "", uint64(1000), filtersTarget).Return([]*route.Route{}, nil)
+	mockDB.EXPECT().RouteList(ctx, "", uint64(1000), filtersAll).Return(nil, fmt.Errorf("database error"))
+
+	res, err := h.ListByTarget(ctx, customerID, "+82")
+	if err != nil {
+		t.Errorf("Expected no error (error is ignored), got %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("Expected empty result, got %v items", len(res))
+	}
+}
+
+func Test_NewRouteHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := NewRouteHandler(mockDB, mockReq, mockNotify)
+	if h == nil {
+		t.Errorf("Expected handler to be created, got nil")
 	}
 }


### PR DESCRIPTION
Increase test coverage for bin-route-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-route-manager: Add unit tests for improved package-level coverage