### PR TITLE
NOJIRA-Test-coverage-rag-manager

### DIFF
--- a/bin-rag-manager/pkg/chunker/chunker_test.go
+++ b/bin-rag-manager/pkg/chunker/chunker_test.go
@@ -1,0 +1,121 @@
+package chunker
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
+
+func TestDocType_Constants(t *testing.T) {
+	tests := []struct {
+		name     string
+		docType  DocType
+		expected string
+	}{
+		{"devdoc", DocTypeDevDoc, "devdoc"},
+		{"openapi", DocTypeOpenAPI, "openapi"},
+		{"design", DocTypeDesign, "design"},
+		{"guideline", DocTypeGuideline, "guideline"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.docType) != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, string(tt.docType))
+			}
+		})
+	}
+}
+
+func TestChunk_Fields(t *testing.T) {
+	chunk := Chunk{
+		ID:           "test-id",
+		Text:         "test text",
+		SourceFile:   "test.md",
+		DocType:      DocTypeDesign,
+		SectionTitle: "Test Section",
+	}
+
+	if chunk.ID != "test-id" {
+		t.Errorf("expected ID 'test-id', got %q", chunk.ID)
+	}
+	if chunk.Text != "test text" {
+		t.Errorf("expected Text 'test text', got %q", chunk.Text)
+	}
+	if chunk.SourceFile != "test.md" {
+		t.Errorf("expected SourceFile 'test.md', got %q", chunk.SourceFile)
+	}
+	if chunk.DocType != DocTypeDesign {
+		t.Errorf("expected DocType 'design', got %q", chunk.DocType)
+	}
+	if chunk.SectionTitle != "Test Section" {
+		t.Errorf("expected SectionTitle 'Test Section', got %q", chunk.SectionTitle)
+	}
+}
+
+func TestGenerateChunkID(t *testing.T) {
+	tests := []struct {
+		name         string
+		sourceFile   string
+		sectionTitle string
+	}{
+		{
+			name:         "simple",
+			sourceFile:   "test.md",
+			sectionTitle: "Section 1",
+		},
+		{
+			name:         "with special chars",
+			sourceFile:   "path/to/file.md",
+			sectionTitle: "Section: Special!",
+		},
+		{
+			name:         "empty section",
+			sourceFile:   "test.md",
+			sectionTitle: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := generateChunkID(tt.sourceFile, tt.sectionTitle)
+
+			// Check ID is not empty
+			if id == "" {
+				t.Error("expected non-empty ID")
+			}
+
+			// Check ID length (should be 16 chars from hex)
+			if len(id) != 16 {
+				t.Errorf("expected ID length 16, got %d", len(id))
+			}
+
+			// Verify consistency - same input produces same ID
+			id2 := generateChunkID(tt.sourceFile, tt.sectionTitle)
+			if id != id2 {
+				t.Error("expected same ID for same input")
+			}
+
+			// Verify it matches expected hash
+			h := sha256.New()
+			h.Write([]byte(tt.sourceFile + "|" + tt.sectionTitle))
+			expected := fmt.Sprintf("%x", h.Sum(nil))[:16]
+			if id != expected {
+				t.Errorf("expected ID %q, got %q", expected, id)
+			}
+		})
+	}
+}
+
+func TestGenerateChunkID_Different(t *testing.T) {
+	id1 := generateChunkID("file1.md", "Section 1")
+	id2 := generateChunkID("file2.md", "Section 1")
+	id3 := generateChunkID("file1.md", "Section 2")
+
+	if id1 == id2 {
+		t.Error("expected different IDs for different files")
+	}
+	if id1 == id3 {
+		t.Error("expected different IDs for different sections")
+	}
+}

--- a/bin-rag-manager/pkg/chunker/openapi_test.go
+++ b/bin-rag-manager/pkg/chunker/openapi_test.go
@@ -1,0 +1,281 @@
+package chunker
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestOpenAPIChunker_Chunk(t *testing.T) {
+	content := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: List users
+      description: Returns a list of users
+      tags:
+        - users
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of results
+      responses:
+        200:
+          description: Success
+    post:
+      summary: Create user
+      description: Creates a new user
+      requestBody:
+        description: User data
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        201:
+          description: Created
+components:
+  schemas:
+    User:
+      type: object
+      description: User model
+      properties:
+        id:
+          type: string
+          description: User ID
+        name:
+          type: string
+          description: User name
+    Profile:
+      type: object
+      description: Profile model
+      properties:
+        avatar:
+          type: string
+          description: Avatar URL
+`
+
+	tmpFile, err := os.CreateTemp("", "test_*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmpFile.Close()
+
+	c := NewOpenAPIChunker()
+	chunks, err := c.Chunk(tmpFile.Name(), 800)
+	if err != nil {
+		t.Fatalf("chunk error: %v", err)
+	}
+
+	if len(chunks) == 0 {
+		t.Error("expected at least one chunk")
+	}
+
+	// Verify doc type
+	for _, chunk := range chunks {
+		if chunk.DocType != DocTypeOpenAPI {
+			t.Errorf("expected doc type openapi, got %s", chunk.DocType)
+		}
+	}
+
+	// Verify we have both endpoint and schema chunks
+	hasEndpoint := false
+	hasSchema := false
+	for _, chunk := range chunks {
+		if strings.Contains(chunk.SectionTitle, "GET /users") {
+			hasEndpoint = true
+		}
+		if strings.Contains(chunk.SectionTitle, "Schema: User") {
+			hasSchema = true
+		}
+	}
+	if !hasEndpoint {
+		t.Error("expected endpoint chunk for GET /users")
+	}
+	if !hasSchema {
+		t.Error("expected schema chunk for User")
+	}
+}
+
+func TestOpenAPIChunker_InvalidYAML(t *testing.T) {
+	content := `invalid: yaml: content: [[[`
+
+	tmpFile, err := os.CreateTemp("", "test_*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmpFile.Close()
+
+	c := NewOpenAPIChunker()
+	_, err = c.Chunk(tmpFile.Name(), 800)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestOpenAPIChunker_NonExistentFile(t *testing.T) {
+	c := NewOpenAPIChunker()
+	_, err := c.Chunk("/nonexistent/file.yaml", 800)
+	if err == nil {
+		t.Error("expected error for non-existent file")
+	}
+}
+
+func TestFormatEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		method   string
+		details  any
+		expected []string
+	}{
+		{
+			name:   "full endpoint details",
+			path:   "/users",
+			method: "get",
+			details: map[string]any{
+				"summary":     "List users",
+				"description": "Returns a list of users",
+				"tags":        []any{"users", "admin"},
+				"parameters": []any{
+					map[string]any{
+						"name":        "limit",
+						"in":          "query",
+						"description": "Maximum results",
+					},
+				},
+				"requestBody": map[string]any{
+					"description": "User data",
+					"content": map[string]any{
+						"application/json": map[string]any{},
+					},
+				},
+				"responses": map[string]any{
+					"200": map[string]any{
+						"description": "Success",
+					},
+				},
+			},
+			expected: []string{"Endpoint: GET /users", "Summary:", "Description:", "Tags:", "Parameters:", "Request Body:", "Responses:"},
+		},
+		{
+			name:     "minimal endpoint",
+			path:     "/health",
+			method:   "get",
+			details:  map[string]any{},
+			expected: []string{"Endpoint: GET /health"},
+		},
+		{
+			name:     "invalid details type",
+			path:     "/test",
+			method:   "post",
+			details:  "invalid",
+			expected: []string{"Endpoint: POST /test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatEndpoint(tt.path, tt.method, tt.details)
+			for _, expected := range tt.expected {
+				if !strings.Contains(result, expected) {
+					t.Errorf("expected result to contain %q, got: %s", expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		schemaName string
+		schema   any
+		expected []string
+	}{
+		{
+			name:       "full schema",
+			schemaName: "User",
+			schema: map[string]any{
+				"type":        "object",
+				"description": "User model",
+				"properties": map[string]any{
+					"id": map[string]any{
+						"type":        "string",
+						"description": "User ID",
+					},
+					"name": map[string]any{
+						"type":        "string",
+						"description": "User name",
+					},
+				},
+			},
+			expected: []string{"Schema: User", "Description:", "Type:", "Properties:"},
+		},
+		{
+			name:       "minimal schema",
+			schemaName: "Empty",
+			schema:     map[string]any{},
+			expected:   []string{"Schema: Empty"},
+		},
+		{
+			name:       "invalid schema type",
+			schemaName: "Invalid",
+			schema:     "invalid",
+			expected:   []string{"Schema: Invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatSchema(tt.schemaName, tt.schema)
+			for _, expected := range tt.expected {
+				if !strings.Contains(result, expected) {
+					t.Errorf("expected result to contain %q, got: %s", expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenAPIChunker_EmptyPaths(t *testing.T) {
+	content := `openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+`
+
+	tmpFile, err := os.CreateTemp("", "test_*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	_ = tmpFile.Close()
+
+	c := NewOpenAPIChunker()
+	chunks, err := c.Chunk(tmpFile.Name(), 800)
+	if err != nil {
+		t.Fatalf("chunk error: %v", err)
+	}
+
+	if len(chunks) != 0 {
+		t.Errorf("expected 0 chunks for empty spec, got %d", len(chunks))
+	}
+}

--- a/bin-rag-manager/pkg/embedder/embedder_test.go
+++ b/bin-rag-manager/pkg/embedder/embedder_test.go
@@ -1,0 +1,130 @@
+package embedder
+
+import (
+	"context"
+	"testing"
+)
+
+// mockEmbedder is a mock implementation for testing
+type mockEmbedder struct {
+	embedTextsFunc func(ctx context.Context, texts []string) ([][]float32, error)
+	embedTextFunc  func(ctx context.Context, text string) ([]float32, error)
+}
+
+func (m *mockEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]float32, error) {
+	if m.embedTextsFunc != nil {
+		return m.embedTextsFunc(ctx, texts)
+	}
+	// Default implementation
+	result := make([][]float32, len(texts))
+	for i := range texts {
+		result[i] = []float32{0.1, 0.2, 0.3}
+	}
+	return result, nil
+}
+
+func (m *mockEmbedder) EmbedText(ctx context.Context, text string) ([]float32, error) {
+	if m.embedTextFunc != nil {
+		return m.embedTextFunc(ctx, text)
+	}
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+
+func TestEmbedder_Interface(t *testing.T) {
+	var _ Embedder = &mockEmbedder{}
+	var _ Embedder = &openaiEmbedder{}
+}
+
+func TestNewOpenAIEmbedder(t *testing.T) {
+	embedder := NewOpenAIEmbedder("test-api-key", "text-embedding-ada-002")
+	if embedder == nil {
+		t.Error("expected non-nil embedder")
+	}
+}
+
+func TestOpenAIEmbedder_EmbedTexts_EmptyInput(t *testing.T) {
+	// Create a custom embedder for testing
+	e := &openaiEmbedder{}
+
+	ctx := context.Background()
+	result, err := e.EmbedTexts(ctx, []string{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil result for empty input")
+	}
+}
+
+func TestMockEmbedder_EmbedTexts(t *testing.T) {
+	tests := []struct {
+		name    string
+		texts   []string
+		wantLen int
+	}{
+		{
+			name:    "single text",
+			texts:   []string{"test text"},
+			wantLen: 1,
+		},
+		{
+			name:    "multiple texts",
+			texts:   []string{"text 1", "text 2", "text 3"},
+			wantLen: 3,
+		},
+		{
+			name:    "empty texts",
+			texts:   []string{},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mockEmbedder{}
+			ctx := context.Background()
+
+			results, err := m.EmbedTexts(ctx, tt.texts)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(results) != tt.wantLen {
+				t.Errorf("expected %d results, got %d", tt.wantLen, len(results))
+			}
+		})
+	}
+}
+
+func TestMockEmbedder_EmbedText(t *testing.T) {
+	m := &mockEmbedder{}
+	ctx := context.Background()
+
+	result, err := m.EmbedText(ctx, "test text")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected non-empty embedding")
+	}
+}
+
+func TestMockEmbedder_CustomFunctions(t *testing.T) {
+	customResult := [][]float32{{1.0, 2.0}, {3.0, 4.0}}
+	m := &mockEmbedder{
+		embedTextsFunc: func(ctx context.Context, texts []string) ([][]float32, error) {
+			return customResult, nil
+		},
+	}
+
+	ctx := context.Background()
+	result, err := m.EmbedTexts(ctx, []string{"test1", "test2"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 results, got %d", len(result))
+	}
+	if result[0][0] != 1.0 || result[1][0] != 3.0 {
+		t.Error("custom function not called correctly")
+	}
+}

--- a/bin-rag-manager/pkg/generator/generator_test.go
+++ b/bin-rag-manager/pkg/generator/generator_test.go
@@ -1,0 +1,234 @@
+package generator
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"monorepo/bin-rag-manager/pkg/chunker"
+	"monorepo/bin-rag-manager/pkg/store"
+)
+
+// mockGenerator is a mock implementation for testing
+type mockGenerator struct {
+	generateFunc func(ctx context.Context, query string, chunks []store.SearchResult) (string, error)
+}
+
+func (m *mockGenerator) Generate(ctx context.Context, query string, chunks []store.SearchResult) (string, error) {
+	if m.generateFunc != nil {
+		return m.generateFunc(ctx, query, chunks)
+	}
+	return "mock answer", nil
+}
+
+func TestGenerator_Interface(t *testing.T) {
+	var _ Generator = &mockGenerator{}
+	var _ Generator = &generator{}
+}
+
+func TestNewGenerator(t *testing.T) {
+	gen := NewGenerator("test-api-key", "gpt-4")
+	if gen == nil {
+		t.Error("expected non-nil generator")
+	}
+}
+
+func TestBuildUserMessage(t *testing.T) {
+	chunks := []store.SearchResult{
+		{
+			Chunk: chunker.Chunk{
+				ID:           "1",
+				Text:         "How to create a call using POST /calls endpoint",
+				SourceFile:   "openapi.yaml",
+				DocType:      chunker.DocTypeOpenAPI,
+				SectionTitle: "POST /calls",
+			},
+			RelevanceScore: 0.95,
+		},
+		{
+			Chunk: chunker.Chunk{
+				ID:           "2",
+				Text:         "Call creation requires authentication token",
+				SourceFile:   "auth.md",
+				DocType:      chunker.DocTypeDesign,
+				SectionTitle: "Authentication",
+			},
+			RelevanceScore: 0.87,
+		},
+	}
+
+	query := "How do I create a call?"
+	result := buildUserMessage(query, chunks)
+
+	// Verify the message contains context
+	if !strings.Contains(result, "Context:") {
+		t.Error("expected message to contain 'Context:'")
+	}
+
+	// Verify the message contains the question
+	if !strings.Contains(result, "Question:") {
+		t.Error("expected message to contain 'Question:'")
+	}
+	if !strings.Contains(result, query) {
+		t.Error("expected message to contain the query")
+	}
+
+	// Verify source information is included
+	if !strings.Contains(result, "openapi.yaml") {
+		t.Error("expected message to contain source file")
+	}
+	if !strings.Contains(result, "POST /calls") {
+		t.Error("expected message to contain section title")
+	}
+
+	// Verify chunk text is included
+	if !strings.Contains(result, "How to create a call") {
+		t.Error("expected message to contain chunk text")
+	}
+}
+
+func TestBuildUserMessage_EmptyChunks(t *testing.T) {
+	query := "test query"
+	result := buildUserMessage(query, []store.SearchResult{})
+
+	if !strings.Contains(result, "Context:") {
+		t.Error("expected message to contain 'Context:'")
+	}
+	if !strings.Contains(result, query) {
+		t.Error("expected message to contain the query")
+	}
+}
+
+func TestBuildUserMessage_SingleChunk(t *testing.T) {
+	chunks := []store.SearchResult{
+		{
+			Chunk: chunker.Chunk{
+				ID:           "1",
+				Text:         "Test content",
+				SourceFile:   "test.md",
+				DocType:      chunker.DocTypeDesign,
+				SectionTitle: "Test Section",
+			},
+			RelevanceScore: 0.99,
+		},
+	}
+
+	query := "test query"
+	result := buildUserMessage(query, chunks)
+
+	if !strings.Contains(result, "[1]") {
+		t.Error("expected message to contain chunk numbering")
+	}
+	if !strings.Contains(result, "Test content") {
+		t.Error("expected message to contain chunk content")
+	}
+}
+
+func TestMockGenerator_Generate(t *testing.T) {
+	m := &mockGenerator{}
+	ctx := context.Background()
+
+	result, err := m.Generate(ctx, "test query", []store.SearchResult{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result != "mock answer" {
+		t.Errorf("expected 'mock answer', got %q", result)
+	}
+}
+
+func TestMockGenerator_CustomFunction(t *testing.T) {
+	expectedAnswer := "custom answer"
+	m := &mockGenerator{
+		generateFunc: func(ctx context.Context, query string, chunks []store.SearchResult) (string, error) {
+			return expectedAnswer, nil
+		},
+	}
+
+	ctx := context.Background()
+	result, err := m.Generate(ctx, "test", []store.SearchResult{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result != expectedAnswer {
+		t.Errorf("expected %q, got %q", expectedAnswer, result)
+	}
+}
+
+func TestSystemPrompt(t *testing.T) {
+	if systemPrompt == "" {
+		t.Error("system prompt should not be empty")
+	}
+
+	// Verify key elements are in the system prompt
+	expectedElements := []string{
+		"VoIPBin",
+		"context",
+		"information",
+	}
+
+	for _, elem := range expectedElements {
+		if !strings.Contains(systemPrompt, elem) {
+			t.Errorf("expected system prompt to contain %q", elem)
+		}
+	}
+}
+
+func TestBuildUserMessage_MultipleChunksFormatting(t *testing.T) {
+	chunks := []store.SearchResult{
+		{
+			Chunk: chunker.Chunk{
+				ID:           "1",
+				Text:         "First chunk",
+				SourceFile:   "file1.md",
+				DocType:      chunker.DocTypeDevDoc,
+				SectionTitle: "Section 1",
+			},
+			RelevanceScore: 0.95,
+		},
+		{
+			Chunk: chunker.Chunk{
+				ID:           "2",
+				Text:         "Second chunk",
+				SourceFile:   "file2.md",
+				DocType:      chunker.DocTypeOpenAPI,
+				SectionTitle: "Section 2",
+			},
+			RelevanceScore: 0.85,
+		},
+		{
+			Chunk: chunker.Chunk{
+				ID:           "3",
+				Text:         "Third chunk",
+				SourceFile:   "file3.md",
+				DocType:      chunker.DocTypeGuideline,
+				SectionTitle: "Section 3",
+			},
+			RelevanceScore: 0.75,
+		},
+	}
+
+	result := buildUserMessage("test", chunks)
+
+	// Verify all chunks are numbered
+	if !strings.Contains(result, "[1]") {
+		t.Error("expected [1] in result")
+	}
+	if !strings.Contains(result, "[2]") {
+		t.Error("expected [2] in result")
+	}
+	if !strings.Contains(result, "[3]") {
+		t.Error("expected [3] in result")
+	}
+
+	// Verify all chunk texts are included
+	if !strings.Contains(result, "First chunk") {
+		t.Error("expected first chunk text")
+	}
+	if !strings.Contains(result, "Second chunk") {
+		t.Error("expected second chunk text")
+	}
+	if !strings.Contains(result, "Third chunk") {
+		t.Error("expected third chunk text")
+	}
+}

--- a/bin-rag-manager/pkg/listenhandler/main_test.go
+++ b/bin-rag-manager/pkg/listenhandler/main_test.go
@@ -1,0 +1,762 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-rag-manager/pkg/chunker"
+	"monorepo/bin-rag-manager/pkg/raghandler"
+)
+
+// mockSockHandler for testing
+type mockSockHandler struct {
+	queueCreateFunc func(name string, queueType string) error
+	consumeRPCFunc  func(ctx context.Context, queueName, consumerName string, skipVerify, enableDelay, enableDelayHourly bool, delayExpiredMin int, handler sock.CbMsgRPC) error
+}
+
+func (m *mockSockHandler) QueueCreate(name string, queueType string) error {
+	if m.queueCreateFunc != nil {
+		return m.queueCreateFunc(name, queueType)
+	}
+	return nil
+}
+
+func (m *mockSockHandler) ConsumeRPC(ctx context.Context, queueName, consumerName string, skipVerify, enableDelay, enableDelayHourly bool, delayExpiredMin int, handler sock.CbMsgRPC) error {
+	if m.consumeRPCFunc != nil {
+		return m.consumeRPCFunc(ctx, queueName, consumerName, skipVerify, enableDelay, enableDelayHourly, delayExpiredMin, handler)
+	}
+	return nil
+}
+
+func (m *mockSockHandler) Close() {}
+
+func (m *mockSockHandler) Connect() {}
+
+func (m *mockSockHandler) ConsumeMessage(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, numWorkers int, messageConsume sock.CbMsgConsume) error {
+	return nil
+}
+
+func (m *mockSockHandler) TopicCreate(name string) error {
+	return nil
+}
+
+func (m *mockSockHandler) EventPublish(topic string, key string, evt *sock.Event) error {
+	return nil
+}
+
+func (m *mockSockHandler) EventPublishWithDelay(topic string, key string, evt *sock.Event, delay int) error {
+	return nil
+}
+
+func (m *mockSockHandler) RequestPublish(ctx context.Context, queueName string, req *sock.Request) (*sock.Response, error) {
+	return nil, nil
+}
+
+func (m *mockSockHandler) RequestPublishWithDelay(queueName string, req *sock.Request, delay int) error {
+	return nil
+}
+
+func (m *mockSockHandler) QueueSubscribe(name string, topic string) error {
+	return nil
+}
+
+// mockRagHandler for testing
+type mockRagHandlerForListen struct {
+	queryFunc         func(ctx context.Context, req *raghandler.QueryRequest) (*raghandler.QueryResponse, error)
+	indexFullFunc     func(ctx context.Context) error
+	indexIncrFunc     func(ctx context.Context, files []string) error
+	indexStatusFunc   func(ctx context.Context) (*raghandler.IndexStatusResponse, error)
+}
+
+func (m *mockRagHandlerForListen) Query(ctx context.Context, req *raghandler.QueryRequest) (*raghandler.QueryResponse, error) {
+	if m.queryFunc != nil {
+		return m.queryFunc(ctx, req)
+	}
+	return &raghandler.QueryResponse{
+		Answer: "test answer",
+		Sources: []raghandler.Source{
+			{
+				SourceFile:     "test.md",
+				SectionTitle:   "Test",
+				DocType:        chunker.DocTypeDesign,
+				RelevanceScore: 0.95,
+			},
+		},
+	}, nil
+}
+
+func (m *mockRagHandlerForListen) IndexFull(ctx context.Context) error {
+	if m.indexFullFunc != nil {
+		return m.indexFullFunc(ctx)
+	}
+	return nil
+}
+
+func (m *mockRagHandlerForListen) IndexIncremental(ctx context.Context, files []string) error {
+	if m.indexIncrFunc != nil {
+		return m.indexIncrFunc(ctx, files)
+	}
+	return nil
+}
+
+func (m *mockRagHandlerForListen) IndexStatus(ctx context.Context) (*raghandler.IndexStatusResponse, error) {
+	if m.indexStatusFunc != nil {
+		return m.indexStatusFunc(ctx)
+	}
+	return &raghandler.IndexStatusResponse{
+		LastRun:    time.Now(),
+		ChunkCount: 100,
+		Errors:     []string{},
+	}, nil
+}
+
+func TestListenHandler_Interface(t *testing.T) {
+	var _ ListenHandler = &listenHandler{}
+}
+
+func TestNewListenHandler(t *testing.T) {
+	sockHandler := &mockSockHandler{}
+	ragHandler := &mockRagHandlerForListen{}
+
+	h := NewListenHandler(sockHandler, ragHandler)
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}
+
+func TestListenHandler_Run(t *testing.T) {
+	queueCreated := false
+	consumeCalled := false
+
+	sockHandler := &mockSockHandler{
+		queueCreateFunc: func(name string, queueType string) error {
+			queueCreated = true
+			if queueType != "normal" {
+				t.Errorf("expected queueType 'normal', got %q", queueType)
+			}
+			return nil
+		},
+		consumeRPCFunc: func(ctx context.Context, queueName, consumerName string, skipVerify, enableDelay, enableDelayHourly bool, delayExpiredMin int, handler sock.CbMsgRPC) error {
+			consumeCalled = true
+			return nil
+		},
+	}
+	ragHandler := &mockRagHandlerForListen{}
+
+	h := NewListenHandler(sockHandler, ragHandler)
+	err := h.Run("test-queue", "test-exchange")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if !queueCreated {
+		t.Error("expected queue to be created")
+	}
+
+	// Give goroutine time to start
+	time.Sleep(50 * time.Millisecond)
+
+	if !consumeCalled {
+		t.Error("expected ConsumeRPC to be called")
+	}
+}
+
+func TestListenHandler_Run_QueueCreateError(t *testing.T) {
+	expectedErr := errors.New("queue create failed")
+	sockHandler := &mockSockHandler{
+		queueCreateFunc: func(name string, queueType string) error {
+			return expectedErr
+		},
+	}
+	ragHandler := &mockRagHandlerForListen{}
+
+	h := NewListenHandler(sockHandler, ragHandler)
+	err := h.Run("test-queue", "test-exchange")
+	if err == nil {
+		t.Error("expected error from queue creation")
+	}
+}
+
+func TestSimpleResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"success", 200},
+		{"created", 201},
+		{"bad request", 400},
+		{"not found", 404},
+		{"server error", 500},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := simpleResponse(tt.statusCode)
+			if resp.StatusCode != tt.statusCode {
+				t.Errorf("expected status code %d, got %d", tt.statusCode, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestJsonResponse(t *testing.T) {
+	data := map[string]string{"key": "value"}
+	resp := jsonResponse(200, data)
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code 200, got %d", resp.StatusCode)
+	}
+	if resp.DataType != "application/json" {
+		t.Errorf("expected DataType 'application/json', got %q", resp.DataType)
+	}
+
+	var decoded map[string]string
+	if err := json.Unmarshal(resp.Data, &decoded); err != nil {
+		t.Errorf("failed to unmarshal response data: %v", err)
+	}
+	if decoded["key"] != "value" {
+		t.Error("response data not marshalled correctly")
+	}
+}
+
+func TestJsonResponse_MarshalError(t *testing.T) {
+	// Create data that cannot be marshalled (channels, functions, etc.)
+	data := make(chan int)
+	resp := jsonResponse(200, data)
+
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status code 500 for marshal error, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_QueryPost(t *testing.T) {
+	ragHandler := &mockRagHandlerForListen{
+		queryFunc: func(ctx context.Context, req *raghandler.QueryRequest) (*raghandler.QueryResponse, error) {
+			if req.Query != "test query" {
+				t.Errorf("expected query 'test query', got %q", req.Query)
+			}
+			return &raghandler.QueryResponse{
+				Answer:  "test answer",
+				Sources: []raghandler.Source{},
+			}, nil
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	reqData := raghandler.QueryRequest{
+		Query: "test query",
+		TopK:  5,
+	}
+	data, _ := json.Marshal(reqData)
+
+	req := &sock.Request{
+		URI:    "/v1/rags/query",
+		Method: sock.RequestMethodPost,
+		Data:   data,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_QueryPost_EmptyQuery(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	reqData := raghandler.QueryRequest{
+		Query: "",
+	}
+	data, _ := json.Marshal(reqData)
+
+	req := &sock.Request{
+		URI:    "/v1/rags/query",
+		Method: sock.RequestMethodPost,
+		Data:   data,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected status code 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_QueryPost_InvalidJSON(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/rags/query",
+		Method: sock.RequestMethodPost,
+		Data:   []byte("invalid json"),
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected status code 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_IndexPost(t *testing.T) {
+	indexCalled := false
+	ragHandler := &mockRagHandlerForListen{
+		indexFullFunc: func(ctx context.Context) error {
+			indexCalled = true
+			return nil
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/rags/index",
+		Method: sock.RequestMethodPost,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 202 {
+		t.Errorf("expected status code 202, got %d", resp.StatusCode)
+	}
+
+	// Give goroutine time to run
+	time.Sleep(50 * time.Millisecond)
+
+	if !indexCalled {
+		t.Error("expected IndexFull to be called")
+	}
+}
+
+func TestProcessRequest_IndexIncrementalPost(t *testing.T) {
+	filesReceived := []string{}
+	ragHandler := &mockRagHandlerForListen{
+		indexIncrFunc: func(ctx context.Context, files []string) error {
+			filesReceived = files
+			return nil
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	reqData := indexIncrementalRequest{
+		Files: []string{"file1.md", "file2.md"},
+	}
+	data, _ := json.Marshal(reqData)
+
+	req := &sock.Request{
+		URI:    "/v1/rags/index/incremental",
+		Method: sock.RequestMethodPost,
+		Data:   data,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 202 {
+		t.Errorf("expected status code 202, got %d", resp.StatusCode)
+	}
+
+	// Give goroutine time to run
+	time.Sleep(50 * time.Millisecond)
+
+	if len(filesReceived) != 2 {
+		t.Errorf("expected 2 files, got %d", len(filesReceived))
+	}
+}
+
+func TestProcessRequest_IndexIncrementalPost_NoFiles(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	reqData := indexIncrementalRequest{
+		Files: []string{},
+	}
+	data, _ := json.Marshal(reqData)
+
+	req := &sock.Request{
+		URI:    "/v1/rags/index/incremental",
+		Method: sock.RequestMethodPost,
+		Data:   data,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected status code 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_IndexStatusGet(t *testing.T) {
+	ragHandler := &mockRagHandlerForListen{
+		indexStatusFunc: func(ctx context.Context) (*raghandler.IndexStatusResponse, error) {
+			return &raghandler.IndexStatusResponse{
+				LastRun:    time.Now(),
+				ChunkCount: 150,
+				Errors:     []string{},
+			}, nil
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/rags/index/status",
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code 200, got %d", resp.StatusCode)
+	}
+
+	var status raghandler.IndexStatusResponse
+	if err := json.Unmarshal(resp.Data, &status); err != nil {
+		t.Errorf("failed to unmarshal response: %v", err)
+	}
+	if status.ChunkCount != 150 {
+		t.Errorf("expected chunk count 150, got %d", status.ChunkCount)
+	}
+}
+
+func TestProcessRequest_NotFound(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/unknown/endpoint",
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("expected status code 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_QueryError(t *testing.T) {
+	ragHandler := &mockRagHandlerForListen{
+		queryFunc: func(ctx context.Context, req *raghandler.QueryRequest) (*raghandler.QueryResponse, error) {
+			return nil, errors.New("query failed")
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	reqData := raghandler.QueryRequest{
+		Query: "test",
+	}
+	data, _ := json.Marshal(reqData)
+
+	req := &sock.Request{
+		URI:    "/v1/rags/query",
+		Method: sock.RequestMethodPost,
+		Data:   data,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status code 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_IndexStatusError(t *testing.T) {
+	ragHandler := &mockRagHandlerForListen{
+		indexStatusFunc: func(ctx context.Context) (*raghandler.IndexStatusResponse, error) {
+			return nil, errors.New("status failed")
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/rags/index/status",
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status code 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestRegexpPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern *regexp.Regexp
+		uri     string
+		matches bool
+	}{
+		{"query endpoint", regV1RagQuery, "/v1/rags/query", true},
+		{"index endpoint", regV1RagIndex, "/v1/rags/index", true},
+		{"index incremental", regV1RagIndexIncr, "/v1/rags/index/incremental", true},
+		{"index status", regV1RagIndexStatus, "/v1/rags/index/status", true},
+		{"query no match", regV1RagQuery, "/v1/rags/query/other", false},
+		{"index no match", regV1RagIndex, "/v1/rags/index/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.pattern.MatchString(tt.uri)
+			if result != tt.matches {
+				t.Errorf("expected match=%v for pattern and URI %q, got %v", tt.matches, tt.uri, result)
+			}
+		})
+	}
+}
+
+func TestProcessRequest_IndexIncrementalPost_InvalidJSON(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/rags/index/incremental",
+		Method: sock.RequestMethodPost,
+		Data:   []byte("invalid json"),
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected status code 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_WrongMethod(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	tests := []struct {
+		name   string
+		uri    string
+		method sock.RequestMethod
+	}{
+		{"query with GET", "/v1/rags/query", sock.RequestMethodGet},
+		{"index with GET", "/v1/rags/index", sock.RequestMethodGet},
+		{"incremental with GET", "/v1/rags/index/incremental", sock.RequestMethodGet},
+		{"status with POST", "/v1/rags/index/status", sock.RequestMethodPost},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &sock.Request{
+				URI:    tt.uri,
+				Method: tt.method,
+			}
+
+			resp, err := h.processRequest(req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != 404 {
+				t.Errorf("expected status code 404, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestProcessRequest_QueryWithDocTypes(t *testing.T) {
+	docTypesReceived := []chunker.DocType{}
+	ragHandler := &mockRagHandlerForListen{
+		queryFunc: func(ctx context.Context, req *raghandler.QueryRequest) (*raghandler.QueryResponse, error) {
+			docTypesReceived = req.DocTypes
+			return &raghandler.QueryResponse{
+				Answer:  "test answer",
+				Sources: []raghandler.Source{},
+			}, nil
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	reqData := raghandler.QueryRequest{
+		Query:    "test query",
+		TopK:     10,
+		DocTypes: []chunker.DocType{chunker.DocTypeOpenAPI, chunker.DocTypeDesign},
+	}
+	data, _ := json.Marshal(reqData)
+
+	req := &sock.Request{
+		URI:    "/v1/rags/query",
+		Method: sock.RequestMethodPost,
+		Data:   data,
+	}
+
+	resp, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code 200, got %d", resp.StatusCode)
+	}
+	if len(docTypesReceived) != 2 {
+		t.Errorf("expected 2 doc types, got %d", len(docTypesReceived))
+	}
+}
+
+func TestListenHandler_Run_ConsumeRPCError(t *testing.T) {
+	errorReturned := false
+	sockHandler := &mockSockHandler{
+		queueCreateFunc: func(name string, queueType string) error {
+			return nil
+		},
+		consumeRPCFunc: func(ctx context.Context, queueName, consumerName string, skipVerify, enableDelay, enableDelayHourly bool, delayExpiredMin int, handler sock.CbMsgRPC) error {
+			errorReturned = true
+			return errors.New("consume error")
+		},
+	}
+	ragHandler := &mockRagHandlerForListen{}
+
+	h := NewListenHandler(sockHandler, ragHandler)
+	err := h.Run("test-queue", "test-exchange")
+	if err != nil {
+		t.Errorf("Run should not return error, got: %v", err)
+	}
+
+	// Give goroutine time to execute
+	time.Sleep(100 * time.Millisecond)
+
+	if !errorReturned {
+		t.Error("expected ConsumeRPC to be called and return error")
+	}
+}
+
+func TestProcessRequest_AllMethods(t *testing.T) {
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  &mockRagHandlerForListen{},
+	}
+
+	tests := []struct {
+		name           string
+		method         sock.RequestMethod
+		uri            string
+		expectedStatus int
+	}{
+		{"PUT not found", sock.RequestMethodPut, "/v1/rags/query", 404},
+		{"DELETE not found", sock.RequestMethodDelete, "/v1/rags/query", 404},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &sock.Request{
+				URI:    tt.uri,
+				Method: tt.method,
+			}
+
+			resp, err := h.processRequest(req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestProcessRequest_MultipleRequests(t *testing.T) {
+	callCount := 0
+	ragHandler := &mockRagHandlerForListen{
+		queryFunc: func(ctx context.Context, req *raghandler.QueryRequest) (*raghandler.QueryResponse, error) {
+			callCount++
+			return &raghandler.QueryResponse{Answer: "answer", Sources: []raghandler.Source{}}, nil
+		},
+	}
+
+	h := &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  ragHandler,
+	}
+
+	reqData := raghandler.QueryRequest{Query: "test"}
+	data, _ := json.Marshal(reqData)
+
+	// Make multiple requests
+	for i := 0; i < 3; i++ {
+		req := &sock.Request{
+			URI:    "/v1/rags/query",
+			Method: sock.RequestMethodPost,
+			Data:   data,
+		}
+
+		resp, err := h.processRequest(req)
+		if err != nil {
+			t.Errorf("unexpected error on request %d: %v", i, err)
+		}
+		if resp.StatusCode != 200 {
+			t.Errorf("request %d: expected status 200, got %d", i, resp.StatusCode)
+		}
+	}
+
+	if callCount != 3 {
+		t.Errorf("expected 3 query calls, got %d", callCount)
+	}
+}

--- a/bin-rag-manager/pkg/raghandler/main_test.go
+++ b/bin-rag-manager/pkg/raghandler/main_test.go
@@ -1,0 +1,981 @@
+package raghandler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"monorepo/bin-rag-manager/pkg/chunker"
+	"monorepo/bin-rag-manager/pkg/store"
+)
+
+// mockRetriever for testing
+type mockRetriever struct {
+	queryFunc func(ctx context.Context, query string, topK int, docTypes []chunker.DocType) ([]store.SearchResult, error)
+}
+
+func (m *mockRetriever) Query(ctx context.Context, query string, topK int, docTypes []chunker.DocType) ([]store.SearchResult, error) {
+	if m.queryFunc != nil {
+		return m.queryFunc(ctx, query, topK, docTypes)
+	}
+	return []store.SearchResult{
+		{
+			Chunk: chunker.Chunk{
+				ID:           "1",
+				Text:         "test result",
+				SourceFile:   "test.md",
+				DocType:      chunker.DocTypeDesign,
+				SectionTitle: "Test Section",
+			},
+			RelevanceScore: 0.95,
+		},
+	}, nil
+}
+
+// mockGenerator for testing
+type mockGenerator struct {
+	generateFunc func(ctx context.Context, query string, chunks []store.SearchResult) (string, error)
+}
+
+func (m *mockGenerator) Generate(ctx context.Context, query string, chunks []store.SearchResult) (string, error) {
+	if m.generateFunc != nil {
+		return m.generateFunc(ctx, query, chunks)
+	}
+	return "mock answer", nil
+}
+
+// mockEmbedder for testing
+type mockEmbedder struct {
+	embedTextsFunc func(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+func (m *mockEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]float32, error) {
+	if m.embedTextsFunc != nil {
+		return m.embedTextsFunc(ctx, texts)
+	}
+	result := make([][]float32, len(texts))
+	for i := range texts {
+		result[i] = []float32{1.0, 0.0, 0.0}
+	}
+	return result, nil
+}
+
+func (m *mockEmbedder) EmbedText(ctx context.Context, text string) ([]float32, error) {
+	return []float32{1.0, 0.0, 0.0}, nil
+}
+
+func TestRagHandler_Interface(t *testing.T) {
+	var _ RagHandler = &ragHandler{}
+}
+
+func TestNewRagHandler(t *testing.T) {
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "/tmp/store.gob", 5)
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}
+
+func TestRagHandler_Query_Success(t *testing.T) {
+	ret := &mockRetriever{
+		queryFunc: func(ctx context.Context, query string, topK int, docTypes []chunker.DocType) ([]store.SearchResult, error) {
+			return []store.SearchResult{
+				{
+					Chunk: chunker.Chunk{
+						ID:           "1",
+						Text:         "test chunk",
+						SourceFile:   "test.md",
+						DocType:      chunker.DocTypeDesign,
+						SectionTitle: "Section",
+					},
+					RelevanceScore: 0.9,
+				},
+			}, nil
+		},
+	}
+	gen := &mockGenerator{
+		generateFunc: func(ctx context.Context, query string, chunks []store.SearchResult) (string, error) {
+			return "Generated answer", nil
+		},
+	}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	req := &QueryRequest{
+		Query: "test question",
+		TopK:  3,
+	}
+
+	resp, err := h.Query(ctx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if resp.Answer != "Generated answer" {
+		t.Errorf("expected 'Generated answer', got %q", resp.Answer)
+	}
+	if len(resp.Sources) != 1 {
+		t.Errorf("expected 1 source, got %d", len(resp.Sources))
+	}
+}
+
+func TestRagHandler_Query_DefaultTopK(t *testing.T) {
+	topKReceived := 0
+	ret := &mockRetriever{
+		queryFunc: func(ctx context.Context, query string, topK int, docTypes []chunker.DocType) ([]store.SearchResult, error) {
+			topKReceived = topK
+			return []store.SearchResult{}, nil
+		},
+	}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	defaultTopK := 7
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", defaultTopK)
+	ctx := context.Background()
+
+	req := &QueryRequest{
+		Query: "test",
+		TopK:  0, // Should use default
+	}
+
+	_, err := h.Query(ctx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if topKReceived != defaultTopK {
+		t.Errorf("expected topK=%d, got %d", defaultTopK, topKReceived)
+	}
+}
+
+func TestRagHandler_Query_RetrievalError(t *testing.T) {
+	expectedErr := errors.New("retrieval failed")
+	ret := &mockRetriever{
+		queryFunc: func(ctx context.Context, query string, topK int, docTypes []chunker.DocType) ([]store.SearchResult, error) {
+			return nil, expectedErr
+		},
+	}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	req := &QueryRequest{Query: "test"}
+
+	_, err := h.Query(ctx, req)
+	if err == nil {
+		t.Error("expected error from retrieval")
+	}
+}
+
+func TestRagHandler_Query_GenerationError(t *testing.T) {
+	ret := &mockRetriever{}
+	expectedErr := errors.New("generation failed")
+	gen := &mockGenerator{
+		generateFunc: func(ctx context.Context, query string, chunks []store.SearchResult) (string, error) {
+			return "", expectedErr
+		},
+	}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	req := &QueryRequest{Query: "test"}
+
+	_, err := h.Query(ctx, req)
+	if err == nil {
+		t.Error("expected error from generation")
+	}
+}
+
+func TestRagHandler_IndexStatus(t *testing.T) {
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	status, err := h.IndexStatus(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected non-nil status")
+	}
+	if status.ChunkCount != 0 {
+		t.Errorf("expected 0 chunks, got %d", status.ChunkCount)
+	}
+}
+
+func TestRagHandler_IndexIncremental(t *testing.T) {
+	// Create temporary test files
+	tmpDir, err := os.MkdirTemp("", "rag_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	mdFile := filepath.Join(tmpDir, "test.md")
+	if err := os.WriteFile(mdFile, []byte("# Test\n\nContent here"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	err = h.IndexIncremental(ctx, []string{mdFile})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify indexing happened
+	status, _ := h.IndexStatus(ctx)
+	if status.ChunkCount == 0 {
+		t.Error("expected chunks to be indexed")
+	}
+}
+
+func TestCollectFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "collect_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create test files
+	file1 := filepath.Join(tmpDir, "file1.md")
+	file2 := filepath.Join(tmpDir, "file2.md")
+	file3 := filepath.Join(tmpDir, "other.txt")
+
+	for _, f := range []string{file1, file2, file3} {
+		if err := os.WriteFile(f, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := collectFiles(tmpDir, ".md")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 .md files, got %d", len(files))
+	}
+}
+
+func TestCollectFiles_NonExistentDir(t *testing.T) {
+	_, err := collectFiles("/nonexistent/directory", ".md")
+	if err == nil {
+		t.Error("expected error for non-existent directory")
+	}
+}
+
+func TestDetectDocType(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected chunker.DocType
+	}{
+		{
+			name:     "devdoc rst file",
+			path:     "/path/to/docsdev/source/intro.rst",
+			expected: chunker.DocTypeDevDoc,
+		},
+		{
+			name:     "openapi yaml file",
+			path:     "/path/to/openapi/spec.yaml",
+			expected: chunker.DocTypeOpenAPI,
+		},
+		{
+			name:     "openapi yml file",
+			path:     "/path/to/openapi/spec.yml",
+			expected: chunker.DocTypeOpenAPI,
+		},
+		{
+			name:     "CLAUDE.md guideline",
+			path:     "/path/to/bin-service/CLAUDE.md",
+			expected: chunker.DocTypeGuideline,
+		},
+		{
+			name:     "design doc",
+			path:     "/path/to/docs/plans/design.md",
+			expected: chunker.DocTypeDesign,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detectDocType(tt.path)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestCollectCLAUDEMDs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claude_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create bin- directories with CLAUDE.md files
+	binDir1 := filepath.Join(tmpDir, "bin-service1")
+	binDir2 := filepath.Join(tmpDir, "bin-service2")
+	regularDir := filepath.Join(tmpDir, "not-bin-dir")
+
+	for _, dir := range []string{binDir1, binDir2, regularDir} {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create CLAUDE.md files
+	claude1 := filepath.Join(binDir1, "CLAUDE.md")
+	claude2 := filepath.Join(binDir2, "CLAUDE.md")
+	claudeRegular := filepath.Join(regularDir, "CLAUDE.md")
+	rootClaude := filepath.Join(tmpDir, "CLAUDE.md")
+
+	for _, f := range []string{claude1, claude2, claudeRegular, rootClaude} {
+		if err := os.WriteFile(f, []byte("# CLAUDE.md"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := collectCLAUDEMDs(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Should collect bin-* CLAUDE.md files + root CLAUDE.md
+	// Should NOT collect CLAUDE.md from non-bin directories
+	if len(files) != 3 {
+		t.Errorf("expected 3 CLAUDE.md files, got %d", len(files))
+	}
+}
+
+func TestRagHandler_IndexIncremental_EmbedError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	mdFile := filepath.Join(tmpDir, "test.md")
+	if err := os.WriteFile(mdFile, []byte("# Test\n\nSome content to chunk"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{
+		embedTextsFunc: func(ctx context.Context, texts []string) ([][]float32, error) {
+			if len(texts) > 0 {
+				return nil, errors.New("embed error")
+			}
+			return [][]float32{}, nil
+		},
+	}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	err = h.IndexIncremental(ctx, []string{mdFile})
+	if err == nil {
+		t.Error("expected error from embedding")
+	}
+}
+
+func TestRagHandler_IndexStatus_AfterIndexing(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	mdFile := filepath.Join(tmpDir, "test.md")
+	if err := os.WriteFile(mdFile, []byte("# Test\n\nSome content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	// Index the file
+	if err := h.IndexIncremental(ctx, []string{mdFile}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check status
+	status, err := h.IndexStatus(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if status.ChunkCount == 0 {
+		t.Error("expected chunks after indexing")
+	}
+	if status.LastRun.IsZero() {
+		t.Error("expected LastRun to be set")
+	}
+}
+
+func TestRagHandler_Query_WithDocTypeFilter(t *testing.T) {
+	docTypesReceived := []chunker.DocType{}
+	ret := &mockRetriever{
+		queryFunc: func(ctx context.Context, query string, topK int, docTypes []chunker.DocType) ([]store.SearchResult, error) {
+			docTypesReceived = docTypes
+			return []store.SearchResult{}, nil
+		},
+	}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	req := &QueryRequest{
+		Query:    "test",
+		DocTypes: []chunker.DocType{chunker.DocTypeOpenAPI, chunker.DocTypeDesign},
+	}
+
+	_, err := h.Query(ctx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(docTypesReceived) != 2 {
+		t.Errorf("expected 2 doc types to be passed, got %d", len(docTypesReceived))
+	}
+}
+
+func TestRagHandler_IndexIncremental_NoChunks(t *testing.T) {
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	// Index with empty file list
+	err := h.IndexIncremental(ctx, []string{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// LastRun should still be updated
+	impl := h.(*ragHandler)
+	impl.mu.Lock()
+	lastRun := impl.lastRun
+	impl.mu.Unlock()
+
+	if lastRun.IsZero() {
+		t.Error("expected LastRun to be set even with no chunks")
+	}
+}
+
+func TestRagHandler_IndexIncremental_WithSaveError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	mdFile := filepath.Join(tmpDir, "test.md")
+	if err := os.WriteFile(mdFile, []byte("# Test\n\nContent here"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	// Use invalid store path to trigger save error
+	invalidPath := filepath.Join(tmpDir, "nonexistent", "store.gob")
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, invalidPath, 5)
+	ctx := context.Background()
+
+	// Should not return error but should log it
+	err = h.IndexIncremental(ctx, []string{mdFile})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Check that error was recorded
+	status, _ := h.IndexStatus(ctx)
+	if len(status.Errors) == 0 {
+		t.Error("expected save error to be recorded")
+	}
+}
+
+func TestRagHandler_IndexFiles_ChunkError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	// Use non-existent file to trigger chunk error
+	files := []indexFile{
+		{path: "/nonexistent/file.md", docType: chunker.DocTypeDesign},
+	}
+
+	impl := h.(*ragHandler)
+	err = impl.indexFiles(ctx, files)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Check that error was recorded
+	impl.mu.Lock()
+	hasError := len(impl.indexErrors) > 0
+	impl.mu.Unlock()
+
+	if !hasError {
+		t.Error("expected chunk error to be recorded")
+	}
+}
+
+func TestRagHandler_LastRunTimestamp(t *testing.T) {
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, "/tmp/docs", "", 5)
+	ctx := context.Background()
+
+	before := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	// Trigger indexing with empty file list
+	if err := h.IndexIncremental(ctx, []string{}); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	after := time.Now()
+
+	status, _ := h.IndexStatus(ctx)
+	if status.LastRun.Before(before) || status.LastRun.After(after) {
+		t.Error("LastRun timestamp not within expected range")
+	}
+}
+
+func TestRagHandler_IndexFull(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir, err := os.MkdirTemp("", "rag_full_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create bin-api-manager/docsdev/source directory
+	rstDir := filepath.Join(tmpDir, "bin-api-manager", "docsdev", "source")
+	if err := os.MkdirAll(rstDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create RST file
+	rstFile := filepath.Join(rstDir, "test.rst")
+	if err := os.WriteFile(rstFile, []byte("Test\n====\n\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create bin-openapi-manager/openapi directory
+	openapiDir := filepath.Join(tmpDir, "bin-openapi-manager", "openapi")
+	if err := os.MkdirAll(openapiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create OpenAPI YAML file
+	yamlFile := filepath.Join(openapiDir, "openapi.yaml")
+	yamlContent := `openapi: 3.0.0
+paths:
+  /test:
+    get:
+      summary: Test endpoint
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create docs/plans directory
+	designDir := filepath.Join(tmpDir, "docs", "plans")
+	if err := os.MkdirAll(designDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create design doc
+	mdFile := filepath.Join(designDir, "design.md")
+	if err := os.WriteFile(mdFile, []byte("# Design\n\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create bin-service directory with CLAUDE.md
+	binService := filepath.Join(tmpDir, "bin-test-service")
+	if err := os.Mkdir(binService, 0755); err != nil {
+		t.Fatal(err)
+	}
+	claudeFile := filepath.Join(binService, "CLAUDE.md")
+	if err := os.WriteFile(claudeFile, []byte("# CLAUDE.md\n\nGuideline"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	err = h.IndexFull(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify chunks were indexed
+	status, _ := h.IndexStatus(ctx)
+	if status.ChunkCount == 0 {
+		t.Error("expected chunks to be indexed")
+	}
+}
+
+func TestRagHandler_IndexFull_NonExistentDirs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_full_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	// Use tmpDir that doesn't have expected subdirectories
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	// Should not error even if no directories exist
+	err = h.IndexFull(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Should have no chunks
+	status, _ := h.IndexStatus(ctx)
+	if status.ChunkCount != 0 {
+		t.Errorf("expected 0 chunks, got %d", status.ChunkCount)
+	}
+}
+
+func TestRagHandler_IndexFull_WithYmlFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_yml_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create bin-openapi-manager/openapi directory
+	openapiDir := filepath.Join(tmpDir, "bin-openapi-manager", "openapi")
+	if err := os.MkdirAll(openapiDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .yml file (not .yaml)
+	ymlFile := filepath.Join(openapiDir, "spec.yml")
+	ymlContent := `openapi: 3.0.0
+paths:
+  /api:
+    get:
+      summary: API endpoint
+`
+	if err := os.WriteFile(ymlFile, []byte(ymlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	err = h.IndexFull(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	status, _ := h.IndexStatus(ctx)
+	if status.ChunkCount == 0 {
+		t.Error("expected .yml file to be indexed")
+	}
+}
+
+func TestRagHandler_IndexFull_WithRootCLAUDEMD(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_claude_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create root CLAUDE.md
+	rootClaude := filepath.Join(tmpDir, "CLAUDE.md")
+	if err := os.WriteFile(rootClaude, []byte("# Root Guidelines\n\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	ctx := context.Background()
+
+	err = h.IndexFull(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	status, _ := h.IndexStatus(ctx)
+	if status.ChunkCount == 0 {
+		t.Error("expected root CLAUDE.md to be indexed")
+	}
+}
+
+func TestCollectFiles_WithSubdirectories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "collect_sub_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create subdirectories
+	subdir := filepath.Join(tmpDir, "subdir")
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create files at different levels
+	file1 := filepath.Join(tmpDir, "file1.md")
+	file2 := filepath.Join(subdir, "file2.md")
+
+	for _, f := range []string{file1, file2} {
+		if err := os.WriteFile(f, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := collectFiles(tmpDir, ".md")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files (including subdirectories), got %d", len(files))
+	}
+}
+
+func TestRagHandler_IndexFiles_DifferentChunkerTypes(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_chunker_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create RST file
+	rstFile := filepath.Join(tmpDir, "test.rst")
+	if err := os.WriteFile(rstFile, []byte("Title\n=====\n\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create YAML file
+	yamlFile := filepath.Join(tmpDir, "spec.yaml")
+	yamlContent := `openapi: 3.0.0
+paths:
+  /test:
+    get:
+      summary: Test
+`
+	if err := os.WriteFile(yamlFile, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create guideline MD file
+	guideFile := filepath.Join(tmpDir, "guide.md")
+	if err := os.WriteFile(guideFile, []byte("# Guide\n\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create design MD file
+	designFile := filepath.Join(tmpDir, "design.md")
+	if err := os.WriteFile(designFile, []byte("# Design\n\nContent"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	impl := h.(*ragHandler)
+	ctx := context.Background()
+
+	files := []indexFile{
+		{path: rstFile, docType: chunker.DocTypeDevDoc},
+		{path: yamlFile, docType: chunker.DocTypeOpenAPI},
+		{path: guideFile, docType: chunker.DocTypeGuideline},
+		{path: designFile, docType: chunker.DocTypeDesign},
+	}
+
+	err = impl.indexFiles(ctx, files)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	stats := st.Stats()
+	if stats.ChunkCount == 0 {
+		t.Error("expected chunks to be indexed")
+	}
+}
+
+func TestRagHandler_IndexFull_ErrorClearance(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_error_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	impl := h.(*ragHandler)
+
+	// Set some errors
+	impl.mu.Lock()
+	impl.indexErrors = []string{"previous error"}
+	impl.mu.Unlock()
+
+	ctx := context.Background()
+	err = h.IndexFull(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Errors should be cleared
+	status, _ := h.IndexStatus(ctx)
+	if len(status.Errors) != 0 {
+		t.Error("expected errors to be cleared on new indexing")
+	}
+}
+
+func TestRagHandler_IndexIncremental_ErrorClearance(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rag_error_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ret := &mockRetriever{}
+	gen := &mockGenerator{}
+	emb := &mockEmbedder{}
+	st := store.NewMemoryStore()
+
+	h := NewRagHandler(ret, gen, emb, st, tmpDir, "", 5)
+	impl := h.(*ragHandler)
+
+	// Set some errors
+	impl.mu.Lock()
+	impl.indexErrors = []string{"previous error"}
+	impl.mu.Unlock()
+
+	ctx := context.Background()
+	err = h.IndexIncremental(ctx, []string{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Errors should be cleared
+	status, _ := h.IndexStatus(ctx)
+	if len(status.Errors) != 0 {
+		t.Error("expected errors to be cleared on new indexing")
+	}
+}
+
+func TestCollectCLAUDEMDs_ErrorHandling(t *testing.T) {
+	// Test with non-existent directory
+	_, err := collectCLAUDEMDs("/nonexistent/directory")
+	if err == nil {
+		t.Error("expected error for non-existent directory")
+	}
+}
+
+func TestCollectCLAUDEMDs_NoBinDirectories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "claude_nobin_test_*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create some non-bin directories
+	for _, dir := range []string{"src", "docs", "test"} {
+		if err := os.Mkdir(filepath.Join(tmpDir, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := collectCLAUDEMDs(tmpDir)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 files without bin- directories, got %d", len(files))
+	}
+}

--- a/bin-rag-manager/pkg/retriever/retriever_test.go
+++ b/bin-rag-manager/pkg/retriever/retriever_test.go
@@ -1,0 +1,263 @@
+package retriever
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"monorepo/bin-rag-manager/pkg/chunker"
+	"monorepo/bin-rag-manager/pkg/store"
+)
+
+// mockEmbedder for testing
+type mockEmbedder struct {
+	embedTextFunc func(ctx context.Context, text string) ([]float32, error)
+}
+
+func (m *mockEmbedder) EmbedText(ctx context.Context, text string) ([]float32, error) {
+	if m.embedTextFunc != nil {
+		return m.embedTextFunc(ctx, text)
+	}
+	return []float32{1.0, 0.0, 0.0}, nil
+}
+
+func (m *mockEmbedder) EmbedTexts(ctx context.Context, texts []string) ([][]float32, error) {
+	result := make([][]float32, len(texts))
+	for i := range texts {
+		emb, err := m.EmbedText(ctx, texts[i])
+		if err != nil {
+			return nil, err
+		}
+		result[i] = emb
+	}
+	return result, nil
+}
+
+// mockStore for testing
+type mockStore struct {
+	searchFunc func(queryEmbedding []float32, topK int, docTypes []chunker.DocType) []store.SearchResult
+}
+
+func (m *mockStore) Search(queryEmbedding []float32, topK int, docTypes []chunker.DocType) []store.SearchResult {
+	if m.searchFunc != nil {
+		return m.searchFunc(queryEmbedding, topK, docTypes)
+	}
+	return []store.SearchResult{
+		{
+			Chunk: chunker.Chunk{
+				ID:           "1",
+				Text:         "test chunk",
+				SourceFile:   "test.md",
+				DocType:      chunker.DocTypeDesign,
+				SectionTitle: "Test",
+			},
+			RelevanceScore: 0.95,
+		},
+	}
+}
+
+func (m *mockStore) Add(chunks []chunker.Chunk, embeddings [][]float32) {}
+
+func (m *mockStore) DeleteByFile(sourceFile string) {}
+
+func (m *mockStore) Save(filePath string) error {
+	return nil
+}
+
+func (m *mockStore) Load(filePath string) error {
+	return nil
+}
+
+func (m *mockStore) Stats() store.StoreStats {
+	return store.StoreStats{ChunkCount: 1}
+}
+
+func TestRetriever_Interface(t *testing.T) {
+	var _ Retriever = &retriever{}
+}
+
+func TestNewRetriever(t *testing.T) {
+	emb := &mockEmbedder{}
+	st := &mockStore{}
+
+	r := NewRetriever(emb, st)
+	if r == nil {
+		t.Error("expected non-nil retriever")
+	}
+}
+
+func TestRetriever_Query_Success(t *testing.T) {
+	emb := &mockEmbedder{
+		embedTextFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{1.0, 0.5, 0.3}, nil
+		},
+	}
+
+	st := &mockStore{
+		searchFunc: func(queryEmbedding []float32, topK int, docTypes []chunker.DocType) []store.SearchResult {
+			return []store.SearchResult{
+				{
+					Chunk: chunker.Chunk{
+						ID:           "1",
+						Text:         "result 1",
+						SourceFile:   "file1.md",
+						DocType:      chunker.DocTypeDesign,
+						SectionTitle: "Section 1",
+					},
+					RelevanceScore: 0.95,
+				},
+				{
+					Chunk: chunker.Chunk{
+						ID:           "2",
+						Text:         "result 2",
+						SourceFile:   "file2.md",
+						DocType:      chunker.DocTypeOpenAPI,
+						SectionTitle: "Section 2",
+					},
+					RelevanceScore: 0.85,
+				},
+			}
+		},
+	}
+
+	r := NewRetriever(emb, st)
+	ctx := context.Background()
+
+	results, err := r.Query(ctx, "test query", 5, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestRetriever_Query_WithDocTypeFilter(t *testing.T) {
+	emb := &mockEmbedder{}
+	st := &mockStore{
+		searchFunc: func(queryEmbedding []float32, topK int, docTypes []chunker.DocType) []store.SearchResult {
+			// Verify docTypes filter is passed through
+			if len(docTypes) != 2 {
+				return nil
+			}
+			return []store.SearchResult{
+				{
+					Chunk: chunker.Chunk{
+						ID:           "1",
+						Text:         "openapi result",
+						SourceFile:   "api.yaml",
+						DocType:      chunker.DocTypeOpenAPI,
+						SectionTitle: "API",
+					},
+					RelevanceScore: 0.90,
+				},
+			}
+		},
+	}
+
+	r := NewRetriever(emb, st)
+	ctx := context.Background()
+
+	docTypes := []chunker.DocType{chunker.DocTypeOpenAPI, chunker.DocTypeDevDoc}
+	results, err := r.Query(ctx, "test", 10, docTypes)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(results))
+	}
+	if len(results) > 0 && results[0].Chunk.DocType != chunker.DocTypeOpenAPI {
+		t.Error("expected OpenAPI doc type")
+	}
+}
+
+func TestRetriever_Query_EmbedError(t *testing.T) {
+	expectedErr := errors.New("embedding failed")
+	emb := &mockEmbedder{
+		embedTextFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, expectedErr
+		},
+	}
+	st := &mockStore{}
+
+	r := NewRetriever(emb, st)
+	ctx := context.Background()
+
+	_, err := r.Query(ctx, "test query", 5, nil)
+	if err == nil {
+		t.Error("expected error from embedder")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected error to wrap embedding error, got: %v", err)
+	}
+}
+
+func TestRetriever_Query_EmptyResults(t *testing.T) {
+	emb := &mockEmbedder{}
+	st := &mockStore{
+		searchFunc: func(queryEmbedding []float32, topK int, docTypes []chunker.DocType) []store.SearchResult {
+			return []store.SearchResult{}
+		},
+	}
+
+	r := NewRetriever(emb, st)
+	ctx := context.Background()
+
+	results, err := r.Query(ctx, "test", 5, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestRetriever_Query_TopKParameter(t *testing.T) {
+	emb := &mockEmbedder{}
+
+	topKReceived := 0
+	st := &mockStore{
+		searchFunc: func(queryEmbedding []float32, topK int, docTypes []chunker.DocType) []store.SearchResult {
+			topKReceived = topK
+			return []store.SearchResult{}
+		},
+	}
+
+	r := NewRetriever(emb, st)
+	ctx := context.Background()
+
+	expectedTopK := 15
+	_, err := r.Query(ctx, "test", expectedTopK, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if topKReceived != expectedTopK {
+		t.Errorf("expected topK=%d to be passed to store, got %d", expectedTopK, topKReceived)
+	}
+}
+
+func TestRetriever_Query_ContextCancellation(t *testing.T) {
+	emb := &mockEmbedder{
+		embedTextFunc: func(ctx context.Context, text string) ([]float32, error) {
+			// Check if context is cancelled
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				return []float32{1.0}, nil
+			}
+		},
+	}
+	st := &mockStore{}
+
+	r := NewRetriever(emb, st)
+
+	// Create and cancel context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := r.Query(ctx, "test", 5, nil)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-rag-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-rag-manager: Add unit tests for improved package-level coverage