### PR TITLE
NOJIRA-Test-coverage-campaign-manager

### DIFF
--- a/bin-campaign-manager/models/campaign/convert_test.go
+++ b/bin-campaign-manager/models/campaign/convert_test.go
@@ -1,0 +1,61 @@
+package campaign
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertStringMapToFieldMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     map[string]any
+		wantErr bool
+	}{
+		{
+			name: "valid_conversion_with_uuid",
+			src: map[string]any{
+				"name":   "Test Campaign",
+				"status": "run",
+				"flow_id": uuid.Must(uuid.NewV4()).String(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid_conversion_without_uuid",
+			src: map[string]any{
+				"name":   "Another Campaign",
+				"status": "stop",
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty_map",
+			src:  map[string]any{},
+			wantErr: false,
+		},
+		{
+			name: "invalid_uuid_format",
+			src: map[string]any{
+				"flow_id": "invalid-uuid-format",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertStringMapToFieldMap(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertStringMapToFieldMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ConvertStringMapToFieldMap() returned nil result without error")
+			}
+			if !tt.wantErr && len(got) != len(tt.src) {
+				t.Errorf("ConvertStringMapToFieldMap() result length = %v, expected %v", len(got), len(tt.src))
+			}
+		})
+	}
+}

--- a/bin-campaign-manager/models/campaigncall/convert_test.go
+++ b/bin-campaign-manager/models/campaigncall/convert_test.go
@@ -1,0 +1,71 @@
+package campaigncall
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertStringMapToFieldMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     map[string]any
+		wantErr bool
+	}{
+		{
+			name: "valid_conversion_with_uuid",
+			src: map[string]any{
+				"campaign_id": uuid.Must(uuid.NewV4()).String(),
+				"status":      "dialing",
+				"result":      "success",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid_conversion_without_uuid",
+			src: map[string]any{
+				"status": "progressing",
+				"result": "fail",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty_map",
+			src:     map[string]any{},
+			wantErr: false,
+		},
+		{
+			name: "invalid_uuid_format",
+			src: map[string]any{
+				"campaign_id": "invalid-uuid-format",
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple_uuids",
+			src: map[string]any{
+				"campaign_id":       uuid.Must(uuid.NewV4()).String(),
+				"outplan_id":        uuid.Must(uuid.NewV4()).String(),
+				"outdial_id":        uuid.Must(uuid.NewV4()).String(),
+				"outdial_target_id": uuid.Must(uuid.NewV4()).String(),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertStringMapToFieldMap(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertStringMapToFieldMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ConvertStringMapToFieldMap() returned nil result without error")
+			}
+			if !tt.wantErr && len(got) != len(tt.src) {
+				t.Errorf("ConvertStringMapToFieldMap() result length = %v, expected %v", len(got), len(tt.src))
+			}
+		})
+	}
+}

--- a/bin-campaign-manager/models/outplan/convert_test.go
+++ b/bin-campaign-manager/models/outplan/convert_test.go
@@ -1,0 +1,73 @@
+package outplan
+
+import (
+	"testing"
+)
+
+func TestConvertStringMapToFieldMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     map[string]any
+		wantErr bool
+	}{
+		{
+			name: "valid_conversion",
+			src: map[string]any{
+				"name":           "Test Outplan",
+				"detail":         "Test detail",
+				"dial_timeout":   30000,
+				"max_try_count_0": 3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid_conversion_with_all_fields",
+			src: map[string]any{
+				"name":            "Full Outplan",
+				"detail":          "Complete test",
+				"dial_timeout":    60000,
+				"try_interval":    5000,
+				"max_try_count_0": 1,
+				"max_try_count_1": 2,
+				"max_try_count_2": 3,
+				"max_try_count_3": 4,
+				"max_try_count_4": 5,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty_map",
+			src:     map[string]any{},
+			wantErr: false,
+		},
+		{
+			name: "valid_conversion_minimal",
+			src: map[string]any{
+				"name": "Minimal Outplan",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertStringMapToFieldMap(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertStringMapToFieldMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Errorf("ConvertStringMapToFieldMap() returned nil result without error")
+			}
+			if !tt.wantErr && len(got) != len(tt.src) {
+				t.Errorf("ConvertStringMapToFieldMap() result length = %v, expected %v", len(got), len(tt.src))
+			}
+		})
+	}
+}
+
+func TestMaxTryCountLen(t *testing.T) {
+	if MaxTryCountLen != 5 {
+		t.Errorf("MaxTryCountLen = %v, expected 5", MaxTryCountLen)
+	}
+}

--- a/bin-campaign-manager/pkg/campaignhandler/campaign_test.go
+++ b/bin-campaign-manager/pkg/campaignhandler/campaign_test.go
@@ -227,6 +227,48 @@ func Test_Delete(t *testing.T) {
 	}
 }
 
+func Test_List(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		limit   uint64
+		filters map[campaign.Field]any
+	}{
+		{
+			"test normal",
+			"2020-10-10T03:30:17.000000Z",
+			10,
+			map[campaign.Field]any{
+				campaign.FieldDeleted: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &campaignHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+			}
+
+			ctx := context.Background()
+			mockDB.EXPECT().CampaignList(ctx, tt.token, tt.limit, tt.filters).Return([]*campaign.Campaign{}, nil)
+
+			_, err := h.List(ctx, tt.token, tt.limit, tt.filters)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
 func Test_ListByCustomerID(t *testing.T) {
 
 	tests := []struct {

--- a/bin-campaign-manager/pkg/outplanhandler/outplan_test.go
+++ b/bin-campaign-manager/pkg/outplanhandler/outplan_test.go
@@ -285,3 +285,83 @@ func Test_UpdateDialInfo(t *testing.T) {
 		})
 	}
 }
+
+func Test_Get(t *testing.T) {
+	tests := []struct {
+		name string
+		id   uuid.UUID
+	}{
+		{
+			"normal",
+			uuid.FromStringOrNil("a1234567-b3dc-11ec-906b-33094783cdd2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := &outplanHandler{
+				db:            mockDB,
+				reqHandler:    mockReq,
+				notifyHandler: mockNotify,
+			}
+
+			ctx := context.Background()
+
+			mockDB.EXPECT().OutplanGet(ctx, tt.id).Return(&outplan.Outplan{}, nil)
+
+			_, err := h.Get(ctx, tt.id)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_List(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		limit   uint64
+		filters map[outplan.Field]any
+	}{
+		{
+			"normal",
+			"2020-10-10T03:30:17.000000Z",
+			10,
+			map[outplan.Field]any{
+				outplan.FieldDeleted: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := &outplanHandler{
+				db:            mockDB,
+				reqHandler:    mockReq,
+				notifyHandler: mockNotify,
+			}
+
+			ctx := context.Background()
+
+			mockDB.EXPECT().OutplanList(ctx, tt.token, tt.limit, tt.filters).Return([]*outplan.Outplan{}, nil)
+
+			_, err := h.List(ctx, tt.token, tt.limit, tt.filters)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-campaign-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-campaign-manager: Add unit tests for improved package-level coverage