### PR TITLE
NOJIRA-Test-coverage-conference-manager

### DIFF
--- a/bin-conference-manager/internal/config/config_test.go
+++ b/bin-conference-manager/internal/config/config_test.go
@@ -96,3 +96,15 @@ func TestDefaultConstants(t *testing.T) {
 		})
 	}
 }
+
+func TestBootstrap(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+	}
+
+	err := Bootstrap(cmd)
+	if err != nil {
+		t.Errorf("Bootstrap failed: %v", err)
+	}
+}

--- a/bin-conference-manager/models/conference/conference_test.go
+++ b/bin-conference-manager/models/conference/conference_test.go
@@ -83,3 +83,208 @@ func Test_Conference_MarshalUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestMatches(t *testing.T) {
+	tmCreate := time.Date(2025, 4, 2, 0, 0, 0, 0, time.UTC)
+	tmCreate2 := time.Date(2025, 4, 3, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		a        *Conference
+		b        *Conference
+		expected bool
+	}{
+		{
+			name: "identical conferences",
+			a: &Conference{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+					CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+				},
+				Name:     "Test",
+				TMCreate: &tmCreate,
+			},
+			b: &Conference{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+					CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+				},
+				Name:     "Test",
+				TMCreate: &tmCreate,
+			},
+			expected: true,
+		},
+		{
+			name: "different create times should match",
+			a: &Conference{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+					CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+				},
+				Name:     "Test",
+				TMCreate: &tmCreate,
+			},
+			b: &Conference{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+					CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+				},
+				Name:     "Test",
+				TMCreate: &tmCreate2,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.a.Matches(tt.b)
+			if result != tt.expected {
+				t.Errorf("Matches() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	conf := &Conference{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+			CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+		},
+		Name: "Test Conference",
+	}
+
+	str := conf.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+}
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tmEnd := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+	tmCreate := time.Date(2025, 4, 2, 0, 0, 0, 0, time.UTC)
+
+	conf := &Conference{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+			CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+		},
+		Type:   TypeConference,
+		Status: StatusProgressing,
+		Name:   "Test Conference",
+		Detail: "Test Detail",
+		Data: map[string]any{
+			"key": "value",
+		},
+		Timeout:    300,
+		PreFlowID:  uuid.FromStringOrNil("14e81da6-0e44-11f0-aee7-a3902cfbf3fc"),
+		PostFlowID: uuid.FromStringOrNil("6fabe796-1350-11ed-a9be-63d034c16c8d"),
+		ConferencecallIDs: []uuid.UUID{
+			uuid.FromStringOrNil("6fdaccaa-1350-11ed-8a93-cb0e3c8d6bf8"),
+		},
+		RecordingID: uuid.FromStringOrNil("d0278cd8-1350-11ed-91f4-4f03d0c82169"),
+		RecordingIDs: []uuid.UUID{
+			uuid.FromStringOrNil("d0278cd8-1350-11ed-91f4-4f03d0c82169"),
+		},
+		TranscribeID: uuid.FromStringOrNil("e0278cd8-1350-11ed-91f4-4f03d0c82169"),
+		TranscribeIDs: []uuid.UUID{
+			uuid.FromStringOrNil("e0278cd8-1350-11ed-91f4-4f03d0c82169"),
+		},
+		TMEnd:    &tmEnd,
+		TMCreate: &tmCreate,
+	}
+
+	webhook := conf.ConvertWebhookMessage()
+
+	if webhook.ID != conf.ID {
+		t.Errorf("WebhookMessage.ID = %v, expected %v", webhook.ID, conf.ID)
+	}
+	if webhook.Type != conf.Type {
+		t.Errorf("WebhookMessage.Type = %v, expected %v", webhook.Type, conf.Type)
+	}
+	if webhook.Status != conf.Status {
+		t.Errorf("WebhookMessage.Status = %v, expected %v", webhook.Status, conf.Status)
+	}
+	if webhook.Name != conf.Name {
+		t.Errorf("WebhookMessage.Name = %v, expected %v", webhook.Name, conf.Name)
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	conf := &Conference{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("72124710-1e19-11f0-b975-6310cee17b54"),
+			CustomerID: uuid.FromStringOrNil("7260700c-1e19-11f0-81f6-d71f167f930d"),
+		},
+		Type:   TypeConference,
+		Status: StatusProgressing,
+		Name:   "Test Conference",
+	}
+
+	data, err := conf.CreateWebhookEvent()
+	if err != nil {
+		t.Errorf("CreateWebhookEvent failed: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("CreateWebhookEvent returned empty data")
+	}
+}
+
+func TestConvertStringMapToFieldMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		wantErr  bool
+		validate func(t *testing.T, result map[Field]any)
+	}{
+		{
+			name: "convert type field",
+			input: map[string]string{
+				"type": "conference",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, result map[Field]any) {
+				if len(result) == 0 {
+					t.Error("Expected non-empty result")
+				}
+			},
+		},
+		{
+			name: "convert status field",
+			input: map[string]string{
+				"status": "progressing",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, result map[Field]any) {
+				if len(result) == 0 {
+					t.Error("Expected non-empty result")
+				}
+			},
+		},
+		{
+			name:    "empty input",
+			input:   map[string]string{},
+			wantErr: false,
+			validate: func(t *testing.T, result map[Field]any) {
+				if len(result) != 0 {
+					t.Errorf("Expected empty result, got %d fields", len(result))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ConvertStringMapToFieldMap(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertStringMapToFieldMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}

--- a/bin-conference-manager/models/conferencecall/conferencecall_test.go
+++ b/bin-conference-manager/models/conferencecall/conferencecall_test.go
@@ -83,3 +83,139 @@ func TestStatusConstants(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertWebhookMessage(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	conferenceID := uuid.Must(uuid.NewV4())
+	referenceID := uuid.Must(uuid.NewV4())
+	tmCreate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	tmUpdate := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	tmDelete := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	cc := &Conferencecall{
+		ActiveflowID:  activeflowID,
+		ConferenceID:  conferenceID,
+		ReferenceType: ReferenceTypeCall,
+		ReferenceID:   referenceID,
+		Status:        StatusJoined,
+		TMCreate:      &tmCreate,
+		TMUpdate:      &tmUpdate,
+		TMDelete:      &tmDelete,
+	}
+	cc.ID = id
+	cc.CustomerID = customerID
+
+	webhook := cc.ConvertWebhookMessage()
+
+	if webhook.ID != id {
+		t.Errorf("WebhookMessage.ID = %v, expected %v", webhook.ID, id)
+	}
+	if webhook.CustomerID != customerID {
+		t.Errorf("WebhookMessage.CustomerID = %v, expected %v", webhook.CustomerID, customerID)
+	}
+	if webhook.ActiveflowID != activeflowID {
+		t.Errorf("WebhookMessage.ActiveflowID = %v, expected %v", webhook.ActiveflowID, activeflowID)
+	}
+	if webhook.ConferenceID != conferenceID {
+		t.Errorf("WebhookMessage.ConferenceID = %v, expected %v", webhook.ConferenceID, conferenceID)
+	}
+	if webhook.ReferenceType != ReferenceTypeCall {
+		t.Errorf("WebhookMessage.ReferenceType = %v, expected %v", webhook.ReferenceType, ReferenceTypeCall)
+	}
+	if webhook.ReferenceID != referenceID {
+		t.Errorf("WebhookMessage.ReferenceID = %v, expected %v", webhook.ReferenceID, referenceID)
+	}
+	if webhook.Status != StatusJoined {
+		t.Errorf("WebhookMessage.Status = %v, expected %v", webhook.Status, StatusJoined)
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	conferenceID := uuid.Must(uuid.NewV4())
+	referenceID := uuid.Must(uuid.NewV4())
+	tmCreate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cc := &Conferencecall{
+		ActiveflowID:  activeflowID,
+		ConferenceID:  conferenceID,
+		ReferenceType: ReferenceTypeCall,
+		ReferenceID:   referenceID,
+		Status:        StatusJoining,
+		TMCreate:      &tmCreate,
+		TMUpdate:      nil,
+		TMDelete:      nil,
+	}
+	cc.ID = id
+	cc.CustomerID = customerID
+
+	data, err := cc.CreateWebhookEvent()
+	if err != nil {
+		t.Errorf("CreateWebhookEvent failed: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("CreateWebhookEvent returned empty data")
+	}
+}
+
+func TestConvertStringMapToFieldMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		wantErr  bool
+		validate func(t *testing.T, result map[Field]any)
+	}{
+		{
+			name: "convert status field",
+			input: map[string]string{
+				"status": "joined",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, result map[Field]any) {
+				if len(result) == 0 {
+					t.Error("Expected non-empty result")
+				}
+			},
+		},
+		{
+			name: "convert reference_type field",
+			input: map[string]string{
+				"reference_type": "call",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, result map[Field]any) {
+				if len(result) == 0 {
+					t.Error("Expected non-empty result")
+				}
+			},
+		},
+		{
+			name:    "empty input",
+			input:   map[string]string{},
+			wantErr: false,
+			validate: func(t *testing.T, result map[Field]any) {
+				if len(result) != 0 {
+					t.Errorf("Expected empty result, got %d fields", len(result))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ConvertStringMapToFieldMap(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertStringMapToFieldMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}

--- a/bin-conference-manager/pkg/subscribehandler/callmanager_test.go
+++ b/bin-conference-manager/pkg/subscribehandler/callmanager_test.go
@@ -127,3 +127,99 @@ func Test_processEventCMConfbridgeLeaved(t *testing.T) {
 		})
 	}
 }
+
+func Test_processEventUnknown(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *sock.Event
+	}{
+		{
+			"unknown event type",
+			&sock.Event{
+				Type:      "unknown_type",
+				Publisher: "unknown_publisher",
+				DataType:  "application/json",
+				Data:      []byte(`{}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockConf := conferencehandler.NewMockConferenceHandler(mc)
+			mockConfCall := conferencecallhandler.NewMockConferencecallHandler(mc)
+
+			h := &subscribeHandler{
+				sockHandler:           mockSock,
+				conferenceHandler:     mockConf,
+				conferencecallHandler: mockConfCall,
+			}
+
+			h.processEvent(tt.event)
+		})
+	}
+}
+
+func Test_processEventRun(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *sock.Event
+	}{
+		{
+			"processEventRun",
+			&sock.Event{
+				Type:      "unknown_type",
+				Publisher: "unknown_publisher",
+				DataType:  "application/json",
+				Data:      []byte(`{}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockConf := conferencehandler.NewMockConferenceHandler(mc)
+			mockConfCall := conferencecallhandler.NewMockConferencecallHandler(mc)
+
+			h := &subscribeHandler{
+				sockHandler:           mockSock,
+				conferenceHandler:     mockConf,
+				conferencecallHandler: mockConfCall,
+			}
+
+			err := h.processEventRun(tt.event)
+			if err != nil {
+				t.Errorf("processEventRun() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestNewSubscribeHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockConf := conferencehandler.NewMockConferenceHandler(mc)
+	mockConfCall := conferencecallhandler.NewMockConferencecallHandler(mc)
+
+	h := NewSubscribeHandler(
+		mockSock,
+		"test-queue",
+		[]string{"test-target"},
+		mockConf,
+		mockConfCall,
+	)
+
+	if h == nil {
+		t.Error("NewSubscribeHandler() returned nil")
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-conference-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-conference-manager: Add unit tests for improved package-level coverage