### PR TITLE
NOJIRA-Test-coverage-conversation-manager

### DIFF
--- a/bin-conversation-manager/models/media/media_test.go
+++ b/bin-conversation-manager/models/media/media_test.go
@@ -1,0 +1,111 @@
+package media
+
+import (
+	"testing"
+)
+
+func TestMedia(t *testing.T) {
+	tests := []struct {
+		name string
+
+		mediaType Type
+		filename  string
+	}{
+		{
+			name: "creates_media_with_all_fields",
+
+			mediaType: TypeImage,
+			filename:  "image.jpg",
+		},
+		{
+			name: "creates_media_with_empty_fields",
+
+			mediaType: "",
+			filename:  "",
+		},
+		{
+			name: "creates_media_with_video_type",
+
+			mediaType: TypeVideo,
+			filename:  "video.mp4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Media{
+				Type:     tt.mediaType,
+				Filename: tt.filename,
+			}
+
+			if m.Type != tt.mediaType {
+				t.Errorf("Wrong Type. expect: %s, got: %s", tt.mediaType, m.Type)
+			}
+			if m.Filename != tt.filename {
+				t.Errorf("Wrong Filename. expect: %s, got: %s", tt.filename, m.Filename)
+			}
+		})
+	}
+}
+
+func TestTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant Type
+		expected string
+	}{
+		{
+			name:     "type_image",
+			constant: TypeImage,
+			expected: "image",
+		},
+		{
+			name:     "type_video",
+			constant: TypeVideo,
+			expected: "video",
+		},
+		{
+			name:     "type_audio",
+			constant: TypeAudio,
+			expected: "audio",
+		},
+		{
+			name:     "type_file",
+			constant: TypeFile,
+			expected: "file",
+		},
+		{
+			name:     "type_location",
+			constant: TypeLocation,
+			expected: "location",
+		},
+		{
+			name:     "type_sticker",
+			constant: TypeSticker,
+			expected: "sticker",
+		},
+		{
+			name:     "type_template",
+			constant: TypeTemplate,
+			expected: "template",
+		},
+		{
+			name:     "type_imagemap",
+			constant: TypeImagemap,
+			expected: "imagemap",
+		},
+		{
+			name:     "type_flex",
+			constant: TypeFlex,
+			expected: "flex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.constant) != tt.expected {
+				t.Errorf("Wrong constant value. expect: %s, got: %s", tt.expected, tt.constant)
+			}
+		})
+	}
+}

--- a/bin-conversation-manager/pkg/conversationhandler/etc_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/etc_test.go
@@ -1,0 +1,100 @@
+package conversationhandler
+
+import (
+	"context"
+	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	nmnumber "monorepo/bin-number-manager/models/number"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_NumberGet(t *testing.T) {
+	tests := []struct {
+		name string
+
+		number string
+
+		responseNumbers []nmnumber.Number
+		expectNumber    *nmnumber.Number
+	}{
+		{
+			name:   "normal",
+			number: "+1234567890",
+
+			responseNumbers: []nmnumber.Number{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+					},
+					Number: "+1234567890",
+				},
+			},
+			expectNumber: &nmnumber.Number{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+				},
+				Number: "+1234567890",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &conversationHandler{
+				reqHandler: mockReq,
+			}
+			ctx := context.Background()
+
+			filters := map[nmnumber.Field]any{
+				nmnumber.FieldNumber:  tt.number,
+				nmnumber.FieldDeleted: false,
+			}
+
+			mockReq.EXPECT().NumberV1NumberList(ctx, "", uint64(1), filters).Return(tt.responseNumbers, nil)
+
+			res, err := h.NumberGet(ctx, tt.number)
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if res.ID != tt.expectNumber.ID {
+				t.Errorf("Wrong ID. expect: %s, got: %s", tt.expectNumber.ID, res.ID)
+			}
+			if res.Number != tt.expectNumber.Number {
+				t.Errorf("Wrong Number. expect: %s, got: %s", tt.expectNumber.Number, res.Number)
+			}
+		})
+	}
+}
+
+func Test_NumberGet_NotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &conversationHandler{
+		reqHandler: mockReq,
+	}
+	ctx := context.Background()
+
+	number := "+1234567890"
+	filters := map[nmnumber.Field]any{
+		nmnumber.FieldNumber:  number,
+		nmnumber.FieldDeleted: false,
+	}
+
+	mockReq.EXPECT().NumberV1NumberList(ctx, "", uint64(1), filters).Return([]nmnumber.Number{}, nil)
+
+	_, err := h.NumberGet(ctx, number)
+	if err == nil {
+		t.Errorf("Expected error for not found, got nil")
+	}
+}

--- a/bin-conversation-manager/pkg/subscribehandler/main_test.go
+++ b/bin-conversation-manager/pkg/subscribehandler/main_test.go
@@ -1,0 +1,104 @@
+package subscribehandler
+
+import (
+	"encoding/json"
+	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonsock "monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+	mmmessage "monorepo/bin-message-manager/models/message"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-conversation-manager/models/conversation"
+	"monorepo/bin-conversation-manager/pkg/accounthandler"
+	"monorepo/bin-conversation-manager/pkg/conversationhandler"
+)
+
+func Test_NewSubscribeHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockAccount := accounthandler.NewMockAccountHandler(mc)
+	mockConversation := conversationhandler.NewMockConversationHandler(mc)
+
+	subscribeQueue := "test-queue"
+	subscribeTargets := []string{"target1", "target2"}
+
+	h := NewSubscribeHandler(
+		mockSock,
+		subscribeQueue,
+		subscribeTargets,
+		mockAccount,
+		mockConversation,
+	)
+
+	if h == nil {
+		t.Errorf("Expected non-nil SubscribeHandler, got nil")
+	}
+}
+
+// Test_processEventRun is skipped because it launches a goroutine
+// which makes it difficult to test reliably with mocks
+
+func Test_processEvent_MessageManagerMessageCreated(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockAccount := accounthandler.NewMockAccountHandler(mc)
+	mockConversation := conversationhandler.NewMockConversationHandler(mc)
+
+	h := &subscribeHandler{
+		sockHandler:         mockSock,
+		accountHandler:      mockAccount,
+		conversationHandler: mockConversation,
+	}
+
+	msg := &mmmessage.Message{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001"),
+			CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440002"),
+		},
+		Text: "test message",
+	}
+
+	data, _ := json.Marshal(msg)
+
+	event := &commonsock.Event{
+		Publisher: publisherMessageManager,
+		Type:      string(mmmessage.EventTypeMessageCreated),
+		Data:      json.RawMessage(data),
+	}
+
+	mockConversation.EXPECT().Event(gomock.Any(), conversation.TypeMessage, gomock.Any()).Return(nil)
+
+	h.processEvent(event)
+}
+
+func Test_processEvent_UnknownEvent(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockAccount := accounthandler.NewMockAccountHandler(mc)
+	mockConversation := conversationhandler.NewMockConversationHandler(mc)
+
+	h := &subscribeHandler{
+		sockHandler:         mockSock,
+		accountHandler:      mockAccount,
+		conversationHandler: mockConversation,
+	}
+
+	event := &commonsock.Event{
+		Publisher: "unknown-publisher",
+		Type:      "unknown-type",
+		Data:      json.RawMessage("{}"),
+	}
+
+	// Should not panic for unknown events, just return
+	h.processEvent(event)
+}


### PR DESCRIPTION
Increase test coverage for bin-conversation-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-conversation-manager: Add unit tests for improved package-level coverage