### PR TITLE
NOJIRA-Test-coverage-message-manager

### DIFF
--- a/bin-message-manager/internal/config/config_test.go
+++ b/bin-message-manager/internal/config/config_test.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestBootstrap(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupCmd    func() *cobra.Command
+		expectError bool
+	}{
+		{
+			name: "valid_bootstrap",
+			setupCmd: func() *cobra.Command {
+				return &cobra.Command{
+					Use: "test",
+				}
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper for clean test
+			viper.Reset()
+
+			cmd := tt.setupCmd()
+			err := Bootstrap(cmd)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestBindConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupEnv    map[string]string
+		expectError bool
+	}{
+		{
+			name: "all_env_vars",
+			setupEnv: map[string]string{
+				"RABBITMQ_ADDRESS":          "amqp://localhost:5672",
+				"PROMETHEUS_ENDPOINT":       "/metrics",
+				"PROMETHEUS_LISTEN_ADDRESS": ":2112",
+				"DATABASE_DSN":              "user:pass@tcp(localhost:3306)/db",
+				"REDIS_ADDRESS":             "localhost:6379",
+				"REDIS_PASSWORD":            "password",
+				"REDIS_DATABASE":            "0",
+				"AUTHTOKEN_MESSAGEBIRD":     "test-token-mb",
+				"AUTHTOKEN_TELNYX":          "test-token-telnyx",
+			},
+			expectError: false,
+		},
+		{
+			name:        "no_env_vars",
+			setupEnv:    map[string]string{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper for clean test
+			viper.Reset()
+
+			// Set environment variables
+			for key, value := range tt.setupEnv {
+				_ = os.Setenv(key, value)
+				defer func(k string) {
+					_ = os.Unsetenv(k)
+				}(key)
+			}
+
+			cmd := &cobra.Command{
+				Use: "test",
+			}
+
+			err := bindConfig(cmd)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			// Verify that flags are registered
+			if err == nil {
+				flags := []string{
+					"rabbitmq_address",
+					"prometheus_endpoint",
+					"prometheus_listen_address",
+					"database_dsn",
+					"redis_address",
+					"redis_password",
+					"redis_database",
+					"authtoken_messagebird",
+					"authtoken_telnyx",
+				}
+
+				for _, flag := range flags {
+					if cmd.PersistentFlags().Lookup(flag) == nil {
+						t.Errorf("Flag %s was not registered", flag)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	cfg := Get()
+	if cfg == nil {
+		t.Error("Get() returned nil")
+	}
+}
+
+func TestLoadGlobalConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupEnv map[string]string
+	}{
+		{
+			name: "load_with_env_vars",
+			setupEnv: map[string]string{
+				"RABBITMQ_ADDRESS":          "amqp://test:5672",
+				"PROMETHEUS_ENDPOINT":       "/test-metrics",
+				"PROMETHEUS_LISTEN_ADDRESS": ":9090",
+				"DATABASE_DSN":              "test-dsn",
+				"REDIS_ADDRESS":             "test-redis:6379",
+				"REDIS_PASSWORD":            "test-pass",
+				"REDIS_DATABASE":            "5",
+				"AUTHTOKEN_MESSAGEBIRD":     "mb-token",
+				"AUTHTOKEN_TELNYX":          "telnyx-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper
+			viper.Reset()
+
+			// Set environment variables
+			for key, value := range tt.setupEnv {
+				_ = os.Setenv(key, value)
+				defer func(k string) {
+					_ = os.Unsetenv(k)
+				}(key)
+			}
+
+			// Setup command and bind config
+			cmd := &cobra.Command{Use: "test"}
+			if err := bindConfig(cmd); err != nil {
+				t.Fatalf("bindConfig failed: %v", err)
+			}
+
+			// Note: We can't fully test LoadGlobalConfig due to sync.Once,
+			// but we can verify it doesn't panic
+			LoadGlobalConfig()
+
+			cfg := Get()
+			if cfg == nil {
+				t.Error("Config is nil after LoadGlobalConfig")
+			}
+		})
+	}
+}
+
+func TestRegisterFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+
+	// Should not panic
+	RegisterFlags(cmd)
+
+	// Verify flags are registered
+	flags := []string{
+		"rabbitmq_address",
+		"prometheus_endpoint",
+		"prometheus_listen_address",
+		"database_dsn",
+		"redis_address",
+		"redis_password",
+		"redis_database",
+		"authtoken_messagebird",
+		"authtoken_telnyx",
+	}
+
+	for _, flag := range flags {
+		if cmd.PersistentFlags().Lookup(flag) == nil {
+			t.Errorf("Flag %s was not registered", flag)
+		}
+	}
+}
+
+func TestInitConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupEnv map[string]string
+	}{
+		{
+			name: "init_with_env",
+			setupEnv: map[string]string{
+				"RABBITMQ_ADDRESS": "amqp://localhost:5672",
+				"DATABASE_DSN":     "test-dsn",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper
+			viper.Reset()
+
+			// Set environment variables
+			for key, value := range tt.setupEnv {
+				_ = os.Setenv(key, value)
+				defer func(k string) {
+					_ = os.Unsetenv(k)
+				}(key)
+			}
+
+			cmd := &cobra.Command{Use: "test"}
+			RegisterFlags(cmd)
+
+			// Should not panic
+			InitConfig(cmd)
+		})
+	}
+}
+
+func TestConfigStruct(t *testing.T) {
+	cfg := Config{
+		DatabaseDSN:             "test-dsn",
+		PrometheusEndpoint:      "/metrics",
+		PrometheusListenAddress: ":2112",
+		RabbitMQAddress:         "amqp://localhost:5672",
+		RedisAddress:            "localhost:6379",
+		RedisDatabase:           0,
+		RedisPassword:           "password",
+		AuthtokenMessagebird:    "mb-token",
+		AuthtokenTelnyx:         "telnyx-token",
+	}
+
+	if cfg.DatabaseDSN != "test-dsn" {
+		t.Errorf("DatabaseDSN mismatch: got %v, want %v", cfg.DatabaseDSN, "test-dsn")
+	}
+	if cfg.PrometheusEndpoint != "/metrics" {
+		t.Errorf("PrometheusEndpoint mismatch: got %v, want %v", cfg.PrometheusEndpoint, "/metrics")
+	}
+	if cfg.PrometheusListenAddress != ":2112" {
+		t.Errorf("PrometheusListenAddress mismatch: got %v, want %v", cfg.PrometheusListenAddress, ":2112")
+	}
+	if cfg.RabbitMQAddress != "amqp://localhost:5672" {
+		t.Errorf("RabbitMQAddress mismatch: got %v, want %v", cfg.RabbitMQAddress, "amqp://localhost:5672")
+	}
+	if cfg.RedisAddress != "localhost:6379" {
+		t.Errorf("RedisAddress mismatch: got %v, want %v", cfg.RedisAddress, "localhost:6379")
+	}
+	if cfg.RedisDatabase != 0 {
+		t.Errorf("RedisDatabase mismatch: got %v, want %v", cfg.RedisDatabase, 0)
+	}
+	if cfg.RedisPassword != "password" {
+		t.Errorf("RedisPassword mismatch: got %v, want %v", cfg.RedisPassword, "password")
+	}
+	if cfg.AuthtokenMessagebird != "mb-token" {
+		t.Errorf("AuthtokenMessagebird mismatch: got %v, want %v", cfg.AuthtokenMessagebird, "mb-token")
+	}
+	if cfg.AuthtokenTelnyx != "telnyx-token" {
+		t.Errorf("AuthtokenTelnyx mismatch: got %v, want %v", cfg.AuthtokenTelnyx, "telnyx-token")
+	}
+}

--- a/bin-message-manager/models/message/filters_test.go
+++ b/bin-message-manager/models/message/filters_test.go
@@ -1,0 +1,119 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestFieldStruct(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields FieldStruct
+	}{
+		{
+			name: "all_fields",
+			fields: FieldStruct{
+				ID:                  uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000"),
+				CustomerID:          uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426614174000"),
+				Type:                TypeSMS,
+				Source:              "+1234567890",
+				ProviderName:        ProviderNameTelnyx,
+				ProviderReferenceID: "ref-123",
+				Direction:           DirectionOutbound,
+				Deleted:             false,
+			},
+		},
+		{
+			name: "minimal_fields",
+			fields: FieldStruct{
+				ID:         uuid.FromStringOrNil("323e4567-e89b-12d3-a456-426614174000"),
+				CustomerID: uuid.FromStringOrNil("423e4567-e89b-12d3-a456-426614174000"),
+			},
+		},
+		{
+			name: "with_deleted_flag",
+			fields: FieldStruct{
+				ID:       uuid.FromStringOrNil("523e4567-e89b-12d3-a456-426614174000"),
+				Deleted:  true,
+				Type:     TypeSMS,
+				Direction: DirectionInbound,
+			},
+		},
+		{
+			name: "messagebird_provider",
+			fields: FieldStruct{
+				ProviderName:        ProviderNameMessagebird,
+				ProviderReferenceID: "msgbird-ref-456",
+				Type:                TypeSMS,
+			},
+		},
+		{
+			name: "twilio_provider",
+			fields: FieldStruct{
+				ProviderName: ProviderNameTwilio,
+				Direction:    DirectionInbound,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Just verify that the struct can be created and accessed
+			if tt.fields.ID != uuid.Nil {
+				if tt.fields.ID == uuid.Nil {
+					t.Error("ID should not be Nil when set")
+				}
+			}
+
+			if tt.fields.CustomerID != uuid.Nil {
+				if tt.fields.CustomerID == uuid.Nil {
+					t.Error("CustomerID should not be Nil when set")
+				}
+			}
+
+			// Test that type values are preserved
+			if tt.fields.Type != "" {
+				if tt.fields.Type != TypeSMS {
+					t.Errorf("Type mismatch: got %v, want %v", tt.fields.Type, TypeSMS)
+				}
+			}
+
+			// Test provider names
+			if tt.fields.ProviderName != "" {
+				switch tt.fields.ProviderName {
+				case ProviderNameTelnyx, ProviderNameMessagebird, ProviderNameTwilio:
+					// Valid provider
+				default:
+					t.Errorf("Unexpected provider name: %v", tt.fields.ProviderName)
+				}
+			}
+
+			// Test direction values
+			if tt.fields.Direction != "" {
+				if tt.fields.Direction != DirectionInbound && tt.fields.Direction != DirectionOutbound {
+					t.Errorf("Invalid direction: %v", tt.fields.Direction)
+				}
+			}
+		})
+	}
+}
+
+func TestFieldStructFilterTags(t *testing.T) {
+	// Create a sample FieldStruct to verify it compiles
+	fs := FieldStruct{
+		ID:                  uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000"),
+		CustomerID:          uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426614174000"),
+		Type:                TypeSMS,
+		Source:              "+1234567890",
+		ProviderName:        ProviderNameTelnyx,
+		ProviderReferenceID: "ref-123",
+		Direction:           DirectionOutbound,
+		Deleted:             false,
+	}
+
+	// Verify that the struct was created successfully
+	if fs.ID == uuid.Nil {
+		t.Error("Failed to create FieldStruct with valid UUID")
+	}
+}

--- a/bin-message-manager/models/message/webhook_test.go
+++ b/bin-message-manager/models/message/webhook_test.go
@@ -1,0 +1,274 @@
+package message
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-message-manager/models/target"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tmCreate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	tmUpdate := time.Date(2024, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		message  *Message
+		expected *WebhookMessage
+	}{
+		{
+			name: "complete_message",
+			message: &Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000"),
+					CustomerID: uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426614174000"),
+				},
+				Type: TypeSMS,
+				Source: &commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+1234567890",
+				},
+				Targets: []target.Target{
+					{
+						Destination: commonaddress.Address{
+							Type:   commonaddress.TypeTel,
+							Target: "+0987654321",
+						},
+						Status: target.StatusSent,
+					},
+				},
+				ProviderName:        ProviderNameTelnyx,
+				ProviderReferenceID: "ref-12345",
+				Text:                "Test message",
+				Direction:           DirectionOutbound,
+				TMCreate:            &tmCreate,
+				TMUpdate:            &tmUpdate,
+			},
+			expected: &WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000"),
+					CustomerID: uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426614174000"),
+				},
+				Type: TypeSMS,
+				Source: &commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+1234567890",
+				},
+				Targets: []target.Target{
+					{
+						Destination: commonaddress.Address{
+							Type:   commonaddress.TypeTel,
+							Target: "+0987654321",
+						},
+						Status: target.StatusSent,
+					},
+				},
+				Text:      "Test message",
+				Direction: DirectionOutbound,
+				TMCreate:  &tmCreate,
+				TMUpdate:  &tmUpdate,
+			},
+		},
+		{
+			name: "minimal_message",
+			message: &Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("323e4567-e89b-12d3-a456-426614174000"),
+					CustomerID: uuid.FromStringOrNil("423e4567-e89b-12d3-a456-426614174000"),
+				},
+				Type:      TypeSMS,
+				Direction: DirectionInbound,
+			},
+			expected: &WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("323e4567-e89b-12d3-a456-426614174000"),
+					CustomerID: uuid.FromStringOrNil("423e4567-e89b-12d3-a456-426614174000"),
+				},
+				Type:      TypeSMS,
+				Direction: DirectionInbound,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.message.ConvertWebhookMessage()
+
+			// Check all fields
+			if result.ID != tt.expected.ID {
+				t.Errorf("ID mismatch: got %v, want %v", result.ID, tt.expected.ID)
+			}
+			if result.CustomerID != tt.expected.CustomerID {
+				t.Errorf("CustomerID mismatch: got %v, want %v", result.CustomerID, tt.expected.CustomerID)
+			}
+			if result.Type != tt.expected.Type {
+				t.Errorf("Type mismatch: got %v, want %v", result.Type, tt.expected.Type)
+			}
+			if result.Direction != tt.expected.Direction {
+				t.Errorf("Direction mismatch: got %v, want %v", result.Direction, tt.expected.Direction)
+			}
+			if result.Text != tt.expected.Text {
+				t.Errorf("Text mismatch: got %v, want %v", result.Text, tt.expected.Text)
+			}
+
+			// Check that provider info is NOT included
+			if result.TMCreate != tt.expected.TMCreate {
+				if (result.TMCreate == nil && tt.expected.TMCreate != nil) ||
+					(result.TMCreate != nil && tt.expected.TMCreate == nil) ||
+					!result.TMCreate.Equal(*tt.expected.TMCreate) {
+					t.Errorf("TMCreate mismatch: got %v, want %v", result.TMCreate, tt.expected.TMCreate)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	tmCreate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		message     *Message
+		expectError bool
+		checkJSON   bool
+	}{
+		{
+			name: "valid_message",
+			message: &Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000"),
+					CustomerID: uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426614174000"),
+				},
+				Type: TypeSMS,
+				Source: &commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+1234567890",
+				},
+				Targets: []target.Target{
+					{
+						Destination: commonaddress.Address{
+							Type:   commonaddress.TypeTel,
+							Target: "+0987654321",
+						},
+						Status: target.StatusSent,
+					},
+				},
+				Text:      "Test message",
+				Direction: DirectionOutbound,
+				TMCreate:  &tmCreate,
+			},
+			expectError: false,
+			checkJSON:   true,
+		},
+		{
+			name: "minimal_message",
+			message: &Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("323e4567-e89b-12d3-a456-426614174000"),
+					CustomerID: uuid.FromStringOrNil("423e4567-e89b-12d3-a456-426614174000"),
+				},
+				Type:      TypeSMS,
+				Direction: DirectionInbound,
+			},
+			expectError: false,
+			checkJSON:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.message.CreateWebhookEvent()
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result == nil {
+				t.Error("Expected non-nil result")
+				return
+			}
+
+			if tt.checkJSON {
+				// Verify it's valid JSON
+				var webhook WebhookMessage
+				if err := json.Unmarshal(result, &webhook); err != nil {
+					t.Errorf("Result is not valid JSON: %v", err)
+				}
+
+				// Verify essential fields are present
+				if webhook.ID != tt.message.ID {
+					t.Errorf("ID mismatch in JSON: got %v, want %v", webhook.ID, tt.message.ID)
+				}
+				if webhook.CustomerID != tt.message.CustomerID {
+					t.Errorf("CustomerID mismatch in JSON: got %v, want %v", webhook.CustomerID, tt.message.CustomerID)
+				}
+				if webhook.Type != tt.message.Type {
+					t.Errorf("Type mismatch in JSON: got %v, want %v", webhook.Type, tt.message.Type)
+				}
+			}
+		})
+	}
+}
+
+func TestWebhookMessageStruct(t *testing.T) {
+	tmCreate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	id := uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000")
+	customerID := uuid.FromStringOrNil("223e4567-e89b-12d3-a456-426614174000")
+
+	wm := WebhookMessage{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		Type: TypeSMS,
+		Source: &commonaddress.Address{
+			Type:   commonaddress.TypeTel,
+			Target: "+1234567890",
+		},
+		Targets: []target.Target{
+			{
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+0987654321",
+				},
+				Status: target.StatusSent,
+			},
+		},
+		Text:      "Test message",
+		Direction: DirectionOutbound,
+		TMCreate:  &tmCreate,
+	}
+
+	if wm.ID != id {
+		t.Errorf("ID mismatch: got %v, want %v", wm.ID, id)
+	}
+	if wm.CustomerID != customerID {
+		t.Errorf("CustomerID mismatch: got %v, want %v", wm.CustomerID, customerID)
+	}
+	if wm.Type != TypeSMS {
+		t.Errorf("Type mismatch: got %v, want %v", wm.Type, TypeSMS)
+	}
+	if wm.Direction != DirectionOutbound {
+		t.Errorf("Direction mismatch: got %v, want %v", wm.Direction, DirectionOutbound)
+	}
+	if wm.Text != "Test message" {
+		t.Errorf("Text mismatch: got %v, want %v", wm.Text, "Test message")
+	}
+	if wm.TMCreate == nil || !wm.TMCreate.Equal(tmCreate) {
+		t.Errorf("TMCreate mismatch: got %v, want %v", wm.TMCreate, tmCreate)
+	}
+}

--- a/bin-message-manager/pkg/listenhandler/main_test.go
+++ b/bin-message-manager/pkg/listenhandler/main_test.go
@@ -1,0 +1,195 @@
+package listenhandler
+
+import (
+	"testing"
+	"time"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"monorepo/bin-message-manager/pkg/messagehandler"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestNewListenHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+	h := NewListenHandler(mockSock, mockMessage)
+
+	if h == nil {
+		t.Error("Expected non-nil handler")
+	}
+}
+
+func TestSimpleResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"status_200", 200},
+		{"status_400", 400},
+		{"status_404", 404},
+		{"status_500", 500},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := simpleResponse(tt.statusCode)
+
+			if res == nil {
+				t.Error("Expected non-nil response")
+				return
+			}
+
+			if res.StatusCode != tt.statusCode {
+				t.Errorf("StatusCode mismatch: got %d, want %d", res.StatusCode, tt.statusCode)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name          string
+		queue         string
+		exchangeDelay string
+		queueError    error
+		expectError   bool
+	}{
+		{
+			name:          "successful_run",
+			queue:         "test-queue",
+			exchangeDelay: "test-exchange",
+			queueError:    nil,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:    mockSock,
+				messageHandler: mockMessage,
+			}
+
+			mockSock.EXPECT().QueueCreate(tt.queue, "normal").Return(tt.queueError)
+			// The ConsumeRPC call happens in a goroutine, so we need to expect it
+			// We use AnyTimes() because the goroutine may or may not run before test completes
+			mockSock.EXPECT().ConsumeRPC(gomock.Any(), tt.queue, constCosumerName, false, false, false, 10, gomock.Any()).
+				Return(nil).AnyTimes()
+
+			err := h.Run(tt.queue, tt.exchangeDelay)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			// Allow goroutine to start before finishing
+			time.Sleep(10 * time.Millisecond)
+			mc.Finish()
+		})
+	}
+}
+
+func TestProcessRequestNotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:    mockSock,
+		messageHandler: mockMessage,
+	}
+
+	req := &sock.Request{
+		Method: sock.RequestMethodGet,
+		URI:    "/unknown/path",
+		Data:   []byte(""),
+	}
+
+	res, err := h.processRequest(req)
+
+	if err != nil {
+		t.Errorf("Expected no error but got: %v", err)
+	}
+
+	if res == nil {
+		t.Error("Expected non-nil response")
+		return
+	}
+
+	if res.StatusCode != 404 {
+		t.Errorf("Expected status code 404, got %d", res.StatusCode)
+	}
+}
+
+func TestRegexPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		regexMatch  func(string) bool
+		shouldMatch bool
+	}{
+		{
+			name:        "messages_get_with_query",
+			uri:         "/v1/messages?page_size=10",
+			regexMatch:  regV1MessagesGet.MatchString,
+			shouldMatch: true,
+		},
+		{
+			name:        "messages_post",
+			uri:         "/v1/messages",
+			regexMatch:  regV1Messages.MatchString,
+			shouldMatch: true,
+		},
+		{
+			name:        "messages_id",
+			uri:         "/v1/messages/123e4567-e89b-12d3-a456-426614174000",
+			regexMatch:  regV1MessagesID.MatchString,
+			shouldMatch: true,
+		},
+		{
+			name:        "hooks_post",
+			uri:         "/v1/hooks",
+			regexMatch:  regV1Hooks.MatchString,
+			shouldMatch: true,
+		},
+		{
+			name:        "invalid_messages_id",
+			uri:         "/v1/messages/invalid-uuid",
+			regexMatch:  regV1MessagesID.MatchString,
+			shouldMatch: false,
+		},
+		{
+			name:        "messages_get_no_query",
+			uri:         "/v1/messages",
+			regexMatch:  regV1MessagesGet.MatchString,
+			shouldMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := tt.regexMatch(tt.uri)
+
+			if matched != tt.shouldMatch {
+				t.Errorf("Regex match mismatch for URI %s: got %v, want %v", tt.uri, matched, tt.shouldMatch)
+			}
+		})
+	}
+}

--- a/bin-message-manager/pkg/messagehandler/message_test.go
+++ b/bin-message-manager/pkg/messagehandler/message_test.go
@@ -8,6 +8,7 @@ import (
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
@@ -17,6 +18,7 @@ import (
 	"monorepo/bin-message-manager/models/target"
 	"monorepo/bin-message-manager/pkg/dbhandler"
 	"monorepo/bin-message-manager/pkg/messagehandlermessagebird"
+	"monorepo/bin-message-manager/pkg/requestexternal"
 )
 
 func Test_Create(t *testing.T) {
@@ -126,5 +128,21 @@ func Test_Create(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.responseMessage, res)
 			}
 		})
+	}
+}
+
+func TestNewMessageHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+	h := NewMessageHandler(mockReq, mockNotify, mockDB, mockExternal)
+
+	if h == nil {
+		t.Error("Expected non-nil handler")
 	}
 }

--- a/bin-message-manager/pkg/messagehandler/provider_messagebird_test.go
+++ b/bin-message-manager/pkg/messagehandler/provider_messagebird_test.go
@@ -1,0 +1,188 @@
+package messagehandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-message-manager/models/messagebird"
+	"monorepo/bin-message-manager/models/target"
+	"monorepo/bin-message-manager/pkg/requestexternal"
+)
+
+func TestNewMessageHandlerMessagebird(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+	h := NewMessageHandlerMessagebird(mockExternal)
+
+	if h == nil {
+		t.Error("Expected non-nil handler")
+	}
+}
+
+func TestMessageHandlerMessagebird_SendMessage(t *testing.T) {
+	messageID := uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000")
+
+	tests := []struct {
+		name            string
+		messageID       uuid.UUID
+		source          *commonaddress.Address
+		targets         []target.Target
+		text            string
+		messagebirdResp *messagebird.Message
+		messagebirdErr  error
+		expectError     bool
+		expectCount     int
+	}{
+		{
+			name:      "successful_send",
+			messageID: messageID,
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1234567890",
+			},
+			targets: []target.Target{
+				{
+					Destination: commonaddress.Address{
+						Type:   commonaddress.TypeTel,
+						Target: "+0987654321",
+					},
+					Status: target.StatusQueued,
+				},
+			},
+			text: "Test message",
+			messagebirdResp: &messagebird.Message{
+				ID: "msg-123",
+				Recipients: messagebird.RecipientStruct{
+					TotalCount: 1,
+					Items: []messagebird.Recipient{
+						{
+							Recipient: 987654321,
+							Status:    "sent",
+						},
+					},
+				},
+			},
+			messagebirdErr: nil,
+			expectError:    false,
+			expectCount:    1,
+		},
+		{
+			name:      "multiple_targets",
+			messageID: messageID,
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1234567890",
+			},
+			targets: []target.Target{
+				{
+					Destination: commonaddress.Address{
+						Type:   commonaddress.TypeTel,
+						Target: "+0987654321",
+					},
+					Status: target.StatusQueued,
+				},
+				{
+					Destination: commonaddress.Address{
+						Type:   commonaddress.TypeTel,
+						Target: "+1111111111",
+					},
+					Status: target.StatusQueued,
+				},
+			},
+			text: "Test message",
+			messagebirdResp: &messagebird.Message{
+				ID: "msg-456",
+				Recipients: messagebird.RecipientStruct{
+					TotalCount: 2,
+					Items: []messagebird.Recipient{
+						{
+							Recipient: 987654321,
+							Status:    "sent",
+						},
+						{
+							Recipient: 1111111111,
+							Status:    "sent",
+						},
+					},
+				},
+			},
+			messagebirdErr: nil,
+			expectError:    false,
+			expectCount:    2,
+		},
+		{
+			name:      "messagebird_error",
+			messageID: messageID,
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1234567890",
+			},
+			targets: []target.Target{
+				{
+					Destination: commonaddress.Address{
+						Type:   commonaddress.TypeTel,
+						Target: "+0987654321",
+					},
+					Status: target.StatusQueued,
+				},
+			},
+			text:            "Test message",
+			messagebirdResp: nil,
+			messagebirdErr:  fmt.Errorf("messagebird api error"),
+			expectError:     true,
+			expectCount:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+			h := &messageHandlerMessagebird{
+				requestExternal: mockExternal,
+			}
+
+			ctx := context.Background()
+
+			// Build expected receivers list
+			receivers := []string{}
+			for _, tgt := range tt.targets {
+				receivers = append(receivers, tgt.Destination.Target)
+			}
+
+			mockExternal.EXPECT().
+				MessagebirdSendMessage(ctx, tt.source.Target, receivers, tt.text).
+				Return(tt.messagebirdResp, tt.messagebirdErr)
+
+			result, err := h.SendMessage(ctx, tt.messageID, tt.source, tt.targets, tt.text)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != tt.expectCount {
+				t.Errorf("Result count mismatch: got %d, want %d", len(result), tt.expectCount)
+			}
+		})
+	}
+}

--- a/bin-message-manager/pkg/messagehandler/provider_telnyx_test.go
+++ b/bin-message-manager/pkg/messagehandler/provider_telnyx_test.go
@@ -1,0 +1,194 @@
+package messagehandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-message-manager/models/target"
+	"monorepo/bin-message-manager/models/telnyx"
+	"monorepo/bin-message-manager/pkg/requestexternal"
+)
+
+func TestNewMessageHandlerTelnyx(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+	h := NewMessageHandlerTelnyx(mockExternal)
+
+	if h == nil {
+		t.Error("Expected non-nil handler")
+	}
+}
+
+func TestMessageHandlerTelnyx_SendMessage(t *testing.T) {
+	messageID := uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000")
+
+	tests := []struct {
+		name         string
+		messageID    uuid.UUID
+		source       *commonaddress.Address
+		targets      []target.Target
+		text         string
+		telnyxResp   *telnyx.MessageResponse
+		telnyxErr    error
+		expectError  bool
+		expectCount  int
+	}{
+		{
+			name:      "successful_single_send",
+			messageID: messageID,
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1234567890",
+			},
+			targets: []target.Target{
+				{
+					Destination: commonaddress.Address{
+						Type:   commonaddress.TypeTel,
+						Target: "+0987654321",
+					},
+					Status: target.StatusQueued,
+				},
+			},
+			text: "Test message",
+			telnyxResp: &telnyx.MessageResponse{
+				Data: telnyx.MessageData{
+					ID: "telnyx-msg-123",
+				},
+			},
+			telnyxErr:   nil,
+			expectError: false,
+			expectCount: 1,
+		},
+		{
+			name:      "telnyx_error",
+			messageID: messageID,
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1234567890",
+			},
+			targets: []target.Target{
+				{
+					Destination: commonaddress.Address{
+						Type:   commonaddress.TypeTel,
+						Target: "+0987654321",
+					},
+					Status: target.StatusQueued,
+				},
+			},
+			text:        "Test message",
+			telnyxResp:  nil,
+			telnyxErr:   fmt.Errorf("telnyx api error"),
+			expectError: true,
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+			h := &messageHandlerTelnyx{
+				requestExternal: mockExternal,
+			}
+
+			ctx := context.Background()
+
+			// Setup expectations for each target
+			for _, tgt := range tt.targets {
+				mockExternal.EXPECT().
+					TelnyxSendMessage(ctx, tt.source.Target, tgt.Destination.Target, tt.text).
+					Return(tt.telnyxResp, tt.telnyxErr)
+			}
+
+			result, err := h.SendMessage(ctx, tt.messageID, tt.source, tt.targets, tt.text)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != tt.expectCount {
+				t.Errorf("Result count mismatch: got %d, want %d", len(result), tt.expectCount)
+			}
+		})
+	}
+}
+
+func TestMessageHandlerTelnyx_SendMessage_MultipleTargets(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+	h := &messageHandlerTelnyx{
+		requestExternal: mockExternal,
+	}
+
+	ctx := context.Background()
+	messageID := uuid.FromStringOrNil("123e4567-e89b-12d3-a456-426614174000")
+
+	source := &commonaddress.Address{
+		Type:   commonaddress.TypeTel,
+		Target: "+1234567890",
+	}
+
+	targets := []target.Target{
+		{
+			Destination: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+0987654321",
+			},
+			Status: target.StatusQueued,
+		},
+		{
+			Destination: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1111111111",
+			},
+			Status: target.StatusQueued,
+		},
+	}
+
+	text := "Test message to multiple recipients"
+
+	// Mock successful responses for both targets
+	for _, tgt := range targets {
+		mockExternal.EXPECT().
+			TelnyxSendMessage(ctx, source.Target, tgt.Destination.Target, text).
+			Return(&telnyx.MessageResponse{
+				Data: telnyx.MessageData{
+					ID: "telnyx-msg-" + tgt.Destination.Target,
+				},
+			}, nil)
+	}
+
+	result, err := h.SendMessage(ctx, messageID, source, targets, text)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	if len(result) != 2 {
+		t.Errorf("Expected 2 results, got %d", len(result))
+	}
+}

--- a/bin-message-manager/pkg/messagehandlermessagebird/main_test.go
+++ b/bin-message-manager/pkg/messagehandlermessagebird/main_test.go
@@ -1,0 +1,44 @@
+package messagehandlermessagebird
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-message-manager/pkg/dbhandler"
+	"monorepo/bin-message-manager/pkg/requestexternal"
+)
+
+func TestNewMessageHandlerMessagebird(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockExternal := requestexternal.NewMockRequestExternal(mc)
+
+	h := NewMessageHandlerMessagebird(mockReq, mockDB, mockExternal)
+
+	if h == nil {
+		t.Error("Expected non-nil handler")
+	}
+
+	// Verify the handler is properly initialized
+	handler, ok := h.(*messageHandlerMessagebird)
+	if !ok {
+		t.Error("Handler is not of type *messageHandlerMessagebird")
+		return
+	}
+
+	if handler.reqHandler == nil {
+		t.Error("reqHandler is nil")
+	}
+	if handler.db == nil {
+		t.Error("db is nil")
+	}
+	if handler.requestExternal == nil {
+		t.Error("requestExternal is nil")
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-message-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-message-manager: Add unit tests for improved package-level coverage