### PR TITLE
NOJIRA-Test-coverage-number-manager

### DIFF
--- a/bin-number-manager/internal/config/main_test.go
+++ b/bin-number-manager/internal/config/main_test.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestGet(t *testing.T) {
+	config := Get()
+	if config == nil {
+		t.Error("Expected non-nil config")
+	}
+}
+
+func TestLoadGlobalConfig(t *testing.T) {
+	// Reset viper for testing
+	viper.Reset()
+
+	// Set some test values
+	viper.Set("rabbitmq_address", "amqp://test")
+	viper.Set("prometheus_endpoint", "/metrics")
+	viper.Set("prometheus_listen_address", ":8080")
+	viper.Set("database_dsn", "test_dsn")
+	viper.Set("redis_address", "localhost:6379")
+	viper.Set("redis_password", "test_pass")
+	viper.Set("redis_database", 1)
+	viper.Set("twilio_sid", "test_sid")
+	viper.Set("twilio_token", "test_token")
+	viper.Set("telnyx_connection_id", "test_conn_id")
+	viper.Set("telnyx_profile_id", "test_profile_id")
+	viper.Set("telnyx_token", "test_telnyx_token")
+
+	// Reset the once to allow re-execution
+	once = *new(sync.Once)
+
+	LoadGlobalConfig()
+
+	config := Get()
+	if config.RabbitMQAddress != "amqp://test" {
+		t.Errorf("Expected RabbitMQAddress to be 'amqp://test', got '%s'", config.RabbitMQAddress)
+	}
+	if config.PrometheusEndpoint != "/metrics" {
+		t.Errorf("Expected PrometheusEndpoint to be '/metrics', got '%s'", config.PrometheusEndpoint)
+	}
+	if config.PrometheusListenAddress != ":8080" {
+		t.Errorf("Expected PrometheusListenAddress to be ':8080', got '%s'", config.PrometheusListenAddress)
+	}
+	if config.DatabaseDSN != "test_dsn" {
+		t.Errorf("Expected DatabaseDSN to be 'test_dsn', got '%s'", config.DatabaseDSN)
+	}
+	if config.RedisAddress != "localhost:6379" {
+		t.Errorf("Expected RedisAddress to be 'localhost:6379', got '%s'", config.RedisAddress)
+	}
+	if config.RedisPassword != "test_pass" {
+		t.Errorf("Expected RedisPassword to be 'test_pass', got '%s'", config.RedisPassword)
+	}
+	if config.RedisDatabase != 1 {
+		t.Errorf("Expected RedisDatabase to be 1, got %d", config.RedisDatabase)
+	}
+	if config.TwilioSID != "test_sid" {
+		t.Errorf("Expected TwilioSID to be 'test_sid', got '%s'", config.TwilioSID)
+	}
+	if config.TwilioToken != "test_token" {
+		t.Errorf("Expected TwilioToken to be 'test_token', got '%s'", config.TwilioToken)
+	}
+	if config.TelnyxConnectionID != "test_conn_id" {
+		t.Errorf("Expected TelnyxConnectionID to be 'test_conn_id', got '%s'", config.TelnyxConnectionID)
+	}
+	if config.TelnyxProfileID != "test_profile_id" {
+		t.Errorf("Expected TelnyxProfileID to be 'test_profile_id', got '%s'", config.TelnyxProfileID)
+	}
+	if config.TelnyxToken != "test_telnyx_token" {
+		t.Errorf("Expected TelnyxToken to be 'test_telnyx_token', got '%s'", config.TelnyxToken)
+	}
+}
+
+func TestBootstrap(t *testing.T) {
+	viper.Reset()
+
+	cmd := &cobra.Command{}
+
+	err := Bootstrap(cmd)
+	if err != nil {
+		t.Errorf("Expected no error from Bootstrap, got %v", err)
+	}
+
+	// Verify flags were created
+	flag := cmd.PersistentFlags().Lookup("rabbitmq_address")
+	if flag == nil {
+		t.Error("Expected rabbitmq_address flag to be defined")
+	}
+
+	flag = cmd.PersistentFlags().Lookup("database_dsn")
+	if flag == nil {
+		t.Error("Expected database_dsn flag to be defined")
+	}
+}
+
+func TestBindConfig(t *testing.T) {
+	viper.Reset()
+
+	cmd := &cobra.Command{}
+
+	err := bindConfig(cmd)
+	if err != nil {
+		t.Errorf("Expected no error from bindConfig, got %v", err)
+	}
+
+	// Verify all expected flags are created
+	expectedFlags := []string{
+		"rabbitmq_address",
+		"prometheus_endpoint",
+		"prometheus_listen_address",
+		"database_dsn",
+		"redis_address",
+		"redis_password",
+		"redis_database",
+		"twilio_sid",
+		"twilio_token",
+		"telnyx_connection_id",
+		"telnyx_profile_id",
+		"telnyx_token",
+	}
+
+	for _, flagName := range expectedFlags {
+		flag := cmd.PersistentFlags().Lookup(flagName)
+		if flag == nil {
+			t.Errorf("Expected flag '%s' to be defined", flagName)
+		}
+	}
+}

--- a/bin-number-manager/models/availablenumber/available_number_test.go
+++ b/bin-number-manager/models/availablenumber/available_number_test.go
@@ -1,0 +1,175 @@
+package availablenumber
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"monorepo/bin-number-manager/models/number"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *AvailableNumber
+		expected *WebhookMessage
+	}{
+		{
+			name: "basic conversion",
+			input: &AvailableNumber{
+				Number:       "+15551234567",
+				ProviderName: number.ProviderNameTelnyx,
+				Country:      "US",
+				Region:       "CA",
+				PostalCode:   "94105",
+				Features:     []Feature{FeatureVoice, FeatureSMS},
+			},
+			expected: &WebhookMessage{
+				Number:     "+15551234567",
+				Country:    "US",
+				Region:     "CA",
+				PostalCode: "94105",
+				Features:   []Feature{FeatureVoice, FeatureSMS},
+			},
+		},
+		{
+			name: "with all features",
+			input: &AvailableNumber{
+				Number:       "+15551234567",
+				ProviderName: number.ProviderNameTelnyx,
+				Country:      "US",
+				Region:       "NY",
+				PostalCode:   "10001",
+				Features:     []Feature{FeatureVoice, FeatureSMS, FeatureMMS, FeatureFax, FeatureEmergency},
+			},
+			expected: &WebhookMessage{
+				Number:     "+15551234567",
+				Country:    "US",
+				Region:     "NY",
+				PostalCode: "10001",
+				Features:   []Feature{FeatureVoice, FeatureSMS, FeatureMMS, FeatureFax, FeatureEmergency},
+			},
+		},
+		{
+			name: "empty features",
+			input: &AvailableNumber{
+				Number:       "+15551234567",
+				ProviderName: number.ProviderNameTelnyx,
+				Country:      "US",
+				Region:       "TX",
+				PostalCode:   "75001",
+				Features:     []Feature{},
+			},
+			expected: &WebhookMessage{
+				Number:     "+15551234567",
+				Country:    "US",
+				Region:     "TX",
+				PostalCode: "75001",
+				Features:   []Feature{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.input.ConvertWebhookMessage()
+			if result.Number != tt.expected.Number {
+				t.Errorf("Expected Number %v, got %v", tt.expected.Number, result.Number)
+			}
+			if result.Country != tt.expected.Country {
+				t.Errorf("Expected Country %v, got %v", tt.expected.Country, result.Country)
+			}
+			if result.Region != tt.expected.Region {
+				t.Errorf("Expected Region %v, got %v", tt.expected.Region, result.Region)
+			}
+			if result.PostalCode != tt.expected.PostalCode {
+				t.Errorf("Expected PostalCode %v, got %v", tt.expected.PostalCode, result.PostalCode)
+			}
+			if len(result.Features) != len(tt.expected.Features) {
+				t.Errorf("Expected %d features, got %d", len(tt.expected.Features), len(result.Features))
+			}
+		})
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     *AvailableNumber
+		shouldErr bool
+	}{
+		{
+			name: "valid available number",
+			input: &AvailableNumber{
+				Number:       "+15551234567",
+				ProviderName: number.ProviderNameTelnyx,
+				Country:      "US",
+				Region:       "CA",
+				PostalCode:   "94105",
+				Features:     []Feature{FeatureVoice, FeatureSMS},
+			},
+			shouldErr: false,
+		},
+		{
+			name: "with timestamps",
+			input: &AvailableNumber{
+				Number:       "+15551234567",
+				ProviderName: number.ProviderNameTelnyx,
+				Country:      "US",
+				Region:       "NY",
+				PostalCode:   "10001",
+				Features:     []Feature{FeatureVoice},
+				TMCreate:     timePtr(time.Now()),
+				TMUpdate:     timePtr(time.Now()),
+			},
+			shouldErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.input.CreateWebhookEvent()
+			if tt.shouldErr && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.shouldErr && err != nil {
+				t.Errorf("Expected no error but got %v", err)
+			}
+			if !tt.shouldErr {
+				// Verify it's valid JSON
+				var msg WebhookMessage
+				if err := json.Unmarshal(data, &msg); err != nil {
+					t.Errorf("Failed to unmarshal webhook event: %v", err)
+				}
+				if msg.Number != tt.input.Number {
+					t.Errorf("Expected Number %v, got %v", tt.input.Number, msg.Number)
+				}
+			}
+		})
+	}
+}
+
+func TestFeatureConstants(t *testing.T) {
+	tests := []struct {
+		feature  Feature
+		expected string
+	}{
+		{FeatureEmergency, "emergency"},
+		{FeatureFax, "fax"},
+		{FeatureMMS, "mms"},
+		{FeatureSMS, "sms"},
+		{FeatureVoice, "voice"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.feature), func(t *testing.T) {
+			if string(tt.feature) != tt.expected {
+				t.Errorf("Expected feature %v, got %v", tt.expected, string(tt.feature))
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/bin-number-manager/models/providernumber/provider_number_test.go
+++ b/bin-number-manager/models/providernumber/provider_number_test.go
@@ -1,0 +1,79 @@
+package providernumber
+
+import (
+	"testing"
+
+	"monorepo/bin-number-manager/models/number"
+)
+
+func TestProviderNumberStruct(t *testing.T) {
+	tests := []struct {
+		name   string
+		number ProviderNumber
+	}{
+		{
+			name: "basic provider number",
+			number: ProviderNumber{
+				ID:               "test-id-123",
+				Status:           number.StatusActive,
+				T38Enabled:       true,
+				EmergencyEnabled: false,
+			},
+		},
+		{
+			name: "provider number with emergency",
+			number: ProviderNumber{
+				ID:               "test-id-456",
+				Status:           number.StatusActive,
+				T38Enabled:       false,
+				EmergencyEnabled: true,
+			},
+		},
+		{
+			name: "deleted provider number",
+			number: ProviderNumber{
+				ID:               "test-id-789",
+				Status:           number.StatusDeleted,
+				T38Enabled:       false,
+				EmergencyEnabled: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Verify all fields are set correctly
+			if tt.number.ID == "" {
+				t.Error("Expected ID to be set")
+			}
+			if tt.number.Status == "" {
+				t.Error("Expected Status to be set")
+			}
+			// Just verify the struct can be created and accessed
+			_ = tt.number.T38Enabled
+			_ = tt.number.EmergencyEnabled
+		})
+	}
+}
+
+func TestProviderNumberFields(t *testing.T) {
+	pn := ProviderNumber{
+		ID:               "unique-id",
+		Status:           number.StatusActive,
+		T38Enabled:       true,
+		EmergencyEnabled: true,
+	}
+
+	if pn.ID != "unique-id" {
+		t.Errorf("Expected ID to be 'unique-id', got '%s'", pn.ID)
+	}
+	if pn.Status != number.StatusActive {
+		t.Errorf("Expected Status to be StatusActive, got %v", pn.Status)
+	}
+	if !pn.T38Enabled {
+		t.Error("Expected T38Enabled to be true")
+	}
+	if !pn.EmergencyEnabled {
+		t.Error("Expected EmergencyEnabled to be true")
+	}
+}

--- a/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
+++ b/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
@@ -622,3 +622,161 @@ func Test_processV1NumbersRenewPost(t *testing.T) {
 		})
 	}
 }
+
+func Test_processV1NumbersPost_VirtualType(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	customerID := uuid.FromStringOrNil("72f3b054-7ff4-11ec-9af9-0b8c5dbee258")
+	callFlowID := uuid.FromStringOrNil("7051e796-8821-11ec-9b7d-d322b1036e7d")
+	messageFlowID := uuid.FromStringOrNil("c5f1dffc-a866-11ec-be0a-a3c412cba4dc")
+	num := "+999123456789"
+
+	createdNumber := &number.Number{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("3a379dce-792a-11eb-a8e1-9f51cab620f8"),
+			CustomerID: customerID,
+		},
+		Number:       num,
+		Type:         number.TypeVirtual,
+		CallFlowID:   callFlowID,
+		Status:       number.StatusActive,
+		ProviderName: number.ProviderNameNone,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/numbers",
+		Method:   sock.RequestMethodPost,
+		DataType: "application/json",
+		Data:     []byte(`{"customer_id": "72f3b054-7ff4-11ec-9af9-0b8c5dbee258", "call_flow_id": "7051e796-8821-11ec-9b7d-d322b1036e7d", "message_flow_id": "c5f1dffc-a866-11ec-be0a-a3c412cba4dc", "number": "+999123456789", "name": "", "detail": "", "type": "virtual"}`),
+	}
+
+	mockNumber.EXPECT().CreateVirtual(gomock.Any(), customerID, num, callFlowID, messageFlowID, "", "", false).Return(createdNumber, nil)
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("Expected status 200, got %d", res.StatusCode)
+	}
+}
+
+func Test_processV1NumbersPost_InvalidJSON(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/numbers",
+		Method:   sock.RequestMethodPost,
+		DataType: "application/json",
+		Data:     []byte(`{invalid json`),
+	}
+
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("Expected status 400, got %d", res.StatusCode)
+	}
+}
+
+func Test_processV1NumbersIDPut_InvalidJSON(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/numbers/935190b4-7c58-11eb-8b90-f777a56fe90f",
+		Method:   sock.RequestMethodPut,
+		DataType: "application/json",
+		Data:     []byte(`{invalid`),
+	}
+
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("Expected status 400, got %d", res.StatusCode)
+	}
+}
+
+func Test_processV1NumbersIDFlowIDsPut_InvalidJSON(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/numbers/935190b4-7c58-11eb-8b90-f777a56fe90f/flow_ids",
+		Method:   sock.RequestMethodPut,
+		DataType: "application/json",
+		Data:     []byte(`{invalid`),
+	}
+
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("Expected status 400, got %d", res.StatusCode)
+	}
+}
+
+func Test_processV1NumbersRenewPost_InvalidJSON(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/numbers/renew",
+		Method:   sock.RequestMethodPost,
+		DataType: "application/json",
+		Data:     []byte(`{invalid`),
+	}
+
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("Expected status 400, got %d", res.StatusCode)
+	}
+}

--- a/bin-number-manager/pkg/subscribehandler/customer_manager_test.go
+++ b/bin-number-manager/pkg/subscribehandler/customer_manager_test.go
@@ -1,13 +1,15 @@
 package subscribehandler
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
-	cucustomer "monorepo/bin-customer-manager/models/customer"
+	cmcustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -21,19 +23,19 @@ func Test_processEvent_processEventCUCustomerDeleted(t *testing.T) {
 		name  string
 		event *sock.Event
 
-		expectCustomer *cucustomer.Customer
+		expectCustomer *cmcustomer.Customer
 	}{
 		{
 			name: "normal",
 
 			event: &sock.Event{
 				Publisher: string(commonoutline.ServiceNameCustomerManager),
-				Type:      cucustomer.EventTypeCustomerDeleted,
+				Type:      cmcustomer.EventTypeCustomerDeleted,
 				DataType:  "application/json",
 				Data:      []byte(`{"id":"c7e1cd82-ecb5-11ee-8425-779e09b1f43b"}`),
 			},
 
-			expectCustomer: &cucustomer.Customer{
+			expectCustomer: &cmcustomer.Customer{
 				ID: uuid.FromStringOrNil("c7e1cd82-ecb5-11ee-8425-779e09b1f43b"),
 			},
 		},
@@ -56,5 +58,61 @@ func Test_processEvent_processEventCUCustomerDeleted(t *testing.T) {
 
 			h.processEvent(tt.event)
 		})
+	}
+}
+
+func Test_processEventCUCustomerDeleted_UnmarshalError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := subscribeHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	event := &sock.Event{
+		Publisher: "customer-manager",
+		Type:      string(cmcustomer.EventTypeCustomerDeleted),
+		DataType:  "application/json",
+		Data:      []byte(`{invalid json`),
+	}
+
+	err := h.processEventCUCustomerDeleted(context.Background(), event)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func Test_processEventCUCustomerDeleted_HandlerError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := subscribeHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	customer := &cmcustomer.Customer{
+		ID: uuid.FromStringOrNil("12345678-1234-1234-1234-123456789012"),
+	}
+
+	event := &sock.Event{
+		Publisher: "customer-manager",
+		Type:      string(cmcustomer.EventTypeCustomerDeleted),
+		DataType:  "application/json",
+		Data:      []byte(`{"id":"12345678-1234-1234-1234-123456789012"}`),
+	}
+
+	mockNumber.EXPECT().EventCustomerDeleted(gomock.Any(), customer).Return(fmt.Errorf("handler error"))
+
+	err := h.processEventCUCustomerDeleted(context.Background(), event)
+	if err == nil {
+		t.Error("Expected error from handler, got nil")
 	}
 }

--- a/bin-number-manager/pkg/subscribehandler/flow_manager_test.go
+++ b/bin-number-manager/pkg/subscribehandler/flow_manager_test.go
@@ -1,6 +1,8 @@
 package subscribehandler
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
@@ -58,5 +60,63 @@ func Test_processEvent_processEventFMFlowDeleted(t *testing.T) {
 
 			h.processEvent(tt.event)
 		})
+	}
+}
+
+func Test_processEventFMFlowDeleted_UnmarshalError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := subscribeHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	event := &sock.Event{
+		Publisher: "flow-manager",
+		Type:      fmflow.EventTypeFlowDeleted,
+		DataType:  "application/json",
+		Data:      []byte(`{invalid json`),
+	}
+
+	err := h.processEventFMFlowDeleted(context.Background(), event)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func Test_processEventFMFlowDeleted_HandlerError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+	h := subscribeHandler{
+		sockHandler:   mockSock,
+		numberHandler: mockNumber,
+	}
+
+	flow := &fmflow.Flow{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("7d08051c-2d64-11ee-92d1-bf5dc689d1d5"),
+		},
+	}
+
+	event := &sock.Event{
+		Publisher: "flow-manager",
+		Type:      fmflow.EventTypeFlowDeleted,
+		DataType:  "application/json",
+		Data:      []byte(`{"id":"7d08051c-2d64-11ee-92d1-bf5dc689d1d5"}`),
+	}
+
+	mockNumber.EXPECT().EventFlowDeleted(gomock.Any(), flow).Return(fmt.Errorf("handler error"))
+
+	err := h.processEventFMFlowDeleted(context.Background(), event)
+	if err == nil {
+		t.Error("Expected error from handler, got nil")
 	}
 }


### PR DESCRIPTION
Increase test coverage for bin-number-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-number-manager: Add unit tests for improved package-level coverage