### PR TITLE
NOJIRA-Test-coverage-transcribe-manager

### DIFF
--- a/bin-transcribe-manager/internal/config/main_test.go
+++ b/bin-transcribe-manager/internal/config/main_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestGet(t *testing.T) {
+	cfg := Get()
+	if cfg == nil {
+		t.Error("Get() returned nil")
+	}
+}
+
+func TestBootstrap(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "successful_bootstrap",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper for each test
+			viper.Reset()
+
+			cmd := &cobra.Command{}
+			err := Bootstrap(cmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Bootstrap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBindConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "successful_bind",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			cmd := &cobra.Command{}
+			err := bindConfig(cmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bindConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInitLog(t *testing.T) {
+	// This just ensures initLog doesn't panic
+	initLog()
+}

--- a/bin-transcribe-manager/models/transcribe/webhook_test.go
+++ b/bin-transcribe-manager/models/transcribe/webhook_test.go
@@ -1,0 +1,103 @@
+package transcribe
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	onEndFlowID := uuid.Must(uuid.NewV4())
+	referenceID := uuid.Must(uuid.NewV4())
+
+	tmCreate := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tr := &Transcribe{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		ActiveflowID:  activeflowID,
+		OnEndFlowID:   onEndFlowID,
+		ReferenceType: ReferenceTypeCall,
+		ReferenceID:   referenceID,
+		Status:        StatusProgressing,
+		Language:      "en-US",
+		Direction:     DirectionBoth,
+		TMCreate:      &tmCreate,
+		TMUpdate:      nil,
+		TMDelete:      nil,
+	}
+
+	msg := tr.ConvertWebhookMessage()
+
+	if msg.ID != id {
+		t.Errorf("ConvertWebhookMessage().ID = %v, expected %v", msg.ID, id)
+	}
+	if msg.CustomerID != customerID {
+		t.Errorf("ConvertWebhookMessage().CustomerID = %v, expected %v", msg.CustomerID, customerID)
+	}
+	if msg.ActiveflowID != activeflowID {
+		t.Errorf("ConvertWebhookMessage().ActiveflowID = %v, expected %v", msg.ActiveflowID, activeflowID)
+	}
+	if msg.OnEndFlowID != onEndFlowID {
+		t.Errorf("ConvertWebhookMessage().OnEndFlowID = %v, expected %v", msg.OnEndFlowID, onEndFlowID)
+	}
+	if msg.ReferenceType != ReferenceTypeCall {
+		t.Errorf("ConvertWebhookMessage().ReferenceType = %v, expected %v", msg.ReferenceType, ReferenceTypeCall)
+	}
+	if msg.ReferenceID != referenceID {
+		t.Errorf("ConvertWebhookMessage().ReferenceID = %v, expected %v", msg.ReferenceID, referenceID)
+	}
+	if msg.Status != StatusProgressing {
+		t.Errorf("ConvertWebhookMessage().Status = %v, expected %v", msg.Status, StatusProgressing)
+	}
+	if msg.Language != "en-US" {
+		t.Errorf("ConvertWebhookMessage().Language = %v, expected %v", msg.Language, "en-US")
+	}
+	if msg.Direction != DirectionBoth {
+		t.Errorf("ConvertWebhookMessage().Direction = %v, expected %v", msg.Direction, DirectionBoth)
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+
+	tr := &Transcribe{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		ReferenceType: ReferenceTypeCall,
+		ReferenceID:   uuid.Must(uuid.NewV4()),
+		Status:        StatusProgressing,
+		Language:      "en-US",
+		Direction:     DirectionIn,
+	}
+
+	data, err := tr.CreateWebhookEvent()
+	if err != nil {
+		t.Errorf("CreateWebhookEvent() error = %v, expected nil", err)
+	}
+	if data == nil {
+		t.Error("CreateWebhookEvent() returned nil data")
+	}
+
+	// Verify it's valid JSON
+	var msg WebhookMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Errorf("CreateWebhookEvent() produced invalid JSON: %v", err)
+	}
+
+	if msg.ID != id {
+		t.Errorf("CreateWebhookEvent() ID = %v, expected %v", msg.ID, id)
+	}
+}

--- a/bin-transcribe-manager/models/transcript/webhook_test.go
+++ b/bin-transcribe-manager/models/transcript/webhook_test.go
@@ -1,0 +1,84 @@
+package transcript
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestConvertWebhookMessage(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	transcribeID := uuid.Must(uuid.NewV4())
+
+	tmTranscript := time.Date(2023, 1, 1, 0, 0, 1, 0, time.UTC)
+	tmCreate := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tr := &Transcript{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		TranscribeID: transcribeID,
+		Direction:    DirectionIn,
+		Message:      "test message",
+		TMTranscript: &tmTranscript,
+		TMCreate:     &tmCreate,
+	}
+
+	msg := tr.ConvertWebhookMessage()
+
+	if msg.ID != id {
+		t.Errorf("ConvertWebhookMessage().ID = %v, expected %v", msg.ID, id)
+	}
+	if msg.CustomerID != customerID {
+		t.Errorf("ConvertWebhookMessage().CustomerID = %v, expected %v", msg.CustomerID, customerID)
+	}
+	if msg.TranscribeID != transcribeID {
+		t.Errorf("ConvertWebhookMessage().TranscribeID = %v, expected %v", msg.TranscribeID, transcribeID)
+	}
+	if msg.Direction != DirectionIn {
+		t.Errorf("ConvertWebhookMessage().Direction = %v, expected %v", msg.Direction, DirectionIn)
+	}
+	if msg.Message != "test message" {
+		t.Errorf("ConvertWebhookMessage().Message = %v, expected %v", msg.Message, "test message")
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	transcribeID := uuid.Must(uuid.NewV4())
+
+	tr := &Transcript{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		TranscribeID: transcribeID,
+		Direction:    DirectionOut,
+		Message:      "test message",
+	}
+
+	data, err := tr.CreateWebhookEvent()
+	if err != nil {
+		t.Errorf("CreateWebhookEvent() error = %v, expected nil", err)
+	}
+	if data == nil {
+		t.Error("CreateWebhookEvent() returned nil data")
+	}
+
+	// Verify it's valid JSON
+	var msg WebhookMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Errorf("CreateWebhookEvent() produced invalid JSON: %v", err)
+	}
+
+	if msg.ID != id {
+		t.Errorf("CreateWebhookEvent() ID = %v, expected %v", msg.ID, id)
+	}
+}

--- a/bin-transcribe-manager/pkg/dbhandler/streaming_test.go
+++ b/bin-transcribe-manager/pkg/dbhandler/streaming_test.go
@@ -1,1 +1,116 @@
 package dbhandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"monorepo/bin-transcribe-manager/models/streaming"
+	"monorepo/bin-transcribe-manager/models/transcript"
+	"monorepo/bin-transcribe-manager/pkg/cachehandler"
+)
+
+func Test_StreamingCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		streaming *streaming.Streaming
+		wantErr   bool
+	}{
+		{
+			name: "successful_create",
+			streaming: &streaming.Streaming{
+				Identity: commonidentity.Identity{
+					ID:         uuid.Must(uuid.NewV4()),
+					CustomerID: uuid.Must(uuid.NewV4()),
+				},
+				TranscribeID: uuid.Must(uuid.NewV4()),
+				Language:     "en-US",
+				Direction:    transcript.DirectionIn,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().StreamingSet(ctx, tt.streaming).Return(nil)
+
+			err := h.StreamingCreate(ctx, tt.streaming)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StreamingCreate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_StreamingGet(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        uuid.UUID
+		streaming *streaming.Streaming
+		wantErr   bool
+	}{
+		{
+			name: "successful_get",
+			id:   uuid.Must(uuid.NewV4()),
+			streaming: &streaming.Streaming{
+				Identity: commonidentity.Identity{
+					ID:         uuid.Must(uuid.NewV4()),
+					CustomerID: uuid.Must(uuid.NewV4()),
+				},
+				TranscribeID: uuid.Must(uuid.NewV4()),
+				Language:     "en-US",
+				Direction:    transcript.DirectionIn,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().StreamingGet(ctx, tt.id).Return(tt.streaming, nil)
+
+			res, err := h.StreamingGet(ctx, tt.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StreamingGet() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && res == nil {
+				t.Error("StreamingGet() returned nil result")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-transcribe-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-transcribe-manager: Add unit tests for improved package-level coverage