### PR TITLE
NOJIRA-Test-coverage-call-manager

### DIFF
--- a/bin-call-manager/models/groupcall/groupcall_test.go
+++ b/bin-call-manager/models/groupcall/groupcall_test.go
@@ -1,7 +1,12 @@
 package groupcall
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
 
 	"github.com/gofrs/uuid"
 )
@@ -108,5 +113,122 @@ func TestAnswerMethodConstants(t *testing.T) {
 				t.Errorf("Wrong constant value. expect: %s, got: %s", tt.expected, tt.constant)
 			}
 		})
+	}
+}
+
+func TestConvertWebhookMessage(t *testing.T) {
+	now := time.Now()
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	ownerID := uuid.Must(uuid.NewV4())
+	flowID := uuid.Must(uuid.NewV4())
+	masterCallID := uuid.Must(uuid.NewV4())
+	answerCallID := uuid.Must(uuid.NewV4())
+	callID1 := uuid.Must(uuid.NewV4())
+	callID2 := uuid.Must(uuid.NewV4())
+
+	source := &commonaddress.Address{
+		Type:   commonaddress.TypeTel,
+		Target: "+1234567890",
+	}
+	dest1 := commonaddress.Address{
+		Type:   commonaddress.TypeTel,
+		Target: "+0987654321",
+	}
+
+	g := &Groupcall{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		Owner: commonidentity.Owner{
+			OwnerType: commonidentity.OwnerTypeAgent,
+			OwnerID:   ownerID,
+		},
+		Status:         StatusProgressing,
+		FlowID:         flowID,
+		Source:         source,
+		Destinations:   []commonaddress.Address{dest1},
+		MasterCallID:   masterCallID,
+		RingMethod:     RingMethodRingAll,
+		AnswerMethod:   AnswerMethodHangupOthers,
+		AnswerCallID:   answerCallID,
+		CallIDs:        []uuid.UUID{callID1, callID2},
+		CallCount:      2,
+		GroupcallCount: 1,
+		DialIndex:      0,
+		TMCreate:       &now,
+		TMUpdate:       &now,
+	}
+
+	webhook := g.ConvertWebhookMessage()
+
+	if webhook.ID != id {
+		t.Errorf("ConvertWebhookMessage ID = %v, expected %v", webhook.ID, id)
+	}
+	if webhook.CustomerID != customerID {
+		t.Errorf("ConvertWebhookMessage CustomerID = %v, expected %v", webhook.CustomerID, customerID)
+	}
+	if webhook.Status != StatusProgressing {
+		t.Errorf("ConvertWebhookMessage Status = %v, expected %v", webhook.Status, StatusProgressing)
+	}
+	if webhook.FlowID != flowID {
+		t.Errorf("ConvertWebhookMessage FlowID = %v, expected %v", webhook.FlowID, flowID)
+	}
+	if webhook.Source.Target != "+1234567890" {
+		t.Errorf("ConvertWebhookMessage Source = %v, expected +1234567890", webhook.Source.Target)
+	}
+	if len(webhook.Destinations) != 1 {
+		t.Errorf("ConvertWebhookMessage Destinations length = %v, expected 1", len(webhook.Destinations))
+	}
+	if webhook.MasterCallID != masterCallID {
+		t.Errorf("ConvertWebhookMessage MasterCallID = %v, expected %v", webhook.MasterCallID, masterCallID)
+	}
+	if webhook.AnswerCallID != answerCallID {
+		t.Errorf("ConvertWebhookMessage AnswerCallID = %v, expected %v", webhook.AnswerCallID, answerCallID)
+	}
+	if len(webhook.CallIDs) != 2 {
+		t.Errorf("ConvertWebhookMessage CallIDs length = %v, expected 2", len(webhook.CallIDs))
+	}
+	if webhook.CallCount != 2 {
+		t.Errorf("ConvertWebhookMessage CallCount = %v, expected 2", webhook.CallCount)
+	}
+}
+
+func TestCreateWebhookEvent(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	flowID := uuid.Must(uuid.NewV4())
+
+	g := &Groupcall{
+		Identity: commonidentity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+		Owner: commonidentity.Owner{},
+		Status: StatusProgressing,
+		FlowID: flowID,
+	}
+
+	data, err := g.CreateWebhookEvent()
+	if err != nil {
+		t.Fatalf("CreateWebhookEvent returned error: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("CreateWebhookEvent returned empty data")
+	}
+
+	// Verify it's valid JSON
+	var webhook WebhookMessage
+	if err := json.Unmarshal(data, &webhook); err != nil {
+		t.Errorf("CreateWebhookEvent returned invalid JSON: %v", err)
+	}
+
+	if webhook.ID != id {
+		t.Errorf("Unmarshalled webhook ID = %v, expected %v", webhook.ID, id)
+	}
+	if webhook.Status != StatusProgressing {
+		t.Errorf("Unmarshalled webhook Status = %v, expected %v", webhook.Status, StatusProgressing)
 	}
 }

--- a/bin-call-manager/pkg/dbhandler/call_application_test.go
+++ b/bin-call-manager/pkg/dbhandler/call_application_test.go
@@ -1,0 +1,126 @@
+package dbhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	callapplication "monorepo/bin-call-manager/models/callapplication"
+	"monorepo/bin-call-manager/pkg/cachehandler"
+)
+
+func Test_CallApplicationAMDGet(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelID   string
+		cacheReturn *callapplication.AMD
+		cacheErr    error
+		expectErr   bool
+	}{
+		{
+			name:      "successful get",
+			channelID: "test-channel-1",
+			cacheReturn: &callapplication.AMD{
+				CallID:        uuid.Must(uuid.NewV4()),
+				MachineHandle: "continue",
+				Async:         true,
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+		{
+			name:        "cache error",
+			channelID:   "test-channel-2",
+			cacheReturn: nil,
+			cacheErr:    fmt.Errorf("cache error"),
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().
+				CallAppAMDGet(ctx, tt.channelID).
+				Return(tt.cacheReturn, tt.cacheErr)
+
+			res, err := h.CallApplicationAMDGet(ctx, tt.channelID)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("CallApplicationAMDGet() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && res != tt.cacheReturn {
+				t.Errorf("CallApplicationAMDGet() = %v, want %v", res, tt.cacheReturn)
+			}
+		})
+	}
+}
+
+func Test_CallApplicationAMDSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		channelID string
+		app       *callapplication.AMD
+		cacheErr  error
+		expectErr bool
+	}{
+		{
+			name:      "successful set",
+			channelID: "test-channel-1",
+			app: &callapplication.AMD{
+				CallID:        uuid.Must(uuid.NewV4()),
+				MachineHandle: "continue",
+				Async:         true,
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+		{
+			name:      "cache error",
+			channelID: "test-channel-2",
+			app: &callapplication.AMD{
+				CallID:        uuid.Must(uuid.NewV4()),
+				MachineHandle: "hangup",
+				Async:         false,
+			},
+			cacheErr:  fmt.Errorf("cache error"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().
+				CallAppAMDSet(ctx, tt.channelID, tt.app).
+				Return(tt.cacheErr)
+
+			err := h.CallApplicationAMDSet(ctx, tt.channelID, tt.app)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("CallApplicationAMDSet() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+

--- a/bin-call-manager/pkg/dbhandler/externalmedia_test.go
+++ b/bin-call-manager/pkg/dbhandler/externalmedia_test.go
@@ -1,0 +1,215 @@
+package dbhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-call-manager/models/externalmedia"
+	"monorepo/bin-call-manager/pkg/cachehandler"
+)
+
+func Test_ExternalMediaGet(t *testing.T) {
+	tests := []struct {
+		name            string
+		externalMediaID uuid.UUID
+		cacheReturn     *externalmedia.ExternalMedia
+		cacheErr        error
+		expectErr       bool
+	}{
+		{
+			name:            "successful get",
+			externalMediaID: uuid.Must(uuid.NewV4()),
+			cacheReturn: &externalmedia.ExternalMedia{
+				ReferenceID: uuid.Must(uuid.NewV4()),
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+		{
+			name:            "cache error",
+			externalMediaID: uuid.Must(uuid.NewV4()),
+			cacheReturn:     nil,
+			cacheErr:        fmt.Errorf("cache error"),
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().
+				ExternalMediaGet(ctx, tt.externalMediaID).
+				Return(tt.cacheReturn, tt.cacheErr)
+
+			res, err := h.ExternalMediaGet(ctx, tt.externalMediaID)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ExternalMediaGet() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && res != tt.cacheReturn {
+				t.Errorf("ExternalMediaGet() = %v, want %v", res, tt.cacheReturn)
+			}
+		})
+	}
+}
+
+func Test_ExternalMediaGetByReferenceID(t *testing.T) {
+	tests := []struct {
+		name        string
+		referenceID uuid.UUID
+		cacheReturn *externalmedia.ExternalMedia
+		cacheErr    error
+		expectErr   bool
+	}{
+		{
+			name:        "successful get by reference id",
+			referenceID: uuid.Must(uuid.NewV4()),
+			cacheReturn: &externalmedia.ExternalMedia{
+				ReferenceID: uuid.Must(uuid.NewV4()),
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+		{
+			name:        "cache error",
+			referenceID: uuid.Must(uuid.NewV4()),
+			cacheReturn: nil,
+			cacheErr:    fmt.Errorf("cache error"),
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().
+				ExternalMediaGetByReferenceID(ctx, tt.referenceID).
+				Return(tt.cacheReturn, tt.cacheErr)
+
+			res, err := h.ExternalMediaGetByReferenceID(ctx, tt.referenceID)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ExternalMediaGetByReferenceID() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && res != tt.cacheReturn {
+				t.Errorf("ExternalMediaGetByReferenceID() = %v, want %v", res, tt.cacheReturn)
+			}
+		})
+	}
+}
+
+func Test_ExternalMediaSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      *externalmedia.ExternalMedia
+		cacheErr  error
+		expectErr bool
+	}{
+		{
+			name: "successful set",
+			data: &externalmedia.ExternalMedia{
+				ReferenceID: uuid.Must(uuid.NewV4()),
+			},
+			cacheErr:  nil,
+			expectErr: false,
+		},
+		{
+			name: "cache error",
+			data: &externalmedia.ExternalMedia{
+				ReferenceID: uuid.Must(uuid.NewV4()),
+			},
+			cacheErr:  fmt.Errorf("cache error"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().
+				ExternalMediaSet(ctx, tt.data).
+				Return(tt.cacheErr)
+
+			err := h.ExternalMediaSet(ctx, tt.data)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ExternalMediaSet() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func Test_ExternalMediaDelete(t *testing.T) {
+	tests := []struct {
+		name            string
+		externalMediaID uuid.UUID
+		cacheErr        error
+		expectErr       bool
+	}{
+		{
+			name:            "successful delete",
+			externalMediaID: uuid.Must(uuid.NewV4()),
+			cacheErr:        nil,
+			expectErr:       false,
+		},
+		{
+			name:            "cache error",
+			externalMediaID: uuid.Must(uuid.NewV4()),
+			cacheErr:        fmt.Errorf("cache error"),
+			expectErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				cache: mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockCache.EXPECT().
+				ExternalMediaDelete(ctx, tt.externalMediaID).
+				Return(tt.cacheErr)
+
+			err := h.ExternalMediaDelete(ctx, tt.externalMediaID)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ExternalMediaDelete() error = %v, expectErr %v", err, tt.expectErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Increase test coverage for bin-call-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-call-manager: Add unit tests for improved package-level coverage