### PR TITLE
NOJIRA-Test-coverage-api-manager

### DIFF
--- a/bin-api-manager/internal/config/main_test.go
+++ b/bin-api-manager/internal/config/main_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/base64"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -108,4 +110,140 @@ func TestSSLFilenameConstants(t *testing.T) {
 	if constSSLCertFilename != "/tmp/ssl_cert.pem" {
 		t.Errorf("constSSLCertFilename = %v, expected /tmp/ssl_cert.pem", constSSLCertFilename)
 	}
+}
+
+func TestLoadGlobalConfig(t *testing.T) {
+	// Set up environment variables for config
+	os.Setenv("RABBITMQ_ADDRESS", "amqp://test:5672")
+	os.Setenv("PROMETHEUS_ENDPOINT", "/test-metrics")
+	os.Setenv("REDIS_DATABASE", "2")
+	defer func() {
+		os.Unsetenv("RABBITMQ_ADDRESS")
+		os.Unsetenv("PROMETHEUS_ENDPOINT")
+		os.Unsetenv("REDIS_DATABASE")
+	}()
+
+	// Create a test command and bootstrap
+	cmd := &cobra.Command{Use: "test"}
+	if err := Bootstrap(cmd); err != nil {
+		t.Fatalf("Bootstrap failed: %v", err)
+	}
+
+	// Load global config
+	LoadGlobalConfig()
+
+	// Verify config was loaded
+	cfg := Get()
+	if cfg == nil {
+		t.Fatal("Get() returned nil")
+	}
+
+	// Note: LoadGlobalConfig uses sync.Once, so it can only be tested once per test run
+	// Multiple calls should not reload
+	LoadGlobalConfig()
+	LoadGlobalConfig()
+}
+
+func TestWriteBase64(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		expectErr bool
+	}{
+		{
+			name:      "valid base64",
+			data:      base64.StdEncoding.EncodeToString([]byte("test content")),
+			expectErr: false,
+		},
+		{
+			name:      "empty data",
+			data:      "",
+			expectErr: false,
+		},
+		{
+			name:      "invalid base64",
+			data:      "not!!!valid!!!base64",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile := "/tmp/test-write-base64-" + tt.name + ".txt"
+			defer os.Remove(tmpFile)
+
+			err := writeBase64(tmpFile, tt.data)
+
+			if tt.expectErr && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			// Verify file content if no error expected and data is not empty
+			if !tt.expectErr && tt.data != "" {
+				content, readErr := os.ReadFile(tmpFile)
+				if readErr != nil {
+					t.Errorf("Could not read written file: %v", readErr)
+				}
+				expected, _ := base64.StdEncoding.DecodeString(tt.data)
+				if string(content) != string(expected) {
+					t.Errorf("File content mismatch. expected: %s, got: %s", expected, content)
+				}
+			}
+
+			// Verify empty file is not created when data is empty
+			if tt.data == "" {
+				if _, err := os.Stat(tmpFile); err == nil {
+					t.Error("Expected no file to be created for empty data, but file exists")
+				}
+			}
+		})
+	}
+}
+
+func TestPostBootstrap(t *testing.T) {
+	// Create test command and bootstrap first
+	cmd := &cobra.Command{Use: "test"}
+	if err := Bootstrap(cmd); err != nil {
+		t.Fatalf("Bootstrap failed: %v", err)
+	}
+
+	// Set valid base64 test data
+	testCert := base64.StdEncoding.EncodeToString([]byte("test cert"))
+	testKey := base64.StdEncoding.EncodeToString([]byte("test key"))
+
+	globalConfig.SSLCertBase64 = testCert
+	globalConfig.SSLPrivKeyBase64 = testKey
+	globalConfig.PrometheusEndpoint = "/test-metrics"
+	globalConfig.PrometheusListenAddress = ":0" // Use port 0 to avoid conflicts
+
+	defer func() {
+		os.Remove(constSSLCertFilename)
+		os.Remove(constSSLPrivFilename)
+	}()
+
+	err := PostBootstrap()
+	if err != nil {
+		t.Errorf("PostBootstrap() returned error: %v", err)
+	}
+
+	// Verify SSL files were created
+	if _, err := os.Stat(constSSLCertFilename); os.IsNotExist(err) {
+		t.Error("SSL cert file was not created")
+	}
+	if _, err := os.Stat(constSSLPrivFilename); os.IsNotExist(err) {
+		t.Error("SSL private key file was not created")
+	}
+}
+
+func TestInitLog(t *testing.T) {
+	// This function modifies global logrus state, just ensure it doesn't panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("initLog() panicked: %v", r)
+		}
+	}()
+	initLog()
 }

--- a/bin-api-manager/lib/middleware/authenticate_test.go
+++ b/bin-api-manager/lib/middleware/authenticate_test.go
@@ -6,7 +6,14 @@ import (
 	"reflect"
 	"testing"
 
+	amagent "monorepo/bin-agent-manager/models/agent"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	modelscommon "monorepo/bin-api-manager/models/common"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+
 	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
 )
 
 func Test_getTokenString(t *testing.T) {
@@ -68,5 +75,409 @@ func Test_getTokenString(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_getAccesskey(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupRequest func(c *gin.Context)
+		expectRes    string
+	}{
+		{
+			name: "Accesskey from Cookie",
+			setupRequest: func(c *gin.Context) {
+				c.Request.AddCookie(&http.Cookie{Name: "accesskey", Value: "cookieAccesskey"})
+			},
+			expectRes: "cookieAccesskey",
+		},
+		{
+			name: "Accesskey from Query Parameter",
+			setupRequest: func(c *gin.Context) {
+				c.Request.URL.RawQuery = "accesskey=queryAccesskey"
+			},
+			expectRes: "queryAccesskey",
+		},
+		{
+			name:         "No Accesskey Provided",
+			setupRequest: func(c *gin.Context) {},
+			expectRes:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			// Apply the test setup
+			tt.setupRequest(c)
+
+			res := getAccesskey(c)
+			if !reflect.DeepEqual(tt.expectRes, res) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_getAuthString(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupRequest  func(c *gin.Context)
+		expectType    string
+		expectString  string
+		expectErr     bool
+	}{
+		{
+			name: "Token auth",
+			setupRequest: func(c *gin.Context) {
+				c.Request.Header.Set("Authorization", "Bearer testToken")
+			},
+			expectType:   authTypeToken,
+			expectString: "testToken",
+			expectErr:    false,
+		},
+		{
+			name: "Accesskey auth",
+			setupRequest: func(c *gin.Context) {
+				c.Request.URL.RawQuery = "accesskey=testAccesskey"
+			},
+			expectType:   authTypeAccesskey,
+			expectString: "testAccesskey",
+			expectErr:    false,
+		},
+		{
+			name:         "No auth provided",
+			setupRequest: func(c *gin.Context) {},
+			expectType:   authTypeNone,
+			expectString: "",
+			expectErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+
+			tt.setupRequest(c)
+
+			authType, authString, err := getAuthString(c)
+
+			if tt.expectErr && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+			if authType != tt.expectType {
+				t.Errorf("Wrong auth type. expect: %v, got: %v", tt.expectType, authType)
+			}
+			if authString != tt.expectString {
+				t.Errorf("Wrong auth string. expect: %v, got: %v", tt.expectString, authString)
+			}
+		})
+	}
+}
+
+func Test_getAuthData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testAgent := amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	}
+
+	tests := []struct {
+		name          string
+		setupRequest  func(c *gin.Context)
+		authType      string
+		mockSetup     func(mockSH *servicehandler.MockServiceHandler)
+		expectErr     bool
+	}{
+		{
+			name: "Token auth success",
+			setupRequest: func(c *gin.Context) {
+				c.Request.Header.Set("Authorization", "Bearer validToken")
+			},
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+				mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
+					"agent": testAgent,
+				}, nil)
+			},
+			expectErr: false,
+		},
+		{
+			name: "Accesskey auth success",
+			setupRequest: func(c *gin.Context) {
+				c.Request.URL.RawQuery = "accesskey=validAccesskey"
+			},
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+				mockSH.EXPECT().AuthAccesskeyParse(gomock.Any(), "validAccesskey").Return(map[string]interface{}{
+					"agent": testAgent,
+				}, nil)
+			},
+			expectErr: false,
+		},
+		{
+			name: "No auth",
+			setupRequest: func(c *gin.Context) {
+			},
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSH := servicehandler.NewMockServiceHandler(mc)
+			tt.mockSetup(mockSH)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = req
+			c.Set(modelscommon.OBJServiceHandler, mockSH)
+
+			tt.setupRequest(c)
+
+			_, err := getAuthData(c)
+
+			if tt.expectErr && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestAuthenticate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testAgent := amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	}
+
+	tests := []struct {
+		name           string
+		setupRequest   func(c *gin.Context)
+		mockSetup      func(mockSH *servicehandler.MockServiceHandler)
+		expectStatus   int
+		expectAborted  bool
+	}{
+		{
+			name: "Valid authentication",
+			setupRequest: func(c *gin.Context) {
+				c.Request.Header.Set("Authorization", "Bearer validToken")
+			},
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+				mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
+					"agent": testAgent,
+				}, nil)
+			},
+			expectStatus:  200,
+			expectAborted: false,
+		},
+		{
+			name: "Invalid authentication - no token",
+			setupRequest: func(c *gin.Context) {
+			},
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+			},
+			expectStatus:  401,
+			expectAborted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSH := servicehandler.NewMockServiceHandler(mc)
+			tt.mockSetup(mockSH)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			w := httptest.NewRecorder()
+			c, router := gin.CreateTestContext(w)
+			c.Request = req
+
+			router.Use(func(c *gin.Context) {
+				c.Set(modelscommon.OBJServiceHandler, mockSH)
+			})
+			router.Use(Authenticate())
+			router.GET("/", func(c *gin.Context) {
+				c.Status(200)
+			})
+
+			tt.setupRequest(c)
+
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong status code. expect: %v, got: %v", tt.expectStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestAuthenticateWithInvalidAgentData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSH := servicehandler.NewMockServiceHandler(mc)
+
+	// Return invalid agent data that can't be marshaled
+	mockSH.EXPECT().AuthJWTParse(gomock.Any(), "invalidToken").Return(map[string]interface{}{
+		"agent": make(chan int), // channels can't be marshaled
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer invalidToken")
+	w := httptest.NewRecorder()
+	c, router := gin.CreateTestContext(w)
+	c.Request = req
+
+	router.Use(func(c *gin.Context) {
+		c.Set(modelscommon.OBJServiceHandler, mockSH)
+	})
+	router.Use(Authenticate())
+	router.GET("/", func(c *gin.Context) {
+		c.Status(200)
+	})
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 401 {
+		t.Errorf("Expected 401 for invalid agent data, got: %v", w.Code)
+	}
+}
+
+func TestAuthenticateWithMalformedAgentJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSH := servicehandler.NewMockServiceHandler(mc)
+
+	// Return data where agent field exists but is not valid Agent struct
+	mockSH.EXPECT().AuthJWTParse(gomock.Any(), "malformedToken").Return(map[string]interface{}{
+		"agent": map[string]interface{}{
+			"invalid_field": "this won't unmarshal to Agent",
+		},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer malformedToken")
+	w := httptest.NewRecorder()
+	c, router := gin.CreateTestContext(w)
+	c.Request = req
+
+	router.Use(func(c *gin.Context) {
+		c.Set(modelscommon.OBJServiceHandler, mockSH)
+	})
+	router.Use(Authenticate())
+	router.GET("/", func(c *gin.Context) {
+		c.Status(200)
+	})
+
+	router.ServeHTTP(w, req)
+
+	// Should succeed but agent might be partially populated
+	// The actual behavior depends on how json.Unmarshal handles extra fields
+	// For Agent struct, it should handle missing fields gracefully
+	if w.Code == 500 {
+		t.Errorf("Unexpected 500 error")
+	}
+}
+
+func TestAuthConstants(t *testing.T) {
+	if authTypeNone != "" {
+		t.Errorf("authTypeNone should be empty string, got: %v", authTypeNone)
+	}
+	if authTypeToken != "token" {
+		t.Errorf("authTypeToken should be 'token', got: %v", authTypeToken)
+	}
+	if authTypeAccesskey != "accesskey" {
+		t.Errorf("authTypeAccesskey should be 'accesskey', got: %v", authTypeAccesskey)
+	}
+}
+
+func TestAuthenticateAgentStoredInContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	testAgent := amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+		Username:   "testuser",
+	}
+
+	mockSH := servicehandler.NewMockServiceHandler(mc)
+	mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
+		"agent": testAgent,
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer validToken")
+	w := httptest.NewRecorder()
+	c, router := gin.CreateTestContext(w)
+	c.Request = req
+
+	var capturedAgent amagent.Agent
+	router.Use(func(c *gin.Context) {
+		c.Set(modelscommon.OBJServiceHandler, mockSH)
+	})
+	router.Use(Authenticate())
+	router.GET("/", func(c *gin.Context) {
+		// Capture the agent from context
+		if agent, exists := c.Get("agent"); exists {
+			capturedAgent = agent.(amagent.Agent)
+		}
+		c.Status(200)
+	})
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("Expected 200, got: %v", w.Code)
+	}
+
+	// Verify agent was stored correctly in context
+	if capturedAgent.ID != testAgent.ID {
+		t.Errorf("Agent ID mismatch. expect: %v, got: %v", testAgent.ID, capturedAgent.ID)
+	}
+	if capturedAgent.Username != testAgent.Username {
+		t.Errorf("Agent username mismatch. expect: %v, got: %v", testAgent.Username, capturedAgent.Username)
 	}
 }

--- a/bin-api-manager/lib/service/auth_test.go
+++ b/bin-api-manager/lib/service/auth_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"monorepo/bin-api-manager/models/common"
 	"monorepo/bin-api-manager/pkg/servicehandler"
 	"net/http"
@@ -17,6 +18,9 @@ import (
 func setupServer(app *gin.Engine) {
 	auth := app.Group("/auth")
 	auth.POST("/login", PostLogin)
+	auth.POST("/password-forgot", PostPasswordForgot)
+	auth.POST("/password-reset", PostPasswordReset)
+	auth.GET("/password-reset", GetPasswordReset)
 }
 
 func Test_loginPOST(t *testing.T) {
@@ -84,6 +88,329 @@ func Test_loginPOST(t *testing.T) {
 
 			if w.Body.String() != tt.expectRes {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
+			}
+		})
+	}
+}
+
+func TestPostLogin_InvalidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set(common.OBJServiceHandler, mockSvc)
+	})
+	setupServer(r)
+
+	// Invalid JSON
+	req, _ := http.NewRequest("POST", "/auth/login", bytes.NewBuffer([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected 400 for invalid JSON, got: %d", w.Code)
+	}
+}
+
+func TestPostLogin_AuthFailed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set(common.OBJServiceHandler, mockSvc)
+	})
+	setupServer(r)
+
+	reqBody := RequestBodyLoginPOST{
+		Username: "test@test.com",
+		Password: "wrongpassword",
+	}
+
+	body, _ := json.Marshal(reqBody)
+	req, _ := http.NewRequest("POST", "/auth/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	mockSvc.EXPECT().AuthLogin(req.Context(), reqBody.Username, reqBody.Password).Return("", errors.New("auth failed"))
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected 400 for auth failure, got: %d", w.Code)
+	}
+}
+
+func TestPostPasswordForgot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		reqBody      RequestBodyPasswordForgotPOST
+		expectStatus int
+	}{
+		{
+			name: "valid request",
+			reqBody: RequestBodyPasswordForgotPOST{
+				Username: "test@test.com",
+			},
+			expectStatus: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set(common.OBJServiceHandler, mockSvc)
+			})
+			setupServer(r)
+
+			body, _ := json.Marshal(tt.reqBody)
+			req, _ := http.NewRequest("POST", "/auth/password-forgot", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().AuthPasswordForgot(req.Context(), tt.reqBody.Username).Return(nil)
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Expected status %d, got: %d", tt.expectStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestPostPasswordForgot_InvalidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set(common.OBJServiceHandler, mockSvc)
+	})
+	setupServer(r)
+
+	req, _ := http.NewRequest("POST", "/auth/password-forgot", bytes.NewBuffer([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected 400 for invalid JSON, got: %d", w.Code)
+	}
+}
+
+func TestPostPasswordReset(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		reqBody      RequestBodyPasswordResetPOST
+		mockSetup    func(*servicehandler.MockServiceHandler)
+		expectStatus int
+	}{
+		{
+			name: "valid reset",
+			reqBody: RequestBodyPasswordResetPOST{
+				Token:    "valid_reset_token_64_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				Password: "newpassword",
+			},
+			mockSetup: func(m *servicehandler.MockServiceHandler) {
+				m.EXPECT().AuthPasswordReset(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expectStatus: 200,
+		},
+		{
+			name: "invalid reset - error from service",
+			reqBody: RequestBodyPasswordResetPOST{
+				Token:    "invalid_token",
+				Password: "newpassword",
+			},
+			mockSetup: func(m *servicehandler.MockServiceHandler) {
+				m.EXPECT().AuthPasswordReset(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("invalid token"))
+			},
+			expectStatus: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set(common.OBJServiceHandler, mockSvc)
+			})
+			setupServer(r)
+
+			tt.mockSetup(mockSvc)
+
+			body, _ := json.Marshal(tt.reqBody)
+			req, _ := http.NewRequest("POST", "/auth/password-reset", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Expected status %d, got: %d", tt.expectStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestPostPasswordReset_InvalidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set(common.OBJServiceHandler, mockSvc)
+	})
+	setupServer(r)
+
+	req, _ := http.NewRequest("POST", "/auth/password-reset", bytes.NewBuffer([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected 400 for invalid JSON, got: %d", w.Code)
+	}
+}
+
+func TestGetPasswordReset(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		token        string
+		expectStatus int
+	}{
+		{
+			name:         "valid token",
+			token:        "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd",
+			expectStatus: 200,
+		},
+		{
+			name:         "invalid token - too short",
+			token:        "short",
+			expectStatus: 400,
+		},
+		{
+			name:         "invalid token - invalid chars",
+			token:        "invalid!!!token!!!aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectStatus: 400,
+		},
+		{
+			name:         "empty token",
+			token:        "",
+			expectStatus: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			setupServer(r)
+
+			req, _ := http.NewRequest("GET", "/auth/password-reset?token="+tt.token, nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Expected status %d, got: %d", tt.expectStatus, w.Code)
+			}
+
+			// Verify HTML content is returned for valid tokens
+			if tt.expectStatus == 200 {
+				if !strings.Contains(w.Body.String(), "<!DOCTYPE html>") {
+					t.Error("Expected HTML response for valid token")
+				}
+				if !strings.Contains(w.Body.String(), "Reset Password") {
+					t.Error("Expected 'Reset Password' in HTML response")
+				}
+			}
+		})
+	}
+}
+
+func TestValidResetTokenRegex(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		valid bool
+	}{
+		{
+			name:  "valid 64 char hex",
+			token: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd",
+			valid: true,
+		},
+		{
+			name:  "valid 64 char all numbers",
+			token: "1234567890123456789012345678901234567890123456789012345678901234",
+			valid: true,
+		},
+		{
+			name:  "invalid - too short",
+			token: "abc123",
+			valid: false,
+		},
+		{
+			name:  "invalid - uppercase hex",
+			token: "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6ABCD",
+			valid: false,
+		},
+		{
+			name:  "invalid - special chars",
+			token: "a1b2c3d4!!!6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd",
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validResetToken.MatchString(tt.token)
+			if result != tt.valid {
+				t.Errorf("Expected %v for token %s, got %v", tt.valid, tt.token, result)
 			}
 		})
 	}

--- a/bin-api-manager/lib/service/ping_test.go
+++ b/bin-api-manager/lib/service/ping_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetPing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	GetPing(c)
+
+	if w.Code != 200 {
+		t.Errorf("Expected status 200, got: %v", w.Code)
+	}
+
+	expectedBody := `{"message":"pong"}`
+	if w.Body.String() != expectedBody {
+		t.Errorf("Expected body %v, got: %v", expectedBody, w.Body.String())
+	}
+}

--- a/bin-api-manager/lib/service/signup_test.go
+++ b/bin-api-manager/lib/service/signup_test.go
@@ -1,0 +1,326 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"monorepo/bin-api-manager/models/common"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	cscustomer "monorepo/bin-customer-manager/models/customer"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPostCustomerSignup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		reqBody      RequestBodySignupPOST
+		mockSetup    func(*servicehandler.MockServiceHandler)
+		expectStatus int
+	}{
+		{
+			name: "valid signup",
+			reqBody: RequestBodySignupPOST{
+				Name:          "Test Customer",
+				Detail:        "Test details",
+				Email:         "test@example.com",
+				PhoneNumber:   "+1234567890",
+				Address:       "123 Test St",
+				WebhookMethod: "POST",
+				WebhookURI:    "https://example.com/webhook",
+			},
+			mockSetup: func(m *servicehandler.MockServiceHandler) {
+				m.EXPECT().CustomerSignup(
+					gomock.Any(),
+					"Test Customer",
+					"Test details",
+					"test@example.com",
+					"+1234567890",
+					"123 Test St",
+					cscustomer.WebhookMethod("POST"),
+					"https://example.com/webhook",
+				).Return(&cscustomer.WebhookMessage{
+					ID: uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+				}, nil)
+			},
+			expectStatus: 200,
+		},
+		{
+			name: "signup failed - email already exists",
+			reqBody: RequestBodySignupPOST{
+				Name:          "Test Customer",
+				Detail:        "Test details",
+				Email:         "existing@example.com",
+				PhoneNumber:   "+1234567890",
+				Address:       "123 Test St",
+				WebhookMethod: "POST",
+				WebhookURI:    "https://example.com/webhook",
+			},
+			mockSetup: func(m *servicehandler.MockServiceHandler) {
+				m.EXPECT().CustomerSignup(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, errors.New("email already exists"))
+			},
+			expectStatus: 200, // Returns 200 to prevent email enumeration
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set(common.OBJServiceHandler, mockSvc)
+			})
+			r.POST("/auth/signup", PostCustomerSignup)
+
+			tt.mockSetup(mockSvc)
+
+			body, _ := json.Marshal(tt.reqBody)
+			req, _ := http.NewRequest("POST", "/auth/signup", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Expected status %d, got: %d", tt.expectStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestPostCustomerSignup_InvalidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set(common.OBJServiceHandler, mockSvc)
+	})
+	r.POST("/auth/signup", PostCustomerSignup)
+
+	req, _ := http.NewRequest("POST", "/auth/signup", bytes.NewBuffer([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected 400 for invalid JSON, got: %d", w.Code)
+	}
+}
+
+func TestPostCustomerEmailVerify(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		reqBody      RequestBodyEmailVerifyPOST
+		mockSetup    func(*servicehandler.MockServiceHandler)
+		expectStatus int
+	}{
+		{
+			name: "valid verification",
+			reqBody: RequestBodyEmailVerifyPOST{
+				Token: "valid_token_64_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			mockSetup: func(m *servicehandler.MockServiceHandler) {
+				m.EXPECT().CustomerEmailVerify(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
+					ID: uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+				}, nil)
+			},
+			expectStatus: 200,
+		},
+		{
+			name: "invalid verification",
+			reqBody: RequestBodyEmailVerifyPOST{
+				Token: "invalid_token",
+			},
+			mockSetup: func(m *servicehandler.MockServiceHandler) {
+				m.EXPECT().CustomerEmailVerify(gomock.Any(), gomock.Any()).Return(nil, errors.New("invalid token"))
+			},
+			expectStatus: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set(common.OBJServiceHandler, mockSvc)
+			})
+			r.POST("/auth/email-verify", PostCustomerEmailVerify)
+
+			tt.mockSetup(mockSvc)
+
+			body, _ := json.Marshal(tt.reqBody)
+			req, _ := http.NewRequest("POST", "/auth/email-verify", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Expected status %d, got: %d", tt.expectStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestPostCustomerEmailVerify_InvalidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set(common.OBJServiceHandler, mockSvc)
+	})
+	r.POST("/auth/email-verify", PostCustomerEmailVerify)
+
+	req, _ := http.NewRequest("POST", "/auth/email-verify", bytes.NewBuffer([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("Expected 400 for invalid JSON, got: %d", w.Code)
+	}
+}
+
+func TestGetCustomerEmailVerify(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		token        string
+		expectStatus int
+	}{
+		{
+			name:         "valid token",
+			token:        "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd",
+			expectStatus: 200,
+		},
+		{
+			name:         "invalid token - too short",
+			token:        "short",
+			expectStatus: 400,
+		},
+		{
+			name:         "invalid token - invalid chars",
+			token:        "invalid!!!token!!!aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expectStatus: 400,
+		},
+		{
+			name:         "empty token",
+			token:        "",
+			expectStatus: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.GET("/auth/email-verify", GetCustomerEmailVerify)
+
+			req, _ := http.NewRequest("GET", "/auth/email-verify?token="+tt.token, nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectStatus {
+				t.Errorf("Expected status %d, got: %d", tt.expectStatus, w.Code)
+			}
+
+			// Verify HTML content is returned for valid tokens
+			if tt.expectStatus == 200 {
+				if !strings.Contains(w.Body.String(), "<!DOCTYPE html>") {
+					t.Error("Expected HTML response for valid token")
+				}
+				if !strings.Contains(w.Body.String(), "Verify Your Email") {
+					t.Error("Expected 'Verify Your Email' in HTML response")
+				}
+			}
+		})
+	}
+}
+
+func TestValidVerifyTokenRegex(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		valid bool
+	}{
+		{
+			name:  "valid 64 char hex",
+			token: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd",
+			valid: true,
+		},
+		{
+			name:  "valid 64 char all numbers",
+			token: "1234567890123456789012345678901234567890123456789012345678901234",
+			valid: true,
+		},
+		{
+			name:  "invalid - too short",
+			token: "abc123",
+			valid: false,
+		},
+		{
+			name:  "invalid - uppercase hex",
+			token: "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6ABCD",
+			valid: false,
+		},
+		{
+			name:  "invalid - special chars",
+			token: "a1b2c3d4!!!6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd",
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validVerifyToken.MatchString(tt.token)
+			if result != tt.valid {
+				t.Errorf("Expected %v for token %s, got %v", tt.valid, tt.token, result)
+			}
+		})
+	}
+}

--- a/bin-api-manager/server/main_test.go
+++ b/bin-api-manager/server/main_test.go
@@ -2,12 +2,16 @@ package server
 
 import (
 	"monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/pkg/servicehandler"
 	commonaddress "monorepo/bin-common-handler/models/address"
+	ememail "monorepo/bin-email-manager/models/email"
 	fmaction "monorepo/bin-flow-manager/models/action"
+	"reflect"
 	"testing"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func Test_ConvertFlowManagerAction(t *testing.T) {
@@ -83,6 +87,23 @@ func Test_ConvertFlowManagerAction(t *testing.T) {
 				NextID:    uuid.Must(uuid.FromString("b1eebc99-9c0b-4ef8-bb6d-6bb9bd380a12")),
 				Type:      "example",
 				Option:    map[string]any{"key": "value"},
+				TMExecute: nil,
+			},
+		},
+		{
+			name: "Empty NextId string",
+			input: openapi_server.FlowManagerAction{
+				Id:        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+				NextId:    stringPtr(""),
+				Option:    nil,
+				TmExecute: nil,
+				Type:      "example",
+			},
+			expected: fmaction.Action{
+				ID:        uuid.Must(uuid.FromString("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")),
+				NextID:    uuid.Nil,
+				Type:      "example",
+				Option:    nil,
 				TMExecute: nil,
 			},
 		},
@@ -169,6 +190,227 @@ func TestConvertCommonAddress(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ConvertCommonAddress(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewServer(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSH := servicehandler.NewMockServiceHandler(mc)
+
+	srv := NewServer(mockSH)
+
+	if srv == nil {
+		t.Error("NewServer returned nil")
+	}
+
+	// Verify it's the correct type
+	if _, ok := srv.(openapi_server.ServerInterface); !ok {
+		t.Error("NewServer did not return ServerInterface")
+	}
+}
+
+func TestConvertEmailManagerEmailAttachment(t *testing.T) {
+	testID := "d152e69e-105b-11ee-b395-eb18426de979"
+
+	tests := []struct {
+		name   string
+		input  openapi_server.EmailManagerEmailAttachment
+		expect ememail.Attachment
+	}{
+		{
+			name: "storage attachment",
+			input: openapi_server.EmailManagerEmailAttachment{
+				ReferenceType: "storage",
+				ReferenceId:   testID,
+			},
+			expect: ememail.Attachment{
+				ReferenceType: ememail.AttachmentReferenceType("storage"),
+				ReferenceID:   uuid.FromStringOrNil(testID),
+			},
+		},
+		{
+			name: "file attachment",
+			input: openapi_server.EmailManagerEmailAttachment{
+				ReferenceType: "file",
+				ReferenceId:   testID,
+			},
+			expect: ememail.Attachment{
+				ReferenceType: ememail.AttachmentReferenceType("file"),
+				ReferenceID:   uuid.FromStringOrNil(testID),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertEmailMamagerEmailAttachment(tt.input)
+
+			if !reflect.DeepEqual(result, tt.expect) {
+				t.Errorf("Wrong match.\nexpect: %+v\ngot: %+v", tt.expect, result)
+			}
+		})
+	}
+}
+
+func TestStringPtr(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"normal string", "test"},
+		{"long string", "this is a longer test string"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stringPtr(tt.input)
+
+			if result == nil {
+				t.Error("stringPtr returned nil")
+			}
+			if *result != tt.input {
+				t.Errorf("Wrong value. expect: %v, got: %v", tt.input, *result)
+			}
+		})
+	}
+}
+
+func TestGenerateListResponse(t *testing.T) {
+	type TestStruct struct {
+		ID   string
+		Name string
+	}
+
+	tests := []struct {
+		name            string
+		items           []*TestStruct
+		nextToken       string
+		expectNextToken string
+	}{
+		{
+			name: "with items",
+			items: []*TestStruct{
+				{ID: "1", Name: "Test1"},
+				{ID: "2", Name: "Test2"},
+			},
+			nextToken:       "next_token_value",
+			expectNextToken: "next_token_value",
+		},
+		{
+			name:            "empty items",
+			items:           []*TestStruct{},
+			nextToken:       "next_token_value",
+			expectNextToken: "",
+		},
+		{
+			name:            "nil items",
+			items:           nil,
+			nextToken:       "next_token_value",
+			expectNextToken: "",
+		},
+		{
+			name: "single item",
+			items: []*TestStruct{
+				{ID: "1", Name: "Test1"},
+			},
+			nextToken:       "single_next",
+			expectNextToken: "single_next",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GenerateListResponse(tt.items, tt.nextToken)
+
+			if len(result.Result) != len(tt.items) {
+				t.Errorf("Wrong result length. expect: %v, got: %v", len(tt.items), len(result.Result))
+			}
+
+			if result.NextPageToken == nil {
+				t.Error("NextPageToken is nil")
+			} else if *result.NextPageToken != tt.expectNextToken {
+				t.Errorf("Wrong next token. expect: %v, got: %v", tt.expectNextToken, *result.NextPageToken)
+			}
+		})
+	}
+}
+
+func TestStructToFilteredMap(t *testing.T) {
+	type TestStruct struct {
+		Name  string `json:"name"`
+		Age   int    `json:"age"`
+		Email string `json:"email,omitempty"`
+	}
+
+	tests := []struct {
+		name      string
+		input     any
+		expectErr bool
+		expectMap map[string]any
+	}{
+		{
+			name: "valid struct",
+			input: TestStruct{
+				Name:  "John",
+				Age:   30,
+				Email: "john@example.com",
+			},
+			expectErr: false,
+			expectMap: map[string]any{
+				"name":  "John",
+				"age":   float64(30), // JSON numbers unmarshal to float64
+				"email": "john@example.com",
+			},
+		},
+		{
+			name: "struct with omitempty empty field",
+			input: TestStruct{
+				Name: "Jane",
+				Age:  25,
+			},
+			expectErr: false,
+			expectMap: map[string]any{
+				"name": "Jane",
+				"age":  float64(25),
+			},
+		},
+		{
+			name: "map input",
+			input: map[string]any{
+				"key": "value",
+				"num": 42,
+			},
+			expectErr: false,
+			expectMap: map[string]any{
+				"key": "value",
+				"num": float64(42),
+			},
+		},
+		{
+			name:      "invalid input - chan",
+			input:     make(chan int),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := structToFilteredMap(tt.input)
+
+			if tt.expectErr && err == nil {
+				t.Error("Expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if !tt.expectErr && !reflect.DeepEqual(result, tt.expectMap) {
+				t.Errorf("Wrong map.\nexpect: %+v\ngot: %+v", tt.expectMap, result)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Increase test coverage for bin-api-manager. Added comprehensive unit tests across
in-scope packages following table-driven test patterns with gomock for
interface dependencies.

- bin-api-manager: Add unit tests for improved package-level coverage