### PR TITLE
NOJIRA-Fix-gcp-streaming-tts-encoding

### DIFF
--- a/bin-tts-manager/k8s/deployment.yml
+++ b/bin-tts-manager/k8s/deployment.yml
@@ -68,7 +68,7 @@ spec:
               containerPort: 2112
           resources:
             limits:
-              cpu: "20m"
+              cpu: "200m"
               memory: "60M"
 
         - name: http-server

--- a/bin-tts-manager/pkg/streaminghandler/audiosocket.go
+++ b/bin-tts-manager/pkg/streaminghandler/audiosocket.go
@@ -16,8 +16,8 @@ import (
 
 const (
 	audiosocketFormatSLIN      = 0x10                  // SLIN format for 16-bit PCM audio
-	audiosocketMaxFragmentSize = 320                   // Maximum fragment size for Audiosocket messages
-	audiosocketWriteDelay      = 20 * time.Millisecond // Delay between writing fragments to avoid flooding the connection
+	audiosocketMaxFragmentSize  = 320                   // Maximum fragment size for Audiosocket messages (160 samples * 2 bytes/sample = 20ms at 8kHz 16-bit mono)
+	audiosocketWriteDelay       = 20 * time.Millisecond // Delay between writing fragments to avoid flooding the connection
 	audiosocketSilenceFrameSize = 320                   // 160 samples * 2 bytes/sample = 20ms at 8kHz 16-bit mono
 )
 
@@ -166,3 +166,4 @@ func audiosocketWrite(ctx context.Context, conn net.Conn, data []byte) error {
 
 	return nil
 }
+

--- a/bin-tts-manager/pkg/streaminghandler/elevenlabs.go
+++ b/bin-tts-manager/pkg/streaminghandler/elevenlabs.go
@@ -69,7 +69,7 @@ const (
 
 	defaultElevenlabsVoiceID      = "EXAVITQu4vr4xnSDxMaL"   // Default voice ID for ElevenLabs(Rachel)
 	defaultElevenlabsModelID      = "eleven_multilingual_v2" // Default model ID for ElevenLabs
-	defaultConvertSampleRate      = 8000                     // Default sample rate for conversion to 8kHz. This must not be changed as it is the minimum sample rate for audiosocket.
+	defaultConvertSampleRate      = 8000                     // Default sample rate for AudioSocket output (8kHz).
 	defaultElevenlabsOutputFormat = "pcm_16000"              // Default output format for ElevenLabs. PCM (S16LE - Signed 16-bit Little Endian), Sample rate: 16kHz, Bit depth: 16-bit as it's the minimum raw PCM output from ElevenLabs.
 
 	defaultElevenlabsVoiceIDLength = 20

--- a/bin-tts-manager/pkg/streaminghandler/gcp_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/gcp_test.go
@@ -1,0 +1,210 @@
+package streaminghandler
+
+import (
+	"context"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	fmvariable "monorepo/bin-flow-manager/models/variable"
+	"monorepo/bin-tts-manager/models/streaming"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func Test_gcpHandler_extractLangCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		voiceID      string
+		fallbackLang string
+		expected     string
+	}{
+		{
+			name:         "standard Chirp3-HD voice",
+			voiceID:      "en-US-Chirp3-HD-Charon",
+			fallbackLang: "",
+			expected:     "en-US",
+		},
+		{
+			name:         "Japanese voice",
+			voiceID:      "ja-JP-Chirp3-HD-Aoede",
+			fallbackLang: "",
+			expected:     "ja-JP",
+		},
+		{
+			name:         "Chinese voice",
+			voiceID:      "cmn-CN-Chirp3-HD-Charon",
+			fallbackLang: "",
+			expected:     "cmn-CN",
+		},
+		{
+			name:         "non-Chirp3 voice with fallback",
+			voiceID:      "some-custom-voice",
+			fallbackLang: "fr-FR",
+			expected:     "some-custom-voice",
+		},
+		{
+			name:         "empty voice ID with fallback",
+			voiceID:      "",
+			fallbackLang: "de-DE",
+			expected:     "de-DE",
+		},
+		{
+			name:         "empty voice ID without fallback",
+			voiceID:      "",
+			fallbackLang: "",
+			expected:     "en-US",
+		},
+	}
+
+	h := &gcpHandler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.extractLangCode(tt.voiceID, tt.fallbackLang)
+			if result != tt.expected {
+				t.Errorf("got %s, expected %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_gcpHandler_getVoiceIDByLangGender(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		gender   streaming.Gender
+		expected string
+	}{
+		{
+			name:     "english male",
+			language: "english",
+			gender:   streaming.GenderMale,
+			expected: "en-US-Chirp3-HD-Charon",
+		},
+		{
+			name:     "english female",
+			language: "english",
+			gender:   streaming.GenderFemale,
+			expected: "en-US-Chirp3-HD-Aoede",
+		},
+		{
+			name:     "japanese male",
+			language: "japanese",
+			gender:   streaming.GenderMale,
+			expected: "ja-JP-Chirp3-HD-Charon",
+		},
+		{
+			name:     "french neutral fallback",
+			language: "french",
+			gender:   streaming.GenderNeutral,
+			expected: "fr-FR-Chirp3-HD-Aoede",
+		},
+		{
+			name:     "language with region code",
+			language: "english_us",
+			gender:   streaming.GenderMale,
+			expected: "en-US-Chirp3-HD-Charon",
+		},
+		{
+			name:     "case insensitive",
+			language: "JAPANESE",
+			gender:   streaming.GenderFemale,
+			expected: "ja-JP-Chirp3-HD-Aoede",
+		},
+		{
+			name:     "language with dash region",
+			language: "english-us",
+			gender:   streaming.GenderMale,
+			expected: "en-US-Chirp3-HD-Charon",
+		},
+		{
+			name:     "unknown language returns empty",
+			language: "klingon",
+			gender:   streaming.GenderMale,
+			expected: "",
+		},
+	}
+
+	h := &gcpHandler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := h.getVoiceIDByLangGender(tt.language, tt.gender)
+			if result != tt.expected {
+				t.Errorf("got %s, expected %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_gcpHandler_getVoiceID(t *testing.T) {
+	tests := []struct {
+		name string
+
+		streaming *streaming.Streaming
+
+		// mock setup
+		responseVariable *fmvariable.Variable
+		responseErr      error
+
+		expected string
+	}{
+		{
+			name: "explicit voice ID takes priority",
+			streaming: &streaming.Streaming{
+				VoiceID:  "custom-voice-id",
+				Language: "english",
+				Gender:   streaming.GenderMale,
+			},
+			expected: "custom-voice-id",
+		},
+		{
+			name: "flow variable takes priority over language/gender",
+			streaming: &streaming.Streaming{
+				ActiveflowID: uuid.FromStringOrNil("f05c4fa0-87d0-11f0-9e6c-c393f26cfebb"),
+				Language:      "english",
+				Gender:        streaming.GenderMale,
+			},
+			responseVariable: &fmvariable.Variable{
+				Variables: map[string]string{
+					variableGCPVoiceID: "variable-voice-id",
+				},
+			},
+			expected: "variable-voice-id",
+		},
+		{
+			name: "language/gender mapping",
+			streaming: &streaming.Streaming{
+				Language: "japanese",
+				Gender:   streaming.GenderFemale,
+			},
+			expected: "ja-JP-Chirp3-HD-Aoede",
+		},
+		{
+			name: "fallback to default",
+			streaming: &streaming.Streaming{
+				Language: "klingon",
+				Gender:   streaming.GenderMale,
+			},
+			expected: defaultGCPDefaultVoiceID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &gcpHandler{reqHandler: mockReq}
+			ctx := context.Background()
+
+			if tt.streaming.ActiveflowID != uuid.Nil {
+				mockReq.EXPECT().FlowV1VariableGet(ctx, tt.streaming.ActiveflowID).Return(tt.responseVariable, tt.responseErr)
+			}
+
+			result := h.getVoiceID(ctx, tt.streaming)
+			if result != tt.expected {
+				t.Errorf("got %s, expected %s", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix GCP streaming TTS "Unsupported audio encoding" error for Chirp3-HD voices.

GCP's StreamingSynthesize API for Chirp3-HD voices supports PCM (raw, no header)
but not LINEAR16 (includes WAV header). The audio encoding was incorrectly set to
AudioEncoding_LINEAR16 (value 1) instead of AudioEncoding_PCM (value 7).

- bin-tts-manager: Use AudioEncoding_PCM instead of AudioEncoding_LINEAR16 for GCP streaming TTS