### PR TITLE
NOJIRA-upgrade-asterisk-to-23.2.2

### DIFF
--- a/bin-dbscheme-manager/asterisk_config/config/versions/bb6d54e22913_add_follow_redirect_methods_to_ps_.py
+++ b/bin-dbscheme-manager/asterisk_config/config/versions/bb6d54e22913_add_follow_redirect_methods_to_ps_.py
@@ -1,0 +1,22 @@
+"""add follow_redirect_methods to ps_endpoints
+
+Revision ID: bb6d54e22913
+Revises: dc7c357dc178 
+Create Date: 2025-12-12 11:26:36.591932
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bb6d54e22913'
+down_revision = 'dc7c357dc178'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('ps_endpoints', sa.Column('follow_redirect_methods', sa.String(95)))
+
+
+def downgrade():
+    op.drop_column('ps_endpoints', 'follow_redirect_methods')

--- a/bin-dbscheme-manager/asterisk_config/config/versions/dc7c357dc178_add_taskpool_options_to_system.py
+++ b/bin-dbscheme-manager/asterisk_config/config/versions/dc7c357dc178_add_taskpool_options_to_system.py
@@ -1,0 +1,29 @@
+"""add taskpool options to system
+
+Revision ID: dc7c357dc178
+Revises: abdc9ede147d
+Create Date: 2025-09-24 09:45:17.609185
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dc7c357dc178'
+down_revision = 'abdc9ede147d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('ps_systems', sa.Column('taskpool_minimum_size', sa.Integer))
+    op.add_column('ps_systems', sa.Column('taskpool_initial_size', sa.Integer))
+    op.add_column('ps_systems', sa.Column('taskpool_auto_increment', sa.Integer))
+    op.add_column('ps_systems', sa.Column('taskpool_idle_timeout', sa.Integer))
+    op.add_column('ps_systems', sa.Column('taskpool_max_size', sa.Integer))
+
+def downgrade():
+    op.drop_column('ps_systems', 'taskpool_minimum_size')
+    op.drop_column('ps_systems', 'taskpool_initial_size')
+    op.drop_column('ps_systems', 'taskpool_auto_increment')
+    op.drop_column('ps_systems', 'taskpool_idle_timeout')
+    op.drop_column('ps_systems', 'taskpool_max_size')


### PR DESCRIPTION
Sync 2 missing upstream Alembic migrations from Asterisk 23.2.2 for database
schema compatibility with the Asterisk version upgrade (monorepo-voip PR #53).

- bin-dbscheme-manager: Add taskpool options columns to ps_systems table (dc7c357dc178)
- bin-dbscheme-manager: Add follow_redirect_methods column to ps_endpoints table (bb6d54e22913)