### PR TITLE
NOJIRA-Add-guest-customer-delete-protection

### DIFF
--- a/bin-customer-manager/models/customer/customer.go
+++ b/bin-customer-manager/models/customer/customer.go
@@ -60,4 +60,7 @@ var (
 	// voipbin internal service's customer id
 	IDCallManager = uuid.FromStringOrNil("00000000-0000-0000-0001-00000000001")
 	IDAIManager   = uuid.FromStringOrNil("00000000-0000-0000-0001-00000000002")
+
+	// GuestCustomerID is the guest/demo account customer id.
+	GuestCustomerID = uuid.FromStringOrNil("a856c986-4b06-4496-9641-4d0ecbc67df5")
 )

--- a/bin-customer-manager/pkg/customerhandler/customer.go
+++ b/bin-customer-manager/pkg/customerhandler/customer.go
@@ -2,6 +2,7 @@ package customerhandler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -19,6 +20,11 @@ func (h *customerHandler) Delete(ctx context.Context, id uuid.UUID) (*customer.C
 		"customer_id": id,
 	})
 	log.Debug("Deleteing the customer.")
+
+	// check the customer is deletable
+	if id == customer.GuestCustomerID {
+		return nil, fmt.Errorf("customer is guest customer")
+	}
 
 	// get customer info
 	c, err := h.Get(ctx, id)

--- a/bin-customer-manager/pkg/customerhandler/customer_test.go
+++ b/bin-customer-manager/pkg/customerhandler/customer_test.go
@@ -66,6 +66,27 @@ func Test_Delete(t *testing.T) {
 	}
 }
 
+func Test_Delete_GuestCustomer(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &customerHandler{
+		reqHandler:    mockReq,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	_, err := h.Delete(ctx, customer.GuestCustomerID)
+	if err == nil {
+		t.Errorf("Wrong match. expect: error, got: ok")
+	}
+}
+
 func Test_validateCreate(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Add delete protection for the guest/demo customer account in customer-manager,
preventing accidental deletion of the guest customer (a856c986-4b06-4496-9641-4d0ecbc67df5).

- bin-customer-manager: Add GuestCustomerID constant to customer model
- bin-customer-manager: Add guest customer guard in Delete to reject deletion attempts
- bin-customer-manager: Add unit test for guest customer delete protection