### PR TITLE
NOJIRA-add-external-media-type-field

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -14454,6 +14454,18 @@
               "e5f6a7b8-c9d0-1234-5678-90abcdef0123"
             ]
           },
+          "external_media_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "x-go-type": "string"
+            },
+            "description": "External media IDs associated with this call. Multiple external media streams (e.g., transcription + TTS) can run simultaneously.",
+            "example": [
+              "f6a7b8c9-d0e1-2345-6789-0abcdef01234"
+            ]
+          },
           "groupcall_id": {
             "type": "string",
             "format": "uuid",

--- a/bin-api-manager/pkg/streamhandler/start.go
+++ b/bin-api-manager/pkg/streamhandler/start.go
@@ -37,6 +37,7 @@ func (h *streamHandler) Start(
 	em, err := h.reqHandler.CallV1ExternalMediaStart(
 		ctx,
 		tmp.ID,
+		cmexternalmedia.TypeNormal,
 		referenceType,
 		referenceID,
 		h.listenAddress,

--- a/bin-api-manager/pkg/streamhandler/start_test.go
+++ b/bin-api-manager/pkg/streamhandler/start_test.go
@@ -75,6 +75,7 @@ func Test_Start(t *testing.T) {
 			mockReq.EXPECT().CallV1ExternalMediaStart(
 				ctx,
 				tt.responseUUID,
+				gomock.Any(),
 				tt.referenceType,
 				tt.referenceID,
 				localhost,

--- a/bin-call-manager/models/externalmedia/externalmedia_test.go
+++ b/bin-call-manager/models/externalmedia/externalmedia_test.go
@@ -12,6 +12,7 @@ func TestExternalMediaStruct(t *testing.T) {
 
 	e := ExternalMedia{
 		ID:              id,
+		Type:            TypeNormal,
 		AsteriskID:      "asterisk-1",
 		ChannelID:       "channel-123",
 		BridgeID:        "bridge-456",
@@ -32,6 +33,9 @@ func TestExternalMediaStruct(t *testing.T) {
 
 	if e.ID != id {
 		t.Errorf("ExternalMedia.ID = %v, expected %v", e.ID, id)
+	}
+	if e.Type != TypeNormal {
+		t.Errorf("ExternalMedia.Type = %v, expected %v", e.Type, TypeNormal)
 	}
 	if e.AsteriskID != "asterisk-1" {
 		t.Errorf("ExternalMedia.AsteriskID = %v, expected %v", e.AsteriskID, "asterisk-1")
@@ -170,6 +174,25 @@ func TestStatusConstants(t *testing.T) {
 		{"status_running", StatusRunning, "running"},
 		{"status_terminating", StatusTerminating, "terminating"},
 		{"status_terminated", StatusTerminated, "terminated"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.constant) != tt.expected {
+				t.Errorf("Wrong constant value. expect: %s, got: %s", tt.expected, tt.constant)
+			}
+		})
+	}
+}
+
+func TestTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant Type
+		expected string
+	}{
+		{"type_normal", TypeNormal, "normal"},
+		{"type_websocket", TypeWebsocket, "websocket"},
 	}
 
 	for _, tt := range tests {

--- a/bin-call-manager/models/externalmedia/field.go
+++ b/bin-call-manager/models/externalmedia/field.go
@@ -15,6 +15,7 @@ const (
 	FieldReferenceID   Field = "reference_id"   // reference_id
 
 	FieldStatus Field = "status" // status of the external media
+	FieldType   Field = "type"   // type of the external media
 
 	FieldLocalIP   Field = "local_ip"   // local_ip
 	FieldLocalPort Field = "local_port" // local_port

--- a/bin-call-manager/models/externalmedia/field_test.go
+++ b/bin-call-manager/models/externalmedia/field_test.go
@@ -18,6 +18,7 @@ func TestFieldConstants(t *testing.T) {
 		{"field_reference_type", FieldReferenceType, "reference_type"},
 		{"field_reference_id", FieldReferenceID, "reference_id"},
 		{"field_status", FieldStatus, "status"},
+		{"field_type", FieldType, "type"},
 		{"field_local_ip", FieldLocalIP, "local_ip"},
 		{"field_local_port", FieldLocalPort, "local_port"},
 		{"field_external_host", FieldExternalHost, "external_host"},

--- a/bin-call-manager/models/externalmedia/filters.go
+++ b/bin-call-manager/models/externalmedia/filters.go
@@ -12,4 +12,5 @@ type FieldStruct struct {
 	ReferenceType ReferenceType `filter:"reference_type"`
 	ReferenceID   uuid.UUID     `filter:"reference_id"`
 	Status        Status        `filter:"status"`
+	Type          Type          `filter:"type"`
 }

--- a/bin-call-manager/models/externalmedia/main.go
+++ b/bin-call-manager/models/externalmedia/main.go
@@ -6,7 +6,8 @@ import (
 
 // ExternalMedia defines external media detail info
 type ExternalMedia struct {
-	ID uuid.UUID `json:"id"`
+	ID   uuid.UUID `json:"id"`
+	Type Type      `json:"type"` // type of the external media
 
 	AsteriskID string `json:"asterisk_id"`           // asterisk id
 	ChannelID  string `json:"channel_id"`            // external media channel id
@@ -74,4 +75,13 @@ const (
 	StatusRunning     Status = "running"     // running status
 	StatusTerminating Status = "terminating" // terminating status
 	StatusTerminated  Status = "terminated"  // terminated status
+)
+
+// Type define
+type Type string
+
+// list of Type types
+const (
+	TypeNormal    Type = "normal"
+	TypeWebsocket Type = "websocket"
 )

--- a/bin-call-manager/pkg/callhandler/action.go
+++ b/bin-call-manager/pkg/callhandler/action.go
@@ -679,6 +679,7 @@ func (h *callHandler) actionExecuteExternalMediaStart(ctx context.Context, c *ca
 		ctx,
 		c.ID,
 		uuid.Nil,
+		externalmedia.Type(option.Type),
 		option.ExternalHost,
 		externalmedia.Encapsulation(option.Encapsulation),
 		externalmedia.Transport(option.Transport),

--- a/bin-call-manager/pkg/callhandler/action_test.go
+++ b/bin-call-manager/pkg/callhandler/action_test.go
@@ -980,6 +980,7 @@ func Test_ActionExecute_actionExecuteExternalMediaStart(t *testing.T) {
 			mockExternal.EXPECT().Start(
 				ctx,
 				uuid.Nil,
+				gomock.Any(),
 				externalmedia.ReferenceTypeCall,
 				tt.call.ID,
 				tt.expectHost,

--- a/bin-call-manager/pkg/callhandler/external_media.go
+++ b/bin-call-manager/pkg/callhandler/external_media.go
@@ -24,6 +24,7 @@ func (h *callHandler) ExternalMediaStart(
 	ctx context.Context,
 	id uuid.UUID,
 	externalMediaID uuid.UUID,
+	typ externalmedia.Type,
 	externalHost string,
 	encapsulation externalmedia.Encapsulation,
 	transport externalmedia.Transport,
@@ -53,6 +54,7 @@ func (h *callHandler) ExternalMediaStart(
 	tmp, err := h.externalMediaHandler.Start(
 		ctx,
 		externalMediaID,
+		typ,
 		externalmedia.ReferenceTypeCall,
 		c.ID,
 		externalHost,

--- a/bin-call-manager/pkg/callhandler/external_media_test.go
+++ b/bin-call-manager/pkg/callhandler/external_media_test.go
@@ -84,6 +84,7 @@ func Test_ExternalMediaStart(t *testing.T) {
 			mockExternal.EXPECT().Start(
 				ctx,
 				tt.externalMediaID,
+				gomock.Any(),
 				externalmedia.ReferenceTypeCall,
 				tt.id,
 				tt.externalHost,
@@ -101,6 +102,7 @@ func Test_ExternalMediaStart(t *testing.T) {
 				ctx,
 				tt.id,
 				tt.externalMediaID,
+				externalmedia.TypeNormal,
 				tt.externalHost,
 				tt.encapsulation,
 				tt.transport,

--- a/bin-call-manager/pkg/callhandler/main.go
+++ b/bin-call-manager/pkg/callhandler/main.go
@@ -120,6 +120,7 @@ type CallHandler interface {
 		ctx context.Context,
 		id uuid.UUID,
 		externalMediaID uuid.UUID,
+		typ externalmedia.Type,
 		externalHost string,
 		encapsulation externalmedia.Encapsulation,
 		transport externalmedia.Transport,

--- a/bin-call-manager/pkg/callhandler/mock_main.go
+++ b/bin-call-manager/pkg/callhandler/mock_main.go
@@ -341,18 +341,18 @@ func (mr *MockCallHandlerMockRecorder) EventSMPodDeleted(ctx, p any) *gomock.Cal
 }
 
 // ExternalMediaStart mocks base method.
-func (m *MockCallHandler) ExternalMediaStart(ctx context.Context, id, externalMediaID uuid.UUID, externalHost string, encapsulation externalmedia.Encapsulation, transport externalmedia.Transport, connectionType, format string, directionListen, directionSpeak externalmedia.Direction) (*call.Call, error) {
+func (m *MockCallHandler) ExternalMediaStart(ctx context.Context, id, externalMediaID uuid.UUID, typ externalmedia.Type, externalHost string, encapsulation externalmedia.Encapsulation, transport externalmedia.Transport, connectionType, format string, directionListen, directionSpeak externalmedia.Direction) (*call.Call, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExternalMediaStart", ctx, id, externalMediaID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
+	ret := m.ctrl.Call(m, "ExternalMediaStart", ctx, id, externalMediaID, typ, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
 	ret0, _ := ret[0].(*call.Call)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExternalMediaStart indicates an expected call of ExternalMediaStart.
-func (mr *MockCallHandlerMockRecorder) ExternalMediaStart(ctx, id, externalMediaID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak any) *gomock.Call {
+func (mr *MockCallHandlerMockRecorder) ExternalMediaStart(ctx, id, externalMediaID, typ, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalMediaStart", reflect.TypeOf((*MockCallHandler)(nil).ExternalMediaStart), ctx, id, externalMediaID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalMediaStart", reflect.TypeOf((*MockCallHandler)(nil).ExternalMediaStart), ctx, id, externalMediaID, typ, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
 }
 
 // ExternalMediaStop mocks base method.

--- a/bin-call-manager/pkg/confbridgehandler/external_media.go
+++ b/bin-call-manager/pkg/confbridgehandler/external_media.go
@@ -18,6 +18,7 @@ func (h *confbridgeHandler) ExternalMediaStart(
 	ctx context.Context,
 	id uuid.UUID,
 	externalMediaID uuid.UUID,
+	typ externalmedia.Type,
 	externalHost string,
 	encapsulation externalmedia.Encapsulation,
 	transport externalmedia.Transport,
@@ -45,6 +46,7 @@ func (h *confbridgeHandler) ExternalMediaStart(
 	tmp, err := h.externalMediaHandler.Start(
 		ctx,
 		externalMediaID,
+		typ,
 		externalmedia.ReferenceTypeConfbridge,
 		c.ID,
 		externalHost,

--- a/bin-call-manager/pkg/confbridgehandler/external_media_test.go
+++ b/bin-call-manager/pkg/confbridgehandler/external_media_test.go
@@ -79,6 +79,7 @@ func Test_ExternalMediaStart(t *testing.T) {
 			mockExternal.EXPECT().Start(
 				ctx,
 				tt.externalMediaID,
+				gomock.Any(),
 				externalmedia.ReferenceTypeConfbridge,
 				tt.id,
 				tt.externalHost,
@@ -96,6 +97,7 @@ func Test_ExternalMediaStart(t *testing.T) {
 				ctx,
 				tt.id,
 				tt.externalMediaID,
+				externalmedia.TypeNormal,
 				tt.externalHost,
 				tt.encapsulation,
 				tt.transport,

--- a/bin-call-manager/pkg/confbridgehandler/main.go
+++ b/bin-call-manager/pkg/confbridgehandler/main.go
@@ -73,6 +73,7 @@ type ConfbridgeHandler interface {
 		ctx context.Context,
 		id uuid.UUID,
 		externalMediaID uuid.UUID,
+		typ externalmedia.Type,
 		externalHost string,
 		encapsulation externalmedia.Encapsulation,
 		transport externalmedia.Transport,

--- a/bin-call-manager/pkg/confbridgehandler/mock_main.go
+++ b/bin-call-manager/pkg/confbridgehandler/mock_main.go
@@ -162,18 +162,18 @@ func (mr *MockConfbridgeHandlerMockRecorder) EventCUCustomerDeleted(ctx, cu any)
 }
 
 // ExternalMediaStart mocks base method.
-func (m *MockConfbridgeHandler) ExternalMediaStart(ctx context.Context, id, externalMediaID uuid.UUID, externalHost string, encapsulation externalmedia.Encapsulation, transport externalmedia.Transport, connectionType, format string) (*confbridge.Confbridge, error) {
+func (m *MockConfbridgeHandler) ExternalMediaStart(ctx context.Context, id, externalMediaID uuid.UUID, typ externalmedia.Type, externalHost string, encapsulation externalmedia.Encapsulation, transport externalmedia.Transport, connectionType, format string) (*confbridge.Confbridge, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExternalMediaStart", ctx, id, externalMediaID, externalHost, encapsulation, transport, connectionType, format)
+	ret := m.ctrl.Call(m, "ExternalMediaStart", ctx, id, externalMediaID, typ, externalHost, encapsulation, transport, connectionType, format)
 	ret0, _ := ret[0].(*confbridge.Confbridge)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ExternalMediaStart indicates an expected call of ExternalMediaStart.
-func (mr *MockConfbridgeHandlerMockRecorder) ExternalMediaStart(ctx, id, externalMediaID, externalHost, encapsulation, transport, connectionType, format any) *gomock.Call {
+func (mr *MockConfbridgeHandlerMockRecorder) ExternalMediaStart(ctx, id, externalMediaID, typ, externalHost, encapsulation, transport, connectionType, format any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalMediaStart", reflect.TypeOf((*MockConfbridgeHandler)(nil).ExternalMediaStart), ctx, id, externalMediaID, externalHost, encapsulation, transport, connectionType, format)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalMediaStart", reflect.TypeOf((*MockConfbridgeHandler)(nil).ExternalMediaStart), ctx, id, externalMediaID, typ, externalHost, encapsulation, transport, connectionType, format)
 }
 
 // ExternalMediaStop mocks base method.

--- a/bin-call-manager/pkg/externalmediahandler/db.go
+++ b/bin-call-manager/pkg/externalmediahandler/db.go
@@ -13,6 +13,7 @@ import (
 func (h *externalMediaHandler) Create(
 	ctx context.Context,
 	id uuid.UUID,
+	typ externalmedia.Type,
 	asteriskID string,
 	channelID string,
 	bridgeID string,
@@ -33,7 +34,8 @@ func (h *externalMediaHandler) Create(
 		id = h.utilHandler.UUIDCreate()
 	}
 	extMedia := &externalmedia.ExternalMedia{
-		ID: id,
+		ID:   id,
+		Type: typ,
 
 		AsteriskID: asteriskID,
 		ChannelID:  channelID,

--- a/bin-call-manager/pkg/externalmediahandler/db_test.go
+++ b/bin-call-manager/pkg/externalmediahandler/db_test.go
@@ -64,6 +64,7 @@ func Test_Create(t *testing.T) {
 
 			expectExternalMedia: &externalmedia.ExternalMedia{
 				ID:              uuid.FromStringOrNil("a59fb054-b32f-11ef-8b11-6395ff848e6c"),
+				Type:            externalmedia.TypeNormal,
 				AsteriskID:      "3e:50:6b:43:bb:30",
 				ChannelID:       "6295f80e-97b6-11ed-88e0-ffb00420fb1a",
 				BridgeID:        "7f34278a-7d9e-11f0-ba9f-97cef5bed809",
@@ -105,6 +106,7 @@ func Test_Create(t *testing.T) {
 			responseUUID: uuid.FromStringOrNil("0a05e55e-b330-11ef-a24c-07a8913a053b"),
 			expectExternalMedia: &externalmedia.ExternalMedia{
 				ID:              uuid.FromStringOrNil("0a05e55e-b330-11ef-a24c-07a8913a053b"),
+				Type:            externalmedia.TypeNormal,
 				AsteriskID:      "3e:50:6b:43:bb:30",
 				ChannelID:       "09d1321e-b330-11ef-ad3e-170da10752c8",
 				BridgeID:        "96b5355c-7d9e-11f0-a2ca-b3875a58d870",
@@ -151,6 +153,7 @@ func Test_Create(t *testing.T) {
 			res, err := h.Create(
 				ctx,
 				tt.id,
+				externalmedia.TypeNormal,
 				tt.asteriskID,
 				tt.channelID,
 				tt.bridgeID,

--- a/bin-call-manager/pkg/externalmediahandler/main.go
+++ b/bin-call-manager/pkg/externalmediahandler/main.go
@@ -30,6 +30,7 @@ type ExternalMediaHandler interface {
 	Start(
 		ctx context.Context,
 		id uuid.UUID,
+		typ externalmedia.Type,
 		referenceType externalmedia.ReferenceType,
 		referenceID uuid.UUID,
 		externalHost string,

--- a/bin-call-manager/pkg/externalmediahandler/mock_main.go
+++ b/bin-call-manager/pkg/externalmediahandler/mock_main.go
@@ -89,18 +89,18 @@ func (mr *MockExternalMediaHandlerMockRecorder) List(ctx, size, token, filters a
 }
 
 // Start mocks base method.
-func (m *MockExternalMediaHandler) Start(ctx context.Context, id uuid.UUID, referenceType externalmedia.ReferenceType, referenceID uuid.UUID, externalHost string, encapsulation externalmedia.Encapsulation, transport externalmedia.Transport, connectionType, format string, directionListen, directionSpeak externalmedia.Direction) (*externalmedia.ExternalMedia, error) {
+func (m *MockExternalMediaHandler) Start(ctx context.Context, id uuid.UUID, typ externalmedia.Type, referenceType externalmedia.ReferenceType, referenceID uuid.UUID, externalHost string, encapsulation externalmedia.Encapsulation, transport externalmedia.Transport, connectionType, format string, directionListen, directionSpeak externalmedia.Direction) (*externalmedia.ExternalMedia, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", ctx, id, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
+	ret := m.ctrl.Call(m, "Start", ctx, id, typ, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
 	ret0, _ := ret[0].(*externalmedia.ExternalMedia)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockExternalMediaHandlerMockRecorder) Start(ctx, id, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak any) *gomock.Call {
+func (mr *MockExternalMediaHandlerMockRecorder) Start(ctx, id, typ, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockExternalMediaHandler)(nil).Start), ctx, id, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockExternalMediaHandler)(nil).Start), ctx, id, typ, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
 }
 
 // Stop mocks base method.

--- a/bin-call-manager/pkg/externalmediahandler/start.go
+++ b/bin-call-manager/pkg/externalmediahandler/start.go
@@ -19,6 +19,7 @@ import (
 func (h *externalMediaHandler) Start(
 	ctx context.Context,
 	id uuid.UUID,
+	typ externalmedia.Type,
 	referenceType externalmedia.ReferenceType,
 	referenceID uuid.UUID,
 	externalHost string,
@@ -41,14 +42,18 @@ func (h *externalMediaHandler) Start(
 		id = h.utilHandler.UUIDCreate()
 	}
 
+	if typ == "" {
+		typ = externalmedia.TypeNormal
+	}
+
 	promExternalMediaStartTotal.WithLabelValues(string(referenceType), string(encapsulation)).Inc()
 
 	switch referenceType {
 	case externalmedia.ReferenceTypeCall:
-		return h.startReferenceTypeCall(ctx, id, referenceID, externalHost, encapsulation, transport, format, directionListen, directionSpeak)
+		return h.startReferenceTypeCall(ctx, id, typ, referenceID, externalHost, encapsulation, transport, format, directionListen, directionSpeak)
 
 	case externalmedia.ReferenceTypeConfbridge:
-		return h.startReferenceTypeConfbridge(ctx, id, referenceID, externalHost, encapsulation, transport, format)
+		return h.startReferenceTypeConfbridge(ctx, id, typ, referenceID, externalHost, encapsulation, transport, format)
 
 	default:
 		return nil, fmt.Errorf("unsupported reference type")
@@ -59,6 +64,7 @@ func (h *externalMediaHandler) Start(
 func (h *externalMediaHandler) startReferenceTypeCall(
 	ctx context.Context,
 	id uuid.UUID,
+	typ externalmedia.Type,
 	callID uuid.UUID,
 	externalHost string,
 	encapsulation externalmedia.Encapsulation,
@@ -126,6 +132,7 @@ func (h *externalMediaHandler) startReferenceTypeCall(
 	res, err := h.startExternalMedia(
 		ctx,
 		id,
+		typ,
 		ch.AsteriskID,
 		br.ID,
 		playbackID,
@@ -150,6 +157,7 @@ func (h *externalMediaHandler) startReferenceTypeCall(
 func (h *externalMediaHandler) startReferenceTypeConfbridge(
 	ctx context.Context,
 	id uuid.UUID,
+	typ externalmedia.Type,
 	confbridgeID uuid.UUID,
 	externalHost string,
 	encapsulation externalmedia.Encapsulation,
@@ -183,6 +191,7 @@ func (h *externalMediaHandler) startReferenceTypeConfbridge(
 	res, err := h.startExternalMedia(
 		ctx,
 		id,
+		typ,
 		br.AsteriskID,
 		br.ID,
 		"", // playbackID is not used in confbridge
@@ -207,6 +216,7 @@ func (h *externalMediaHandler) startReferenceTypeConfbridge(
 func (h *externalMediaHandler) startExternalMedia(
 	ctx context.Context,
 	id uuid.UUID,
+	typ externalmedia.Type,
 	asteriskID string,
 	bridgeID string,
 	playbackID string,
@@ -268,6 +278,7 @@ func (h *externalMediaHandler) startExternalMedia(
 	em, err := h.Create(
 		ctx,
 		id,
+		typ,
 		asteriskID,
 		extChannelID,
 		bridgeID,

--- a/bin-call-manager/pkg/externalmediahandler/start_test.go
+++ b/bin-call-manager/pkg/externalmediahandler/start_test.go
@@ -89,6 +89,7 @@ func Test_Start_startReferenceTypeCall(t *testing.T) {
 			expectPlaybackID:  playback.IDPrefixExternalMedia + "78473c24-b331-11ef-aa9c-e7c52f9d3f7b",
 			expectExternalMedia: &externalmedia.ExternalMedia{
 				ID:              uuid.FromStringOrNil("78473c24-b331-11ef-aa9c-e7c52f9d3f7b"),
+				Type:            externalmedia.TypeNormal,
 				AsteriskID:      "42:01:0a:a4:00:05",
 				ChannelID:       "488feb00-96e3-11ed-8ae7-1fe9bc7a995f",
 				ReferenceType:   externalmedia.ReferenceTypeCall,
@@ -149,6 +150,7 @@ func Test_Start_startReferenceTypeCall(t *testing.T) {
 			res, err := h.Start(
 				ctx,
 				tt.id,
+				externalmedia.TypeNormal,
 				tt.referenceType,
 				tt.referenceID,
 				tt.externalHost,
@@ -223,6 +225,7 @@ func Test_Start_reference_type_confbridge(t *testing.T) {
 			expectChannelData:  "context_type=call,context=call-externalmedia,bridge_id=5466b238-97ba-11ed-9021-0b336edbced2,reference_type=confbridge,reference_id=543f0d00-97ba-11ed-86fe-ef2b82ea3c6f,external_media_id=79076e90-b331-11ef-bc31-33cb17f32724",
 			expectExternalMedia: &externalmedia.ExternalMedia{
 				ID:              uuid.FromStringOrNil("79076e90-b331-11ef-bc31-33cb17f32724"),
+				Type:            externalmedia.TypeNormal,
 				AsteriskID:      "42:01:0a:a4:00:05",
 				ChannelID:       "548cc82e-97ba-11ed-9f0c-43e1928c2d6e",
 				ReferenceType:   externalmedia.ReferenceTypeConfbridge,
@@ -275,6 +278,7 @@ func Test_Start_reference_type_confbridge(t *testing.T) {
 			res, err := h.Start(
 				ctx,
 				tt.id,
+				externalmedia.TypeNormal,
 				tt.referenceType,
 				tt.referenceID,
 				tt.externalHost,

--- a/bin-call-manager/pkg/listenhandler/models/request/calls.go
+++ b/bin-call-manager/pkg/listenhandler/models/request/calls.go
@@ -75,8 +75,9 @@ type V1DataCallsIDActionNextPost struct {
 // v1 data type for V1DataCallsIDExternalMediaPost
 // /v1/calls/<call-id>/external-media POST
 type V1DataCallsIDExternalMediaPost struct {
-	ExternalMediaID uuid.UUID               `json:"external_media_id,omitempty"`
-	ExternalHost    string                  `json:"external_host,omitempty"`
+	ExternalMediaID uuid.UUID              `json:"external_media_id,omitempty"`
+	Type            externalmedia.Type     `json:"type,omitempty"`
+	ExternalHost    string                 `json:"external_host,omitempty"`
 	Encapsulation   string                  `json:"encapsulation,omitempty"`
 	Transport       string                  `json:"transport,omitempty"`
 	ConnectionType  string                  `json:"connection_type,omitempty"`

--- a/bin-call-manager/pkg/listenhandler/models/request/confbridge.go
+++ b/bin-call-manager/pkg/listenhandler/models/request/confbridge.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"monorepo/bin-call-manager/models/confbridge"
+	"monorepo/bin-call-manager/models/externalmedia"
 	"monorepo/bin-call-manager/models/recording"
 )
 
@@ -22,8 +23,9 @@ type V1DataConfbridgesPost struct {
 // v1 data type for
 // /v1/confbridges/<confbridge-id>/external-media POST
 type V1DataConfbridgesIDExternalMediaPost struct {
-	ExternalMediaID uuid.UUID `json:"external_media_id,omitempty"`
-	ExternalHost    string    `json:"external_host,omitempty"`
+	ExternalMediaID uuid.UUID          `json:"external_media_id,omitempty"`
+	Type            externalmedia.Type `json:"type,omitempty"`
+	ExternalHost    string             `json:"external_host,omitempty"`
 	Encapsulation   string    `json:"encapsulation,omitempty"`
 	Transport       string    `json:"transport,omitempty"`
 	ConnectionType  string    `json:"connection_type,omitempty"`

--- a/bin-call-manager/pkg/listenhandler/models/request/externalmedias.go
+++ b/bin-call-manager/pkg/listenhandler/models/request/externalmedias.go
@@ -10,8 +10,9 @@ import (
 // v1 data type request struct for
 // /v1/external-medias POST
 type V1DataExternalMediasPost struct {
-	ID              uuid.UUID                   `json:"id,omitempty"`
-	ReferenceType   externalmedia.ReferenceType `json:"reference_type,omitempty"`
+	ID            uuid.UUID                   `json:"id,omitempty"`
+	Type          externalmedia.Type          `json:"type,omitempty"`
+	ReferenceType externalmedia.ReferenceType `json:"reference_type,omitempty"`
 	ReferenceID     uuid.UUID                   `json:"reference_id,omitempty"`
 	ExternalHost    string                      `json:"external_host,omitempty"`
 	Encapsulation   string                      `json:"encapsulation,omitempty"`

--- a/bin-call-manager/pkg/listenhandler/v1_calls.go
+++ b/bin-call-manager/pkg/listenhandler/v1_calls.go
@@ -484,6 +484,7 @@ func (h *listenHandler) processV1CallsIDExternalMediaPost(ctx context.Context, m
 		ctx,
 		id,
 		req.ExternalMediaID,
+		req.Type,
 		req.ExternalHost,
 		externalmedia.Encapsulation(req.Encapsulation),
 		externalmedia.Transport(req.Transport),

--- a/bin-call-manager/pkg/listenhandler/v1_calls_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_calls_test.go
@@ -987,6 +987,7 @@ func Test_processV1CallsIDExternalMediaPost(t *testing.T) {
 				context.Background(),
 				tt.expectCallID,
 				tt.expectExternalMediaID,
+				gomock.Any(),
 				tt.expectExternalHost,
 				tt.expectEncapsulation,
 				tt.expectTransport,

--- a/bin-call-manager/pkg/listenhandler/v1_confbridge_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_confbridge_test.go
@@ -358,6 +358,7 @@ func Test_processV1ConfbridgesIDExternalMediaPost(t *testing.T) {
 				gomock.Any(),
 				tt.expectConfbridgeID,
 				tt.expectExternalMediaID,
+				gomock.Any(),
 				tt.expectExternalHost,
 				tt.expectEncapsulation,
 				tt.expectTransport,

--- a/bin-call-manager/pkg/listenhandler/v1_confbridges.go
+++ b/bin-call-manager/pkg/listenhandler/v1_confbridges.go
@@ -226,6 +226,7 @@ func (h *listenHandler) processV1ConfbridgesIDExternalMediaPost(ctx context.Cont
 		ctx,
 		id,
 		req.ExternalMediaID,
+		req.Type,
 		req.ExternalHost,
 		externalmedia.Encapsulation(req.Encapsulation),
 		externalmedia.Transport(req.Transport),

--- a/bin-call-manager/pkg/listenhandler/v1_external_medias.go
+++ b/bin-call-manager/pkg/listenhandler/v1_external_medias.go
@@ -85,6 +85,7 @@ func (h *listenHandler) processV1ExternalMediasPost(ctx context.Context, m *sock
 	tmp, err := h.externalMediaHandler.Start(
 		ctx,
 		req.ID,
+		req.Type,
 		req.ReferenceType,
 		req.ReferenceID,
 		req.ExternalHost,

--- a/bin-call-manager/pkg/listenhandler/v1_external_medias_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_external_medias_test.go
@@ -63,7 +63,7 @@ func Test_processV1ExternalMediasPost(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"id":"077a8dce-b332-11ef-a775-d39c4839f5a6","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}`),
+				Data:       []byte(`{"id":"077a8dce-b332-11ef-a775-d39c4839f5a6","type":"","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}`),
 			},
 		},
 	}
@@ -84,6 +84,7 @@ func Test_processV1ExternalMediasPost(t *testing.T) {
 			mockExternal.EXPECT().Start(
 				gomock.Any(),
 				tt.expectID,
+				gomock.Any(),
 				tt.expectReferenceType,
 				tt.expectReferenceID,
 				tt.expectExternalHost,
@@ -138,7 +139,7 @@ func Test_processV1ExternalMediasGet(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`[{"id":"28db3628-e829-11ee-a39e-83e2f12ec29f","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}]`),
+				Data:       []byte(`[{"id":"28db3628-e829-11ee-a39e-83e2f12ec29f","type":"","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}]`),
 			},
 		},
 		{
@@ -163,7 +164,7 @@ func Test_processV1ExternalMediasGet(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`[{"id":"98fda9f4-e829-11ee-83bd-233ee47d5cb3","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""},{"id":"992a4cca-e829-11ee-83e5-4bc5ace56a63","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}]`),
+				Data:       []byte(`[{"id":"98fda9f4-e829-11ee-83bd-233ee47d5cb3","type":"","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""},{"id":"992a4cca-e829-11ee-83e5-4bc5ace56a63","type":"","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}]`),
 			},
 		},
 	}
@@ -225,7 +226,7 @@ func Test_processV1ExternalMediasIDGet(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"id":"86d29aa4-97b3-11ed-a086-eb62e01c6736","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}`),
+				Data:       []byte(`{"id":"86d29aa4-97b3-11ed-a086-eb62e01c6736","type":"","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}`),
 			},
 		},
 	}
@@ -285,7 +286,7 @@ func Test_processV1ExternalMediasIDDelete(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"id":"bbfd5cdc-97b3-11ed-8caa-e705f8c7d343","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}`),
+				Data:       []byte(`{"id":"bbfd5cdc-97b3-11ed-8caa-e705f8c7d343","type":"","asterisk_id":"","channel_id":"","reference_typee":"","reference_id":"00000000-0000-0000-0000-000000000000","local_ip":"","local_port":0,"external_host":"","encapsulation":"","transport":"","connection_type":"","format":""}`),
 			},
 		},
 	}

--- a/bin-common-handler/pkg/requesthandler/call_externalmedias.go
+++ b/bin-common-handler/pkg/requesthandler/call_externalmedias.go
@@ -63,6 +63,7 @@ func (r *requestHandler) CallV1ExternalMediaGet(ctx context.Context, externalMed
 func (r *requestHandler) CallV1ExternalMediaStart(
 	ctx context.Context,
 	externalMediaID uuid.UUID,
+	typ cmexternalmedia.Type,
 	referenceType cmexternalmedia.ReferenceType,
 	referenceID uuid.UUID,
 	externalHost string,
@@ -76,8 +77,9 @@ func (r *requestHandler) CallV1ExternalMediaStart(
 	uri := "/v1/external-medias"
 
 	reqData := &cmrequest.V1DataExternalMediasPost{
-		ID:              externalMediaID,
-		ReferenceType:   referenceType,
+		ID:            externalMediaID,
+		Type:          typ,
+		ReferenceType: referenceType,
 		ReferenceID:     referenceID,
 		ExternalHost:    externalHost,
 		Encapsulation:   encapsulation,

--- a/bin-common-handler/pkg/requesthandler/call_externalmedias_test.go
+++ b/bin-common-handler/pkg/requesthandler/call_externalmedias_test.go
@@ -118,6 +118,7 @@ func Test_CallV1ExternalMediaStart(t *testing.T) {
 		name string
 
 		externalMediaID uuid.UUID
+		typ             cmexternalmedia.Type
 		referenceType   cmexternalmedia.ReferenceType
 		referenceID     uuid.UUID
 		externalHost    string
@@ -137,6 +138,7 @@ func Test_CallV1ExternalMediaStart(t *testing.T) {
 			name: "normal",
 
 			externalMediaID: uuid.FromStringOrNil("7f655194-b336-11ef-ad61-e340f855ae0d"),
+			typ:             cmexternalmedia.TypeNormal,
 			referenceType:   cmexternalmedia.ReferenceTypeCall,
 			referenceID:     uuid.FromStringOrNil("94a6ec48-97c2-11ed-bd66-afb196d5c598"),
 			externalHost:    "localhost:5060",
@@ -157,7 +159,7 @@ func Test_CallV1ExternalMediaStart(t *testing.T) {
 				URI:      "/v1/external-medias",
 				Method:   sock.RequestMethodPost,
 				DataType: ContentTypeJSON,
-				Data:     []byte(`{"id":"7f655194-b336-11ef-ad61-e340f855ae0d","reference_type":"call","reference_id":"94a6ec48-97c2-11ed-bd66-afb196d5c598","external_host":"localhost:5060","encapsulation":"rtp","transport":"udp","connection_type":"client","format":"ulaw","direction_listen":"in","direction_speak":"out"}`),
+				Data:     []byte(`{"id":"7f655194-b336-11ef-ad61-e340f855ae0d","type":"normal","reference_type":"call","reference_id":"94a6ec48-97c2-11ed-bd66-afb196d5c598","external_host":"localhost:5060","encapsulation":"rtp","transport":"udp","connection_type":"client","format":"ulaw","direction_listen":"in","direction_speak":"out"}`),
 			},
 			expectRes: &cmexternalmedia.ExternalMedia{
 				ID: uuid.FromStringOrNil("e8337d9a-97c2-11ed-93ad-5bcba5332622"),
@@ -182,6 +184,7 @@ func Test_CallV1ExternalMediaStart(t *testing.T) {
 			res, err := reqHandler.CallV1ExternalMediaStart(
 				ctx,
 				tt.externalMediaID,
+				tt.typ,
 				tt.referenceType,
 				tt.referenceID,
 				tt.externalHost,

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -522,6 +522,7 @@ type RequestHandler interface {
 	CallV1ExternalMediaStart(
 		ctx context.Context,
 		externalMediaID uuid.UUID,
+		typ cmexternalmedia.Type,
 		referenceType cmexternalmedia.ReferenceType,
 		referenceID uuid.UUID,
 		externalHost string,

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -2089,18 +2089,18 @@ func (mr *MockRequestHandlerMockRecorder) CallV1ExternalMediaList(ctx, pageToken
 }
 
 // CallV1ExternalMediaStart mocks base method.
-func (m *MockRequestHandler) CallV1ExternalMediaStart(ctx context.Context, externalMediaID uuid.UUID, referenceType externalmedia.ReferenceType, referenceID uuid.UUID, externalHost, encapsulation, transport, connectionType, format string, directionListen, directionSpeak externalmedia.Direction) (*externalmedia.ExternalMedia, error) {
+func (m *MockRequestHandler) CallV1ExternalMediaStart(ctx context.Context, externalMediaID uuid.UUID, typ externalmedia.Type, referenceType externalmedia.ReferenceType, referenceID uuid.UUID, externalHost, encapsulation, transport, connectionType, format string, directionListen, directionSpeak externalmedia.Direction) (*externalmedia.ExternalMedia, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CallV1ExternalMediaStart", ctx, externalMediaID, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
+	ret := m.ctrl.Call(m, "CallV1ExternalMediaStart", ctx, externalMediaID, typ, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
 	ret0, _ := ret[0].(*externalmedia.ExternalMedia)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CallV1ExternalMediaStart indicates an expected call of CallV1ExternalMediaStart.
-func (mr *MockRequestHandlerMockRecorder) CallV1ExternalMediaStart(ctx, externalMediaID, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) CallV1ExternalMediaStart(ctx, externalMediaID, typ, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallV1ExternalMediaStart", reflect.TypeOf((*MockRequestHandler)(nil).CallV1ExternalMediaStart), ctx, externalMediaID, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallV1ExternalMediaStart", reflect.TypeOf((*MockRequestHandler)(nil).CallV1ExternalMediaStart), ctx, externalMediaID, typ, referenceType, referenceID, externalHost, encapsulation, transport, connectionType, format, directionListen, directionSpeak)
 }
 
 // CallV1ExternalMediaStop mocks base method.

--- a/bin-flow-manager/models/action/option.go
+++ b/bin-flow-manager/models/action/option.go
@@ -210,6 +210,7 @@ type OptionEmpty struct {
 // OptionExternalMediaStart defines action OptionExternalMediaStart's option.
 type OptionExternalMediaStart struct {
 	ExternalHost    string `json:"external_host,omitempty"`    // external media target host address
+	Type            string `json:"type,omitempty"`             // type. default: normal (normal, websocket)
 	Encapsulation   string `json:"encapsulation,omitempty"`    // encapsulation. default: rtp
 	Transport       string `json:"transport,omitempty"`        // transport. default: udp
 	ConnectionType  string `json:"connection_type,omitempty"`  // connection type. default: client

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
@@ -93,6 +93,7 @@ func (h *pipecatcallHandler) startReferenceTypeCall(ctx context.Context, pc *pip
 	em, err := h.requestHandler.CallV1ExternalMediaStart(
 		ctx,
 		pc.ID,
+		cmexternalmedia.TypeNormal,
 		cmexternalmedia.ReferenceTypeCall,
 		c.ID,
 		h.listenAddress,
@@ -131,6 +132,7 @@ func (h *pipecatcallHandler) startReferenceTypeAIcall(ctx context.Context, pc *p
 		em, err := h.requestHandler.CallV1ExternalMediaStart(
 			ctx,
 			pc.ID,
+			cmexternalmedia.TypeNormal,
 			cmexternalmedia.ReferenceTypeCall,
 			c.ReferenceID,
 			h.listenAddress,

--- a/bin-transcribe-manager/pkg/streaminghandler/start.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/start.go
@@ -37,6 +37,7 @@ func (h *streamingHandler) Start(ctx context.Context, customerID uuid.UUID, tran
 	em, err := h.reqHandler.CallV1ExternalMediaStart(
 		ctx,
 		res.ID,
+		externalmedia.TypeNormal,
 		externalmedia.ReferenceType(referenceType),
 		referenceID,
 		h.listenAddress,

--- a/bin-transcribe-manager/pkg/streaminghandler/start_test.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/start_test.go
@@ -90,6 +90,7 @@ func Test_Start(t *testing.T) {
 			mockReq.EXPECT().CallV1ExternalMediaStart(
 				ctx,
 				tt.responseUUID,
+				gomock.Any(),
 				cmexternalmedia.ReferenceType(tt.referenceType),
 				tt.referenceID,
 				tt.listenAddress,

--- a/bin-tts-manager/pkg/streaminghandler/start.go
+++ b/bin-tts-manager/pkg/streaminghandler/start.go
@@ -91,6 +91,7 @@ func (h *streamingHandler) startExternalMedia(ctx context.Context, st *streaming
 	em, err := h.requestHandler.CallV1ExternalMediaStart(
 		ctx,
 		st.ID,
+		externalmedia.TypeNormal,
 		externalmedia.ReferenceType(st.ReferenceType),
 		st.ReferenceID,
 		h.listenAddress,

--- a/bin-tts-manager/pkg/streaminghandler/start_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/start_test.go
@@ -90,6 +90,7 @@ func Test_Start(t *testing.T) {
 			mockReq.EXPECT().CallV1ExternalMediaStart(
 				ctx,
 				tt.responseUUID,
+				gomock.Any(),
 				cmexternalmedia.ReferenceType(tt.referenceType),
 				tt.referenceID,
 				tt.listenAddress,
@@ -209,6 +210,7 @@ func Test_StartWithID(t *testing.T) {
 				mockReq.EXPECT().CallV1ExternalMediaStart(
 					ctx,
 					tt.id,
+					gomock.Any(),
 					cmexternalmedia.ReferenceType(tt.referenceType),
 					tt.referenceID,
 					tt.listenAddress,

--- a/docs/plans/2026-02-19-external-media-type-field-design.md
+++ b/docs/plans/2026-02-19-external-media-type-field-design.md
@@ -1,0 +1,87 @@
+# Add Type Field to External Media
+
+## Problem
+
+External media currently has no way to distinguish between different channel technologies. We need a `Type` field to differentiate between normal external media (RTP-based via ARI ExternalMedia) and websocket-based external media (via `chan_websocket`, a new Asterisk channel technology).
+
+This is the model-layer preparation. The actual `chan_websocket` integration will be a follow-up change.
+
+## Approach
+
+Add `Type` as a string type with two constants (`TypeNormal = "normal"`, `TypeWebsocket = "websocket"`) and thread it through the entire creation flow — from request structs through handler interfaces to the stored model.
+
+When `Type` is empty, it defaults to `TypeNormal` to maintain backward compatibility.
+
+## Files to Modify
+
+### Layer 1: Model (bin-call-manager/models/externalmedia/)
+
+- `main.go` — Add `Type` type, constants, and struct field
+- `field.go` — Add `FieldType`
+- `filters.go` — Add `Type` to `FieldStruct`
+- `externalmedia_test.go` — Add tests for new type and constants
+- `field_test.go` — Add `FieldType` to test table
+
+### Layer 2: Request structs (bin-call-manager/pkg/listenhandler/models/request/)
+
+- `externalmedias.go` — Add `Type` to `V1DataExternalMediasPost`
+- `calls.go` — Add `Type` to `V1DataCallsIDExternalMediaPost`
+- `confbridge.go` — Add `Type` to `V1DataConfbridgesIDExternalMediaPost`
+
+### Layer 3: Handler interfaces + implementations (bin-call-manager/pkg/)
+
+- `externalmediahandler/main.go` — Add `typ` param to `Start()` interface
+- `externalmediahandler/start.go` — Thread `typ` through `Start()` → `startReferenceTypeCall()` / `startReferenceTypeConfbridge()` → `startExternalMedia()` → `Create()`; default to `TypeNormal` when empty
+- `externalmediahandler/db.go` — Add `typ` param to `Create()`, set on struct
+
+- `callhandler/main.go` — Add `typ` param to `ExternalMediaStart()` interface
+- `callhandler/external_media.go` — Thread `typ` to `externalMediaHandler.Start()`
+
+- `confbridgehandler/main.go` — Add `typ` param to `ExternalMediaStart()` interface
+- `confbridgehandler/external_media.go` — Thread `typ` to `externalMediaHandler.Start()`
+
+### Layer 4: Listen handler routing (bin-call-manager/pkg/listenhandler/)
+
+- `v1_external_medias.go` — Pass `req.Type` to `externalMediaHandler.Start()`
+- `v1_calls.go` — Pass `req.Type` to `callHandler.ExternalMediaStart()`
+- `v1_confbridges.go` — Pass `req.Type` to `confbridgeHandler.ExternalMediaStart()`
+
+### Layer 5: bin-common-handler (shared RPC client)
+
+- `pkg/requesthandler/main.go` — Add `typ` param to `CallV1ExternalMediaStart()` interface
+- `pkg/requesthandler/call_externalmedias.go` — Add `typ` param, set on request struct
+
+### Layer 6: Cross-service callers of CallV1ExternalMediaStart
+
+These services call the RPC client and need the new parameter (pass empty string or `TypeNormal`):
+
+- `bin-tts-manager/pkg/streaminghandler/start.go`
+- `bin-transcribe-manager/pkg/streaminghandler/start.go`
+- `bin-api-manager/pkg/streamhandler/start.go`
+- `bin-pipecat-manager/pkg/pipecatcallhandler/start.go`
+
+### Layer 7: Flow manager action option
+
+- `bin-flow-manager/models/action/option.go` — Add `Type` to `OptionExternalMediaStart`
+
+### Layer 8: Mock regeneration
+
+Run `go generate ./...` in:
+- `bin-call-manager`
+- `bin-common-handler`
+
+### Layer 9: Tests
+
+Update all affected test files for the new parameter.
+
+## Default Behavior
+
+- Empty `Type` defaults to `TypeNormal` in `startExternalMedia()`
+- Existing callers that don't specify type get normal (current) behavior
+- No behavior change for `TypeWebsocket` yet — it stores the value but follows the same code path as normal
+
+## Not in Scope
+
+- `chan_websocket` Asterisk channel creation logic
+- OpenAPI spec changes (ExternalMedia is not exposed in the public API spec)
+- Database migration (external media is stored in Redis cache)

--- a/docs/plans/2026-02-19-external-media-type-field-plan.md
+++ b/docs/plans/2026-02-19-external-media-type-field-plan.md
@@ -1,0 +1,694 @@
+# External Media Type Field Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `Type` field (`TypeNormal`, `TypeWebsocket`) to the external media model and thread it through the entire creation flow across 7 services.
+
+**Architecture:** The `Type` is added to the `ExternalMedia` struct in `bin-call-manager/models/externalmedia/`, then threaded through all handler interfaces and function signatures in bin-call-manager, through the shared RPC client in bin-common-handler, and to all 4 cross-service callers. When empty, it defaults to `TypeNormal`.
+
+**Tech Stack:** Go, RabbitMQ RPC (via bin-common-handler requesthandler), Redis cache, gomock
+
+---
+
+### Task 1: Add Type to externalmedia model
+
+**Files:**
+- Modify: `bin-call-manager/models/externalmedia/main.go:8-31` (struct), `main.go:71-77` (add after Status type)
+- Modify: `bin-call-manager/models/externalmedia/field.go:17` (add after FieldStatus)
+- Modify: `bin-call-manager/models/externalmedia/filters.go:14` (add after Status)
+
+**Step 1: Add Type type, constants, and struct field to main.go**
+
+After the `Status` type block (line 77), add:
+
+```go
+// Type define
+type Type string
+
+// list of Type types
+const (
+	TypeNormal    Type = "normal"
+	TypeWebsocket Type = "websocket"
+)
+```
+
+In the `ExternalMedia` struct (after line 9 `ID`), add:
+
+```go
+	Type Type `json:"type"` // type of the external media
+```
+
+**Step 2: Add FieldType to field.go**
+
+After `FieldStatus` (line 17), add:
+
+```go
+	FieldType Field = "type" // type of the external media
+```
+
+**Step 3: Add Type to FieldStruct in filters.go**
+
+After `Status` (line 14), add:
+
+```go
+	Type Type `filter:"type"`
+```
+
+**Step 4: Run model tests**
+
+Run: `cd bin-call-manager && go test ./models/externalmedia/... -v`
+Expected: existing tests pass (they don't yet test the new field — that's next task)
+
+---
+
+### Task 2: Add tests for Type in externalmedia model
+
+**Files:**
+- Modify: `bin-call-manager/models/externalmedia/externalmedia_test.go:13-31` (struct test), add new TestTypeConstants
+- Modify: `bin-call-manager/models/externalmedia/field_test.go:12-33` (add FieldType to table)
+
+**Step 1: Update TestExternalMediaStruct to include Type**
+
+In `externalmedia_test.go`, add `Type: TypeNormal,` to the struct literal (after `ID:` line 14):
+
+```go
+	e := ExternalMedia{
+		ID:              id,
+		Type:            TypeNormal,
+		AsteriskID:      "asterisk-1",
+```
+
+Add assertion after the ID check (after line 35):
+
+```go
+	if e.Type != TypeNormal {
+		t.Errorf("ExternalMedia.Type = %v, expected %v", e.Type, TypeNormal)
+	}
+```
+
+**Step 2: Add TestTypeConstants**
+
+After `TestStatusConstants` (after line 182), add:
+
+```go
+func TestTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant Type
+		expected string
+	}{
+		{"type_normal", TypeNormal, "normal"},
+		{"type_websocket", TypeWebsocket, "websocket"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.constant) != tt.expected {
+				t.Errorf("Wrong constant value. expect: %s, got: %s", tt.expected, tt.constant)
+			}
+		})
+	}
+}
+```
+
+**Step 3: Add FieldType to field_test.go**
+
+In the test table (after `{"field_status", FieldStatus, "status"},` line 20), add:
+
+```go
+		{"field_type", FieldType, "type"},
+```
+
+**Step 4: Run tests**
+
+Run: `cd bin-call-manager && go test ./models/externalmedia/... -v`
+Expected: ALL tests pass including new TestTypeConstants
+
+---
+
+### Task 3: Add Type to request structs
+
+**Files:**
+- Modify: `bin-call-manager/pkg/listenhandler/models/request/externalmedias.go:12-24`
+- Modify: `bin-call-manager/pkg/listenhandler/models/request/calls.go:77-86`
+- Modify: `bin-call-manager/pkg/listenhandler/models/request/confbridge.go:24-31`
+
+**Step 1: Add Type to V1DataExternalMediasPost**
+
+In `externalmedias.go`, add after `ID` field (line 13):
+
+```go
+	Type          externalmedia.Type          `json:"type,omitempty"`
+```
+
+**Step 2: Add Type to V1DataCallsIDExternalMediaPost**
+
+In `calls.go`, add after `ExternalMediaID` field (line 78):
+
+```go
+	Type            externalmedia.Type         `json:"type,omitempty"`
+```
+
+**Step 3: Add Type to V1DataConfbridgesIDExternalMediaPost**
+
+In `confbridge.go`, add after `ExternalMediaID` field (line 25):
+
+```go
+	Type            externalmedia.Type `json:"type,omitempty"`
+```
+
+**Step 4: Verify build**
+
+Run: `cd bin-call-manager && go build ./...`
+Expected: builds successfully
+
+---
+
+### Task 4: Thread Type through externalmediahandler
+
+**Files:**
+- Modify: `bin-call-manager/pkg/externalmediahandler/main.go:30-42` (Start interface)
+- Modify: `bin-call-manager/pkg/externalmediahandler/start.go:19-31` (Start impl), `start.go:59-69` (startReferenceTypeCall), `start.go:150-158` (startReferenceTypeConfbridge), `start.go:207-221` (startExternalMedia)
+- Modify: `bin-call-manager/pkg/externalmediahandler/db.go:13-31` (Create)
+
+**Step 1: Add typ param to Start() in main.go interface**
+
+In `main.go`, add `typ externalmedia.Type` after `id uuid.UUID` (line 32):
+
+```go
+	Start(
+		ctx context.Context,
+		id uuid.UUID,
+		typ externalmedia.Type,
+		referenceType externalmedia.ReferenceType,
+```
+
+**Step 2: Add typ param to Start() implementation in start.go**
+
+Update the `Start` function signature (line 19-31):
+
+```go
+func (h *externalMediaHandler) Start(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	referenceType externalmedia.ReferenceType,
+```
+
+Add default after the `id` nil check (after line 43):
+
+```go
+	if typ == "" {
+		typ = externalmedia.TypeNormal
+	}
+```
+
+Pass `typ` to both `startReferenceTypeCall` and `startReferenceTypeConfbridge`:
+
+```go
+	case externalmedia.ReferenceTypeCall:
+		return h.startReferenceTypeCall(ctx, id, typ, referenceID, externalHost, encapsulation, transport, format, directionListen, directionSpeak)
+
+	case externalmedia.ReferenceTypeConfbridge:
+		return h.startReferenceTypeConfbridge(ctx, id, typ, referenceID, externalHost, encapsulation, transport, format)
+```
+
+**Step 3: Add typ param to startReferenceTypeCall**
+
+Update signature (line 59):
+
+```go
+func (h *externalMediaHandler) startReferenceTypeCall(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	callID uuid.UUID,
+```
+
+Pass `typ` to `startExternalMedia` call (line 126):
+
+```go
+	res, err := h.startExternalMedia(
+		ctx,
+		id,
+		typ,
+		ch.AsteriskID,
+```
+
+**Step 4: Add typ param to startReferenceTypeConfbridge**
+
+Update signature (line 150):
+
+```go
+func (h *externalMediaHandler) startReferenceTypeConfbridge(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	confbridgeID uuid.UUID,
+```
+
+Pass `typ` to `startExternalMedia` call (line 183):
+
+```go
+	res, err := h.startExternalMedia(
+		ctx,
+		id,
+		typ,
+		br.AsteriskID,
+```
+
+**Step 5: Add typ param to startExternalMedia**
+
+Update signature (line 207):
+
+```go
+func (h *externalMediaHandler) startExternalMedia(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	asteriskID string,
+```
+
+Pass `typ` to `h.Create` call (line 268):
+
+```go
+	em, err := h.Create(
+		ctx,
+		id,
+		typ,
+		asteriskID,
+```
+
+**Step 6: Add typ param to Create in db.go**
+
+Update signature (line 13):
+
+```go
+func (h *externalMediaHandler) Create(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	asteriskID string,
+```
+
+Set Type on the struct (after `ID: id,` line 36):
+
+```go
+	extMedia := &externalmedia.ExternalMedia{
+		ID:   id,
+		Type: typ,
+```
+
+**Step 7: Verify build**
+
+Run: `cd bin-call-manager && go build ./...`
+Expected: build errors from callers not yet updated (callhandler, confbridgehandler, listenhandler) — that's expected, we fix them next
+
+---
+
+### Task 5: Thread Type through callhandler and confbridgehandler
+
+**Files:**
+- Modify: `bin-call-manager/pkg/callhandler/main.go:119-130` (ExternalMediaStart interface)
+- Modify: `bin-call-manager/pkg/callhandler/external_media.go:23-34` (ExternalMediaStart impl)
+- Modify: `bin-call-manager/pkg/confbridgehandler/main.go:72-81` (ExternalMediaStart interface)
+- Modify: `bin-call-manager/pkg/confbridgehandler/external_media.go:17-26` (ExternalMediaStart impl)
+
+**Step 1: Add typ param to CallHandler.ExternalMediaStart interface**
+
+In `callhandler/main.go` (line 119):
+
+```go
+	ExternalMediaStart(
+		ctx context.Context,
+		id uuid.UUID,
+		typ externalmedia.Type,
+		externalMediaID uuid.UUID,
+```
+
+**Step 2: Add typ param to callHandler.ExternalMediaStart implementation**
+
+In `callhandler/external_media.go` (line 23):
+
+```go
+func (h *callHandler) ExternalMediaStart(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	externalMediaID uuid.UUID,
+```
+
+Pass `typ` to `externalMediaHandler.Start` (line 53):
+
+```go
+	tmp, err := h.externalMediaHandler.Start(
+		ctx,
+		externalMediaID,
+		typ,
+		externalmedia.ReferenceTypeCall,
+```
+
+**Step 3: Add typ param to ConfbridgeHandler.ExternalMediaStart interface**
+
+In `confbridgehandler/main.go` (line 72):
+
+```go
+	ExternalMediaStart(
+		ctx context.Context,
+		id uuid.UUID,
+		typ externalmedia.Type,
+		externalMediaID uuid.UUID,
+```
+
+**Step 4: Add typ param to confbridgeHandler.ExternalMediaStart implementation**
+
+In `confbridgehandler/external_media.go` (line 17):
+
+```go
+func (h *confbridgeHandler) ExternalMediaStart(
+	ctx context.Context,
+	id uuid.UUID,
+	typ externalmedia.Type,
+	externalMediaID uuid.UUID,
+```
+
+Pass `typ` to `externalMediaHandler.Start` (line 45):
+
+```go
+	tmp, err := h.externalMediaHandler.Start(
+		ctx,
+		externalMediaID,
+		typ,
+		externalmedia.ReferenceTypeConfbridge,
+```
+
+**Step 5: Verify build**
+
+Run: `cd bin-call-manager && go build ./...`
+Expected: build errors from listenhandler callers — fixed next
+
+---
+
+### Task 6: Thread Type through listenhandler routes
+
+**Files:**
+- Modify: `bin-call-manager/pkg/listenhandler/v1_external_medias.go:85-97` (processV1ExternalMediasPost)
+- Modify: `bin-call-manager/pkg/listenhandler/v1_calls.go:483-493` (processV1CallsIDExternalMediaPost)
+- Modify: `bin-call-manager/pkg/listenhandler/v1_confbridges.go:225-234` (processV1ConfbridgesIDExternalMediaPost)
+
+**Step 1: Pass Type in processV1ExternalMediasPost**
+
+In `v1_external_medias.go` (line 85), add `req.Type` after `req.ID`:
+
+```go
+	tmp, err := h.externalMediaHandler.Start(
+		ctx,
+		req.ID,
+		req.Type,
+		req.ReferenceType,
+```
+
+**Step 2: Pass Type in processV1CallsIDExternalMediaPost**
+
+In `v1_calls.go` (line 483), add `req.Type` after `id`:
+
+```go
+	tmp, err := h.callHandler.ExternalMediaStart(
+		ctx,
+		id,
+		req.Type,
+		req.ExternalMediaID,
+```
+
+**Step 3: Pass Type in processV1ConfbridgesIDExternalMediaPost**
+
+In `v1_confbridges.go` (line 225), add `req.Type` after `id`:
+
+```go
+	tmp, err := h.confbridgeHandler.ExternalMediaStart(
+		ctx,
+		id,
+		req.Type,
+		req.ExternalMediaID,
+```
+
+**Step 4: Regenerate mocks for bin-call-manager**
+
+Run: `cd bin-call-manager && go generate ./...`
+Expected: mocks regenerated successfully
+
+**Step 5: Verify build**
+
+Run: `cd bin-call-manager && go build ./...`
+Expected: builds successfully (all internal callers updated)
+
+---
+
+### Task 7: Thread Type through bin-common-handler requesthandler
+
+**Files:**
+- Modify: `bin-common-handler/pkg/requesthandler/main.go:522-534` (interface)
+- Modify: `bin-common-handler/pkg/requesthandler/call_externalmedias.go:63-74` (implementation)
+
+**Step 1: Add typ param to CallV1ExternalMediaStart interface**
+
+In `main.go` (line 522):
+
+```go
+	CallV1ExternalMediaStart(
+		ctx context.Context,
+		externalMediaID uuid.UUID,
+		typ cmexternalmedia.Type,
+		referenceType cmexternalmedia.ReferenceType,
+```
+
+**Step 2: Add typ param to CallV1ExternalMediaStart implementation**
+
+In `call_externalmedias.go` (line 63):
+
+```go
+func (r *requestHandler) CallV1ExternalMediaStart(
+	ctx context.Context,
+	externalMediaID uuid.UUID,
+	typ cmexternalmedia.Type,
+	referenceType cmexternalmedia.ReferenceType,
+```
+
+Set `Type` on the request struct (after `ID:` line 79):
+
+```go
+	reqData := &cmrequest.V1DataExternalMediasPost{
+		ID:              externalMediaID,
+		Type:            typ,
+		ReferenceType:   referenceType,
+```
+
+**Step 3: Regenerate mocks for bin-common-handler**
+
+Run: `cd bin-common-handler && go generate ./...`
+Expected: mocks regenerated (this will break cross-service callers until they're updated)
+
+**Step 4: Verify build**
+
+Run: `cd bin-common-handler && go build ./...`
+Expected: builds successfully
+
+---
+
+### Task 8: Update cross-service callers
+
+**Files:**
+- Modify: `bin-tts-manager/pkg/streaminghandler/start.go:91-103`
+- Modify: `bin-transcribe-manager/pkg/streaminghandler/start.go:37-49`
+- Modify: `bin-api-manager/pkg/streamhandler/start.go:37-49`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/start.go:93-105` and `start.go:131-143`
+
+All callers pass `externalmedia.TypeNormal` (or `cmexternalmedia.TypeNormal`) as the new `typ` parameter after `externalMediaID`.
+
+**Step 1: Update bin-tts-manager**
+
+In `bin-tts-manager/pkg/streaminghandler/start.go` (line 91), add `externalmedia.TypeNormal` after `st.ID`:
+
+```go
+	em, err := h.requestHandler.CallV1ExternalMediaStart(
+		ctx,
+		st.ID,
+		externalmedia.TypeNormal,
+		externalmedia.ReferenceType(st.ReferenceType),
+```
+
+**Step 2: Update bin-transcribe-manager**
+
+In `bin-transcribe-manager/pkg/streaminghandler/start.go` (line 37), add `externalmedia.TypeNormal` after `res.ID`:
+
+```go
+	em, err := h.reqHandler.CallV1ExternalMediaStart(
+		ctx,
+		res.ID,
+		externalmedia.TypeNormal,
+		externalmedia.ReferenceType(referenceType),
+```
+
+**Step 3: Update bin-api-manager**
+
+In `bin-api-manager/pkg/streamhandler/start.go` (line 37), add `cmexternalmedia.TypeNormal` after `tmp.ID`:
+
+```go
+	em, err := h.reqHandler.CallV1ExternalMediaStart(
+		ctx,
+		tmp.ID,
+		cmexternalmedia.TypeNormal,
+		referenceType,
+```
+
+**Step 4: Update bin-pipecat-manager (two call sites)**
+
+In `bin-pipecat-manager/pkg/pipecatcallhandler/start.go`, update `startReferenceTypeCall` (line 93):
+
+```go
+	em, err := h.requestHandler.CallV1ExternalMediaStart(
+		ctx,
+		pc.ID,
+		cmexternalmedia.TypeNormal,
+		cmexternalmedia.ReferenceTypeCall,
+```
+
+And `startReferenceTypeAIcall` (line 131):
+
+```go
+		em, err := h.requestHandler.CallV1ExternalMediaStart(
+			ctx,
+			pc.ID,
+			cmexternalmedia.TypeNormal,
+			cmexternalmedia.ReferenceTypeCall,
+```
+
+**Step 5: Verify each service builds**
+
+Run each in parallel or sequence:
+```bash
+cd bin-tts-manager && go build ./...
+cd bin-transcribe-manager && go build ./...
+cd bin-api-manager && go build ./...
+cd bin-pipecat-manager && go build ./...
+```
+Expected: all build successfully
+
+---
+
+### Task 9: Add Type to flow-manager action option
+
+**Files:**
+- Modify: `bin-flow-manager/models/action/option.go:211-220`
+
+**Step 1: Add Type field to OptionExternalMediaStart**
+
+After `ExternalHost` (line 212), add:
+
+```go
+	Type            string `json:"type,omitempty"`             // type. default: normal (normal, websocket)
+```
+
+**Step 2: Verify build**
+
+Run: `cd bin-flow-manager && go build ./...`
+Expected: builds successfully
+
+---
+
+### Task 10: Update tests across all services
+
+**Files:**
+- Test files in `bin-call-manager/pkg/externalmediahandler/` (start_test.go, db_test.go, stop_test.go)
+- Test files in `bin-call-manager/pkg/listenhandler/` (v1_calls_test.go, v1_confbridge_test.go, v1_external_medias_test.go)
+- Test files in `bin-call-manager/pkg/callhandler/` (external_media_test.go, action_test.go)
+- Test files in `bin-call-manager/pkg/confbridgehandler/` (external_media_test.go)
+- Test files in `bin-common-handler/pkg/requesthandler/` (call_externalmedias_test.go)
+- Test files in cross-service callers (start_test.go in tts, transcribe, api-manager)
+
+**Step 1: Fix all test compilation errors**
+
+Every test that calls `Start()`, `ExternalMediaStart()`, `Create()`, or `CallV1ExternalMediaStart()` needs the new `typ` parameter added. Pass `externalmedia.TypeNormal` in all existing tests.
+
+Search for all affected test call sites:
+
+```bash
+grep -rn "\.Start(" bin-call-manager/pkg/externalmediahandler/*_test.go
+grep -rn "\.ExternalMediaStart(" bin-call-manager/pkg/listenhandler/*_test.go bin-call-manager/pkg/callhandler/*_test.go bin-call-manager/pkg/confbridgehandler/*_test.go
+grep -rn "CallV1ExternalMediaStart(" bin-common-handler/pkg/requesthandler/*_test.go bin-tts-manager/pkg/streaminghandler/*_test.go bin-transcribe-manager/pkg/streaminghandler/*_test.go bin-api-manager/pkg/streamhandler/*_test.go
+```
+
+For each call site, add the `typ` parameter (or `gomock.Any()` for mock expectations).
+
+**Step 2: Run tests**
+
+Run: `cd bin-call-manager && go test ./... -count=1`
+Expected: all tests pass
+
+---
+
+### Task 11: Full verification workflow
+
+**Step 1: Run verification for bin-common-handler**
+
+```bash
+cd bin-common-handler && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Expected: all pass
+
+**Step 2: Run verification for bin-call-manager**
+
+```bash
+cd bin-call-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Expected: all pass
+
+**Step 3: Run verification for cross-service callers**
+
+```bash
+cd bin-tts-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+cd bin-transcribe-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+cd bin-api-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+cd bin-pipecat-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Expected: all pass
+
+**Step 4: Run verification for bin-flow-manager**
+
+```bash
+cd bin-flow-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Expected: all pass
+
+---
+
+### Task 12: Commit
+
+**Step 1: Stage and commit**
+
+```bash
+git add -A
+git commit -m "NOJIRA-add-external-media-type-field
+
+Add Type field to external media model with TypeNormal and TypeWebsocket
+constants. Thread the type through all handler interfaces and the shared
+RPC client. All existing callers pass TypeNormal. This prepares for
+chan_websocket integration in a follow-up change.
+
+- bin-call-manager: Add Type type, constants, and field to externalmedia model
+- bin-call-manager: Thread typ param through externalmediahandler Start/Create
+- bin-call-manager: Thread typ param through callhandler/confbridgehandler ExternalMediaStart
+- bin-call-manager: Thread typ param through listenhandler request structs and routes
+- bin-common-handler: Add typ param to CallV1ExternalMediaStart RPC client
+- bin-tts-manager: Pass TypeNormal to CallV1ExternalMediaStart
+- bin-transcribe-manager: Pass TypeNormal to CallV1ExternalMediaStart
+- bin-api-manager: Pass TypeNormal to CallV1ExternalMediaStart
+- bin-pipecat-manager: Pass TypeNormal to CallV1ExternalMediaStart
+- bin-flow-manager: Add Type field to OptionExternalMediaStart"
+```
+
+**Step 2: Push and create PR**
+
+```bash
+git push -u origin NOJIRA-add-external-media-type-field
+```


### PR DESCRIPTION
Add Type field to external media model to distinguish between normal (RTP-based
via ARI ExternalMedia) and websocket-based (via chan_websocket) external media
channels. This is the model-layer preparation; actual chan_websocket integration
follows in a separate change. When Type is empty, it defaults to TypeNormal for
backward compatibility.

- bin-call-manager: Add Type type with TypeNormal/TypeWebsocket constants and Type field to ExternalMedia struct
- bin-call-manager: Add FieldType to field constants and Type to filter struct
- bin-call-manager: Thread typ param through externalmediahandler Start/Create, callhandler ExternalMediaStart, confbridgehandler ExternalMediaStart
- bin-call-manager: Add Type to request structs for external media, call, and confbridge endpoints
- bin-call-manager: Pass req.Type from listenhandler routes to handler methods
- bin-call-manager: Default empty Type to TypeNormal in startExternalMedia
- bin-common-handler: Add typ param to CallV1ExternalMediaStart interface and implementation
- bin-tts-manager: Pass externalmedia.TypeNormal to CallV1ExternalMediaStart
- bin-transcribe-manager: Pass externalmedia.TypeNormal to CallV1ExternalMediaStart
- bin-api-manager: Pass cmexternalmedia.TypeNormal to CallV1ExternalMediaStart
- bin-pipecat-manager: Pass cmexternalmedia.TypeNormal to CallV1ExternalMediaStart
- bin-flow-manager: Add Type field to OptionExternalMediaStart action option
- docs: Add design document and implementation plan