### PR TITLE
NOJIRA-tts-websocket-disconnect-cleanup

### DIFF
--- a/bin-tts-manager/models/streaming/streaming.go
+++ b/bin-tts-manager/models/streaming/streaming.go
@@ -31,8 +31,9 @@ type Streaming struct {
 	VendorName   VendorName `json:"-"` // Vendor of the service (e.g., gcp, aws)
 	VendorConfig any        `json:"-"`
 
-	ConnAst   *websocket.Conn `json:"-"` // Connection to the Asterisk for the streaming
-	CreatedAt time.Time `json:"-"` // Timestamp of when the streaming was created (for metrics)
+	ConnAst     *websocket.Conn `json:"-"` // Connection to the Asterisk for the streaming
+	ConnAstDone chan struct{}    `json:"-"` // Closed when ConnAst disconnects (Asterisk gone)
+	CreatedAt   time.Time       `json:"-"` // Timestamp of when the streaming was created (for metrics)
 }
 
 // // Direction represents the direction of the streaming in a call.

--- a/bin-tts-manager/pkg/streaminghandler/aws_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/aws_test.go
@@ -1,0 +1,190 @@
+package streaminghandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-tts-manager/models/message"
+	"monorepo/bin-tts-manager/models/streaming"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_awsHandler_Run_exitsOnConnAstDone(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &awsHandler{
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+
+	connAstDone := make(chan struct{})
+	cfCtx, cfCancel := context.WithCancel(context.Background())
+	defer cfCancel()
+
+	cf := &AWSConfig{
+		Streaming: &streaming.Streaming{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000001"),
+			},
+		},
+		Ctx:         cfCtx,
+		Cancel:      cfCancel,
+		ConnAstDone: connAstDone,
+		Message: &message.Message{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("d0000000-0000-0000-0000-000000000001"),
+			},
+		},
+		audioCh: make(chan []byte, defaultAWSAudioChBuffer),
+	}
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Run(cf)
+	}()
+
+	// Close ConnAstDone to simulate Asterisk WebSocket disconnect
+	close(connAstDone)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not exit after ConnAstDone was closed")
+	}
+
+	// Verify the context was cancelled by Run()
+	select {
+	case <-cfCtx.Done():
+		// Context was cancelled — correct
+	default:
+		t.Fatal("context was not cancelled after Run() exited via ConnAstDone")
+	}
+}
+
+func Test_awsHandler_Run_exitsOnCtxDone(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &awsHandler{
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+
+	connAstDone := make(chan struct{})
+	cfCtx, cfCancel := context.WithCancel(context.Background())
+
+	cf := &AWSConfig{
+		Streaming: &streaming.Streaming{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000002"),
+			},
+		},
+		Ctx:         cfCtx,
+		Cancel:      cfCancel,
+		ConnAstDone: connAstDone,
+		Message: &message.Message{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("d0000000-0000-0000-0000-000000000002"),
+			},
+		},
+		audioCh: make(chan []byte, defaultAWSAudioChBuffer),
+	}
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Run(cf)
+	}()
+
+	// Cancel context directly
+	cfCancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not exit after context cancellation")
+	}
+}
+
+func Test_awsHandler_Run_exitsImmediatelyIfConnAstDoneAlreadyClosed(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &awsHandler{
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+
+	// Pre-close the channel
+	connAstDone := make(chan struct{})
+	close(connAstDone)
+
+	cfCtx, cfCancel := context.WithCancel(context.Background())
+	defer cfCancel()
+
+	cf := &AWSConfig{
+		Streaming: &streaming.Streaming{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000003"),
+			},
+		},
+		Ctx:         cfCtx,
+		Cancel:      cfCancel,
+		ConnAstDone: connAstDone,
+		Message: &message.Message{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("d0000000-0000-0000-0000-000000000003"),
+			},
+		},
+		audioCh: make(chan []byte, defaultAWSAudioChBuffer),
+	}
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Run(cf)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not exit immediately when ConnAstDone was already closed")
+	}
+
+	// Context should be cancelled
+	select {
+	case <-cfCtx.Done():
+		// correct
+	default:
+		t.Fatal("context was not cancelled")
+	}
+}

--- a/bin-tts-manager/pkg/streaminghandler/gcp_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/gcp_test.go
@@ -1,0 +1,203 @@
+package streaminghandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-tts-manager/models/message"
+	"monorepo/bin-tts-manager/models/streaming"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_gcpHandler_Run_exitsOnConnAstDone(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &gcpHandler{
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+
+	connAstDone := make(chan struct{})
+	cfCtx, cfCancel := context.WithCancel(context.Background())
+	defer cfCancel()
+
+	streamCtx, streamCancel := context.WithCancel(cfCtx)
+
+	cf := &GCPConfig{
+		Streaming: &streaming.Streaming{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("a0000000-0000-0000-0000-000000000001"),
+			},
+		},
+		Ctx:          cfCtx,
+		Cancel:       cfCancel,
+		StreamCtx:    streamCtx,
+		StreamCancel: streamCancel,
+		ConnAstDone:  connAstDone,
+		Message: &message.Message{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("b0000000-0000-0000-0000-000000000001"),
+			},
+		},
+		processDone: make(chan struct{}),
+	}
+
+	// runProcess and runKeepalive will publish events
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Run(cf)
+	}()
+
+	// Close ConnAstDone to simulate Asterisk WebSocket disconnect
+	close(connAstDone)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not exit after ConnAstDone was closed")
+	}
+
+	// Verify the session context was cancelled by terminate()
+	select {
+	case <-cfCtx.Done():
+		// Context was cancelled — correct
+	default:
+		t.Fatal("session context was not cancelled after Run() exited")
+	}
+}
+
+func Test_gcpHandler_Run_exitsOnCtxDone(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &gcpHandler{
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+
+	connAstDone := make(chan struct{})
+	cfCtx, cfCancel := context.WithCancel(context.Background())
+
+	streamCtx, streamCancel := context.WithCancel(cfCtx)
+
+	cf := &GCPConfig{
+		Streaming: &streaming.Streaming{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("a0000000-0000-0000-0000-000000000002"),
+			},
+		},
+		Ctx:          cfCtx,
+		Cancel:       cfCancel,
+		StreamCtx:    streamCtx,
+		StreamCancel: streamCancel,
+		ConnAstDone:  connAstDone,
+		Message: &message.Message{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("b0000000-0000-0000-0000-000000000002"),
+			},
+		},
+		processDone: make(chan struct{}),
+	}
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Run(cf)
+	}()
+
+	// Cancel context directly (simulating SayStop)
+	cfCancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not exit after context cancellation")
+	}
+}
+
+func Test_gcpHandler_Run_exitsImmediatelyIfConnAstDoneAlreadyClosed(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &gcpHandler{
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+
+	// Pre-close the channel (simulating WebSocket disconnected before Init/Run)
+	connAstDone := make(chan struct{})
+	close(connAstDone)
+
+	cfCtx, cfCancel := context.WithCancel(context.Background())
+	defer cfCancel()
+
+	streamCtx, streamCancel := context.WithCancel(cfCtx)
+
+	cf := &GCPConfig{
+		Streaming: &streaming.Streaming{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("a0000000-0000-0000-0000-000000000003"),
+			},
+		},
+		Ctx:          cfCtx,
+		Cancel:       cfCancel,
+		StreamCtx:    streamCtx,
+		StreamCancel: streamCancel,
+		ConnAstDone:  connAstDone,
+		Message: &message.Message{
+			Identity: commonidentity.Identity{
+				ID: uuid.FromStringOrNil("b0000000-0000-0000-0000-000000000003"),
+			},
+		},
+		processDone: make(chan struct{}),
+	}
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Run(cf)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not exit immediately when ConnAstDone was already closed")
+	}
+
+	// Context should be cancelled by terminate()
+	select {
+	case <-cfCtx.Done():
+		// correct
+	default:
+		t.Fatal("session context was not cancelled")
+	}
+}

--- a/bin-tts-manager/pkg/streaminghandler/websocket.go
+++ b/bin-tts-manager/pkg/streaminghandler/websocket.go
@@ -104,9 +104,12 @@ func websocketWrite(ctx context.Context, conn *websocket.Conn, data []byte) erro
 
 // runWebSocketRead reads from the WebSocket connection to handle ping/pong and
 // close frames. Without a read loop, gorilla/websocket won't acknowledge pings.
-// Returns when the connection is closed or encounters an error.
-func runWebSocketRead(conn *websocket.Conn) {
+// Closes doneCh when the connection is closed or encounters an error, signalling
+// vendor handlers to tear down their sessions.
+func runWebSocketRead(conn *websocket.Conn, doneCh chan struct{}) {
 	log := logrus.WithField("func", "runWebSocketRead")
+
+	defer close(doneCh)
 
 	for {
 		_, _, err := conn.ReadMessage()

--- a/bin-tts-manager/pkg/streaminghandler/websocket_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/websocket_test.go
@@ -1,0 +1,118 @@
+package streaminghandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newTestWebSocketPair creates a connected client/server WebSocket pair for testing.
+// Returns the client conn, a function to close the server conn, and a cleanup function.
+func newTestWebSocketPair(t *testing.T) (client *websocket.Conn, closeServer func(), cleanup func()) {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	serverConnCh := make(chan *websocket.Conn, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("server upgrade failed: %v", err)
+		}
+		serverConnCh <- conn
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("client dial failed: %v", err)
+	}
+
+	serverConn := <-serverConnCh
+
+	return clientConn,
+		func() { _ = serverConn.Close() },
+		func() {
+			_ = clientConn.Close()
+			_ = serverConn.Close()
+			srv.Close()
+		}
+}
+
+func Test_runWebSocketRead_closesChannelOnDisconnect(t *testing.T) {
+	client, closeServer, cleanup := newTestWebSocketPair(t)
+	defer cleanup()
+
+	doneCh := make(chan struct{})
+	go runWebSocketRead(client, doneCh)
+
+	// Close the server side to trigger a read error on the client
+	closeServer()
+
+	select {
+	case <-doneCh:
+		// doneCh was closed — correct behavior
+	case <-time.After(2 * time.Second):
+		t.Fatal("doneCh was not closed after WebSocket disconnect")
+	}
+}
+
+func Test_runWebSocketRead_closesChannelOnClientClose(t *testing.T) {
+	client, _, cleanup := newTestWebSocketPair(t)
+	defer cleanup()
+
+	doneCh := make(chan struct{})
+	go runWebSocketRead(client, doneCh)
+
+	// Close the client side directly (simulating Stop() closing ConnAst)
+	_ = client.Close()
+
+	select {
+	case <-doneCh:
+		// doneCh was closed — correct behavior
+	case <-time.After(2 * time.Second):
+		t.Fatal("doneCh was not closed after client close")
+	}
+}
+
+func Test_websocketWrite_stopsOnContextCancel(t *testing.T) {
+	client, _, cleanup := newTestWebSocketPair(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create a large payload that needs many fragments (160 bytes each with 20ms pacing)
+	// 16000 bytes = 100 fragments × 20ms = 2 seconds if not cancelled
+	data := make([]byte, 16000)
+
+	cancel() // cancel immediately
+
+	err := websocketWrite(ctx, client, data)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func Test_websocketWrite_emptyData(t *testing.T) {
+	client, _, cleanup := newTestWebSocketPair(t)
+	defer cleanup()
+
+	err := websocketWrite(context.Background(), client, nil)
+	if err != nil {
+		t.Fatalf("expected nil error for empty data, got: %v", err)
+	}
+
+	err = websocketWrite(context.Background(), client, []byte{})
+	if err != nil {
+		t.Fatalf("expected nil error for zero-length data, got: %v", err)
+	}
+}


### PR DESCRIPTION
Tear down TTS vendor sessions when the Asterisk WebSocket disconnects.
Previously, vendor handlers (GCP, ElevenLabs, AWS) leaked goroutines and
streams because their Run() methods only blocked on their own context,
which was never cancelled on WebSocket disconnect.

- bin-tts-manager: Add ConnAstDone channel to Streaming struct, closed by runWebSocketRead on disconnect
- bin-tts-manager: Select on ConnAstDone in GCP, ElevenLabs, and AWS Run() methods to trigger teardown
- bin-tts-manager: Add tests for runWebSocketRead channel close, websocketWrite context cancellation
- bin-tts-manager: Add tests for GCP and AWS Run() exit on ConnAstDone, Ctx.Done, and pre-closed channel