### PR TITLE
NOJIRA-vendor-native-codec-format

### DIFF
--- a/bin-tts-manager/pkg/streaminghandler/aws.go
+++ b/bin-tts-manager/pkg/streaminghandler/aws.go
@@ -245,10 +245,7 @@ func (h *awsHandler) runProcess(cf *AWSConfig) {
 				continue
 			}
 
-			// TODO: AWS Polly outputs raw PCM, but the Asterisk channel is configured for MULAW.
-			// A PCM-to-MULAW conversion step is needed here for correct audio output.
-			// Currently only GCP streaming is used in production.
-			if errWrite := websocketWrite(cf.Ctx, cf.ConnAst, audioData); errWrite != nil {
+			if errWrite := websocketWrite(cf.Ctx, cf.ConnAst, audioData, frameSizeSlin); errWrite != nil {
 				log.Errorf("Could not write audio to asterisk: %v", errWrite)
 				return
 			}

--- a/bin-tts-manager/pkg/streaminghandler/elevenlabs_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/elevenlabs_test.go
@@ -1,7 +1,6 @@
 package streaminghandler
 
 import (
-	"bytes"
 	"context"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	fmvariable "monorepo/bin-flow-manager/models/variable"
@@ -11,86 +10,6 @@ import (
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
-
-func Test_getDataSamples(t *testing.T) {
-	type test struct {
-		name       string
-		inputRate  int
-		inputData  []byte
-		expectData []byte
-		expectErr  bool
-	}
-
-	tests := []test{
-		{
-			name:       "same sample rate (8000Hz), no change",
-			inputRate:  8000,
-			inputData:  []byte{0x01, 0x02, 0x03, 0x04},
-			expectData: []byte{0x01, 0x02, 0x03, 0x04},
-			expectErr:  false,
-		},
-		{
-			name:      "16000Hz downsample to 8000Hz",
-			inputRate: 16000,
-			inputData: []byte{
-				0x01, 0x02, // sample 1
-				0x03, 0x04, // skip
-				0x05, 0x06, // sample 2
-				0x07, 0x08, // skip
-			},
-			expectData: []byte{
-				0x01, 0x02,
-				0x05, 0x06,
-			},
-			expectErr: false,
-		},
-		{
-			name:      "unsupported rate 11025Hz",
-			inputRate: 11025,
-			inputData: []byte{0x01, 0x02, 0x03, 0x04},
-			expectErr: true,
-		},
-		{
-			name:      "24000Hz downsample to 8000Hz (factor 3)",
-			inputRate: 24000,
-			inputData: []byte{
-				0x01, 0x02, // keep
-				0x03, 0x04, // skip
-				0x05, 0x06, // skip
-				0x07, 0x08, // keep
-				0x09, 0x0A, // skip
-				0x0B, 0x0C, // skip
-			},
-			expectData: []byte{
-				0x01, 0x02,
-				0x07, 0x08,
-			},
-			expectErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := &elevenlabsHandler{}
-			output, err := handler.getDataSamples(tt.inputRate, tt.inputData)
-
-			if tt.expectErr {
-				if err == nil {
-					t.Errorf("expected error but got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-
-			if !bytes.Equal(output, tt.expectData) {
-				t.Errorf("mismatched data.\nexpected: %v\ngot:      %v", tt.expectData, output)
-			}
-		})
-	}
-}
 
 func Test_getVoiceID_getVoiceIDByLangGender(t *testing.T) {
 
@@ -208,62 +127,6 @@ func Test_getVoiceID_getVoiceIDByVariable(t *testing.T) {
 			result := h.getVoiceID(ctx, st)
 			if result != tt.expectedRes {
 				t.Errorf("Wrong match. got: %s, expected: %s", result, tt.expectedRes)
-			}
-		})
-	}
-}
-
-func Test_convertAndWrapPCMData(t *testing.T) {
-
-	tests := []struct {
-		name        string
-		inputFormat string
-		rawData     []byte
-		expectedRes []byte
-		expectError bool
-	}{
-		{
-			name:        "valid pcm_16000 input",
-			inputFormat: "pcm_16000",
-			rawData:     []byte{0x11, 0x22, 0x33, 0x44}, // 2 samples
-			expectedRes: []byte{
-				0x11, 0x22,
-			},
-			expectError: false,
-		},
-		{
-			name:        "odd length input (error)",
-			inputFormat: "pcm_16000",
-			rawData:     []byte{0x01},
-			expectError: true,
-		},
-		{
-			name:        "unsupported format",
-			inputFormat: "mp3_44100",
-			rawData:     []byte{0x00, 0x01},
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := &elevenlabsHandler{}
-
-			res, err := handler.convertAndWrapPCMData(tt.inputFormat, tt.rawData)
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("expected error, but got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
-			}
-
-			if !bytes.Equal(res, tt.expectedRes) {
-				t.Errorf("unexpected output:\nExpected: %v\nGot:      %v", tt.expectedRes, res)
 			}
 		})
 	}

--- a/bin-tts-manager/pkg/streaminghandler/gcp.go
+++ b/bin-tts-manager/pkg/streaminghandler/gcp.go
@@ -348,7 +348,7 @@ func (h *gcpHandler) runProcess(cf *GCPConfig) {
 			continue
 		}
 
-		if errWrite := websocketWrite(streamCtx, cf.ConnAst, audioData); errWrite != nil {
+		if errWrite := websocketWrite(streamCtx, cf.ConnAst, audioData, frameSizeUlaw); errWrite != nil {
 			log.Errorf("Could not write audio to asterisk: %v", errWrite)
 			return
 		}

--- a/bin-tts-manager/pkg/streaminghandler/main.go
+++ b/bin-tts-manager/pkg/streaminghandler/main.go
@@ -59,8 +59,35 @@ const (
 	defaultEncapsulation  = string(cmexternalmedia.EncapsulationNone)
 	defaultTransport      = string(cmexternalmedia.TransportWebsocket)
 	defaultConnectionType = "server"
-	defaultFormat         = "ulaw"
 )
+
+// Asterisk external media format strings and their corresponding
+// WebSocket frame sizes for 20ms of audio.
+const (
+	formatUlaw   = "ulaw"   // 8kHz 8-bit µ-law (GCP native output)
+	formatSlin   = "slin"   // 8kHz 16-bit signed linear PCM (AWS Polly native output)
+	formatSlin16 = "slin16" // 16kHz 16-bit signed linear PCM (ElevenLabs native output)
+
+	frameSizeUlaw   = 160 // 8000 * 1 * 0.020
+	frameSizeSlin   = 320 // 8000 * 2 * 0.020
+	frameSizeSlin16 = 640 // 16000 * 2 * 0.020
+)
+
+// formatForProvider returns the Asterisk external media format string
+// matching the vendor's native audio output.
+func formatForProvider(provider string) string {
+	switch streaming.VendorName(provider) {
+	case streaming.VendorNameGCP:
+		return formatUlaw
+	case streaming.VendorNameAWS:
+		return formatSlin
+	case streaming.VendorNameElevenlabs:
+		return formatSlin16
+	default:
+		// Empty provider defaults to ElevenLabs (see getStreamerByProvider).
+		return formatSlin16
+	}
+}
 
 const (
 	variableElevenlabsVoiceID = "voipbin.tts.elevenlabs.voice_id"

--- a/bin-tts-manager/pkg/streaminghandler/main_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/main_test.go
@@ -1,0 +1,26 @@
+package streaminghandler
+
+import "testing"
+
+func Test_formatForProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		expected string
+	}{
+		{"gcp", "gcp", formatUlaw},
+		{"aws", "aws", formatSlin},
+		{"elevenlabs", "elevenlabs", formatSlin16},
+		{"empty defaults to slin16", "", formatSlin16},
+		{"unknown defaults to slin16", "unknown_vendor", formatSlin16},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatForProvider(tt.provider)
+			if got != tt.expected {
+				t.Errorf("formatForProvider(%q) = %q, want %q", tt.provider, got, tt.expected)
+			}
+		})
+	}
+}

--- a/bin-tts-manager/pkg/streaminghandler/start.go
+++ b/bin-tts-manager/pkg/streaminghandler/start.go
@@ -89,6 +89,9 @@ func (h *streamingHandler) startExternalMedia(ctx context.Context, st *streaming
 		"streaming_id": st.ID,
 	})
 
+	format := formatForProvider(st.Provider)
+	log.Debugf("Using external media format %q for provider %q", format, st.Provider)
+
 	em, err := h.requestHandler.CallV1ExternalMediaStart(
 		ctx,
 		st.ID,
@@ -99,7 +102,7 @@ func (h *streamingHandler) startExternalMedia(ctx context.Context, st *streaming
 		defaultTransport,
 		"", // transportData
 		defaultConnectionType,
-		defaultFormat,
+		format,
 		externalmedia.DirectionNone,
 		externalmedia.Direction(st.Direction),
 	)

--- a/bin-tts-manager/pkg/streaminghandler/start_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/start_test.go
@@ -84,7 +84,7 @@ func Test_Start(t *testing.T) {
 				defaultTransport,
 				"", // transportData
 				defaultConnectionType,
-				defaultFormat,
+				formatSlin16, // empty provider defaults to ElevenLabs (slin16)
 				cmexternalmedia.DirectionNone,
 				cmexternalmedia.Direction(tt.direction),
 			).Return(tt.responseExternalMedia, nil)
@@ -123,7 +123,7 @@ func Test_StartWithID(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "normal - verifies CallV1ExternalMediaStart is called with INCOMING host",
+			name: "elevenlabs provider uses slin16 format",
 
 			id:            uuid.FromStringOrNil("f0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
 			customerID:    uuid.FromStringOrNil("e1d034f4-e9df-11ef-990b-2f91a795184b"),
@@ -139,6 +139,42 @@ func Test_StartWithID(t *testing.T) {
 			},
 
 			// websocketConnect will fail because there is no real WebSocket server
+			expectErr: true,
+		},
+		{
+			name: "gcp provider uses ulaw format",
+
+			id:            uuid.FromStringOrNil("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
+			customerID:    uuid.FromStringOrNil("e1d034f4-e9df-11ef-990b-2f91a795184b"),
+			referenceType: streaming.ReferenceTypeCall,
+			referenceID:   uuid.FromStringOrNil("e24d0934-e9df-11ef-9193-e30e5103f5bd"),
+			language:      "en-US",
+			provider:      "gcp",
+			voiceID:       "en-US-Wavenet-D",
+			direction:     streaming.DirectionIncoming,
+
+			responseExternalMedia: &cmexternalmedia.ExternalMedia{
+				ID: uuid.FromStringOrNil("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
+			},
+
+			expectErr: true,
+		},
+		{
+			name: "aws provider uses slin format",
+
+			id:            uuid.FromStringOrNil("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
+			customerID:    uuid.FromStringOrNil("e1d034f4-e9df-11ef-990b-2f91a795184b"),
+			referenceType: streaming.ReferenceTypeCall,
+			referenceID:   uuid.FromStringOrNil("e24d0934-e9df-11ef-9193-e30e5103f5bd"),
+			language:      "en-US",
+			provider:      "aws",
+			voiceID:       "Joanna",
+			direction:     streaming.DirectionIncoming,
+
+			responseExternalMedia: &cmexternalmedia.ExternalMedia{
+				ID: uuid.FromStringOrNil("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
+			},
+
 			expectErr: true,
 		},
 		{
@@ -206,7 +242,7 @@ func Test_StartWithID(t *testing.T) {
 					defaultTransport,
 					"", // transportData
 					defaultConnectionType,
-					defaultFormat,
+					formatForProvider(tt.provider),
 					cmexternalmedia.DirectionNone,
 					cmexternalmedia.Direction(tt.direction),
 				).Return(tt.responseExternalMedia, tt.responseExternalMediaErr)

--- a/bin-tts-manager/pkg/streaminghandler/websocket_test.go
+++ b/bin-tts-manager/pkg/streaminghandler/websocket_test.go
@@ -1,6 +1,7 @@
 package streaminghandler
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -87,13 +88,13 @@ func Test_websocketWrite_stopsOnContextCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Create a large payload that needs many fragments (160 bytes each with 20ms pacing)
+	// Create a large payload that needs many fragments (frameSizeUlaw bytes each with 20ms pacing)
 	// 16000 bytes = 100 fragments × 20ms = 2 seconds if not cancelled
 	data := make([]byte, 16000)
 
 	cancel() // cancel immediately
 
-	err := websocketWrite(ctx, client, data)
+	err := websocketWrite(ctx, client, data, frameSizeUlaw)
 	if err == nil {
 		t.Fatal("expected error from cancelled context, got nil")
 	}
@@ -106,13 +107,181 @@ func Test_websocketWrite_emptyData(t *testing.T) {
 	client, _, cleanup := newTestWebSocketPair(t)
 	defer cleanup()
 
-	err := websocketWrite(context.Background(), client, nil)
+	err := websocketWrite(context.Background(), client, nil, frameSizeUlaw)
 	if err != nil {
 		t.Fatalf("expected nil error for empty data, got: %v", err)
 	}
 
-	err = websocketWrite(context.Background(), client, []byte{})
+	err = websocketWrite(context.Background(), client, []byte{}, frameSizeUlaw)
 	if err != nil {
 		t.Fatalf("expected nil error for zero-length data, got: %v", err)
+	}
+}
+
+func Test_websocketWrite_invalidFrameSize(t *testing.T) {
+	client, _, cleanup := newTestWebSocketPair(t)
+	defer cleanup()
+
+	data := []byte{1, 2, 3}
+
+	tests := []struct {
+		name      string
+		frameSize int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := websocketWrite(context.Background(), client, data, tt.frameSize)
+			if err == nil {
+				t.Fatal("expected error for invalid frameSize, got nil")
+			}
+		})
+	}
+}
+
+// readAllFrames reads binary WebSocket frames from the server side until an error
+// (connection closed). Returns concatenated data and the individual frame sizes.
+func readAllFrames(t *testing.T, serverConn *websocket.Conn) ([]byte, []int) {
+	t.Helper()
+
+	var allData []byte
+	var frameSizes []int
+
+	for {
+		msgType, msg, err := serverConn.ReadMessage()
+		if err != nil {
+			break
+		}
+		if msgType != websocket.BinaryMessage {
+			t.Fatalf("expected binary message, got type %d", msgType)
+		}
+		allData = append(allData, msg...)
+		frameSizes = append(frameSizes, len(msg))
+	}
+	return allData, frameSizes
+}
+
+func Test_websocketWrite_fragmentsData(t *testing.T) {
+	tests := []struct {
+		name              string
+		dataLen           int
+		frameSize         int
+		expectedFragments int
+		lastFragmentSize  int
+	}{
+		{
+			name:              "single fragment - data smaller than frame",
+			dataLen:           100,
+			frameSize:         frameSizeUlaw, // 160
+			expectedFragments: 1,
+			lastFragmentSize:  100,
+		},
+		{
+			name:              "single fragment - data equals frame",
+			dataLen:           frameSizeUlaw, // 160
+			frameSize:         frameSizeUlaw,
+			expectedFragments: 1,
+			lastFragmentSize:  frameSizeUlaw,
+		},
+		{
+			name:              "multiple fragments - exact division",
+			dataLen:           frameSizeUlaw * 3, // 480
+			frameSize:         frameSizeUlaw,
+			expectedFragments: 3,
+			lastFragmentSize:  frameSizeUlaw,
+		},
+		{
+			name:              "multiple fragments - partial last frame",
+			dataLen:           frameSizeUlaw*2 + 50, // 370
+			frameSize:         frameSizeUlaw,
+			expectedFragments: 3,
+			lastFragmentSize:  50,
+		},
+		{
+			name:              "slin frame size",
+			dataLen:           frameSizeSlin * 2, // 640
+			frameSize:         frameSizeSlin,     // 320
+			expectedFragments: 2,
+			lastFragmentSize:  frameSizeSlin,
+		},
+		{
+			name:              "slin16 frame size - partial",
+			dataLen:           frameSizeSlin16 + 100, // 740
+			frameSize:         frameSizeSlin16,        // 640
+			expectedFragments: 2,
+			lastFragmentSize:  100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build a WebSocket pair where we can read from the server side
+			upgrader := websocket.Upgrader{}
+			serverConnCh := make(chan *websocket.Conn, 1)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					t.Fatalf("server upgrade failed: %v", err)
+				}
+				serverConnCh <- conn
+			}))
+			defer srv.Close()
+
+			wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+			clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				t.Fatalf("client dial failed: %v", err)
+			}
+			serverConn := <-serverConnCh
+			defer func() {
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			}()
+
+			// Fill data with a recognizable pattern
+			data := make([]byte, tt.dataLen)
+			for i := range data {
+				data[i] = byte(i % 256)
+			}
+
+			// Write in a goroutine, read from server side
+			writeDone := make(chan error, 1)
+			go func() {
+				writeDone <- websocketWrite(context.Background(), clientConn, data, tt.frameSize)
+				_ = clientConn.Close() // close so readAllFrames stops
+			}()
+
+			received, frameSizes := readAllFrames(t, serverConn)
+
+			if err := <-writeDone; err != nil {
+				t.Fatalf("websocketWrite returned error: %v", err)
+			}
+
+			// Verify all data arrived intact
+			if !bytes.Equal(received, data) {
+				t.Fatalf("received data mismatch: got %d bytes, want %d bytes", len(received), len(data))
+			}
+
+			// Verify fragment count
+			if len(frameSizes) != tt.expectedFragments {
+				t.Fatalf("expected %d fragments, got %d (sizes: %v)", tt.expectedFragments, len(frameSizes), frameSizes)
+			}
+
+			// Verify last fragment size
+			if frameSizes[len(frameSizes)-1] != tt.lastFragmentSize {
+				t.Fatalf("last fragment size: got %d, want %d", frameSizes[len(frameSizes)-1], tt.lastFragmentSize)
+			}
+
+			// Verify all non-last fragments are exactly frameSize
+			for i := 0; i < len(frameSizes)-1; i++ {
+				if frameSizes[i] != tt.frameSize {
+					t.Fatalf("fragment %d size: got %d, want %d", i, frameSizes[i], tt.frameSize)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Use each TTS vendor's native audio format for the Asterisk external media
channel instead of hardcoding ulaw for all vendors. Asterisk handles the
transcoding internally, eliminating the need for Go-side codec conversion.

- bin-tts-manager: Replace defaultFormat with per-vendor format constants (ulaw, slin, slin16)
- bin-tts-manager: Add formatForProvider() to select format based on TTS vendor
- bin-tts-manager: Make websocketWrite accept frameSize parameter for correct 20ms framing
- bin-tts-manager: GCP uses ulaw (160 bytes/frame), AWS uses slin (320), ElevenLabs uses slin16 (640)
- bin-tts-manager: Remove ElevenLabs PCM downsampling code (convertAndWrapPCMData, getDataSamples)
- bin-tts-manager: Remove PCM-to-MULAW TODO comments from AWS and ElevenLabs handlers