### PR TITLE
NOJIRA-fix-agent-manager-customer-created-race-condition

### DIFF
--- a/bin-agent-manager/go.mod
+++ b/bin-agent-manager/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
@@ -119,6 +120,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
+	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto v0.0.0-20251222181119-0a764e51fe1b // indirect

--- a/bin-agent-manager/go.sum
+++ b/bin-agent-manager/go.sum
@@ -566,6 +566,8 @@ github.com/googleapis/gax-go/v2 v2.6.0/go.mod h1:1mjbznJAPHFpesgE5ucqfYEscaz5kMd
 github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57QpBWsYpwqHJx8=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=

--- a/docs/plans/2026-02-21-fix-agent-manager-customer-created-race-condition-design.md
+++ b/docs/plans/2026-02-21-fix-agent-manager-customer-created-race-condition-design.md
@@ -1,0 +1,41 @@
+# Fix Agent Manager Customer Created Race Condition
+
+## Problem
+
+When a new customer is created, the `customer_created` event is published and consumed by two services asynchronously:
+
+1. **billing-manager** creates a billing account and updates the customer's `BillingAccountID`
+2. **agent-manager** creates a default admin agent, which requires validating resource limits against the billing account
+
+If agent-manager processes the event before billing-manager has finished, the resource limit validation call (`BillingV1AccountIsValidResourceLimitByCustomerID`) fails because the customer's `BillingAccountID` is still `uuid.Nil`, and the billing account lookup returns "Not Found".
+
+Error chain:
+```
+agent-manager: EventCustomerCreated
+  -> agentHandler.Create
+    -> reqHandler.BillingV1AccountIsValidResourceLimitByCustomerID
+      -> billing-manager: GetByCustomerID
+        -> CustomerV1CustomerGet (returns customer with BillingAccountID = uuid.Nil)
+        -> db.AccountGet(uuid.Nil) -> Not Found
+```
+
+## Approach
+
+Skip resource limit validation when creating the initial admin agent in `EventCustomerCreated`. The three pre-checks in `Create` are all logically unnecessary for this scenario:
+
+1. **Resource limit validation** - The customer was just created and has zero agents. It cannot exceed any plan limit.
+2. **Username format validation** - The customer's email was already validated at signup time.
+3. **Username uniqueness check** - The customer was just created and no agents exist yet.
+
+## Change
+
+**File:** `bin-agent-manager/pkg/agenthandler/event.go`
+
+In `EventCustomerCreated` (line 153), change `h.Create(...)` to `h.dbCreate(...)`.
+
+`dbCreate` handles password hashing, DB insertion, and event publishing - everything needed for agent creation. It's already called by `Create` itself (`agent.go:124`), so it's a well-tested code path.
+
+## Alternatives Considered
+
+- **Retry with backoff** in agent-manager: Adds complexity, still fragile if billing-manager takes longer than retries.
+- **Chain events** (agent-manager listens to `account_created` instead of `customer_created`): Clean but more complex refactor, changes the event dependency chain.

--- a/docs/plans/2026-02-21-fix-agent-manager-customer-created-race-condition-plan.md
+++ b/docs/plans/2026-02-21-fix-agent-manager-customer-created-race-condition-plan.md
@@ -1,0 +1,139 @@
+# Fix Agent Manager Customer Created Race Condition - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the race condition where agent-manager's `EventCustomerCreated` fails because billing-manager hasn't yet created the billing account.
+
+**Architecture:** Change one function call in `EventCustomerCreated` from `h.Create()` to `h.dbCreate()`, bypassing resource limit validation that depends on the billing account existing. Update three existing tests to remove mock expectations for the skipped checks.
+
+**Tech Stack:** Go, gomock
+
+**Design doc:** `docs/plans/2026-02-21-fix-agent-manager-customer-created-race-condition-design.md`
+
+---
+
+### Task 1: Update EventCustomerCreated to use dbCreate
+
+**Files:**
+- Modify: `bin-agent-manager/pkg/agenthandler/event.go:153`
+
+**Step 1: Change `h.Create` to `h.dbCreate`**
+
+In `EventCustomerCreated`, change line 153 from:
+
+```go
+	a, err := h.Create(
+```
+
+to:
+
+```go
+	a, err := h.dbCreate(
+```
+
+No other changes needed — `dbCreate` has the same signature as `Create`.
+
+**Step 2: Verify the code compiles**
+
+Run: `cd bin-agent-manager && go build ./...`
+Expected: No errors (both functions have identical signatures).
+
+---
+
+### Task 2: Update Test_EventCustomerCreated
+
+**Files:**
+- Modify: `bin-agent-manager/pkg/agenthandler/event_test.go:276-278`
+
+**Step 1: Remove mock expectations for skipped checks**
+
+In `Test_EventCustomerCreated`, the test currently sets up mock expectations for `Create`'s pre-checks (lines 277-279). Remove these three lines:
+
+```go
+// REMOVE these three lines:
+mockReq.EXPECT().BillingV1AccountIsValidResourceLimitByCustomerID(ctx, tt.customer.ID, bmaccount.ResourceTypeAgent).Return(true, nil)
+mockUtil.EXPECT().EmailIsValid(tt.customer.Email).Return(true)
+mockDB.EXPECT().AgentGetByUsername(ctx, tt.customer.Email).Return(nil, fmt.Errorf(""))
+```
+
+The remaining expectations (HashGenerate, UUIDCreate, AgentCreate, AgentGet, PublishWebhookEvent, and the PasswordForgot chain) stay as-is — those are `dbCreate` expectations.
+
+**Step 2: Run the test**
+
+Run: `cd bin-agent-manager && go test -v ./pkg/agenthandler/ -run Test_EventCustomerCreated -count=1`
+Expected: PASS
+
+---
+
+### Task 3: Update Test_EventCustomerCreated_Headless
+
+**Files:**
+- Modify: `bin-agent-manager/pkg/agenthandler/event_test.go:334-336`
+
+**Step 1: Remove mock expectations for skipped checks**
+
+In `Test_EventCustomerCreated_Headless`, remove these three lines:
+
+```go
+// REMOVE these three lines:
+mockReq.EXPECT().BillingV1AccountIsValidResourceLimitByCustomerID(ctx, cu.ID, bmaccount.ResourceTypeAgent).Return(true, nil)
+mockUtil.EXPECT().EmailIsValid(cu.Email).Return(true)
+mockDB.EXPECT().AgentGetByUsername(ctx, cu.Email).Return(nil, fmt.Errorf(""))
+```
+
+**Step 2: Run the test**
+
+Run: `cd bin-agent-manager && go test -v ./pkg/agenthandler/ -run Test_EventCustomerCreated_Headless -count=1`
+Expected: PASS
+
+---
+
+### Task 4: Update Test_EventCustomerCreated_EmailFails
+
+**Files:**
+- Modify: `bin-agent-manager/pkg/agenthandler/event_test.go:385-387`
+
+**Step 1: Remove mock expectations for skipped checks**
+
+In `Test_EventCustomerCreated_EmailFails`, remove these three lines:
+
+```go
+// REMOVE these three lines:
+mockReq.EXPECT().BillingV1AccountIsValidResourceLimitByCustomerID(ctx, customer.ID, bmaccount.ResourceTypeAgent).Return(true, nil)
+mockUtil.EXPECT().EmailIsValid(customer.Email).Return(true)
+mockDB.EXPECT().AgentGetByUsername(ctx, customer.Email).Return(nil, fmt.Errorf(""))
+```
+
+**Step 2: Run the test**
+
+Run: `cd bin-agent-manager && go test -v ./pkg/agenthandler/ -run Test_EventCustomerCreated_EmailFails -count=1`
+Expected: PASS
+
+---
+
+### Task 5: Run full verification and commit
+
+**Step 1: Run full verification workflow**
+
+```bash
+cd bin-agent-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+Expected: All steps pass, no lint errors.
+
+**Step 2: Check for unused imports**
+
+After removing the `BillingV1AccountIsValidResourceLimitByCustomerID` mock expectations from all three tests, verify whether the `bmaccount` import in `event_test.go` is still used by any remaining test. If not, remove it.
+
+Also verify whether the `bmaccount` import in `event.go` is still used. Since we removed the call to `Create` (which was the only place in event.go referencing billing models), check if the import needs removal.
+
+**Step 3: Commit**
+
+```bash
+git add bin-agent-manager/pkg/agenthandler/event.go bin-agent-manager/pkg/agenthandler/event_test.go
+git commit -m "NOJIRA-fix-agent-manager-customer-created-race-condition
+
+- bin-agent-manager: Use dbCreate instead of Create in EventCustomerCreated to skip
+  resource limit validation that races with billing-manager account creation
+- bin-agent-manager: Update event tests to remove billing validation mock expectations"
+```


### PR DESCRIPTION
Fix race condition where agent-manager's EventCustomerCreated fails because
billing-manager hasn't yet created the billing account when resource limit
validation is attempted. Both services subscribe to the customer_created event
asynchronously, and if agent-manager processes it first, the billing account
lookup returns "Not Found".

- bin-agent-manager: Use dbCreate instead of Create in EventCustomerCreated to
  skip resource limit validation that races with billing-manager account creation
- bin-agent-manager: Add idempotency guard to skip agent creation if admin agent
  already exists (handles event redelivery)
- bin-agent-manager: Update EventCustomerCreated tests to match new code path
- bin-agent-manager: Add Test_EventCustomerCreated_AlreadyExists for idempotency
- docs: Add design doc and implementation plan