### PR TITLE
NOJIRA-fix-alembic-revision-id

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/455debd049b2_customer_add_terms_agreed_columns.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/455debd049b2_customer_add_terms_agreed_columns.py
@@ -1,6 +1,6 @@
 """customer_add_terms_agreed_columns
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 455debd049b2
 Revises: 8f42ac0555e7
 Create Date: 2026-02-22 00:00:00.000000
 
@@ -9,7 +9,7 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = 'a1b2c3d4e5f6'
+revision = '455debd049b2'
 down_revision = '8f42ac0555e7'
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
Fix Alembic migration revision ID collision. The customer_add_terms_agreed_columns
migration used revision ID a1b2c3d4e5f6, which was already taken by
contact_create_tables. Changed to unique ID 455debd049b2.

- bin-dbscheme-manager: Rename migration file and update revision ID to 455debd049b2