### PR TITLE
NOJIRA-fix-alembic-duplicate-revision

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/ebbb033028db_customer_fix_empty_status.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/ebbb033028db_customer_fix_empty_status.py
@@ -1,6 +1,6 @@
 """customer_customers fix empty status values
 
-Revision ID: a1b2c3d4e5f7
+Revision ID: ebbb033028db
 Revises: 455debd049b2
 Create Date: 2026-02-23 00:00:00.000000
 
@@ -9,7 +9,7 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = 'a1b2c3d4e5f7'
+revision = 'ebbb033028db'
 down_revision = '455debd049b2'
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
Fix Alembic cycle error caused by duplicate revision ID a1b2c3d4e5f7 shared between customer_fix_empty_status and billing_allowances_fix_tm_delete_sentinel migrations.

- bin-dbscheme-manager: Rename customer_fix_empty_status migration revision from a1b2c3d4e5f7 to ebbb033028db to eliminate duplicate