### PR TITLE
NOJIRA-add-main-pull-rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,12 +240,20 @@ git push -u origin NOJIRA-descriptive-change-summary
 
 **CRITICAL: Before creating a PR or merging, ALWAYS pull the latest `main` and check for conflicts.**
 
-This is mandatory — no exceptions. Follow this sequence:
+This is mandatory — no exceptions. Run these steps **from the worktree directory** (where your feature branch lives):
 1. **Fetch latest main:** `git fetch origin main`
 2. **Check for conflicts:** `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"`
 3. **Review what changed on main:** `git log --oneline HEAD..origin/main`
 4. **If conflicts exist:** Rebase or merge main into your branch, resolve conflicts, and re-run the full verification workflow before proceeding.
 5. **If no conflicts:** Proceed with PR creation or merge.
+
+**CRITICAL: After a PR is merged on GitHub, ALWAYS sync the local main branch:**
+
+```bash
+cd ~/gitvoipbin/monorepo && git pull origin main
+```
+
+This keeps the main repository directory in sync with remote so new worktrees start from the latest code.
 
 **For detailed branch strategies and merge workflows, see [git-workflow-guide.md](docs/git-workflow-guide.md)**
 

--- a/docs/git-workflow-guide.md
+++ b/docs/git-workflow-guide.md
@@ -275,3 +275,13 @@ Claude: "I'll push the current branch to remote. Should I also merge it to main,
 - "merge to main"
 - "merge it to main and push"
 - "yes, merge to main" (in response to your question)
+
+### After PR is Merged
+
+**After a PR is merged on GitHub, ALWAYS sync the local main branch:**
+
+```bash
+cd ~/gitvoipbin/monorepo && git pull origin main
+```
+
+This keeps the main repository directory in sync with remote so new worktrees start from the latest code.

--- a/docs/plans/2026-02-23-add-main-pull-rules-design.md
+++ b/docs/plans/2026-02-23-add-main-pull-rules-design.md
@@ -1,0 +1,29 @@
+# Design: Add Main Branch Pull Rules to Git Workflow
+
+**Date:** 2026-02-23
+
+## Problem
+
+The current git workflow rules specify conflict-checking before PR/merge but don't clarify that this should happen from the worktree directory. Additionally, there's no rule for pulling the latest main into the local main repository after a PR is merged, which can cause the local main branch to drift from remote.
+
+## Rules to Add
+
+### Rule 1: Before PR/Merge — Fetch from Worktree
+
+Update the existing "Pull Main and Check Conflicts Before PR/Merge" section to explicitly state that the conflict check must be done **from the worktree directory** (where the feature branch lives).
+
+### Rule 2: After Merge — Pull Main from Main Directory
+
+Add a new rule: after a PR is merged on GitHub, go to the **main repository directory** (`~/gitvoipbin/monorepo`) and run `git pull origin main` to keep the local main branch in sync with remote.
+
+## Files to Update
+
+1. `~/CLAUDE.md` — "Pull Main and Check Conflicts Before PR/Merge" section
+2. `monorepo/CLAUDE.md` — Branch Management section
+3. `docs/git-workflow-guide.md` — Merging to Main section
+
+## Changes
+
+Each file gets:
+- Worktree context added to the pre-PR conflict check steps
+- A new "After Merge" subsection with `cd ~/gitvoipbin/monorepo && git pull origin main`

--- a/docs/plans/2026-02-23-add-main-pull-rules-plan.md
+++ b/docs/plans/2026-02-23-add-main-pull-rules-plan.md
@@ -1,0 +1,150 @@
+# Add Main Branch Pull Rules - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add two git workflow rules: (1) clarify that pre-PR conflict checks run from the worktree, (2) add post-merge pull of main from the main directory.
+
+**Architecture:** Documentation-only changes to three files that define git workflow rules.
+
+**Tech Stack:** Markdown documentation
+
+---
+
+### Task 1: Update ~/CLAUDE.md — Add worktree context and post-merge rule
+
+**Files:**
+- Modify: `~/CLAUDE.md:21-31` (the "Pull Main and Check Conflicts" section)
+
+**Step 1: Edit the conflict-check section**
+
+Replace the existing section (lines 21-31) with this updated version that adds worktree context and a post-merge rule:
+
+```markdown
+### CRITICAL: Pull Main and Check Conflicts Before PR/Merge
+
+**🚨 THIS IS A MANDATORY RULE - NO EXCEPTIONS 🚨**
+
+**Before creating a PR or merging, ALWAYS pull the latest `main` and check for conflicts.**
+
+Run these steps **from the worktree directory** (where your feature branch lives):
+
+1. **Fetch latest main:** `git fetch origin main`
+2. **Check for conflicts:** `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"`
+3. **Review what changed on main:** `git log --oneline HEAD..origin/main`
+4. **If conflicts exist:** Rebase or merge main into your branch, resolve conflicts, and re-run the full verification workflow before proceeding.
+5. **If no conflicts:** Proceed with PR creation or merge.
+
+### CRITICAL: Pull Main After PR Merge
+
+**After a PR is merged on GitHub, ALWAYS sync the local main branch:**
+
+```bash
+cd ~/gitvoipbin/monorepo && git pull origin main
+```
+
+This keeps the main repository directory in sync with remote so new worktrees start from the latest code.
+```
+
+**Step 2: Verify the edit**
+
+Read `~/CLAUDE.md` and confirm the new sections are present and properly formatted.
+
+**Step 3: Commit**
+
+```bash
+git add ~/CLAUDE.md
+# Note: ~/CLAUDE.md is outside the repo, so this will be committed separately or skipped if not tracked
+```
+
+---
+
+### Task 2: Update monorepo CLAUDE.md — Add worktree context and post-merge rule
+
+**Files:**
+- Modify: `CLAUDE.md:241-248` (the "Before creating a PR" conflict-check block)
+
+**Step 1: Edit the conflict-check block**
+
+Replace the existing block (lines 241-248) with this updated version:
+
+```markdown
+**CRITICAL: Before creating a PR or merging, ALWAYS pull the latest `main` and check for conflicts.**
+
+This is mandatory — no exceptions. Run these steps **from the worktree directory** (where your feature branch lives):
+1. **Fetch latest main:** `git fetch origin main`
+2. **Check for conflicts:** `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"`
+3. **Review what changed on main:** `git log --oneline HEAD..origin/main`
+4. **If conflicts exist:** Rebase or merge main into your branch, resolve conflicts, and re-run the full verification workflow before proceeding.
+5. **If no conflicts:** Proceed with PR creation or merge.
+
+**CRITICAL: After a PR is merged on GitHub, ALWAYS sync the local main branch:**
+
+```bash
+cd ~/gitvoipbin/monorepo && git pull origin main
+```
+
+This keeps the main repository directory in sync with remote so new worktrees start from the latest code.
+```
+
+**Step 2: Verify the edit**
+
+Read `CLAUDE.md` around lines 241-260 and confirm the new content is correct.
+
+---
+
+### Task 3: Update docs/git-workflow-guide.md — Add post-merge section
+
+**Files:**
+- Modify: `docs/git-workflow-guide.md:242-278` (the "Merging to Main Branch" section)
+
+**Step 1: Add post-merge rule at end of file**
+
+After the "Only Merge When" subsection (line 278, end of file), append:
+
+```markdown
+
+### After PR is Merged
+
+**After a PR is merged on GitHub, ALWAYS sync the local main branch:**
+
+```bash
+cd ~/gitvoipbin/monorepo && git pull origin main
+```
+
+This keeps the main repository directory in sync with remote so new worktrees start from the latest code.
+```
+
+**Step 2: Verify the edit**
+
+Read the end of `docs/git-workflow-guide.md` and confirm the new section is present.
+
+---
+
+### Task 4: Commit all changes
+
+**Step 1: Stage and commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-add-main-pull-rules
+git add CLAUDE.md docs/git-workflow-guide.md docs/plans/
+git commit -m "NOJIRA-add-main-pull-rules
+
+Add git workflow rules for pulling main branch before and after PR merge.
+
+- docs: Add worktree context to pre-PR conflict check in CLAUDE.md
+- docs: Add post-merge 'pull main' rule to CLAUDE.md
+- docs: Add post-merge section to git-workflow-guide.md
+- docs: Add design and plan documents"
+```
+
+**Step 2: Also update ~/CLAUDE.md separately**
+
+`~/CLAUDE.md` is outside the repo. Edit it directly (it's the user's private Claude instructions).
+
+**Step 3: Push and create PR**
+
+```bash
+git push -u origin NOJIRA-add-main-pull-rules
+```
+
+Then create PR with `gh pr create`.


### PR DESCRIPTION
Add git workflow rules for pulling main branch before and after PR merge.

- docs: Add worktree context to pre-PR conflict check in CLAUDE.md
- docs: Add post-merge 'pull main' rule to CLAUDE.md
- docs: Add post-merge section to git-workflow-guide.md
- docs: Add design and plan documents