### PR TITLE
NOJIRA-pipecat-manager-websocket-external-media

### DIFF
--- a/bin-pipecat-manager/cmd/pipecat-control/main.go
+++ b/bin-pipecat-manager/cmd/pipecat-control/main.go
@@ -66,7 +66,7 @@ func initPipecatcallHandler(sqlDB *sql.DB, cache cachehandler.CacheHandler) (pip
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, outline.QueueNamePipecatEvent, serviceName, "")
 	toolHandler := toolhandler.NewToolHandler(reqHandler)
 
-	return pipecatcallhandler.NewPipecatcallHandler(reqHandler, notifyHandler, db, toolHandler, "localhost:0", "cli-host"), nil
+	return pipecatcallhandler.NewPipecatcallHandler(reqHandler, notifyHandler, db, toolHandler, "cli-host"), nil
 }
 
 func initCommand() *cobra.Command {

--- a/bin-pipecat-manager/cmd/pipecat-manager/main.go
+++ b/bin-pipecat-manager/cmd/pipecat-manager/main.go
@@ -116,8 +116,6 @@ func run() error {
 	if listenIP == "" {
 		return fmt.Errorf("could not get the listen ip address")
 	}
-	listenAddress := fmt.Sprintf("%s:%d", listenIP, 8080)
-
 	requestHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, requestHandler, commonoutline.QueueNamePipecatEvent, serviceName, "")
 
@@ -127,19 +125,13 @@ func run() error {
 		log.Warnf("Could not fetch tools from ai-manager: %v. Continuing with empty tool set.", err)
 	}
 
-	pipecatcallHandler := pipecatcallhandler.NewPipecatcallHandler(requestHandler, notifyHandler, dbHandler, toolHandler, listenAddress, listenIP)
+	pipecatcallHandler := pipecatcallhandler.NewPipecatcallHandler(requestHandler, notifyHandler, dbHandler, toolHandler, listenIP)
 	httpHandler := httphandler.NewHttpHandler(requestHandler, pipecatcallHandler)
 
 	// run listen
 	if errListen := runListen(sockHandler, listenIP, pipecatcallHandler); errListen != nil {
 		log.Errorf("Could not start runListen. err: %v", errListen)
 		return errors.Wrapf(errListen, "could not start runListen")
-	}
-
-	// run streaming
-	if errStreaming := runStreaming(pipecatcallHandler); errStreaming != nil {
-		log.Errorf("Could not start runStreaming. err: %v", errStreaming)
-		return errors.Wrapf(errStreaming, "could not start runStreaming")
 	}
 
 	// run http
@@ -164,20 +156,6 @@ func runListen(
 	if err := listenHandler.Run(string("bin-manager.pipecat-manager.request"), listenQueue, string(commonoutline.QueueNameDelay)); err != nil {
 		return errors.Wrapf(err, "could not run the listenhandler correctly")
 	}
-
-	return nil
-}
-
-func runStreaming(pipecatcallHandler pipecatcallhandler.PipecatcallHandler) error {
-	log := logrus.WithFields(logrus.Fields{
-		"func": "runStreaming",
-	})
-
-	go func() {
-		if errRun := pipecatcallHandler.Run(); errRun != nil {
-			log.Errorf("Could not run the streaming handler correctly. err: %v", errRun)
-		}
-	}()
 
 	return nil
 }

--- a/bin-pipecat-manager/go.mod
+++ b/bin-pipecat-manager/go.mod
@@ -61,7 +61,6 @@ replace monorepo/bin-tts-manager => ../bin-tts-manager
 replace monorepo/bin-webhook-manager => ../bin-webhook-manager
 
 require (
-	github.com/CyCoreSystems/audiosocket v0.3.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-redsync/redsync/v4 v4.15.0

--- a/bin-pipecat-manager/go.sum
+++ b/bin-pipecat-manager/go.sum
@@ -398,8 +398,6 @@ github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoy
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
-github.com/CyCoreSystems/audiosocket v0.3.0 h1:Uu2QcXa2VxO4SavSzEanIjsIHvFfGYCs0q48bz6tu08=
-github.com/CyCoreSystems/audiosocket v0.3.0/go.mod h1:SQ0fEFxff9mLkLacI7GGVL/8y88bz0OmPcmTVol547A=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/bin-pipecat-manager/models/pipecatcall/session.go
+++ b/bin-pipecat-manager/models/pipecatcall/session.go
@@ -3,9 +3,9 @@ package pipecatcall
 import (
 	"context"
 	"monorepo/bin-common-handler/models/identity"
-	"net"
 
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/websocket"
 )
 
 type Session struct {
@@ -21,8 +21,9 @@ type Session struct {
 	RunnerWebsocketChan chan *SessionFrame `json:"-"`
 
 	// asterisk info
-	AsteriskStreamingID uuid.UUID `json:"-"`
-	AsteriskConn        net.Conn  `json:"-"`
+	AsteriskStreamingID uuid.UUID       `json:"-"`
+	ConnAst             *websocket.Conn `json:"-"`
+	ConnAstDone         chan struct{}    `json:"-"`
 
 	// llm
 	LLMKey     string `json:"-"`

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket.go
@@ -3,30 +3,17 @@ package pipecatcallhandler
 //go:generate mockgen -package pipecatcallhandler -destination ./mock_audiosocket.go -source audiosocket.go -build_flags=-mod=mod
 
 import (
-	"context"
-	"encoding/binary"
 	"fmt"
-	"net"
 
-	"github.com/CyCoreSystems/audiosocket"
-	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 	"github.com/zaf/resample"
 )
 
 type AudiosocketHandler interface {
-	GetStreamingID(conn net.Conn) (uuid.UUID, error)
-	GetNextMedia(conn net.Conn) (audiosocket.Message, error)
 	GetDataSamples(inputRate int, data []byte) ([]byte, error)
-	Upsample8kTo16k(data []byte) ([]byte, error)
-	WrapDataPCM16Bit(data []byte) ([]byte, error)
-	Write(ctx context.Context, conn net.Conn, data []byte) error
 }
 
 const (
-	defaultAudiosocketFormatSLIN        = 0x10 // SLIN format for 16-bit PCM audio
-	defaultAudiosocketMaxFragmentSize   = 320  // Maximum fragment size for Audiosocket messages
-	defaultAudiosocketConvertSampleRate = 8000 // Default sample rate for conversion to 8kHz. This must not be changed as it is the minimum sample rate for audiosocket.
+	defaultConvertSampleRate = 16000 // Target sample rate for resampling (16kHz slin16)
 )
 
 type audiosocketHandler struct{}
@@ -35,48 +22,10 @@ func NewAudiosocketHandler() AudiosocketHandler {
 	return &audiosocketHandler{}
 }
 
-// GetStreamingID gets the streaming id from the connection
-// the first message of the audiosocket should be the streaming id
-func (h *audiosocketHandler) GetStreamingID(conn net.Conn) (uuid.UUID, error) {
-	m, err := audiosocket.NextMessage(conn)
-	if err != nil {
-		return uuid.Nil, err
-	}
-
-	if m.Kind() != audiosocket.KindID {
-		return uuid.Nil, fmt.Errorf("wrong message kind. kind: %v", m.Kind())
-	}
-
-	res := uuid.FromBytesOrNil(m.Payload())
-	return res, nil
-}
-
-func (h *audiosocketHandler) GetNextMedia(conn net.Conn) (audiosocket.Message, error) {
-	m, err := audiosocket.NextMessage(conn)
-	if err != nil {
-		return nil, err
-	}
-
-	if m.Kind() != audiosocket.KindSlin {
-		if m.Kind() == audiosocket.KindHangup {
-			return nil, fmt.Errorf("received hangup. content_len: %d, kind: %v", m.ContentLength(), m.Kind())
-		}
-
-		return nil, nil
-	}
-
-	if m.ContentLength() < 1 {
-		return nil, nil
-	}
-
-	return m, nil
-}
-
-// GetDataSamples processes 16-bit PCM data with the given inputRate sample rate.
-// It uses libsoxr (via zaf/resample) for high-quality resampling with proper anti-aliasing.
-// If inputRate equals defaultConvertSampleRate (8kHz), it returns data as is.
+// GetDataSamples resamples 16-bit PCM data from inputRate to 16kHz.
+// If inputRate already equals 16kHz, it returns data unchanged.
 func (h *audiosocketHandler) GetDataSamples(inputRate int, data []byte) ([]byte, error) {
-	if inputRate == defaultAudiosocketConvertSampleRate {
+	if inputRate == defaultConvertSampleRate {
 		// No conversion needed
 		return data, nil
 	}
@@ -87,15 +36,15 @@ func (h *audiosocketHandler) GetDataSamples(inputRate int, data []byte) ([]byte,
 
 	// Get buffer from pool and estimate output size
 	inputSamples := len(data) / 2
-	outputSamples := inputSamples * defaultAudiosocketConvertSampleRate / inputRate
+	outputSamples := inputSamples * defaultConvertSampleRate / inputRate
 	output := getBuffer()
 	output.Grow(outputSamples * 2)
 
-	// Create resampler: input rate -> 8kHz, mono channel, I16 format, MediumQ quality
+	// Create resampler: input rate -> 16kHz, mono channel, I16 format, MediumQ quality
 	resampler, err := resample.New(
 		output,
 		float64(inputRate),
-		float64(defaultAudiosocketConvertSampleRate),
+		float64(defaultConvertSampleRate),
 		1,                // mono
 		resample.I16,     // 16-bit signed linear PCM
 		resample.MediumQ, // balance quality vs CPU
@@ -125,162 +74,4 @@ func (h *audiosocketHandler) GetDataSamples(inputRate int, data []byte) ([]byte,
 	putBuffer(output)
 
 	return result, nil
-}
-
-// Upsample8kTo16k performs a simple 2× upsampling from 8 kHz to 16 kHz.
-//
-// It assumes the input is 16-bit little-endian PCM mono audio (int16 per sample).
-// The algorithm uses linear interpolation: for each original sample pair (s1, s2),
-// it inserts one midpoint sample (average of s1 and s2), effectively doubling
-// the sample rate. This produces smoother playback than simple duplication while
-// remaining computationally lightweight.
-//
-// Note: This method is designed for low-latency real-time audio streaming, not
-// high-fidelity resampling. For higher quality, consider using a windowed
-func (h *audiosocketHandler) Upsample8kTo16k(data []byte) ([]byte, error) {
-	if len(data)%2 != 0 {
-		return nil, fmt.Errorf("the PCM data must be 16-bit aligned (even number of bytes). bytes: %d", len(data))
-	}
-
-	numSamples := len(data) / 2
-	if numSamples == 0 {
-		return []byte{}, nil
-	}
-
-	// Pre-allocate output buffer: (n-1)*2 + 1 samples = 2n-1 samples
-	// Each sample is 2 bytes, so output size is (2*numSamples - 1) * 2
-	outputSize := (2*numSamples - 1) * 2
-	out := getBuffer()
-	out.Grow(outputSize)
-
-	for i := 0; i < numSamples-1; i++ {
-		s1 := int16(binary.LittleEndian.Uint16(data[i*2 : i*2+2]))
-		s2 := int16(binary.LittleEndian.Uint16(data[(i+1)*2 : (i+1)*2+2]))
-
-		_ = binary.Write(out, binary.LittleEndian, s1)
-		mid := int16((int32(s1) + int32(s2)) / 2)
-		_ = binary.Write(out, binary.LittleEndian, mid)
-	}
-
-	// Write last sample
-	last := int16(binary.LittleEndian.Uint16(data[(numSamples-1)*2:]))
-	_ = binary.Write(out, binary.LittleEndian, last)
-
-	// Copy result before returning buffer to pool
-	result := make([]byte, out.Len())
-	copy(result, out.Bytes())
-	putBuffer(out)
-
-	return result, nil
-}
-
-// WrapDataPCM16Bit wraps raw 16-bit PCM audio data into the Audiosocket transmission format.
-//
-// The wrapped byte slice has the following structure:
-//   - 2 bytes: Audio format identifier (uint16, BigEndian), fixed to audiosocketFormatSLIN (0x10 for signed linear PCM)
-//   - 2 bytes: Sample count (uint16, BigEndian), representing the number of 16-bit samples
-//   - N bytes: Raw audio payload (16-bit PCM data)
-//
-// Parameters:
-//
-//	data []byte - Raw audio data buffer, must be 16-bit aligned (even length) since each sample is 2 bytes.
-//
-// Returns:
-//
-//	[]byte - The wrapped byte slice ready to be sent via Audiosocket.
-//	error  - Returns an error if the input data length is not valid or if writing to the buffer fails.
-//
-// Notes:
-//   - The function expects input PCM data to be signed 16-bit samples (little or big endian doesn't matter here,
-//     since this function only wraps data without conversion).
-//   - The sample count is calculated as len(data) / 2 because each sample consists of 2 bytes.
-//   - The resulting byte slice can be directly transmitted over Audiosocket protocol.
-func (h *audiosocketHandler) WrapDataPCM16Bit(data []byte) ([]byte, error) {
-	if len(data)%2 != 0 {
-		return nil, fmt.Errorf("the PCM data must be 16-bit aligned (even number of bytes). bytes: %d", len(data))
-	}
-
-	// Header: 1 byte format + 2 bytes length + data
-	headerSize := 3
-	buf := getBuffer()
-	buf.Grow(headerSize + len(data))
-
-	// Write audio format (SLIN)
-	if errWrite := buf.WriteByte(defaultAudiosocketFormatSLIN); errWrite != nil {
-		putBuffer(buf)
-		return nil, fmt.Errorf("failed to write data type: %w", errWrite)
-	}
-
-	// Write payload length
-	payloadLength := uint16(len(data))
-	if errWrite := binary.Write(buf, binary.BigEndian, payloadLength); errWrite != nil {
-		putBuffer(buf)
-		return nil, errors.Wrapf(errWrite, "could not write sample count")
-	}
-
-	// Write raw PCM data
-	_, err := buf.Write(data)
-	if err != nil {
-		putBuffer(buf)
-		return nil, errors.Wrapf(err, "could not write raw audio data")
-	}
-
-	// Copy result before returning buffer to pool
-	result := make([]byte, buf.Len())
-	copy(result, buf.Bytes())
-	putBuffer(buf)
-
-	return result, nil
-}
-
-// Write fragments and sends large 16-bit PCM audio data over an Audiosocket connection.
-//
-// Purpose:
-//   - To avoid overwhelming the connection, this function splits the input audio data into smaller fragments,
-//     wraps each fragment in the Audiosocket format, and writes them sequentially to the connection with a short delay between each write.
-//
-// Parameters:
-//   - ctx: Context for cancellation and timeout control.
-//   - conn: The net.Conn connection to which audio data will be sent.
-//   - data: Raw audio data as a byte slice (must be 16-bit PCM, i.e., even number of bytes).
-//
-// Behavior:
-//   - The function divides the input data into fragments of up to audiosocketMaxFragmentSize bytes.
-//   - Each fragment is wrapped using audiosocketWrapDataPCM16Bit before being sent.
-//   - After each fragment is written, the function waits for audiosocketWriteDelay to prevent flooding the connection.
-//   - If the context is cancelled or an error occurs during wrapping or writing, the function returns an error.
-//
-// Returns:
-//   - error: Returns an error if the context is cancelled, the data is invalid, or writing fails.
-func (h *audiosocketHandler) Write(ctx context.Context, conn net.Conn, data []byte) error {
-	if len(data) == 0 {
-		// nothing to send
-		return nil
-	}
-
-	payloadLen := len(data)
-	offset := 0
-
-	for offset < payloadLen {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		fragmentLen := min(defaultAudiosocketMaxFragmentSize, payloadLen-offset)
-		fragment := data[offset : offset+fragmentLen]
-
-		tmp, err := h.WrapDataPCM16Bit(fragment)
-		if err != nil {
-			return errors.Wrapf(err, "failed to wrap data for audiosocket")
-		}
-
-		_, err = conn.Write(tmp)
-		if err != nil {
-			return errors.Wrapf(err, "failed to write wrapped data to connection")
-		}
-
-		offset += fragmentLen
-	}
-
-	return nil
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket_test.go
@@ -3,7 +3,6 @@ package pipecatcallhandler
 import (
 	"bytes"
 	"encoding/binary"
-	reflect "reflect"
 	"testing"
 )
 
@@ -18,35 +17,35 @@ func Test_audiosocketGetDataSamples(t *testing.T) {
 	}{
 		{
 			name:             "no conversion needed (same sample rate)",
-			inputRate:        defaultAudiosocketConvertSampleRate,
+			inputRate:        defaultConvertSampleRate,
 			inputSamples:     100,
 			expectExactMatch: true,
 			expectError:      false,
 		},
 		{
-			name:             "downsample 2x (16000 → 8000)",
-			inputRate:        defaultAudiosocketConvertSampleRate * 2,
+			name:             "downsample 2x (32000 → 16000)",
+			inputRate:        defaultConvertSampleRate * 2,
 			inputSamples:     100,
 			expectExactMatch: false,
 			expectError:      false,
 		},
 		{
-			name:             "downsample 3x (24000 → 8000)",
-			inputRate:        defaultAudiosocketConvertSampleRate * 3,
+			name:             "downsample 3x (48000 → 16000)",
+			inputRate:        defaultConvertSampleRate * 3,
 			inputSamples:     120,
 			expectExactMatch: false,
 			expectError:      false,
 		},
 		{
-			name:             "downsample 4x (32000 → 8000)",
-			inputRate:        defaultAudiosocketConvertSampleRate * 4,
+			name:             "downsample 4x (64000 → 16000)",
+			inputRate:        defaultConvertSampleRate * 4,
 			inputSamples:     200,
 			expectExactMatch: false,
 			expectError:      false,
 		},
 		{
 			name:             "empty input",
-			inputRate:        defaultAudiosocketConvertSampleRate * 2,
+			inputRate:        defaultConvertSampleRate * 2,
 			inputSamples:     0,
 			expectExactMatch: true,
 			expectError:      false,
@@ -83,7 +82,7 @@ func Test_audiosocketGetDataSamples(t *testing.T) {
 			}
 
 			// For resampled data, verify approximate output size
-			expectedSamples := tt.inputSamples * defaultAudiosocketConvertSampleRate / tt.inputRate
+			expectedSamples := tt.inputSamples * defaultConvertSampleRate / tt.inputRate
 			actualSamples := len(res) / 2
 
 			// Allow 10% margin for resampling variations
@@ -98,119 +97,6 @@ func Test_audiosocketGetDataSamples(t *testing.T) {
 			// Verify output is valid (even number of bytes)
 			if len(res)%2 != 0 {
 				t.Errorf("output length must be even (16-bit aligned), got %d", len(res))
-			}
-		})
-	}
-}
-
-func Test_audiosocketUpsample8kTo16k(t *testing.T) {
-
-	tests := []struct {
-		name       string
-		inputData  []int16
-		expectData []int16
-	}{
-		{
-			name:      "normal upsample",
-			inputData: []int16{1000, 2000, 3000, 4000},
-			expectData: []int16{
-				1000, 1500, 2000, 2500, 3000, 3500, 4000,
-			},
-		},
-		{
-			name:       "empty input",
-			inputData:  []int16{},
-			expectData: []int16{},
-		},
-		{
-			name:      "odd length input",
-			inputData: []int16{1000, 2000, 3000},
-			expectData: []int16{
-				1000, 1500, 2000, 2500, 3000,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			h := &audiosocketHandler{}
-
-			var inputBytes bytes.Buffer
-			for _, v := range tt.inputData {
-				_ = binary.Write(&inputBytes, binary.LittleEndian, v)
-			}
-
-			out, err := h.Upsample8kTo16k(inputBytes.Bytes())
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-
-			outSamples := make([]int16, len(out)/2)
-			for i := 0; i < len(outSamples); i++ {
-				outSamples[i] = int16(binary.LittleEndian.Uint16(out[i*2 : i*2+2]))
-			}
-
-			if len(outSamples) != len(tt.expectData) {
-				t.Fatalf("length mismatch: expect %d, got %d", len(tt.expectData), len(outSamples))
-			}
-
-			for i := range outSamples {
-				if outSamples[i] != tt.expectData[i] {
-					t.Errorf("index %d: expect %d, got %d", i, tt.expectData[i], outSamples[i])
-				}
-			}
-		})
-	}
-}
-
-func Test_audiosocketWrapDataPCM16Bit(t *testing.T) {
-	tests := []struct {
-		name      string
-		inputData []int16
-		expectRes []byte
-	}{
-		{
-			name:      "normal pcm data",
-			inputData: []int16{1000, 2000},
-			// 0x10                : format byte (defaultAudiosocketFormatSLIN)
-			// 0x00, 0x04          : sample count (BigEndian, 2)
-			// 0xE8, 0x03, 0xD0, 0x07 : PCM16 LE(1000, 2000)
-			expectRes: []byte{0x10, 0x00, 0x04, 0xE8, 0x03, 0xD0, 0x07},
-		},
-		{
-			name:      "empty pcm data",
-			inputData: []int16{},
-			// 0x10 : format
-			// 0x00, 0x01 : sample count = 1
-			// 0xD2, 0x04 : PCM16 LE(1234)
-			expectRes: []byte{0x10, 0x00, 0x00},
-		},
-		{
-			name:      "single sample",
-			inputData: []int16{1234},
-			// 0x10 : format
-			// 0x00, 0x01 : sample count = 1
-			// 0xD2, 0x04 : PCM16 LE(1234)
-			expectRes: []byte{0x10, 0x00, 0x02, 0xD2, 0x04},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			h := &audiosocketHandler{}
-
-			var inputBuf bytes.Buffer
-			for _, v := range tt.inputData {
-				_ = binary.Write(&inputBuf, binary.LittleEndian, v)
-			}
-
-			out, err := h.WrapDataPCM16Bit(inputBuf.Bytes())
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(out, tt.expectRes) {
-				t.Errorf("output mismatch\nexpect: %v\ngot:    %v", tt.expectRes, out)
 			}
 		})
 	}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/main.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/main.go
@@ -22,8 +22,6 @@ import (
 )
 
 type PipecatcallHandler interface {
-	Run() error
-
 	Start(
 		ctx context.Context,
 		id uuid.UUID,
@@ -53,20 +51,16 @@ type PipecatcallHandler interface {
 //
 //nolint:deadcode,varcheck
 const (
-	defaultEncapsulation  = string(cmexternalmedia.EncapsulationAudioSocket)
-	defaultTransport      = string(cmexternalmedia.TransportTCP)
-	defaultConnectionType = "client"
-	defaultFormat         = "slin" // 8kHz, 16bit, mono signed linear PCM
+	defaultEncapsulation  = string(cmexternalmedia.EncapsulationNone)
+	defaultTransport      = string(cmexternalmedia.TransportWebsocket)
+	defaultConnectionType = "server"
+	defaultFormat         = "slin16" // 16kHz, 16bit, mono signed linear PCM
 )
 
 const (
-	defaultKeepAliveInterval = 10 * time.Second // 10 seconds
-	defaultMaxRetryAttempts  = 3
-	defaultInitialBackoff    = 100 * time.Millisecond // 100 milliseconds
-	defaultPushFrameTimeout  = 50 * time.Millisecond  // 50ms for real-time audio
+	defaultPushFrameTimeout = 50 * time.Millisecond // 50ms for real-time audio
 
 	defaultRunnerWebsocketChanBufferSize = 150 // ~3 seconds at 50fps
-	defaultRunnerWebsocketListenAddress  = "localhost:0"
 )
 
 type pipecatcallHandler struct {
@@ -81,8 +75,7 @@ type pipecatcallHandler struct {
 	websocketHandler    WebsocketHandler
 	pipecatframeHandler PipecatframeHandler
 
-	listenAddress string
-	hostID        string
+	hostID string
 
 	mapPipecatcallSession map[uuid.UUID]*pipecatcall.Session
 	muPipecatcallSession  sync.Mutex
@@ -94,7 +87,6 @@ func NewPipecatcallHandler(
 	dbHandler dbhandler.DBHandler,
 	toolHandler toolhandler.ToolHandler,
 
-	listenAddress string,
 	hostID string,
 ) PipecatcallHandler {
 	return &pipecatcallHandler{
@@ -109,8 +101,7 @@ func NewPipecatcallHandler(
 		websocketHandler:    NewWebsocketHandler(),
 		pipecatframeHandler: NewPipecatframeHandler(),
 
-		listenAddress: listenAddress,
-		hostID:        hostID,
+		hostID: hostID,
 
 		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
 		muPipecatcallSession:  sync.Mutex{},

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/mock_audiosocket.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/mock_audiosocket.go
@@ -10,12 +10,8 @@
 package pipecatcallhandler
 
 import (
-	context "context"
-	net "net"
 	reflect "reflect"
 
-	audiosocket "github.com/CyCoreSystems/audiosocket"
-	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -56,78 +52,4 @@ func (m *MockAudiosocketHandler) GetDataSamples(inputRate int, data []byte) ([]b
 func (mr *MockAudiosocketHandlerMockRecorder) GetDataSamples(inputRate, data any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataSamples", reflect.TypeOf((*MockAudiosocketHandler)(nil).GetDataSamples), inputRate, data)
-}
-
-// GetNextMedia mocks base method.
-func (m *MockAudiosocketHandler) GetNextMedia(conn net.Conn) (audiosocket.Message, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextMedia", conn)
-	ret0, _ := ret[0].(audiosocket.Message)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNextMedia indicates an expected call of GetNextMedia.
-func (mr *MockAudiosocketHandlerMockRecorder) GetNextMedia(conn any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextMedia", reflect.TypeOf((*MockAudiosocketHandler)(nil).GetNextMedia), conn)
-}
-
-// GetStreamingID mocks base method.
-func (m *MockAudiosocketHandler) GetStreamingID(conn net.Conn) (uuid.UUID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStreamingID", conn)
-	ret0, _ := ret[0].(uuid.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetStreamingID indicates an expected call of GetStreamingID.
-func (mr *MockAudiosocketHandlerMockRecorder) GetStreamingID(conn any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamingID", reflect.TypeOf((*MockAudiosocketHandler)(nil).GetStreamingID), conn)
-}
-
-// Upsample8kTo16k mocks base method.
-func (m *MockAudiosocketHandler) Upsample8kTo16k(data []byte) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Upsample8kTo16k", data)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Upsample8kTo16k indicates an expected call of Upsample8kTo16k.
-func (mr *MockAudiosocketHandlerMockRecorder) Upsample8kTo16k(data any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsample8kTo16k", reflect.TypeOf((*MockAudiosocketHandler)(nil).Upsample8kTo16k), data)
-}
-
-// WrapDataPCM16Bit mocks base method.
-func (m *MockAudiosocketHandler) WrapDataPCM16Bit(data []byte) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WrapDataPCM16Bit", data)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WrapDataPCM16Bit indicates an expected call of WrapDataPCM16Bit.
-func (mr *MockAudiosocketHandlerMockRecorder) WrapDataPCM16Bit(data any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WrapDataPCM16Bit", reflect.TypeOf((*MockAudiosocketHandler)(nil).WrapDataPCM16Bit), data)
-}
-
-// Write mocks base method.
-func (m *MockAudiosocketHandler) Write(ctx context.Context, conn net.Conn, data []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", ctx, conn, data)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Write indicates an expected call of Write.
-func (mr *MockAudiosocketHandlerMockRecorder) Write(ctx, conn, data any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockAudiosocketHandler)(nil).Write), ctx, conn, data)
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/mock_main.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/mock_main.go
@@ -59,20 +59,6 @@ func (mr *MockPipecatcallHandlerMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPipecatcallHandler)(nil).Get), ctx, id)
 }
 
-// Run mocks base method.
-func (m *MockPipecatcallHandler) Run() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Run indicates an expected call of Run.
-func (mr *MockPipecatcallHandlerMockRecorder) Run() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockPipecatcallHandler)(nil).Run))
-}
-
 // RunnerToolHandle mocks base method.
 func (m *MockPipecatcallHandler) RunnerToolHandle(id uuid.UUID, c *gin.Context) error {
 	m.ctrl.T.Helper()

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/mock_websocket.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/mock_websocket.go
@@ -10,6 +10,7 @@
 package pipecatcallhandler
 
 import (
+	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -39,6 +40,22 @@ func NewMockWebsocketHandler(ctrl *gomock.Controller) *MockWebsocketHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWebsocketHandler) EXPECT() *MockWebsocketHandlerMockRecorder {
 	return m.recorder
+}
+
+// DialContext mocks base method.
+func (m *MockWebsocketHandler) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DialContext", ctx, urlStr, requestHeader)
+	ret0, _ := ret[0].(*websocket.Conn)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DialContext indicates an expected call of DialContext.
+func (mr *MockWebsocketHandlerMockRecorder) DialContext(ctx, urlStr, requestHeader any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DialContext", reflect.TypeOf((*MockWebsocketHandler)(nil).DialContext), ctx, urlStr, requestHeader)
 }
 
 // ReadMessage mocks base method.

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/pipecatframe_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/pipecatframe_test.go
@@ -3,38 +3,12 @@ package pipecatcallhandler
 import (
 	"context"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
-	"net"
 	reflect "reflect"
 	"testing"
-	"time"
 
 	"github.com/gorilla/websocket"
 	gomock "go.uber.org/mock/gomock"
 )
-
-type DummyConn struct {
-	Written [][]byte
-}
-
-func NewDummyConn() *DummyConn {
-	return &DummyConn{
-		Written: make([][]byte, 0),
-	}
-}
-
-func (d *DummyConn) Write(b []byte) (n int, err error) {
-	cpy := make([]byte, len(b))
-	copy(cpy, b)
-	d.Written = append(d.Written, cpy)
-	return len(b), nil
-}
-func (d *DummyConn) Read(b []byte) (n int, err error)   { return 0, nil }
-func (d *DummyConn) Close() error                       { return nil }
-func (d *DummyConn) LocalAddr() net.Addr                { return nil }
-func (d *DummyConn) RemoteAddr() net.Addr               { return nil }
-func (d *DummyConn) SetDeadline(t time.Time) error      { return nil }
-func (d *DummyConn) SetReadDeadline(t time.Time) error  { return nil }
-func (d *DummyConn) SetWriteDeadline(t time.Time) error { return nil }
 
 func Test_SendData(t *testing.T) {
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
@@ -2,13 +2,9 @@ package pipecatcallhandler
 
 import (
 	"context"
-	"fmt"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
-	"net"
-	"time"
 
-	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
+	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,135 +13,16 @@ const (
 	defaultMediaNumChannel = 1
 )
 
-func (h *pipecatcallHandler) Run() error {
-	log := logrus.WithFields(logrus.Fields{
-		"func": "Run",
-	})
-
-	log.Debugf("Listening the audiosocket stream. address: %s", h.listenAddress)
-	listener, err := net.Listen("tcp", h.listenAddress)
-	if err != nil {
-		return errors.Wrapf(err, "could not listen on the address. addres: %s", h.listenAddress)
-	}
-
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			fmt.Println("Error accepting connection:", err)
-			continue
-		}
-		log.Debugf("Accepted connection. remote_addr: %s", conn.RemoteAddr())
-
-		go h.runStart(conn) // Handle connection concurrently
-	}
-}
-
-func (h *pipecatcallHandler) runStart(conn net.Conn) {
-	log := logrus.WithField("func", "runStart")
-
-	// Get streamingID
-	streamingID, err := h.audiosocketHandler.GetStreamingID(conn)
-	if err != nil {
-		log.Errorf("Could not get streaming ID. err: %v", err)
-		return
-	}
-	log = log.WithField("streaming_id", streamingID)
-	log.Debugf("Found streaming id: %s", streamingID)
-
-	// get pipecatcall info by using streamingID
-	pc, err := h.Get(context.Background(), streamingID)
-	if err != nil {
-		log.Errorf("Could not get streaming: %v", err)
-		return
-	}
-	log.WithField("pipecatcall", pc).Debugf("Pipecatcall info retrieved. pipecatcall_id: %s", pc.ID)
-
-	// create a new session
-	llmKey := h.runGetLLMKey(context.Background(), pc)
-	se, err := h.SessionCreate(pc, streamingID, conn, llmKey)
-	if err != nil {
-		log.Errorf("Could not add pipecatcall session: %v", err)
-		return
-	}
-	log.WithField("session", se).Debugf("Pipecatcall session added. pipecatcall_id: %s", pc.ID)
-
-	// Start keep-alive in a separate goroutine
-	go func() {
-		defer se.Cancel()
-		h.runAsteriskKeepAlive(se, conn, defaultKeepAliveInterval, streamingID)
-	}()
-
-	// run the pipecat runner
-	go func() {
-		defer se.Cancel()
-		h.RunnerStart(pc, se)
-	}()
-
-	// run the media handler
-	go func() {
-		defer se.Cancel()
-		h.runAsteriskReceivedMediaHandle(se)
-	}()
-
-	<-se.Ctx.Done()
-
-	log.Debugf("Context done, stopping pipecatcall. pipecatcall_id: %s", pc.ID)
-	h.terminate(context.Background(), pc)
-}
-
-func (h *pipecatcallHandler) runAsteriskKeepAlive(se *pipecatcall.Session, conn net.Conn, interval time.Duration, streamingID uuid.UUID) {
-	log := logrus.WithFields(logrus.Fields{
-		"func":         "runAsteriskKeepAlive",
-		"streaming_id": streamingID,
-	})
-
-	ticker := time.NewTicker(interval) // Use configurable interval
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-se.Ctx.Done():
-			log.Debug("Keep-alive stopped")
-			return
-
-		case <-ticker.C:
-			// Create AudioSocket keepalive message
-			keepAliveMessage := []byte{0x10, 0x00, 0x01, 0x00} // Header: type (0x10) + length (0x0001) + data (0x00)
-
-			errRetry := h.retryWithBackoff(func() error {
-				_, writeErr := conn.Write(keepAliveMessage)
-				return writeErr
-			}, defaultMaxRetryAttempts, defaultInitialBackoff)
-			if errRetry != nil {
-				log.Errorf("Failed to send keep alive message after retries: %v", errRetry)
-				return
-			}
-		}
-	}
-}
-
-func (h *pipecatcallHandler) retryWithBackoff(operation func() error, maxAttempts int, initialBackoff time.Duration) error {
-	backoff := initialBackoff
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		if err := operation(); err != nil {
-			if attempt == maxAttempts {
-				return err
-			}
-			time.Sleep(backoff)
-			backoff *= 2
-		} else {
-			return nil
-		}
-	}
-
-	return nil
-}
-
 func (h *pipecatcallHandler) runAsteriskReceivedMediaHandle(se *pipecatcall.Session) {
 	log := logrus.WithFields(logrus.Fields{
-		"func":           "runReceivedAsteriskMediaHandle",
+		"func":           "runAsteriskReceivedMediaHandle",
 		"pipecatcall_id": se.ID,
 	})
+
+	if se.ConnAst == nil {
+		log.Debugf("No Asterisk WebSocket connection, skipping media handle.")
+		return
+	}
 
 	packetID := uint64(0)
 	for {
@@ -154,15 +31,21 @@ func (h *pipecatcallHandler) runAsteriskReceivedMediaHandle(se *pipecatcall.Sess
 			return
 		}
 
-		m, err := h.audiosocketHandler.GetNextMedia(se.AsteriskConn)
+		msgType, data, err := h.websocketHandler.ReadMessage(se.ConnAst)
 		if err != nil {
-			log.Infof("Connection has closed. err: %v", err)
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				log.Debugf("Asterisk WebSocket closed normally.")
+			} else {
+				log.Infof("Asterisk WebSocket read error: %v", err)
+			}
 			return
 		}
 
-		data, err := h.audiosocketHandler.Upsample8kTo16k(m.Payload())
-		if err != nil {
-			// invalid audio data, skip this packet
+		if msgType != websocket.BinaryMessage {
+			continue
+		}
+
+		if len(data) == 0 {
 			continue
 		}
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
@@ -2,48 +2,160 @@ package pipecatcallhandler
 
 import (
 	"context"
-	"monorepo/bin-pipecat-manager/models/pipecatcall"
-	"reflect"
+	"fmt"
 	"testing"
-	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
 
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/websocket"
+	gomock "go.uber.org/mock/gomock"
 )
 
-func Test_runKeepAlive(t *testing.T) {
+func Test_runAsteriskReceivedMediaHandle(t *testing.T) {
 	tests := []struct {
-		name        string
-		session     *pipecatcall.Session
-		interval    time.Duration
-		streamingID uuid.UUID
+		name string
+
+		readMessages []struct {
+			msgType int
+			data    []byte
+			err     error
+		}
+
+		expectAudioFrames int
 	}{
 		{
-			name:        "send keep-alive once",
-			session:     &pipecatcall.Session{},
-			interval:    10 * time.Millisecond,
-			streamingID: uuid.FromStringOrNil("10c6616e-af26-11f0-9407-e352eaba2dd0"),
+			name: "receives binary audio frames",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: 0, data: nil, err: fmt.Errorf("connection closed")},
+			},
+			expectAudioFrames: 2,
+		},
+		{
+			name: "skips non-binary messages",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: websocket.TextMessage, data: []byte("text"), err: nil},
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: 0, data: nil, err: fmt.Errorf("connection closed")},
+			},
+			expectAudioFrames: 1,
+		},
+		{
+			name: "skips empty binary messages",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: websocket.BinaryMessage, data: []byte{}, err: nil},
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: 0, data: nil, err: fmt.Errorf("connection closed")},
+			},
+			expectAudioFrames: 1,
+		},
+		{
+			name:              "nil ConnAst returns immediately",
+			readMessages:      nil,
+			expectAudioFrames: 0,
+		},
+		{
+			name: "websocket close normal closure",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: 0, data: nil, err: &websocket.CloseError{Code: websocket.CloseNormalClosure, Text: "normal"}},
+			},
+			expectAudioFrames: 1,
+		},
+		{
+			name: "websocket close going away",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: 0, data: nil, err: &websocket.CloseError{Code: websocket.CloseGoingAway, Text: "going away"}},
+			},
+			expectAudioFrames: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := &pipecatcallHandler{}
+			mc := gomock.NewController(t)
+			defer mc.Finish()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-			defer cancel()
+			mockWS := NewMockWebsocketHandler(mc)
+			mockPF := NewMockPipecatframeHandler(mc)
 
-			tt.session.Ctx = ctx
-			conn := &DummyConn{}
-			h.runAsteriskKeepAlive(tt.session, conn, tt.interval, tt.streamingID)
-
-			expectMessage := []byte{0x10, 0x00, 0x01, 0x00}
-			if !reflect.DeepEqual(conn.Written[0], expectMessage) {
-				t.Errorf("KeepAlive message mismatch.\nexpect: %v\ngot:    %v", expectMessage, conn.Written)
+			var conn *websocket.Conn
+			if tt.readMessages != nil {
+				conn = &websocket.Conn{}
+				for _, msg := range tt.readMessages {
+					mockWS.EXPECT().ReadMessage(conn).Return(msg.msgType, msg.data, msg.err)
+				}
 			}
 
-			if len(conn.Written) == 0 {
-				t.Errorf("No keep-alive messages were written to DummyConn")
+			if tt.expectAudioFrames > 0 {
+				mockPF.EXPECT().SendAudio(gomock.Any(), gomock.Any(), gomock.Any()).Times(tt.expectAudioFrames).Return(nil)
 			}
+
+			se := &pipecatcall.Session{
+				Identity: commonidentity.Identity{
+					ID: uuid.Must(uuid.NewV4()),
+				},
+				Ctx:     context.Background(),
+				ConnAst: conn,
+			}
+
+			h := &pipecatcallHandler{
+				websocketHandler:    mockWS,
+				pipecatframeHandler: mockPF,
+			}
+
+			h.runAsteriskReceivedMediaHandle(se)
 		})
 	}
+}
+
+func Test_runAsteriskReceivedMediaHandle_contextCancelled(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockWS := NewMockWebsocketHandler(mc)
+	mockPF := NewMockPipecatframeHandler(mc)
+	// No ReadMessage expectations — context is cancelled before any read
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID: uuid.Must(uuid.NewV4()),
+		},
+		Ctx:     ctx,
+		ConnAst: &websocket.Conn{},
+	}
+
+	h := &pipecatcallHandler{
+		websocketHandler:    mockWS,
+		pipecatframeHandler: mockPF,
+	}
+
+	h.runAsteriskReceivedMediaHandle(se)
+	// Should return without panic or hanging
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -485,13 +485,21 @@ func (h *pipecatcallHandler) runnerWebsocketHandleAudio(se *pipecatcall.Session,
 		return errors.Errorf("only mono audio is supported. num_channels: %d", numChannels)
 	}
 
-	audioData, err := h.audiosocketHandler.GetDataSamples(sampleRate, data)
-	if err != nil {
-		return errors.Wrapf(err, "could not get audio data samples")
+	audioData := data
+	if sampleRate != defaultMediaSampleRate {
+		var err error
+		audioData, err = h.audiosocketHandler.GetDataSamples(sampleRate, data)
+		if err != nil {
+			return errors.Wrapf(err, "could not resample audio data")
+		}
 	}
 
-	if errWrite := h.audiosocketHandler.Write(se.Ctx, se.AsteriskConn, audioData); errWrite != nil {
-		return errors.Wrapf(errWrite, "could not write processed audio data to asterisk connection")
+	if se.ConnAst == nil {
+		return nil
+	}
+
+	if errWrite := h.websocketAsteriskWrite(se.Ctx, se.ConnAst, audioData, websocketAsteriskFrameSize); errWrite != nil {
+		return errors.Wrapf(errWrite, "could not write audio data to asterisk websocket")
 	}
 
 	return nil

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/websocket"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -104,64 +105,105 @@ func Test_receiveMessageFrameTypeMessage(t *testing.T) {
 }
 
 func Test_runnerWebsocketHandleAudio(t *testing.T) {
-	tests := []struct {
-		name string
 
-		se          *pipecatcall.Session
-		sampleRate  int
-		numChannels int
-		data        []byte
+	t.Run("16kHz mono audio passes through without resampling", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
 
-		responseDataSamples []byte
-		expectWriteData     []byte
-	}{
-		{
-			name: "normal mono audio",
+		mockWS := NewMockWebsocketHandler(mc)
+		h := &pipecatcallHandler{
+			websocketHandler: mockWS,
+		}
 
-			se: &pipecatcall.Session{
-				AsteriskConn: NewDummyConn(),
-				Ctx:          context.Background(),
-			},
-			sampleRate:  16000,
-			numChannels: 1,
-			data:        []byte{0x01, 0x02, 0x03, 0x04},
+		// ConnAst is non-nil so websocketAsteriskWrite will be called.
+		// Data is 4 bytes which is smaller than websocketAsteriskFrameSize (640),
+		// so it will be written as a single fragment.
+		conn := &websocket.Conn{}
+		se := &pipecatcall.Session{
+			Ctx:     context.Background(),
+			ConnAst: conn,
+		}
 
-			responseDataSamples: []byte{0x10, 0x20, 0x30, 0x40},
-			expectWriteData:     []byte{0x10, 0x20, 0x30, 0x40},
-		},
-		{
-			name: "empty data",
+		data := []byte{0x01, 0x02, 0x03, 0x04}
+		mockWS.EXPECT().WriteMessage(conn, websocket.BinaryMessage, data).Return(nil)
 
-			se: &pipecatcall.Session{
-				AsteriskConn: NewDummyConn(),
-				Ctx:          context.Background(),
-			},
-			sampleRate:  8000,
-			numChannels: 1,
-			data:        []byte{},
+		if err := h.runnerWebsocketHandleAudio(se, 16000, 1, data); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 
-			responseDataSamples: []byte{},
-			expectWriteData:     []byte{},
-		},
-	}
+	t.Run("non-16kHz audio is resampled before writing", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mc := gomock.NewController(t)
-			defer mc.Finish()
+		mockAudio := NewMockAudiosocketHandler(mc)
+		mockWS := NewMockWebsocketHandler(mc)
+		h := &pipecatcallHandler{
+			audiosocketHandler: mockAudio,
+			websocketHandler:   mockWS,
+		}
 
-			mockAudio := NewMockAudiosocketHandler(mc)
-			h := &pipecatcallHandler{
-				audiosocketHandler: mockAudio,
-			}
+		conn := &websocket.Conn{}
+		se := &pipecatcall.Session{
+			Ctx:     context.Background(),
+			ConnAst: conn,
+		}
 
-			mockAudio.EXPECT().GetDataSamples(tt.sampleRate, tt.data).Return(tt.responseDataSamples, nil)
-			mockAudio.EXPECT().Write(tt.se.Ctx, tt.se.AsteriskConn, tt.expectWriteData).Return(nil)
+		inputData := []byte{0x01, 0x02, 0x03, 0x04}
+		resampledData := []byte{0x10, 0x20}
 
-			if err := h.runnerWebsocketHandleAudio(tt.se, tt.sampleRate, tt.numChannels, tt.data); err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+		mockAudio.EXPECT().GetDataSamples(8000, inputData).Return(resampledData, nil)
+		mockWS.EXPECT().WriteMessage(conn, websocket.BinaryMessage, resampledData).Return(nil)
 
-		})
-	}
+		if err := h.runnerWebsocketHandleAudio(se, 8000, 1, inputData); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("stereo audio is rejected", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		h := &pipecatcallHandler{}
+		se := &pipecatcall.Session{
+			Ctx: context.Background(),
+		}
+
+		err := h.runnerWebsocketHandleAudio(se, 16000, 2, []byte{0x01, 0x02})
+		if err == nil {
+			t.Errorf("expected error for stereo audio, got nil")
+		}
+	})
+
+	t.Run("nil ConnAst returns nil without writing", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		h := &pipecatcallHandler{}
+		se := &pipecatcall.Session{
+			Ctx:     context.Background(),
+			ConnAst: nil,
+		}
+
+		if err := h.runnerWebsocketHandleAudio(se, 16000, 1, []byte{0x01, 0x02}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty data returns nil", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		h := &pipecatcallHandler{}
+		conn := &websocket.Conn{}
+		se := &pipecatcall.Session{
+			Ctx:     context.Background(),
+			ConnAst: conn,
+		}
+
+		// websocketAsteriskWrite returns nil for empty data without calling WriteMessage
+		if err := h.runnerWebsocketHandleAudio(se, 16000, 1, []byte{}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
@@ -5,16 +5,17 @@ import (
 	"fmt"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
-	"net"
 
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
 )
 
 func (h *pipecatcallHandler) SessionCreate(
 	pc *pipecatcall.Pipecatcall,
 	asteriskStreamingID uuid.UUID,
-	asteriskConn net.Conn,
+	connAst *websocket.Conn,
+	connAstDone chan struct{},
 	llmKey string,
 ) (*pipecatcall.Session, error) {
 
@@ -34,7 +35,8 @@ func (h *pipecatcallHandler) SessionCreate(
 		RunnerWebsocketChan: make(chan *pipecatcall.SessionFrame, defaultRunnerWebsocketChanBufferSize),
 
 		AsteriskStreamingID: asteriskStreamingID,
-		AsteriskConn:        asteriskConn,
+		ConnAst:             connAst,
+		ConnAstDone:         connAstDone,
 
 		LLMKey: llmKey,
 	}
@@ -63,11 +65,6 @@ func (h *pipecatcallHandler) SessionGet(id uuid.UUID) (*pipecatcall.Session, err
 	return res, nil
 }
 
-func (h *pipecatcallHandler) SessionsetAsteriskInfo(pc *pipecatcall.Session, streamingID uuid.UUID, conn net.Conn) {
-	pc.AsteriskConn = conn
-	pc.AsteriskStreamingID = streamingID
-}
-
 func (h *pipecatcallHandler) sessionDelete(id uuid.UUID) {
 	h.muPipecatcallSession.Lock()
 	defer h.muPipecatcallSession.Unlock()
@@ -88,8 +85,8 @@ func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
 		return
 	}
 
-	if pc.AsteriskConn != nil {
-		if errClose := pc.AsteriskConn.Close(); errClose != nil {
+	if pc.ConnAst != nil {
+		if errClose := pc.ConnAst.Close(); errClose != nil {
 			log.Errorf("Could not close the asterisk connection. err: %v", errClose)
 		} else {
 			log.Infof("Closed the asterisk connection.")

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go
@@ -1,14 +1,18 @@
 package pipecatcallhandler
 
 import (
-	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
 
 	"github.com/gofrs/uuid"
+	"github.com/gorilla/websocket"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -75,7 +79,7 @@ func TestSessionCreate(t *testing.T) {
 				h.mapPipecatcallSession[tt.existingSession.ID] = tt.existingSession
 			}
 
-			result, err := h.SessionCreate(tt.pc, tt.asteriskStreamingID, nil, tt.llmKey)
+			result, err := h.SessionCreate(tt.pc, tt.asteriskStreamingID, nil, nil, tt.llmKey)
 
 			if tt.expectErr {
 				if err == nil {
@@ -193,51 +197,6 @@ func TestSessionGet(t *testing.T) {
 	}
 }
 
-func TestSessionsetAsteriskInfo(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	h := &pipecatcallHandler{}
-
-	pc := &pipecatcall.Session{
-		Identity: commonidentity.Identity{
-			ID: uuid.FromStringOrNil("496365e2-88e6-11ea-956c-e3dfb6eaf1e8"),
-		},
-	}
-
-	streamingID := uuid.FromStringOrNil("5b374a54-b48c-11f0-8c36-477d3f6baf0d")
-
-	// Create a mock connection
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Failed to create listener: %v", err)
-	}
-	defer listener.Close()
-
-	go func() {
-		conn, _ := listener.Accept()
-		if conn != nil {
-			defer conn.Close()
-		}
-	}()
-
-	conn, err := net.Dial("tcp", listener.Addr().String())
-	if err != nil {
-		t.Fatalf("Failed to dial: %v", err)
-	}
-	defer conn.Close()
-
-	h.SessionsetAsteriskInfo(pc, streamingID, conn)
-
-	if pc.AsteriskStreamingID != streamingID {
-		t.Errorf("SessionsetAsteriskInfo() AsteriskStreamingID = %v, want %v", pc.AsteriskStreamingID, streamingID)
-	}
-
-	if pc.AsteriskConn != conn {
-		t.Errorf("SessionsetAsteriskInfo() AsteriskConn mismatch")
-	}
-}
-
 func TestSessionDelete(t *testing.T) {
 	id := uuid.FromStringOrNil("496365e2-88e6-11ea-956c-e3dfb6eaf1e8")
 
@@ -322,5 +281,66 @@ func TestSessionStop(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSessionStop_closesWebSocket(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockPythonRunner := NewMockPythonRunner(mc)
+
+	id := uuid.FromStringOrNil("496365e2-88e6-11ea-956c-e3dfb6eaf1e8")
+
+	// Create a real WebSocket server/client pair so ConnAst.Close() works on
+	// an actual connection.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := websocket.Upgrader{}
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Keep server side alive until the client disconnects
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial test ws: %v", err)
+	}
+
+	h := &pipecatcallHandler{
+		pythonRunner:          mockPythonRunner,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+	}
+
+	h.mapPipecatcallSession[id] = &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		ConnAst: conn,
+	}
+
+	mockPythonRunner.EXPECT().Stop(gomock.Any(), id).Return(nil)
+
+	h.SessionStop(id)
+
+	// Verify the WebSocket connection was closed: a subsequent read should fail.
+	_ = conn.SetReadDeadline(time.Now().Add(1 * time.Second))
+	_, _, readErr := conn.ReadMessage()
+	if readErr == nil {
+		t.Errorf("expected read error after SessionStop closed the WebSocket, but got nil")
+	}
+
+	// Verify session was removed
+	if _, ok := h.mapPipecatcallSession[id]; ok {
+		t.Errorf("session should be deleted after SessionStop")
 	}
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
@@ -77,7 +77,7 @@ func (h *pipecatcallHandler) Start(
 
 func (h *pipecatcallHandler) startReferenceTypeCall(ctx context.Context, pc *pipecatcall.Pipecatcall) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":           "startReferenceTypeAIcall",
+		"func":           "startReferenceTypeCall",
 		"pipecatcall_id": pc.ID,
 	})
 
@@ -88,14 +88,12 @@ func (h *pipecatcallHandler) startReferenceTypeCall(ctx context.Context, pc *pip
 	log.WithField("call", c).Info("Retrieved call info. call_id: ", c.ID)
 
 	// start the external media
-	// send request to the call-manager
-	// currently only supporting call reference type
 	em, err := h.requestHandler.CallV1ExternalMediaStart(
 		ctx,
 		pc.ID,
 		cmexternalmedia.ReferenceTypeCall,
 		c.ID,
-		h.listenAddress,
+		"INCOMING",
 		defaultEncapsulation,
 		defaultTransport,
 		"", // transportData
@@ -108,6 +106,51 @@ func (h *pipecatcallHandler) startReferenceTypeCall(ctx context.Context, pc *pip
 		return errors.Wrapf(err, "could not create external media")
 	}
 	log.WithField("external_media", em).Info("Created external media. external_media_id: ", em.ID)
+
+	// Connect to Asterisk via WebSocket
+	conn, err := h.websocketAsteriskConnect(ctx, em.MediaURI)
+	if err != nil {
+		log.Errorf("Could not connect WebSocket to Asterisk. err: %v", err)
+		if _, errStop := h.requestHandler.CallV1ExternalMediaStop(ctx, em.ID); errStop != nil {
+			log.Errorf("Could not stop orphaned external media. err: %v", errStop)
+		}
+		return errors.Wrapf(err, "could not connect to asterisk websocket")
+	}
+	log.Debugf("WebSocket connected to Asterisk. media_uri: %s", em.MediaURI)
+
+	connAstDone := make(chan struct{})
+
+	llmKey := h.runGetLLMKey(ctx, pc)
+	se, err := h.SessionCreate(pc, pc.ID, conn, connAstDone, llmKey)
+	if err != nil {
+		_ = conn.Close()
+		return errors.Wrapf(err, "could not create pipecatcall session")
+	}
+
+	// Start WebSocket read lifecycle goroutine
+	go runWebSocketAsteriskRead(conn, connAstDone)
+
+	// Start pipecat runner
+	go func() {
+		defer se.Cancel()
+		h.RunnerStart(pc, se)
+	}()
+
+	// Start media handler (reads audio from Asterisk WebSocket, sends to Python)
+	go func() {
+		defer se.Cancel()
+		h.runAsteriskReceivedMediaHandle(se)
+	}()
+
+	// Monitor lifecycle — when context or WebSocket dies, terminate
+	go func() {
+		select {
+		case <-se.Ctx.Done():
+		case <-connAstDone:
+		}
+		log.Debugf("Asterisk connection or context done, terminating. pipecatcall_id: %s", pc.ID)
+		h.terminate(context.Background(), pc)
+	}()
 
 	return nil
 }
@@ -127,14 +170,12 @@ func (h *pipecatcallHandler) startReferenceTypeAIcall(ctx context.Context, pc *p
 	switch c.ReferenceType {
 	case amaicall.ReferenceTypeCall:
 		// start the external media
-		// send request to the call-manager
-		// currently only supporting call reference type
 		em, err := h.requestHandler.CallV1ExternalMediaStart(
 			ctx,
 			pc.ID,
 			cmexternalmedia.ReferenceTypeCall,
 			c.ReferenceID,
-			h.listenAddress,
+			"INCOMING",
 			defaultEncapsulation,
 			defaultTransport,
 			"", // transportData
@@ -147,11 +188,57 @@ func (h *pipecatcallHandler) startReferenceTypeAIcall(ctx context.Context, pc *p
 			return errors.Wrapf(err, "could not create external media")
 		}
 		log.WithField("external_media", em).Info("Created external media. external_media_id: ", em.ID)
+
+		// Connect to Asterisk via WebSocket
+		conn, err := h.websocketAsteriskConnect(ctx, em.MediaURI)
+		if err != nil {
+			log.Errorf("Could not connect WebSocket to Asterisk. err: %v", err)
+			if _, errStop := h.requestHandler.CallV1ExternalMediaStop(ctx, em.ID); errStop != nil {
+				log.Errorf("Could not stop orphaned external media. err: %v", errStop)
+			}
+			return errors.Wrapf(err, "could not connect to asterisk websocket")
+		}
+		log.Debugf("WebSocket connected to Asterisk. media_uri: %s", em.MediaURI)
+
+		connAstDone := make(chan struct{})
+
+		llmKey := h.runGetLLMKey(ctx, pc)
+		se, err := h.SessionCreate(pc, pc.ID, conn, connAstDone, llmKey)
+		if err != nil {
+			_ = conn.Close()
+			return errors.Wrapf(err, "could not create pipecatcall session")
+		}
+
+		// Start WebSocket read lifecycle goroutine
+		go runWebSocketAsteriskRead(conn, connAstDone)
+
+		// Start pipecat runner
+		go func() {
+			defer se.Cancel()
+			h.RunnerStart(pc, se)
+		}()
+
+		// Start media handler (reads audio from Asterisk WebSocket, sends to Python)
+		go func() {
+			defer se.Cancel()
+			h.runAsteriskReceivedMediaHandle(se)
+		}()
+
+		// Monitor lifecycle — when context or WebSocket dies, terminate
+		go func() {
+			select {
+			case <-se.Ctx.Done():
+			case <-connAstDone:
+			}
+			log.Debugf("Asterisk connection or context done, terminating. pipecatcall_id: %s", pc.ID)
+			h.terminate(context.Background(), pc)
+		}()
+
 		return nil
 
 	default:
 		llmKey := h.runGetLLMKey(ctx, pc)
-		se, err := h.SessionCreate(pc, uuid.Nil, nil, llmKey)
+		se, err := h.SessionCreate(pc, uuid.Nil, nil, nil, llmKey)
 		if err != nil {
 			return errors.Wrapf(err, "could not create pipecatcall session")
 		}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
@@ -1,0 +1,176 @@
+package pipecatcallhandler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	cmcall "monorepo/bin-call-manager/models/call"
+	cmexternalmedia "monorepo/bin-call-manager/models/externalmedia"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func Test_startReferenceTypeCall_callGetFailure(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &pipecatcallHandler{
+		requestHandler:        mockReq,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+	}
+
+	pcID := uuid.FromStringOrNil("a1b2c3d4-1111-2222-3333-444455556666")
+	referenceID := uuid.FromStringOrNil("b2c3d4e5-1111-2222-3333-444455556666")
+
+	pc := &pipecatcall.Pipecatcall{
+		Identity: commonidentity.Identity{
+			ID:         pcID,
+			CustomerID: uuid.FromStringOrNil("c3d4e5f6-1111-2222-3333-444455556666"),
+		},
+		ReferenceType: pipecatcall.ReferenceTypeCall,
+		ReferenceID:   referenceID,
+	}
+
+	// CallV1CallGet fails
+	mockReq.EXPECT().CallV1CallGet(gomock.Any(), referenceID).
+		Return(nil, fmt.Errorf("call not found"))
+
+	err := h.startReferenceTypeCall(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func Test_startReferenceTypeCall_externalMediaFailure(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &pipecatcallHandler{
+		requestHandler:        mockReq,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+	}
+
+	pcID := uuid.FromStringOrNil("a1b2c3d4-1111-2222-3333-444455556666")
+	referenceID := uuid.FromStringOrNil("b2c3d4e5-1111-2222-3333-444455556666")
+	callID := uuid.FromStringOrNil("d4e5f6a7-1111-2222-3333-444455556666")
+
+	pc := &pipecatcall.Pipecatcall{
+		Identity: commonidentity.Identity{
+			ID:         pcID,
+			CustomerID: uuid.FromStringOrNil("c3d4e5f6-1111-2222-3333-444455556666"),
+		},
+		ReferenceType: pipecatcall.ReferenceTypeCall,
+		ReferenceID:   referenceID,
+	}
+
+	// CallV1CallGet succeeds
+	mockReq.EXPECT().CallV1CallGet(gomock.Any(), referenceID).
+		Return(&cmcall.Call{
+			Identity: commonidentity.Identity{
+				ID: callID,
+			},
+		}, nil)
+
+	// CallV1ExternalMediaStart fails
+	mockReq.EXPECT().CallV1ExternalMediaStart(
+		gomock.Any(),
+		pcID,
+		cmexternalmedia.ReferenceTypeCall,
+		callID,
+		"INCOMING",
+		defaultEncapsulation,
+		defaultTransport,
+		"",
+		defaultConnectionType,
+		defaultFormat,
+		cmexternalmedia.DirectionIn,
+		cmexternalmedia.DirectionOut,
+	).Return(nil, fmt.Errorf("external media creation failed"))
+
+	err := h.startReferenceTypeCall(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func Test_startReferenceTypeCall_websocketDialFailure(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockWS := NewMockWebsocketHandler(mc)
+
+	h := &pipecatcallHandler{
+		requestHandler:        mockReq,
+		websocketHandler:      mockWS,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+	}
+
+	pcID := uuid.FromStringOrNil("a1b2c3d4-1111-2222-3333-444455556666")
+	referenceID := uuid.FromStringOrNil("b2c3d4e5-1111-2222-3333-444455556666")
+	callID := uuid.FromStringOrNil("d4e5f6a7-1111-2222-3333-444455556666")
+	emID := uuid.FromStringOrNil("e5f6a7b8-1111-2222-3333-444455556666")
+	mediaURI := "ws://asterisk:8088/ws/test-media"
+
+	pc := &pipecatcall.Pipecatcall{
+		Identity: commonidentity.Identity{
+			ID:         pcID,
+			CustomerID: uuid.FromStringOrNil("c3d4e5f6-1111-2222-3333-444455556666"),
+		},
+		ReferenceType: pipecatcall.ReferenceTypeCall,
+		ReferenceID:   referenceID,
+	}
+
+	// CallV1CallGet succeeds
+	mockReq.EXPECT().CallV1CallGet(gomock.Any(), referenceID).
+		Return(&cmcall.Call{
+			Identity: commonidentity.Identity{
+				ID: callID,
+			},
+		}, nil)
+
+	// CallV1ExternalMediaStart succeeds
+	mockReq.EXPECT().CallV1ExternalMediaStart(
+		gomock.Any(),
+		pcID,
+		cmexternalmedia.ReferenceTypeCall,
+		callID,
+		"INCOMING",
+		defaultEncapsulation,
+		defaultTransport,
+		"",
+		defaultConnectionType,
+		defaultFormat,
+		cmexternalmedia.DirectionIn,
+		cmexternalmedia.DirectionOut,
+	).Return(&cmexternalmedia.ExternalMedia{
+		ID:       emID,
+		MediaURI: mediaURI,
+	}, nil)
+
+	// WebSocket dial fails
+	mockWS.EXPECT().DialContext(gomock.Any(), mediaURI, gomock.Any()).
+		Return(nil, nil, fmt.Errorf("connection refused"))
+
+	// Cleanup: CallV1ExternalMediaStop should be called with em.ID
+	mockReq.EXPECT().CallV1ExternalMediaStop(gomock.Any(), emID).
+		Return(&cmexternalmedia.ExternalMedia{ID: emID}, nil)
+
+	err := h.startReferenceTypeCall(context.Background(), pc)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/websocket.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/websocket.go
@@ -3,15 +3,27 @@ package pipecatcallhandler
 //go:generate mockgen -package pipecatcallhandler -destination ./mock_websocket.go -source websocket.go -build_flags=-mod=mod
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	websocketAsteriskSubprotocol = "media"
+	websocketAsteriskWriteDelay  = 20 * time.Millisecond
+	websocketAsteriskFrameSize   = 640 // 16000 Hz * 2 bytes * 20ms
 )
 
 type WebsocketHandler interface {
 	Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header) (*websocket.Conn, error)
 	ReadMessage(conn *websocket.Conn) (int, []byte, error)
 	WriteMessage(conn *websocket.Conn, messageType int, data []byte) error
+	DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error)
 }
 
 var upgrader = websocket.Upgrader{
@@ -38,4 +50,110 @@ func (h *websocketHandler) ReadMessage(conn *websocket.Conn) (int, []byte, error
 
 func (h *websocketHandler) WriteMessage(conn *websocket.Conn, messageType int, data []byte) error {
 	return conn.WriteMessage(messageType, data)
+}
+
+func (h *websocketHandler) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+	dialer := websocket.Dialer{
+		Subprotocols: []string{websocketAsteriskSubprotocol},
+	}
+	return dialer.DialContext(ctx, urlStr, requestHeader)
+}
+
+// websocketAsteriskConnect dials the Asterisk chan_websocket endpoint and waits
+// for the MEDIA_START text message that signals the channel is ready.
+func (h *pipecatcallHandler) websocketAsteriskConnect(ctx context.Context, mediaURI string) (*websocket.Conn, error) {
+	conn, _, err := h.websocketHandler.DialContext(ctx, mediaURI, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not dial WebSocket. media_uri: %s", mediaURI)
+	}
+
+	if errDeadline := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); errDeadline != nil {
+		_ = conn.Close()
+		return nil, errors.Wrapf(errDeadline, "could not set read deadline")
+	}
+
+	msgType, _, err := h.websocketHandler.ReadMessage(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, errors.Wrapf(err, "could not read MEDIA_START message")
+	}
+
+	if errDeadline := conn.SetReadDeadline(time.Time{}); errDeadline != nil {
+		_ = conn.Close()
+		return nil, errors.Wrapf(errDeadline, "could not clear read deadline")
+	}
+
+	if msgType != websocket.TextMessage {
+		_ = conn.Close()
+		return nil, errors.Errorf("expected text message for MEDIA_START, got type %d", msgType)
+	}
+
+	return conn, nil
+}
+
+// websocketAsteriskWrite fragments and sends raw audio data over a WebSocket
+// connection as binary frames with 20ms pacing. frameSize is the number of
+// bytes per 20ms frame for the channel's audio format.
+func (h *pipecatcallHandler) websocketAsteriskWrite(ctx context.Context, conn *websocket.Conn, data []byte, frameSize int) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if frameSize <= 0 {
+		return fmt.Errorf("frameSize must be positive, got %d", frameSize)
+	}
+
+	ticker := time.NewTicker(websocketAsteriskWriteDelay)
+	defer ticker.Stop()
+
+	offset := 0
+	payloadLen := len(data)
+
+	for offset < payloadLen {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		fragmentLen := min(frameSize, payloadLen-offset)
+		fragment := data[offset : offset+fragmentLen]
+
+		if err := h.websocketHandler.WriteMessage(conn, websocket.BinaryMessage, fragment); err != nil {
+			return errors.Wrapf(err, "failed to write WebSocket binary frame")
+		}
+
+		offset += fragmentLen
+
+		if offset >= payloadLen {
+			break
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+// runWebSocketAsteriskRead reads from the WebSocket connection to handle
+// ping/pong and close frames. Without a read loop, gorilla/websocket won't
+// acknowledge pings. Closes doneCh when the connection is closed or encounters
+// an error, signalling handlers to tear down their sessions.
+func runWebSocketAsteriskRead(conn *websocket.Conn, doneCh chan struct{}) {
+	log := logrus.WithField("func", "runWebSocketAsteriskRead")
+	defer close(doneCh)
+
+	for {
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				log.Debugf("Asterisk WebSocket closed normally: %v", err)
+			} else {
+				log.Errorf("Asterisk WebSocket read error: %v", err)
+			}
+			return
+		}
+	}
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/websocket_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/websocket_test.go
@@ -1,7 +1,16 @@
 package pipecatcallhandler
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	gomock "go.uber.org/mock/gomock"
 )
 
 func Test_upgraderBufferSizes(t *testing.T) {
@@ -19,5 +28,312 @@ func Test_upgraderBufferSizes(t *testing.T) {
 	if upgrader.WriteBufferSize < minBufferSize {
 		t.Errorf("WriteBufferSize too small: got %d, want >= %d",
 			upgrader.WriteBufferSize, minBufferSize)
+	}
+}
+
+func Test_websocketAsteriskWrite(t *testing.T) {
+	tests := []struct {
+		name string
+
+		data      []byte
+		frameSize int
+
+		expectWriteCalls int
+		expectErr        bool
+	}{
+		{
+			name: "single frame (640 bytes)",
+
+			data:      make([]byte, 640),
+			frameSize: 640,
+
+			expectWriteCalls: 1,
+			expectErr:        false,
+		},
+		{
+			name: "multiple frames (1280 bytes, 2 writes)",
+
+			data:      make([]byte, 1280),
+			frameSize: 640,
+
+			expectWriteCalls: 2,
+			expectErr:        false,
+		},
+		{
+			name: "data smaller than frame size (320 bytes, 1 write)",
+
+			data:      make([]byte, 320),
+			frameSize: 640,
+
+			expectWriteCalls: 1,
+			expectErr:        false,
+		},
+		{
+			name: "empty data (0 writes)",
+
+			data:      []byte{},
+			frameSize: 640,
+
+			expectWriteCalls: 0,
+			expectErr:        false,
+		},
+		{
+			name: "invalid frame size (0)",
+
+			data:      make([]byte, 640),
+			frameSize: 0,
+
+			expectWriteCalls: 0,
+			expectErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockWS := NewMockWebsocketHandler(mc)
+
+			h := &pipecatcallHandler{
+				websocketHandler: mockWS,
+			}
+
+			if tt.expectWriteCalls > 0 {
+				mockWS.EXPECT().WriteMessage(gomock.Any(), websocket.BinaryMessage, gomock.Any()).
+					Return(nil).
+					Times(tt.expectWriteCalls)
+			}
+
+			err := h.websocketAsteriskWrite(context.Background(), nil, tt.data, tt.frameSize)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_websocketAsteriskWrite_contextCancelled(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockWS := NewMockWebsocketHandler(mc)
+
+	h := &pipecatcallHandler{
+		websocketHandler: mockWS,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// First write succeeds, then cancel before second frame
+	mockWS.EXPECT().WriteMessage(gomock.Any(), websocket.BinaryMessage, gomock.Any()).
+		DoAndReturn(func(_ *websocket.Conn, _ int, _ []byte) error {
+			cancel()
+			return nil
+		}).
+		Times(1)
+
+	data := make([]byte, 1280)
+	err := h.websocketAsteriskWrite(ctx, nil, data, 640)
+
+	if err == nil {
+		t.Errorf("expected context cancelled error but got nil")
+	}
+	if err != nil && err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func Test_runWebSocketAsteriskRead(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "normal closure closes doneCh",
+		},
+		{
+			name: "going away closes doneCh",
+		},
+		{
+			name: "unexpected error closes doneCh",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use a real test WebSocket server/client pair.
+			// runWebSocketAsteriskRead calls conn.ReadMessage() directly (not
+			// through the mock interface), so we need real WebSocket connections.
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				up := websocket.Upgrader{}
+				c, err := up.Upgrade(w, r, nil)
+				if err != nil {
+					return
+				}
+				// Close the server side immediately to trigger read error on client
+				_ = c.Close()
+			}))
+			defer srv.Close()
+
+			wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+			conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				t.Fatalf("failed to dial test ws: %v", err)
+			}
+
+			doneCh := make(chan struct{})
+			go runWebSocketAsteriskRead(conn, doneCh)
+
+			// doneCh should be closed when read fails
+			select {
+			case <-doneCh:
+				// success
+			case <-time.After(5 * time.Second):
+				t.Fatal("doneCh was not closed within timeout")
+			}
+		})
+	}
+}
+
+func Test_websocketAsteriskWrite_writeErrorMidWrite(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockWS := NewMockWebsocketHandler(mc)
+
+	// First write succeeds, second write fails
+	gomock.InOrder(
+		mockWS.EXPECT().WriteMessage(gomock.Any(), websocket.BinaryMessage, gomock.Any()).Return(nil),
+		mockWS.EXPECT().WriteMessage(gomock.Any(), websocket.BinaryMessage, gomock.Any()).Return(fmt.Errorf("connection closed")),
+	)
+
+	h := &pipecatcallHandler{
+		websocketHandler: mockWS,
+	}
+
+	err := h.websocketAsteriskWrite(context.Background(), nil, make([]byte, 1280), 640)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+}
+
+func Test_websocketAsteriskConnect(t *testing.T) {
+	tests := []struct {
+		name string
+
+		dialErr    error
+		msgType    int
+		readErr    error
+
+		expectErr       bool
+		expectErrSubstr string
+	}{
+		{
+			name: "successful connection",
+
+			dialErr: nil,
+			msgType: websocket.TextMessage,
+			readErr: nil,
+
+			expectErr: false,
+		},
+		{
+			name: "dial failure",
+
+			dialErr: fmt.Errorf("connection refused"),
+
+			expectErr:       true,
+			expectErrSubstr: "could not dial WebSocket",
+		},
+		{
+			name: "wrong message type (binary instead of text)",
+
+			dialErr: nil,
+			msgType: websocket.BinaryMessage,
+			readErr: nil,
+
+			expectErr:       true,
+			expectErrSubstr: "expected text message for MEDIA_START",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockWS := NewMockWebsocketHandler(mc)
+
+			h := &pipecatcallHandler{
+				websocketHandler: mockWS,
+			}
+
+			if tt.dialErr != nil {
+				// Dial fails, no further calls expected
+				mockWS.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, nil, tt.dialErr)
+			} else {
+				// Dial succeeds — we need a real *websocket.Conn so SetReadDeadline works.
+				// Start a test WebSocket server to get a real connection.
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					up := websocket.Upgrader{}
+					c, err := up.Upgrade(w, r, nil)
+					if err != nil {
+						return
+					}
+					// Keep the server connection open until the test completes
+					defer func() { _ = c.Close() }()
+					// Read loop to consume the client side
+					for {
+						if _, _, err := c.ReadMessage(); err != nil {
+							return
+						}
+					}
+				}))
+				defer srv.Close()
+
+				// Dial the test server to get a real *websocket.Conn
+				wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+				realConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+				if err != nil {
+					t.Fatalf("failed to create test websocket conn: %v", err)
+				}
+				defer func() { _ = realConn.Close() }()
+
+				mockWS.EXPECT().DialContext(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(realConn, &http.Response{StatusCode: 101}, nil)
+
+				mockWS.EXPECT().ReadMessage(realConn).
+					Return(tt.msgType, []byte("MEDIA_START"), tt.readErr)
+			}
+
+			conn, err := h.websocketAsteriskConnect(context.Background(), "ws://test:8088/ws")
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				} else if tt.expectErrSubstr != "" && !strings.Contains(err.Error(), tt.expectErrSubstr) {
+					t.Errorf("expected error containing %q, got: %v", tt.expectErrSubstr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if conn == nil {
+				t.Errorf("expected non-nil connection")
+			}
+		})
 	}
 }

--- a/docs/plans/2026-02-23-pipecat-manager-websocket-external-media-design.md
+++ b/docs/plans/2026-02-23-pipecat-manager-websocket-external-media-design.md
@@ -1,0 +1,167 @@
+# Pipecat Manager: Replace Audiosocket with WebSocket External Media
+
+## Problem
+
+The pipecat-manager currently uses Audiosocket TCP (`encapsulation: "audiosocket"`, `transport: "tcp"`) to communicate with Asterisk. This requires:
+- A TCP listener goroutine in the Go service
+- Asterisk connecting as a client to the listener
+- 8kHz SLIN audio with manual upsample/downsample to/from 16kHz for the Python Pipecat side
+
+The tts-manager already uses WebSocket external media (`encapsulation: "none"`, `transport: "websocket"`), which is simpler and better supported. Pipecat-manager should use the same pattern.
+
+## Approach
+
+Full replacement of Audiosocket with WebSocket, following the tts-manager pattern.
+
+### Current Architecture
+
+```
+Asterisk --[Audiosocket TCP, 8kHz slin]--> Go (TCP listener port 8080)
+                                           Go --[internal WS, 16kHz protobuf]--> Python Pipecat
+                                           Go <--[internal WS, 16kHz protobuf]-- Python Pipecat
+Asterisk <--[Audiosocket TCP, 8kHz slin]-- Go
+```
+
+### Target Architecture
+
+```
+Asterisk (WS server) --[WebSocket, 16kHz slin16]--> Go (dials em.MediaURI)
+                                                     Go --[internal WS, 16kHz protobuf]--> Python Pipecat
+                                                     Go <--[internal WS, 16kHz protobuf]-- Python Pipecat
+Asterisk (WS server) <--[WebSocket, 16kHz slin16]-- Go
+```
+
+No sample rate conversion needed. The internal Go ↔ Python WebSocket connections (input/output) remain unchanged.
+
+## Design
+
+### 1. Constants Update (main.go)
+
+```go
+const (
+    defaultEncapsulation  = string(cmexternalmedia.EncapsulationNone)     // was "audiosocket"
+    defaultTransport      = string(cmexternalmedia.TransportWebsocket)    // was "tcp"
+    defaultConnectionType = "server"                                      // was "client"
+    defaultFormat         = "slin16"                                      // was "slin"
+    defaultFrameSize      = 640     // 16000 Hz * 2 bytes * 20ms
+    websocketSubprotocol  = "media"
+    websocketWriteDelay   = 20 * time.Millisecond
+)
+```
+
+Remove `listenAddress` field from handler struct and configuration.
+
+### 2. External Media Creation (start.go)
+
+Update `CallV1ExternalMediaStart` parameters:
+- `externalHost`: `h.listenAddress` → `"INCOMING"`
+- `encapsulation`: `"audiosocket"` → `"none"`
+- `transport`: `"tcp"` → `"websocket"`
+- `connectionType`: `"client"` → `"server"`
+- `format`: `"slin"` → `"slin16"`
+
+After external media is created, immediately dial `em.MediaURI` using the WebSocket connect pattern from tts-manager:
+1. Dial with `"media"` subprotocol
+2. Wait for `MEDIA_START` text message (10s timeout)
+3. Store `*websocket.Conn` and `ConnAstDone` channel in session
+
+### 3. Session Model (models/pipecatcall/session.go)
+
+Replace:
+- `AsteriskConn net.Conn` → `ConnAst *websocket.Conn`
+- Add `ConnAstDone chan struct{}` for lifecycle management
+
+### 4. Remove TCP Listener (run.go)
+
+Remove:
+- `Run()` TCP listener (`net.Listen`, `listener.Accept`)
+- `runStart()` Audiosocket connection handler
+- Streaming ID extraction from Audiosocket first message
+
+The connection is now established in `start.go` after external media creation. The session is created there too, since we have the WebSocket connection immediately.
+
+### 5. Audio Reading: Asterisk → Go → Python (run.go)
+
+Replace `runAsteriskReceivedMediaHandle()`:
+- Current: `audiosocketHandler.GetNextMedia(conn)` → `Upsample8kTo16k()` → `SendAudio()`
+- New: Read binary WebSocket frame (raw slin16 bytes) → `SendAudio()` directly
+
+No sample rate conversion needed since both Asterisk and Python use 16kHz.
+
+### 6. Audio Writing: Python → Go → Asterisk (runner.go)
+
+Replace audio write in `runnerWebsocketHandleAudio()`:
+- Current: `GetDataSamples(sampleRate, data)` → `audiosocketHandler.Write(conn, data)`
+- New: If `sampleRate != 16000`, resample to 16kHz (safety net). Write binary WebSocket frames with 640-byte chunks and 20ms pacing.
+
+Follow tts-manager's `websocketWrite()` pattern for frame pacing.
+
+### 7. WebSocket Helper Functions
+
+Add new functions (in existing `websocket.go` or new file):
+- `websocketAsteriskConnect(ctx, mediaURI)` — dial with "media" subprotocol, wait for MEDIA_START
+- `websocketAsteriskWrite(ctx, conn, data, frameSize)` — write with 20ms pacing
+- `runWebSocketAsteriskRead(conn, doneCh)` — lifecycle goroutine (closes doneCh on disconnect)
+
+### 8. Cleanup
+
+Remove from `audiosocket.go`:
+- `GetStreamingID()` — Audiosocket first message parsing
+- `GetNextMedia()` — Audiosocket audio frame reading
+- `Upsample8kTo16k()` — no longer needed with slin16
+- `WrapDataPCM16Bit()` — Audiosocket framing
+- `Write()` — Audiosocket fragmented writing
+
+Keep:
+- `GetDataSamples()` — safety net for resampling if Python sends non-16kHz audio
+
+### 9. Test Coverage
+
+**WebSocket connection tests:**
+- Successful connection with MEDIA_START handshake
+- Connection dial failure
+- MEDIA_START timeout (>10s)
+- Unexpected first message (not MEDIA_START)
+
+**Audio reading tests (Asterisk → Go):**
+- Read binary WebSocket frame, verify raw slin16 bytes forwarded to Python channel
+- WebSocket close mid-read (clean shutdown)
+- Context cancellation during read loop
+
+**Audio writing tests (Go → Asterisk):**
+- Write with correct 640-byte frame size and 20ms pacing
+- Data smaller than one frame
+- Data spanning multiple frames
+- WebSocket close mid-write
+- Context cancellation during write
+
+**External media start tests:**
+- Verify correct parameters passed (encapsulation: "none", transport: "websocket", etc.)
+- External media creation failure → clean error
+- WebSocket dial failure after external media created → stop external media and clean up
+
+**Session lifecycle tests:**
+- ConnAstDone channel closes when WebSocket disconnects
+- Terminate properly closes WebSocket and stops external media
+
+**Resampling safety net:**
+- Audio at 16kHz passes through unchanged
+- Audio at non-16kHz gets resampled to 16kHz
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `pkg/pipecatcallhandler/main.go` | Update constants, remove listenAddress |
+| `pkg/pipecatcallhandler/start.go` | New external media params + WebSocket dial + session creation |
+| `pkg/pipecatcallhandler/run.go` | Remove TCP listener, update audio read to WebSocket |
+| `pkg/pipecatcallhandler/runner.go` | Update audio write to use WebSocket frames |
+| `pkg/pipecatcallhandler/audiosocket.go` | Remove Audiosocket-specific functions, keep GetDataSamples |
+| `pkg/pipecatcallhandler/websocket.go` | Add Asterisk WebSocket connect/write/lifecycle functions |
+| `models/pipecatcall/session.go` | Replace net.Conn with *websocket.Conn + done channel |
+
+## Trade-offs
+
+- **Removes Audiosocket fallback** — if WebSocket has issues in some environment, there's no fallback. Mitigated by tts-manager already proving WebSocket works.
+- **Eliminates resampling** — better audio quality (no interpolation artifacts), less CPU usage.
+- **Simpler connection model** — no TCP listener needed, Go dials Asterisk's MediaURI directly.

--- a/docs/plans/2026-02-23-pipecat-manager-websocket-external-media-plan.md
+++ b/docs/plans/2026-02-23-pipecat-manager-websocket-external-media-plan.md
@@ -1,0 +1,1104 @@
+# Pipecat Manager WebSocket External Media Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace pipecat-manager's Audiosocket TCP external media with WebSocket external media, eliminating sample rate conversion and simplifying the connection model.
+
+**Architecture:** Asterisk acts as WebSocket server, pipecat-manager dials `em.MediaURI` to connect. Audio format is slin16 (16kHz, 16-bit signed linear PCM) end-to-end, matching Pipecat Python's native 16kHz. The internal Go↔Python WebSocket connections (input/output) are unchanged.
+
+**Tech Stack:** Go, gorilla/websocket, gomock, zaf/resample (retained for safety), protobuf
+
+**Design doc:** `docs/plans/2026-02-23-pipecat-manager-websocket-external-media-design.md`
+
+---
+
+### Task 1: Update Session Model
+
+**Files:**
+- Modify: `bin-pipecat-manager/models/pipecatcall/session.go`
+
+**Step 1: Update the Session struct**
+
+Replace `net.Conn` fields with WebSocket equivalents:
+
+```go
+package pipecatcall
+
+import (
+	"context"
+	"monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+	"github.com/gorilla/websocket"
+)
+
+type Session struct {
+	identity.Identity // copied from pipecatcall
+
+	PipecatcallReferenceType ReferenceType `json:"reference_type,omitempty"` // copied from pipecatcall
+	PipecatcallReferenceID   uuid.UUID     `json:"reference_id,omitempty"`   // copied from pipecatcall
+
+	Ctx    context.Context    `json:"-"`
+	Cancel context.CancelFunc `json:"-"`
+
+	// Runner info
+	RunnerWebsocketChan chan *SessionFrame `json:"-"`
+
+	// asterisk info
+	AsteriskStreamingID uuid.UUID       `json:"-"`
+	ConnAst             *websocket.Conn `json:"-"`
+	ConnAstDone         chan struct{}    `json:"-"`
+
+	// llm
+	LLMKey     string `json:"-"`
+	LLMBotText string `json:"-"`
+}
+```
+
+**Step 2: Verify the change compiles**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go build ./...`
+
+Expected: Compile errors in files that reference `AsteriskConn net.Conn` — this is expected and will be fixed in subsequent tasks.
+
+---
+
+### Task 2: Add Asterisk WebSocket Helper Functions
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/websocket.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/websocket_test.go`
+
+**Step 1: Write tests for the new WebSocket helpers**
+
+Add to `websocket_test.go`:
+
+```go
+func Test_websocketAsteriskWrite(t *testing.T) {
+	tests := []struct {
+		name string
+
+		data      []byte
+		frameSize int
+
+		expectErr     bool
+		expectWrites  int
+	}{
+		{
+			name:         "single frame",
+			data:         make([]byte, 640),
+			frameSize:    640,
+			expectErr:    false,
+			expectWrites: 1,
+		},
+		{
+			name:         "multiple frames",
+			data:         make([]byte, 1280),
+			frameSize:    640,
+			expectErr:    false,
+			expectWrites: 2,
+		},
+		{
+			name:         "data smaller than frame size",
+			data:         make([]byte, 320),
+			frameSize:    640,
+			expectErr:    false,
+			expectWrites: 1,
+		},
+		{
+			name:         "empty data",
+			data:         []byte{},
+			frameSize:    640,
+			expectErr:    false,
+			expectWrites: 0,
+		},
+		{
+			name:      "invalid frame size",
+			data:      make([]byte, 640),
+			frameSize: 0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockWS := NewMockWebsocketHandler(mc)
+
+			if tt.expectWrites > 0 {
+				mockWS.EXPECT().WriteMessage(gomock.Any(), websocket.BinaryMessage, gomock.Any()).Times(tt.expectWrites).Return(nil)
+			}
+
+			conn := &websocket.Conn{} // placeholder, WriteMessage is mocked
+
+			h := &pipecatcallHandler{
+				websocketHandler: mockWS,
+			}
+
+			err := h.websocketAsteriskWrite(context.Background(), conn, tt.data, tt.frameSize)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_websocketAsteriskWrite_contextCancelled(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockWS := NewMockWebsocketHandler(mc)
+
+	// First write succeeds, then context is cancelled before second frame
+	mockWS.EXPECT().WriteMessage(gomock.Any(), websocket.BinaryMessage, gomock.Any()).Return(nil).Times(1)
+
+	conn := &websocket.Conn{}
+
+	h := &pipecatcallHandler{
+		websocketHandler: mockWS,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	// With cancelled context and multi-frame data, should return context error
+	err := h.websocketAsteriskWrite(ctx, conn, make([]byte, 1280), 640)
+	if err == nil {
+		t.Errorf("expected context error but got nil")
+	}
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./pkg/pipecatcallhandler/... -run Test_websocketAsterisk -v`
+
+Expected: FAIL — `websocketAsteriskWrite` not defined.
+
+**Step 3: Add the WebSocket helper functions to websocket.go**
+
+Add `websocketAsteriskConnect`, `websocketAsteriskWrite`, and `runWebSocketAsteriskRead` to `websocket.go`. Also add the new constants. The `WebsocketHandler` interface gets a `DialContext` method added.
+
+```go
+// Add to the WebsocketHandler interface:
+type WebsocketHandler interface {
+	Upgrade(w http.ResponseWriter, r *http.Request, responseHeader http.Header) (*websocket.Conn, error)
+	ReadMessage(conn *websocket.Conn) (int, []byte, error)
+	WriteMessage(conn *websocket.Conn, messageType int, data []byte) error
+	DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error)
+}
+
+// Add to websocketHandler:
+func (h *websocketHandler) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+	dialer := websocket.Dialer{
+		Subprotocols: []string{websocketAsteriskSubprotocol},
+	}
+	return dialer.DialContext(ctx, urlStr, requestHeader)
+}
+```
+
+Then the Asterisk-specific functions are methods on `pipecatcallHandler` using the mockable `WebsocketHandler`:
+
+```go
+const (
+	websocketAsteriskSubprotocol = "media"
+	websocketAsteriskWriteDelay  = 20 * time.Millisecond
+	websocketAsteriskFrameSize   = 640 // 16000 Hz * 2 bytes * 20ms
+)
+
+// websocketAsteriskConnect dials the Asterisk chan_websocket endpoint and waits for MEDIA_START.
+func (h *pipecatcallHandler) websocketAsteriskConnect(ctx context.Context, mediaURI string) (*websocket.Conn, error) {
+	conn, _, err := h.websocketHandler.DialContext(ctx, mediaURI, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not dial WebSocket. media_uri: %s", mediaURI)
+	}
+
+	if errDeadline := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); errDeadline != nil {
+		_ = conn.Close()
+		return nil, errors.Wrapf(errDeadline, "could not set read deadline")
+	}
+
+	msgType, _, err := h.websocketHandler.ReadMessage(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, errors.Wrapf(err, "could not read MEDIA_START message")
+	}
+
+	if errDeadline := conn.SetReadDeadline(time.Time{}); errDeadline != nil {
+		_ = conn.Close()
+		return nil, errors.Wrapf(errDeadline, "could not clear read deadline")
+	}
+
+	if msgType != websocket.TextMessage {
+		_ = conn.Close()
+		return nil, errors.Errorf("expected text message for MEDIA_START, got type %d", msgType)
+	}
+
+	return conn, nil
+}
+
+// websocketAsteriskWrite fragments and sends raw audio data over a WebSocket connection
+// as binary frames with 20ms pacing.
+func (h *pipecatcallHandler) websocketAsteriskWrite(ctx context.Context, conn *websocket.Conn, data []byte, frameSize int) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if frameSize <= 0 {
+		return fmt.Errorf("frameSize must be positive, got %d", frameSize)
+	}
+
+	ticker := time.NewTicker(websocketAsteriskWriteDelay)
+	defer ticker.Stop()
+
+	offset := 0
+	payloadLen := len(data)
+
+	for offset < payloadLen {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		fragmentLen := min(frameSize, payloadLen-offset)
+		fragment := data[offset : offset+fragmentLen]
+
+		if err := h.websocketHandler.WriteMessage(conn, websocket.BinaryMessage, fragment); err != nil {
+			return errors.Wrapf(err, "failed to write WebSocket binary frame")
+		}
+
+		offset += fragmentLen
+
+		if offset >= payloadLen {
+			break
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+// runWebSocketAsteriskRead reads from the WebSocket connection to handle ping/pong and close frames.
+// Closes doneCh when the connection is closed or encounters an error.
+func runWebSocketAsteriskRead(conn *websocket.Conn, doneCh chan struct{}) {
+	log := logrus.WithField("func", "runWebSocketAsteriskRead")
+	defer close(doneCh)
+
+	for {
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				log.Debugf("Asterisk WebSocket closed normally: %v", err)
+			} else {
+				log.Errorf("Asterisk WebSocket read error: %v", err)
+			}
+			return
+		}
+	}
+}
+```
+
+**Step 4: Regenerate mocks**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go generate ./pkg/pipecatcallhandler/...`
+
+**Step 5: Run tests to verify they pass**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./pkg/pipecatcallhandler/... -run Test_websocketAsterisk -v`
+
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/models/pipecatcall/session.go bin-pipecat-manager/pkg/pipecatcallhandler/websocket.go bin-pipecat-manager/pkg/pipecatcallhandler/websocket_test.go bin-pipecat-manager/pkg/pipecatcallhandler/mock_websocket.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Update Session model to use *websocket.Conn instead of net.Conn
+- bin-pipecat-manager: Add Asterisk WebSocket connect, write, and read lifecycle helpers
+- bin-pipecat-manager: Add DialContext to WebsocketHandler interface
+- bin-pipecat-manager: Add tests for WebSocket write with fragmentation and pacing"
+```
+
+---
+
+### Task 3: Update Constants and Remove listenAddress
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/main.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/main_test.go`
+- Modify: `bin-pipecat-manager/cmd/pipecat-manager/main.go`
+- Modify: `bin-pipecat-manager/cmd/pipecat-control/main.go`
+
+**Step 1: Update constants in main.go**
+
+Replace the external media defaults:
+
+```go
+const (
+	defaultEncapsulation  = string(cmexternalmedia.EncapsulationNone)
+	defaultTransport      = string(cmexternalmedia.TransportWebsocket)
+	defaultConnectionType = "server"
+	defaultFormat         = "slin16"
+)
+```
+
+Remove `listenAddress` from the struct and constructor:
+
+```go
+type pipecatcallHandler struct {
+	utilHandler    utilhandler.UtilHandler
+	requestHandler requesthandler.RequestHandler
+	notifyHandler  notifyhandler.NotifyHandler
+	db             dbhandler.DBHandler
+	toolHandler    toolhandler.ToolHandler
+
+	pythonRunner        PythonRunner
+	audiosocketHandler  AudiosocketHandler
+	websocketHandler    WebsocketHandler
+	pipecatframeHandler PipecatframeHandler
+
+	hostID string
+
+	mapPipecatcallSession map[uuid.UUID]*pipecatcall.Session
+	muPipecatcallSession  sync.Mutex
+}
+
+func NewPipecatcallHandler(
+	reqHandler requesthandler.RequestHandler,
+	notifyHandler notifyhandler.NotifyHandler,
+	dbHandler dbhandler.DBHandler,
+	toolHandler toolhandler.ToolHandler,
+	hostID string,
+) PipecatcallHandler {
+	return &pipecatcallHandler{
+		utilHandler:    utilhandler.NewUtilHandler(),
+		requestHandler: reqHandler,
+		notifyHandler:  notifyHandler,
+		db:             dbHandler,
+		toolHandler:    toolHandler,
+
+		pythonRunner:        NewPythonRunner(),
+		audiosocketHandler:  NewAudiosocketHandler(),
+		websocketHandler:    NewWebsocketHandler(),
+		pipecatframeHandler: NewPipecatframeHandler(),
+
+		hostID: hostID,
+
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+	}
+}
+```
+
+Remove `Run()` from the `PipecatcallHandler` interface (it's no longer needed — no TCP listener).
+
+**Step 2: Update cmd/pipecat-manager/main.go**
+
+- Remove the `listenAddress` variable and the `listenIP` → `listenAddress` construction (lines 115-119)
+- Update `NewPipecatcallHandler` call to remove `listenAddress` parameter (keep `listenIP` as `hostID`)
+- Remove the `runStreaming` function and its call (the TCP listener goroutine is no longer needed)
+
+```go
+// In run() function:
+pipecatcallHandler := pipecatcallhandler.NewPipecatcallHandler(requestHandler, notifyHandler, dbHandler, toolHandler, listenIP)
+// Remove: listenAddress variable
+// Remove: runStreaming call and function
+```
+
+**Step 3: Update cmd/pipecat-control/main.go**
+
+Remove the `listenAddress` parameter from `NewPipecatcallHandler`:
+
+```go
+return pipecatcallhandler.NewPipecatcallHandler(reqHandler, notifyHandler, db, toolHandler, "cli-host"), nil
+```
+
+**Step 4: Verify compilation**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go build ./...`
+
+Expected: May have errors in files referencing `h.listenAddress` or `AsteriskConn` — those will be fixed in subsequent tasks.
+
+**Step 5: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/main.go bin-pipecat-manager/cmd/pipecat-manager/main.go bin-pipecat-manager/cmd/pipecat-control/main.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Update external media defaults to websocket/none/server/slin16
+- bin-pipecat-manager: Remove listenAddress from handler and constructor
+- bin-pipecat-manager: Remove Run() TCP listener from interface
+- bin-pipecat-manager: Remove runStreaming goroutine from daemon"
+```
+
+---
+
+### Task 4: Update Session Management
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/session.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go`
+
+**Step 1: Write updated tests for SessionCreate and SessionStop**
+
+Update `session_test.go`:
+- `TestSessionCreate`: Remove `asteriskStreamingID` parameter since the session no longer takes `net.Conn`. The new signature takes `*websocket.Conn` and streaming ID.
+- `TestSessionStop`: Update to verify `ConnAst.Close()` is called on a `*websocket.Conn` (can be nil for sessions without Asterisk).
+- Remove `TestSessionsetAsteriskInfo` (the `SessionsetAsteriskInfo` function is removed since connection is set at creation time).
+
+**Step 2: Update session.go**
+
+Update `SessionCreate` signature to accept `*websocket.Conn` and `chan struct{}`:
+
+```go
+func (h *pipecatcallHandler) SessionCreate(
+	pc *pipecatcall.Pipecatcall,
+	asteriskStreamingID uuid.UUID,
+	connAst *websocket.Conn,
+	connAstDone chan struct{},
+	llmKey string,
+) (*pipecatcall.Session, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	res := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         pc.ID,
+			CustomerID: pc.CustomerID,
+		},
+
+		PipecatcallReferenceType: pc.ReferenceType,
+		PipecatcallReferenceID:   pc.ReferenceID,
+
+		Ctx:    ctx,
+		Cancel: cancel,
+
+		RunnerWebsocketChan: make(chan *pipecatcall.SessionFrame, defaultRunnerWebsocketChanBufferSize),
+
+		AsteriskStreamingID: asteriskStreamingID,
+		ConnAst:             connAst,
+		ConnAstDone:         connAstDone,
+
+		LLMKey: llmKey,
+	}
+	// ... rest unchanged
+}
+```
+
+Update `SessionStop` to close `*websocket.Conn`:
+
+```go
+func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
+	// ...
+	if pc.ConnAst != nil {
+		if errClose := pc.ConnAst.Close(); errClose != nil {
+			log.Errorf("Could not close the asterisk connection. err: %v", errClose)
+		}
+	}
+	// ... rest unchanged
+}
+```
+
+Remove `SessionsetAsteriskInfo` (no longer needed — connection set at creation).
+
+**Step 3: Run tests**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./pkg/pipecatcallhandler/... -run TestSession -v`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/session.go bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Update SessionCreate to accept *websocket.Conn and done channel
+- bin-pipecat-manager: Update SessionStop to close WebSocket connection
+- bin-pipecat-manager: Remove SessionsetAsteriskInfo helper"
+```
+
+---
+
+### Task 5: Update External Media Start (start.go)
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/start.go`
+
+**Step 1: Update startReferenceTypeCall**
+
+After creating external media, dial the WebSocket, create session, and start goroutines:
+
+```go
+func (h *pipecatcallHandler) startReferenceTypeCall(ctx context.Context, pc *pipecatcall.Pipecatcall) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":           "startReferenceTypeCall",
+		"pipecatcall_id": pc.ID,
+	})
+
+	c, err := h.requestHandler.CallV1CallGet(ctx, pc.ReferenceID)
+	if err != nil {
+		return errors.Wrapf(err, "could not get call info")
+	}
+	log.WithField("call", c).Debugf("Retrieved call info. call_id: %s", c.ID)
+
+	em, err := h.requestHandler.CallV1ExternalMediaStart(
+		ctx,
+		pc.ID,
+		cmexternalmedia.ReferenceTypeCall,
+		c.ID,
+		"INCOMING",
+		defaultEncapsulation,
+		defaultTransport,
+		"",
+		defaultConnectionType,
+		defaultFormat,
+		cmexternalmedia.DirectionIn,
+		cmexternalmedia.DirectionOut,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "could not create external media")
+	}
+	log.WithField("external_media", em).Debugf("Created external media. external_media_id: %s, media_uri: %s", em.ID, em.MediaURI)
+
+	// Connect to Asterisk via WebSocket
+	conn, err := h.websocketAsteriskConnect(ctx, em.MediaURI)
+	if err != nil {
+		log.Errorf("Could not connect WebSocket to Asterisk. err: %v", err)
+		if _, errStop := h.requestHandler.CallV1ExternalMediaStop(ctx, em.ID); errStop != nil {
+			log.Errorf("Could not stop orphaned external media. err: %v", errStop)
+		}
+		return errors.Wrapf(err, "could not connect to asterisk websocket")
+	}
+	log.Debugf("WebSocket connected to Asterisk. media_uri: %s", em.MediaURI)
+
+	connAstDone := make(chan struct{})
+
+	// Create session
+	llmKey := h.runGetLLMKey(ctx, pc)
+	se, err := h.SessionCreate(pc, pc.ID, conn, connAstDone, llmKey)
+	if err != nil {
+		_ = conn.Close()
+		return errors.Wrapf(err, "could not create pipecatcall session")
+	}
+
+	// Start WebSocket read lifecycle goroutine
+	go runWebSocketAsteriskRead(conn, connAstDone)
+
+	// Start pipecat runner
+	go func() {
+		defer se.Cancel()
+		h.RunnerStart(pc, se)
+	}()
+
+	// Start media handler (reads audio from Asterisk WebSocket, sends to Python)
+	go func() {
+		defer se.Cancel()
+		h.runAsteriskReceivedMediaHandle(se)
+	}()
+
+	// Monitor lifecycle — when context or WebSocket dies, terminate
+	go func() {
+		select {
+		case <-se.Ctx.Done():
+		case <-connAstDone:
+		}
+		log.Debugf("Asterisk connection or context done, terminating. pipecatcall_id: %s", pc.ID)
+		h.terminate(context.Background(), pc)
+	}()
+
+	return nil
+}
+```
+
+**Step 2: Apply the same pattern to startReferenceTypeAIcall**
+
+For the `amaicall.ReferenceTypeCall` case, apply the same WebSocket connect + session creation pattern. The `default` case (non-call reference types) stays mostly the same but uses `nil` for WebSocket connection and done channel.
+
+```go
+case amaicall.ReferenceTypeCall:
+	em, err := h.requestHandler.CallV1ExternalMediaStart(
+		ctx,
+		pc.ID,
+		cmexternalmedia.ReferenceTypeCall,
+		c.ReferenceID,
+		"INCOMING",
+		defaultEncapsulation,
+		defaultTransport,
+		"",
+		defaultConnectionType,
+		defaultFormat,
+		cmexternalmedia.DirectionIn,
+		cmexternalmedia.DirectionOut,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "could not create external media")
+	}
+	log.WithField("external_media", em).Debugf("Created external media. external_media_id: %s, media_uri: %s", em.ID, em.MediaURI)
+
+	conn, err := h.websocketAsteriskConnect(ctx, em.MediaURI)
+	if err != nil {
+		log.Errorf("Could not connect WebSocket to Asterisk. err: %v", err)
+		if _, errStop := h.requestHandler.CallV1ExternalMediaStop(ctx, em.ID); errStop != nil {
+			log.Errorf("Could not stop orphaned external media. err: %v", errStop)
+		}
+		return errors.Wrapf(err, "could not connect to asterisk websocket")
+	}
+
+	connAstDone := make(chan struct{})
+	llmKey := h.runGetLLMKey(ctx, pc)
+	se, err := h.SessionCreate(pc, pc.ID, conn, connAstDone, llmKey)
+	if err != nil {
+		_ = conn.Close()
+		return errors.Wrapf(err, "could not create pipecatcall session")
+	}
+
+	go runWebSocketAsteriskRead(conn, connAstDone)
+
+	go func() {
+		defer se.Cancel()
+		h.RunnerStart(pc, se)
+	}()
+
+	go func() {
+		defer se.Cancel()
+		h.runAsteriskReceivedMediaHandle(se)
+	}()
+
+	go func() {
+		select {
+		case <-se.Ctx.Done():
+		case <-connAstDone:
+		}
+		h.terminate(context.Background(), pc)
+	}()
+
+	return nil
+
+default:
+	llmKey := h.runGetLLMKey(ctx, pc)
+	se, err := h.SessionCreate(pc, uuid.Nil, nil, nil, llmKey)
+	if err != nil {
+		return errors.Wrapf(err, "could not create pipecatcall session")
+	}
+
+	go h.RunnerStart(pc, se)
+	return nil
+```
+
+**Step 3: Verify compilation**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go build ./...`
+
+**Step 4: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Update external media start to use websocket transport
+- bin-pipecat-manager: Dial Asterisk MediaURI after external media creation
+- bin-pipecat-manager: Create session with WebSocket connection in start flow
+- bin-pipecat-manager: Add lifecycle monitoring for Asterisk WebSocket connection"
+```
+
+---
+
+### Task 6: Rewrite Audio Read (run.go)
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/run.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go`
+
+**Step 1: Write tests for the new audio read function**
+
+```go
+func Test_runAsteriskReceivedMediaHandle(t *testing.T) {
+	tests := []struct {
+		name string
+
+		readMessages []struct {
+			msgType int
+			data    []byte
+			err     error
+		}
+
+		expectAudioFrames int
+	}{
+		{
+			name: "receives binary audio frames",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: 0, data: nil, err: fmt.Errorf("connection closed")},
+			},
+			expectAudioFrames: 2,
+		},
+		{
+			name: "skips non-binary messages",
+			readMessages: []struct {
+				msgType int
+				data    []byte
+				err     error
+			}{
+				{msgType: websocket.TextMessage, data: []byte("text"), err: nil},
+				{msgType: websocket.BinaryMessage, data: make([]byte, 640), err: nil},
+				{msgType: 0, data: nil, err: fmt.Errorf("connection closed")},
+			},
+			expectAudioFrames: 1,
+		},
+	}
+	// ... test implementation using mocked WebsocketHandler
+}
+```
+
+**Step 2: Rewrite run.go**
+
+Remove the TCP listener (`Run()`, `runStart()`, `runAsteriskKeepAlive()`, `retryWithBackoff()`).
+
+Rewrite `runAsteriskReceivedMediaHandle()` to read from WebSocket instead of Audiosocket:
+
+```go
+package pipecatcallhandler
+
+import (
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultMediaSampleRate = 16000
+	defaultMediaNumChannel = 1
+)
+
+func (h *pipecatcallHandler) runAsteriskReceivedMediaHandle(se *pipecatcall.Session) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":           "runAsteriskReceivedMediaHandle",
+		"pipecatcall_id": se.ID,
+	})
+
+	if se.ConnAst == nil {
+		log.Debugf("No Asterisk WebSocket connection, skipping media handle.")
+		return
+	}
+
+	packetID := uint64(0)
+	for {
+		if se.Ctx.Err() != nil {
+			log.Debugf("Context has finished. pipecatcall_id: %s", se.ID)
+			return
+		}
+
+		msgType, data, err := h.websocketHandler.ReadMessage(se.ConnAst)
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				log.Debugf("Asterisk WebSocket closed normally.")
+			} else {
+				log.Infof("Asterisk WebSocket read error: %v", err)
+			}
+			return
+		}
+
+		if msgType != websocket.BinaryMessage {
+			continue
+		}
+
+		if len(data) == 0 {
+			continue
+		}
+
+		if errSend := h.pipecatframeHandler.SendAudio(se, packetID, data); errSend != nil {
+			log.Errorf("Could not send audio frame. err: %v", errSend)
+		}
+
+		packetID++
+	}
+}
+```
+
+Also keep `runGetLLMKey` in this file (it's unrelated to audio transport).
+
+**Step 3: Run tests**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./pkg/pipecatcallhandler/... -run Test_runAsterisk -v`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/run.go bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Remove TCP listener, keep-alive, and Audiosocket read loop
+- bin-pipecat-manager: Rewrite audio read to use WebSocket binary frames at 16kHz
+- bin-pipecat-manager: Update tests for WebSocket-based audio reading"
+```
+
+---
+
+### Task 7: Update Audio Write (runner.go)
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go`
+
+**Step 1: Write tests for updated runnerWebsocketHandleAudio**
+
+```go
+func Test_runnerWebsocketHandleAudio(t *testing.T) {
+	tests := []struct {
+		name string
+
+		se          *pipecatcall.Session
+		sampleRate  int
+		numChannels int
+		data        []byte
+
+		responseDataSamples []byte
+		expectWriteErr      error
+		expectErr           bool
+	}{
+		{
+			name: "16kHz mono audio - no conversion needed",
+			se: &pipecatcall.Session{
+				ConnAst: &websocket.Conn{}, // placeholder, write is mocked
+				Ctx:     context.Background(),
+			},
+			sampleRate:  16000,
+			numChannels: 1,
+			data:        make([]byte, 640),
+			expectErr:   false,
+		},
+		{
+			name: "non-16kHz audio - resampled to 16kHz",
+			se: &pipecatcall.Session{
+				ConnAst: &websocket.Conn{},
+				Ctx:     context.Background(),
+			},
+			sampleRate:          24000,
+			numChannels:         1,
+			data:                make([]byte, 960),
+			responseDataSamples: make([]byte, 640),
+			expectErr:           false,
+		},
+		{
+			name: "stereo audio - rejected",
+			se: &pipecatcall.Session{
+				ConnAst: &websocket.Conn{},
+				Ctx:     context.Background(),
+			},
+			sampleRate:  16000,
+			numChannels: 2,
+			data:        make([]byte, 1280),
+			expectErr:   true,
+		},
+	}
+	// ... test implementation
+}
+```
+
+**Step 2: Update runnerWebsocketHandleAudio in runner.go**
+
+Replace the Audiosocket write with WebSocket write:
+
+```go
+func (h *pipecatcallHandler) runnerWebsocketHandleAudio(se *pipecatcall.Session, sampleRate int, numChannels int, data []byte) error {
+	if numChannels != 1 {
+		return errors.Errorf("only mono audio is supported. num_channels: %d", numChannels)
+	}
+
+	audioData := data
+	if sampleRate != defaultMediaSampleRate {
+		var err error
+		audioData, err = h.audiosocketHandler.GetDataSamples(sampleRate, data)
+		if err != nil {
+			return errors.Wrapf(err, "could not resample audio data")
+		}
+	}
+
+	if errWrite := h.websocketAsteriskWrite(se.Ctx, se.ConnAst, audioData, websocketAsteriskFrameSize); errWrite != nil {
+		return errors.Wrapf(errWrite, "could not write audio data to asterisk websocket")
+	}
+
+	return nil
+}
+```
+
+**Step 3: Run tests**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./pkg/pipecatcallhandler/... -run Test_runnerWebsocketHandleAudio -v`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Update audio write to use WebSocket binary frames
+- bin-pipecat-manager: Skip resampling when Python sends 16kHz audio
+- bin-pipecat-manager: Add safety net resampling for non-16kHz audio from Python"
+```
+
+---
+
+### Task 8: Clean Up Audiosocket Code
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket_test.go`
+
+**Step 1: Remove unused Audiosocket functions**
+
+Remove from the interface and implementation:
+- `GetStreamingID`
+- `GetNextMedia`
+- `Upsample8kTo16k`
+- `WrapDataPCM16Bit`
+- `Write`
+
+Keep only `GetDataSamples` (safety net for resampling).
+
+Updated interface:
+
+```go
+type AudiosocketHandler interface {
+	GetDataSamples(inputRate int, data []byte) ([]byte, error)
+}
+```
+
+**Step 2: Remove unused Audiosocket tests**
+
+Remove from `audiosocket_test.go`:
+- `Test_audiosocketUpsample8kTo16k`
+- `Test_audiosocketWrapDataPCM16Bit`
+
+Keep `Test_audiosocketGetDataSamples`.
+
+**Step 3: Remove unused imports**
+
+Remove `net`, `github.com/CyCoreSystems/audiosocket`, `github.com/gofrs/uuid`, `context` from audiosocket.go if they are no longer used (only `resample` and `fmt` may remain). Also remove `defaultAudiosocketFormatSLIN` and `defaultAudiosocketMaxFragmentSize` constants.
+
+**Step 4: Regenerate mocks**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go generate ./pkg/pipecatcallhandler/...`
+
+**Step 5: Run all tests**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./pkg/pipecatcallhandler/... -v`
+
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket.go bin-pipecat-manager/pkg/pipecatcallhandler/audiosocket_test.go bin-pipecat-manager/pkg/pipecatcallhandler/mock_audiosocket.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Remove Audiosocket protocol functions no longer needed
+- bin-pipecat-manager: Keep GetDataSamples as safety net for non-16kHz resampling
+- bin-pipecat-manager: Remove Audiosocket-specific tests"
+```
+
+---
+
+### Task 9: Remove DummyConn Test Helper and Fix Remaining Tests
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/pipecatframe_test.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go`
+
+**Step 1: Remove DummyConn from pipecatframe_test.go**
+
+The `DummyConn` struct implements `net.Conn` for test purposes. Since we no longer use `net.Conn` for Asterisk connections, remove it. If `run_test.go` still references it (for keepalive test), that test should also be removed since `runAsteriskKeepAlive` is gone.
+
+**Step 2: Update run_test.go**
+
+Remove `Test_runKeepAlive` — the Audiosocket keepalive is gone. Add tests for the new `runAsteriskReceivedMediaHandle` if not already done in Task 6.
+
+**Step 3: Run all tests**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./... -v`
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git add bin-pipecat-manager/pkg/pipecatcallhandler/pipecatframe_test.go bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
+git commit -m "NOJIRA-pipecat-manager-websocket-external-media
+
+- bin-pipecat-manager: Remove DummyConn test helper (net.Conn no longer used)
+- bin-pipecat-manager: Remove Audiosocket keepalive test"
+```
+
+---
+
+### Task 10: Full Verification and Final Commit
+
+**Files:** All changed files
+
+**Step 1: Run full verification workflow**
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: All steps pass with no errors.
+
+**Step 2: Fix any lint or test issues**
+
+Address any remaining compilation errors, unused imports, or lint warnings.
+
+**Step 3: Verify all tests pass**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media/bin-pipecat-manager && go test ./... -count=1`
+
+Expected: PASS
+
+**Step 4: Review the diff**
+
+Run: `cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media && git diff --stat HEAD~9`
+
+Verify the changes match the design document.
+
+**Step 5: Squash or create final commit if needed**
+
+If there were fix-up commits, consider squashing. Otherwise, push and create PR.
+
+```bash
+cd ~/gitvoipbin/monorepo-worktrees/NOJIRA-pipecat-manager-websocket-external-media
+git push -u origin NOJIRA-pipecat-manager-websocket-external-media
+```


### PR DESCRIPTION
Replace pipecat-manager's Audiosocket TCP external media with WebSocket external media,
following the proven tts-manager pattern. This eliminates 8kHz/16kHz sample rate conversion,
removes the TCP listener, and simplifies the connection model.

- bin-pipecat-manager: Update Session model to use *websocket.Conn instead of net.Conn
- bin-pipecat-manager: Add Asterisk WebSocket connect, write, and read lifecycle helpers
- bin-pipecat-manager: Add DialContext to WebsocketHandler interface for mockable dialing
- bin-pipecat-manager: Update external media defaults to none/websocket/server/slin16
- bin-pipecat-manager: Remove listenAddress from handler and TCP listener from daemon
- bin-pipecat-manager: Dial Asterisk MediaURI after external media creation in start flow
- bin-pipecat-manager: Add lifecycle monitoring for Asterisk WebSocket connection
- bin-pipecat-manager: Rewrite audio read to use WebSocket binary frames at 16kHz
- bin-pipecat-manager: Update audio write to use WebSocket frames with 20ms pacing
- bin-pipecat-manager: Remove Audiosocket protocol functions, keep GetDataSamples safety net
- bin-pipecat-manager: Fix GetDataSamples to resample to 16kHz instead of 8kHz
- bin-pipecat-manager: Remove DummyConn test helper and Audiosocket keepalive tests
- bin-pipecat-manager: Add comprehensive tests for WebSocket connect, write, and audio handling
- docs: Add design and implementation plan documents