### PR TITLE
NOJIRA-fix-pipecat-websocket-dual-reader

### DIFF
--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
@@ -24,6 +24,13 @@ func (h *pipecatcallHandler) runAsteriskReceivedMediaHandle(se *pipecatcall.Sess
 		return
 	}
 
+	// This goroutine is the sole reader on se.ConnAst. gorilla/websocket supports
+	// only one concurrent reader, so no other goroutine should read from this
+	// connection. Close ConnAstDone on exit to signal the lifecycle monitor.
+	if se.ConnAstDone != nil {
+		defer close(se.ConnAstDone)
+	}
+
 	packetID := uint64(0)
 	for {
 		if se.Ctx.Err() != nil {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
@@ -127,16 +127,14 @@ func (h *pipecatcallHandler) startReferenceTypeCall(ctx context.Context, pc *pip
 		return errors.Wrapf(err, "could not create pipecatcall session")
 	}
 
-	// Start WebSocket read lifecycle goroutine
-	go runWebSocketAsteriskRead(conn, connAstDone)
-
 	// Start pipecat runner
 	go func() {
 		defer se.Cancel()
 		h.RunnerStart(pc, se)
 	}()
 
-	// Start media handler (reads audio from Asterisk WebSocket, sends to Python)
+	// Start media handler — sole reader on the Asterisk WebSocket.
+	// Closes connAstDone on exit to signal the lifecycle monitor.
 	go func() {
 		defer se.Cancel()
 		h.runAsteriskReceivedMediaHandle(se)
@@ -209,16 +207,14 @@ func (h *pipecatcallHandler) startReferenceTypeAIcall(ctx context.Context, pc *p
 			return errors.Wrapf(err, "could not create pipecatcall session")
 		}
 
-		// Start WebSocket read lifecycle goroutine
-		go runWebSocketAsteriskRead(conn, connAstDone)
-
 		// Start pipecat runner
 		go func() {
 			defer se.Cancel()
 			h.RunnerStart(pc, se)
 		}()
 
-		// Start media handler (reads audio from Asterisk WebSocket, sends to Python)
+		// Start media handler — sole reader on the Asterisk WebSocket.
+		// Closes connAstDone on exit to signal the lifecycle monitor.
 		go func() {
 			defer se.Cancel()
 			h.runAsteriskReceivedMediaHandle(se)


### PR DESCRIPTION
Fix STT not working due to concurrent WebSocket readers on the Asterisk
connection. gorilla/websocket only supports one concurrent reader, but both
runWebSocketAsteriskRead and runAsteriskReceivedMediaHandle were reading from
the same connection — runWebSocketAsteriskRead consumed all audio frames
before the media handler could process them for STT.

- bin-pipecat-manager: Remove runWebSocketAsteriskRead goroutine from start.go
- bin-pipecat-manager: Make runAsteriskReceivedMediaHandle close ConnAstDone on exit