### PR TITLE
NOJIRA-increase-pipecat-cpu-limit

### DIFF
--- a/bin-pipecat-manager/k8s/deployment.yml
+++ b/bin-pipecat-manager/k8s/deployment.yml
@@ -66,7 +66,7 @@ spec:
               containerPort: 8080
           resources:
             limits:
-              cpu: "100m"
+              cpu: "200m"
               memory: "100Mi"
 
         - name: pipecat-script-runner


### PR DESCRIPTION
Increase pipecat-manager container CPU limit from 100m to 200m to provide more headroom for WebSocket audio processing.

- bin-pipecat-manager: Increase pipecat-manager container CPU limit from 100m to 200m