### PR TITLE
NOJIRA-burstable-qos-all-services

### DIFF
--- a/bin-agent-manager/k8s/deployment.yml
+++ b/bin-agent-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "20m"
+              memory: "10Mi"
             limits:
               cpu: "200m"
               memory: "100Mi"

--- a/bin-ai-manager/k8s/deployment.yml
+++ b/bin-ai-manager/k8s/deployment.yml
@@ -45,6 +45,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "4m"
+              memory: "4M"
             limits:
               cpu: "40m"
               memory: "40M"

--- a/bin-api-manager/k8s/deployment.yml
+++ b/bin-api-manager/k8s/deployment.yml
@@ -66,6 +66,9 @@ spec:
               port: 443
               scheme: HTTPS
           resources:
+            requests:
+              cpu: "20m"
+              memory: "10Mi"
             limits:
               cpu: "200m"
               memory: "100Mi"

--- a/bin-billing-manager/k8s/deployment.yml
+++ b/bin-billing-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "2M"
             limits:
               cpu: "20m"
               memory: "20M"

--- a/bin-call-manager/k8s/deployment.yml
+++ b/bin-call-manager/k8s/deployment.yml
@@ -63,6 +63,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "3m"
+              memory: "3M"
             limits:
               cpu: "30m"
               memory: "30M"

--- a/bin-campaign-manager/k8s/deployment.yml
+++ b/bin-campaign-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "3M"
             limits:
               cpu: "5m"
               memory: "30M"

--- a/bin-conference-manager/k8s/deployment.yml
+++ b/bin-conference-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "2M"
             limits:
               cpu: "20m"
               memory: "20M"

--- a/bin-contact-manager/k8s/deployment.yml
+++ b/bin-contact-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "3M"
             limits:
               cpu: "10m"
               memory: "30M"

--- a/bin-conversation-manager/k8s/deployment.yml
+++ b/bin-conversation-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "2M"
             limits:
               cpu: "10m"
               memory: "20M"

--- a/bin-customer-manager/k8s/deployment.yml
+++ b/bin-customer-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "3M"
             limits:
               cpu: "20m"
               memory: "30M"

--- a/bin-email-manager/k8s/deployment.yml
+++ b/bin-email-manager/k8s/deployment.yml
@@ -58,6 +58,9 @@ spec:
               protocol: "TCP"
               containerPort: 80
           resources:
+            requests:
+              cpu: "2m"
+              memory: "3M"
             limits:
               cpu: "20m"
               memory: "30M"

--- a/bin-flow-manager/k8s/deployment.yml
+++ b/bin-flow-manager/k8s/deployment.yml
@@ -56,6 +56,9 @@ spec:
               protocol: "TCP"
               containerPort: 80
           resources:
+            requests:
+              cpu: "10m"
+              memory: "10Mi"
             limits:
               cpu: "100m"
               memory: "100Mi"

--- a/bin-hook-manager/k8s/deployment.yml
+++ b/bin-hook-manager/k8s/deployment.yml
@@ -58,6 +58,9 @@ spec:
               port: 443
               scheme: HTTPS
           resources:
+            requests:
+              cpu: "1m"
+              memory: "3M"
             limits:
               cpu: "10m"
               memory: "30M"

--- a/bin-message-manager/k8s/deployment.yml
+++ b/bin-message-manager/k8s/deployment.yml
@@ -47,6 +47,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "2M"
             limits:
               cpu: "10m"
               memory: "20M"

--- a/bin-number-manager/k8s/deployment.yml
+++ b/bin-number-manager/k8s/deployment.yml
@@ -53,6 +53,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "3m"
+              memory: "2M"
             limits:
               cpu: "30m"
               memory: "20M"

--- a/bin-outdial-manager/k8s/deployment.yml
+++ b/bin-outdial-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "3M"
             limits:
               cpu: "5m"
               memory: "30M"

--- a/bin-pipecat-manager/k8s/deployment.yml
+++ b/bin-pipecat-manager/k8s/deployment.yml
@@ -65,6 +65,9 @@ spec:
               protocol: "TCP"
               containerPort: 8080
           resources:
+            requests:
+              cpu: "20m"
+              memory: "10Mi"
             limits:
               cpu: "200m"
               memory: "100Mi"
@@ -86,6 +89,9 @@ spec:
             - name: XAI_API_KEY
               value: ${XAI_API_KEY}
           resources:
+            requests:
+              cpu: "20m"
+              memory: "50Mi"
             limits:
               cpu: "200m"
               memory: "500Mi"

--- a/bin-queue-manager/k8s/deployment.yml
+++ b/bin-queue-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "3M"
             limits:
               cpu: "20m"
               memory: "30M"

--- a/bin-rag-manager/k8s/deployment.yml
+++ b/bin-rag-manager/k8s/deployment.yml
@@ -51,6 +51,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "10m"
+              memory: "13M"
             limits:
               cpu: "100m"
               memory: "128M"

--- a/bin-registrar-manager/k8s/deployment.yml
+++ b/bin-registrar-manager/k8s/deployment.yml
@@ -49,6 +49,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "3M"
             limits:
               cpu: "10m"
               memory: "30M"

--- a/bin-route-manager/k8s/deployment.yml
+++ b/bin-route-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "3M"
             limits:
               cpu: "20m"
               memory: "30M"

--- a/bin-sentinel-manager/k8s/deployment.yml
+++ b/bin-sentinel-manager/k8s/deployment.yml
@@ -40,6 +40,9 @@ spec:
               protocol: "TCP"
               containerPort: 80
           resources:
+            requests:
+              cpu: "3m"
+              memory: "2Mi"
             limits:
               cpu: "30m"
               memory: "20Mi"

--- a/bin-storage-manager/k8s/deployment.yml
+++ b/bin-storage-manager/k8s/deployment.yml
@@ -51,6 +51,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "10m"
+              memory: "10M"
             limits:
               cpu: "100m"
               memory: "100M"

--- a/bin-tag-manager/k8s/deployment.yml
+++ b/bin-tag-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "1m"
+              memory: "3M"
             limits:
               cpu: "10m"
               memory: "30M"

--- a/bin-talk-manager/k8s/deployment.yml
+++ b/bin-talk-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "3M"
             limits:
               cpu: "20m"
               memory: "30M"

--- a/bin-timeline-manager/k8s/deployment.yml
+++ b/bin-timeline-manager/k8s/deployment.yml
@@ -51,6 +51,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "3m"
+              memory: "3Mi"
             limits:
               cpu: "30m"
               memory: "30Mi"

--- a/bin-transcribe-manager/k8s/deployment.yml
+++ b/bin-transcribe-manager/k8s/deployment.yml
@@ -55,6 +55,9 @@ spec:
             - name: STT_PROVIDER_PRIORITY
               value: "GCP,AWS"
           resources:
+            requests:
+              cpu: "6m"
+              memory: "8M"
             limits:
               cpu: "60m"
               memory: "80M"

--- a/bin-transfer-manager/k8s/deployment.yml
+++ b/bin-transfer-manager/k8s/deployment.yml
@@ -51,6 +51,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "6m"
+              memory: "3M"
             limits:
               cpu: "60m"
               memory: "30M"

--- a/bin-tts-manager/k8s/deployment.yml
+++ b/bin-tts-manager/k8s/deployment.yml
@@ -67,6 +67,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "6M"
             limits:
               cpu: "20m"
               memory: "60M"
@@ -89,6 +92,9 @@ spec:
               protocol: "TCP"
               containerPort: 80
           resources:
+            requests:
+              cpu: "2m"
+              memory: "3M"
             limits:
               cpu: "20m"
               memory: "30M"

--- a/bin-webhook-manager/k8s/deployment.yml
+++ b/bin-webhook-manager/k8s/deployment.yml
@@ -43,6 +43,9 @@ spec:
               protocol: "TCP"
               containerPort: 2112
           resources:
+            requests:
+              cpu: "2m"
+              memory: "2M"
             limits:
               cpu: "20m"
               memory: "20M"

--- a/docs/plans/2026-02-23-burstable-qos-all-services-design.md
+++ b/docs/plans/2026-02-23-burstable-qos-all-services-design.md
@@ -1,0 +1,32 @@
+# Burstable QoS for All Services
+
+**Goal:** Switch all 30 services from Guaranteed to Burstable QoS class by adding explicit `requests` at 10% of `limits` for both CPU and memory.
+
+**Problem:** All deployments only specify `limits`, which makes Kubernetes set `requests = limits` (Guaranteed QoS). This reserves the full limit on each node even though actual usage is 12-17% CPU. Result: nodes appear full at 80-92% allocated CPU while being mostly idle.
+
+**Solution:** Add explicit `requests` at 10% of `limits`. This tells the scheduler "reserve 10% but allow bursting up to the limit." Changes QoS class from Guaranteed to Burstable.
+
+**Before:**
+```yaml
+resources:
+  limits:
+    cpu: "200m"
+    memory: "100Mi"
+```
+
+**After:**
+```yaml
+resources:
+  requests:
+    cpu: "20m"
+    memory: "10Mi"
+  limits:
+    cpu: "200m"
+    memory: "100Mi"
+```
+
+**Minimum floor:** 1m CPU, 2M memory (for services with very small limits).
+
+**Scope:** All 30 `bin-*/k8s/deployment.yml` files, including multi-container pods (pipecat-manager, tts-manager).
+
+**Risk:** Under extreme memory pressure, Kubernetes may evict Burstable pods before Guaranteed ones. Acceptable given current low utilization.


### PR DESCRIPTION
Switch all 30 services from Guaranteed to Burstable QoS class by adding
explicit resource requests at 10% of limits for both CPU and memory.
Nodes showed 80-92% allocated CPU while actual usage was 12-17%, preventing
new pods from scheduling. This change reduces scheduler reservations while
keeping the same burst limits.

- docs: Add design document for burstable QoS change
- bin-*-manager: Add explicit resource requests at 10% of limits across all 30 services (32 containers)
- bin-pipecat-manager: Both containers updated (pipecat-manager + pipecat-script-runner)
- bin-tts-manager: Both containers updated (tts-manager + http-server)