### PR TITLE
NOJIRA-fix-ai-prometheus-metrics

### DIFF
--- a/bin-ai-manager/CLAUDE.md
+++ b/bin-ai-manager/CLAUDE.md
@@ -311,9 +311,11 @@ The service reads configuration from environment variables (though not explicitl
 ## Prometheus Metrics
 
 The service exports metrics on:
-- `ai_manager_ai_create_total`: AI configurations created (by engine_type)
-- `ai_manager_message_create_total`: Messages created (by engine_type)
-- `ai_manager_message_process_time`: Message processing latency
+- `ai_manager_aicall_create_total`: AIcalls created (by reference_type)
+- `ai_manager_aicall_end_total`: AIcalls ended (by reference_type)
+- `ai_manager_aicall_duration_seconds`: AIcall duration histogram (by reference_type)
+- `ai_manager_aicall_tool_execute_total`: Tool executions (by tool_name)
+- `ai_manager_message_create_total`: Messages created (by role)
 - `ai_manager_subscribe_event_process_time`: Event processing latency (by publisher and type)
 
 ## CI/CD Pipeline

--- a/bin-ai-manager/pkg/aicallhandler/main.go
+++ b/bin-ai-manager/pkg/aicallhandler/main.go
@@ -152,28 +152,6 @@ var (
 		},
 		[]string{"reference_type"},
 	)
-	promAIcallInitProcessTime = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metricsNamespace,
-			Name:      "aicall_init_process_time",
-			Help:      "Process time of aicall initialization.",
-			Buckets: []float64{
-				50, 100, 500, 1000, 3000, 6000,
-			},
-		},
-		[]string{"engine_type"},
-	)
-	promAIcallMessageProcessTime = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metricsNamespace,
-			Name:      "aicall_message_process_time",
-			Help:      "Process time of aicall message.",
-			Buckets: []float64{
-				50, 100, 500, 1000, 3000, 6000,
-			},
-		},
-		[]string{"engine_type"},
-	)
 	promAIcallToolExecuteTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -189,8 +167,6 @@ func init() {
 		promAIcallCreateTotal,
 		promAIcallEndTotal,
 		promAIcallDurationSeconds,
-		promAIcallInitProcessTime,
-		promAIcallMessageProcessTime,
 		promAIcallToolExecuteTotal,
 	)
 }

--- a/bin-ai-manager/pkg/messagehandler/main.go
+++ b/bin-ai-manager/pkg/messagehandler/main.go
@@ -55,25 +55,13 @@ var (
 			Name:      "message_create_total",
 			Help:      "Total number of created message with role.",
 		},
-		[]string{"engine_type"},
-	)
-	promMessageProcessTime = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metricsNamespace,
-			Name:      "message_process_time",
-			Help:      "Process time of message.",
-			Buckets: []float64{
-				50, 100, 500, 1000, 3000, 6000,
-			},
-		},
-		[]string{"engine_type"},
+		[]string{"role"},
 	)
 )
 
 func init() {
 	prometheus.MustRegister(
 		promMessageCreateTotal,
-		promMessageProcessTime,
 	)
 }
 

--- a/monitoring/grafana/dashboards/ai-manager.json
+++ b/monitoring/grafana/dashboards/ai-manager.json
@@ -290,33 +290,6 @@
       "type": "timeseries"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 20,
-            "spanNulls": false,
-            "stacking": { "mode": "none" }
-          },
-          "unit": "ms"
-        }
-      },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
-      "id": 8,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "targets": [
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "expr": "histogram_quantile(0.95, sum by (le, engine_type) (rate(ai_manager_aicall_init_process_time_bucket[5m])))",
-          "legendFormat": "p95 {{engine_type}}"
-        }
-      ],
-      "title": "AIcall Init Time p95",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
       "id": 102,
@@ -343,38 +316,11 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "expr": "sum by (engine_type) (rate(ai_manager_message_create_total[5m])) * 60",
-          "legendFormat": "{{engine_type}}"
+          "expr": "sum by (role) (rate(ai_manager_message_create_total[5m])) * 60",
+          "legendFormat": "{{role}}"
         }
       ],
-      "title": "Messages by Engine Type",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 20,
-            "spanNulls": false,
-            "stacking": { "mode": "none" }
-          },
-          "unit": "ms"
-        }
-      },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 17 },
-      "id": 10,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "targets": [
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "expr": "histogram_quantile(0.95, sum by (le, engine_type) (rate(ai_manager_message_process_time_bucket[5m])))",
-          "legendFormat": "p95 {{engine_type}}"
-        }
-      ],
-      "title": "Message Process Time p95",
+      "title": "Messages by Role",
       "type": "timeseries"
     },
     {
@@ -402,33 +348,6 @@
         }
       ],
       "title": "Tool Executions by Tool Name",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 20,
-            "spanNulls": false,
-            "stacking": { "mode": "none" }
-          },
-          "unit": "ms"
-        }
-      },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 17 },
-      "id": 12,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "targets": [
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "expr": "histogram_quantile(0.95, sum by (le, engine_type) (rate(ai_manager_aicall_message_process_time_bucket[5m])))",
-          "legendFormat": "p95 {{engine_type}}"
-        }
-      ],
-      "title": "AIcall Message Process Time p95",
       "type": "timeseries"
     },
     {
@@ -490,33 +409,6 @@
         }
       ],
       "title": "Summary Completions by Reference Type",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 20,
-            "spanNulls": false,
-            "stacking": { "mode": "none" }
-          },
-          "unit": "short"
-        }
-      },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 26 },
-      "id": 15,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] }, "tooltip": { "mode": "multi" } },
-      "targets": [
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "expr": "sum by (engine_type) (rate(ai_manager_ai_create_total[5m])) * 60",
-          "legendFormat": "{{engine_type}}"
-        }
-      ],
-      "title": "AI Configs Created by Engine Type",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Fix mislabeled and remove unused Prometheus metrics in ai-manager.

- bin-ai-manager: Rename message_create_total label from "engine_type" to "role" to match actual values being tracked
- bin-ai-manager: Remove unused promMessageProcessTime metric from messagehandler
- bin-ai-manager: Remove unused promAIcallInitProcessTime and promAIcallMessageProcessTime from aicallhandler
- monitoring: Remove Grafana panels for deleted metrics
- monitoring: Remove Grafana panel for ai_create_total metric deleted in previous PR
- monitoring: Rename "Messages by Engine Type" panel to "Messages by Role"