### PR TITLE
NOJIRA-restrict-customers-api-permissions

### DIFF
--- a/bin-api-manager/pkg/servicehandler/customer.go
+++ b/bin-api-manager/pkg/servicehandler/customer.go
@@ -67,22 +67,48 @@ func (h *serviceHandler) CustomerCreate(
 }
 
 // CustomerGet returns customer info of given customerID.
+// Requires ProjectSuperAdmin permission.
 func (h *serviceHandler) CustomerGet(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "CustomerGet",
-		"customer_id": a.CustomerID,
+		"customer_id": customerID,
 	})
+
+	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
 
 	tmp, err := h.customerGet(ctx, customerID)
 	if err != nil {
-		log.Errorf("Could not validate the customer info. err: %v", err)
+		log.Errorf("Could not get the customer info. err: %v", err)
 		return nil, err
 	}
+	log.WithField("customer", tmp).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
 
-	if !h.hasPermission(ctx, a, tmp.ID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		log.Info("The agent has no permission for this agent.")
+	res := tmp.ConvertWebhookMessage()
+	return res, nil
+}
+
+// CustomerSelfGet returns the authenticated agent's own customer info.
+// Requires CustomerAdmin or CustomerManager permission.
+func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "CustomerSelfGet",
+		"customer_id": a.CustomerID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		log.Info("The agent has no permission.")
 		return nil, fmt.Errorf("agent has no permission")
 	}
+
+	tmp, err := h.customerGet(ctx, a.CustomerID)
+	if err != nil {
+		log.Errorf("Could not get the customer info. err: %v", err)
+		return nil, err
+	}
+	log.WithField("customer", tmp).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
 
 	res := tmp.ConvertWebhookMessage()
 	return res, nil
@@ -135,6 +161,7 @@ func (h *serviceHandler) CustomerList(ctx context.Context, a *amagent.Agent, siz
 
 // CustomerUpdate sends a request to customer-manager
 // to update the customer's basic info.
+// Requires ProjectSuperAdmin permission.
 func (h *serviceHandler) CustomerUpdate(
 	ctx context.Context,
 	a *amagent.Agent,
@@ -149,7 +176,7 @@ func (h *serviceHandler) CustomerUpdate(
 ) (*cscustomer.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":           "CustomerUpdate",
-		"customer_id":    a.CustomerID,
+		"customer_id":    id,
 		"username":       a.Username,
 		"name":           name,
 		"detail":         detail,
@@ -160,19 +187,52 @@ func (h *serviceHandler) CustomerUpdate(
 		"webhook_uri":    webhookURI,
 	})
 
+	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
 	c, err := h.customerGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not validate the customer info. err: %v", err)
 		return nil, err
 	}
-
-	if !h.hasPermission(ctx, a, c.ID, amagent.PermissionCustomerAdmin) {
-		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
-	}
+	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	// send request
 	res, err := h.reqHandler.CustomerV1CustomerUpdate(ctx, id, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
+	if err != nil {
+		log.Errorf("Could not update the customer's basic info. err: %v", err)
+		return nil, err
+	}
+
+	return res.ConvertWebhookMessage(), nil
+}
+
+// CustomerSelfUpdate updates the authenticated agent's own customer info.
+// Requires CustomerAdmin permission.
+func (h *serviceHandler) CustomerSelfUpdate(
+	ctx context.Context,
+	a *amagent.Agent,
+	name string,
+	detail string,
+	email string,
+	phoneNumber string,
+	address string,
+	webhookMethod cscustomer.WebhookMethod,
+	webhookURI string,
+) (*cscustomer.WebhookMessage, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "CustomerSelfUpdate",
+		"customer_id": a.CustomerID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
+	res, err := h.reqHandler.CustomerV1CustomerUpdate(ctx, a.CustomerID, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
 	if err != nil {
 		log.Errorf("Could not update the customer's basic info. err: %v", err)
 		return nil, err
@@ -334,22 +394,52 @@ func (h *serviceHandler) CustomerSelfRecover(ctx context.Context, a *amagent.Age
 
 // CustomerUpdateBillingAccountID sends a request to customer-manager
 // to update the customer's billing account id.
+// Requires ProjectSuperAdmin permission.
 func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "CustomerUpdateBillingAccountID",
-		"customer_id":        a.CustomerID,
-		"username":           a.Username,
+		"customer_id":        customerID,
 		"billing_account_id": billingAccountID,
 	})
 
-	c, err := h.customerGet(ctx, customerID)
+	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
+	_, err := h.customerGet(ctx, customerID)
 	if err != nil {
 		log.Errorf("Could not validate the customer info. err: %v", err)
 		return nil, err
 	}
 
-	if !h.hasPermission(ctx, a, c.ID, amagent.PermissionCustomerAdmin) {
-		log.Info("The agent has no permission for this agent.")
+	_, err = h.billingAccountGet(ctx, billingAccountID)
+	if err != nil {
+		log.Errorf("Could not validate the billing account info. err: %v", err)
+		return nil, err
+	}
+
+	// send request
+	res, err := h.reqHandler.CustomerV1CustomerUpdateBillingAccountID(ctx, customerID, billingAccountID)
+	if err != nil {
+		log.Errorf("Could not update the customer's billing account. err: %v", err)
+		return nil, err
+	}
+
+	return res.ConvertWebhookMessage(), nil
+}
+
+// CustomerSelfUpdateBillingAccountID updates the authenticated agent's own customer's billing account ID.
+// Requires CustomerAdmin permission.
+func (h *serviceHandler) CustomerSelfUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":               "CustomerSelfUpdateBillingAccountID",
+		"customer_id":        a.CustomerID,
+		"billing_account_id": billingAccountID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
+		log.Info("The agent has no permission.")
 		return nil, fmt.Errorf("agent has no permission")
 	}
 
@@ -364,10 +454,9 @@ func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *
 		return nil, fmt.Errorf("agent has no permission")
 	}
 
-	// send request
-	res, err := h.reqHandler.CustomerV1CustomerUpdateBillingAccountID(ctx, customerID, billingAccountID)
+	res, err := h.reqHandler.CustomerV1CustomerUpdateBillingAccountID(ctx, a.CustomerID, billingAccountID)
 	if err != nil {
-		log.Errorf("Could not update the customer's permission. err: %v", err)
+		log.Errorf("Could not update the customer's billing account. err: %v", err)
 		return nil, err
 	}
 

--- a/bin-api-manager/pkg/servicehandler/customer_test.go
+++ b/bin-api-manager/pkg/servicehandler/customer_test.go
@@ -120,8 +120,8 @@ func TestCustomerGet(t *testing.T) {
 	type test struct {
 		name string
 
-		customer *amagent.Agent
-		id       uuid.UUID
+		agent *amagent.Agent
+		id    uuid.UUID
 
 		responseCustomer *cscustomer.Customer
 		expectRes        *cscustomer.WebhookMessage
@@ -133,10 +133,9 @@ func TestCustomerGet(t *testing.T) {
 
 			&amagent.Agent{
 				Identity: commonidentity.Identity{
-					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-					CustomerID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+					ID: uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
 				},
-				Permission: amagent.PermissionCustomerAdmin,
+				Permission: amagent.PermissionProjectSuperAdmin,
 			},
 			uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
 
@@ -166,7 +165,65 @@ func TestCustomerGet(t *testing.T) {
 
 			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.id).Return(tt.responseCustomer, nil)
 
-			res, err := h.CustomerGet(ctx, tt.customer, tt.id)
+			res, err := h.CustomerGet(ctx, tt.agent, tt.id)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_CustomerSelfGet(t *testing.T) {
+	tests := []struct {
+		name string
+
+		agent *amagent.Agent
+
+		responseCustomer *cscustomer.Customer
+		expectRes        *cscustomer.WebhookMessage
+	}{
+		{
+			name: "normal",
+
+			agent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+
+			responseCustomer: &cscustomer.Customer{
+				ID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+			},
+			expectRes: &cscustomer.WebhookMessage{
+				ID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.agent.CustomerID).Return(tt.responseCustomer, nil)
+
+			res, err := h.CustomerSelfGet(ctx, tt.agent)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
@@ -279,10 +336,9 @@ func Test_CustomerUpdate(t *testing.T) {
 
 			&amagent.Agent{
 				Identity: commonidentity.Identity{
-					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-					CustomerID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
+					ID: uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
 				},
-				Permission: amagent.PermissionCustomerAdmin,
+				Permission: amagent.PermissionProjectSuperAdmin,
 			},
 			uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 			"name new",
@@ -321,6 +377,78 @@ func Test_CustomerUpdate(t *testing.T) {
 			mockReq.EXPECT().CustomerV1CustomerUpdate(ctx, tt.id, tt.customerName, tt.detail, tt.email, tt.phoneNumber, tt.address, tt.webhookMethod, tt.webhookURI).Return(tt.responseCustomers, nil)
 
 			res, err := h.CustomerUpdate(ctx, tt.agent, tt.id, tt.customerName, tt.detail, tt.email, tt.phoneNumber, tt.address, tt.webhookMethod, tt.webhookURI)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_CustomerSelfUpdate(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *amagent.Agent
+
+		customerName  string
+		detail        string
+		email         string
+		phoneNumber   string
+		address       string
+		webhookMethod cscustomer.WebhookMethod
+		webhookURI    string
+
+		responseCustomer *cscustomer.Customer
+		expectRes        *cscustomer.WebhookMessage
+	}{
+		{
+			name: "normal",
+
+			agent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+			customerName:  "name new",
+			detail:        "detail new",
+			email:         "test@test.com",
+			phoneNumber:   "+821100000001",
+			address:       "somewhere",
+			webhookMethod: cscustomer.WebhookMethodPost,
+			webhookURI:    "test.com",
+
+			responseCustomer: &cscustomer.Customer{
+				ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
+			},
+			expectRes: &cscustomer.WebhookMessage{
+				ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().CustomerV1CustomerUpdate(ctx, tt.agent.CustomerID, tt.customerName, tt.detail, tt.email, tt.phoneNumber, tt.address, tt.webhookMethod, tt.webhookURI).Return(tt.responseCustomer, nil)
+
+			res, err := h.CustomerSelfUpdate(ctx, tt.agent, tt.customerName, tt.detail, tt.email, tt.phoneNumber, tt.address, tt.webhookMethod, tt.webhookURI)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
@@ -416,10 +544,9 @@ func Test_CustomerUpdateBillingAccountID(t *testing.T) {
 
 			agent: &amagent.Agent{
 				Identity: commonidentity.Identity{
-					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-					CustomerID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
+					ID: uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
 				},
-				Permission: amagent.PermissionCustomerAdmin,
+				Permission: amagent.PermissionProjectSuperAdmin,
 			},
 
 			customerID:       uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
@@ -433,7 +560,6 @@ func Test_CustomerUpdateBillingAccountID(t *testing.T) {
 					ID:         uuid.FromStringOrNil("96a2ce84-1771-11ee-a155-83bf9a14ae55"),
 					CustomerID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
 				},
-				TMDelete: nil,
 			},
 			expectRes: &cscustomer.WebhookMessage{
 				ID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
@@ -460,6 +586,79 @@ func Test_CustomerUpdateBillingAccountID(t *testing.T) {
 			mockReq.EXPECT().CustomerV1CustomerUpdateBillingAccountID(ctx, tt.customerID, tt.billingAccountID).Return(tt.responseCustomer, nil)
 
 			res, err := h.CustomerUpdateBillingAccountID(ctx, tt.agent, tt.customerID, tt.billingAccountID)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_CustomerSelfUpdateBillingAccountID(t *testing.T) {
+
+	type test struct {
+		name string
+
+		agent *amagent.Agent
+
+		billingAccountID uuid.UUID
+
+		responseBillingAccount *bmaccount.Account
+		responseCustomer       *cscustomer.Customer
+		expectRes              *cscustomer.WebhookMessage
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+
+			agent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			},
+
+			billingAccountID: uuid.FromStringOrNil("96a2ce84-1771-11ee-a155-83bf9a14ae55"),
+
+			responseBillingAccount: &bmaccount.Account{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("96a2ce84-1771-11ee-a155-83bf9a14ae55"),
+					CustomerID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
+				},
+				TMDelete: nil,
+			},
+			responseCustomer: &cscustomer.Customer{
+				ID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
+			},
+			expectRes: &cscustomer.WebhookMessage{
+				ID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().BillingV1AccountGet(ctx, tt.billingAccountID).Return(tt.responseBillingAccount, nil)
+			mockReq.EXPECT().CustomerV1CustomerUpdateBillingAccountID(ctx, tt.agent.CustomerID, tt.billingAccountID).Return(tt.responseCustomer, nil)
+
+			res, err := h.CustomerSelfUpdateBillingAccountID(ctx, tt.agent, tt.billingAccountID)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -447,11 +447,23 @@ type ServiceHandler interface {
 		webhookURI string,
 	) (*cscustomer.WebhookMessage, error)
 	CustomerGet(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error)
+	CustomerSelfGet(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
 	CustomerList(ctx context.Context, a *amagent.Agent, size uint64, token string, filters map[string]string) ([]*cscustomer.WebhookMessage, error)
 	CustomerUpdate(
 		ctx context.Context,
 		a *amagent.Agent,
 		id uuid.UUID,
+		name string,
+		detail string,
+		email string,
+		phoneNumber string,
+		address string,
+		webhookMethod cscustomer.WebhookMethod,
+		webhookURI string,
+	) (*cscustomer.WebhookMessage, error)
+	CustomerSelfUpdate(
+		ctx context.Context,
+		a *amagent.Agent,
 		name string,
 		detail string,
 		email string,
@@ -466,6 +478,7 @@ type ServiceHandler interface {
 	CustomerSelfFreeze(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
 	CustomerSelfRecover(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
 	CustomerUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error)
+	CustomerSelfUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error)
 	CustomerSignup(
 		ctx context.Context,
 		name string,

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -2020,6 +2020,21 @@ func (mr *MockServiceHandlerMockRecorder) CustomerSelfFreeze(ctx, a any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerSelfFreeze", reflect.TypeOf((*MockServiceHandler)(nil).CustomerSelfFreeze), ctx, a)
 }
 
+// CustomerSelfGet mocks base method.
+func (m *MockServiceHandler) CustomerSelfGet(ctx context.Context, a *agent.Agent) (*customer.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CustomerSelfGet", ctx, a)
+	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CustomerSelfGet indicates an expected call of CustomerSelfGet.
+func (mr *MockServiceHandlerMockRecorder) CustomerSelfGet(ctx, a any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerSelfGet", reflect.TypeOf((*MockServiceHandler)(nil).CustomerSelfGet), ctx, a)
+}
+
 // CustomerSelfRecover mocks base method.
 func (m *MockServiceHandler) CustomerSelfRecover(ctx context.Context, a *agent.Agent) (*customer.WebhookMessage, error) {
 	m.ctrl.T.Helper()
@@ -2033,6 +2048,36 @@ func (m *MockServiceHandler) CustomerSelfRecover(ctx context.Context, a *agent.A
 func (mr *MockServiceHandlerMockRecorder) CustomerSelfRecover(ctx, a any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerSelfRecover", reflect.TypeOf((*MockServiceHandler)(nil).CustomerSelfRecover), ctx, a)
+}
+
+// CustomerSelfUpdate mocks base method.
+func (m *MockServiceHandler) CustomerSelfUpdate(ctx context.Context, a *agent.Agent, name, detail, email, phoneNumber, address string, webhookMethod customer.WebhookMethod, webhookURI string) (*customer.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CustomerSelfUpdate", ctx, a, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
+	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CustomerSelfUpdate indicates an expected call of CustomerSelfUpdate.
+func (mr *MockServiceHandlerMockRecorder) CustomerSelfUpdate(ctx, a, name, detail, email, phoneNumber, address, webhookMethod, webhookURI any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerSelfUpdate", reflect.TypeOf((*MockServiceHandler)(nil).CustomerSelfUpdate), ctx, a, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
+}
+
+// CustomerSelfUpdateBillingAccountID mocks base method.
+func (m *MockServiceHandler) CustomerSelfUpdateBillingAccountID(ctx context.Context, a *agent.Agent, billingAccountID uuid.UUID) (*customer.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CustomerSelfUpdateBillingAccountID", ctx, a, billingAccountID)
+	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CustomerSelfUpdateBillingAccountID indicates an expected call of CustomerSelfUpdateBillingAccountID.
+func (mr *MockServiceHandlerMockRecorder) CustomerSelfUpdateBillingAccountID(ctx, a, billingAccountID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerSelfUpdateBillingAccountID", reflect.TypeOf((*MockServiceHandler)(nil).CustomerSelfUpdateBillingAccountID), ctx, a, billingAccountID)
 }
 
 // CustomerSignup mocks base method.

--- a/bin-api-manager/server/customer.go
+++ b/bin-api-manager/server/customer.go
@@ -25,7 +25,7 @@ func (h *server) GetCustomer(c *gin.Context) {
 	a := tmp.(amagent.Agent)
 	log = log.WithField("agent", a)
 
-	res, err := h.serviceHandler.CustomerGet(c.Request.Context(), &a, a.CustomerID)
+	res, err := h.serviceHandler.CustomerSelfGet(c.Request.Context(), &a)
 	if err != nil {
 		log.Infof("Could not get the customer info. err: %v", err)
 		c.AbortWithStatus(400)
@@ -57,7 +57,7 @@ func (h *server) PutCustomer(c *gin.Context) {
 		return
 	}
 
-	res, err := h.serviceHandler.CustomerUpdate(c.Request.Context(), &a, a.CustomerID, req.Name, req.Detail, req.Email, req.PhoneNumber, req.Address, cmcustomer.WebhookMethod(req.WebhookMethod), req.WebhookUri)
+	res, err := h.serviceHandler.CustomerSelfUpdate(c.Request.Context(), &a, req.Name, req.Detail, req.Email, req.PhoneNumber, req.Address, cmcustomer.WebhookMethod(req.WebhookMethod), req.WebhookUri)
 	if err != nil {
 		log.Errorf("Could not update the customer. err: %v", err)
 		c.AbortWithStatus(400)
@@ -96,7 +96,7 @@ func (h *server) PutCustomerBillingAccountId(c *gin.Context) {
 		return
 	}
 
-	res, err := h.serviceHandler.CustomerUpdateBillingAccountID(c.Request.Context(), &a, a.CustomerID, billingAccountID)
+	res, err := h.serviceHandler.CustomerSelfUpdateBillingAccountID(c.Request.Context(), &a, billingAccountID)
 	if err != nil {
 		log.Errorf("Could not update the customer. err: %v", err)
 		c.AbortWithStatus(400)

--- a/bin-api-manager/server/customer_test.go
+++ b/bin-api-manager/server/customer_test.go
@@ -28,8 +28,7 @@ func Test_customerGET(t *testing.T) {
 
 		responseCustomer *cscustomer.WebhookMessage
 
-		expectedCustomerID uuid.UUID
-		expectedRes        string
+		expectedRes string
 	}{
 		{
 			name: "normal",
@@ -47,8 +46,7 @@ func Test_customerGET(t *testing.T) {
 				ID: uuid.FromStringOrNil("e25f1af8-c44f-11ef-9d46-bfaf61e659c2"),
 			},
 
-			expectedCustomerID: uuid.FromStringOrNil("e25f1af8-c44f-11ef-9d46-bfaf61e659c2"),
-			expectedRes:        `{"id":"e25f1af8-c44f-11ef-9d46-bfaf61e659c2","billing_account_id":"00000000-0000-0000-0000-000000000000","email_verified":false,"status":"","tm_deletion_scheduled":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectedRes: `{"id":"e25f1af8-c44f-11ef-9d46-bfaf61e659c2","billing_account_id":"00000000-0000-0000-0000-000000000000","email_verified":false,"status":"","tm_deletion_scheduled":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -71,7 +69,7 @@ func Test_customerGET(t *testing.T) {
 			openapi_server.RegisterHandlers(r, h)
 
 			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
-			mockSvc.EXPECT().CustomerGet(req.Context(), &tt.agent, tt.expectedCustomerID).Return(tt.responseCustomer, nil)
+			mockSvc.EXPECT().CustomerSelfGet(req.Context(), &tt.agent).Return(tt.responseCustomer, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {
@@ -96,7 +94,6 @@ func Test_customerPut(t *testing.T) {
 
 		responseCustomer *cscustomer.WebhookMessage
 
-		expectedCustomerID    uuid.UUID
 		expectecName          string
 		expectedDetail        string
 		expectedEmail         string
@@ -123,7 +120,6 @@ func Test_customerPut(t *testing.T) {
 				ID: uuid.FromStringOrNil("4b7dcc68-c451-11ef-a289-33cbfe065115"),
 			},
 
-			expectedCustomerID:    uuid.FromStringOrNil("4b7dcc68-c451-11ef-a289-33cbfe065115"),
 			expectecName:          "new name",
 			expectedDetail:        "new detail",
 			expectedEmail:         "test@test.com",
@@ -156,7 +152,7 @@ func Test_customerPut(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPut, tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().CustomerUpdate(req.Context(), &tt.agent, tt.expectedCustomerID, tt.expectecName, tt.expectedDetail, tt.expectedEmail, tt.expectedPhoneNumber, tt.expectedAddress, tt.expectedWebhookMethod, tt.expectedWebhookURI).Return(tt.responseCustomer, nil)
+			mockSvc.EXPECT().CustomerSelfUpdate(req.Context(), &tt.agent, tt.expectecName, tt.expectedDetail, tt.expectedEmail, tt.expectedPhoneNumber, tt.expectedAddress, tt.expectedWebhookMethod, tt.expectedWebhookURI).Return(tt.responseCustomer, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {
@@ -181,7 +177,6 @@ func Test_customerBillingAccountIDPut(t *testing.T) {
 
 		responseCustomer *cscustomer.WebhookMessage
 
-		expectedCustomerID       uuid.UUID
 		expectedBillingAccountID uuid.UUID
 		expectedRes              string
 	}{
@@ -202,7 +197,6 @@ func Test_customerBillingAccountIDPut(t *testing.T) {
 				ID: uuid.FromStringOrNil("2422306e-c514-11ef-a89d-2f0585ee15f9"),
 			},
 
-			expectedCustomerID:       uuid.FromStringOrNil("2422306e-c514-11ef-a89d-2f0585ee15f9"),
 			expectedBillingAccountID: uuid.FromStringOrNil("245bc55e-c514-11ef-85d3-23d66dfc487a"),
 			expectedRes:              `{"id":"2422306e-c514-11ef-a89d-2f0585ee15f9","billing_account_id":"00000000-0000-0000-0000-000000000000","email_verified":false,"status":"","tm_deletion_scheduled":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
@@ -229,7 +223,7 @@ func Test_customerBillingAccountIDPut(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPut, tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().CustomerUpdateBillingAccountID(req.Context(), &tt.agent, tt.expectedCustomerID, tt.expectedBillingAccountID).Return(tt.responseCustomer, nil)
+			mockSvc.EXPECT().CustomerSelfUpdateBillingAccountID(req.Context(), &tt.agent, tt.expectedBillingAccountID).Return(tt.responseCustomer, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {

--- a/docs/plans/2026-02-25-restrict-customers-api-permissions-design.md
+++ b/docs/plans/2026-02-25-restrict-customers-api-permissions-design.md
@@ -1,0 +1,278 @@
+# Restrict /customers API Permissions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restrict all `/customers` (plural) admin endpoints to ProjectSuperAdmin only, while keeping `/customer` (singular) self-service endpoints at their appropriate permission levels.
+
+**Architecture:** Currently, the self-service `/customer` routes and admin `/customers/{id}` routes share the same servicehandler functions (`CustomerGet`, `CustomerUpdate`, `CustomerUpdateBillingAccountID`). Since these two route groups now need different permission levels, we split them: the existing functions become SuperAdmin-only for the admin routes, and new `CustomerSelf*` methods handle the self-service routes with their own permission checks.
+
+**Tech Stack:** Go, gomock
+
+---
+
+## Target Access Matrix
+
+| Endpoint | Agent | Manager | Admin | Super Admin |
+|---|---|---|---|---|
+| `GET /customer` (own) | - | yes | yes | yes |
+| `PUT /customer` (own) | - | - | yes | yes |
+| `PUT /customer/billing_account_id` (own) | - | - | yes | yes |
+| `GET /service_agents/customer` (own) | yes | yes | yes | yes |
+| `POST /customers` | - | - | - | yes |
+| `GET /customers` | - | - | - | yes |
+| `GET /customers/{id}` | - | - | - | yes |
+| `PUT /customers/{id}` | - | - | - | yes |
+| `DELETE /customers/{id}` | - | - | - | yes |
+| `PUT /customers/{id}/billing_account_id` | - | - | - | yes |
+| `POST /customers/{id}/freeze` | - | - | - | yes |
+| `POST /customers/{id}/recover` | - | - | - | yes |
+
+## Files to Change
+
+- `bin-api-manager/pkg/servicehandler/main.go` — Add 3 new methods to ServiceHandler interface
+- `bin-api-manager/pkg/servicehandler/customer.go` — Change 3 existing permission checks to SuperAdmin; add 3 new CustomerSelf* methods
+- `bin-api-manager/pkg/servicehandler/customer_test.go` — Update 3 existing tests (SuperAdmin agents); add 3 new self-service tests
+- `bin-api-manager/server/customer.go` — Update 3 route handlers to call CustomerSelf* methods
+- `bin-api-manager/server/customer_test.go` — Update mock expectations to call CustomerSelf* methods
+
+---
+
+### Task 1: Change CustomerGet to SuperAdmin-only and create CustomerSelfGet
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/customer.go:82`
+- Modify: `bin-api-manager/pkg/servicehandler/customer_test.go:118-179`
+
+**Step 1: Update CustomerGet permission check**
+
+In `customer.go`, change line 82 from:
+```go
+if !h.hasPermission(ctx, a, tmp.ID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+```
+to:
+```go
+if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
+```
+
+**Step 2: Update TestCustomerGet to use SuperAdmin agent**
+
+In `customer_test.go`, change the test agent from `PermissionCustomerAdmin` to `PermissionProjectSuperAdmin` and remove the CustomerID match (since SuperAdmin bypasses ownership check).
+
+**Step 3: Create CustomerSelfGet method**
+
+Add to `customer.go`:
+```go
+func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "CustomerSelfGet",
+		"customer_id": a.CustomerID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
+	tmp, err := h.customerGet(ctx, a.CustomerID)
+	if err != nil {
+		log.Errorf("Could not get the customer info. err: %v", err)
+		return nil, err
+	}
+
+	return tmp.ConvertWebhookMessage(), nil
+}
+```
+
+**Step 4: Add CustomerSelfGet to ServiceHandler interface**
+
+In `main.go`, add after `CustomerGet`:
+```go
+CustomerSelfGet(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
+```
+
+**Step 5: Write test for CustomerSelfGet**
+
+Add to `customer_test.go`:
+```go
+func Test_CustomerSelfGet(t *testing.T) {
+	tests := []test with PermissionCustomerAdmin agent, calling CustomerSelfGet
+```
+
+**Step 6: Update server/customer.go GetCustomer route**
+
+Change `server/customer.go` `GetCustomer` from:
+```go
+res, err := h.serviceHandler.CustomerGet(c.Request.Context(), &a, a.CustomerID)
+```
+to:
+```go
+res, err := h.serviceHandler.CustomerSelfGet(c.Request.Context(), &a)
+```
+
+**Step 7: Update server/customer_test.go**
+
+Update `Test_customerGET` mock expectation from `CustomerGet` to `CustomerSelfGet`.
+
+**Step 8: Run tests**
+
+```bash
+cd bin-api-manager && go generate ./... && go test ./pkg/servicehandler/... ./server/...
+```
+
+---
+
+### Task 2: Change CustomerUpdate to SuperAdmin-only and create CustomerSelfUpdate
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/customer.go:169`
+- Modify: `bin-api-manager/pkg/servicehandler/customer_test.go:257-333`
+
+**Step 1: Update CustomerUpdate permission check**
+
+In `customer.go`, change line 169 from:
+```go
+if !h.hasPermission(ctx, a, c.ID, amagent.PermissionCustomerAdmin) {
+```
+to:
+```go
+if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
+```
+
+**Step 2: Update Test_CustomerUpdate to use SuperAdmin agent**
+
+Change the test agent from `PermissionCustomerAdmin` to `PermissionProjectSuperAdmin`.
+
+**Step 3: Create CustomerSelfUpdate method**
+
+Add to `customer.go`:
+```go
+func (h *serviceHandler) CustomerSelfUpdate(
+	ctx context.Context,
+	a *amagent.Agent,
+	name string,
+	detail string,
+	email string,
+	phoneNumber string,
+	address string,
+	webhookMethod cscustomer.WebhookMethod,
+	webhookURI string,
+) (*cscustomer.WebhookMessage, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "CustomerSelfUpdate",
+		"customer_id": a.CustomerID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
+	res, err := h.reqHandler.CustomerV1CustomerUpdate(ctx, a.CustomerID, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
+	if err != nil {
+		log.Errorf("Could not update the customer's basic info. err: %v", err)
+		return nil, err
+	}
+
+	return res.ConvertWebhookMessage(), nil
+}
+```
+
+**Step 4: Add CustomerSelfUpdate to ServiceHandler interface**
+
+**Step 5: Write test for CustomerSelfUpdate**
+
+**Step 6: Update server/customer.go PutCustomer route to call CustomerSelfUpdate**
+
+**Step 7: Update server/customer_test.go Test_customerPut**
+
+**Step 8: Run tests**
+
+---
+
+### Task 3: Change CustomerUpdateBillingAccountID to SuperAdmin-only and create CustomerSelfUpdateBillingAccountID
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/customer.go:351,362`
+- Modify: `bin-api-manager/pkg/servicehandler/customer_test.go:398-472`
+
+**Step 1: Update CustomerUpdateBillingAccountID permission checks**
+
+Change both `hasPermission` calls (lines 351, 362) from `PermissionCustomerAdmin` to `PermissionProjectSuperAdmin` with `uuid.Nil`.
+
+**Step 2: Update Test_CustomerUpdateBillingAccountID to use SuperAdmin agent**
+
+**Step 3: Create CustomerSelfUpdateBillingAccountID method**
+
+```go
+func (h *serviceHandler) CustomerSelfUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":               "CustomerSelfUpdateBillingAccountID",
+		"customer_id":        a.CustomerID,
+		"billing_account_id": billingAccountID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
+	ba, err := h.billingAccountGet(ctx, billingAccountID)
+	if err != nil {
+		log.Errorf("Could not validate the billing account info. err: %v", err)
+		return nil, err
+	}
+
+	if !h.hasPermission(ctx, a, ba.CustomerID, amagent.PermissionCustomerAdmin) {
+		log.Info("The agent has no permission.")
+		return nil, fmt.Errorf("agent has no permission")
+	}
+
+	res, err := h.reqHandler.CustomerV1CustomerUpdateBillingAccountID(ctx, a.CustomerID, billingAccountID)
+	if err != nil {
+		log.Errorf("Could not update the customer's billing account. err: %v", err)
+		return nil, err
+	}
+
+	return res.ConvertWebhookMessage(), nil
+}
+```
+
+**Step 4: Add to interface, write test, update server route, update server test**
+
+**Step 5: Run tests**
+
+---
+
+### Task 4: Regenerate mocks and run full verification
+
+**Step 1: Regenerate mocks**
+
+```bash
+cd bin-api-manager && go generate ./...
+```
+
+**Step 2: Run full verification workflow**
+
+```bash
+cd bin-api-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+**Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "NOJIRA-restrict-customers-api-permissions
+
+Restrict all /customers (plural) admin endpoints to ProjectSuperAdmin only.
+Create CustomerSelf* methods for /customer (singular) self-service routes.
+
+- bin-api-manager: Change CustomerGet permission to ProjectSuperAdmin
+- bin-api-manager: Change CustomerUpdate permission to ProjectSuperAdmin
+- bin-api-manager: Change CustomerUpdateBillingAccountID permission to ProjectSuperAdmin
+- bin-api-manager: Add CustomerSelfGet (Manager+Admin) for GET /customer
+- bin-api-manager: Add CustomerSelfUpdate (Admin) for PUT /customer
+- bin-api-manager: Add CustomerSelfUpdateBillingAccountID (Admin) for PUT /customer/billing_account_id
+- bin-api-manager: Update server routes to use new self-service methods
+- bin-api-manager: Update tests for new permission requirements
+"
+```


### PR DESCRIPTION
Restrict all /customers (plural) admin endpoints to ProjectSuperAdmin only.
Create CustomerSelf* methods for /customer (singular) self-service routes
with appropriate permission levels.

Access matrix after this change:
- GET /customer (own): Manager + Admin + SuperAdmin
- PUT /customer (own): Admin + SuperAdmin
- PUT /customer/billing_account_id (own): Admin + SuperAdmin
- All /customers/* endpoints: SuperAdmin only

- bin-api-manager: Change CustomerGet permission to ProjectSuperAdmin
- bin-api-manager: Change CustomerUpdate permission to ProjectSuperAdmin
- bin-api-manager: Change CustomerUpdateBillingAccountID permission to ProjectSuperAdmin
- bin-api-manager: Add CustomerSelfGet (Manager+Admin) for GET /customer
- bin-api-manager: Add CustomerSelfUpdate (Admin) for PUT /customer
- bin-api-manager: Add CustomerSelfUpdateBillingAccountID (Admin) for PUT /customer/billing_account_id
- bin-api-manager: Update server routes to use new self-service methods
- bin-api-manager: Update tests for new permission requirements
- docs: Add design document for permission changes