### PR TITLE
NOJIRA-return-internal-structs-for-superadmin-endpoints

### DIFF
--- a/bin-api-manager/lib/middleware/authenticate_test.go
+++ b/bin-api-manager/lib/middleware/authenticate_test.go
@@ -299,7 +299,7 @@ func TestAuthenticate(t *testing.T) {
 				mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 					"agent": testAgent,
 				}, nil)
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testAgent.CustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testAgent.CustomerID).Return(&cscustomer.Customer{
 					Status: cscustomer.StatusActive,
 				}, nil)
 			},
@@ -398,7 +398,7 @@ func TestAuthenticateWithMalformedAgentJSON(t *testing.T) {
 		},
 	}, nil)
 	// Agent will have zero-value fields (including zero Permission), so frozen check runs
-	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), uuid.Nil).Return(&cscustomer.WebhookMessage{
+	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), uuid.Nil).Return(&cscustomer.Customer{
 		Status: cscustomer.StatusActive,
 	}, nil)
 
@@ -457,7 +457,7 @@ func TestAuthenticateAgentStoredInContext(t *testing.T) {
 	mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 		"agent": testAgent,
 	}, nil)
-	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testAgent.CustomerID).Return(&cscustomer.WebhookMessage{
+	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testAgent.CustomerID).Return(&cscustomer.Customer{
 		Status: cscustomer.StatusActive,
 	}, nil)
 
@@ -519,7 +519,7 @@ func Test_isFrozenAccountBlocked(t *testing.T) {
 			method: http.MethodGet,
 			path:   "/v1.0/agents",
 			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.Customer{
 					Status: cscustomer.StatusActive,
 				}, nil)
 			},
@@ -535,7 +535,7 @@ func Test_isFrozenAccountBlocked(t *testing.T) {
 			method: http.MethodGet,
 			path:   "/v1.0/agents",
 			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.Customer{
 					Status:              cscustomer.StatusFrozen,
 					TMDeletionScheduled: &deletionTime,
 				}, nil)
@@ -649,7 +649,7 @@ func TestAuthenticateFrozenAccount(t *testing.T) {
 				mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 					"agent": testAgent,
 				}, nil)
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.Customer{
 					Status:              cscustomer.StatusFrozen,
 					TMDeletionScheduled: &deletionTime,
 				}, nil)

--- a/bin-api-manager/pkg/servicehandler/billingaccount.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount.go
@@ -129,7 +129,7 @@ func (h *serviceHandler) BillingAccountUpdatePaymentInfo(ctx context.Context, a 
 
 // BillingAccountAddBalanceForce sends a request to billing-manager
 // to add the given billing account's balance.
-func (h *serviceHandler) BillingAccountAddBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.WebhookMessage, error) {
+func (h *serviceHandler) BillingAccountAddBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.Account, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "BillingAccountAddBalanceForce",
 		"customer_id":        a.CustomerID,
@@ -149,13 +149,12 @@ func (h *serviceHandler) BillingAccountAddBalanceForce(ctx context.Context, a *a
 		return nil, errors.Wrap(err, "could not add the balance")
 	}
 
-	res := b.ConvertWebhookMessage()
-	return res, nil
+	return b, nil
 }
 
 // BillingAccountSubtractBalanceForce sends a request to billing-manager
 // to subtract the given billing account's balance.
-func (h *serviceHandler) BillingAccountSubtractBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.WebhookMessage, error) {
+func (h *serviceHandler) BillingAccountSubtractBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.Account, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "BillingAccountSubtractBalanceForce",
 		"customer_id":        a.CustomerID,
@@ -175,7 +174,6 @@ func (h *serviceHandler) BillingAccountSubtractBalanceForce(ctx context.Context,
 		return nil, errors.Wrap(err, "could not subtract the balance")
 	}
 
-	res := b.ConvertWebhookMessage()
-	return res, nil
+	return b, nil
 }
 

--- a/bin-api-manager/pkg/servicehandler/billingaccount_test.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount_test.go
@@ -231,7 +231,7 @@ func Test_BillingAccountAddBalanceForce(t *testing.T) {
 		balance   int64
 
 		responseBillingAccount *bmaccount.Account
-		expectRes              *bmaccount.WebhookMessage
+		expectRes              *bmaccount.Account
 	}{
 		{
 			name: "normal",
@@ -251,7 +251,7 @@ func Test_BillingAccountAddBalanceForce(t *testing.T) {
 					ID: uuid.FromStringOrNil("650daee2-1060-11ee-aac3-a3c291ad39f5"),
 				},
 			},
-			expectRes: &bmaccount.WebhookMessage{
+			expectRes: &bmaccount.Account{
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("650daee2-1060-11ee-aac3-a3c291ad39f5"),
 				},

--- a/bin-api-manager/pkg/servicehandler/customer.go
+++ b/bin-api-manager/pkg/servicehandler/customer.go
@@ -42,7 +42,7 @@ func (h *serviceHandler) CustomerCreate(
 	address string,
 	webhookMethod cscustomer.WebhookMethod,
 	webhookURI string,
-) (*cscustomer.WebhookMessage, error) {
+) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"agent": a,
 		"email": email,
@@ -56,19 +56,18 @@ func (h *serviceHandler) CustomerCreate(
 	}
 
 	// create customer
-	cu, err := h.reqHandler.CustomerV1CustomerCreate(ctx, 30000, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
+	res, err := h.reqHandler.CustomerV1CustomerCreate(ctx, 30000, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
 	if err != nil {
 		log.Errorf("Could not create a new customer. err: %v", err)
 		return nil, err
 	}
 
-	res := cu.ConvertWebhookMessage()
 	return res, nil
 }
 
 // CustomerGet returns customer info of given customerID.
 // Requires ProjectSuperAdmin permission.
-func (h *serviceHandler) CustomerGet(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+func (h *serviceHandler) CustomerGet(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "CustomerGet",
 		"customer_id": customerID,
@@ -86,8 +85,7 @@ func (h *serviceHandler) CustomerGet(ctx context.Context, a *amagent.Agent, cust
 	}
 	log.WithField("customer", tmp).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // CustomerSelfGet returns the authenticated agent's own customer info.
@@ -115,7 +113,7 @@ func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *amagent.Agent) 
 }
 
 // CustomerGets returns list of all customers
-func (h *serviceHandler) CustomerList(ctx context.Context, a *amagent.Agent, size uint64, token string, filters map[string]string) ([]*cscustomer.WebhookMessage, error) {
+func (h *serviceHandler) CustomerList(ctx context.Context, a *amagent.Agent, size uint64, token string, filters map[string]string) ([]*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "CustomerGets",
 		"agent":   a,
@@ -144,16 +142,15 @@ func (h *serviceHandler) CustomerList(ctx context.Context, a *amagent.Agent, siz
 		return nil, err
 	}
 
-	tmp, err := h.reqHandler.CustomerV1CustomerList(ctx, token, size, typedFilters)
+	tmps, err := h.reqHandler.CustomerV1CustomerList(ctx, token, size, typedFilters)
 	if err != nil {
 		log.Errorf("Could not get customers info. err: %v", err)
 		return nil, err
 	}
 
-	res := []*cscustomer.WebhookMessage{}
-	for _, u := range tmp {
-		t := u.ConvertWebhookMessage()
-		res = append(res, t)
+	res := make([]*cscustomer.Customer, len(tmps))
+	for i := range tmps {
+		res[i] = &tmps[i]
 	}
 
 	return res, nil
@@ -173,7 +170,7 @@ func (h *serviceHandler) CustomerUpdate(
 	address string,
 	webhookMethod cscustomer.WebhookMethod,
 	webhookURI string,
-) (*cscustomer.WebhookMessage, error) {
+) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":           "CustomerUpdate",
 		"customer_id":    id,
@@ -206,7 +203,7 @@ func (h *serviceHandler) CustomerUpdate(
 		return nil, err
 	}
 
-	return res.ConvertWebhookMessage(), nil
+	return res, nil
 }
 
 // CustomerSelfUpdate updates the authenticated agent's own customer info.
@@ -243,7 +240,7 @@ func (h *serviceHandler) CustomerSelfUpdate(
 
 // CustomerDelete sends a request to customer-manager
 // to delete the customer.
-func (h *serviceHandler) CustomerDelete(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+func (h *serviceHandler) CustomerDelete(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "CustomerDelete",
 		"customer_id": a.CustomerID,
@@ -269,12 +266,12 @@ func (h *serviceHandler) CustomerDelete(ctx context.Context, a *amagent.Agent, c
 		return nil, err
 	}
 
-	return res.ConvertWebhookMessage(), nil
+	return res, nil
 }
 
 // CustomerFreeze sends a request to customer-manager
 // to freeze the customer account (schedule deletion).
-func (h *serviceHandler) CustomerFreeze(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+func (h *serviceHandler) CustomerFreeze(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "CustomerFreeze",
 		"customer_id": a.CustomerID,
@@ -300,12 +297,12 @@ func (h *serviceHandler) CustomerFreeze(ctx context.Context, a *amagent.Agent, c
 		return nil, err
 	}
 
-	return res.ConvertWebhookMessage(), nil
+	return res, nil
 }
 
 // CustomerRecover sends a request to customer-manager
 // to recover the customer account (cancel scheduled deletion).
-func (h *serviceHandler) CustomerRecover(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+func (h *serviceHandler) CustomerRecover(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "CustomerRecover",
 		"customer_id": a.CustomerID,
@@ -331,7 +328,7 @@ func (h *serviceHandler) CustomerRecover(ctx context.Context, a *amagent.Agent, 
 		return nil, err
 	}
 
-	return res.ConvertWebhookMessage(), nil
+	return res, nil
 }
 
 // CustomerSelfFreeze handles self-service account freeze (schedule deletion).
@@ -425,7 +422,7 @@ func (h *serviceHandler) CustomerSelfRecover(ctx context.Context, a *amagent.Age
 // CustomerUpdateBillingAccountID sends a request to customer-manager
 // to update the customer's billing account id.
 // Requires ProjectSuperAdmin permission.
-func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error) {
+func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, billingAccountID uuid.UUID) (*cscustomer.Customer, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "CustomerUpdateBillingAccountID",
 		"customer_id":        customerID,
@@ -456,7 +453,7 @@ func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *
 		return nil, err
 	}
 
-	return res.ConvertWebhookMessage(), nil
+	return res, nil
 }
 
 // CustomerSelfUpdateBillingAccountID updates the authenticated agent's own customer's billing account ID.

--- a/bin-api-manager/pkg/servicehandler/customer_test.go
+++ b/bin-api-manager/pkg/servicehandler/customer_test.go
@@ -39,7 +39,7 @@ func Test_CustomerCreate(t *testing.T) {
 		responseBillingAccount *bmaccount.Account
 
 		expectFilters map[cscustomer.Field]any
-		expectRes     *cscustomer.WebhookMessage
+		expectRes     *cscustomer.Customer
 	}
 
 	tests := []test{
@@ -79,7 +79,7 @@ func Test_CustomerCreate(t *testing.T) {
 				"deleted":  "false",
 				"username": "test@test.com",
 			},
-			expectRes: &cscustomer.WebhookMessage{
+			expectRes: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("ade4707c-837d-11ec-a600-f30a3ccf56ae"),
 			},
 		},
@@ -124,7 +124,7 @@ func TestCustomerGet(t *testing.T) {
 		id    uuid.UUID
 
 		responseCustomer *cscustomer.Customer
-		expectRes        *cscustomer.WebhookMessage
+		expectRes        *cscustomer.Customer
 	}
 
 	tests := []test{
@@ -142,7 +142,7 @@ func TestCustomerGet(t *testing.T) {
 			&cscustomer.Customer{
 				ID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
 			},
-			&cscustomer.WebhookMessage{
+			&cscustomer.Customer{
 				ID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
 			},
 		},
@@ -247,7 +247,7 @@ func Test_CustomerList(t *testing.T) {
 		expectFilters map[cscustomer.Field]any
 
 		responseCustomers []cscustomer.Customer
-		expectRes         []*cscustomer.WebhookMessage
+		expectRes         []*cscustomer.Customer
 	}
 
 	tests := []test{
@@ -275,7 +275,7 @@ func Test_CustomerList(t *testing.T) {
 					ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 				},
 			},
-			[]*cscustomer.WebhookMessage{
+			[]*cscustomer.Customer{
 				{
 					ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 				},
@@ -327,7 +327,7 @@ func Test_CustomerUpdate(t *testing.T) {
 		webhookURI    string
 
 		responseCustomers *cscustomer.Customer
-		expectRes         *cscustomer.WebhookMessage
+		expectRes         *cscustomer.Customer
 	}
 
 	tests := []test{
@@ -352,7 +352,7 @@ func Test_CustomerUpdate(t *testing.T) {
 			&cscustomer.Customer{
 				ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 			},
-			&cscustomer.WebhookMessage{
+			&cscustomer.Customer{
 				ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 			},
 		},
@@ -469,7 +469,7 @@ func Test_CustomerDelete(t *testing.T) {
 		id    uuid.UUID
 
 		responseCustomers *cscustomer.Customer
-		expectRes         *cscustomer.WebhookMessage
+		expectRes         *cscustomer.Customer
 	}
 
 	tests := []test{
@@ -487,7 +487,7 @@ func Test_CustomerDelete(t *testing.T) {
 			&cscustomer.Customer{
 				ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 			},
-			&cscustomer.WebhookMessage{
+			&cscustomer.Customer{
 				ID: uuid.FromStringOrNil("8ffa19a2-837f-11ec-b57e-9f3906006c0a"),
 			},
 		},
@@ -535,7 +535,7 @@ func Test_CustomerUpdateBillingAccountID(t *testing.T) {
 
 		responseCustomer       *cscustomer.Customer
 		responseBillingAccount *bmaccount.Account
-		expectRes              *cscustomer.WebhookMessage
+		expectRes              *cscustomer.Customer
 	}
 
 	tests := []test{
@@ -561,7 +561,7 @@ func Test_CustomerUpdateBillingAccountID(t *testing.T) {
 					CustomerID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
 				},
 			},
-			expectRes: &cscustomer.WebhookMessage{
+			expectRes: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("965f317e-1771-11ee-ac07-77247b121f85"),
 			},
 		},

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -150,8 +150,8 @@ type ServiceHandler interface {
 
 	// billing accounts
 	BillingAccountGet(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID) (*bmaccount.WebhookMessage, error)
-	BillingAccountAddBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.WebhookMessage, error)
-	BillingAccountSubtractBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.WebhookMessage, error)
+	BillingAccountAddBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.Account, error)
+	BillingAccountSubtractBalanceForce(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, balance int64) (*bmaccount.Account, error)
 	BillingAccountUpdateBasicInfo(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, name string, detail string) (*bmaccount.WebhookMessage, error)
 	BillingAccountUpdatePaymentInfo(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID, paymentType bmaccount.PaymentType, paymentMethod bmaccount.PaymentMethod) (*bmaccount.WebhookMessage, error)
 
@@ -445,10 +445,10 @@ type ServiceHandler interface {
 		address string,
 		webhookMethod cscustomer.WebhookMethod,
 		webhookURI string,
-	) (*cscustomer.WebhookMessage, error)
-	CustomerGet(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error)
+	) (*cscustomer.Customer, error)
+	CustomerGet(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error)
 	CustomerSelfGet(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
-	CustomerList(ctx context.Context, a *amagent.Agent, size uint64, token string, filters map[string]string) ([]*cscustomer.WebhookMessage, error)
+	CustomerList(ctx context.Context, a *amagent.Agent, size uint64, token string, filters map[string]string) ([]*cscustomer.Customer, error)
 	CustomerUpdate(
 		ctx context.Context,
 		a *amagent.Agent,
@@ -460,7 +460,7 @@ type ServiceHandler interface {
 		address string,
 		webhookMethod cscustomer.WebhookMethod,
 		webhookURI string,
-	) (*cscustomer.WebhookMessage, error)
+	) (*cscustomer.Customer, error)
 	CustomerSelfUpdate(
 		ctx context.Context,
 		a *amagent.Agent,
@@ -472,13 +472,13 @@ type ServiceHandler interface {
 		webhookMethod cscustomer.WebhookMethod,
 		webhookURI string,
 	) (*cscustomer.WebhookMessage, error)
-	CustomerDelete(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error)
-	CustomerFreeze(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error)
-	CustomerRecover(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.WebhookMessage, error)
+	CustomerDelete(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error)
+	CustomerFreeze(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error)
+	CustomerRecover(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*cscustomer.Customer, error)
 	CustomerSelfFreeze(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
 	CustomerSelfFreezeAndDelete(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
 	CustomerSelfRecover(ctx context.Context, a *amagent.Agent) (*cscustomer.WebhookMessage, error)
-	CustomerUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error)
+	CustomerUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, billingAccountID uuid.UUID) (*cscustomer.Customer, error)
 	CustomerSelfUpdateBillingAccountID(ctx context.Context, a *amagent.Agent, billingAccountID uuid.UUID) (*cscustomer.WebhookMessage, error)
 	CustomerSignup(
 		ctx context.Context,
@@ -557,7 +557,7 @@ type ServiceHandler interface {
 	NumberDelete(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*nmnumber.WebhookMessage, error)
 	NumberUpdate(ctx context.Context, a *amagent.Agent, id uuid.UUID, callFlowID uuid.UUID, messageFlowID uuid.UUID, name string, detail string) (*nmnumber.WebhookMessage, error)
 	NumberUpdateFlowIDs(ctx context.Context, a *amagent.Agent, id, callFlowID uuid.UUID, messageFlowID uuid.UUID) (*nmnumber.WebhookMessage, error)
-	NumberRenew(ctx context.Context, a *amagent.Agent, tmRenew string) ([]*nmnumber.WebhookMessage, error)
+	NumberRenew(ctx context.Context, a *amagent.Agent, tmRenew string) ([]*nmnumber.Number, error)
 
 	// outdials
 	OutdialCreate(ctx context.Context, a *amagent.Agent, campaignID uuid.UUID, name, detail, data string) (*omoutdial.WebhookMessage, error)
@@ -629,10 +629,10 @@ type ServiceHandler interface {
 		techHeaders map[string]string,
 		name string,
 		detail string,
-	) (*rmprovider.WebhookMessage, error)
-	ProviderDelete(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*rmprovider.WebhookMessage, error)
-	ProviderGet(ctx context.Context, a *amagent.Agent, providerID uuid.UUID) (*rmprovider.WebhookMessage, error)
-	ProviderList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmprovider.WebhookMessage, error)
+	) (*rmprovider.Provider, error)
+	ProviderDelete(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*rmprovider.Provider, error)
+	ProviderGet(ctx context.Context, a *amagent.Agent, providerID uuid.UUID) (*rmprovider.Provider, error)
+	ProviderList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmprovider.Provider, error)
 	ProviderUpdate(
 		ctx context.Context,
 		a *amagent.Agent,
@@ -644,7 +644,7 @@ type ServiceHandler interface {
 		techHeaders map[string]string,
 		name string,
 		detail string,
-	) (*rmprovider.WebhookMessage, error)
+	) (*rmprovider.Provider, error)
 
 	// queue handlers
 	QueueGet(ctx context.Context, a *amagent.Agent, queueID uuid.UUID) (*qmqueue.WebhookMessage, error)
@@ -692,9 +692,9 @@ type ServiceHandler interface {
 	RecordingfileGet(ctx context.Context, a *amagent.Agent, id uuid.UUID) (string, error)
 
 	// route handlers
-	RouteGet(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.WebhookMessage, error)
-	RouteGetsByCustomerID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, size uint64, token string) ([]*rmroute.WebhookMessage, error)
-	RouteList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmroute.WebhookMessage, error)
+	RouteGet(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.Route, error)
+	RouteGetsByCustomerID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, size uint64, token string) ([]*rmroute.Route, error)
+	RouteList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmroute.Route, error)
 	RouteCreate(
 		ctx context.Context,
 		a *amagent.Agent,
@@ -704,8 +704,8 @@ type ServiceHandler interface {
 		providerID uuid.UUID,
 		priority int,
 		target string,
-	) (*rmroute.WebhookMessage, error)
-	RouteDelete(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.WebhookMessage, error)
+	) (*rmroute.Route, error)
+	RouteDelete(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.Route, error)
 	RouteUpdate(
 		ctx context.Context,
 		a *amagent.Agent,
@@ -715,7 +715,7 @@ type ServiceHandler interface {
 		providerID uuid.UUID,
 		priority int,
 		target string,
-	) (*rmroute.WebhookMessage, error)
+	) (*rmroute.Route, error)
 
 	// service_agent agent
 	ServiceAgentAgentList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*amagent.WebhookMessage, error)
@@ -829,11 +829,11 @@ type ServiceHandler interface {
 	ServiceAgentMeUpdatePassword(ctx context.Context, a *amagent.Agent, password string) (*amagent.WebhookMessage, error)
 
 	// storage account
-	StorageAccountCreate(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*smaccount.WebhookMessage, error)
+	StorageAccountCreate(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*smaccount.Account, error)
 	StorageAccountGet(ctx context.Context, a *amagent.Agent, storageAccountID uuid.UUID) (*smaccount.WebhookMessage, error)
 	StorageAccountGetByCustomerID(ctx context.Context, a *amagent.Agent) (*smaccount.WebhookMessage, error)
-	StorageAccountList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*smaccount.WebhookMessage, error)
-	StorageAccountDelete(ctx context.Context, a *amagent.Agent, storageAccountID uuid.UUID) (*smaccount.WebhookMessage, error)
+	StorageAccountList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*smaccount.Account, error)
+	StorageAccountDelete(ctx context.Context, a *amagent.Agent, storageAccountID uuid.UUID) (*smaccount.Account, error)
 
 	// storage file
 	StorageFileCreate(ctx context.Context, a *amagent.Agent, f multipart.File, name string, detail string, filename string) (*smfile.WebhookMessage, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -771,10 +771,10 @@ func (mr *MockServiceHandlerMockRecorder) AvailableNumberList(ctx, a, size, coun
 }
 
 // BillingAccountAddBalanceForce mocks base method.
-func (m *MockServiceHandler) BillingAccountAddBalanceForce(ctx context.Context, a *agent.Agent, billingAccountID uuid.UUID, balance int64) (*account.WebhookMessage, error) {
+func (m *MockServiceHandler) BillingAccountAddBalanceForce(ctx context.Context, a *agent.Agent, billingAccountID uuid.UUID, balance int64) (*account.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BillingAccountAddBalanceForce", ctx, a, billingAccountID, balance)
-	ret0, _ := ret[0].(*account.WebhookMessage)
+	ret0, _ := ret[0].(*account.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -801,10 +801,10 @@ func (mr *MockServiceHandlerMockRecorder) BillingAccountGet(ctx, a, billingAccou
 }
 
 // BillingAccountSubtractBalanceForce mocks base method.
-func (m *MockServiceHandler) BillingAccountSubtractBalanceForce(ctx context.Context, a *agent.Agent, billingAccountID uuid.UUID, balance int64) (*account.WebhookMessage, error) {
+func (m *MockServiceHandler) BillingAccountSubtractBalanceForce(ctx context.Context, a *agent.Agent, billingAccountID uuid.UUID, balance int64) (*account.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BillingAccountSubtractBalanceForce", ctx, a, billingAccountID, balance)
-	ret0, _ := ret[0].(*account.WebhookMessage)
+	ret0, _ := ret[0].(*account.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1901,10 +1901,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerCompleteSignup(ctx, tempToken,
 }
 
 // CustomerCreate mocks base method.
-func (m *MockServiceHandler) CustomerCreate(ctx context.Context, a *agent.Agent, name, detail, email, phoneNumber, address string, webhookMethod customer.WebhookMethod, webhookURI string) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerCreate(ctx context.Context, a *agent.Agent, name, detail, email, phoneNumber, address string, webhookMethod customer.WebhookMethod, webhookURI string) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerCreate", ctx, a, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1916,10 +1916,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerCreate(ctx, a, name, detail, e
 }
 
 // CustomerDelete mocks base method.
-func (m *MockServiceHandler) CustomerDelete(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerDelete(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerDelete", ctx, a, customerID)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1946,10 +1946,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerEmailVerify(ctx, token any) *g
 }
 
 // CustomerFreeze mocks base method.
-func (m *MockServiceHandler) CustomerFreeze(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerFreeze(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerFreeze", ctx, a, customerID)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1961,10 +1961,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerFreeze(ctx, a, customerID any)
 }
 
 // CustomerGet mocks base method.
-func (m *MockServiceHandler) CustomerGet(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerGet(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerGet", ctx, a, customerID)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1976,10 +1976,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerGet(ctx, a, customerID any) *g
 }
 
 // CustomerList mocks base method.
-func (m *MockServiceHandler) CustomerList(ctx context.Context, a *agent.Agent, size uint64, token string, filters map[string]string) ([]*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerList(ctx context.Context, a *agent.Agent, size uint64, token string, filters map[string]string) ([]*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerList", ctx, a, size, token, filters)
-	ret0, _ := ret[0].([]*customer.WebhookMessage)
+	ret0, _ := ret[0].([]*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1991,10 +1991,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerList(ctx, a, size, token, filt
 }
 
 // CustomerRecover mocks base method.
-func (m *MockServiceHandler) CustomerRecover(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerRecover(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerRecover", ctx, a, customerID)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2111,10 +2111,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerSignup(ctx, name, detail, emai
 }
 
 // CustomerUpdate mocks base method.
-func (m *MockServiceHandler) CustomerUpdate(ctx context.Context, a *agent.Agent, id uuid.UUID, name, detail, email, phoneNumber, address string, webhookMethod customer.WebhookMethod, webhookURI string) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerUpdate(ctx context.Context, a *agent.Agent, id uuid.UUID, name, detail, email, phoneNumber, address string, webhookMethod customer.WebhookMethod, webhookURI string) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerUpdate", ctx, a, id, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2126,10 +2126,10 @@ func (mr *MockServiceHandlerMockRecorder) CustomerUpdate(ctx, a, id, name, detai
 }
 
 // CustomerUpdateBillingAccountID mocks base method.
-func (m *MockServiceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *agent.Agent, customerID, billingAccountID uuid.UUID) (*customer.WebhookMessage, error) {
+func (m *MockServiceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *agent.Agent, customerID, billingAccountID uuid.UUID) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CustomerUpdateBillingAccountID", ctx, a, customerID, billingAccountID)
-	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret0, _ := ret[0].(*customer.Customer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2546,10 +2546,10 @@ func (mr *MockServiceHandlerMockRecorder) NumberList(ctx, a, size, token any) *g
 }
 
 // NumberRenew mocks base method.
-func (m *MockServiceHandler) NumberRenew(ctx context.Context, a *agent.Agent, tmRenew string) ([]*number.WebhookMessage, error) {
+func (m *MockServiceHandler) NumberRenew(ctx context.Context, a *agent.Agent, tmRenew string) ([]*number.Number, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NumberRenew", ctx, a, tmRenew)
-	ret0, _ := ret[0].([]*number.WebhookMessage)
+	ret0, _ := ret[0].([]*number.Number)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2846,10 +2846,10 @@ func (mr *MockServiceHandlerMockRecorder) OutplanUpdateDialInfo(ctx, a, id, sour
 }
 
 // ProviderCreate mocks base method.
-func (m *MockServiceHandler) ProviderCreate(ctx context.Context, a *agent.Agent, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.WebhookMessage, error) {
+func (m *MockServiceHandler) ProviderCreate(ctx context.Context, a *agent.Agent, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderCreate", ctx, a, providerType, hostname, techPrefix, techPostfix, techHeaders, name, detail)
-	ret0, _ := ret[0].(*provider.WebhookMessage)
+	ret0, _ := ret[0].(*provider.Provider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2861,10 +2861,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderCreate(ctx, a, providerType, h
 }
 
 // ProviderDelete mocks base method.
-func (m *MockServiceHandler) ProviderDelete(ctx context.Context, a *agent.Agent, id uuid.UUID) (*provider.WebhookMessage, error) {
+func (m *MockServiceHandler) ProviderDelete(ctx context.Context, a *agent.Agent, id uuid.UUID) (*provider.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderDelete", ctx, a, id)
-	ret0, _ := ret[0].(*provider.WebhookMessage)
+	ret0, _ := ret[0].(*provider.Provider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2876,10 +2876,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderDelete(ctx, a, id any) *gomock
 }
 
 // ProviderGet mocks base method.
-func (m *MockServiceHandler) ProviderGet(ctx context.Context, a *agent.Agent, providerID uuid.UUID) (*provider.WebhookMessage, error) {
+func (m *MockServiceHandler) ProviderGet(ctx context.Context, a *agent.Agent, providerID uuid.UUID) (*provider.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderGet", ctx, a, providerID)
-	ret0, _ := ret[0].(*provider.WebhookMessage)
+	ret0, _ := ret[0].(*provider.Provider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2891,10 +2891,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderGet(ctx, a, providerID any) *g
 }
 
 // ProviderList mocks base method.
-func (m *MockServiceHandler) ProviderList(ctx context.Context, a *agent.Agent, size uint64, token string) ([]*provider.WebhookMessage, error) {
+func (m *MockServiceHandler) ProviderList(ctx context.Context, a *agent.Agent, size uint64, token string) ([]*provider.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderList", ctx, a, size, token)
-	ret0, _ := ret[0].([]*provider.WebhookMessage)
+	ret0, _ := ret[0].([]*provider.Provider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2906,10 +2906,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderList(ctx, a, size, token any) 
 }
 
 // ProviderUpdate mocks base method.
-func (m *MockServiceHandler) ProviderUpdate(ctx context.Context, a *agent.Agent, providerID uuid.UUID, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.WebhookMessage, error) {
+func (m *MockServiceHandler) ProviderUpdate(ctx context.Context, a *agent.Agent, providerID uuid.UUID, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderUpdate", ctx, a, providerID, providerType, hostname, techPrefix, techPostfix, techHeaders, name, detail)
-	ret0, _ := ret[0].(*provider.WebhookMessage)
+	ret0, _ := ret[0].(*provider.Provider)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3176,10 +3176,10 @@ func (mr *MockServiceHandlerMockRecorder) RecordingfileGet(ctx, a, id any) *gomo
 }
 
 // RouteCreate mocks base method.
-func (m *MockServiceHandler) RouteCreate(ctx context.Context, a *agent.Agent, customerID uuid.UUID, name, detail string, providerID uuid.UUID, priority int, target string) (*route.WebhookMessage, error) {
+func (m *MockServiceHandler) RouteCreate(ctx context.Context, a *agent.Agent, customerID uuid.UUID, name, detail string, providerID uuid.UUID, priority int, target string) (*route.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RouteCreate", ctx, a, customerID, name, detail, providerID, priority, target)
-	ret0, _ := ret[0].(*route.WebhookMessage)
+	ret0, _ := ret[0].(*route.Route)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3191,10 +3191,10 @@ func (mr *MockServiceHandlerMockRecorder) RouteCreate(ctx, a, customerID, name, 
 }
 
 // RouteDelete mocks base method.
-func (m *MockServiceHandler) RouteDelete(ctx context.Context, a *agent.Agent, routeID uuid.UUID) (*route.WebhookMessage, error) {
+func (m *MockServiceHandler) RouteDelete(ctx context.Context, a *agent.Agent, routeID uuid.UUID) (*route.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RouteDelete", ctx, a, routeID)
-	ret0, _ := ret[0].(*route.WebhookMessage)
+	ret0, _ := ret[0].(*route.Route)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3206,10 +3206,10 @@ func (mr *MockServiceHandlerMockRecorder) RouteDelete(ctx, a, routeID any) *gomo
 }
 
 // RouteGet mocks base method.
-func (m *MockServiceHandler) RouteGet(ctx context.Context, a *agent.Agent, routeID uuid.UUID) (*route.WebhookMessage, error) {
+func (m *MockServiceHandler) RouteGet(ctx context.Context, a *agent.Agent, routeID uuid.UUID) (*route.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RouteGet", ctx, a, routeID)
-	ret0, _ := ret[0].(*route.WebhookMessage)
+	ret0, _ := ret[0].(*route.Route)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3221,10 +3221,10 @@ func (mr *MockServiceHandlerMockRecorder) RouteGet(ctx, a, routeID any) *gomock.
 }
 
 // RouteGetsByCustomerID mocks base method.
-func (m *MockServiceHandler) RouteGetsByCustomerID(ctx context.Context, a *agent.Agent, customerID uuid.UUID, size uint64, token string) ([]*route.WebhookMessage, error) {
+func (m *MockServiceHandler) RouteGetsByCustomerID(ctx context.Context, a *agent.Agent, customerID uuid.UUID, size uint64, token string) ([]*route.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RouteGetsByCustomerID", ctx, a, customerID, size, token)
-	ret0, _ := ret[0].([]*route.WebhookMessage)
+	ret0, _ := ret[0].([]*route.Route)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3236,10 +3236,10 @@ func (mr *MockServiceHandlerMockRecorder) RouteGetsByCustomerID(ctx, a, customer
 }
 
 // RouteList mocks base method.
-func (m *MockServiceHandler) RouteList(ctx context.Context, a *agent.Agent, size uint64, token string) ([]*route.WebhookMessage, error) {
+func (m *MockServiceHandler) RouteList(ctx context.Context, a *agent.Agent, size uint64, token string) ([]*route.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RouteList", ctx, a, size, token)
-	ret0, _ := ret[0].([]*route.WebhookMessage)
+	ret0, _ := ret[0].([]*route.Route)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3251,10 +3251,10 @@ func (mr *MockServiceHandlerMockRecorder) RouteList(ctx, a, size, token any) *go
 }
 
 // RouteUpdate mocks base method.
-func (m *MockServiceHandler) RouteUpdate(ctx context.Context, a *agent.Agent, routeID uuid.UUID, name, detail string, providerID uuid.UUID, priority int, target string) (*route.WebhookMessage, error) {
+func (m *MockServiceHandler) RouteUpdate(ctx context.Context, a *agent.Agent, routeID uuid.UUID, name, detail string, providerID uuid.UUID, priority int, target string) (*route.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RouteUpdate", ctx, a, routeID, name, detail, providerID, priority, target)
-	ret0, _ := ret[0].(*route.WebhookMessage)
+	ret0, _ := ret[0].(*route.Route)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4151,10 +4151,10 @@ func (mr *MockServiceHandlerMockRecorder) SpeakingStop(ctx, a, speakingID any) *
 }
 
 // StorageAccountCreate mocks base method.
-func (m *MockServiceHandler) StorageAccountCreate(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*account1.WebhookMessage, error) {
+func (m *MockServiceHandler) StorageAccountCreate(ctx context.Context, a *agent.Agent, customerID uuid.UUID) (*account1.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageAccountCreate", ctx, a, customerID)
-	ret0, _ := ret[0].(*account1.WebhookMessage)
+	ret0, _ := ret[0].(*account1.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4166,10 +4166,10 @@ func (mr *MockServiceHandlerMockRecorder) StorageAccountCreate(ctx, a, customerI
 }
 
 // StorageAccountDelete mocks base method.
-func (m *MockServiceHandler) StorageAccountDelete(ctx context.Context, a *agent.Agent, storageAccountID uuid.UUID) (*account1.WebhookMessage, error) {
+func (m *MockServiceHandler) StorageAccountDelete(ctx context.Context, a *agent.Agent, storageAccountID uuid.UUID) (*account1.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageAccountDelete", ctx, a, storageAccountID)
-	ret0, _ := ret[0].(*account1.WebhookMessage)
+	ret0, _ := ret[0].(*account1.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4211,10 +4211,10 @@ func (mr *MockServiceHandlerMockRecorder) StorageAccountGetByCustomerID(ctx, a a
 }
 
 // StorageAccountList mocks base method.
-func (m *MockServiceHandler) StorageAccountList(ctx context.Context, a *agent.Agent, size uint64, token string) ([]*account1.WebhookMessage, error) {
+func (m *MockServiceHandler) StorageAccountList(ctx context.Context, a *agent.Agent, size uint64, token string) ([]*account1.Account, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StorageAccountList", ctx, a, size, token)
-	ret0, _ := ret[0].([]*account1.WebhookMessage)
+	ret0, _ := ret[0].([]*account1.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/bin-api-manager/pkg/servicehandler/numbers.go
+++ b/bin-api-manager/pkg/servicehandler/numbers.go
@@ -261,7 +261,7 @@ func (h *serviceHandler) NumberUpdateFlowIDs(ctx context.Context, a *amagent.Age
 // NumberRenew handles number renew request.
 // It sends a request to the number-manager to renew the numbers.
 // it returns renewed numbers information if it succeed.
-func (h *serviceHandler) NumberRenew(ctx context.Context, a *amagent.Agent, tmRenew string) ([]*nmnumber.WebhookMessage, error) {
+func (h *serviceHandler) NumberRenew(ctx context.Context, a *amagent.Agent, tmRenew string) ([]*nmnumber.Number, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "NumberRenew",
 		"customer_id": a.CustomerID,
@@ -281,10 +281,9 @@ func (h *serviceHandler) NumberRenew(ctx context.Context, a *amagent.Agent, tmRe
 		return nil, err
 	}
 
-	res := []*nmnumber.WebhookMessage{}
-	for _, tmp := range tmps {
-		c := tmp.ConvertWebhookMessage()
-		res = append(res, c)
+	res := make([]*nmnumber.Number, len(tmps))
+	for i := range tmps {
+		res[i] = &tmps[i]
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/numbers_test.go
+++ b/bin-api-manager/pkg/servicehandler/numbers_test.go
@@ -571,7 +571,7 @@ func Test_NumberRenew(t *testing.T) {
 		tmRenew string
 
 		responseNumbers []nmnumber.Number
-		expectRes       []*nmnumber.WebhookMessage
+		expectRes       []*nmnumber.Number
 	}
 
 	tests := []test{
@@ -599,7 +599,7 @@ func Test_NumberRenew(t *testing.T) {
 					},
 				},
 			},
-			expectRes: []*nmnumber.WebhookMessage{
+			expectRes: []*nmnumber.Number{
 				{
 					Identity: commonidentity.Identity{
 						ID: uuid.FromStringOrNil("92647ae8-161d-11ee-9746-6387778bd96f"),

--- a/bin-api-manager/pkg/servicehandler/provider.go
+++ b/bin-api-manager/pkg/servicehandler/provider.go
@@ -33,7 +33,7 @@ func (h *serviceHandler) providerGet(ctx context.Context, id uuid.UUID) (*rmprov
 
 // ProviderGet sends a request to route-manager
 // to getting the provider.
-func (h *serviceHandler) ProviderGet(ctx context.Context, a *amagent.Agent, providerID uuid.UUID) (*rmprovider.WebhookMessage, error) {
+func (h *serviceHandler) ProviderGet(ctx context.Context, a *amagent.Agent, providerID uuid.UUID) (*rmprovider.Provider, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderGet",
 		"customer_id": a.CustomerID,
@@ -52,14 +52,13 @@ func (h *serviceHandler) ProviderGet(ctx context.Context, a *amagent.Agent, prov
 		return nil, fmt.Errorf("agent has no permission")
 	}
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // ProviderGets sends a request to route-manager
 // to getting a list of providers.
 // it returns providers info if it succeed.
-func (h *serviceHandler) ProviderList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmprovider.WebhookMessage, error) {
+func (h *serviceHandler) ProviderList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmprovider.Provider, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderGets",
 		"customer_id": a.CustomerID,
@@ -85,10 +84,9 @@ func (h *serviceHandler) ProviderList(ctx context.Context, a *amagent.Agent, siz
 		return nil, err
 	}
 
-	res := []*rmprovider.WebhookMessage{}
-	for _, tmp := range tmps {
-		e := tmp.ConvertWebhookMessage()
-		res = append(res, e)
+	res := make([]*rmprovider.Provider, len(tmps))
+	for i := range tmps {
+		res[i] = &tmps[i]
 	}
 
 	return res, nil
@@ -105,7 +103,7 @@ func (h *serviceHandler) ProviderCreate(
 	techHeaders map[string]string,
 	name string,
 	detail string,
-) (*rmprovider.WebhookMessage, error) {
+) (*rmprovider.Provider, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderCreate",
 		"customer_id": a.CustomerID,
@@ -134,12 +132,11 @@ func (h *serviceHandler) ProviderCreate(
 		return nil, err
 	}
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // ProviderDelete deletes the provider.
-func (h *serviceHandler) ProviderDelete(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*rmprovider.WebhookMessage, error) {
+func (h *serviceHandler) ProviderDelete(ctx context.Context, a *amagent.Agent, id uuid.UUID) (*rmprovider.Provider, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderDelete",
 		"customer_id": a.CustomerID,
@@ -168,8 +165,7 @@ func (h *serviceHandler) ProviderDelete(ctx context.Context, a *amagent.Agent, i
 		return nil, err
 	}
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // ProviderUpdate sends a request to route-manager
@@ -186,7 +182,7 @@ func (h *serviceHandler) ProviderUpdate(
 	techHeaders map[string]string,
 	name string,
 	detail string,
-) (*rmprovider.WebhookMessage, error) {
+) (*rmprovider.Provider, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderUpdate",
 		"customer_id": a.CustomerID,
@@ -221,6 +217,5 @@ func (h *serviceHandler) ProviderUpdate(
 	}
 	log.WithField("queue", tmp).Debugf("Updated queue. queue_id: %s", tmp.ID)
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }

--- a/bin-api-manager/pkg/servicehandler/provider_test.go
+++ b/bin-api-manager/pkg/servicehandler/provider_test.go
@@ -27,7 +27,7 @@ func Test_ProviderGet(t *testing.T) {
 		id    uuid.UUID
 
 		response  *rmprovider.Provider
-		expectRes *rmprovider.WebhookMessage
+		expectRes *rmprovider.Provider
 	}
 
 	tests := []test{
@@ -46,7 +46,7 @@ func Test_ProviderGet(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("0c6f3dd3-929e-4d3b-8231-5e8c10db6c21"),
 			},
-			&rmprovider.WebhookMessage{
+			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("0c6f3dd3-929e-4d3b-8231-5e8c10db6c21"),
 			},
 		},
@@ -91,7 +91,7 @@ func Test_ProviderList(t *testing.T) {
 		pageSize  uint64
 
 		responseProviders []rmprovider.Provider
-		expectRes         []*rmprovider.WebhookMessage
+		expectRes         []*rmprovider.Provider
 	}
 
 	tests := []test{
@@ -113,7 +113,7 @@ func Test_ProviderList(t *testing.T) {
 					ID: uuid.FromStringOrNil("d9603c2b-643c-43f2-9d58-71733785d45b"),
 				},
 			},
-			[]*rmprovider.WebhookMessage{
+			[]*rmprovider.Provider{
 				{
 					ID: uuid.FromStringOrNil("d9603c2b-643c-43f2-9d58-71733785d45b"),
 				},
@@ -164,7 +164,7 @@ func Test_ProviderCreate(t *testing.T) {
 		detail       string
 
 		response  *rmprovider.Provider
-		expectRes *rmprovider.WebhookMessage
+		expectRes *rmprovider.Provider
 	}
 
 	tests := []test{
@@ -192,7 +192,7 @@ func Test_ProviderCreate(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("c26e8f5b-5d5b-4618-a386-e633773f538e"),
 			},
-			&rmprovider.WebhookMessage{
+			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("c26e8f5b-5d5b-4618-a386-e633773f538e"),
 			},
 		},
@@ -255,7 +255,7 @@ func Test_ProviderDelete(t *testing.T) {
 		providerID uuid.UUID
 
 		responseProvider *rmprovider.Provider
-		expectRes        *rmprovider.WebhookMessage
+		expectRes        *rmprovider.Provider
 	}
 
 	tests := []test{
@@ -274,7 +274,7 @@ func Test_ProviderDelete(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("3b889381-8944-49fa-8220-1a3b8b4d0894"),
 			},
-			&rmprovider.WebhookMessage{
+			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("3b889381-8944-49fa-8220-1a3b8b4d0894"),
 			},
 		},
@@ -327,7 +327,7 @@ func Test_ProviderUpdate(t *testing.T) {
 		detail       string
 
 		responseProvider *rmprovider.Provider
-		expectRes        *rmprovider.WebhookMessage
+		expectRes        *rmprovider.Provider
 	}
 
 	tests := []test{
@@ -357,7 +357,7 @@ func Test_ProviderUpdate(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("9d4a55e6-f197-497a-a359-06d1858de39e"),
 			},
-			&rmprovider.WebhookMessage{
+			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("9d4a55e6-f197-497a-a359-06d1858de39e"),
 			},
 		},

--- a/bin-api-manager/pkg/servicehandler/route.go
+++ b/bin-api-manager/pkg/servicehandler/route.go
@@ -33,7 +33,7 @@ func (h *serviceHandler) routeGet(ctx context.Context, routeID uuid.UUID) (*rmro
 
 // RouteGet sends a request to route-manager
 // to getting the route.
-func (h *serviceHandler) RouteGet(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.WebhookMessage, error) {
+func (h *serviceHandler) RouteGet(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.Route, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "RouteGet",
 		"customer_id": a.CustomerID,
@@ -54,14 +54,13 @@ func (h *serviceHandler) RouteGet(ctx context.Context, a *amagent.Agent, routeID
 		return nil, err
 	}
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // RouteGets sends a request to route-manager
 // to getting a list of routes.
 // it returns route info if it succeed.
-func (h *serviceHandler) RouteList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmroute.WebhookMessage, error) {
+func (h *serviceHandler) RouteList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*rmroute.Route, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":     "RouteGets",
 		"username": a.Username,
@@ -88,10 +87,9 @@ func (h *serviceHandler) RouteList(ctx context.Context, a *amagent.Agent, size u
 		return nil, err
 	}
 
-	res := []*rmroute.WebhookMessage{}
-	for _, tmp := range tmps {
-		e := tmp.ConvertWebhookMessage()
-		res = append(res, e)
+	res := make([]*rmroute.Route, len(tmps))
+	for i := range tmps {
+		res[i] = &tmps[i]
 	}
 
 	return res, nil
@@ -100,7 +98,7 @@ func (h *serviceHandler) RouteList(ctx context.Context, a *amagent.Agent, size u
 // RouteGetsByCustomerID sends a request to route-manager
 // to getting a list of routes.
 // it returns route info if it succeed.
-func (h *serviceHandler) RouteGetsByCustomerID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, size uint64, token string) ([]*rmroute.WebhookMessage, error) {
+func (h *serviceHandler) RouteGetsByCustomerID(ctx context.Context, a *amagent.Agent, customerID uuid.UUID, size uint64, token string) ([]*rmroute.Route, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "RouteGetsByCustomerID",
 		"customer_id": customerID,
@@ -129,10 +127,9 @@ func (h *serviceHandler) RouteGetsByCustomerID(ctx context.Context, a *amagent.A
 		return nil, err
 	}
 
-	res := []*rmroute.WebhookMessage{}
-	for _, tmp := range tmps {
-		e := tmp.ConvertWebhookMessage()
-		res = append(res, e)
+	res := make([]*rmroute.Route, len(tmps))
+	for i := range tmps {
+		res[i] = &tmps[i]
 	}
 
 	return res, nil
@@ -150,7 +147,7 @@ func (h *serviceHandler) RouteCreate(
 	providerID uuid.UUID,
 	priority int,
 	target string,
-) (*rmroute.WebhookMessage, error) {
+) (*rmroute.Route, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "RouteCreate",
 		"customer_id": customerID,
@@ -180,14 +177,13 @@ func (h *serviceHandler) RouteCreate(
 	}
 	log.WithField("route", tmp).Debug("Created a new route.")
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // RouteDelete sends a request to route-manager
 // to deleting the route.
 // it returns error if it failed.
-func (h *serviceHandler) RouteDelete(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.WebhookMessage, error) {
+func (h *serviceHandler) RouteDelete(ctx context.Context, a *amagent.Agent, routeID uuid.UUID) (*rmroute.Route, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "RouteDelete",
 		"customer_id": a.CustomerID,
@@ -215,8 +211,7 @@ func (h *serviceHandler) RouteDelete(ctx context.Context, a *amagent.Agent, rout
 	}
 	log.WithField("route", tmp).Debugf("Deleted route. route_id: %s", tmp.ID)
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }
 
 // RouteUpdate sends a request to route-manager
@@ -231,7 +226,7 @@ func (h *serviceHandler) RouteUpdate(
 	providerID uuid.UUID,
 	priority int,
 	target string,
-) (*rmroute.WebhookMessage, error) {
+) (*rmroute.Route, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "RouteUpdate",
 		"customer_id": a.CustomerID,
@@ -258,6 +253,5 @@ func (h *serviceHandler) RouteUpdate(
 	}
 	log.WithField("route", tmp).Debugf("Updated route. route_id: %s", tmp.ID)
 
-	res := tmp.ConvertWebhookMessage()
-	return res, nil
+	return tmp, nil
 }

--- a/bin-api-manager/pkg/servicehandler/route_test.go
+++ b/bin-api-manager/pkg/servicehandler/route_test.go
@@ -27,7 +27,7 @@ func Test_RouteGet(t *testing.T) {
 		id    uuid.UUID
 
 		responseRoute *rmroute.Route
-		expectRes     *rmroute.WebhookMessage
+		expectRes     *rmroute.Route
 	}
 
 	tests := []test{
@@ -47,7 +47,7 @@ func Test_RouteGet(t *testing.T) {
 				ID:         uuid.FromStringOrNil("19dd98af-0e61-4735-909f-e0da0873ef44"),
 				CustomerID: uuid.FromStringOrNil("1e7f44c4-7fff-11ec-98ef-c70700134988"),
 			},
-			&rmroute.WebhookMessage{
+			&rmroute.Route{
 				ID:         uuid.FromStringOrNil("19dd98af-0e61-4735-909f-e0da0873ef44"),
 				CustomerID: uuid.FromStringOrNil("1e7f44c4-7fff-11ec-98ef-c70700134988"),
 			},
@@ -94,7 +94,7 @@ func Test_RouteList(t *testing.T) {
 		pageSize  uint64
 
 		responseRoutes []rmroute.Route
-		expectRes      []*rmroute.WebhookMessage
+		expectRes      []*rmroute.Route
 	}
 
 	tests := []test{
@@ -117,7 +117,7 @@ func Test_RouteList(t *testing.T) {
 					ID: uuid.FromStringOrNil("f65b0310-68a1-11ee-8c62-73e88f334b47"),
 				},
 			},
-			[]*rmroute.WebhookMessage{
+			[]*rmroute.Route{
 				{
 					ID: uuid.FromStringOrNil("f65b0310-68a1-11ee-8c62-73e88f334b47"),
 				},
@@ -165,7 +165,7 @@ func Test_RouteListByCustomerID(t *testing.T) {
 		pageSize   uint64
 
 		responseRoutes []rmroute.Route
-		expectRes      []*rmroute.WebhookMessage
+		expectRes      []*rmroute.Route
 	}
 
 	tests := []test{
@@ -189,7 +189,7 @@ func Test_RouteListByCustomerID(t *testing.T) {
 					ID: uuid.FromStringOrNil("99a7ea66-d257-4b5c-8be3-47ddd6373c95"),
 				},
 			},
-			[]*rmroute.WebhookMessage{
+			[]*rmroute.Route{
 				{
 					ID: uuid.FromStringOrNil("99a7ea66-d257-4b5c-8be3-47ddd6373c95"),
 				},
@@ -240,7 +240,7 @@ func Test_RouteCreate(t *testing.T) {
 		target     string
 
 		responseRoute *rmroute.Route
-		expectRes     *rmroute.WebhookMessage
+		expectRes     *rmroute.Route
 	}
 
 	tests := []test{
@@ -265,7 +265,7 @@ func Test_RouteCreate(t *testing.T) {
 			&rmroute.Route{
 				ID: uuid.FromStringOrNil("5bbbe36b-ec7b-480d-8bb8-28dc43328269"),
 			},
-			&rmroute.WebhookMessage{
+			&rmroute.Route{
 				ID: uuid.FromStringOrNil("5bbbe36b-ec7b-480d-8bb8-28dc43328269"),
 			},
 		},
@@ -326,7 +326,7 @@ func Test_RouteDelete(t *testing.T) {
 		routeID uuid.UUID
 
 		responseRoute *rmroute.Route
-		expectRes     *rmroute.WebhookMessage
+		expectRes     *rmroute.Route
 	}
 
 	tests := []test{
@@ -346,7 +346,7 @@ func Test_RouteDelete(t *testing.T) {
 				ID:         uuid.FromStringOrNil("15700708-0f25-4d46-b72e-1d489abc2cea"),
 				CustomerID: uuid.FromStringOrNil("1e7f44c4-7fff-11ec-98ef-c70700134988"),
 			},
-			&rmroute.WebhookMessage{
+			&rmroute.Route{
 				ID:         uuid.FromStringOrNil("15700708-0f25-4d46-b72e-1d489abc2cea"),
 				CustomerID: uuid.FromStringOrNil("1e7f44c4-7fff-11ec-98ef-c70700134988"),
 			},
@@ -398,7 +398,7 @@ func Test_RouteUpdate(t *testing.T) {
 		target     string
 
 		responseRoute *rmroute.Route
-		expectRes     *rmroute.WebhookMessage
+		expectRes     *rmroute.Route
 	}
 
 	tests := []test{
@@ -424,7 +424,7 @@ func Test_RouteUpdate(t *testing.T) {
 				ID:         uuid.FromStringOrNil("88c8938c-8dd3-4fcf-887f-c0e026912a6b"),
 				CustomerID: uuid.FromStringOrNil("1e7f44c4-7fff-11ec-98ef-c70700134988"),
 			},
-			&rmroute.WebhookMessage{
+			&rmroute.Route{
 				ID:         uuid.FromStringOrNil("88c8938c-8dd3-4fcf-887f-c0e026912a6b"),
 				CustomerID: uuid.FromStringOrNil("1e7f44c4-7fff-11ec-98ef-c70700134988"),
 			},

--- a/bin-api-manager/pkg/servicehandler/storage_account_test.go
+++ b/bin-api-manager/pkg/servicehandler/storage_account_test.go
@@ -82,7 +82,7 @@ func Test_StorageAccountDelete(t *testing.T) {
 		storageAccountID uuid.UUID
 
 		responseStorageAccount *smaccount.Account
-		expectRes              *smaccount.WebhookMessage
+		expectRes              *smaccount.Account
 	}{
 		{
 			name: "normal",
@@ -101,7 +101,7 @@ func Test_StorageAccountDelete(t *testing.T) {
 				CustomerID: uuid.FromStringOrNil("1a73a632-1bd8-11ef-8c46-4fdca968dac2"),
 				TMDelete: nil,
 			},
-			expectRes: &smaccount.WebhookMessage{
+			expectRes: &smaccount.Account{
 				ID:         uuid.FromStringOrNil("1aa43522-1bd8-11ef-870e-4f7d5cfff4f5"),
 				CustomerID: uuid.FromStringOrNil("1a73a632-1bd8-11ef-8c46-4fdca968dac2"),
 				TMDelete: nil,
@@ -149,7 +149,7 @@ func Test_StorageAccountList(t *testing.T) {
 
 		responseStorageAcounts []smaccount.Account
 		expectFilters          map[smaccount.Field]any
-		expectRes              []*smaccount.WebhookMessage
+		expectRes              []*smaccount.Account
 	}{
 		{
 			name: "normal",
@@ -174,7 +174,7 @@ func Test_StorageAccountList(t *testing.T) {
 			expectFilters: map[smaccount.Field]any{
 				smaccount.FieldDeleted: false,
 			},
-			expectRes: []*smaccount.WebhookMessage{
+			expectRes: []*smaccount.Account{
 				{
 					ID: uuid.FromStringOrNil("6a1a3db8-1bd8-11ef-bffb-8bab4b517f52"),
 				},
@@ -223,7 +223,7 @@ func Test_StorageAccountCreate(t *testing.T) {
 		customerID uuid.UUID
 
 		responseStorageAccount *smaccount.Account
-		expectRes              *smaccount.WebhookMessage
+		expectRes              *smaccount.Account
 	}{
 		{
 			name: "normal",
@@ -240,7 +240,7 @@ func Test_StorageAccountCreate(t *testing.T) {
 			responseStorageAccount: &smaccount.Account{
 				ID: uuid.FromStringOrNil("f27afcba-1bd8-11ef-a4b8-6f4d6a5ab550"),
 			},
-			expectRes: &smaccount.WebhookMessage{
+			expectRes: &smaccount.Account{
 				ID: uuid.FromStringOrNil("f27afcba-1bd8-11ef-a4b8-6f4d6a5ab550"),
 			},
 		},

--- a/bin-api-manager/pkg/servicehandler/storage_accounts.go
+++ b/bin-api-manager/pkg/servicehandler/storage_accounts.go
@@ -92,7 +92,7 @@ func (h *serviceHandler) StorageAccountGetByCustomerID(ctx context.Context, a *a
 // StorageAccountDelete sends a request to storage-manager
 // to deleting a storage account.
 // it returns storage account if it succeed.
-func (h *serviceHandler) StorageAccountDelete(ctx context.Context, a *amagent.Agent, storageAccountID uuid.UUID) (*smaccount.WebhookMessage, error) {
+func (h *serviceHandler) StorageAccountDelete(ctx context.Context, a *amagent.Agent, storageAccountID uuid.UUID) (*smaccount.Account, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "StorageAccountDelete",
 		"customer_id":        a.CustomerID,
@@ -111,19 +111,18 @@ func (h *serviceHandler) StorageAccountDelete(ctx context.Context, a *amagent.Ag
 		return nil, fmt.Errorf("user has no permission")
 	}
 
-	tmp, err := h.reqHandler.StorageV1AccountDelete(ctx, storageAccountID, 60000)
+	res, err := h.reqHandler.StorageV1AccountDelete(ctx, storageAccountID, 60000)
 	if err != nil {
 		log.Errorf("Could not delete storage account. err: %v", err)
 	}
 
-	res := tmp.ConvertWebhookMessage()
 	return res, nil
 }
 
 // StorageAccountGets sends a request to storage-manager
 // to getting a list of storage accounts.
 // it returns list of storage accounts if it succeed.
-func (h *serviceHandler) StorageAccountList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*smaccount.WebhookMessage, error) {
+func (h *serviceHandler) StorageAccountList(ctx context.Context, a *amagent.Agent, size uint64, token string) ([]*smaccount.Account, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "StorageAccountGets",
 		"customer_id": a.CustomerID,
@@ -159,11 +158,9 @@ func (h *serviceHandler) StorageAccountList(ctx context.Context, a *amagent.Agen
 		return nil, err
 	}
 
-	// create result
-	res := []*smaccount.WebhookMessage{}
-	for _, tmp := range tmps {
-		c := tmp.ConvertWebhookMessage()
-		res = append(res, c)
+	res := make([]*smaccount.Account, len(tmps))
+	for i := range tmps {
+		res[i] = &tmps[i]
 	}
 
 	return res, nil
@@ -172,7 +169,7 @@ func (h *serviceHandler) StorageAccountList(ctx context.Context, a *amagent.Agen
 // StorageAccountCreate sends a request to storage-manager
 // to create a new storage accounts.
 // it returns created storage account if it succeed.
-func (h *serviceHandler) StorageAccountCreate(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*smaccount.WebhookMessage, error) {
+func (h *serviceHandler) StorageAccountCreate(ctx context.Context, a *amagent.Agent, customerID uuid.UUID) (*smaccount.Account, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "StorageAccountCreate",
 		"customer_id": a.CustomerID,
@@ -184,13 +181,12 @@ func (h *serviceHandler) StorageAccountCreate(ctx context.Context, a *amagent.Ag
 	}
 
 	// create storage accounts
-	tmp, err := h.reqHandler.StorageV1AccountCreate(ctx, a.CustomerID)
+	res, err := h.reqHandler.StorageV1AccountCreate(ctx, a.CustomerID)
 	if err != nil {
 		log.Infof("Could not get storage account info. err: %v", err)
 		return nil, err
 	}
 
-	res := tmp.ConvertWebhookMessage()
 	return res, nil
 }
 

--- a/bin-api-manager/server/billing_accounts_test.go
+++ b/bin-api-manager/server/billing_accounts_test.go
@@ -253,7 +253,7 @@ func Test_PostBillingAccountsIdBalanceAddForce(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseBillingAccount *bmaccount.WebhookMessage
+		responseBillingAccount *bmaccount.Account
 
 		expectBillingAccountID uuid.UUID
 		expectBalance          int64
@@ -272,7 +272,7 @@ func Test_PostBillingAccountsIdBalanceAddForce(t *testing.T) {
 			reqQuery: "/billing_accounts/605eae78-11eb-11ee-b8d3-6fd8da9d9879/balance_add_force",
 			reqBody:  []byte(`{"balance": 20.0}`),
 
-			responseBillingAccount: &bmaccount.WebhookMessage{
+			responseBillingAccount: &bmaccount.Account{
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("605eae78-11eb-11ee-b8d3-6fd8da9d9879"),
 				},
@@ -280,7 +280,7 @@ func Test_PostBillingAccountsIdBalanceAddForce(t *testing.T) {
 
 			expectBillingAccountID: uuid.FromStringOrNil("605eae78-11eb-11ee-b8d3-6fd8da9d9879"),
 			expectBalance:          20000000,
-			expectRes:              `{"id":"605eae78-11eb-11ee-b8d3-6fd8da9d9879","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","plan_type":"","balance_credit":0,"balance_token":0,"payment_type":"","payment_method":"","tm_last_topup":null,"tm_next_topup":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:              `{"id":"605eae78-11eb-11ee-b8d3-6fd8da9d9879","customer_id":"00000000-0000-0000-0000-000000000000","status":"","name":"","detail":"","plan_type":"","balance_credit":0,"balance_token":0,"payment_type":"","payment_method":"","tm_last_topup":null,"tm_next_topup":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -327,7 +327,7 @@ func Test_PostBillingAccountsIdBalanceSubtractForce(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseBillingAccount *bmaccount.WebhookMessage
+		responseBillingAccount *bmaccount.Account
 
 		expectBillingAccountID uuid.UUID
 		expectBalance          int64
@@ -346,7 +346,7 @@ func Test_PostBillingAccountsIdBalanceSubtractForce(t *testing.T) {
 			reqQuery: "/billing_accounts/e4e38ff6-11eb-11ee-879b-cb22a78168e4/balance_subtract_force",
 			reqBody:  []byte(`{"balance": 20.0}`),
 
-			responseBillingAccount: &bmaccount.WebhookMessage{
+			responseBillingAccount: &bmaccount.Account{
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("e4e38ff6-11eb-11ee-879b-cb22a78168e4"),
 				},
@@ -354,7 +354,7 @@ func Test_PostBillingAccountsIdBalanceSubtractForce(t *testing.T) {
 
 			expectBillingAccountID: uuid.FromStringOrNil("e4e38ff6-11eb-11ee-879b-cb22a78168e4"),
 			expectBalance:          20000000,
-			expectRes:              `{"id":"e4e38ff6-11eb-11ee-879b-cb22a78168e4","customer_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","plan_type":"","balance_credit":0,"balance_token":0,"payment_type":"","payment_method":"","tm_last_topup":null,"tm_next_topup":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:              `{"id":"e4e38ff6-11eb-11ee-879b-cb22a78168e4","customer_id":"00000000-0000-0000-0000-000000000000","status":"","name":"","detail":"","plan_type":"","balance_credit":0,"balance_token":0,"payment_type":"","payment_method":"","tm_last_topup":null,"tm_next_topup":null,"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 

--- a/bin-api-manager/server/customers_test.go
+++ b/bin-api-manager/server/customers_test.go
@@ -26,7 +26,7 @@ func Test_customersPOST(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseCustomer *cscustomer.WebhookMessage
+		responseCustomer *cscustomer.Customer
 
 		expectName          string
 		expectDetail        string
@@ -49,7 +49,7 @@ func Test_customersPOST(t *testing.T) {
 			reqQuery: "/customers",
 			reqBody:  []byte(`{"name":"test name","detail":"test detail","email":"test@test.com","phone_number":"+821100000001","address":"somewhere","webhook_method":"POST","webhook_uri":"test.com"}`),
 
-			responseCustomer: &cscustomer.WebhookMessage{
+			responseCustomer: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("271353a8-83f3-11ec-9386-8be19d563155"),
 			},
 
@@ -118,7 +118,7 @@ func Test_customersGet(t *testing.T) {
 
 		reqQuery string
 
-		responseCustomers []*cscustomer.WebhookMessage
+		responseCustomers []*cscustomer.Customer
 
 		expectPageSize  uint64
 		expectPageToken string
@@ -135,7 +135,7 @@ func Test_customersGet(t *testing.T) {
 
 			reqQuery: "/customers?page_size=20&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseCustomers: []*cscustomer.WebhookMessage{
+			responseCustomers: []*cscustomer.Customer{
 				{
 					ID: uuid.FromStringOrNil("52bac7ec-83f4-11ec-a083-c3cf3f92a2e3"),
 				},
@@ -194,7 +194,7 @@ func Test_customersIDGet(t *testing.T) {
 
 		reqQuery string
 
-		responseCustomer *cscustomer.WebhookMessage
+		responseCustomer *cscustomer.Customer
 
 		expectCustomerID uuid.UUID
 		expectRes        string
@@ -210,7 +210,7 @@ func Test_customersIDGet(t *testing.T) {
 
 			reqQuery: "/customers/d98ed7ec-83f7-11ec-8b43-e7de0184974f",
 
-			responseCustomer: &cscustomer.WebhookMessage{
+			responseCustomer: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("d98ed7ec-83f7-11ec-8b43-e7de0184974f"),
 			},
 
@@ -264,7 +264,7 @@ func Test_customersIDPut(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseCustomer *cscustomer.WebhookMessage
+		responseCustomer *cscustomer.Customer
 
 		expectCustomerID    uuid.UUID
 		expectName          string
@@ -288,7 +288,7 @@ func Test_customersIDPut(t *testing.T) {
 			reqQuery: "/customers/d98ed7ec-83f7-11ec-8b43-e7de0184974f",
 			reqBody:  []byte(`{"name":"new name","detail":"new detail","email":"test@test.com","phone_number":"+821100000001","address":"somewhere","webhook_method":"POST","webhook_uri":"test.com"}`),
 
-			responseCustomer: &cscustomer.WebhookMessage{
+			responseCustomer: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("d98ed7ec-83f7-11ec-8b43-e7de0184974f"),
 			},
 
@@ -348,7 +348,7 @@ func Test_customersIDDelete(t *testing.T) {
 
 		reqQuery string
 
-		responseCustomer *cscustomer.WebhookMessage
+		responseCustomer *cscustomer.Customer
 
 		expectCustomerID uuid.UUID
 		expectRes        string
@@ -364,7 +364,7 @@ func Test_customersIDDelete(t *testing.T) {
 
 			reqQuery: "/customers/d98ed7ec-83f7-11ec-8b43-e7de0184974f",
 
-			responseCustomer: &cscustomer.WebhookMessage{
+			responseCustomer: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("d98ed7ec-83f7-11ec-8b43-e7de0184974f"),
 			},
 
@@ -418,7 +418,7 @@ func Test_customersIDBillingAccountIDPut(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseCustomer *cscustomer.WebhookMessage
+		responseCustomer *cscustomer.Customer
 
 		expectedCustomerID       uuid.UUID
 		expectedBillingAccountID uuid.UUID
@@ -436,7 +436,7 @@ func Test_customersIDBillingAccountIDPut(t *testing.T) {
 			reqQuery: "/customers/cc876058-1773-11ee-9694-136fe246dd34/billing_account_id",
 			reqBody:  []byte(`{"billing_account_id":"ccc776b6-1773-11ee-bea5-d78345c015af"}`),
 
-			responseCustomer: &cscustomer.WebhookMessage{
+			responseCustomer: &cscustomer.Customer{
 				ID: uuid.FromStringOrNil("cc876058-1773-11ee-9694-136fe246dd34"),
 			},
 

--- a/bin-api-manager/server/numbers_test.go
+++ b/bin-api-manager/server/numbers_test.go
@@ -477,7 +477,7 @@ func Test_NumbersRenewPOST(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseNumbers []*nmnumber.WebhookMessage
+		responseNumbers []*nmnumber.Number
 
 		expectTMRenew string
 		expectRes     string
@@ -495,7 +495,7 @@ func Test_NumbersRenewPOST(t *testing.T) {
 			reqQuery: "/numbers/renew",
 			reqBody:  []byte(`{"tm_renew":"2023-04-06T14:54:24.652558Z"}`),
 
-			responseNumbers: []*nmnumber.WebhookMessage{
+			responseNumbers: []*nmnumber.Number{
 				{
 					Identity: commonidentity.Identity{
 						ID: uuid.FromStringOrNil("c2998386-1634-11ee-993a-37ac8d7a675d"),
@@ -509,7 +509,7 @@ func Test_NumbersRenewPOST(t *testing.T) {
 			},
 
 			expectTMRenew: "2023-04-06T14:54:24.652558Z",
-			expectRes:     (`[{"id":"c2998386-1634-11ee-993a-37ac8d7a675d","customer_id":"00000000-0000-0000-0000-000000000000","number":"","type":"","call_flow_id":"00000000-0000-0000-0000-000000000000","message_flow_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","status":"","t38_enabled":false,"emergency_enabled":false,"tm_purchase":null,"tm_renew":null,"tm_create":null,"tm_update":null,"tm_delete":null},{"id":"c2e1ff3a-1634-11ee-bcc7-9f2a231b7b8a","customer_id":"00000000-0000-0000-0000-000000000000","number":"","type":"","call_flow_id":"00000000-0000-0000-0000-000000000000","message_flow_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","status":"","t38_enabled":false,"emergency_enabled":false,"tm_purchase":null,"tm_renew":null,"tm_create":null,"tm_update":null,"tm_delete":null}]`),
+			expectRes:     (`[{"id":"c2998386-1634-11ee-993a-37ac8d7a675d","customer_id":"00000000-0000-0000-0000-000000000000","number":"","type":"","call_flow_id":"00000000-0000-0000-0000-000000000000","message_flow_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","provider_name":"","provider_reference_id":"","status":"","t38_enabled":false,"emergency_enabled":false,"tm_purchase":null,"tm_renew":null,"tm_create":null,"tm_update":null,"tm_delete":null},{"id":"c2e1ff3a-1634-11ee-bcc7-9f2a231b7b8a","customer_id":"00000000-0000-0000-0000-000000000000","number":"","type":"","call_flow_id":"00000000-0000-0000-0000-000000000000","message_flow_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","provider_name":"","provider_reference_id":"","status":"","t38_enabled":false,"emergency_enabled":false,"tm_purchase":null,"tm_renew":null,"tm_create":null,"tm_update":null,"tm_delete":null}]`),
 		},
 	}
 

--- a/bin-api-manager/server/providers_test.go
+++ b/bin-api-manager/server/providers_test.go
@@ -25,7 +25,7 @@ func Test_providersGet(t *testing.T) {
 
 		reqQuery string
 
-		responseProviders []*rmprovider.WebhookMessage
+		responseProviders []*rmprovider.Provider
 
 		expectPageSize  uint64
 		expectPageToken string
@@ -43,7 +43,7 @@ func Test_providersGet(t *testing.T) {
 
 			reqQuery: "/providers?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseProviders: []*rmprovider.WebhookMessage{
+			responseProviders: []*rmprovider.Provider{
 				{
 					ID:       uuid.FromStringOrNil("088b16ac-515f-11ed-a848-cb013a2391a9"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -64,7 +64,7 @@ func Test_providersGet(t *testing.T) {
 
 			reqQuery: "/providers?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseProviders: []*rmprovider.WebhookMessage{
+			responseProviders: []*rmprovider.Provider{
 				{
 					ID:       uuid.FromStringOrNil("3829653a-515f-11ed-a1a8-6b5ca0211d65"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -129,7 +129,7 @@ func Test_providersPost(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseProvider *rmprovider.WebhookMessage
+		responseProvider *rmprovider.Provider
 
 		expectType        rmprovider.Type
 		expectHostname    string
@@ -153,7 +153,7 @@ func Test_providersPost(t *testing.T) {
 			reqQuery: "/providers",
 			reqBody:  []byte(`{"type":"sip","hostname":"test.com","tech_prefix":"0001","tech_postfix":"1000","tech_headers":{"header_1":"val1","header_2":"val2"},"name":"test name","detail":"test detail"}`),
 
-			responseProvider: &rmprovider.WebhookMessage{
+			responseProvider: &rmprovider.Provider{
 				ID: uuid.FromStringOrNil("72fe03fa-6475-11ec-b559-0fdf19201178"),
 			},
 
@@ -225,7 +225,7 @@ func Test_providersIDGet(t *testing.T) {
 
 		reqQuery string
 
-		responseProvider *rmprovider.WebhookMessage
+		responseProvider *rmprovider.Provider
 
 		expectProviderID uuid.UUID
 		expectRes        string
@@ -242,7 +242,7 @@ func Test_providersIDGet(t *testing.T) {
 
 			reqQuery: "/providers/d091abe2-5160-11ed-b13c-57769429b0f0",
 
-			responseProvider: &rmprovider.WebhookMessage{
+			responseProvider: &rmprovider.Provider{
 				ID:       uuid.FromStringOrNil("d091abe2-5160-11ed-b13c-57769429b0f0"),
 				TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
 			},
@@ -295,7 +295,7 @@ func Test_providersIDDelete(t *testing.T) {
 
 		reqQuery string
 
-		responseProvider *rmprovider.WebhookMessage
+		responseProvider *rmprovider.Provider
 
 		expectProviderID uuid.UUID
 		expectRes        string
@@ -312,7 +312,7 @@ func Test_providersIDDelete(t *testing.T) {
 
 			reqQuery: "/providers/528bae9a-5161-11ed-b6c1-03e42a38600c",
 
-			responseProvider: &rmprovider.WebhookMessage{
+			responseProvider: &rmprovider.Provider{
 				ID: uuid.FromStringOrNil("528bae9a-5161-11ed-b6c1-03e42a38600c"),
 			},
 
@@ -374,7 +374,7 @@ func Test_providersIDPut(t *testing.T) {
 		expectName         string
 		expectDetail       string
 
-		responseProvider *rmprovider.WebhookMessage
+		responseProvider *rmprovider.Provider
 
 		expectRes string
 	}{
@@ -401,7 +401,7 @@ func Test_providersIDPut(t *testing.T) {
 			expectName:   "update name",
 			expectDetail: "update detail",
 
-			responseProvider: &rmprovider.WebhookMessage{
+			responseProvider: &rmprovider.Provider{
 				ID: uuid.FromStringOrNil("169cbfe0-5162-11ed-9be1-872503f37e02"),
 			},
 

--- a/bin-api-manager/server/routes.go
+++ b/bin-api-manager/server/routes.go
@@ -42,7 +42,7 @@ func (h *server) GetRoutes(c *gin.Context, params openapi_server.GetRoutesParams
 		pageToken = *params.PageToken
 	}
 
-	var tmps []*rmroute.WebhookMessage
+	var tmps []*rmroute.Route
 	var err error
 
 	if params.CustomerId != nil {

--- a/bin-api-manager/server/routes_test.go
+++ b/bin-api-manager/server/routes_test.go
@@ -25,7 +25,7 @@ func Test_routesGet_customer_id(t *testing.T) {
 
 		reqQuery string
 
-		responseRoutes []*rmroute.WebhookMessage
+		responseRoutes []*rmroute.Route
 
 		expectPageSize   uint64
 		expectPageToken  string
@@ -42,7 +42,7 @@ func Test_routesGet_customer_id(t *testing.T) {
 
 			reqQuery: "/routes?customer_id=de748080-7939-4625-a929-459c09a08448&page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseRoutes: []*rmroute.WebhookMessage{
+			responseRoutes: []*rmroute.Route{
 				{
 					ID:       uuid.FromStringOrNil("611c9384-5166-11ed-aee0-43c348138b55"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -65,7 +65,7 @@ func Test_routesGet_customer_id(t *testing.T) {
 
 			reqQuery: "/routes?customer_id=0e4bcfb0-f90a-4abf-83e1-08a4f0cd0260&page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseRoutes: []*rmroute.WebhookMessage{
+			responseRoutes: []*rmroute.Route{
 				{
 					ID:       uuid.FromStringOrNil("6158d6dc-5166-11ed-9a8c-7f1a71b3baaa"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -133,7 +133,7 @@ func Test_routesGet_without_customer_id(t *testing.T) {
 
 		reqQuery string
 
-		responseRoutes []*rmroute.WebhookMessage
+		responseRoutes []*rmroute.Route
 
 		expectPageSize  uint64
 		expectPageToken string
@@ -149,7 +149,7 @@ func Test_routesGet_without_customer_id(t *testing.T) {
 
 			reqQuery: "/routes?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseRoutes: []*rmroute.WebhookMessage{
+			responseRoutes: []*rmroute.Route{
 				{
 					ID:       uuid.FromStringOrNil("93b9143a-68a2-11ee-b676-8718718cd43e"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -169,7 +169,7 @@ func Test_routesGet_without_customer_id(t *testing.T) {
 			},
 			reqQuery: "/routes?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseRoutes: []*rmroute.WebhookMessage{
+			responseRoutes: []*rmroute.Route{
 				{
 					ID:       uuid.FromStringOrNil("941551f0-68a2-11ee-889c-ff0e92d76ad5"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -234,7 +234,7 @@ func Test_routesPost(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseRoute *rmroute.WebhookMessage
+		responseRoute *rmroute.Route
 
 		expectCustomerID uuid.UUID
 		expectName       string
@@ -255,7 +255,7 @@ func Test_routesPost(t *testing.T) {
 			reqQuery: "/routes",
 			reqBody:  []byte(`{"customer_id":"04303d61-d8c9-477c-8b54-254af0cb499f","name":"test name","detail":"test detail","provider_id":"a7efc236-5166-11ed-bdea-631379fb1515","priority":1,"target":"+82"}`),
 
-			responseRoute: &rmroute.WebhookMessage{
+			responseRoute: &rmroute.Route{
 				ID: uuid.FromStringOrNil("e1d75c98-5166-11ed-b2ff-1bb082f1fc25"),
 			},
 
@@ -319,7 +319,7 @@ func Test_routesIDGet(t *testing.T) {
 
 		reqQuery string
 
-		responseRoute *rmroute.WebhookMessage
+		responseRoute *rmroute.Route
 
 		expectRouteID uuid.UUID
 		expectRes     string
@@ -334,7 +334,7 @@ func Test_routesIDGet(t *testing.T) {
 
 			reqQuery: "/routes/1c776852-5167-11ed-bf9a-eba39c6546e4",
 
-			responseRoute: &rmroute.WebhookMessage{
+			responseRoute: &rmroute.Route{
 				ID:       uuid.FromStringOrNil("1c776852-5167-11ed-bf9a-eba39c6546e4"),
 				TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
 			},
@@ -387,7 +387,7 @@ func Test_routesIDDelete(t *testing.T) {
 
 		reqQuery string
 
-		responseRoute *rmroute.WebhookMessage
+		responseRoute *rmroute.Route
 
 		expectRouteID uuid.UUID
 		expectRes     string
@@ -402,7 +402,7 @@ func Test_routesIDDelete(t *testing.T) {
 
 			reqQuery: "/routes/4d1e5ab0-5167-11ed-98ff-f7ff08fc0833",
 
-			responseRoute: &rmroute.WebhookMessage{
+			responseRoute: &rmroute.Route{
 				ID: uuid.FromStringOrNil("4d1e5ab0-5167-11ed-98ff-f7ff08fc0833"),
 			},
 
@@ -455,7 +455,7 @@ func Test_routesIDPut(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseRoute *rmroute.WebhookMessage
+		responseRoute *rmroute.Route
 
 		expectRouteID    uuid.UUID
 		expectName       string
@@ -476,7 +476,7 @@ func Test_routesIDPut(t *testing.T) {
 			reqQuery: "/routes/cd2b8926-5167-11ed-a158-ffb3472a3a4d",
 			reqBody:  []byte(`{"name":"update name","detail":"update detail","provider_id":"cd58db88-5167-11ed-8d35-e3209648ccf8","priority":1,"target":"+82"}`),
 
-			responseRoute: &rmroute.WebhookMessage{
+			responseRoute: &rmroute.Route{
 				ID: uuid.FromStringOrNil("169cbfe0-5162-11ed-9be1-872503f37e02"),
 			},
 

--- a/bin-api-manager/server/storage_accounts_test.go
+++ b/bin-api-manager/server/storage_accounts_test.go
@@ -25,7 +25,7 @@ func Test_storageAccountsGet(t *testing.T) {
 
 		reqQuery string
 
-		responseAccounts []*smaccount.WebhookMessage
+		responseAccounts []*smaccount.Account
 
 		expectPageSize  uint64
 		expectPageToken string
@@ -46,7 +46,7 @@ func Test_storageAccountsGet(t *testing.T) {
 			expectPageSize:  20,
 			expectPageToken: "2020-09-20T03:23:20.995000Z",
 
-			responseAccounts: []*smaccount.WebhookMessage{
+			responseAccounts: []*smaccount.Account{
 				{
 					ID: uuid.FromStringOrNil("6adce0da-004e-11ee-b74a-23da476139db"),
 				},
@@ -100,7 +100,7 @@ func Test_storageAccountsPost(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseAccount *smaccount.WebhookMessage
+		responseAccount *smaccount.Account
 
 		expectCustomerID uuid.UUID
 		expectRes        string
@@ -118,7 +118,7 @@ func Test_storageAccountsPost(t *testing.T) {
 			reqQuery: "/storage_accounts",
 			reqBody:  []byte(`{"customer_id":"a77397a6-1bef-11ef-bb4f-d76f9d478e32"}`),
 
-			responseAccount: &smaccount.WebhookMessage{
+			responseAccount: &smaccount.Account{
 				ID: uuid.FromStringOrNil("ae58a520-1bef-11ef-afdc-571791bb0855"),
 			},
 
@@ -242,7 +242,7 @@ func Test_storageAccountsIDDelete(t *testing.T) {
 
 		reqQuery string
 
-		responseAccount        *smaccount.WebhookMessage
+		responseAccount        *smaccount.Account
 		expectStorageAccountID uuid.UUID
 		expectRes              string
 	}
@@ -258,7 +258,7 @@ func Test_storageAccountsIDDelete(t *testing.T) {
 
 			reqQuery: "/storage_accounts/c88754b4-1bef-11ef-b6d2-0b09724bcbc3",
 
-			responseAccount: &smaccount.WebhookMessage{
+			responseAccount: &smaccount.Account{
 				ID: uuid.FromStringOrNil("c88754b4-1bef-11ef-b6d2-0b09724bcbc3"),
 			},
 


### PR DESCRIPTION
Return internal model structs instead of WebhookMessage for all 25
ProjectSuperAdmin-only endpoints. These admin-only endpoints do not need
field hiding, so returning internal structs provides full visibility into
resource details like account status, provider names, and terms agreement info.

- bin-api-manager: Change 25 super-admin method return types from WebhookMessage to internal structs
- bin-api-manager: Remove ConvertWebhookMessage() calls in customer, provider, route, billingaccount, numbers, storage_accounts
- bin-api-manager: Add value-to-pointer conversion loops for list methods returning []T from reqHandler
- bin-api-manager: Update all servicehandler and server test expectations to match new return types
- bin-api-manager: Update expected JSON strings to include newly visible fields (status, provider_name, etc.)