### PR TITLE
NOJIRA-fix-circuitbreakerhandler-vendor

### DIFF
--- a/bin-api-manager/vendor/modules.txt
+++ b/bin-api-manager/vendor/modules.txt
@@ -1077,6 +1077,7 @@ monorepo/bin-common-handler/models/identity
 monorepo/bin-common-handler/models/outline
 monorepo/bin-common-handler/models/service
 monorepo/bin-common-handler/models/sock
+monorepo/bin-common-handler/pkg/circuitbreakerhandler
 monorepo/bin-common-handler/pkg/databasehandler
 monorepo/bin-common-handler/pkg/rabbitmqhandler
 monorepo/bin-common-handler/pkg/requesthandler


### PR DESCRIPTION
Fix bin-api-manager Docker build failure caused by missing circuitbreakerhandler
entry in vendor/modules.txt after the circuit-breaker PR (#620).

- bin-api-manager: Add missing circuitbreakerhandler entry in vendor/modules.txt