### PR TITLE
NOJIRA-add-gemini-llm-support

### DIFF
--- a/bin-pipecat-manager/CLAUDE.md
+++ b/bin-pipecat-manager/CLAUDE.md
@@ -201,7 +201,7 @@ Environment variables / flags:
 - `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint
 
 Python environment variables (in `.env` or exported):
-- LLM provider API keys: `OPENAI_API_KEY`, `XAI_API_KEY` (Grok), `ANTHROPIC_API_KEY`, etc.
+- LLM provider API keys: `OPENAI_API_KEY`, `XAI_API_KEY` (Grok), `GOOGLE_API_KEY` (Gemini), `ANTHROPIC_API_KEY`, etc.
 - STT provider keys: `DEEPGRAM_API_KEY`
 - TTS provider keys: `CARTESIA_API_KEY`, `ELEVENLABS_API_KEY`, `GOOGLE_API_KEY`
 
@@ -209,7 +209,7 @@ Python environment variables (in `.env` or exported):
 
 - **pipecat-ai framework**: Python library for building voice AI pipelines
 - **Supported providers**:
-  - LLM: OpenAI (e.g., `openai.gpt-4o`), Grok (e.g., `grok.grok-3`, `grok.grok-3-mini`)
+  - LLM: OpenAI (e.g., `openai.gpt-4o`), Grok (e.g., `grok.grok-3`, `grok.grok-3-mini`), Gemini (e.g., `gemini.gemini-2.5-flash`, `gemini.gemini-1.5-pro`)
   - STT: Deepgram, Whisper
   - TTS: Cartesia, ElevenLabs, Google
 - **RTVI protocol**: Used for runtime control and tool calling

--- a/bin-pipecat-manager/scripts/pipecat/conftest.py
+++ b/bin-pipecat-manager/scripts/pipecat/conftest.py
@@ -36,6 +36,7 @@ _mocks = {
     "pipecat.services.google": MagicMock(),
     "pipecat.services.google.tts": _make_mock_module("GoogleTTSService"),
     "pipecat.services.google.stt": _make_mock_module("GoogleSTTService"),
+    "pipecat.services.google.llm": _make_mock_module("GoogleLLMService"),
     "pipecat.services.deepgram": MagicMock(),
     "pipecat.services.deepgram.stt": _make_mock_module("DeepgramSTTService"),
     "pipecat.services.whisper": MagicMock(),

--- a/bin-pipecat-manager/scripts/pipecat/run.py
+++ b/bin-pipecat-manager/scripts/pipecat/run.py
@@ -22,6 +22,7 @@ from pipecat.processors.filters.stt_mute_filter import STTMuteConfig, STTMuteFil
 
 # llm
 from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 # aggregators / context
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
@@ -365,6 +366,15 @@ def create_llm_service(type: str, key: str, messages: list[dict], tools: list[di
             model=model_name,
             base_url="https://api.x.ai/v1"
         )
+
+        ctx = OpenAILLMContext(messages=valid_messages, tools=tools)
+        aggregator = llm.create_context_aggregator(ctx)
+
+        return llm, aggregator
+
+    elif service_name == "gemini":
+        api_key = key or os.getenv("GOOGLE_API_KEY")
+        llm = GoogleLLMService(api_key=api_key, model=model_name)
 
         ctx = OpenAILLMContext(messages=valid_messages, tools=tools)
         aggregator = llm.create_context_aggregator(ctx)

--- a/bin-pipecat-manager/scripts/pipecat/test_run.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_run.py
@@ -74,6 +74,180 @@ class TestCreateLLMService:
             base_url="https://api.x.ai/v1"
         )
 
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_service_creation(self, mock_context, mock_service):
+        """Test Gemini service is created with GoogleLLMService and correct parameters."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        llm, aggregator = create_llm_service(
+            type="gemini.gemini-2.5-flash",
+            key="google-test-key",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[]
+        )
+
+        mock_service.assert_called_once_with(api_key="google-test-key", model="gemini-2.5-flash")
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_uses_env_var_fallback(self, mock_context, mock_service):
+        """Test Gemini falls back to GOOGLE_API_KEY env var when key is empty."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        with patch.dict(os.environ, {"GOOGLE_API_KEY": "env-google-key"}):
+            llm, aggregator = create_llm_service(
+                type="gemini.gemini-1.5-pro",
+                key="",
+                messages=[],
+                tools=[]
+            )
+
+        mock_service.assert_called_once_with(api_key="env-google-key", model="gemini-1.5-pro")
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_with_colon_separator(self, mock_context, mock_service):
+        """Test Gemini service works with colon separator format."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        llm, aggregator = create_llm_service(
+            type="gemini:gemini-flash",
+            key="test-key",
+            messages=[],
+            tools=[]
+        )
+
+        mock_service.assert_called_once_with(api_key="test-key", model="gemini-flash")
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_case_insensitive(self, mock_context, mock_service):
+        """Test Gemini service name matching is case-insensitive."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        llm, aggregator = create_llm_service(
+            type="Gemini.gemini-2.5-flash",
+            key="test-key",
+            messages=[],
+            tools=[]
+        )
+
+        mock_service.assert_called_once_with(api_key="test-key", model="gemini-2.5-flash")
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_model_name_with_dots_preserved(self, mock_context, mock_service):
+        """Test model names containing dots are preserved (split on first dot only)."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        llm, aggregator = create_llm_service(
+            type="gemini.gemini-1.5-pro-latest",
+            key="test-key",
+            messages=[],
+            tools=[]
+        )
+
+        mock_service.assert_called_once_with(api_key="test-key", model="gemini-1.5-pro-latest")
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_filters_invalid_messages(self, mock_context, mock_service):
+        """Test messages without role or content are filtered before passing to context."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "", "content": "no role"},
+            {"content": "missing role key"},
+            {"role": "user"},
+            {"role": "user", "content": ""},
+            {"role": "user", "content": "valid message"},
+        ]
+
+        create_llm_service(
+            type="gemini.gemini-2.5-flash",
+            key="test-key",
+            messages=messages,
+            tools=[]
+        )
+
+        mock_context.assert_called_once()
+        passed_messages = mock_context.call_args[1]["messages"]
+        assert len(passed_messages) == 2
+        assert passed_messages[0] == {"role": "system", "content": "You are helpful."}
+        assert passed_messages[1] == {"role": "user", "content": "valid message"}
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_passes_tools_to_context(self, mock_context, mock_service):
+        """Test tools list is correctly passed to OpenAILLMContext."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_llm.create_context_aggregator.return_value = MagicMock()
+
+        tools = [{"type": "function", "function": {"name": "connect_call", "parameters": {}}}]
+
+        create_llm_service(
+            type="gemini.gemini-2.5-flash",
+            key="test-key",
+            messages=[],
+            tools=tools
+        )
+
+        mock_context.assert_called_once_with(messages=[], tools=tools)
+
+    @patch("run.GoogleLLMService")
+    @patch("run.OpenAILLMContext")
+    def test_gemini_returns_llm_and_aggregator(self, mock_context, mock_service):
+        """Test Gemini returns the correct (llm, aggregator) tuple."""
+        from run import create_llm_service
+
+        mock_llm = MagicMock()
+        mock_service.return_value = mock_llm
+        mock_aggregator = MagicMock()
+        mock_llm.create_context_aggregator.return_value = mock_aggregator
+
+        mock_ctx_instance = MagicMock()
+        mock_context.return_value = mock_ctx_instance
+
+        llm, aggregator = create_llm_service(
+            type="gemini.gemini-2.5-flash",
+            key="test-key",
+            messages=[],
+            tools=[]
+        )
+
+        assert llm is mock_llm
+        assert aggregator is mock_aggregator
+        mock_llm.create_context_aggregator.assert_called_once_with(mock_ctx_instance)
+
     def test_unsupported_service_raises_error(self):
         """Test unsupported service raises ValueError."""
         from run import create_llm_service


### PR DESCRIPTION
Add Gemini LLM service support to pipecat runner's create_llm_service function
using pipecat-ai's native GoogleLLMService. This fixes calls that use
gemini.* engine_model (e.g., gemini.gemini-1.5-pro) which previously failed
with "Unsupported LLM service: gemini".

- bin-pipecat-manager: Add GoogleLLMService import and gemini elif branch in create_llm_service
- bin-pipecat-manager: Add pipecat.services.google.llm mock entry in conftest.py for pytest
- bin-pipecat-manager: Add 8 Gemini test cases covering service creation, env var fallback, colon separator, case insensitivity, model name preservation, message filtering, tools passthrough, and return value wiring
- bin-pipecat-manager: Document Gemini as supported LLM provider and GOOGLE_API_KEY as LLM key in CLAUDE.md