### PR TITLE
NOJIRA-fix-missing-google-stt-type

### DIFF
--- a/bin-ai-manager/models/ai/main.go
+++ b/bin-ai-manager/models/ai/main.go
@@ -223,11 +223,13 @@ const (
 	STTTypeCartesia   STTType = "cartesia"
 	STTTypeDeepgram   STTType = "deepgram"
 	STTTypeElevenLabs STTType = "elevenlabs"
+	STTTypeGoogle     STTType = "google"
 )
 
 var validSTTTypes = map[STTType]bool{
 	STTTypeNone: true, STTTypeCartesia: true,
 	STTTypeDeepgram: true, STTTypeElevenLabs: true,
+	STTTypeGoogle: true,
 }
 
 // IsValid returns true if the STTType is a known valid value.

--- a/bin-ai-manager/models/ai/main_test.go
+++ b/bin-ai-manager/models/ai/main_test.go
@@ -432,6 +432,11 @@ func TestSTTTypeConstants(t *testing.T) {
 			constant: STTTypeElevenLabs,
 			expected: "elevenlabs",
 		},
+		{
+			name:     "stt_type_google",
+			constant: STTTypeGoogle,
+			expected: "google",
+		},
 	}
 
 	for _, tt := range tests {
@@ -532,8 +537,8 @@ func TestSTTTypeIsValid(t *testing.T) {
 		{"cartesia_is_valid", STTTypeCartesia, true},
 		{"deepgram_is_valid", STTTypeDeepgram, true},
 		{"elevenlabs_is_valid", STTTypeElevenLabs, true},
+		{"google_is_valid", STTTypeGoogle, true},
 		{"gcp_is_invalid", STTType("gcp"), false},
-		{"google_is_invalid", STTType("google"), false},
 		{"random_string_is_invalid", STTType("random"), false},
 	}
 
@@ -569,7 +574,7 @@ func TestSTTTypeValidValues(t *testing.T) {
 
 	// Should contain known values
 	knownValues := map[string]bool{
-		"deepgram": false, "cartesia": false, "elevenlabs": false,
+		"deepgram": false, "cartesia": false, "elevenlabs": false, "google": false,
 	}
 	for _, v := range values {
 		if _, ok := knownValues[v]; ok {


### PR DESCRIPTION
Fix missing google STT type in ai-manager validation that was causing
AI update requests with stt_type=google to be rejected with
"invalid stt_type: google" after the validation added in
NOJIRA-validate-tts-stt-types.

- bin-ai-manager: Add STTTypeGoogle constant and include it in validSTTTypes map
- bin-ai-manager: Update tests to verify google is a valid STT type