### PR TITLE
NOJIRA-add-pod-crash-alerts

### DIFF
--- a/docs/plans/2026-03-03-pod-crash-alerting-design.md
+++ b/docs/plans/2026-03-03-pod-crash-alerting-design.md
@@ -1,0 +1,108 @@
+# Pod Crash Alerting Design
+
+**Date:** 2026-03-03
+**Branch:** NOJIRA-add-pod-crash-alerts
+
+## Problem Statement
+
+We have no alerting or metrics for pod crashes across the platform. When a pod crashes, restarts, or goes down, there is no automated notification. Operators must manually check `kubectl` to discover issues.
+
+## Current State
+
+- **Prometheus** deployed in `infrastructure` namespace, scrapes pods via annotations on port 2112
+- **AlertManager** deployed with Discord webhook (Slack-compatible API) already configured
+- **Grafana** deployed with persistent storage, dashboards in `monitoring/grafana/dashboards/`
+- **Existing alerts:** InstanceDown, KamailioDown, RabbitMQ, Redis, CPU/Memory/Disk, RTPEngine
+- **No kube-state-metrics** — Kubernetes pod state is not exposed as Prometheus metrics
+- **sentinel-manager** watches Asterisk pods in `voip` namespace for application-level recovery (different concern)
+
+## Approach
+
+Deploy **kube-state-metrics** to expose Kubernetes object states as Prometheus metrics. Add Prometheus alert rules for pod crash/down scenarios. Create a Grafana dashboard for visibility.
+
+### Why kube-state-metrics (not extending sentinel-manager)
+
+- kube-state-metrics is the standard, well-maintained Kubernetes component for this purpose
+- Zero custom Go code needed
+- Covers all namespaces automatically (voip + bin-manager)
+- sentinel-manager serves a different purpose (RabbitMQ events for call recovery)
+- kube-state-metrics exposes dozens of useful metrics beyond just crashes
+
+## Changes
+
+### 1. Deploy kube-state-metrics
+
+Create Kubernetes manifests in `monorepo-etc/infra-prometheus/k8s_kube_state_metrics/`:
+- `deployment.yml` — kube-state-metrics deployment in `infrastructure` namespace
+- `service.yml` — ClusterIP service with Prometheus scrape annotations
+- `rbac.yml` — ClusterRole + ClusterRoleBinding for reading cluster state
+- `kustomization.yml` — Kustomize root (with image override via Kustomize `images`)
+
+Key metrics exposed:
+- `kube_pod_container_status_restarts_total` — restart count per container
+- `kube_pod_container_status_waiting_reason` — CrashLoopBackOff, ImagePullBackOff
+- `kube_pod_container_status_terminated_reason` — OOMKilled, Error
+- `kube_deployment_status_replicas_available` — available replicas per deployment
+- `kube_deployment_spec_replicas` — desired replicas per deployment
+
+### 2. Prometheus Alert Rules
+
+Add pod-health rule group to `monorepo-etc/infra-prometheus/k8s_prometheus/alert-rules-config-map.yml`. New rules:
+
+| Alert | Expression | For | Severity |
+|-------|-----------|-----|----------|
+| PodCrashLooping | `increase(kube_pod_container_status_restarts_total{namespace=~"bin-manager\|voip"}[15m]) > 3` | 5m | critical |
+| PodOOMKilled | `kube_pod_container_status_terminated_reason{reason="OOMKilled",namespace=~"bin-manager\|voip"} > 0` | 1m | critical |
+| PodNotReady | `kube_pod_status_ready{condition="true",namespace=~"bin-manager\|voip"} == 0` | 5m | critical |
+| PodDown | `kube_deployment_status_replicas_available{namespace=~"bin-manager\|voip"} == 0` | 2m | critical |
+
+Alerts auto-flow to Discord via the existing AlertManager webhook.
+
+### 3. Grafana Dashboard
+
+Create `monorepo/monitoring/grafana/dashboards/pod-crash-overview.json` with panels:
+- Pod restart counts by service (bar chart, last 24h)
+- Restart timeline (time series graph)
+- OOMKill events table
+- Deployment availability (available vs desired replicas)
+- Currently crashing pods (stat panel)
+- Namespace breakdown (voip vs bin-manager)
+
+### 4. Update Prometheus ConfigMap
+
+The existing `prometheus-server-conf` ConfigMap already has a `kubernetes-service-endpoints` job that scrapes services with `prometheus.io/scrape: "true"` annotation. kube-state-metrics service will include this annotation, so Prometheus will auto-discover and scrape it.
+
+The `prometheus-alert-rules` ConfigMap needs a new rule group for pod health.
+
+## Files Created/Modified
+
+**monorepo-etc** (infra-prometheus):
+| File | Action |
+|------|--------|
+| `infra-prometheus/k8s_kube_state_metrics/deployment.yml` | Create |
+| `infra-prometheus/k8s_kube_state_metrics/service.yml` | Create |
+| `infra-prometheus/k8s_kube_state_metrics/rbac.yml` | Create |
+| `infra-prometheus/k8s_kube_state_metrics/kustomization.yml` | Create |
+| `infra-prometheus/k8s_prometheus/alert-rules-config-map.yml` | Modify (add pod-health group) |
+
+**monorepo** (monitoring):
+| File | Action |
+|------|--------|
+| `monitoring/grafana/dashboards/pod-crash-overview.json` | Create |
+| `docs/plans/2026-03-03-pod-crash-alerting-design.md` | Create |
+
+## Deployment Steps
+
+1. Apply kube-state-metrics manifests: `kubectl apply -k infra-prometheus/k8s_kube_state_metrics/`
+2. Verify kube-state-metrics is running: `kubectl get pods -n infrastructure | grep kube-state`
+3. Verify Prometheus scrapes it: check Prometheus targets page
+4. Apply updated alert rules: `kubectl apply -k infra-prometheus/k8s_prometheus/`
+5. Reload Prometheus config (restart pod or wait for ConfigMap propagation)
+6. Import Grafana dashboard JSON from `monitoring/grafana/dashboards/pod-crash-overview.json`
+7. Verify alerts fire correctly (optional: test by killing a pod)
+
+## Risks and Mitigations
+
+- **kube-state-metrics RBAC too broad:** Mitigated by using the official minimal ClusterRole
+- **Alert noise from expected restarts (e.g., deployments):** Mitigated by `for` duration on alerts
+- **Prometheus scrape load:** kube-state-metrics is lightweight; 5s scrape interval is fine

--- a/monitoring/grafana/dashboards/pod-crash-overview.json
+++ b/monitoring/grafana/dashboards/pod-crash-overview.json
@@ -1,0 +1,651 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "title": "Pods Currently Crash Looping",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "count(increase(kube_pod_container_status_restarts_total{namespace=~\"bin-manager|voip\"}[15m]) > 3) OR vector(0)",
+          "legendFormat": "Crash Looping Pods",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "title": "OOM Killed Containers",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "count(kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\", namespace=~\"bin-manager|voip\"} > 0) OR vector(0)",
+          "legendFormat": "OOM Killed",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "title": "Pods Not Ready",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "count(kube_pod_status_ready{condition=\"true\", namespace=~\"bin-manager|voip\"} == 0) OR vector(0)",
+          "legendFormat": "Not Ready",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "title": "Deployments Down (0 replicas)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "count(kube_deployment_status_replicas_available{namespace=~\"bin-manager|voip\"} == 0) OR vector(0)",
+          "legendFormat": "Deployments Down",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 101,
+      "title": "Restart Timeline",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "drawStyle": "line",
+            "gradientMode": "none",
+            "spanNulls": false
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["sum", "lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Pod Restarts Over Time (bin-manager)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"bin-manager\"}[5m]) > 0",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "drawStyle": "line",
+            "gradientMode": "none",
+            "spanNulls": false
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["sum", "lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Pod Restarts Over Time (voip)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"voip\"}[5m]) > 0",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 102,
+      "title": "Restart Counts",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "gradientMode": "none"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 7,
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "legend": {
+          "displayMode": "hidden"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "title": "Total Restarts by Pod (bin-manager, last 24h)",
+      "type": "barchart",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "topk(20, increase(kube_pod_container_status_restarts_total{namespace=\"bin-manager\"}[24h]) > 0)",
+          "legendFormat": "{{ pod }}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "gradientMode": "none"
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 8,
+      "options": {
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "legend": {
+          "displayMode": "hidden"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "title": "Total Restarts by Pod (voip, last 24h)",
+      "type": "barchart",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "topk(20, increase(kube_pod_container_status_restarts_total{namespace=\"voip\"}[24h]) > 0)",
+          "legendFormat": "{{ pod }}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 103,
+      "title": "Deployment Availability",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "drawStyle": "line",
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["min", "lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Available Replicas (bin-manager)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "kube_deployment_status_replicas_available{namespace=\"bin-manager\"}",
+          "legendFormat": "{{ deployment }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "drawStyle": "line",
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": ["min", "lastNotNull"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Available Replicas (voip)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "kube_deployment_status_replicas_available{namespace=\"voip\"}",
+          "legendFormat": "{{ deployment }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 42 },
+      "id": 104,
+      "title": "Pod Events Detail",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "color-background-solid"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Pod" },
+            "properties": [{ "id": "custom.width", "value": 300 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Namespace" },
+            "properties": [{ "id": "custom.width", "value": 120 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Reason" },
+            "properties": [{ "id": "custom.width", "value": 120 }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
+      "id": 11,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          { "desc": true, "displayName": "Value" }
+        ]
+      },
+      "title": "Last Terminated Reason (OOMKilled / Error)",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "kube_pod_container_status_last_terminated_reason{namespace=~\"bin-manager|voip\"} > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "uid": true,
+              "endpoint": true,
+              "service": true
+            },
+            "renameByName": {
+              "pod": "Pod",
+              "namespace": "Namespace",
+              "container": "Container",
+              "reason": "Reason",
+              "Value": "Count"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "orange", "value": 3 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "color-background-solid"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Pod" },
+            "properties": [{ "id": "custom.width", "value": 300 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Namespace" },
+            "properties": [{ "id": "custom.width", "value": 120 }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 51 },
+      "id": 12,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          { "desc": true, "displayName": "Restarts" }
+        ]
+      },
+      "title": "Total Restart Counts by Pod",
+      "type": "table",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "expr": "kube_pod_container_status_restarts_total{namespace=~\"bin-manager|voip\"} > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "uid": true,
+              "endpoint": true,
+              "service": true
+            },
+            "renameByName": {
+              "pod": "Pod",
+              "namespace": "Namespace",
+              "container": "Container",
+              "Value": "Restarts"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["kubernetes", "pod-health", "crashes"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Pod Crash Overview",
+  "uid": "pod-crash-overview",
+  "version": 1
+}


### PR DESCRIPTION
Add Grafana dashboard and design doc for pod crash alerting feature.
Companion PR to monorepo-etc NOJIRA-add-pod-crash-alerts.

- monitoring: Add pod-crash-overview Grafana dashboard with restart timeline, OOM events, and deployment availability panels
- docs: Add design document for pod crash alerting implementation