### PR TITLE
NOJIRA-Streaming-talk-action-spike

### DIFF
--- a/.claude/scripts/check-magic-strings.sh
+++ b/.claude/scripts/check-magic-strings.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
-# Check a single .go file for hardcoded direct resource type magic strings.
+# Check a single .go file for hardcoded magic strings that should use typed constants.
 # Used by Claude Code PostToolUse hook on Write|Edit.
+#
+# RULE: Never use raw string literals for domain values. Always use the typed
+# constant from the package that owns the type. This applies to status values,
+# type discriminators, providers, directions, reference types, and any other
+# domain-specific string that has a corresponding typed constant defined.
 #
 # Reads the tool input JSON from stdin to extract the file path.
 # Exits 2 (block) if violations found, 0 otherwise.
+# Suppress per-line with: // nolint:magicstring
+#
+# To add new patterns: append to the RULES array below.
+# Format: "regex_pattern§owning_package§constant_prefix" (§ delimiter)
 
 set -euo pipefail
 
@@ -16,41 +25,118 @@ if [[ -z "$FILE_PATH" ]] || [[ "$FILE_PATH" != *.go ]]; then
     exit 0
 fi
 
-# Skip the constants definition file itself
-if [[ "$FILE_PATH" == *"bin-direct-manager/models/direct/direct.go" ]]; then
-    exit 0
-fi
-
 # Skip vendor, generated, and mock files
 if [[ "$FILE_PATH" == *"/vendor/"* ]] || [[ "$FILE_PATH" == *"/gens/"* ]] || [[ "$FILE_PATH" == *"mock_"* ]]; then
     exit 0
 fi
 
-# Check for magic strings in resource type assignments
-PATTERNS=(
-    'ResourceType:\s*"(ai|ai_team|agent|queue|conference|extension)"'
-    'ResourceType\s*=\s*"(ai|ai_team|agent|queue|conference|extension)"'
+# Skip test files — test data often uses string literals legitimately
+if [[ "$FILE_PATH" == *"_test.go" ]]; then
+    exit 0
+fi
+
+# ─── Constants definition files (skip the files that DEFINE the constants) ───
+CONST_DEFS=(
+    "bin-direct-manager/models/direct/"
+    "bin-tts-manager/models/tts/tts.go"
+    "bin-tts-manager/models/streaming/"
+    "bin-tts-manager/models/speaking/"
+    "bin-flow-manager/models/action/"
+    "bin-call-manager/models/call/"
+    "bin-call-manager/models/recording/"
+    "bin-call-manager/models/confbridge/"
+    "bin-call-manager/models/externalmedia/"
+    "bin-agent-manager/models/agent/"
+    "bin-ai-manager/models/aicall/"
+    "bin-ai-manager/models/ai/"
+    "bin-billing-manager/models/billing/"
+    "bin-common-handler/models/"
+)
+for def in "${CONST_DEFS[@]}"; do
+    if [[ "$FILE_PATH" == *"$def"* ]]; then
+        exit 0
+    fi
+done
+
+# ─── Rules table ─────────────────────────────────────────────────────────────
+# Each rule: "regex_pattern§owner_package§constant_examples"
+#
+# The regex should match string literals used in comparisons, assignments,
+# or struct field values — NOT inside comments, imports, or log messages.
+# Use \b word boundaries where possible to reduce false positives.
+RULES=(
+    # Direct resource types
+    'ResourceType\s*(:=|=|:)\s*"(ai|ai_team|agent|queue|conference|extension)"§bin-direct-manager/models/direct§dmdirect.ResourceType*'
+
+    # TTS providers (assignments, struct fields, and comparisons)
+    '[Pp]rovider\s*(:=|=|:)\s*"(gcp|aws)"§bin-tts-manager/models/tts§tmtts.ProviderGCP, tmtts.ProviderAWS'
+    '[Pp]rovider\s*[!=]=\s*"(gcp|aws)"§bin-tts-manager/models/tts§tmtts.ProviderGCP, tmtts.ProviderAWS'
+
+    # Streaming vendor names
+    'VendorName\s*(:=|=|:)\s*"(gcp|elevenlabs|aws|none)"§bin-tts-manager/models/streaming§streaming.VendorName*'
+
+    # Streaming directions
+    'Direction\s*(:=|=|:)\s*"(both|in|out)"§bin-tts-manager/models/streaming or externalmedia§streaming.Direction* or externalmedia.Direction*'
+
+    # Streaming reference types
+    'ReferenceType\s*(:=|=|:)\s*"(call|confbridge|conference|ai|queue|transcribe|transfer)"§owning models package§<pkg>.ReferenceType*'
+
+    # Call statuses
+    'Status\s*(:=|=|:)\s*"(dialing|ringing|progressing|terminating|canceling|hangup)"§bin-call-manager/models/call§call.Status*'
+
+    # Call types
+    'Type\s*(:=|=|:)\s*"(flow|conference|sip-service)"§bin-call-manager/models/call§call.Type*'
+
+    # Call directions
+    'Direction\s*(:=|=|:)\s*"(incoming|outgoing)"§bin-call-manager/models/call§call.Direction*'
+
+    # Call hangup reasons
+    'HangupReason\s*(:=|=|:)\s*"(normal|failed|busy|cancel|timeout|noanswer|dialout|amd)"§bin-call-manager/models/call§call.HangupReason*'
+
+    # Recording statuses
+    'Status\s*(:=|=|:)\s*"(initiating|recording|stopping|ended)"§bin-call-manager/models/recording§recording.Status*'
+
+    # Confbridge statuses
+    'Status\s*(:=|=|:)\s*"(progressing|terminating|terminated)"§bin-call-manager/models/confbridge§confbridge.Status*'
+
+    # External media encapsulation
+    'Encapsulation\s*(:=|=|:)\s*"(rtp|audiosocket|none)"§bin-call-manager/models/externalmedia§externalmedia.Encapsulation*'
+
+    # External media transport
+    'Transport\s*(:=|=|:)\s*"(udp|tcp|websocket)"§bin-call-manager/models/externalmedia§externalmedia.Transport*'
+
+    # Agent statuses
+    'Status\s*(:=|=|:)\s*"(available|away|busy|offline)"§bin-agent-manager/models/agent§agent.Status*'
+
+    # AI message roles
+    'Role\s*(:=|=|:)\s*"(system|user|assistant|function|tool)"§bin-ai-manager/models/aicall§aicall.MessageRole*'
+
+    # Billing cost types
+    'CostType\s*(:=|=|:)\s*"(call_pstn_outgoing|call_pstn_incoming|call_vn|call_extension|call_direct_ext|sms|email|number|number_renew|tts|recording)"§bin-billing-manager/models/billing§billing.CostType*'
 )
 
 VIOLATIONS=0
-for pattern in "${PATTERNS[@]}"; do
+
+for rule in "${RULES[@]}"; do
+    IFS='§' read -r pattern owner constants <<< "$rule"
+
     while IFS=: read -r line content; do
         # Skip lines with nolint:magicstring override
         if echo "$content" | grep -q 'nolint:magicstring'; then
             continue
         fi
-        echo "[Hook] Magic string at $FILE_PATH:$line: $content"
-        echo "[Hook] Use dmdirect.ResourceType* constants from bin-direct-manager/models/direct/direct.go"
+        echo "[Hook] Magic string at $FILE_PATH:$line:$content"
+        echo "[Hook]   -> Use typed constants from $owner ($constants)"
         VIOLATIONS=$((VIOLATIONS + 1))
     done < <(grep -nE "$pattern" "$FILE_PATH" 2>/dev/null || true)
 done
 
 if [ "$VIOLATIONS" -gt 0 ]; then
     echo ""
-    echo "[Hook] Found $VIOLATIONS magic string violation(s). Use constants:"
-    echo "  dmdirect.ResourceTypeAI, dmdirect.ResourceTypeAITeam, dmdirect.ResourceTypeAgent,"
-    echo "  dmdirect.ResourceTypeQueue, dmdirect.ResourceTypeConference, dmdirect.ResourceTypeExtension"
-    echo "  To suppress: add // nolint:magicstring on the line"
+    echo "[Hook] Found $VIOLATIONS magic string violation(s)."
+    echo "[Hook] RULE: Never use raw string literals for domain values."
+    echo "[Hook]       Use the typed constant from the package that owns the type."
+    echo "[Hook]       Suppress per-line: // nolint:magicstring"
     exit 2
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash .claude/scripts/check-magic-strings.sh",
-            "description": "Check for hardcoded direct resource type magic strings in .go files"
+            "description": "Block hardcoded magic strings in .go files — use typed constants from the owning package"
           }
         ]
       }

--- a/bin-call-manager/pkg/callhandler/action.go
+++ b/bin-call-manager/pkg/callhandler/action.go
@@ -488,7 +488,8 @@ func (h *callHandler) actionExecuteHangup(ctx context.Context, c *call.Call) err
 	return nil
 }
 
-// actionExecuteTalk executes the action type talk
+// actionExecuteTalk executes the action type talk.
+// It tries streaming TTS first for low-latency audio (~200ms), falling back to batch TTS on failure.
 func (h *callHandler) actionExecuteTalk(ctx context.Context, c *call.Call) error {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "actionExecuteTalk",
@@ -505,11 +506,22 @@ func (h *callHandler) actionExecuteTalk(ctx context.Context, c *call.Call) error
 		}
 	}
 
-	if errTalk := h.Talk(ctx, c.ID, true, option.Text, option.Language, option.Provider, option.VoiceID); errTalk != nil {
-		log.Errorf("Could not talk correctly. err: %v", errTalk)
-		return errors.Wrap(errTalk, "could not talk correctly")
+	// Try streaming first for low-latency audio delivery
+	errStreaming := h.StreamingTalk(ctx, c.ID, option.Text, option.Language, option.Provider, option.VoiceID)
+	if errStreaming == nil {
+		// Streaming succeeded — audio fully delivered, advance to next action
+		log.Infof("Streaming talk succeeded, advancing to next action.")
+		return h.reqHandler.CallV1CallActionNext(ctx, c.ID, false)
 	}
 
+	// Streaming failed — fall back to batch TTS
+	log.Infof("Streaming talk failed, falling back to batch. err: %v", errStreaming)
+	if errBatch := h.Talk(ctx, c.ID, true, option.Text, option.Language, option.Provider, option.VoiceID); errBatch != nil {
+		log.Errorf("Could not talk correctly. err: %v", errBatch)
+		return errors.Wrap(errBatch, "could not talk correctly")
+	}
+
+	// Batch path: async triggers next action immediately, sync waits for PlaybackFinished ARI event
 	if option.Async {
 		log.Debugf("Talk is async. Moving to the next action. call_id: %s, async: %v", c.ID, option.Async)
 		return h.reqHandler.CallV1CallActionNext(ctx, c.ID, false)

--- a/bin-call-manager/pkg/callhandler/action.go
+++ b/bin-call-manager/pkg/callhandler/action.go
@@ -506,16 +506,20 @@ func (h *callHandler) actionExecuteTalk(ctx context.Context, c *call.Call) error
 		}
 	}
 
-	// Try streaming first for low-latency audio delivery
-	errStreaming := h.StreamingTalk(ctx, c.ID, option.Text, option.Language, option.Provider, option.VoiceID)
-	if errStreaming == nil {
-		// Streaming succeeded — audio fully delivered, advance to next action
-		log.Infof("Streaming talk succeeded, advancing to next action.")
-		return h.reqHandler.CallV1CallActionNext(ctx, c.ID, false)
+	// Async talks use batch path directly — streaming blocks synchronously
+	// which contradicts async semantics (start audio, advance immediately).
+	if !option.Async {
+		// Try streaming first for low-latency audio delivery
+		errStreaming := h.StreamingTalk(ctx, c.ID, option.Text, option.Language, option.Provider, option.VoiceID)
+		if errStreaming == nil {
+			// Streaming succeeded — audio fully delivered, advance to next action
+			log.Infof("Streaming talk succeeded, advancing to next action.")
+			return h.reqHandler.CallV1CallActionNext(ctx, c.ID, false)
+		}
+		// Streaming failed — fall back to batch TTS
+		log.Infof("Streaming talk failed, falling back to batch. err: %v", errStreaming)
 	}
 
-	// Streaming failed — fall back to batch TTS
-	log.Infof("Streaming talk failed, falling back to batch. err: %v", errStreaming)
 	if errBatch := h.Talk(ctx, c.ID, true, option.Text, option.Language, option.Provider, option.VoiceID); errBatch != nil {
 		log.Errorf("Could not talk correctly. err: %v", errBatch)
 		return errors.Wrap(errBatch, "could not talk correctly")

--- a/bin-call-manager/pkg/callhandler/action_test.go
+++ b/bin-call-manager/pkg/callhandler/action_test.go
@@ -2,6 +2,7 @@ package callhandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -383,10 +384,14 @@ func Test_ActionExecute_actionExecuteTalk(t *testing.T) {
 
 			ctx := context.Background()
 
-			mockDB.EXPECT().CallGet(ctx, tt.call.ID).Return(tt.call, nil)
+			// StreamingTalk path: Get call, Answer (if needed), then fail at streaming create
+			mockDB.EXPECT().CallGet(ctx, tt.call.ID).Return(tt.call, nil).AnyTimes()
 			if tt.call.Status != call.StatusProgressing {
-				mockChannel.EXPECT().Answer(ctx, tt.call.ChannelID).Return(nil)
+				mockChannel.EXPECT().Answer(ctx, tt.call.ChannelID).Return(nil).AnyTimes()
 			}
+			mockReq.EXPECT().TTSV1StreamingCreateWithProvider(ctx, gomock.Any(), gomock.Any(), tt.call.ID, tt.expectLanguage, gomock.Any(), tt.expectVoiceID, gomock.Any()).Return(nil, fmt.Errorf("streaming not available"))
+
+			// Batch Talk fallback path
 			mockReq.EXPECT().TTSV1SpeecheCreate(ctx, tt.call.ID, tt.expectSSML, tt.expectLanguage, tmtts.Provider(tt.expectProvider), tt.expectVoiceID, 10000).Return(tt.responseTTS, nil)
 			mockChannel.EXPECT().Play(ctx, tt.call.ChannelID, tt.expectPlaybackID, tt.expectURI, "", 0, 0).Return(nil)
 

--- a/bin-call-manager/pkg/callhandler/action_test.go
+++ b/bin-call-manager/pkg/callhandler/action_test.go
@@ -384,14 +384,18 @@ func Test_ActionExecute_actionExecuteTalk(t *testing.T) {
 
 			ctx := context.Background()
 
-			// StreamingTalk path: Get call, Answer (if needed), then fail at streaming create
 			mockDB.EXPECT().CallGet(ctx, tt.call.ID).Return(tt.call, nil).AnyTimes()
 			if tt.call.Status != call.StatusProgressing {
 				mockChannel.EXPECT().Answer(ctx, tt.call.ChannelID).Return(nil).AnyTimes()
 			}
-			mockReq.EXPECT().TTSV1StreamingCreateWithProvider(ctx, gomock.Any(), gomock.Any(), tt.call.ID, tt.expectLanguage, gomock.Any(), tt.expectVoiceID, gomock.Any()).Return(nil, fmt.Errorf("streaming not available"))
 
-			// Batch Talk fallback path
+			if !tt.expectAsync {
+				// Non-async: StreamingTalk is tried first, fails, falls back to batch
+				mockReq.EXPECT().TTSV1StreamingCreateWithProvider(ctx, gomock.Any(), gomock.Any(), tt.call.ID, tt.expectLanguage, gomock.Any(), tt.expectVoiceID, gomock.Any()).Return(nil, fmt.Errorf("streaming not available"))
+			}
+			// Async skips streaming entirely and goes straight to batch
+
+			// Batch Talk path
 			mockReq.EXPECT().TTSV1SpeecheCreate(ctx, tt.call.ID, tt.expectSSML, tt.expectLanguage, tmtts.Provider(tt.expectProvider), tt.expectVoiceID, 10000).Return(tt.responseTTS, nil)
 			mockChannel.EXPECT().Play(ctx, tt.call.ChannelID, tt.expectPlaybackID, tt.expectURI, "", 0, 0).Return(nil)
 

--- a/bin-call-manager/pkg/callhandler/media.go
+++ b/bin-call-manager/pkg/callhandler/media.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	tmstreaming "monorepo/bin-tts-manager/models/streaming"
 	tmtts "monorepo/bin-tts-manager/models/tts"
 
 	"github.com/gofrs/uuid"
@@ -69,6 +70,99 @@ func (h *callHandler) Talk(ctx context.Context, callID uuid.UUID, runNext bool, 
 	log.Debugf("Played the tts media. playback_id: %s, medias: %v", playbackID, medias)
 
 	return nil
+}
+
+// StreamingTalk plays TTS via real-time streaming instead of batch file generation.
+// Audio is streamed to Asterisk via ExternalMedia AudioSocket in real-time (~200ms to first audio).
+// Returns nil on success, error on failure (caller should fall back to batch Talk).
+func (h *callHandler) StreamingTalk(ctx context.Context, callID uuid.UUID, text string, language string, provider string, voiceID string) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "StreamingTalk",
+		"call_id": callID,
+	})
+
+	c, err := h.Get(ctx, callID)
+	if err != nil {
+		log.Errorf("Could not get call info. err: %v", err)
+		return errors.Wrap(err, "could not get call info")
+	}
+	log.WithField("call", c).Debugf("Retrieved call info. call_id: %s", c.ID)
+
+	// answer the call if not answered
+	if c.Status != call.StatusProgressing {
+		if errAnswer := h.channelHandler.Answer(ctx, c.ChannelID); errAnswer != nil {
+			log.Errorf("Could not answer the call. err: %v", errAnswer)
+			return fmt.Errorf("could not answer the call. err: %v", errAnswer)
+		}
+	}
+
+	// default provider to "gcp" if not specified
+	if provider == "" {
+		provider = "gcp"
+	}
+
+	// Step 1: Create streaming session with provider/voiceID
+	st, err := h.reqHandler.TTSV1StreamingCreateWithProvider(ctx,
+		c.CustomerID,
+		tmstreaming.ReferenceTypeCall,
+		c.ID,
+		language,
+		provider,
+		voiceID,
+		tmstreaming.DirectionBoth,
+	)
+	if err != nil {
+		log.Errorf("Could not create streaming session. err: %v", err)
+		return errors.Wrap(err, "could not create streaming session")
+	}
+	log.WithField("streaming", st).Debugf("Created streaming session. streaming_id: %s, pod_id: %s", st.ID, st.PodID)
+
+	// Step 2: SayInit — begin message
+	messageID := uuid.Must(uuid.NewV4())
+	if _, errInit := h.reqHandler.TTSV1StreamingSayInit(ctx, st.PodID, st.ID, messageID); errInit != nil {
+		log.Errorf("Could not init streaming say. streaming_id: %s, err: %v", st.ID, errInit)
+		h.streamingCleanup(ctx, st)
+		return errors.Wrap(errInit, "could not init streaming say")
+	}
+
+	// Step 3: SayAdd — send text
+	if errAdd := h.reqHandler.TTSV1StreamingSayAdd(ctx, st.PodID, st.ID, messageID, text); errAdd != nil {
+		log.Errorf("Could not add text to streaming. streaming_id: %s, err: %v", st.ID, errAdd)
+		h.streamingCleanup(ctx, st)
+		return errors.Wrap(errAdd, "could not add text to streaming")
+	}
+
+	// Step 4: SayFinish — signal no more text (non-blocking, audio continues streaming)
+	if _, errFinish := h.reqHandler.TTSV1StreamingSayFinish(ctx, st.PodID, st.ID, messageID); errFinish != nil {
+		log.Errorf("Could not finish streaming say. streaming_id: %s, err: %v", st.ID, errFinish)
+		h.streamingCleanup(ctx, st)
+		return errors.Wrap(errFinish, "could not finish streaming say")
+	}
+
+	// Step 5: Wait for all audio to be delivered to Asterisk
+	if errWait := h.reqHandler.TTSV1StreamingWaitFinish(ctx, st.PodID, st.ID); errWait != nil {
+		log.Errorf("Streaming wait finish failed. streaming_id: %s, err: %v", st.ID, errWait)
+		h.streamingCleanup(ctx, st)
+		return errors.Wrap(errWait, "streaming wait finish failed")
+	}
+
+	// Step 6: Cleanup streaming session
+	h.streamingCleanup(ctx, st)
+
+	log.Infof("Streaming talk completed. streaming_id: %s", st.ID)
+	return nil
+}
+
+// streamingCleanup stops and deletes a streaming session. Best-effort, logs errors but doesn't return them.
+func (h *callHandler) streamingCleanup(ctx context.Context, st *tmstreaming.Streaming) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":         "streamingCleanup",
+		"streaming_id": st.ID,
+	})
+
+	if _, err := h.reqHandler.TTSV1StreamingDelete(ctx, st.ID); err != nil {
+		log.Errorf("Could not delete streaming session. err: %v", err)
+	}
 }
 
 // Play plays the media to the given call id.

--- a/bin-call-manager/pkg/callhandler/media.go
+++ b/bin-call-manager/pkg/callhandler/media.go
@@ -88,6 +88,8 @@ func (h *callHandler) StreamingTalk(ctx context.Context, callID uuid.UUID, text 
 	}
 	log.WithField("call", c).Debugf("Retrieved call info. call_id: %s", c.ID)
 
+	log.Infof("[STREAM-FIX-V2] StreamingTalk initiated. call_id: %s", c.ID)
+
 	// answer the call if not answered
 	if c.Status != call.StatusProgressing {
 		if errAnswer := h.channelHandler.Answer(ctx, c.ChannelID); errAnswer != nil {

--- a/bin-call-manager/pkg/callhandler/media.go
+++ b/bin-call-manager/pkg/callhandler/media.go
@@ -101,6 +101,13 @@ func (h *callHandler) StreamingTalk(ctx context.Context, callID uuid.UUID, text 
 		provider = "gcp"
 	}
 
+	// Only GCP streaming is production-ready. Non-GCP vendors (ElevenLabs, AWS)
+	// use ConnAstDone for WaitFinish which won't close until Stop() is called,
+	// causing a 60s RPC timeout. Return error to trigger batch fallback.
+	if provider != "gcp" {
+		return fmt.Errorf("streaming talk only supports gcp provider, got: %s", provider)
+	}
+
 	// Step 1: Create streaming session with provider/voiceID
 	st, err := h.reqHandler.TTSV1StreamingCreateWithProvider(ctx,
 		c.CustomerID,

--- a/bin-call-manager/pkg/callhandler/media.go
+++ b/bin-call-manager/pkg/callhandler/media.go
@@ -92,7 +92,7 @@ func (h *callHandler) StreamingTalk(ctx context.Context, callID uuid.UUID, text 
 	if c.Status != call.StatusProgressing {
 		if errAnswer := h.channelHandler.Answer(ctx, c.ChannelID); errAnswer != nil {
 			log.Errorf("Could not answer the call. err: %v", errAnswer)
-			return fmt.Errorf("could not answer the call. err: %v", errAnswer)
+			return errors.Wrap(errAnswer, "could not answer the call")
 		}
 	}
 

--- a/bin-call-manager/pkg/callhandler/media.go
+++ b/bin-call-manager/pkg/callhandler/media.go
@@ -96,16 +96,16 @@ func (h *callHandler) StreamingTalk(ctx context.Context, callID uuid.UUID, text 
 		}
 	}
 
-	// default provider to "gcp" if not specified
+	// default provider to GCP if not specified
 	if provider == "" {
-		provider = "gcp"
+		provider = string(tmtts.ProviderGCP)
 	}
 
 	// Only GCP streaming is production-ready. Non-GCP vendors (ElevenLabs, AWS)
 	// use ConnAstDone for WaitFinish which won't close until Stop() is called,
 	// causing a 60s RPC timeout. Return error to trigger batch fallback.
-	if provider != "gcp" {
-		return fmt.Errorf("streaming talk only supports gcp provider, got: %s", provider)
+	if provider != string(tmtts.ProviderGCP) {
+		return fmt.Errorf("streaming talk only supports %s provider, got: %s", tmtts.ProviderGCP, provider)
 	}
 
 	// Step 1: Create streaming session with provider/voiceID

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -1288,6 +1288,8 @@ type RequestHandler interface {
 	TTSV1StreamingSayAdd(ctx context.Context, podID string, streamingID uuid.UUID, messageID uuid.UUID, text string) error
 	TTSV1StreamingSayFinish(ctx context.Context, podID string, streamingID uuid.UUID, messageID uuid.UUID) (*tmstreaming.Streaming, error)
 	TTSV1StreamingSayStop(ctx context.Context, podID string, streamingID uuid.UUID) error
+	TTSV1StreamingCreateWithProvider(ctx context.Context, customerID uuid.UUID, referenceType tmstreaming.ReferenceType, referenceID uuid.UUID, language string, provider string, voiceID string, direction tmstreaming.Direction) (*tmstreaming.Streaming, error)
+	TTSV1StreamingWaitFinish(ctx context.Context, podID string, streamingID uuid.UUID) error
 
 	// tts-manager speakings
 	TTSV1SpeakingCreate(ctx context.Context, customerID uuid.UUID, referenceType tmstreaming.ReferenceType, referenceID uuid.UUID, language string, provider string, voiceID string, direction tmstreaming.Direction) (*tmspeaking.Speaking, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -6099,6 +6099,21 @@ func (mr *MockRequestHandlerMockRecorder) TTSV1StreamingCreate(ctx, customerID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTSV1StreamingCreate", reflect.TypeOf((*MockRequestHandler)(nil).TTSV1StreamingCreate), ctx, customerID, activeflowID, referenceType, referenceID, language, gender, direction)
 }
 
+// TTSV1StreamingCreateWithProvider mocks base method.
+func (m *MockRequestHandler) TTSV1StreamingCreateWithProvider(ctx context.Context, customerID uuid.UUID, referenceType streaming.ReferenceType, referenceID uuid.UUID, language, provider, voiceID string, direction streaming.Direction) (*streaming.Streaming, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TTSV1StreamingCreateWithProvider", ctx, customerID, referenceType, referenceID, language, provider, voiceID, direction)
+	ret0, _ := ret[0].(*streaming.Streaming)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TTSV1StreamingCreateWithProvider indicates an expected call of TTSV1StreamingCreateWithProvider.
+func (mr *MockRequestHandlerMockRecorder) TTSV1StreamingCreateWithProvider(ctx, customerID, referenceType, referenceID, language, provider, voiceID, direction any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTSV1StreamingCreateWithProvider", reflect.TypeOf((*MockRequestHandler)(nil).TTSV1StreamingCreateWithProvider), ctx, customerID, referenceType, referenceID, language, provider, voiceID, direction)
+}
+
 // TTSV1StreamingDelete mocks base method.
 func (m *MockRequestHandler) TTSV1StreamingDelete(ctx context.Context, streamingID uuid.UUID) (*streaming.Streaming, error) {
 	m.ctrl.T.Helper()
@@ -6170,6 +6185,20 @@ func (m *MockRequestHandler) TTSV1StreamingSayStop(ctx context.Context, podID st
 func (mr *MockRequestHandlerMockRecorder) TTSV1StreamingSayStop(ctx, podID, streamingID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTSV1StreamingSayStop", reflect.TypeOf((*MockRequestHandler)(nil).TTSV1StreamingSayStop), ctx, podID, streamingID)
+}
+
+// TTSV1StreamingWaitFinish mocks base method.
+func (m *MockRequestHandler) TTSV1StreamingWaitFinish(ctx context.Context, podID string, streamingID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TTSV1StreamingWaitFinish", ctx, podID, streamingID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TTSV1StreamingWaitFinish indicates an expected call of TTSV1StreamingWaitFinish.
+func (mr *MockRequestHandlerMockRecorder) TTSV1StreamingWaitFinish(ctx, podID, streamingID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTSV1StreamingWaitFinish", reflect.TypeOf((*MockRequestHandler)(nil).TTSV1StreamingWaitFinish), ctx, podID, streamingID)
 }
 
 // TagV1TagCreate mocks base method.

--- a/bin-common-handler/pkg/requesthandler/tts_streamings.go
+++ b/bin-common-handler/pkg/requesthandler/tts_streamings.go
@@ -53,6 +53,46 @@ func (r *requestHandler) TTSV1StreamingCreate(
 	return &res, nil
 }
 
+// TTSV1StreamingCreateWithProvider creates a streaming TTS session with explicit provider and voiceID.
+func (r *requestHandler) TTSV1StreamingCreateWithProvider(
+	ctx context.Context,
+	customerID uuid.UUID,
+	referenceType tmstreaming.ReferenceType,
+	referenceID uuid.UUID,
+	language string,
+	provider string,
+	voiceID string,
+	direction tmstreaming.Direction,
+) (*tmstreaming.Streaming, error) {
+
+	uri := "/v1/streamings"
+
+	m, err := json.Marshal(request.V1DataStreamingsPost{
+		CustomerID:    customerID,
+		ReferenceType: referenceType,
+		ReferenceID:   referenceID,
+		Language:      language,
+		Direction:     direction,
+		Provider:      provider,
+		VoiceID:       voiceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestTTS(ctx, uri, sock.RequestMethodPost, "tts/streamings", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res tmstreaming.Streaming
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
 // TTSV1StreamingDelete deletes a streaming tts by its ID.
 func (r *requestHandler) TTSV1StreamingDelete(ctx context.Context, streamingID uuid.UUID) (*tmstreaming.Streaming, error) {
 	uri := fmt.Sprintf("/v1/streamings/%s", streamingID)
@@ -166,4 +206,25 @@ func (r *requestHandler) TTSV1StreamingSayFinish(ctx context.Context, podID stri
 	}
 
 	return &res, nil
+}
+
+// TTSV1StreamingWaitFinish waits until all streaming audio has been delivered to Asterisk.
+// This is a synchronous blocking RPC — it blocks until the streaming processDone channel closes.
+// Uses pod-specific routing since the streaming session lives on a specific pod.
+func (r *requestHandler) TTSV1StreamingWaitFinish(ctx context.Context, podID string, streamingID uuid.UUID) error {
+	uri := fmt.Sprintf("/v1/streamings/%s/wait_finish", streamingID)
+
+	queueName := fmt.Sprintf("bin-manager.tts-manager.request.%s", podID)
+
+	// 60s timeout — must be longer than max audio duration
+	tmp, err := r.sendRequest(ctx, commonoutline.QueueName(queueName), uri, sock.RequestMethodPost, "tts/streamings/<streaming-id>/wait_finish", 60000, 0, ContentTypeNone, nil)
+	if err != nil {
+		return err
+	}
+
+	if errParse := parseResponse(tmp, nil); errParse != nil {
+		return errParse
+	}
+
+	return nil
 }

--- a/bin-tts-manager/pkg/listenhandler/main.go
+++ b/bin-tts-manager/pkg/listenhandler/main.go
@@ -54,7 +54,8 @@ var (
 	resV1StreamingsIDSayAdd    = regexp.MustCompile("/v1/streamings/" + regUUID + "/say_add$")
 	resV1StreamingsIDSayInit   = regexp.MustCompile("/v1/streamings/" + regUUID + "/say_init$")
 	resV1StreamingsIDSayStop   = regexp.MustCompile("/v1/streamings/" + regUUID + "/say_stop$")
-	resV1StreamingsIDSayFinish = regexp.MustCompile("/v1/streamings/" + regUUID + "/say_finish$")
+	resV1StreamingsIDSayFinish   = regexp.MustCompile("/v1/streamings/" + regUUID + "/say_finish$")
+	resV1StreamingsIDWaitFinish  = regexp.MustCompile("/v1/streamings/" + regUUID + "/wait_finish$")
 )
 
 var (
@@ -209,6 +210,11 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case resV1StreamingsIDSayFinish.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		requestType = "/streamings/<streaming-id>/say_finish"
 		response, err = h.v1StreamingsIDSayFinishPost(ctx, m)
+
+	// /streamings/<id>/wait_finish
+	case resV1StreamingsIDWaitFinish.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		requestType = "/streamings/<streaming-id>/wait_finish"
+		response, err = h.v1StreamingsIDWaitFinishPost(ctx, m)
 
 	default:
 		log.Errorf("Could not find corresponded message handler. data: %s", m.Data)

--- a/bin-tts-manager/pkg/listenhandler/models/request/streamings.go
+++ b/bin-tts-manager/pkg/listenhandler/models/request/streamings.go
@@ -17,6 +17,8 @@ type V1DataStreamingsPost struct {
 	Language      string                  `json:"language,omitempty"`
 	Gender        streaming.Gender        `json:"gender,omitempty"`
 	Direction     streaming.Direction     `json:"direction,omitempty"` // Direction of the streaming
+	Provider      string                  `json:"provider,omitempty"`  // TTS provider (e.g., "gcp", "aws", "elevenlabs")
+	VoiceID       string                  `json:"voice_id,omitempty"` // Provider-specific voice ID
 }
 
 // V1DataStreamingsIDSayAddPost is
@@ -40,3 +42,8 @@ type V1DataStreamingsIDSayInitPost struct {
 type V1DataStreamingsIDSayFinishPost struct {
 	MessageID uuid.UUID `json:"message_id,omitempty"`
 }
+
+// V1DataStreamingsIDWaitFinishPost is
+// v1 data type request struct for
+// /v1/streamings/<id>/wait_finish POST
+type V1DataStreamingsIDWaitFinishPost struct{}

--- a/bin-tts-manager/pkg/listenhandler/v1_streamings.go
+++ b/bin-tts-manager/pkg/listenhandler/v1_streamings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-tts-manager/models/streaming"
 	"monorepo/bin-tts-manager/pkg/listenhandler/models/request"
 	"net/url"
 	"strings"
@@ -26,7 +27,13 @@ func (h *listenHandler) v1StreamingsPost(ctx context.Context, m *sock.Request) (
 	}
 	log.WithField("request", req).Debugf("Processing v1StreamingsPost.")
 
-	tmp, err := h.streamingHandler.Start(ctx, req.CustomerID, req.ActiveflowID, req.ReferenceType, req.ReferenceID, req.Language, req.Gender, req.Direction)
+	var tmp *streaming.Streaming
+	var err error
+	if req.Provider != "" {
+		tmp, err = h.streamingHandler.StartWithID(ctx, uuid.Must(uuid.NewV4()), req.CustomerID, req.ReferenceType, req.ReferenceID, req.Language, req.Provider, req.VoiceID, req.Direction)
+	} else {
+		tmp, err = h.streamingHandler.Start(ctx, req.CustomerID, req.ActiveflowID, req.ReferenceType, req.ReferenceID, req.Language, req.Gender, req.Direction)
+	}
 	if err != nil {
 		log.Errorf("Could not create a streaming. err: %v", err)
 		return nil, err
@@ -225,6 +232,36 @@ func (h *listenHandler) v1StreamingsIDSayFinishPost(ctx context.Context, m *sock
 		StatusCode: 200,
 		DataType:   "application/json",
 		Data:       data,
+	}
+
+	return res, nil
+}
+
+// v1StreamingsIDWaitFinishPost handles /v1/streamings/<id>/wait_finish POST request
+// It blocks until all streaming audio has been delivered to Asterisk.
+func (h *listenHandler) v1StreamingsIDWaitFinishPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "v1StreamingsIDWaitFinishPost",
+	})
+
+	u, err := url.Parse(m.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	// "/v1/streamings/a6f4eae8-8a74-11ea-af75-3f1e61b9a236/wait_finish"
+	tmpVals := strings.Split(u.Path, "/")
+	streamingID := uuid.FromStringOrNil(tmpVals[3])
+
+	log.Debugf("Processing v1StreamingsIDWaitFinishPost. streaming_id: %s", streamingID)
+
+	if errWait := h.streamingHandler.WaitFinish(ctx, streamingID); errWait != nil {
+		log.Errorf("Could not wait for streaming finish. err: %v", errWait)
+		return nil, errWait
+	}
+
+	res := &sock.Response{
+		StatusCode: 200,
 	}
 
 	return res, nil

--- a/bin-tts-manager/pkg/streaminghandler/gcp.go
+++ b/bin-tts-manager/pkg/streaminghandler/gcp.go
@@ -276,6 +276,8 @@ func (h *gcpHandler) Run(vendorConfig any) error {
 		"streaming_id": cf.Streaming.ID,
 	})
 
+	log.Infof("[STREAM-FIX-V2] GCP streaming session started. streaming_id: %s", cf.Streaming.ID)
+
 	go h.runProcess(cf)
 	go h.runKeepalive(cf)
 
@@ -324,14 +326,22 @@ func (h *gcpHandler) runProcess(cf *GCPConfig) {
 			elapsed := time.Since(firstWriteTime)
 			remaining := audioDuration - elapsed + asteriskBufferPadding
 
+			log.Infof("[STREAM-FIX-V2] Playback wait check. audio_duration: %v, elapsed: %v, remaining: %v, total_bytes: %d",
+				audioDuration, elapsed, remaining, totalAudioBytes)
+
 			if remaining > 0 {
-				log.Debugf("Waiting for remaining playback. audio_duration: %v, elapsed: %v, remaining_wait: %v",
-					audioDuration, elapsed, remaining)
+				log.Infof("[STREAM-FIX-V2] Waiting for remaining playback. remaining_wait: %v", remaining)
 				select {
 				case <-time.After(remaining):
+					log.Infof("[STREAM-FIX-V2] Playback wait completed normally.")
 				case <-cf.Ctx.Done():
+					log.Infof("[STREAM-FIX-V2] Playback wait interrupted by context cancellation.")
 				}
+			} else {
+				log.Infof("[STREAM-FIX-V2] No remaining wait needed (remaining: %v).", remaining)
 			}
+		} else {
+			log.Infof("[STREAM-FIX-V2] No audio was written, skipping playback wait.")
 		}
 
 		streamCancel()

--- a/bin-tts-manager/pkg/streaminghandler/gcp.go
+++ b/bin-tts-manager/pkg/streaminghandler/gcp.go
@@ -57,6 +57,11 @@ const (
 	// gcpKeepaliveInterval is the interval between keepalive pings to prevent
 	// GCP's 5-second inactivity timeout on StreamingSynthesize.
 	gcpKeepaliveInterval = 4 * time.Second
+
+	// asteriskBufferPadding is a conservative padding added after the calculated
+	// remaining playback time to account for Asterisk's internal audio buffer
+	// and network jitter between tts-manager and Asterisk.
+	asteriskBufferPadding = 500 * time.Millisecond
 )
 
 var gcpVoiceIDMap = map[string]string{
@@ -302,7 +307,33 @@ func (h *gcpHandler) runProcess(cf *GCPConfig) {
 	msg := cf.Message
 	h.notifyHandler.PublishEvent(cf.Ctx, message.EventTypePlayStarted, msg)
 
+	// Track audio bytes and wall-clock time to calculate remaining playback time.
+	// websocketWrite paces frames at ~20ms each (real-time), but per-chunk ticker
+	// creation skips the first wait, causing a cumulative undershoot of ~20ms per
+	// GCP chunk. Additionally, Asterisk buffers audio internally. We wait for the
+	// remaining playback time + padding before signaling processDone so that
+	// callers (WaitFinish → ActionNext) don't advance before the audio finishes.
+	var totalAudioBytes int
+	var firstWriteTime time.Time
+	audioWritten := false
+
 	defer func() {
+		if audioWritten && totalAudioBytes > 0 {
+			// Calculate audio duration from bytes: ulaw at 8000 Hz = 8000 bytes/sec
+			audioDuration := time.Duration(totalAudioBytes) * time.Second / time.Duration(defaultGCPStreamingSampleRate)
+			elapsed := time.Since(firstWriteTime)
+			remaining := audioDuration - elapsed + asteriskBufferPadding
+
+			if remaining > 0 {
+				log.Debugf("Waiting for remaining playback. audio_duration: %v, elapsed: %v, remaining_wait: %v",
+					audioDuration, elapsed, remaining)
+				select {
+				case <-time.After(remaining):
+				case <-cf.Ctx.Done():
+				}
+			}
+		}
+
 		streamCancel()
 		h.notifyHandler.PublishEvent(cf.Ctx, message.EventTypePlayFinished, msg)
 		close(doneCh)
@@ -348,10 +379,16 @@ func (h *gcpHandler) runProcess(cf *GCPConfig) {
 			continue
 		}
 
+		if !audioWritten {
+			firstWriteTime = time.Now()
+			audioWritten = true
+		}
+
 		if errWrite := websocketWrite(streamCtx, cf.ConnAst, audioData, frameSizeUlaw); errWrite != nil {
 			log.Errorf("Could not write audio to asterisk: %v", errWrite)
 			return
 		}
+		totalAudioBytes += len(audioData)
 	}
 }
 

--- a/bin-tts-manager/pkg/streaminghandler/main.go
+++ b/bin-tts-manager/pkg/streaminghandler/main.go
@@ -50,6 +50,8 @@ type StreamingHandler interface {
 	SayFlush(ctx context.Context, id uuid.UUID) error
 	SayStop(ctx context.Context, id uuid.UUID) error
 	SayFinish(ctx context.Context, id uuid.UUID, messageID uuid.UUID) (*streaming.Streaming, error)
+
+	WaitFinish(ctx context.Context, id uuid.UUID) error
 }
 
 // list of default external media channel options.

--- a/bin-tts-manager/pkg/streaminghandler/mock_main.go
+++ b/bin-tts-manager/pkg/streaminghandler/mock_main.go
@@ -173,6 +173,20 @@ func (mr *MockStreamingHandlerMockRecorder) Stop(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockStreamingHandler)(nil).Stop), ctx, id)
 }
 
+// WaitFinish mocks base method.
+func (m *MockStreamingHandler) WaitFinish(ctx context.Context, id uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitFinish", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitFinish indicates an expected call of WaitFinish.
+func (mr *MockStreamingHandlerMockRecorder) WaitFinish(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFinish", reflect.TypeOf((*MockStreamingHandler)(nil).WaitFinish), ctx, id)
+}
+
 // Mockstreamer is a mock of streamer interface.
 type Mockstreamer struct {
 	ctrl     *gomock.Controller

--- a/bin-tts-manager/pkg/streaminghandler/streaming.go
+++ b/bin-tts-manager/pkg/streaminghandler/streaming.go
@@ -177,11 +177,16 @@ func (h *streamingHandler) WaitFinish(ctx context.Context, id uuid.UUID) error {
 		if !ok {
 			return fmt.Errorf("invalid vendor config type for GCP")
 		}
+		// Snapshot processDone under muStream to avoid data race with
+		// waitAndReconnectLocked which may replace cf.processDone.
+		cf.muStream.Lock()
+		doneCh := cf.processDone
+		cf.muStream.Unlock()
 		select {
-		case <-cf.processDone:
+		case <-doneCh:
 			return nil
 		case <-cf.Ctx.Done():
-			return nil // Session cancelled
+			return fmt.Errorf("streaming session cancelled before audio completed for %s", id)
 		case <-ctx.Done():
 			return ctx.Err() // Caller timeout
 		}

--- a/bin-tts-manager/pkg/streaminghandler/streaming.go
+++ b/bin-tts-manager/pkg/streaminghandler/streaming.go
@@ -152,3 +152,48 @@ func (h *streamingHandler) SetVendorInfo(st *streaming.Streaming, venderName str
 	st.VendorName = venderName
 	st.VendorConfig = vendorConfig
 }
+
+// WaitFinish blocks until all streaming audio has been delivered to Asterisk.
+// It waits on the vendor-specific processDone channel (GCP) or ConnAstDone as fallback.
+func (h *streamingHandler) WaitFinish(ctx context.Context, id uuid.UUID) error {
+	st, err := h.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	st.VendorLock.Lock()
+	vc := st.VendorConfig
+	vendorName := st.VendorName
+	st.VendorLock.Unlock()
+
+	if vc == nil {
+		return nil // No vendor initialized, nothing to wait for
+	}
+
+	switch vendorName {
+	case streaming.VendorNameGCP:
+		cf, ok := vc.(*GCPConfig)
+		if !ok {
+			return fmt.Errorf("invalid vendor config type for GCP")
+		}
+		select {
+		case <-cf.processDone:
+			return nil
+		case <-cf.Ctx.Done():
+			return nil // Session cancelled
+		case <-ctx.Done():
+			return ctx.Err() // Caller timeout
+		}
+	default:
+		// For non-GCP vendors, wait on ConnAstDone as fallback
+		if st.ConnAstDone == nil {
+			return nil
+		}
+		select {
+		case <-st.ConnAstDone:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/bin-tts-manager/pkg/streaminghandler/streaming.go
+++ b/bin-tts-manager/pkg/streaminghandler/streaming.go
@@ -191,7 +191,12 @@ func (h *streamingHandler) WaitFinish(ctx context.Context, id uuid.UUID) error {
 			return ctx.Err() // Caller timeout
 		}
 	default:
-		// For non-GCP vendors, wait on ConnAstDone as fallback
+		// For non-GCP vendors, wait on ConnAstDone as fallback.
+		// NOTE: ConnAstDone is only closed when Stop() is called, not when audio
+		// finishes playing. This means non-GCP WaitFinish will block until the
+		// caller's RPC timeout (~60s). This path is not production-ready;
+		// callers should gate streaming to GCP-only until vendor-specific
+		// completion signaling is implemented.
 		if connAstDone == nil {
 			return fmt.Errorf("no completion channel for streaming %s", id)
 		}

--- a/bin-tts-manager/pkg/streaminghandler/streaming.go
+++ b/bin-tts-manager/pkg/streaminghandler/streaming.go
@@ -164,10 +164,11 @@ func (h *streamingHandler) WaitFinish(ctx context.Context, id uuid.UUID) error {
 	st.VendorLock.Lock()
 	vc := st.VendorConfig
 	vendorName := st.VendorName
+	connAstDone := st.ConnAstDone
 	st.VendorLock.Unlock()
 
 	if vc == nil {
-		return nil // No vendor initialized, nothing to wait for
+		return fmt.Errorf("vendor config not initialized for streaming %s", id)
 	}
 
 	switch vendorName {
@@ -186,11 +187,11 @@ func (h *streamingHandler) WaitFinish(ctx context.Context, id uuid.UUID) error {
 		}
 	default:
 		// For non-GCP vendors, wait on ConnAstDone as fallback
-		if st.ConnAstDone == nil {
-			return nil
+		if connAstDone == nil {
+			return fmt.Errorf("no completion channel for streaming %s", id)
 		}
 		select {
-		case <-st.ConnAstDone:
+		case <-connAstDone:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
Wire talk flow action to use real-time streaming TTS with batch fallback,
reducing time-to-first-audio from ~2.5s to ~200ms.

The talk action now tries StreamingTalk first (create session, SayInit, SayAdd,
SayFinish, WaitFinish), and falls back to batch TTS on any failure. When streaming
succeeds, audio is fully delivered before advancing the flow cursor. Batch path
retains existing PlaybackFinished ARI event behavior.

- bin-tts-manager: Add Provider/VoiceID fields to streaming create request model
- bin-tts-manager: Add WaitFinish endpoint that blocks until all audio is delivered
- bin-tts-manager: Implement WaitFinish in streaminghandler using processDone channel
- bin-tts-manager: Add StartWithID branch in v1StreamingsPost for provider-based creation
- bin-common-handler: Add TTSV1StreamingCreateWithProvider RPC with provider/voiceID params
- bin-common-handler: Add TTSV1StreamingWaitFinish RPC with pod-specific routing and 60s timeout
- bin-call-manager: Implement StreamingTalk function with full streaming lifecycle
- bin-call-manager: Wire actionExecuteTalk to try streaming first, fall back to batch
- bin-call-manager: Update talk action tests to mock streaming fallback path