### PR TITLE
NOJIRA-Add-developer-operations-toolkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,143 @@
+# VoIPBin Monorepo Developer Operations
+#
+# Usage:
+#   make help                           Show all targets
+#   make doctor                         Check prerequisites
+#   make verify SERVICE=bin-call-manager Full 5-step verification
+#   make verify-all                     Verify all services
+#   make verify-common                  Verify common-handler + all dependents
+#   make test SERVICE=bin-call-manager   Run tests (clears cache first)
+#   make lint SERVICE=bin-call-manager   Run golangci-lint
+#   make generate SERVICE=bin-call-manager Run go generate
+#   make build SERVICE=bin-call-manager  Build service binary
+#   make dev-up                         Start local dev infrastructure
+#   make dev-down                       Stop local dev infrastructure
+#   make services                       List all services
+
+.PHONY: help doctor verify verify-all verify-common test lint generate build \
+        dev-up dev-down dev-logs services clean
+
+SHELL := /bin/bash
+PARALLEL ?= 4
+SERVICE ?=
+
+# ── Help ────────────────────────────────────────────────────────────────────
+
+help: ## Show this help
+	@echo "VoIPBin Monorepo Developer Operations"
+	@echo ""
+	@echo "Usage: make <target> [SERVICE=bin-xxx-manager] [PARALLEL=N]"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Examples:"
+	@echo "  make verify SERVICE=bin-call-manager"
+	@echo "  make verify-all PARALLEL=8"
+	@echo "  make verify-common --skip-lint"
+	@echo "  make dev-up"
+
+# ── Prerequisites ───────────────────────────────────────────────────────────
+
+doctor: ## Check development environment prerequisites
+	@./scripts/doctor.sh
+
+# ── Verification (the 5-step workflow) ──────────────────────────────────────
+
+verify: _require-service ## Run full 5-step verification for SERVICE
+	@./scripts/verify.sh $(SERVICE)
+
+verify-all: ## Verify ALL Go services (use PARALLEL=N for concurrency)
+	@./scripts/verify.sh --all --parallel $(PARALLEL)
+
+verify-common: ## Verify bin-common-handler + update all dependent services
+	@./scripts/update-common.sh --parallel $(PARALLEL)
+
+verify-quick: _require-service ## Verify SERVICE without linting (faster)
+	@./scripts/verify.sh --skip-lint $(SERVICE)
+
+# ── Individual Steps ────────────────────────────────────────────────────────
+
+test: _require-service ## Run tests for SERVICE (clears cache first)
+	@echo "Testing $(SERVICE)..."
+	@cd $(SERVICE) && go clean -testcache && go test ./...
+
+lint: _require-service ## Run golangci-lint for SERVICE
+	@echo "Linting $(SERVICE)..."
+	@cd $(SERVICE) && golangci-lint run -v --timeout 5m
+
+generate: _require-service ## Run go generate for SERVICE
+	@echo "Generating code for $(SERVICE)..."
+	@cd $(SERVICE) && go generate ./...
+
+tidy: _require-service ## Run go mod tidy + vendor for SERVICE
+	@echo "Tidying $(SERVICE)..."
+	@cd $(SERVICE) && go mod tidy && go mod vendor
+
+build: _require-service ## Build SERVICE binary
+	@echo "Building $(SERVICE)..."
+	@cd $(SERVICE) && go build -o /dev/null ./cmd/...
+
+# ── Local Development Infrastructure ────────────────────────────────────────
+
+dev-up: ## Start local dev infrastructure (MySQL, Redis, RabbitMQ)
+	@echo "Starting local development infrastructure..."
+	@docker compose -f docker-compose.dev.yml up -d
+	@echo ""
+	@echo "Services:"
+	@echo "  MySQL:    localhost:3306  (user: voipbin, pass: voipbin)"
+	@echo "  Redis:    localhost:6379  (pass: voipbin)"
+	@echo "  RabbitMQ: localhost:5672  (user: guest, pass: guest)"
+	@echo "  RabbitMQ: localhost:15672 (management UI)"
+
+dev-down: ## Stop local dev infrastructure
+	@docker compose -f docker-compose.dev.yml down
+
+dev-logs: ## Show logs from local dev infrastructure
+	@docker compose -f docker-compose.dev.yml logs -f
+
+dev-reset: ## Reset local dev infrastructure (destroy volumes)
+	@docker compose -f docker-compose.dev.yml down -v
+	@echo "Volumes destroyed. Run 'make dev-up' to recreate."
+
+# ── Information ─────────────────────────────────────────────────────────────
+
+services: ## List all services in the monorepo
+	@echo "Go services:"
+	@for dir in bin-*/; do \
+		svc=$$(basename "$$dir"); \
+		if [ -f "$$dir/go.mod" ]; then \
+			echo "  $$svc"; \
+		fi; \
+	done
+	@echo ""
+	@echo "Other:"
+	@for dir in voip-*/; do \
+		echo "  $$(basename $$dir)"; \
+	done
+
+# ── Cleanup ─────────────────────────────────────────────────────────────────
+
+clean: _require-service ## Clean build artifacts and test cache for SERVICE
+	@echo "Cleaning $(SERVICE)..."
+	@cd $(SERVICE) && go clean -testcache -cache
+
+clean-all: ## Clean test cache for ALL services
+	@echo "Cleaning all services..."
+	@for dir in bin-*/; do \
+		if [ -f "$$dir/go.mod" ]; then \
+			(cd "$$dir" && go clean -testcache) 2>/dev/null; \
+		fi; \
+	done
+	@echo "Done."
+
+# ── Internal ────────────────────────────────────────────────────────────────
+
+_require-service:
+ifndef SERVICE
+	$(error SERVICE is required. Usage: make <target> SERVICE=bin-xxx-manager)
+endif
+	@if [ ! -d "$(SERVICE)" ]; then \
+		echo "Error: $(SERVICE) directory not found"; \
+		exit 1; \
+	fi

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,77 @@
+# Local development infrastructure for VoIPBin monorepo.
+#
+# Usage:
+#   make dev-up          Start all services
+#   make dev-down        Stop all services
+#   make dev-reset       Stop and destroy volumes
+#
+# Or directly:
+#   docker compose -f docker-compose.dev.yml up -d
+#
+# Connection details:
+#   MySQL:    localhost:3306  user=voipbin  password=voipbin  db=voipbin
+#   Redis:    localhost:6379  password=voipbin
+#   RabbitMQ: localhost:5672  user=guest    password=guest
+#   RabbitMQ: localhost:15672 (management UI)
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: voipbin-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: voipbin
+      MYSQL_USER: voipbin
+      MYSQL_PASSWORD: voipbin
+    ports:
+      - "3306:3306"
+    volumes:
+      - voipbin-mysql-data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-authentication-plugin=mysql_native_password
+      - --max-connections=200
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: redis:7-alpine
+    container_name: voipbin-redis
+    command: redis-server --requirepass voipbin --maxmemory 256mb --maxmemory-policy allkeys-lru
+    ports:
+      - "6379:6379"
+    volumes:
+      - voipbin-redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "voipbin", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:3.12-management
+    container_name: voipbin-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - voipbin-rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  voipbin-mysql-data:
+  voipbin-redis-data:
+  voipbin-rabbitmq-data:

--- a/docs/plans/2026-04-10-developer-operations-toolkit-design.md
+++ b/docs/plans/2026-04-10-developer-operations-toolkit-design.md
@@ -1,0 +1,110 @@
+# Developer Operations Toolkit Design
+
+**Date:** 2026-04-10
+**Status:** Approved
+**Author:** AI-assisted
+
+## Problem
+
+Developers working in the voipbin monorepo face significant daily friction:
+
+1. **Manual 5-step verification** must be run before every commit:
+   `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`
+   This takes 5-10 minutes per run and is easy to forget steps.
+
+2. **The `go clean -testcache` footgun**: After any `bin-common-handler` change, cached test results mask failures. This is documented as the #1 cause of CI failures.
+
+3. **Cascading common-handler updates** require running the full verification across all 30+ services manually, with no automation or parallelism.
+
+4. **No local dev environment**: No docker-compose file to spin up MySQL, Redis, and RabbitMQ for local development or testing.
+
+5. **No prerequisites checker**: Developers must manually verify they have the right Go version, golangci-lint, and other tools installed.
+
+## Solution
+
+A developer operations toolkit consisting of:
+
+- **Root `Makefile`**: Unified entry point for all common operations
+- **`scripts/verify.sh`**: Automated 5-step verification with proper cache clearing
+- **`scripts/update-common.sh`**: Cascading bin-common-handler updates across all services
+- **`docker-compose.dev.yml`**: Local development infrastructure
+- **`scripts/doctor.sh`**: Environment prerequisites checker
+
+## Components
+
+### Makefile
+
+Provides these targets:
+- `make verify SERVICE=<name>` - Full 5-step verification for one service
+- `make verify-all` - Verify all Go services in parallel
+- `make verify-common` - Special workflow for common-handler changes
+- `make test SERVICE=<name>` - Run tests with cache clearing
+- `make lint SERVICE=<name>` - Run linting only
+- `make generate SERVICE=<name>` - Run code generation only
+- `make build SERVICE=<name>` - Build the service binary
+- `make dev-up` / `make dev-down` - Start/stop local infrastructure
+- `make doctor` - Check prerequisites
+- `make services` - List all services
+
+### scripts/verify.sh
+
+Core verification engine that:
+- Runs all 5 steps in correct order
+- Always clears test cache (prevents the #1 footgun)
+- Supports single service or all-services mode
+- Reports timing and pass/fail per step
+- Returns non-zero exit code on any failure
+
+### scripts/update-common.sh
+
+Common handler cascade updater that:
+- First verifies bin-common-handler itself
+- Then runs full verification across all dependent services
+- Supports parallel execution with configurable concurrency
+- Produces a summary report of pass/fail per service
+
+### docker-compose.dev.yml
+
+Local dev infrastructure:
+- MySQL 8.0 on port 3306 (matching service config defaults)
+- Redis 7 on port 6379 with password
+- RabbitMQ 3.12 on ports 5672 (AMQP) and 15672 (management UI)
+
+### scripts/doctor.sh
+
+Prerequisites checker that verifies:
+- Go version (1.25+)
+- golangci-lint installed
+- Docker and Docker Compose available
+- mockgen installed
+- Required CLI tools present
+
+## Design Decisions
+
+1. **Shell scripts over Go CLI**: The toolkit is shell-based because it orchestrates existing Go tooling. A Go CLI would add a build step and dependency management overhead for simple orchestration.
+
+2. **Makefile as entry point**: Make is universally available, self-documenting (via `make help`), and familiar to Go developers.
+
+3. **Parallel execution**: `update-common.sh` uses `xargs -P` for parallel service verification, significantly reducing wall-clock time.
+
+4. **Docker Compose for dev**: Provides consistent, reproducible local infrastructure without requiring manual setup of MySQL, Redis, and RabbitMQ.
+
+## File Layout
+
+```
+monorepo/
+├── Makefile
+├── docker-compose.dev.yml
+└── scripts/
+    ├── verify.sh
+    ├── update-common.sh
+    └── doctor.sh
+```
+
+## Success Criteria
+
+- `make doctor` validates development environment
+- `make verify SERVICE=bin-agent-manager` completes the full 5-step verification automatically
+- `make verify-common` detects failures across all services after a common-handler change
+- `make dev-up` starts MySQL, Redis, RabbitMQ for local development
+- All scripts have `--help` flags and clear error messages

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# doctor.sh - Check development environment prerequisites
+#
+# Usage: ./scripts/doctor.sh
+#
+# Verifies that all required tools are installed and at acceptable versions.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+pass_count=0
+warn_count=0
+fail_count=0
+
+pass() {
+    echo -e "  ${GREEN}✓${NC} $1"
+    pass_count=$((pass_count + 1))
+}
+
+warn() {
+    echo -e "  ${YELLOW}!${NC} $1"
+    warn_count=$((warn_count + 1))
+}
+
+fail() {
+    echo -e "  ${RED}✗${NC} $1"
+    fail_count=$((fail_count + 1))
+}
+
+header() {
+    echo -e "\n${BOLD}$1${NC}"
+}
+
+# ── Go ──────────────────────────────────────────────────────────────────────
+header "Go Toolchain"
+
+if command -v go &>/dev/null; then
+    go_version=$(go version | grep -oP 'go\K[0-9]+\.[0-9]+(\.[0-9]+)?')
+    go_major=$(echo "$go_version" | cut -d. -f1)
+    go_minor=$(echo "$go_version" | cut -d. -f2)
+    if [[ "$go_major" -ge 1 && "$go_minor" -ge 23 ]]; then
+        pass "go $go_version"
+    else
+        warn "go $go_version (recommend 1.23+)"
+    fi
+else
+    fail "go not found (install from https://go.dev/dl/)"
+fi
+
+if command -v mockgen &>/dev/null; then
+    pass "mockgen $(mockgen --version 2>&1 | head -1 || echo 'installed')"
+else
+    warn "mockgen not found (install: go install go.uber.org/mock/mockgen@latest)"
+fi
+
+# ── Linting ─────────────────────────────────────────────────────────────────
+header "Linting"
+
+if command -v golangci-lint &>/dev/null; then
+    lint_version=$(golangci-lint version --format short 2>/dev/null || echo "unknown")
+    pass "golangci-lint $lint_version"
+else
+    fail "golangci-lint not found (install: https://golangci-lint.run/welcome/install/)"
+fi
+
+# ── Containers ──────────────────────────────────────────────────────────────
+header "Containers"
+
+if command -v docker &>/dev/null; then
+    docker_version=$(docker version --format '{{.Client.Version}}' 2>/dev/null || echo "unknown")
+    pass "docker $docker_version"
+else
+    warn "docker not found (needed for make dev-up)"
+fi
+
+if docker compose version &>/dev/null 2>&1; then
+    compose_version=$(docker compose version --short 2>/dev/null || echo "unknown")
+    pass "docker compose $compose_version"
+elif command -v docker-compose &>/dev/null; then
+    compose_version=$(docker-compose version --short 2>/dev/null || echo "unknown")
+    pass "docker-compose (legacy) $compose_version"
+else
+    warn "docker compose not found (needed for make dev-up)"
+fi
+
+# ── Database Tools ──────────────────────────────────────────────────────────
+header "Database Tools"
+
+if command -v mysql &>/dev/null; then
+    mysql_version=$(mysql --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+    pass "mysql client $mysql_version"
+else
+    warn "mysql client not found (optional, for direct DB access)"
+fi
+
+if command -v alembic &>/dev/null; then
+    pass "alembic $(alembic --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo 'installed')"
+else
+    warn "alembic not found (optional, for schema migrations)"
+fi
+
+# ── Git ─────────────────────────────────────────────────────────────────────
+header "Git"
+
+if command -v git &>/dev/null; then
+    git_version=$(git version | grep -oP '[0-9]+\.[0-9]+\.[0-9]+')
+    pass "git $git_version"
+else
+    fail "git not found"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Summary${NC}"
+echo -e "  ${GREEN}${pass_count} passed${NC}  ${YELLOW}${warn_count} warnings${NC}  ${RED}${fail_count} failed${NC}"
+
+if [[ "$fail_count" -gt 0 ]]; then
+    echo -e "\n${RED}Fix the failures above before developing.${NC}"
+    exit 1
+elif [[ "$warn_count" -gt 0 ]]; then
+    echo -e "\n${YELLOW}Warnings are optional but recommended.${NC}"
+    exit 0
+else
+    echo -e "\n${GREEN}Environment is ready.${NC}"
+    exit 0
+fi

--- a/scripts/update-common.sh
+++ b/scripts/update-common.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# update-common.sh - Update bin-common-handler across all dependent services
+#
+# Usage:
+#   ./scripts/update-common.sh                  # Verify common, then update all
+#   ./scripts/update-common.sh --parallel 4     # Update 4 services at a time
+#   ./scripts/update-common.sh --skip-lint      # Skip linting (faster)
+#   ./scripts/update-common.sh --update-only    # Skip common-handler verification
+#
+# This script automates the most error-prone workflow in the monorepo:
+# after changing bin-common-handler, every dependent service must run
+# go mod tidy && go mod vendor && go generate && go clean -testcache && go test
+#
+# IMPORTANT: Always clears the test cache to prevent false passes.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PARALLEL=1
+SKIP_LINT=false
+UPDATE_ONLY=false
+
+usage() {
+    echo "Usage: $(basename "$0") [options]"
+    echo ""
+    echo "Options:"
+    echo "  --parallel N       Update N services in parallel (default: 1)"
+    echo "  --skip-lint        Skip golangci-lint step"
+    echo "  --update-only      Skip bin-common-handler verification"
+    echo "  -h, --help         Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  $(basename "$0")                      # Full workflow, sequential"
+    echo "  $(basename "$0") --parallel 4          # 4 services at a time"
+    echo "  $(basename "$0") --skip-lint           # Faster, no linting"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --parallel)
+            PARALLEL="${2:?--parallel requires a number}"
+            shift 2
+            ;;
+        --skip-lint)
+            SKIP_LINT=true
+            shift
+            ;;
+        --update-only)
+            UPDATE_ONLY=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Step 1: Verify bin-common-handler ───────────────────────────────────────
+
+if [[ "$UPDATE_ONLY" == "false" ]]; then
+    echo -e "${BOLD}Step 1: Verify bin-common-handler${NC}"
+    lint_flag=""
+    if [[ "$SKIP_LINT" == "true" ]]; then lint_flag="--skip-lint"; fi
+
+    if ! "$SCRIPT_DIR/verify.sh" $lint_flag bin-common-handler; then
+        echo -e "\n${RED}bin-common-handler verification failed. Fix errors before updating services.${NC}"
+        exit 1
+    fi
+    echo -e "\n${GREEN}bin-common-handler verified successfully.${NC}\n"
+else
+    echo -e "${YELLOW}Skipping bin-common-handler verification (--update-only).${NC}\n"
+fi
+
+# ── Step 2: Collect dependent services ──────────────────────────────────────
+
+echo -e "${BOLD}Step 2: Collecting dependent services${NC}"
+
+services=()
+for dir in "$REPO_ROOT"/bin-*/; do
+    svc=$(basename "$dir")
+    # Skip common-handler itself and services without go.mod
+    if [[ "$svc" == "bin-common-handler" ]]; then continue; fi
+    if [[ ! -f "$dir/go.mod" ]]; then continue; fi
+    services+=("$svc")
+done
+
+echo -e "Found ${#services[@]} dependent services\n"
+
+# ── Step 3: Update and verify all services ──────────────────────────────────
+
+echo -e "${BOLD}Step 3: Updating all services (parallel=$PARALLEL)${NC}\n"
+
+update_service() {
+    local svc="$1"
+    local svc_path="$REPO_ROOT/$svc"
+    local start
+    start=$(date +%s)
+
+    cd "$svc_path"
+
+    # Run update steps
+    local failed=false
+
+    echo -e "  ${DIM}[$svc]${NC} go mod tidy..."
+    if ! go mod tidy > /tmp/update_common_${svc}_$$ 2>&1; then
+        echo -e "  ${RED}✗ $svc: go mod tidy failed${NC}"
+        tail -5 /tmp/update_common_${svc}_$$ | sed 's/^/    /'
+        rm -f /tmp/update_common_${svc}_$$
+        return 1
+    fi
+
+    echo -e "  ${DIM}[$svc]${NC} go mod vendor..."
+    if ! go mod vendor >> /tmp/update_common_${svc}_$$ 2>&1; then
+        echo -e "  ${RED}✗ $svc: go mod vendor failed${NC}"
+        tail -5 /tmp/update_common_${svc}_$$ | sed 's/^/    /'
+        rm -f /tmp/update_common_${svc}_$$
+        return 1
+    fi
+
+    echo -e "  ${DIM}[$svc]${NC} go generate..."
+    if ! go generate ./... >> /tmp/update_common_${svc}_$$ 2>&1; then
+        echo -e "  ${RED}✗ $svc: go generate failed${NC}"
+        tail -5 /tmp/update_common_${svc}_$$ | sed 's/^/    /'
+        rm -f /tmp/update_common_${svc}_$$
+        return 1
+    fi
+
+    echo -e "  ${DIM}[$svc]${NC} go clean -testcache && go test..."
+    go clean -testcache 2>/dev/null
+    if ! go test ./... >> /tmp/update_common_${svc}_$$ 2>&1; then
+        echo -e "  ${RED}✗ $svc: go test failed${NC}"
+        tail -10 /tmp/update_common_${svc}_$$ | sed 's/^/    /'
+        rm -f /tmp/update_common_${svc}_$$
+        return 1
+    fi
+
+    if [[ "$SKIP_LINT" == "false" ]]; then
+        echo -e "  ${DIM}[$svc]${NC} golangci-lint..."
+        if ! golangci-lint run -v --timeout 5m >> /tmp/update_common_${svc}_$$ 2>&1; then
+            echo -e "  ${RED}✗ $svc: golangci-lint failed${NC}"
+            tail -10 /tmp/update_common_${svc}_$$ | sed 's/^/    /'
+            rm -f /tmp/update_common_${svc}_$$
+            return 1
+        fi
+    fi
+
+    local elapsed=$(( $(date +%s) - start ))
+    echo -e "  ${GREEN}✓ $svc${NC} ${DIM}(${elapsed}s)${NC}"
+    rm -f /tmp/update_common_${svc}_$$
+    return 0
+}
+
+if [[ "$PARALLEL" -gt 1 ]]; then
+    # Parallel mode
+    results_dir=$(mktemp -d)
+    trap 'rm -rf "$results_dir"' EXIT
+
+    printf '%s\n' "${services[@]}" | xargs -I{} -P "$PARALLEL" bash -c '
+        svc="$1"
+        results_dir="$2"
+        script_dir="$3"
+        skip_lint="$4"
+        repo_root="$5"
+        svc_path="$repo_root/$svc"
+
+        cd "$svc_path"
+        output=""
+        failed=false
+
+        go mod tidy 2>&1 || failed=true
+        if [[ "$failed" == "false" ]]; then go mod vendor 2>&1 || failed=true; fi
+        if [[ "$failed" == "false" ]]; then go generate ./... 2>&1 || failed=true; fi
+        if [[ "$failed" == "false" ]]; then
+            go clean -testcache 2>/dev/null
+            go test ./... 2>&1 || failed=true
+        fi
+        if [[ "$failed" == "false" && "$skip_lint" == "false" ]]; then
+            golangci-lint run -v --timeout 5m 2>&1 || failed=true
+        fi
+
+        if [[ "$failed" == "true" ]]; then
+            echo "FAIL" > "$results_dir/$svc"
+        else
+            echo "PASS" > "$results_dir/$svc"
+        fi
+    ' _ {} "$results_dir" "$SCRIPT_DIR" "$SKIP_LINT" "$REPO_ROOT"
+
+    # Collect results
+    pass_count=0
+    fail_count=0
+    failed_services=()
+
+    echo -e "\n${BOLD}Results${NC}"
+    for svc in "${services[@]}"; do
+        if [[ -f "$results_dir/$svc" && "$(cat "$results_dir/$svc")" == "PASS" ]]; then
+            echo -e "  ${GREEN}✓${NC} $svc"
+            pass_count=$((pass_count + 1))
+        else
+            echo -e "  ${RED}✗${NC} $svc"
+            fail_count=$((fail_count + 1))
+            failed_services+=("$svc")
+        fi
+    done
+else
+    # Sequential mode
+    pass_count=0
+    fail_count=0
+    failed_services=()
+
+    for svc in "${services[@]}"; do
+        if update_service "$svc"; then
+            pass_count=$((pass_count + 1))
+        else
+            fail_count=$((fail_count + 1))
+            failed_services+=("$svc")
+        fi
+    done
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo -e "\n${BOLD}══════════════════════════════════════${NC}"
+echo -e "${BOLD}Common Handler Update Summary${NC}"
+echo -e "${BOLD}══════════════════════════════════════${NC}"
+echo -e "  ${GREEN}$pass_count passed${NC}"
+echo -e "  ${RED}$fail_count failed${NC}"
+
+if [[ "$fail_count" -gt 0 ]]; then
+    echo -e "\n${RED}Failed services:${NC}"
+    printf '  - %s\n' "${failed_services[@]}"
+    echo -e "\n${YELLOW}Run manually to see full errors:${NC}"
+    echo -e "  ./scripts/verify.sh <service-name>"
+    exit 1
+else
+    echo -e "\n${GREEN}All services updated and verified successfully.${NC}"
+    exit 0
+fi

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# verify.sh - Run the mandatory 5-step verification workflow for a service
+#
+# Usage:
+#   ./scripts/verify.sh <service-dir>           # Verify one service
+#   ./scripts/verify.sh --all                    # Verify all Go services
+#   ./scripts/verify.sh --all --parallel 4       # Verify all, 4 at a time
+#
+# Steps (in order):
+#   1. go mod tidy
+#   2. go mod vendor
+#   3. go generate ./...
+#   4. go clean -testcache && go test ./...
+#   5. golangci-lint run -v --timeout 5m
+#
+# The test cache is ALWAYS cleared before testing. This prevents the #1 cause
+# of false-passing tests after bin-common-handler changes.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+DIM='\033[2m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PARALLEL=1
+MODE="single"
+SERVICE=""
+SKIP_LINT=false
+
+usage() {
+    echo "Usage: $(basename "$0") [options] <service-dir>"
+    echo ""
+    echo "Options:"
+    echo "  --all              Verify all Go services"
+    echo "  --parallel N       Run N services in parallel (default: 1)"
+    echo "  --skip-lint        Skip golangci-lint step"
+    echo "  -h, --help         Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  $(basename "$0") bin-agent-manager"
+    echo "  $(basename "$0") --all --parallel 4"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --all)
+            MODE="all"
+            shift
+            ;;
+        --parallel)
+            PARALLEL="${2:?--parallel requires a number}"
+            shift 2
+            ;;
+        --skip-lint)
+            SKIP_LINT=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            SERVICE="$1"
+            shift
+            ;;
+    esac
+done
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+step() {
+    local step_num="$1"
+    local label="$2"
+    shift 2
+    local start
+    start=$(date +%s)
+
+    echo -e "  ${DIM}[$step_num/5]${NC} $label..."
+    if "$@" > /tmp/verify_step_output_$$ 2>&1; then
+        local elapsed=$(( $(date +%s) - start ))
+        echo -e "  ${GREEN}✓${NC} $label ${DIM}(${elapsed}s)${NC}"
+        rm -f /tmp/verify_step_output_$$
+        return 0
+    else
+        local elapsed=$(( $(date +%s) - start ))
+        echo -e "  ${RED}✗${NC} $label ${DIM}(${elapsed}s)${NC}"
+        echo -e "  ${RED}Output:${NC}"
+        sed 's/^/    /' /tmp/verify_step_output_$$ | tail -30
+        rm -f /tmp/verify_step_output_$$
+        return 1
+    fi
+}
+
+verify_service() {
+    local svc_dir="$1"
+    local svc_path="$REPO_ROOT/$svc_dir"
+
+    if [[ ! -f "$svc_path/go.mod" ]]; then
+        echo -e "${YELLOW}Skipping $svc_dir (no go.mod)${NC}"
+        return 0
+    fi
+
+    echo -e "\n${BOLD}Verifying: $svc_dir${NC}"
+    local start
+    start=$(date +%s)
+    local failed=false
+
+    cd "$svc_path"
+
+    step 1 "go mod tidy"     go mod tidy     || failed=true
+    if [[ "$failed" == "false" ]]; then
+        step 2 "go mod vendor"   go mod vendor   || failed=true
+    fi
+    if [[ "$failed" == "false" ]]; then
+        step 3 "go generate"     go generate ./... || failed=true
+    fi
+    if [[ "$failed" == "false" ]]; then
+        go clean -testcache 2>/dev/null
+        step 4 "go test"         go test ./...   || failed=true
+    fi
+    if [[ "$failed" == "false" && "$SKIP_LINT" == "false" ]]; then
+        step 5 "golangci-lint"   golangci-lint run -v --timeout 5m || failed=true
+    elif [[ "$SKIP_LINT" == "true" ]]; then
+        echo -e "  ${DIM}[5/5]${NC} golangci-lint ${YELLOW}(skipped)${NC}"
+    fi
+
+    local elapsed=$(( $(date +%s) - start ))
+
+    if [[ "$failed" == "true" ]]; then
+        echo -e "${RED}FAIL${NC} $svc_dir ${DIM}(${elapsed}s total)${NC}"
+        return 1
+    else
+        echo -e "${GREEN}PASS${NC} $svc_dir ${DIM}(${elapsed}s total)${NC}"
+        return 0
+    fi
+}
+
+# ── Single service mode ─────────────────────────────────────────────────────
+
+if [[ "$MODE" == "single" ]]; then
+    if [[ -z "$SERVICE" ]]; then
+        echo "Error: specify a service directory or use --all" >&2
+        usage >&2
+        exit 1
+    fi
+    verify_service "$SERVICE"
+    exit $?
+fi
+
+# ── All services mode ───────────────────────────────────────────────────────
+
+echo -e "${BOLD}Verifying all Go services (parallel=$PARALLEL)${NC}"
+
+# Collect all services with go.mod
+services=()
+for dir in "$REPO_ROOT"/bin-*/; do
+    svc=$(basename "$dir")
+    if [[ -f "$dir/go.mod" ]]; then
+        services+=("$svc")
+    fi
+done
+
+echo -e "Found ${#services[@]} Go services\n"
+
+if [[ "$PARALLEL" -gt 1 ]]; then
+    # Parallel mode: run verify.sh for each service in subprocesses
+    results_dir=$(mktemp -d)
+    trap 'rm -rf "$results_dir"' EXIT
+
+    printf '%s\n' "${services[@]}" | xargs -I{} -P "$PARALLEL" bash -c '
+        svc="$1"
+        results_dir="$2"
+        script="$3"
+        skip_lint="$4"
+        lint_flag=""
+        if [[ "$skip_lint" == "true" ]]; then lint_flag="--skip-lint"; fi
+        if "$script" $lint_flag "$svc" >/dev/null 2>&1; then
+            echo "PASS" > "$results_dir/$svc"
+        else
+            echo "FAIL" > "$results_dir/$svc"
+        fi
+    ' _ {} "$results_dir" "$SCRIPT_DIR/verify.sh" "$SKIP_LINT"
+
+    # Collect results
+    pass_count=0
+    fail_count=0
+    failed_services=()
+
+    echo -e "\n${BOLD}Results${NC}"
+    for svc in "${services[@]}"; do
+        result_file="$results_dir/$svc"
+        if [[ -f "$result_file" && "$(cat "$result_file")" == "PASS" ]]; then
+            echo -e "  ${GREEN}✓${NC} $svc"
+            pass_count=$((pass_count + 1))
+        else
+            echo -e "  ${RED}✗${NC} $svc"
+            fail_count=$((fail_count + 1))
+            failed_services+=("$svc")
+        fi
+    done
+
+    echo -e "\n${BOLD}Summary${NC}: ${GREEN}$pass_count passed${NC}, ${RED}$fail_count failed${NC}"
+    if [[ "$fail_count" -gt 0 ]]; then
+        echo -e "${RED}Failed services:${NC}"
+        printf '  %s\n' "${failed_services[@]}"
+        exit 1
+    fi
+else
+    # Sequential mode: run inline with full output
+    pass_count=0
+    fail_count=0
+    failed_services=()
+
+    for svc in "${services[@]}"; do
+        if verify_service "$svc"; then
+            pass_count=$((pass_count + 1))
+        else
+            fail_count=$((fail_count + 1))
+            failed_services+=("$svc")
+        fi
+    done
+
+    echo -e "\n${BOLD}Summary${NC}: ${GREEN}$pass_count passed${NC}, ${RED}$fail_count failed${NC}"
+    if [[ "$fail_count" -gt 0 ]]; then
+        echo -e "${RED}Failed services:${NC}"
+        printf '  %s\n' "${failed_services[@]}"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Add developer operations toolkit to automate the most painful daily workflow
in the monorepo: the mandatory 5-step verification and cascading common-handler
updates across 30+ services.

- docs: Add design document with rationale and component descriptions
- scripts: Add verify.sh — automated 5-step verification (tidy, vendor, generate, test, lint) with automatic test cache clearing
- scripts: Add update-common.sh — cascading bin-common-handler updates across all dependent services with parallel execution support
- scripts: Add doctor.sh — development environment prerequisites checker (Go, golangci-lint, Docker, mockgen, etc.)
- Add root Makefile with unified targets: verify, verify-all, verify-common, test, lint, generate, build, dev-up/down, doctor, services
- Add docker-compose.dev.yml for local development infrastructure (MySQL 8.0, Redis 7, RabbitMQ 3.12 with management UI)