### PR TITLE
NOJIRA-fix-provider-webhook-message

### DIFF
--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -658,10 +658,10 @@ type ServiceHandler interface {
 		techHeaders map[string]string,
 		name string,
 		detail string,
-	) (*rmprovider.Provider, error)
-	ProviderDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmprovider.Provider, error)
-	ProviderGet(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID) (*rmprovider.Provider, error)
-	ProviderList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*rmprovider.Provider, error)
+	) (*rmprovider.WebhookMessage, error)
+	ProviderDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmprovider.WebhookMessage, error)
+	ProviderGet(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID) (*rmprovider.WebhookMessage, error)
+	ProviderList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*rmprovider.WebhookMessage, error)
 	ProviderUpdate(
 		ctx context.Context,
 		a *auth.AuthIdentity,
@@ -673,7 +673,7 @@ type ServiceHandler interface {
 		techHeaders map[string]string,
 		name string,
 		detail string,
-	) (*rmprovider.Provider, error)
+	) (*rmprovider.WebhookMessage, error)
 
 	// queue handlers
 	QueueGet(ctx context.Context, a *auth.AuthIdentity, queueID uuid.UUID) (*qmqueue.WebhookMessage, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -3074,10 +3074,10 @@ func (mr *MockServiceHandlerMockRecorder) OutplanUpdateDialInfo(ctx, a, id, sour
 }
 
 // ProviderCreate mocks base method.
-func (m *MockServiceHandler) ProviderCreate(ctx context.Context, a *auth.AuthIdentity, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.Provider, error) {
+func (m *MockServiceHandler) ProviderCreate(ctx context.Context, a *auth.AuthIdentity, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.WebhookMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderCreate", ctx, a, providerType, hostname, techPrefix, techPostfix, techHeaders, name, detail)
-	ret0, _ := ret[0].(*provider.Provider)
+	ret0, _ := ret[0].(*provider.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3089,10 +3089,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderCreate(ctx, a, providerType, h
 }
 
 // ProviderDelete mocks base method.
-func (m *MockServiceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*provider.Provider, error) {
+func (m *MockServiceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*provider.WebhookMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderDelete", ctx, a, id)
-	ret0, _ := ret[0].(*provider.Provider)
+	ret0, _ := ret[0].(*provider.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3104,10 +3104,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderDelete(ctx, a, id any) *gomock
 }
 
 // ProviderGet mocks base method.
-func (m *MockServiceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID) (*provider.Provider, error) {
+func (m *MockServiceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID) (*provider.WebhookMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderGet", ctx, a, providerID)
-	ret0, _ := ret[0].(*provider.Provider)
+	ret0, _ := ret[0].(*provider.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3119,10 +3119,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderGet(ctx, a, providerID any) *g
 }
 
 // ProviderList mocks base method.
-func (m *MockServiceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*provider.Provider, error) {
+func (m *MockServiceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*provider.WebhookMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderList", ctx, a, size, token)
-	ret0, _ := ret[0].([]*provider.Provider)
+	ret0, _ := ret[0].([]*provider.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3134,10 +3134,10 @@ func (mr *MockServiceHandlerMockRecorder) ProviderList(ctx, a, size, token any) 
 }
 
 // ProviderUpdate mocks base method.
-func (m *MockServiceHandler) ProviderUpdate(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.Provider, error) {
+func (m *MockServiceHandler) ProviderUpdate(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID, providerType provider.Type, hostname, techPrefix, techPostfix string, techHeaders map[string]string, name, detail string) (*provider.WebhookMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProviderUpdate", ctx, a, providerID, providerType, hostname, techPrefix, techPostfix, techHeaders, name, detail)
-	ret0, _ := ret[0].(*provider.Provider)
+	ret0, _ := ret[0].(*provider.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/bin-api-manager/pkg/servicehandler/provider.go
+++ b/bin-api-manager/pkg/servicehandler/provider.go
@@ -26,7 +26,7 @@ func (h *serviceHandler) providerGet(ctx context.Context, id uuid.UUID) (*rmprov
 		log.Errorf("Could not get the provider info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("queue", res).Debug("Received result.")
+	log.WithField("provider", res).Debug("Received result.")
 
 	// create result
 	return res, nil
@@ -34,7 +34,7 @@ func (h *serviceHandler) providerGet(ctx context.Context, id uuid.UUID) (*rmprov
 
 // ProviderGet sends a request to route-manager
 // to getting the provider.
-func (h *serviceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID) (*rmprovider.Provider, error) {
+func (h *serviceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, providerID uuid.UUID) (*rmprovider.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderGet",
 		"customer_id": a.CustomerID,
@@ -57,15 +57,15 @@ func (h *serviceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, 
 		return nil, fmt.Errorf("agent has no permission")
 	}
 
-	return tmp, nil
+	return tmp.ConvertWebhookMessage(), nil
 }
 
-// ProviderGets sends a request to route-manager
+// ProviderList sends a request to route-manager
 // to getting a list of providers.
 // it returns providers info if it succeed.
-func (h *serviceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*rmprovider.Provider, error) {
+func (h *serviceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*rmprovider.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
-		"func":        "ProviderGets",
+		"func":        "ProviderList",
 		"customer_id": a.CustomerID,
 		"username":    a.DisplayName(),
 		"size":        size,
@@ -89,13 +89,13 @@ func (h *serviceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity,
 
 	tmps, err := h.reqHandler.RouteV1ProviderList(ctx, token, size)
 	if err != nil {
-		log.Errorf("Could not get queues from the route-manager. err: %v", err)
+		log.Errorf("Could not get providers from the route-manager. err: %v", err)
 		return nil, err
 	}
 
-	res := make([]*rmprovider.Provider, len(tmps))
+	res := make([]*rmprovider.WebhookMessage, len(tmps))
 	for i := range tmps {
-		res[i] = &tmps[i]
+		res[i] = tmps[i].ConvertWebhookMessage()
 	}
 
 	return res, nil
@@ -112,7 +112,7 @@ func (h *serviceHandler) ProviderCreate(
 	techHeaders map[string]string,
 	name string,
 	detail string,
-) (*rmprovider.Provider, error) {
+) (*rmprovider.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderCreate",
 		"customer_id": a.CustomerID,
@@ -141,15 +141,15 @@ func (h *serviceHandler) ProviderCreate(
 		detail,
 	)
 	if err != nil {
-		log.Errorf("Could not create a new flow. err: %v", err)
+		log.Errorf("Could not create a new provider. err: %v", err)
 		return nil, err
 	}
 
-	return tmp, nil
+	return tmp.ConvertWebhookMessage(), nil
 }
 
 // ProviderDelete deletes the provider.
-func (h *serviceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmprovider.Provider, error) {
+func (h *serviceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmprovider.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderDelete",
 		"customer_id": a.CustomerID,
@@ -160,7 +160,7 @@ func (h *serviceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentit
 		return nil, fmt.Errorf("direct access not supported")
 	}
 
-	log.Debug("Deleting a outplan.")
+	log.Debug("Deleting a provider.")
 
 	// permission check
 	// only project admin allowed
@@ -182,11 +182,11 @@ func (h *serviceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentit
 		return nil, err
 	}
 
-	return tmp, nil
+	return tmp.ConvertWebhookMessage(), nil
 }
 
 // ProviderUpdate sends a request to route-manager
-// to updating the route.
+// to updating the provider.
 // it returns error if it failed.
 func (h *serviceHandler) ProviderUpdate(
 	ctx context.Context,
@@ -199,7 +199,7 @@ func (h *serviceHandler) ProviderUpdate(
 	techHeaders map[string]string,
 	name string,
 	detail string,
-) (*rmprovider.Provider, error) {
+) (*rmprovider.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ProviderUpdate",
 		"customer_id": a.CustomerID,
@@ -233,10 +233,10 @@ func (h *serviceHandler) ProviderUpdate(
 		detail,
 	)
 	if err != nil {
-		log.Errorf("Could not update the queue. err: %v", err)
+		log.Errorf("Could not update the provider. err: %v", err)
 		return nil, err
 	}
-	log.WithField("queue", tmp).Debugf("Updated queue. queue_id: %s", tmp.ID)
+	log.WithField("provider", tmp).Debugf("Updated provider. provider_id: %s", tmp.ID)
 
-	return tmp, nil
+	return tmp.ConvertWebhookMessage(), nil
 }

--- a/bin-api-manager/pkg/servicehandler/provider_test.go
+++ b/bin-api-manager/pkg/servicehandler/provider_test.go
@@ -29,7 +29,7 @@ func Test_ProviderGet(t *testing.T) {
 		id    uuid.UUID
 
 		response  *rmprovider.Provider
-		expectRes *rmprovider.Provider
+		expectRes *rmprovider.WebhookMessage
 	}
 
 	tests := []test{
@@ -48,7 +48,7 @@ func Test_ProviderGet(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("0c6f3dd3-929e-4d3b-8231-5e8c10db6c21"),
 			},
-			&rmprovider.Provider{
+			&rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("0c6f3dd3-929e-4d3b-8231-5e8c10db6c21"),
 			},
 		},
@@ -88,12 +88,12 @@ func Test_ProviderList(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 
 		responseProviders []rmprovider.Provider
-		expectRes         []*rmprovider.Provider
+		expectRes         []*rmprovider.WebhookMessage
 	}
 
 	tests := []test{
@@ -115,7 +115,7 @@ func Test_ProviderList(t *testing.T) {
 					ID: uuid.FromStringOrNil("d9603c2b-643c-43f2-9d58-71733785d45b"),
 				},
 			},
-			[]*rmprovider.Provider{
+			[]*rmprovider.WebhookMessage{
 				{
 					ID: uuid.FromStringOrNil("d9603c2b-643c-43f2-9d58-71733785d45b"),
 				},
@@ -156,7 +156,7 @@ func Test_ProviderCreate(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent        *auth.AuthIdentity
 		providerType rmprovider.Type
 		hostname     string
 		techPrefix   string
@@ -166,7 +166,7 @@ func Test_ProviderCreate(t *testing.T) {
 		detail       string
 
 		response  *rmprovider.Provider
-		expectRes *rmprovider.Provider
+		expectRes *rmprovider.WebhookMessage
 	}
 
 	tests := []test{
@@ -194,7 +194,7 @@ func Test_ProviderCreate(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("c26e8f5b-5d5b-4618-a386-e633773f538e"),
 			},
-			&rmprovider.Provider{
+			&rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("c26e8f5b-5d5b-4618-a386-e633773f538e"),
 			},
 		},
@@ -253,11 +253,11 @@ func Test_ProviderDelete(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		providerID uuid.UUID
 
 		responseProvider *rmprovider.Provider
-		expectRes        *rmprovider.Provider
+		expectRes        *rmprovider.WebhookMessage
 	}
 
 	tests := []test{
@@ -276,7 +276,7 @@ func Test_ProviderDelete(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("3b889381-8944-49fa-8220-1a3b8b4d0894"),
 			},
-			&rmprovider.Provider{
+			&rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("3b889381-8944-49fa-8220-1a3b8b4d0894"),
 			},
 		},
@@ -329,7 +329,7 @@ func Test_ProviderUpdate(t *testing.T) {
 		detail       string
 
 		responseProvider *rmprovider.Provider
-		expectRes        *rmprovider.Provider
+		expectRes        *rmprovider.WebhookMessage
 	}
 
 	tests := []test{
@@ -359,7 +359,7 @@ func Test_ProviderUpdate(t *testing.T) {
 			&rmprovider.Provider{
 				ID: uuid.FromStringOrNil("9d4a55e6-f197-497a-a359-06d1858de39e"),
 			},
-			&rmprovider.Provider{
+			&rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("9d4a55e6-f197-497a-a359-06d1858de39e"),
 			},
 		},

--- a/bin-api-manager/server/providers_test.go
+++ b/bin-api-manager/server/providers_test.go
@@ -26,7 +26,7 @@ func Test_providersGet(t *testing.T) {
 
 		reqQuery string
 
-		responseProviders []*rmprovider.Provider
+		responseProviders []*rmprovider.WebhookMessage
 
 		expectPageSize  uint64
 		expectPageToken string
@@ -44,7 +44,7 @@ func Test_providersGet(t *testing.T) {
 
 			reqQuery: "/providers?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseProviders: []*rmprovider.Provider{
+			responseProviders: []*rmprovider.WebhookMessage{
 				{
 					ID:       uuid.FromStringOrNil("088b16ac-515f-11ed-a848-cb013a2391a9"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -65,7 +65,7 @@ func Test_providersGet(t *testing.T) {
 
 			reqQuery: "/providers?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
 
-			responseProviders: []*rmprovider.Provider{
+			responseProviders: []*rmprovider.WebhookMessage{
 				{
 					ID:       uuid.FromStringOrNil("3829653a-515f-11ed-a1a8-6b5ca0211d65"),
 					TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
@@ -130,7 +130,7 @@ func Test_providersPost(t *testing.T) {
 		reqQuery string
 		reqBody  []byte
 
-		responseProvider *rmprovider.Provider
+		responseProvider *rmprovider.WebhookMessage
 
 		expectType        rmprovider.Type
 		expectHostname    string
@@ -154,7 +154,7 @@ func Test_providersPost(t *testing.T) {
 			reqQuery: "/providers",
 			reqBody:  []byte(`{"type":"sip","hostname":"test.com","tech_prefix":"0001","tech_postfix":"1000","tech_headers":{"header_1":"val1","header_2":"val2"},"name":"test name","detail":"test detail"}`),
 
-			responseProvider: &rmprovider.Provider{
+			responseProvider: &rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("72fe03fa-6475-11ec-b559-0fdf19201178"),
 			},
 
@@ -226,7 +226,7 @@ func Test_providersIDGet(t *testing.T) {
 
 		reqQuery string
 
-		responseProvider *rmprovider.Provider
+		responseProvider *rmprovider.WebhookMessage
 
 		expectProviderID uuid.UUID
 		expectRes        string
@@ -243,7 +243,7 @@ func Test_providersIDGet(t *testing.T) {
 
 			reqQuery: "/providers/d091abe2-5160-11ed-b13c-57769429b0f0",
 
-			responseProvider: &rmprovider.Provider{
+			responseProvider: &rmprovider.WebhookMessage{
 				ID:       uuid.FromStringOrNil("d091abe2-5160-11ed-b13c-57769429b0f0"),
 				TMCreate: timePtr("2020-09-20T03:23:21.995000Z"),
 			},
@@ -296,7 +296,7 @@ func Test_providersIDDelete(t *testing.T) {
 
 		reqQuery string
 
-		responseProvider *rmprovider.Provider
+		responseProvider *rmprovider.WebhookMessage
 
 		expectProviderID uuid.UUID
 		expectRes        string
@@ -313,7 +313,7 @@ func Test_providersIDDelete(t *testing.T) {
 
 			reqQuery: "/providers/528bae9a-5161-11ed-b6c1-03e42a38600c",
 
-			responseProvider: &rmprovider.Provider{
+			responseProvider: &rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("528bae9a-5161-11ed-b6c1-03e42a38600c"),
 			},
 
@@ -375,7 +375,7 @@ func Test_providersIDPut(t *testing.T) {
 		expectName         string
 		expectDetail       string
 
-		responseProvider *rmprovider.Provider
+		responseProvider *rmprovider.WebhookMessage
 
 		expectRes string
 	}{
@@ -402,7 +402,7 @@ func Test_providersIDPut(t *testing.T) {
 			expectName:   "update name",
 			expectDetail: "update detail",
 
-			responseProvider: &rmprovider.Provider{
+			responseProvider: &rmprovider.WebhookMessage{
 				ID: uuid.FromStringOrNil("169cbfe0-5162-11ed-9be1-872503f37e02"),
 			},
 


### PR DESCRIPTION
Fix WebhookMessage pattern violation for provider API responses.

The servicehandler Provider methods were returning raw *rmprovider.Provider structs directly to the HTTP layer, bypassing the required WebhookMessage conversion. This violates the CLAUDE.md mandate that all external-facing API responses use ConvertWebhookMessage().

- bin-api-manager: Update ServiceHandler interface — all 5 Provider methods now return *rmprovider.WebhookMessage instead of *rmprovider.Provider
- bin-api-manager: Update provider.go public methods to call ConvertWebhookMessage() before returning
- bin-api-manager: Regenerate mock_main.go to match updated interface
- bin-api-manager: Update provider_test.go in servicehandler to expect *rmprovider.WebhookMessage
- bin-api-manager: Update providers_test.go in server to use *rmprovider.WebhookMessage mock returns