### PR TITLE
NOJIRA-voip-kamailio-proxy

### DIFF
--- a/bin-common-handler/models/outline/queuename.go
+++ b/bin-common-handler/models/outline/queuename.go
@@ -21,7 +21,7 @@ const (
 	QueueNameAsteriskEventAll QueueName = "asterisk.all.event"
 
 	// kamailio
-	QueueNameKamailioRequest QueueName = "kamailio.request"
+	QueueNameKamailioRequest QueueName = "voip.kamailio.request"
 
 	// agent-manager
 	QueueNameAgentEvent     QueueName = "bin-manager.agent-manager.event"

--- a/bin-common-handler/pkg/requesthandler/kamailio_providers_test.go
+++ b/bin-common-handler/pkg/requesthandler/kamailio_providers_test.go
@@ -27,7 +27,7 @@ func Test_KamailioV1ProviderHealthCheck(t *testing.T) {
 			name:     "healthy provider",
 			hostname: "sip.example.com",
 
-			expectTarget: "kamailio.request",
+			expectTarget: "voip.kamailio.request",
 			expectRequest: &sock.Request{
 				URI:      "/v1/providers/health",
 				Method:   sock.RequestMethodPost,
@@ -50,7 +50,7 @@ func Test_KamailioV1ProviderHealthCheck(t *testing.T) {
 			name:     "unhealthy provider - timeout",
 			hostname: "sip.unreachable.com",
 
-			expectTarget: "kamailio.request",
+			expectTarget: "voip.kamailio.request",
 			expectRequest: &sock.Request{
 				URI:      "/v1/providers/health",
 				Method:   sock.RequestMethodPost,

--- a/voip-kamailio-proxy/cmd/kamailio-proxy/init.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/init.go
@@ -17,6 +17,8 @@ const (
 	defaultRabbitMQAddress     = "amqp://guest:guest@localhost:5672"
 	defaultRabbitMQQueueListen = "voip.kamailio.request"
 
+	defaultInterfaceName = "eth0"
+
 	defaultPrometheusEndpoint      = "/metrics"
 	defaultPrometheusListenAddress = ":2112"
 
@@ -37,6 +39,7 @@ func initVariable() {
 
 	pflag.String("rabbitmq_address", defaultRabbitMQAddress, "Address of the RabbitMQ server")
 	pflag.String("rabbitmq_queue_listen", defaultRabbitMQQueueListen, "Queue name for listening to health check requests")
+	pflag.String("interface_name", defaultInterfaceName, "Network interface name used to derive the kamailio instance ID")
 	pflag.String("prometheus_endpoint", defaultPrometheusEndpoint, "URL for the Prometheus metrics endpoint")
 	pflag.String("prometheus_listen_address", defaultPrometheusListenAddress, "Address for Prometheus to listen on")
 	pflag.String("sip_timeout", defaultSIPTimeout, "Timeout for SIP OPTIONS health check (e.g. 5s, 3s)")
@@ -62,6 +65,16 @@ func initVariable() {
 		panic(errEnv)
 	}
 	rabbitMQQueueListen = viper.GetString("rabbitmq_queue_listen")
+
+	if errFlag := viper.BindPFlag("interface_name", pflag.Lookup("interface_name")); errFlag != nil { //nolint
+		logrus.Errorf("Error binding flag: %v", errFlag)
+		panic(errFlag)
+	}
+	if errEnv := viper.BindEnv("interface_name", "INTERFACE_NAME"); errEnv != nil { //nolint
+		logrus.Errorf("Error binding env: %v", errEnv)
+		panic(errEnv)
+	}
+	interfaceName = viper.GetString("interface_name")
 
 	if errFlag := viper.BindPFlag("prometheus_endpoint", pflag.Lookup("prometheus_endpoint")); errFlag != nil { //nolint
 		logrus.Errorf("Error binding flag: %v", errFlag)

--- a/voip-kamailio-proxy/cmd/kamailio-proxy/init.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/init.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultRabbitMQAddress     = "amqp://guest:guest@localhost:5672"
-	defaultRabbitMQQueueListen = "kamailio.request"
+	defaultRabbitMQQueueListen = "voip.kamailio.request"
 
 	defaultPrometheusEndpoint      = "/metrics"
 	defaultPrometheusListenAddress = ":2112"

--- a/voip-kamailio-proxy/cmd/kamailio-proxy/main.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -16,6 +18,8 @@ var (
 	rabbitMQAddress     = ""
 	rabbitMQQueueListen = ""
 
+	interfaceName = ""
+
 	prometheusEndpoint      = ""
 	prometheusListenAddress = ""
 
@@ -27,13 +31,24 @@ var chSigs = make(chan os.Signal, 1)
 func main() {
 	log := logrus.WithField("func", "main")
 
+	kamailioID, err := getKamailioID(interfaceName)
+	if err != nil {
+		log.Errorf("Could not get kamailio ID from interface %q: %v", interfaceName, err)
+		return
+	}
+
+	rabbitQueueListenPermanent := rabbitMQQueueListen
+	rabbitQueueListenVolatile := fmt.Sprintf("voip.kamailio.%s.request", kamailioID)
+	log.Debugf("Volatile listen queue name: %s", rabbitQueueListenVolatile)
+
 	log.Debugf("Connecting to RabbitMQ. address: %s", rabbitMQAddress)
 	sockHandler := sockhandler.NewSockHandler(sock.TypeRabbitMQ, rabbitMQAddress)
 	sockHandler.Connect()
 
 	listenHandler := listenhandler.NewListenHandler(
 		sockHandler,
-		rabbitMQQueueListen,
+		rabbitQueueListenPermanent,
+		rabbitQueueListenVolatile,
 		sipTimeout,
 		siphandler.SIPChecker(siphandler.SendOptionsCheck),
 	)
@@ -42,8 +57,35 @@ func main() {
 		log.Errorf("Could not run the listen handler: %v", err)
 		return
 	}
-	log.Infof("kamailio-proxy is running. queue: %s", rabbitMQQueueListen)
+	log.Infof("kamailio-proxy is running. permanent_queue: %s, volatile_queue: %s", rabbitQueueListenPermanent, rabbitQueueListenVolatile)
 
 	sig := <-chSigs
 	log.Infof("Terminating kamailio-proxy. sig: %v", sig)
+}
+
+// getKamailioID returns the MAC address of the given network interface,
+// used as the per-instance kamailio identity for the volatile queue name.
+func getKamailioID(ifaceName string) (string, error) {
+	logrus.Debugf("Checking interface name. iface: %s", ifaceName)
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", fmt.Errorf("could not get network interfaces: %w", err)
+	}
+
+	for _, iface := range ifaces {
+		if iface.Name != ifaceName {
+			continue
+		}
+
+		mac := iface.HardwareAddr.String()
+		if mac == "" {
+			return "", fmt.Errorf("interface %q has no MAC address", ifaceName)
+		}
+
+		logrus.Debugf("Found kamailio ID. iface: %s, mac: %s", ifaceName, mac)
+		return mac, nil
+	}
+
+	return "", fmt.Errorf("interface %q not found", ifaceName)
 }

--- a/voip-kamailio-proxy/cmd/kamailio-proxy/main_test.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net"
+	"testing"
+)
+
+func Test_getKamailioID(t *testing.T) {
+	type test struct {
+		name      string
+		ifaceName string
+		wantErr   bool
+	}
+
+	// Find a real interface with a MAC address for the happy path.
+	validIface := ""
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		if len(iface.HardwareAddr) > 0 {
+			validIface = iface.Name
+			break
+		}
+	}
+
+	tests := []test{
+		{
+			name:      "interface not found",
+			ifaceName: "nonexistent999",
+			wantErr:   true,
+		},
+	}
+
+	if validIface != "" {
+		tests = append(tests, test{
+			name:      "valid interface with MAC",
+			ifaceName: validIface,
+			wantErr:   false,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := getKamailioID(tt.ifaceName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getKamailioID(%q) error = %v, wantErr %v", tt.ifaceName, err, tt.wantErr)
+			}
+			if !tt.wantErr && res == "" {
+				t.Errorf("getKamailioID(%q) returned empty string, expected MAC address", tt.ifaceName)
+			}
+		})
+	}
+}

--- a/voip-kamailio-proxy/cmd/kamailio-proxy/main_test.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/main_test.go
@@ -12,13 +12,16 @@ func Test_getKamailioID(t *testing.T) {
 		wantErr   bool
 	}
 
-	// Find a real interface with a MAC address for the happy path.
+	// Find real interfaces for happy and no-MAC test cases.
 	validIface := ""
+	noMACIface := ""
 	ifaces, _ := net.Interfaces()
 	for _, iface := range ifaces {
-		if len(iface.HardwareAddr) > 0 {
+		if len(iface.HardwareAddr) > 0 && validIface == "" {
 			validIface = iface.Name
-			break
+		}
+		if len(iface.HardwareAddr) == 0 && noMACIface == "" {
+			noMACIface = iface.Name
 		}
 	}
 
@@ -35,6 +38,14 @@ func Test_getKamailioID(t *testing.T) {
 			name:      "valid interface with MAC",
 			ifaceName: validIface,
 			wantErr:   false,
+		})
+	}
+
+	if noMACIface != "" {
+		tests = append(tests, test{
+			name:      "interface found but has no MAC address",
+			ifaceName: noMACIface,
+			wantErr:   true,
 		})
 	}
 

--- a/voip-kamailio-proxy/pkg/listenhandler/main.go
+++ b/voip-kamailio-proxy/pkg/listenhandler/main.go
@@ -54,18 +54,13 @@ func NewListenHandler(
 	}
 }
 
-// Run starts the listen handler in a background goroutine with automatic restart on failure.
+// Run starts the listen handler in a background goroutine.
 func (h *listenHandler) Run() error {
 	log := logrus.WithField("func", "Run")
 
 	go func() {
-		for {
-			if err := h.listenRun(); err != nil {
-				log.Errorf("Listen handler exited with error, restarting in 5s: %v", err)
-			} else {
-				log.Warn("Listen handler exited cleanly, restarting in 1s.")
-			}
-			time.Sleep(5 * time.Second)
+		if err := h.listenRun(); err != nil {
+			log.Errorf("Could not execute the listen handler: %v", err)
 		}
 	}()
 

--- a/voip-kamailio-proxy/pkg/listenhandler/main.go
+++ b/voip-kamailio-proxy/pkg/listenhandler/main.go
@@ -19,10 +19,11 @@ type ListenHandler interface {
 }
 
 type listenHandler struct {
-	sockHandler       sockhandler.SockHandler
-	rabbitQueueListen string
-	sipTimeout        time.Duration
-	sipChecker        siphandler.SIPChecker
+	sockHandler                   sockhandler.SockHandler
+	rabbitQueueListenPermanent    string
+	rabbitQueueListenVolatile     string
+	sipTimeout                    time.Duration
+	sipChecker                    siphandler.SIPChecker
 }
 
 var (
@@ -39,15 +40,17 @@ func simpleResponse(code int) *sock.Response {
 // NewListenHandler returns a ListenHandler.
 func NewListenHandler(
 	sockHandler sockhandler.SockHandler,
-	rabbitQueueListen string,
+	rabbitQueueListenPermanent string,
+	rabbitQueueListenVolatile string,
 	sipTimeout time.Duration,
 	sipChecker siphandler.SIPChecker,
 ) ListenHandler {
 	return &listenHandler{
-		sockHandler:       sockHandler,
-		rabbitQueueListen: rabbitQueueListen,
-		sipTimeout:        sipTimeout,
-		sipChecker:        sipChecker,
+		sockHandler:                sockHandler,
+		rabbitQueueListenPermanent: rabbitQueueListenPermanent,
+		rabbitQueueListenVolatile:  rabbitQueueListenVolatile,
+		sipTimeout:                 sipTimeout,
+		sipChecker:                 sipChecker,
 	}
 }
 
@@ -69,24 +72,35 @@ func (h *listenHandler) Run() error {
 	return nil
 }
 
-// listenRun creates the queue and starts consuming RPC messages.
+// listenRun creates both queues and starts consuming RPC messages from each.
 func (h *listenHandler) listenRun() error {
 	log := logrus.WithField("func", "listenRun")
 
-	if err := h.sockHandler.QueueCreate(h.rabbitQueueListen, "normal"); err != nil {
-		return fmt.Errorf("could not declare the queue for listenHandler. err: %v", err)
+	// create permanent (durable) queue
+	if err := h.sockHandler.QueueCreate(h.rabbitQueueListenPermanent, "normal"); err != nil {
+		return fmt.Errorf("could not declare permanent queue for listenHandler. err: %v", err)
 	}
 
-	log.Infof("Running the request listener. queue: %s", h.rabbitQueueListen)
-	if err := h.sockHandler.ConsumeRPC(
-		context.Background(),
-		h.rabbitQueueListen,
-		"kamailio-proxy",
-		false, false, false,
-		10,
-		h.processRequest,
-	); err != nil {
-		return fmt.Errorf("could not consume RPC: %v", err)
+	// create volatile (auto-delete) queue
+	if err := h.sockHandler.QueueCreate(h.rabbitQueueListenVolatile, "volatile"); err != nil {
+		return fmt.Errorf("could not declare volatile queue for listenHandler. err: %v", err)
+	}
+
+	listenQueues := []string{h.rabbitQueueListenPermanent, h.rabbitQueueListenVolatile}
+	for _, queue := range listenQueues {
+		log.Infof("Running the request listener. queue: %s", queue)
+		go func(q string) {
+			if err := h.sockHandler.ConsumeRPC(
+				context.Background(),
+				q,
+				"kamailio-proxy",
+				false, false, false,
+				10,
+				h.processRequest,
+			); err != nil {
+				log.Errorf("Could not consume RPC from queue %s: %v", q, err)
+			}
+		}(queue)
 	}
 
 	return nil

--- a/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
+++ b/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
@@ -83,10 +83,10 @@ func Test_processV1ProvidersHealthPost(t *testing.T) {
 
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
-				sockHandler:       mockSock,
+				sockHandler:                mockSock,
 				rabbitQueueListenPermanent: "voip.kamailio.request",
-				sipTimeout:        5 * time.Second,
-				sipChecker:        tt.sipChecker,
+				sipTimeout:                 5 * time.Second,
+				sipChecker:                 tt.sipChecker,
 			}
 
 			res, err := h.processRequest(tt.request)
@@ -132,10 +132,10 @@ func Test_processRequest_routing(t *testing.T) {
 
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
-				sockHandler:       mockSock,
+				sockHandler:                mockSock,
 				rabbitQueueListenPermanent: "voip.kamailio.request",
-				sipTimeout:        5 * time.Second,
-				sipChecker:        nil, // not called for unknown routes
+				sipTimeout:                 5 * time.Second,
+				sipChecker:                 nil, // not called for unknown routes
 			}
 
 			res, err := h.processRequest(tt.request)

--- a/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
+++ b/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
@@ -84,7 +84,7 @@ func Test_processV1ProvidersHealthPost(t *testing.T) {
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
 				sockHandler:       mockSock,
-				rabbitQueueListen: "voip.kamailio.request",
+				rabbitQueueListenPermanent: "voip.kamailio.request",
 				sipTimeout:        5 * time.Second,
 				sipChecker:        tt.sipChecker,
 			}
@@ -133,7 +133,7 @@ func Test_processRequest_routing(t *testing.T) {
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
 				sockHandler:       mockSock,
-				rabbitQueueListen: "voip.kamailio.request",
+				rabbitQueueListenPermanent: "voip.kamailio.request",
 				sipTimeout:        5 * time.Second,
 				sipChecker:        nil, // not called for unknown routes
 			}

--- a/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
+++ b/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
@@ -84,7 +84,7 @@ func Test_processV1ProvidersHealthPost(t *testing.T) {
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
 				sockHandler:       mockSock,
-				rabbitQueueListen: "kamailio.request",
+				rabbitQueueListen: "voip.kamailio.request",
 				sipTimeout:        5 * time.Second,
 				sipChecker:        tt.sipChecker,
 			}
@@ -133,7 +133,7 @@ func Test_processRequest_routing(t *testing.T) {
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
 				sockHandler:       mockSock,
-				rabbitQueueListen: "kamailio.request",
+				rabbitQueueListen: "voip.kamailio.request",
 				sipTimeout:        5 * time.Second,
 				sipChecker:        nil, // not called for unknown routes
 			}


### PR DESCRIPTION
Add 2-queue listen pattern to voip-kamailio-proxy, mirroring the architecture of voip-asterisk-proxy.

Each kamailio-proxy instance now listens on two RabbitMQ queues:
1. A permanent shared queue (voip.kamailio.request) for commands targeting any instance
2. A volatile per-instance queue (voip.kamailio.<mac-address>.request) for commands targeting a specific instance

The per-instance identity is derived from the MAC address of a configurable network interface (default: eth0), consistent with how voip-asterisk-proxy derives its identity.

- bin-common-handler: Rename QueueNameKamailioRequest constant value from kamailio.request to voip.kamailio.request to align with voip.* namespace convention
- bin-common-handler: Update requesthandler test expected queue name strings
- voip-kamailio-proxy: Add interface_name config flag (env: INTERFACE_NAME, default: eth0)
- voip-kamailio-proxy: Add getKamailioID() to derive instance identity from network interface MAC address
- voip-kamailio-proxy: Build volatile queue name as voip.kamailio.<mac>.request
- voip-kamailio-proxy: Update NewListenHandler to accept both permanent and volatile queue names
- voip-kamailio-proxy: Update listenRun to create normal queue for permanent, volatile queue for volatile, and consume from both concurrently
- voip-kamailio-proxy: Update tests to use renamed rabbitQueueListenPermanent struct field