### PR TITLE
NOJIRA-fix-number-renew-cronjob

### DIFF
--- a/bin-number-manager/k8s/cronjob.yml
+++ b/bin-number-manager/k8s/cronjob.yml
@@ -4,20 +4,32 @@ metadata:
   name: number-renew
 spec:
   schedule: "0 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 3600
       template:
         spec:
           imagePullSecrets:
           - name: gitlab-auth
+          restartPolicy: OnFailure
           containers:
           - name: request-sender
             image: registry.gitlab.com/voipbin/bin-manager/request-sender:latest
             imagePullPolicy: IfNotPresent
+            env:
+            - name: RABBITMQ_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: voipbin
+                  key: RABBITMQ_ADDRESS
             command:
             - /app/request-sender
             - -rabbit_addr
-            - 'amqp://guest:guest@rabbitmq.voipbin.net:5672'
+            - $(RABBITMQ_ADDRESS)
             - -queue
             - 'bin-manager.number-manager.request'
             - -uri
@@ -32,4 +44,3 @@ spec:
             - '3000'
             - -delay
             - '0'
-          restartPolicy: OnFailure


### PR DESCRIPTION
The number-renew CronJob was hardcoded to connect to rabbitmq.voipbin.net
which is no longer reachable from inside the cluster. The request-sender
container retried forever without exiting, causing 300+ stuck jobs to pile up
over 4+ days and no number renewals completed in that window.

Cluster state has already been cleaned up (stuck jobs deleted, manifest applied,
verified with a manual trigger that got a 200 OK RPC response in ~17s). This PR
pins the working configuration into the repo so future applies do not regress.

- bin-number-manager: Source rabbit_addr from the voipbin secret RABBITMQ_ADDRESS so it matches the in-cluster address used by the rest of the services
- bin-number-manager: Set concurrencyPolicy to Forbid so a hanging job cannot be overlapped by the next schedule
- bin-number-manager: Set activeDeadlineSeconds 3600 and backoffLimit 2 so a stuck job self-terminates instead of running forever
- bin-number-manager: Set successfulJobsHistoryLimit and failedJobsHistoryLimit to 3 to keep job history tidy