### PR TITLE
NOJIRA-kamailio-proxy-use-common-queue-name

### DIFF
--- a/voip-kamailio-proxy/cmd/kamailio-proxy/init.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/init.go
@@ -6,6 +6,8 @@ import (
 	"syscall"
 	"time"
 
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	joonix "github.com/joonix/log"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -15,7 +17,7 @@ import (
 
 const (
 	defaultRabbitMQAddress     = "amqp://guest:guest@localhost:5672"
-	defaultRabbitMQQueueListen = "voip.kamailio.request"
+	defaultRabbitMQQueueListen = string(commonoutline.QueueNameKamailioRequest)
 
 	defaultInterfaceName = "eth0"
 

--- a/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
+++ b/voip-kamailio-proxy/pkg/listenhandler/v1_providers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/voip-kamailio-proxy/pkg/listenhandler/request"
@@ -84,7 +85,7 @@ func Test_processV1ProvidersHealthPost(t *testing.T) {
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
 				sockHandler:                mockSock,
-				rabbitQueueListenPermanent: "voip.kamailio.request",
+				rabbitQueueListenPermanent: string(commonoutline.QueueNameKamailioRequest),
 				sipTimeout:                 5 * time.Second,
 				sipChecker:                 tt.sipChecker,
 			}
@@ -133,7 +134,7 @@ func Test_processRequest_routing(t *testing.T) {
 			mockSock := sockhandler.NewMockSockHandler(mc)
 			h := &listenHandler{
 				sockHandler:                mockSock,
-				rabbitQueueListenPermanent: "voip.kamailio.request",
+				rabbitQueueListenPermanent: string(commonoutline.QueueNameKamailioRequest),
 				sipTimeout:                 5 * time.Second,
 				sipChecker:                 nil, // not called for unknown routes
 			}


### PR DESCRIPTION
Replace hardcoded \"voip.kamailio.request\" string with the shared commonoutline.QueueNameKamailioRequest constant so the listen queue stays in lockstep with the bin-common-handler definition used by the RPC client. A future rename of the constant now updates both sides automatically.

- voip-kamailio-proxy: Use commonoutline.QueueNameKamailioRequest for the default listen queue in init.go
- voip-kamailio-proxy: Use the same constant in v1_providers_test.go instead of a hardcoded string