### PR TITLE
NOJIRA-rtp-debug-force-provider-call

### DIFF
--- a/bin-call-manager/models/call/metadata.go
+++ b/bin-call-manager/models/call/metadata.go
@@ -4,10 +4,12 @@ package call
 type MetadataKey = string
 
 const (
-	// MetadataKeyRTPDebug indicates RTP debug capture was enabled for this call.
-	// Set at CREATION TIME in callhandler/outgoing_call.go when the customer has
-	// RTPDebug enabled in their metadata. status.go reads this key to decide
-	// whether to start RTP debug recording, so no customer fetch is needed there.
+	// MetadataKeyRTPDebug triggers RTP packet capture via rtpengine-proxy for debugging.
+	// Set at CREATION TIME:
+	//   - outgoing_call.go: set when cu.Metadata.RTPDebug is true (customer preference)
+	//   - start.go: set when cs.Metadata.RTPDebug is true (incoming calls, customer preference)
+	//   - providercallhandler (bin-route-manager): always forced to true for provider calls
+	// status.go and startCallTypeFlow read this key from call metadata directly (no customer fetch needed).
 	MetadataKeyRTPDebug MetadataKey = "rtp_debug"
 
 	// MetadataKeyRouteProviderIDs lists provider UUIDs (as a []string) that the call

--- a/bin-call-manager/models/call/metadata.go
+++ b/bin-call-manager/models/call/metadata.go
@@ -5,8 +5,9 @@ type MetadataKey = string
 
 const (
 	// MetadataKeyRTPDebug indicates RTP debug capture was enabled for this call.
-	// Set POST-CREATION in callhandler/start.go based on customer/number metadata.
-	// Callers must not pre-set this key — it will be overwritten.
+	// Set at CREATION TIME in callhandler/outgoing_call.go when the customer has
+	// RTPDebug enabled in their metadata. status.go reads this key to decide
+	// whether to start RTP debug recording, so no customer fetch is needed there.
 	MetadataKeyRTPDebug MetadataKey = "rtp_debug"
 
 	// MetadataKeyRouteProviderIDs lists provider UUIDs (as a []string) that the call

--- a/bin-call-manager/pkg/callhandler/arievent_test.go
+++ b/bin-call-manager/pkg/callhandler/arievent_test.go
@@ -18,8 +18,6 @@ import (
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
-	cucustomer "monorepo/bin-customer-manager/models/customer"
-
 	"monorepo/bin-call-manager/models/ari"
 	"monorepo/bin-call-manager/models/call"
 	"monorepo/bin-call-manager/models/channel"
@@ -110,8 +108,7 @@ func Test_ARIChannelStateChangeStatusProgressing(t *testing.T) {
 			mockDB.EXPECT().CallGet(gomock.Any(), tt.call.ID).Return(tt.responseCall, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tt.responseCall.CustomerID, call.EventTypeCallProgressing, tt.responseCall)
 			if tt.call.Direction != call.DirectionIncoming {
-				// RTP debug check
-				mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseCall.CustomerID).Return(&cucustomer.Customer{}, nil)
+				// rtp_debug is now read from call metadata; no CustomerV1CustomerGet expected.
 				// ActionNext
 				// consider the call was hungup already to make this test done quickly.
 				mockDB.EXPECT().CallGet(ctx, gomock.Any()).Return(&call.Call{Status: call.StatusHangup}, nil)

--- a/bin-call-manager/pkg/callhandler/db.go
+++ b/bin-call-manager/pkg/callhandler/db.go
@@ -21,8 +21,7 @@ import (
 
 // Create creates a call record.
 // The metadata parameter is stored verbatim on the Call record; pass nil if the caller
-// has no metadata to seed. Post-creation paths (e.g. rtp_debug in start.go) can still
-// mutate Call.Metadata after Create returns.
+// has no metadata to seed. rtp_debug is embedded at creation time in outgoing_call.go.
 func (h *callHandler) Create(
 	ctx context.Context,
 

--- a/bin-call-manager/pkg/callhandler/db.go
+++ b/bin-call-manager/pkg/callhandler/db.go
@@ -21,7 +21,8 @@ import (
 
 // Create creates a call record.
 // The metadata parameter is stored verbatim on the Call record; pass nil if the caller
-// has no metadata to seed. rtp_debug is embedded at creation time in outgoing_call.go.
+// has no metadata to seed. rtp_debug is embedded at creation time in outgoing_call.go (outgoing)
+// and start.go (incoming); providercallhandler always forces it true for provider calls.
 func (h *callHandler) Create(
 	ctx context.Context,
 

--- a/bin-call-manager/pkg/callhandler/hangup.go
+++ b/bin-call-manager/pkg/callhandler/hangup.go
@@ -62,10 +62,8 @@ func (h *callHandler) Hangup(ctx context.Context, cn *channel.Channel) (*call.Ca
 	}
 
 	// RTP debug: stop recording if enabled for this call
-	if v, ok := res.Metadata[call.MetadataKeyRTPDebug]; ok {
-		if b, isBool := v.(bool); isBool && b {
-			h.rtpDebugStopRecording(ctx, res)
-		}
+	if rtpDebug, _ := res.Metadata[call.MetadataKeyRTPDebug].(bool); rtpDebug {
+		h.rtpDebugStopRecording(ctx, res)
 	}
 
 	// check the call is part of groupcall

--- a/bin-call-manager/pkg/callhandler/outgoing_call.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call.go
@@ -152,12 +152,16 @@ func (h *callHandler) CreateCallOutgoing(
 	}
 	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 
-	// embed rtp_debug in call metadata at creation time so status.go doesn't need to re-fetch the customer
-	if cu.Metadata.RTPDebug {
-		if metadata == nil {
-			metadata = map[string]any{}
+	// embed rtp_debug in call metadata at creation time so status.go doesn't need to re-fetch the customer.
+	// guard: if rtp_debug is already set (e.g. forced by providercallhandler), preserve it even when
+	// the customer has RTPDebug=false — do not overwrite/clear an already-set flag.
+	if _, alreadySet := metadata[call.MetadataKeyRTPDebug]; !alreadySet {
+		if cu.Metadata.RTPDebug {
+			if metadata == nil {
+				metadata = map[string]any{}
+			}
+			metadata[call.MetadataKeyRTPDebug] = true
 		}
-		metadata[call.MetadataKeyRTPDebug] = true
 	}
 
 	// validate outgoing call permission (customer status + identity verification)

--- a/bin-call-manager/pkg/callhandler/outgoing_call.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call.go
@@ -152,6 +152,14 @@ func (h *callHandler) CreateCallOutgoing(
 	}
 	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 
+	// embed rtp_debug in call metadata at creation time so status.go doesn't need to re-fetch the customer
+	if cu.Metadata.RTPDebug {
+		if metadata == nil {
+			metadata = map[string]any{}
+		}
+		metadata[call.MetadataKeyRTPDebug] = true
+	}
+
 	// validate outgoing call permission (customer status + identity verification)
 	if err := h.validateOutgoingCallPermission(ctx, cu, destination); err != nil {
 		return nil, err

--- a/bin-call-manager/pkg/callhandler/outgoing_call_test.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call_test.go
@@ -395,6 +395,173 @@ func Test_CreateCallOutgoing_Metadata(t *testing.T) {
 	}
 }
 
+// Test_CreateCallOutgoing_RTPDebug verifies that when a customer has RTPDebug enabled,
+// the call's Metadata map is populated with rtp_debug=true at creation time.
+func Test_CreateCallOutgoing_RTPDebug(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		id           uuid.UUID
+		customerID   uuid.UUID
+		flowID       uuid.UUID
+		activeflowID uuid.UUID
+		masterCallID uuid.UUID
+		source       commonaddress.Address
+		destination  commonaddress.Address
+
+		responseActiveflow  *fmactiveflow.Activeflow
+		responseAgent       *amagent.Agent
+		responseUUIDChannel uuid.UUID
+		responseCustomer    *cucustomer.Customer
+
+		expectCall *call.Call
+	}{
+		{
+			name: "customer rtp_debug true embeds metadata key at creation",
+
+			id:           uuid.FromStringOrNil("a1b2c3d4-ecb2-11ea-ab94-a768ab787da0"),
+			customerID:   uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+			flowID:       uuid.FromStringOrNil("fd5b3234-ecb2-11ea-8f23-4369cba01ddb"),
+			activeflowID: uuid.FromStringOrNil("679f0eb2-8c21-41a6-876d-9d778b1b0167"),
+			masterCallID: uuid.Nil,
+			source: commonaddress.Address{
+				Type:       commonaddress.TypeSIP,
+				Target:     "testsrc@test.com",
+				TargetName: "test",
+			},
+			destination: commonaddress.Address{
+				Type:       commonaddress.TypeSIP,
+				Target:     "testoutgoing@test.com",
+				TargetName: "test target",
+			},
+
+			responseActiveflow: &fmactiveflow.Activeflow{
+				CurrentAction: fmaction.Action{
+					ID: fmaction.IDStart,
+				},
+			},
+			responseAgent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("1aa075dc-2bfe-11ef-9203-37278cb94d16"),
+					CustomerID: uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+				},
+			},
+			responseUUIDChannel: uuid.FromStringOrNil("80d67b3a-5f3b-11ed-a709-0f2943ef0184"),
+			responseCustomer: &cucustomer.Customer{
+				ID:                         uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+				Status:                     cucustomer.StatusActive,
+				IdentityVerificationStatus: cucustomer.IdentityVerificationStatusVerified,
+				Metadata: cucustomer.Metadata{
+					RTPDebug: true,
+				},
+			},
+
+			expectCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("a1b2c3d4-ecb2-11ea-ab94-a768ab787da0"),
+					CustomerID: uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerType: commonidentity.OwnerTypeAgent,
+					OwnerID:   uuid.FromStringOrNil("1aa075dc-2bfe-11ef-9203-37278cb94d16"),
+				},
+				ChannelID: "80d67b3a-5f3b-11ed-a709-0f2943ef0184",
+				FlowID:    uuid.FromStringOrNil("fd5b3234-ecb2-11ea-8f23-4369cba01ddb"),
+				Type:      call.TypeFlow,
+
+				ChainedCallIDs:   []uuid.UUID{},
+				RecordingIDs:     []uuid.UUID{},
+				ExternalMediaIDs: []uuid.UUID{},
+
+				Status:      call.StatusDialing,
+				Direction:   call.DirectionOutgoing,
+				GroupcallID: uuid.Nil,
+				Source: commonaddress.Address{
+					Type:       commonaddress.TypeSIP,
+					Target:     "testsrc@test.com",
+					TargetName: "test",
+				},
+				Destination: commonaddress.Address{
+					Type:       commonaddress.TypeSIP,
+					Target:     "testoutgoing@test.com",
+					TargetName: "test target",
+				},
+				Data: map[call.DataType]string{
+					call.DataTypeEarlyExecution:            "false",
+					call.DataTypeExecuteNextMasterOnHangup: "true",
+					call.DataTypeAnonymous:                 "false",
+				},
+				// rtp_debug must be embedded in Metadata at creation time
+				Metadata: map[string]any{
+					call.MetadataKeyRTPDebug: true,
+				},
+				Action: fmaction.Action{
+					ID: fmaction.IDStart,
+				},
+
+				Dialroutes: []rmroute.Route{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockChannel := channelhandler.NewMockChannelHandler(mc)
+
+			h := &callHandler{
+				utilHandler:    mockUtil,
+				reqHandler:     mockReq,
+				notifyHandler:  mockNotify,
+				db:             mockDB,
+				channelHandler: mockChannel,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().FlowV1ActiveflowCreate(ctx, tt.activeflowID, tt.customerID, tt.flowID, fmactiveflow.ReferenceTypeCall, tt.id, uuid.Nil).Return(tt.responseActiveflow, nil)
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDChannel)
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(tt.responseCustomer, nil)
+			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.customerID, bmbilling.ReferenceTypeCall, gomock.Any(), 1).Return(true, nil)
+			mockReq.EXPECT().AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, tt.customerID, tt.destination).Return(tt.responseAgent, nil)
+
+			// CRITICAL assertion: CallCreate must receive the call with rtp_debug in Metadata.
+			mockDB.EXPECT().CallCreate(ctx, tt.expectCall).Return(nil)
+			mockDB.EXPECT().CallGet(ctx, tt.id).Return(tt.expectCall, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.expectCall.CustomerID, call.EventTypeCallCreated, tt.expectCall)
+			mockReq.EXPECT().CallV1CallHealth(ctx, tt.expectCall.ID, defaultHealthDelay, 0).Return(nil)
+
+			// setVariables
+			mockReq.EXPECT().FlowV1VariableSetVariable(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			mockChannel.EXPECT().StartChannel(ctx, requesthandler.AsteriskIDCall, gomock.Any(), gomock.Any(), gomock.Any(), "", "", "", gomock.Any()).Return(&channel.Channel{}, nil)
+
+			res, err := h.CreateCallOutgoing(ctx, tt.id, tt.customerID, tt.flowID, tt.activeflowID, tt.masterCallID, uuid.Nil, tt.source, tt.destination, false, true, "", nil)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if res == nil {
+				t.Fatalf("Wrong match. expected non-nil call result")
+			}
+			if !reflect.DeepEqual(res.Metadata, tt.expectCall.Metadata) {
+				t.Errorf("Wrong match. Metadata differs.\nexpect: %v\ngot:    %v", tt.expectCall.Metadata, res.Metadata)
+			}
+			if res.Metadata[call.MetadataKeyRTPDebug] != true {
+				t.Errorf("Wrong match. expected rtp_debug=true in metadata, got: %v", res.Metadata[call.MetadataKeyRTPDebug])
+			}
+		})
+	}
+}
+
 func Test_CreateCallOutgoing_TypeTel(t *testing.T) {
 
 	tests := []struct {

--- a/bin-call-manager/pkg/callhandler/outgoing_call_test.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call_test.go
@@ -397,6 +397,8 @@ func Test_CreateCallOutgoing_Metadata(t *testing.T) {
 
 // Test_CreateCallOutgoing_RTPDebug verifies that when a customer has RTPDebug enabled,
 // the call's Metadata map is populated with rtp_debug=true at creation time.
+// It also verifies that a pre-set rtp_debug=true (e.g., from providercallhandler) is
+// preserved even when the customer has RTPDebug=false.
 func Test_CreateCallOutgoing_RTPDebug(t *testing.T) {
 
 	tests := []struct {
@@ -409,6 +411,7 @@ func Test_CreateCallOutgoing_RTPDebug(t *testing.T) {
 		masterCallID uuid.UUID
 		source       commonaddress.Address
 		destination  commonaddress.Address
+		metadata     map[string]interface{} // incoming metadata passed to CreateCallOutgoing
 
 		responseActiveflow  *fmactiveflow.Activeflow
 		responseAgent       *amagent.Agent
@@ -503,6 +506,97 @@ func Test_CreateCallOutgoing_RTPDebug(t *testing.T) {
 				Dialroutes: []rmroute.Route{},
 			},
 		},
+		{
+			name: "provider call pre-sets rtp_debug=true, customer has RTPDebug=false — flag is preserved",
+
+			id:           uuid.FromStringOrNil("b2c3d4e5-ecb2-11ea-ab94-a768ab787da0"),
+			customerID:   uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+			flowID:       uuid.FromStringOrNil("fd5b3234-ecb2-11ea-8f23-4369cba01ddb"),
+			activeflowID: uuid.FromStringOrNil("679f0eb2-8c21-41a6-876d-9d778b1b0167"),
+			masterCallID: uuid.Nil,
+			source: commonaddress.Address{
+				Type:       commonaddress.TypeSIP,
+				Target:     "testsrc@test.com",
+				TargetName: "test",
+			},
+			destination: commonaddress.Address{
+				Type:       commonaddress.TypeSIP,
+				Target:     "testoutgoing@test.com",
+				TargetName: "test target",
+			},
+			// Simulate what providercallhandler sets: rtp_debug forced to true
+			metadata: map[string]interface{}{
+				call.MetadataKeyRTPDebug: true,
+			},
+
+			responseActiveflow: &fmactiveflow.Activeflow{
+				CurrentAction: fmaction.Action{
+					ID: fmaction.IDStart,
+				},
+			},
+			responseAgent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("1aa075dc-2bfe-11ef-9203-37278cb94d16"),
+					CustomerID: uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+				},
+			},
+			responseUUIDChannel: uuid.FromStringOrNil("90e78c4b-5f3b-11ed-a709-0f2943ef0184"),
+			// Customer has RTPDebug=false — the provider-set flag must NOT be cleared
+			responseCustomer: &cucustomer.Customer{
+				ID:                         uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+				Status:                     cucustomer.StatusActive,
+				IdentityVerificationStatus: cucustomer.IdentityVerificationStatusVerified,
+				Metadata: cucustomer.Metadata{
+					RTPDebug: false,
+				},
+			},
+
+			expectCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("b2c3d4e5-ecb2-11ea-ab94-a768ab787da0"),
+					CustomerID: uuid.FromStringOrNil("5999f628-7f44-11ec-801f-173217f33e3f"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerType: commonidentity.OwnerTypeAgent,
+					OwnerID:   uuid.FromStringOrNil("1aa075dc-2bfe-11ef-9203-37278cb94d16"),
+				},
+				ChannelID: "90e78c4b-5f3b-11ed-a709-0f2943ef0184",
+				FlowID:    uuid.FromStringOrNil("fd5b3234-ecb2-11ea-8f23-4369cba01ddb"),
+				Type:      call.TypeFlow,
+
+				ChainedCallIDs:   []uuid.UUID{},
+				RecordingIDs:     []uuid.UUID{},
+				ExternalMediaIDs: []uuid.UUID{},
+
+				Status:      call.StatusDialing,
+				Direction:   call.DirectionOutgoing,
+				GroupcallID: uuid.Nil,
+				Source: commonaddress.Address{
+					Type:       commonaddress.TypeSIP,
+					Target:     "testsrc@test.com",
+					TargetName: "test",
+				},
+				Destination: commonaddress.Address{
+					Type:       commonaddress.TypeSIP,
+					Target:     "testoutgoing@test.com",
+					TargetName: "test target",
+				},
+				Data: map[call.DataType]string{
+					call.DataTypeEarlyExecution:            "false",
+					call.DataTypeExecuteNextMasterOnHangup: "true",
+					call.DataTypeAnonymous:                 "false",
+				},
+				// rtp_debug must be preserved even though customer has RTPDebug=false
+				Metadata: map[string]any{
+					call.MetadataKeyRTPDebug: true,
+				},
+				Action: fmaction.Action{
+					ID: fmaction.IDStart,
+				},
+
+				Dialroutes: []rmroute.Route{},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -544,7 +638,7 @@ func Test_CreateCallOutgoing_RTPDebug(t *testing.T) {
 
 			mockChannel.EXPECT().StartChannel(ctx, requesthandler.AsteriskIDCall, gomock.Any(), gomock.Any(), gomock.Any(), "", "", "", gomock.Any()).Return(&channel.Channel{}, nil)
 
-			res, err := h.CreateCallOutgoing(ctx, tt.id, tt.customerID, tt.flowID, tt.activeflowID, tt.masterCallID, uuid.Nil, tt.source, tt.destination, false, true, "", nil)
+			res, err := h.CreateCallOutgoing(ctx, tt.id, tt.customerID, tt.flowID, tt.activeflowID, tt.masterCallID, uuid.Nil, tt.source, tt.destination, false, true, "", tt.metadata)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-call-manager/pkg/callhandler/start.go
+++ b/bin-call-manager/pkg/callhandler/start.go
@@ -569,12 +569,13 @@ func (h *callHandler) startCallTypeFlow(ctx context.Context, cn *channel.Channel
 	id := h.utilHandler.UUIDCreate()
 
 	// validate customer status
-	_, validStatus := h.ValidateCustomerStatusIncoming(ctx, customerID)
+	cs, validStatus := h.ValidateCustomerStatusIncoming(ctx, customerID)
 	if !validStatus {
 		log.Errorf("Customer account is not active. Rejecting incoming call. customer_id: %s", customerID)
 		_, _ = h.channelHandler.HangingUp(ctx, cn.ID, ari.ChannelCauseNetworkOutOfOrder)
 		return
 	}
+	log.WithField("customer", cs).Debugf("Retrieved customer info. customer_id: %s", customerID)
 
 	// validate balance
 	if validBalance := h.ValidateCustomerBalance(ctx, id, customerID, call.DirectionIncoming, *source, *destination); !validBalance {
@@ -604,6 +605,19 @@ func (h *callHandler) startCallTypeFlow(ctx context.Context, cn *channel.Channel
 		return
 	}
 	log.WithField("activeflow", af).Debugf("Created an active flow. activeflow_id: %s", af.ID)
+
+	// embed rtp_debug in call metadata at creation time (no post-creation customer fetch needed).
+	// inclusive OR: either customer or number can enable RTP debug.
+	var callMetadata map[string]interface{}
+	rtpDebugEnabled := cs != nil && cs.Metadata.RTPDebug
+	if num != nil {
+		rtpDebugEnabled = rtpDebugEnabled || num.Metadata.RTPDebug
+	}
+	if rtpDebugEnabled {
+		callMetadata = map[string]interface{}{
+			call.MetadataKeyRTPDebug: true,
+		}
+	}
 
 	status := call.GetStatusByChannelState(cn.State)
 	c, err := h.Create(
@@ -636,7 +650,7 @@ func (h *callHandler) startCallTypeFlow(ctx context.Context, cn *channel.Channel
 		uuid.Nil,
 		[]rmroute.Route{},
 
-		nil,
+		callMetadata,
 	)
 	if err != nil {
 		log.Errorf("Could not create a call info. call_id: %s, err: %v", id, err)
@@ -645,29 +659,11 @@ func (h *callHandler) startCallTypeFlow(ctx context.Context, cn *channel.Channel
 	}
 	log.WithField("call", c).Debugf("Created a call. call: %s", c.ID)
 
-	// RTP debug: check if customer or number has RTP debug enabled (inclusive OR)
-	cs, errCS := h.reqHandler.CustomerV1CustomerGet(ctx, customerID)
-	if errCS != nil {
-		log.Errorf("Could not get customer for RTP debug check. customer_id: %s, err: %v", customerID, errCS)
-	} else {
-		log.WithField("customer", cs).Debugf("Retrieved customer for RTP debug check. customer_id: %s", cs.ID)
-		rtpDebugEnabled := cs.Metadata.RTPDebug
-		if num != nil {
-			rtpDebugEnabled = rtpDebugEnabled || num.Metadata.RTPDebug
-		}
-		if rtpDebugEnabled {
-			if c.Metadata == nil {
-				c.Metadata = map[string]interface{}{}
-			}
-			c.Metadata[call.MetadataKeyRTPDebug] = true
-			if errMeta := h.db.CallUpdate(ctx, c.ID, map[call.Field]any{
-				call.FieldMetadata: c.Metadata,
-			}); errMeta != nil {
-				log.Errorf("Could not update call metadata for RTP debug. err: %v", errMeta)
-			} else {
-				h.rtpDebugStartRecording(ctx, c, cn)
-			}
-		}
+	// rtp_debug is set in call metadata at creation time (above).
+	// Read directly from call metadata — no customer fetch needed.
+	if rtpDebug, _ := c.Metadata[call.MetadataKeyRTPDebug].(bool); rtpDebug {
+		log.Debugf("RTP debug enabled from call metadata. call_id: %s", c.ID)
+		h.rtpDebugStartRecording(ctx, c, cn)
 	}
 
 	// set variables

--- a/bin-call-manager/pkg/callhandler/start.go
+++ b/bin-call-manager/pkg/callhandler/start.go
@@ -608,13 +608,13 @@ func (h *callHandler) startCallTypeFlow(ctx context.Context, cn *channel.Channel
 
 	// embed rtp_debug in call metadata at creation time (no post-creation customer fetch needed).
 	// inclusive OR: either customer or number can enable RTP debug.
-	var callMetadata map[string]interface{}
+	var callMetadata map[string]any
 	rtpDebugEnabled := cs != nil && cs.Metadata.RTPDebug
 	if num != nil {
 		rtpDebugEnabled = rtpDebugEnabled || num.Metadata.RTPDebug
 	}
 	if rtpDebugEnabled {
-		callMetadata = map[string]interface{}{
+		callMetadata = map[string]any{
 			call.MetadataKeyRTPDebug: true,
 		}
 	}

--- a/bin-call-manager/pkg/callhandler/start_test.go
+++ b/bin-call-manager/pkg/callhandler/start_test.go
@@ -252,8 +252,8 @@ func Test_Start_incoming_typeConferenceStart(t *testing.T) {
 			mockReq.EXPECT().ConferenceV1ConferenceGet(ctx, uuid.FromStringOrNil(tt.channel.DestinationNumber)).Return(tt.responseConference, nil)
 
 			// addCallBridge
-			// Times(2): first call for ValidateCustomerStatusIncoming, second for RTP debug check
-			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseConference.CustomerID).Return(&cucustomer.Customer{Status: cucustomer.StatusActive}, nil).Times(2)
+			// Times(1): ValidateCustomerStatusIncoming now returns the customer for reuse; rtp_debug embedded at creation, no second fetch
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseConference.CustomerID).Return(&cucustomer.Customer{Status: cucustomer.StatusActive}, nil).Times(1)
 			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.responseConference.CustomerID, bmbilling.ReferenceTypeCall, gomock.Any(), 1).Return(true, nil)
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDBridge)
 			mockBridge.EXPECT().Start(ctx, tt.channel.AsteriskID, tt.responseUUIDBridge.String(), tt.expectBridgeName, []bridge.Type{bridge.TypeMixing, bridge.TypeVideoSFU}).Return(tt.responseBridge, nil)
@@ -449,8 +449,8 @@ func Test_StartCallHandle_IncomingTypeFlow(t *testing.T) {
 			mockReq.EXPECT().NumberV1NumberList(ctx, "", uint64(1), tt.expectFilters).Return(tt.responseNumbers, nil)
 			mockReq.EXPECT().FlowV1ActiveflowCreate(ctx, uuid.Nil, tt.responseNumbers[0].CustomerID, tt.responseNumbers[0].CallFlowID, fmactiveflow.ReferenceTypeCall, gomock.Any(), uuid.Nil).Return(tt.responseActiveflow, nil)
 
-			// Times(2): first call for ValidateCustomerStatusIncoming, second for RTP debug check
-			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseNumbers[0].CustomerID).Return(&cucustomer.Customer{Status: cucustomer.StatusActive}, nil).Times(2)
+			// Times(1): ValidateCustomerStatusIncoming now returns the customer for reuse; rtp_debug embedded at creation, no second fetch
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseNumbers[0].CustomerID).Return(&cucustomer.Customer{Status: cucustomer.StatusActive}, nil).Times(1)
 			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.responseNumbers[0].CustomerID, bmbilling.ReferenceTypeCall, gomock.Any(), 1).Return(true, nil)
 
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDBridge)
@@ -643,8 +643,8 @@ func Test_StartCallHandle_IncomingTypeSIP(t *testing.T) {
 			mockReq.EXPECT().NumberV1NumberList(ctx, "", uint64(1), tt.expectFilters).Return(tt.responseNumbers, nil)
 			mockReq.EXPECT().FlowV1ActiveflowCreate(ctx, uuid.Nil, tt.responseNumbers[0].CustomerID, tt.responseNumbers[0].CallFlowID, fmactiveflow.ReferenceTypeCall, gomock.Any(), uuid.Nil).Return(tt.responseActiveflow, nil)
 
-			// Times(2): first call for ValidateCustomerStatusIncoming, second for RTP debug check
-			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseNumbers[0].CustomerID).Return(&cucustomer.Customer{Status: cucustomer.StatusActive}, nil).Times(2)
+			// Times(1): ValidateCustomerStatusIncoming now returns the customer for reuse; rtp_debug embedded at creation, no second fetch
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseNumbers[0].CustomerID).Return(&cucustomer.Customer{Status: cucustomer.StatusActive}, nil).Times(1)
 			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.responseNumbers[0].CustomerID, bmbilling.ReferenceTypeCall, gomock.Any(), 1).Return(true, nil)
 
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDBridge)
@@ -664,6 +664,215 @@ func Test_StartCallHandle_IncomingTypeSIP(t *testing.T) {
 			// action next part.
 			mockDB.EXPECT().CallSetActionNextHold(ctx, gomock.Any(), gomock.Any()).Return(nil)
 			mockReq.EXPECT().FlowV1ActiveflowGetNextAction(ctx, gomock.Any(), fmaction.IDStart).Return(nil, fmt.Errorf(""))
+
+			if err := h.Start(ctx, tt.channel); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+// Test_StartCallTypeFlow_RTPDebug verifies that when the customer has RTPDebug=true,
+// the incoming call is created with rtp_debug=true in Metadata at creation time,
+// and rtpDebugStartRecording is invoked (early-returns silently because there's no
+// rtpengine_address in the channel's SIPData).
+func Test_StartCallTypeFlow_RTPDebug(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		channel *channel.Channel
+
+		responseSource      *commonaddress.Address
+		responseDestination *commonaddress.Address
+		responseUUIDCall    uuid.UUID
+		responseUUIDBridge  uuid.UUID
+		responseBridge      *bridge.Bridge
+		responseNumbers     []number.Number
+		responseActiveflow  *fmactiveflow.Activeflow
+		responseCall        *call.Call
+		responseCustomer    *cucustomer.Customer
+
+		expectFilters map[number.Field]any
+		expectCall    *call.Call
+	}{
+		{
+			name: "customer rtp_debug=true — call created with rtp_debug in metadata",
+
+			channel: &channel.Channel{
+				AsteriskID:        "80:fa:5b:5e:da:81",
+				ID:                "6e872d74-aaaa-11eb-b3a6-37860f73cbd8",
+				Name:              "PJSIP/in-voipbin-00000999",
+				DestinationNumber: "+123456789",
+				State:             ari.ChannelStateRing,
+				StasisData: map[channel.StasisDataType]string{
+					"context": string(channel.ContextCallIncoming),
+					"domain":  "pstn.voipbin.net",
+				},
+				// No SIPData.rtpengine_address — rtpDebugStartRecording will return early silently
+			},
+
+			responseSource: &commonaddress.Address{
+				Type: commonaddress.TypeTel,
+			},
+			responseDestination: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+123456789",
+			},
+			responseUUIDCall:   uuid.FromStringOrNil("aaaa0001-09ef-11eb-92f7-1b906bde6408"),
+			responseUUIDBridge: uuid.FromStringOrNil("bbbb0001-5e5e-11ed-917e-a70e0240c226"),
+			responseBridge: &bridge.Bridge{
+				ID: "bbbb0001-5e5e-11ed-917e-a70e0240c226",
+			},
+			responseNumbers: []number.Number{
+				{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("cccc0001-09ef-11eb-9347-377b97e1b9ea"),
+						CustomerID: uuid.FromStringOrNil("dddd0001-5e5f-11ed-a85f-9f66d5e00566"),
+					},
+					CallFlowID: uuid.FromStringOrNil("eeee0001-09ef-11eb-bdec-e3ef3b78ac73"),
+				},
+			},
+			responseActiveflow: &fmactiveflow.Activeflow{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("ffff0001-a7b9-11ec-9409-b77946009116"),
+				},
+				ReferenceType: fmactiveflow.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("aaaa0001-09ef-11eb-92f7-1b906bde6408"),
+				FlowID:        uuid.FromStringOrNil("eeee0001-09ef-11eb-bdec-e3ef3b78ac73"),
+				CurrentAction: fmaction.Action{
+					ID: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001"),
+				},
+			},
+			responseCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("aaaa0001-09ef-11eb-92f7-1b906bde6408"),
+				},
+				ChannelID:    "6e872d74-aaaa-11eb-b3a6-37860f73cbd8",
+				FlowID:       uuid.FromStringOrNil("eeee0001-09ef-11eb-bdec-e3ef3b78ac73"),
+				ActiveflowID: uuid.FromStringOrNil("ffff0001-a7b9-11ec-9409-b77946009116"),
+				Direction:    call.DirectionIncoming,
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+123456789",
+				},
+				Action: fmaction.Action{
+					ID: fmaction.IDStart,
+				},
+			},
+			// Customer with RTPDebug=true
+			responseCustomer: &cucustomer.Customer{
+				ID:     uuid.FromStringOrNil("dddd0001-5e5f-11ed-a85f-9f66d5e00566"),
+				Status: cucustomer.StatusActive,
+				Metadata: cucustomer.Metadata{
+					RTPDebug: true,
+				},
+			},
+
+			expectFilters: map[number.Field]any{
+				number.FieldNumber:  "+123456789",
+				number.FieldDeleted: false,
+			},
+			expectCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaa0001-09ef-11eb-92f7-1b906bde6408"),
+					CustomerID: uuid.FromStringOrNil("dddd0001-5e5f-11ed-a85f-9f66d5e00566"),
+				},
+
+				ChannelID: "6e872d74-aaaa-11eb-b3a6-37860f73cbd8",
+				BridgeID:  "bbbb0001-5e5e-11ed-917e-a70e0240c226",
+
+				FlowID:       uuid.FromStringOrNil("eeee0001-09ef-11eb-bdec-e3ef3b78ac73"),
+				ActiveflowID: uuid.FromStringOrNil("ffff0001-a7b9-11ec-9409-b77946009116"),
+				Type:         call.TypeFlow,
+
+				ChainedCallIDs:   []uuid.UUID{},
+				RecordingIDs:     []uuid.UUID{},
+				ExternalMediaIDs: []uuid.UUID{},
+
+				Source: commonaddress.Address{
+					Type: commonaddress.TypeTel,
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+123456789",
+				},
+
+				Status: call.StatusRinging,
+				Data:   map[call.DataType]string{},
+				Action: fmaction.Action{
+					ID: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001"),
+				},
+				Direction:  call.DirectionIncoming,
+				Dialroutes: []rmroute.Route{},
+
+				// rtp_debug must be embedded at creation time
+				Metadata: map[string]interface{}{
+					call.MetadataKeyRTPDebug: true,
+				},
+
+				TMCreate: testhelper.TimePtr("2020-04-18T03:22:17.995000Z"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockChannel := channelhandler.NewMockChannelHandler(mc)
+			mockBridge := bridgehandler.NewMockBridgeHandler(mc)
+
+			h := &callHandler{
+				utilHandler:    mockUtil,
+				reqHandler:     mockReq,
+				notifyHandler:  mockNotify,
+				db:             mockDB,
+				channelHandler: mockChannel,
+				bridgeHandler:  mockBridge,
+			}
+
+			ctx := context.Background()
+
+			mockChannel.EXPECT().HangingUpWithDelay(ctx, tt.channel.ID, ari.ChannelCauseCallDurationTimeout, defaultTimeoutCallDuration).Return(&channel.Channel{}, nil)
+
+			mockChannel.EXPECT().AddressGetSource(tt.channel, commonaddress.TypeTel).Return(tt.responseSource)
+			mockChannel.EXPECT().AddressGetDestination(tt.channel, commonaddress.TypeTel).Return(tt.responseDestination)
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDCall)
+
+			mockReq.EXPECT().NumberV1NumberList(ctx, "", uint64(1), tt.expectFilters).Return(tt.responseNumbers, nil)
+			mockReq.EXPECT().FlowV1ActiveflowCreate(ctx, uuid.Nil, tt.responseNumbers[0].CustomerID, tt.responseNumbers[0].CallFlowID, fmactiveflow.ReferenceTypeCall, gomock.Any(), uuid.Nil).Return(tt.responseActiveflow, nil)
+
+			// Times(1): ValidateCustomerStatusIncoming returns customer for reuse; rtp_debug embedded at creation, no second fetch
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseNumbers[0].CustomerID).Return(tt.responseCustomer, nil).Times(1)
+			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.responseNumbers[0].CustomerID, bmbilling.ReferenceTypeCall, gomock.Any(), 1).Return(true, nil)
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDBridge)
+			mockBridge.EXPECT().Start(ctx, tt.channel.AsteriskID, tt.responseUUIDBridge.String(), gomock.Any(), []bridge.Type{bridge.TypeMixing, bridge.TypeVideoSFU}).Return(tt.responseBridge, nil)
+			mockBridge.EXPECT().ChannelJoin(ctx, tt.responseUUIDBridge.String(), tt.channel.ID, "", false, false).Return(nil)
+
+			mockReq.EXPECT().AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, tt.responseNumbers[0].CustomerID, *tt.responseSource).Return(nil, fmt.Errorf(""))
+
+			// CallCreate must receive the call with rtp_debug=true in Metadata
+			mockDB.EXPECT().CallCreate(ctx, tt.expectCall).Return(nil)
+			mockDB.EXPECT().CallGet(ctx, tt.responseUUIDCall).Return(tt.responseCall, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseCall.CustomerID, call.EventTypeCallCreated, tt.responseCall)
+			mockReq.EXPECT().CallV1CallHealth(ctx, tt.responseCall.ID, defaultHealthDelay, 0).Return(nil)
+
+			// setVariables
+			mockReq.EXPECT().FlowV1VariableSetVariable(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			// action next part.
+			mockDB.EXPECT().CallSetActionNextHold(ctx, gomock.Any(), gomock.Any()).Return(nil)
+			mockReq.EXPECT().FlowV1ActiveflowGetNextAction(ctx, gomock.Any(), fmaction.IDStart).Return(nil, fmt.Errorf(""))
+
+			// rtpDebugStartRecording: responseCall has no SIPData.rtpengine_address → returns early silently (no mock needed)
 
 			if err := h.Start(ctx, tt.channel); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)

--- a/bin-call-manager/pkg/callhandler/status.go
+++ b/bin-call-manager/pkg/callhandler/status.go
@@ -69,7 +69,7 @@ func (h *callHandler) updateStatusProgressing(ctx context.Context, cn *channel.C
 	// rtp_debug is set in call metadata at creation time (outgoing_call.go or providercallhandler).
 	// No customer fetch needed — read directly from call metadata.
 	if rtpDebug, _ := res.Metadata[call.MetadataKeyRTPDebug].(bool); rtpDebug {
-		log.WithField("rtp_debug", rtpDebug).Debugf("RTP debug enabled from call metadata. call_id: %s", res.ID)
+		log.Debugf("RTP debug enabled from call metadata. call_id: %s", res.ID)
 		h.rtpDebugStartRecording(ctx, res, cn)
 	}
 

--- a/bin-call-manager/pkg/callhandler/status.go
+++ b/bin-call-manager/pkg/callhandler/status.go
@@ -66,25 +66,11 @@ func (h *callHandler) updateStatusProgressing(ctx context.Context, cn *channel.C
 		return nil
 	}
 
-	// RTP debug: check if customer has RTP debug enabled (outgoing calls)
-	cs, errCS := h.reqHandler.CustomerV1CustomerGet(ctx, res.CustomerID)
-	if errCS != nil {
-		log.Errorf("Could not get customer for RTP debug check. customer_id: %s, err: %v", res.CustomerID, errCS)
-	} else {
-		log.WithField("customer", cs).Debugf("Retrieved customer for RTP debug check. customer_id: %s", cs.ID)
-		if cs.Metadata.RTPDebug {
-			if res.Metadata == nil {
-				res.Metadata = map[string]interface{}{}
-			}
-			res.Metadata[call.MetadataKeyRTPDebug] = true
-			if errMeta := h.db.CallUpdate(ctx, res.ID, map[call.Field]any{
-				call.FieldMetadata: res.Metadata,
-			}); errMeta != nil {
-				log.Errorf("Could not update call metadata for RTP debug. err: %v", errMeta)
-			} else {
-				h.rtpDebugStartRecording(ctx, res, cn)
-			}
-		}
+	// rtp_debug is set in call metadata at creation time (outgoing_call.go or providercallhandler).
+	// No customer fetch needed — read directly from call metadata.
+	if rtpDebug, _ := res.Metadata[call.MetadataKeyRTPDebug].(bool); rtpDebug {
+		log.WithField("rtp_debug", rtpDebug).Debugf("RTP debug enabled from call metadata. call_id: %s", res.ID)
+		h.rtpDebugStartRecording(ctx, res, cn)
 	}
 
 	// check the groupcall info and answer the groupcall

--- a/bin-call-manager/pkg/callhandler/status_test.go
+++ b/bin-call-manager/pkg/callhandler/status_test.go
@@ -11,8 +11,6 @@ import (
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
-	cucustomer "monorepo/bin-customer-manager/models/customer"
-
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
@@ -289,8 +287,8 @@ func Test_UpdateStatusProgressing(t *testing.T) {
 			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tt.call.CustomerID, call.EventTypeCallProgressing, tt.responseCall)
 
 			if tt.call.Direction != call.DirectionIncoming {
-				mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseCall.CustomerID).Return(&cucustomer.Customer{}, nil)
-
+				// rtp_debug is now read from call metadata (set at creation time);
+				// no CustomerV1CustomerGet call expected here.
 				mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.call, nil)
 				mockDB.EXPECT().CallSetStatus(gomock.Any(), tt.responseCall.ID, gomock.Any())
 				mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.responseCall, nil)
@@ -342,6 +340,10 @@ func Test_UpdateStatusProgressing_rtpDebugEnabled(t *testing.T) {
 				},
 				Status:    call.StatusProgressing,
 				Direction: call.DirectionOutgoing,
+				// rtp_debug set in metadata at creation time — no customer fetch needed
+				Metadata: map[string]any{
+					call.MetadataKeyRTPDebug: true,
+				},
 			},
 		},
 	}
@@ -371,18 +373,9 @@ func Test_UpdateStatusProgressing_rtpDebugEnabled(t *testing.T) {
 			mockDB.EXPECT().CallGet(ctx, tt.call.ID).Return(tt.responseCall, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tt.responseCall.CustomerID, call.EventTypeCallProgressing, tt.responseCall)
 
-			// RTP debug: customer has RTPDebug=true
-			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseCall.CustomerID).Return(&cucustomer.Customer{
-				Metadata: cucustomer.Metadata{
-					RTPDebug: true,
-				},
-			}, nil)
-
-			// RTP debug: metadata update
-			mockDB.EXPECT().CallUpdate(ctx, tt.responseCall.ID, gomock.Any()).Return(nil)
-
-			// RTP debug: start recording command to RTPEngine
-			mockReq.EXPECT().RTPEngineV1CommandsSend(ctx, "10.0.0.1:2223", gomock.Any()).Return(map[string]interface{}{"result": "ok"}, nil)
+			// RTP debug: rtp_debug=true is in call metadata — no customer fetch, no metadata DB update.
+			// rtpDebugStartRecording calls RTPEngineV1CommandsSend (query command first).
+			mockReq.EXPECT().RTPEngineV1CommandsSend(ctx, "10.0.0.1:2223", gomock.Any()).Return(map[string]any{"result": "ok"}, nil)
 
 			// ActionNext path: returns tt.call (no activeflow_id) → hangup flow
 			mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.call, nil)
@@ -472,10 +465,160 @@ func Test_UpdateStatusProgressing_answerGroupcall(t *testing.T) {
 			mockDB.EXPECT().CallGet(ctx, tt.call.ID).Return(tt.responseCall, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tt.responseCall.CustomerID, call.EventTypeCallProgressing, tt.responseCall)
 
-			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.responseCall.CustomerID).Return(&cucustomer.Customer{}, nil)
-
+			// rtp_debug is now read from call metadata; no CustomerV1CustomerGet expected.
 			mockGroupcall.EXPECT().AnswerCall(ctx, tt.responseCall.GroupcallID, tt.responseCall.ID).Return(nil)
 
+			mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.call, nil)
+			mockDB.EXPECT().CallSetStatus(gomock.Any(), tt.responseCall.ID, gomock.Any())
+			mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.responseCall, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, gomock.Any(), gomock.Any(), gomock.Any())
+			mockChannel.EXPECT().HangingUp(gomock.Any(), gomock.Any(), gomock.Any()).Return(&channel.Channel{TMEnd: nil}, nil)
+
+			if err := h.updateStatusProgressing(ctx, tt.channel, tt.call); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			time.Sleep(time.Millisecond * 100)
+		})
+	}
+}
+
+// Test_UpdateStatusProgressing_rtpDebugFromMetadata verifies that updateStatusProgressing
+// reads the rtp_debug flag from call metadata (set at creation time) and does NOT
+// fetch the customer to make the decision.
+func Test_UpdateStatusProgressing_rtpDebugFromMetadata(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		channel      *channel.Channel
+		call         *call.Call
+		responseCall *call.Call
+
+		// expectRTPDebug indicates whether rtpDebugStartRecording should be triggered
+		// (verified via RTPEngineV1CommandsSend mock expectation)
+		expectRTPDebug bool
+	}{
+		{
+			name: "outgoing call with rtp_debug=true in metadata triggers RTP debug",
+			channel: &channel.Channel{
+				ID:        "ch-meta-rtp-001",
+				SIPCallID: "sip-call-id-meta-001",
+				TMAnswer:  testhelper.TimePtr("2020-09-20T03:23:20.995000Z"),
+				SIPData: map[string]string{
+					"rtpengine_address": "10.0.0.2:2223",
+					"from_tag":          "tagxyz",
+				},
+			},
+			call: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("b2c3d4e5-0002-0002-0002-000000000001"),
+					CustomerID: uuid.FromStringOrNil("b2c3d4e5-0002-0002-0002-000000000002"),
+				},
+				Status:    call.StatusDialing,
+				Direction: call.DirectionOutgoing,
+			},
+			responseCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("b2c3d4e5-0002-0002-0002-000000000001"),
+					CustomerID: uuid.FromStringOrNil("b2c3d4e5-0002-0002-0002-000000000002"),
+				},
+				Status:    call.StatusProgressing,
+				Direction: call.DirectionOutgoing,
+				Metadata: map[string]any{
+					call.MetadataKeyRTPDebug: true,
+				},
+			},
+			expectRTPDebug: true,
+		},
+		{
+			name: "outgoing call without rtp_debug in metadata does not trigger RTP debug",
+			channel: &channel.Channel{
+				ID:       "ch-meta-rtp-002",
+				TMAnswer: testhelper.TimePtr("2020-09-20T03:23:20.995000Z"),
+			},
+			call: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c3d4e5f6-0003-0003-0003-000000000001"),
+					CustomerID: uuid.FromStringOrNil("c3d4e5f6-0003-0003-0003-000000000002"),
+				},
+				Status:    call.StatusDialing,
+				Direction: call.DirectionOutgoing,
+			},
+			responseCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c3d4e5f6-0003-0003-0003-000000000001"),
+					CustomerID: uuid.FromStringOrNil("c3d4e5f6-0003-0003-0003-000000000002"),
+				},
+				Status:    call.StatusProgressing,
+				Direction: call.DirectionOutgoing,
+				// Metadata is nil — no rtp_debug key
+			},
+			expectRTPDebug: false,
+		},
+		{
+			name: "outgoing call with rtp_debug=false in metadata does not trigger RTP debug",
+			channel: &channel.Channel{
+				ID:       "ch-meta-rtp-003",
+				TMAnswer: testhelper.TimePtr("2020-09-20T03:23:20.995000Z"),
+			},
+			call: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d4e5f6a7-0004-0004-0004-000000000001"),
+					CustomerID: uuid.FromStringOrNil("d4e5f6a7-0004-0004-0004-000000000002"),
+				},
+				Status:    call.StatusDialing,
+				Direction: call.DirectionOutgoing,
+			},
+			responseCall: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d4e5f6a7-0004-0004-0004-000000000001"),
+					CustomerID: uuid.FromStringOrNil("d4e5f6a7-0004-0004-0004-000000000002"),
+				},
+				Status:    call.StatusProgressing,
+				Direction: call.DirectionOutgoing,
+				// rtp_debug key is explicitly set to false — two-value type assertion returns false
+				Metadata: map[string]any{
+					call.MetadataKeyRTPDebug: false,
+				},
+			},
+			expectRTPDebug: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockChannel := channelhandler.NewMockChannelHandler(mc)
+
+			h := &callHandler{
+				utilHandler:    mockUtil,
+				reqHandler:     mockReq,
+				notifyHandler:  mockNotify,
+				db:             mockDB,
+				channelHandler: mockChannel,
+			}
+
+			ctx := context.Background()
+
+			mockDB.EXPECT().CallSetStatusProgressing(ctx, tt.call.ID).Return(nil)
+			mockDB.EXPECT().CallGet(ctx, tt.call.ID).Return(tt.responseCall, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tt.responseCall.CustomerID, call.EventTypeCallProgressing, tt.responseCall)
+
+			// NEW BEHAVIOR: CustomerV1CustomerGet must NOT be called for rtp_debug decision.
+			// (No mock set up for it — gomock will fail the test if it is called.)
+
+			if tt.expectRTPDebug {
+				// rtpDebugStartRecording calls RTPEngineV1CommandsSend
+				mockReq.EXPECT().RTPEngineV1CommandsSend(ctx, "10.0.0.2:2223", gomock.Any()).Return(map[string]any{"result": "ok"}, nil)
+			}
+
+			// ActionNext path: no activeflow_id → hangup flow
 			mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.call, nil)
 			mockDB.EXPECT().CallSetStatus(gomock.Any(), tt.responseCall.ID, gomock.Any())
 			mockDB.EXPECT().CallGet(ctx, tt.responseCall.ID).Return(tt.responseCall, nil)

--- a/bin-route-manager/pkg/providercallhandler/providercall.go
+++ b/bin-route-manager/pkg/providercallhandler/providercall.go
@@ -73,6 +73,7 @@ func (h *providerCallHandler) Create(
 	metadata := map[string]any{
 		string(cmcall.MetadataKeyRouteProviderIDs):     []string{providerID.String()},
 		string(cmcall.MetadataKeySkipSourceValidation): true,
+		string(cmcall.MetadataKeyRTPDebug):             true, // force rtp_debug for all provider calls
 	}
 
 	// 3. Issue the call creation synchronously. Call-manager persists the Call(s),

--- a/docs/plans/2026-04-22-rtp-debug-force-provider-call.md
+++ b/docs/plans/2026-04-22-rtp-debug-force-provider-call.md
@@ -1,0 +1,252 @@
+# Force rtp_debug for Provider Calls Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Force `rtp_debug` recording on for all provider calls regardless of customer settings, and move all `rtp_debug` decisions to call creation time so `status.go` no longer needs to fetch customer info.
+
+**Architecture:** Add `MetadataKeyRTPDebug: true` to the provider call metadata at creation time. In `outgoing_call.go`, embed the customer's `rtp_debug` preference into call metadata at creation (customer is already fetched there). In `status.go`, remove the customer fetch and DB update — just read `res.Metadata[MetadataKeyRTPDebug]` directly to decide whether to start recording.
+
+**Tech Stack:** Go, RabbitMQ RPC, MySQL (call metadata stored as JSON column)
+
+---
+
+### Task 1: Force `rtp_debug` in `providercallhandler`
+
+**Files:**
+- Modify: `bin-route-manager/pkg/providercallhandler/providercall.go:73-76`
+
+**Step 1: Add `MetadataKeyRTPDebug: true` to the metadata map**
+
+```go
+// bin-route-manager/pkg/providercallhandler/providercall.go
+// lines 73-76 — change:
+metadata := map[string]any{
+    string(cmcall.MetadataKeyRouteProviderIDs):     []string{providerID.String()},
+    string(cmcall.MetadataKeySkipSourceValidation): true,
+    string(cmcall.MetadataKeyRTPDebug):             true, // force rtp_debug for all provider calls
+}
+```
+
+**Step 2: Run tests**
+
+```bash
+cd bin-route-manager
+go test ./pkg/providercallhandler/... -v
+```
+
+Expected: all existing tests pass (adding a metadata key does not break existing logic).
+
+**Step 3: Commit**
+
+```bash
+git add bin-route-manager/pkg/providercallhandler/providercall.go
+git commit -m "NOJIRA-rtp-debug-force-provider-call
+
+- bin-route-manager: force rtp_debug metadata on all provider calls"
+```
+
+---
+
+### Task 2: Embed customer `rtp_debug` preference at outgoing call creation time
+
+**Files:**
+- Modify: `bin-call-manager/pkg/callhandler/outgoing_call.go:153` (after existing customer fetch)
+- Test: `bin-call-manager/pkg/callhandler/outgoing_call_test.go`
+
+**Context:** `CreateCallOutgoing` already fetches the customer at line 149. We add a block immediately after the debug log at line 153 to embed `rtp_debug: true` into the call metadata if the customer has it enabled. This is idempotent — if `providercallhandler` already set it to `true`, setting it again is a no-op.
+
+**Step 1: Write the failing test**
+
+Add a test case to `outgoing_call_test.go` (in the existing table-driven test for `CreateCallOutgoing`) that verifies that when the customer has `Metadata.RTPDebug = true`, the call is created with `rtp_debug: true` in its metadata.
+
+Look for existing test patterns in `outgoing_call_test.go` — find how mock customer responses are set up (`mockReqHandler.EXPECT().CustomerV1CustomerGet(...)`) and follow the same pattern.
+
+```go
+{
+    name: "customer has rtp_debug enabled — metadata embedded at creation",
+    // Set up customer mock to return Metadata.RTPDebug = true
+    // Verify the call passed to h.Create() has metadata[MetadataKeyRTPDebug] == true
+},
+```
+
+**Step 2: Run the test to verify it fails**
+
+```bash
+cd bin-call-manager
+go test ./pkg/callhandler/... -run TestCreateCallOutgoing -v
+```
+
+Expected: FAIL — the metadata block does not exist yet.
+
+**Step 3: Add the implementation block**
+
+In `bin-call-manager/pkg/callhandler/outgoing_call.go`, after line 153 (the `log.WithField("customer", cu).Debugf(...)` line):
+
+```go
+// embed rtp_debug in call metadata at creation time so status.go doesn't need to re-fetch the customer
+if cu.Metadata.RTPDebug {
+    if metadata == nil {
+        metadata = map[string]interface{}{}
+    }
+    metadata[string(call.MetadataKeyRTPDebug)] = true
+}
+```
+
+**Step 4: Run the test to verify it passes**
+
+```bash
+cd bin-call-manager
+go test ./pkg/callhandler/... -run TestCreateCallOutgoing -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-call-manager/pkg/callhandler/outgoing_call.go \
+        bin-call-manager/pkg/callhandler/outgoing_call_test.go
+git commit -m "NOJIRA-rtp-debug-force-provider-call
+
+- bin-call-manager: embed customer rtp_debug preference in call metadata at creation time"
+```
+
+---
+
+### Task 3: Simplify `status.go` — remove customer fetch, read call metadata directly
+
+**Files:**
+- Modify: `bin-call-manager/pkg/callhandler/status.go:69-88`
+- Test: `bin-call-manager/pkg/callhandler/status_test.go`
+
+**Context:** The current block (lines 69–88) fetches the customer, checks `cs.Metadata.RTPDebug`, sets `res.Metadata[MetadataKeyRTPDebug] = true`, calls `h.db.CallUpdate()` to persist it, then calls `rtpDebugStartRecording`. With Task 2 done, the flag is already in `res.Metadata` from creation time — so none of that is needed. The replacement is a single `if` check on the call metadata.
+
+**Step 1: Write the failing test**
+
+In `status_test.go`, add test cases for `updateStatusProgressing` that verify:
+1. When `res.Metadata[MetadataKeyRTPDebug] = true` — `rtpDebugStartRecording` is called (no customer fetch mock needed).
+2. When `res.Metadata` does not have the key — `rtpDebugStartRecording` is NOT called.
+
+Follow the existing table-driven test patterns in `status_test.go`.
+
+**Step 2: Run the test to verify it fails**
+
+```bash
+cd bin-call-manager
+go test ./pkg/callhandler/... -run TestUpdateStatusProgressing -v
+```
+
+Expected: FAIL — the current code fetches customer and checks customer metadata instead of call metadata.
+
+**Step 3: Replace the block in `status.go`**
+
+Remove lines 69–88:
+
+```go
+// DELETE this entire block:
+cs, errCS := h.reqHandler.CustomerV1CustomerGet(ctx, res.CustomerID)
+if errCS != nil {
+    log.Errorf("Could not get customer for RTP debug check. customer_id: %s, err: %v", res.CustomerID, errCS)
+} else {
+    log.WithField("customer", cs).Debugf("Retrieved customer for RTP debug check. customer_id: %s", cs.ID)
+    if cs.Metadata.RTPDebug {
+        if res.Metadata == nil {
+            res.Metadata = map[string]interface{}{}
+        }
+        res.Metadata[call.MetadataKeyRTPDebug] = true
+        if errMeta := h.db.CallUpdate(ctx, res.ID, map[call.Field]any{
+            call.FieldMetadata: res.Metadata,
+        }); errMeta != nil {
+            log.Errorf("Could not update call metadata for RTP debug. err: %v", errMeta)
+        } else {
+            h.rtpDebugStartRecording(ctx, res, cn)
+        }
+    }
+}
+```
+
+Replace with:
+
+```go
+// rtp_debug is set in call metadata at creation time (outgoing_call.go or providercallhandler)
+if rtpDebug, _ := res.Metadata[call.MetadataKeyRTPDebug].(bool); rtpDebug {
+    h.rtpDebugStartRecording(ctx, res, cn)
+}
+```
+
+**Step 4: Run the test to verify it passes**
+
+```bash
+cd bin-call-manager
+go test ./pkg/callhandler/... -run TestUpdateStatusProgressing -v
+```
+
+Expected: PASS.
+
+**Step 5: Run full test suite for bin-call-manager**
+
+```bash
+cd bin-call-manager
+go test ./... -v
+```
+
+Expected: all tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add bin-call-manager/pkg/callhandler/status.go \
+        bin-call-manager/pkg/callhandler/status_test.go
+git commit -m "NOJIRA-rtp-debug-force-provider-call
+
+- bin-call-manager: read rtp_debug from call metadata in status.go instead of fetching customer"
+```
+
+---
+
+### Task 4: Run full verification for both services
+
+**Step 1: Verify bin-call-manager**
+
+```bash
+cd bin-call-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all steps pass with no errors.
+
+**Step 2: Verify bin-route-manager**
+
+```bash
+cd bin-route-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all steps pass with no errors.
+
+**Step 3: Push branch and create PR**
+
+```bash
+# From the worktree:
+git fetch origin main
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"
+# Expected: no output (no conflicts)
+
+git push -u origin NOJIRA-rtp-debug-force-provider-call
+
+gh pr create \
+  --title "NOJIRA-rtp-debug-force-provider-call" \
+  --body "Force rtp_debug on for all provider calls and move rtp_debug decisions to call creation time.
+
+- bin-route-manager: force rtp_debug metadata on all provider calls in providercallhandler
+- bin-call-manager: embed customer rtp_debug preference in call metadata at outgoing_call.go creation time
+- bin-call-manager: simplify status.go — remove customer fetch, read rtp_debug from call metadata directly"
+```


### PR DESCRIPTION
Force rtp_debug on for all provider calls and move rtp_debug decisions to call creation time.

- bin-route-manager: force rtp_debug metadata on all provider calls in providercallhandler
- bin-call-manager: embed customer rtp_debug preference in call metadata at outgoing_call creation time
- bin-call-manager: simplify status.go — remove customer fetch, read rtp_debug from call metadata directly