### PR TITLE
NOJIRA-fix-provider-metadata-migration

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/629a307b92d0_route_providers_add_column_metadata.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/629a307b92d0_route_providers_add_column_metadata.py
@@ -1,0 +1,30 @@
+"""route_providers add column metadata
+
+Revision ID: 629a307b92d0
+Revises: aa0d0a29625e
+Create Date: 2026-04-24 11:35:15.865735
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '629a307b92d0'
+down_revision = 'aa0d0a29625e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE route_providers
+        ADD COLUMN metadata JSON
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE route_providers
+        DROP COLUMN metadata
+    """)


### PR DESCRIPTION
Add missing Alembic migration for the route_providers.metadata column. PR #796 (easy-provider-setup) added the Metadata field to the provider Go struct and the fresh-install table_providers.sql but never generated an Alembic migration, so existing deployments lack the column. The result is route-manager returns 'Unknown column metadata in field list' for every SELECT against route_providers, which surfaces as a 400 on GET /v1.0/providers and a repeating error in the provider health-check cycle.

- bin-dbscheme-manager: Add migration 629a307b92d0 adding JSON metadata column to route_providers (nullable, matches the schema script)