### PR TITLE
NOJIRA-api-error-response-codes

### DIFF
--- a/bin-common-handler/models/errors/constructors.go
+++ b/bin-common-handler/models/errors/constructors.go
@@ -1,58 +1,62 @@
 package errors
 
+import (
+	outline "monorepo/bin-common-handler/models/outline"
+)
+
 // newVoipbinError is the single internal factory. The exported
 // constructors below pin one canonical Status each so callers never
 // pass a free-form status string.
-func newVoipbinError(s Status, domain, reason, message string) *VoipbinError {
-	return &VoipbinError{Status: s, Domain: domain, Reason: reason, Message: message}
+func newVoipbinError(s Status, domain outline.ServiceName, reason, message string) *VoipbinError {
+	return &VoipbinError{Status: s, Domain: string(domain), Reason: reason, Message: message}
 }
 
 // InvalidArgument returns a VoipbinError with StatusInvalidArgument.
-func InvalidArgument(domain, reason, message string) *VoipbinError {
+func InvalidArgument(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusInvalidArgument, domain, reason, message)
 }
 
 // Unauthenticated returns a VoipbinError with StatusUnauthenticated.
-func Unauthenticated(domain, reason, message string) *VoipbinError {
+func Unauthenticated(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusUnauthenticated, domain, reason, message)
 }
 
 // PaymentRequired returns a VoipbinError with StatusPaymentRequired.
-func PaymentRequired(domain, reason, message string) *VoipbinError {
+func PaymentRequired(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusPaymentRequired, domain, reason, message)
 }
 
 // PermissionDenied returns a VoipbinError with StatusPermissionDenied.
-func PermissionDenied(domain, reason, message string) *VoipbinError {
+func PermissionDenied(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusPermissionDenied, domain, reason, message)
 }
 
 // NotFound returns a VoipbinError with StatusNotFound.
-func NotFound(domain, reason, message string) *VoipbinError {
+func NotFound(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusNotFound, domain, reason, message)
 }
 
 // AlreadyExists returns a VoipbinError with StatusAlreadyExists.
-func AlreadyExists(domain, reason, message string) *VoipbinError {
+func AlreadyExists(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusAlreadyExists, domain, reason, message)
 }
 
 // FailedPrecondition returns a VoipbinError with StatusFailedPrecondition.
-func FailedPrecondition(domain, reason, message string) *VoipbinError {
+func FailedPrecondition(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusFailedPrecondition, domain, reason, message)
 }
 
 // ResourceExhausted returns a VoipbinError with StatusResourceExhausted.
-func ResourceExhausted(domain, reason, message string) *VoipbinError {
+func ResourceExhausted(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusResourceExhausted, domain, reason, message)
 }
 
 // Unavailable returns a VoipbinError with StatusUnavailable.
-func Unavailable(domain, reason, message string) *VoipbinError {
+func Unavailable(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusUnavailable, domain, reason, message)
 }
 
 // Internal returns a VoipbinError with StatusInternal.
-func Internal(domain, reason, message string) *VoipbinError {
+func Internal(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusInternal, domain, reason, message)
 }

--- a/bin-common-handler/models/errors/constructors.go
+++ b/bin-common-handler/models/errors/constructors.go
@@ -37,6 +37,12 @@ func NotFound(domain outline.ServiceName, reason, message string) *VoipbinError 
 }
 
 // AlreadyExists returns a VoipbinError with StatusAlreadyExists.
+//
+// Note: the api-manager translator never emits ALREADY_EXISTS as a
+// fallback mapping — 409 responses default to FAILED_PRECONDITION.
+// Use this constructor explicitly at sites that genuinely represent
+// a duplicate-create conflict (e.g., CreateXxx handlers hitting a
+// unique-constraint violation).
 func AlreadyExists(domain outline.ServiceName, reason, message string) *VoipbinError {
 	return newVoipbinError(StatusAlreadyExists, domain, reason, message)
 }

--- a/bin-common-handler/models/errors/constructors.go
+++ b/bin-common-handler/models/errors/constructors.go
@@ -1,0 +1,58 @@
+package errors
+
+// newVoipbinError is the single internal factory. The exported
+// constructors below pin one canonical Status each so callers never
+// pass a free-form status string.
+func newVoipbinError(s Status, domain, reason, message string) *VoipbinError {
+	return &VoipbinError{Status: s, Domain: domain, Reason: reason, Message: message}
+}
+
+// InvalidArgument returns a VoipbinError with StatusInvalidArgument.
+func InvalidArgument(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusInvalidArgument, domain, reason, message)
+}
+
+// Unauthenticated returns a VoipbinError with StatusUnauthenticated.
+func Unauthenticated(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusUnauthenticated, domain, reason, message)
+}
+
+// PaymentRequired returns a VoipbinError with StatusPaymentRequired.
+func PaymentRequired(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusPaymentRequired, domain, reason, message)
+}
+
+// PermissionDenied returns a VoipbinError with StatusPermissionDenied.
+func PermissionDenied(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusPermissionDenied, domain, reason, message)
+}
+
+// NotFound returns a VoipbinError with StatusNotFound.
+func NotFound(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusNotFound, domain, reason, message)
+}
+
+// AlreadyExists returns a VoipbinError with StatusAlreadyExists.
+func AlreadyExists(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusAlreadyExists, domain, reason, message)
+}
+
+// FailedPrecondition returns a VoipbinError with StatusFailedPrecondition.
+func FailedPrecondition(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusFailedPrecondition, domain, reason, message)
+}
+
+// ResourceExhausted returns a VoipbinError with StatusResourceExhausted.
+func ResourceExhausted(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusResourceExhausted, domain, reason, message)
+}
+
+// Unavailable returns a VoipbinError with StatusUnavailable.
+func Unavailable(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusUnavailable, domain, reason, message)
+}
+
+// Internal returns a VoipbinError with StatusInternal.
+func Internal(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusInternal, domain, reason, message)
+}

--- a/bin-common-handler/models/errors/constructors.go
+++ b/bin-common-handler/models/errors/constructors.go
@@ -1,7 +1,7 @@
 package errors
 
 import (
-	outline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/outline"
 )
 
 // newVoipbinError is the single internal factory. The exported

--- a/bin-common-handler/models/errors/constructors_test.go
+++ b/bin-common-handler/models/errors/constructors_test.go
@@ -1,11 +1,15 @@
 package errors
 
-import "testing"
+import (
+	"testing"
+
+	outline "monorepo/bin-common-handler/models/outline"
+)
 
 func TestConstructors(t *testing.T) {
 	tests := []struct {
 		name       string
-		build      func(string, string, string) *VoipbinError
+		build      func(outline.ServiceName, string, string) *VoipbinError
 		wantStatus Status
 	}{
 		{"invalid_argument", InvalidArgument, StatusInvalidArgument},
@@ -21,14 +25,14 @@ func TestConstructors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := tt.build("d", "R", "m")
+			e := tt.build(outline.ServiceNameAPIManager, "R", "m")
 			if e == nil {
 				t.Fatal("nil VoipbinError")
 			}
 			if e.Status != tt.wantStatus {
 				t.Errorf("wrong Status: got %q want %q", e.Status, tt.wantStatus)
 			}
-			if e.Domain != "d" || e.Reason != "R" || e.Message != "m" {
+			if e.Domain != "api-manager" || e.Reason != "R" || e.Message != "m" {
 				t.Errorf("wrong fields: %+v", e)
 			}
 			if e.Cause != nil {

--- a/bin-common-handler/models/errors/constructors_test.go
+++ b/bin-common-handler/models/errors/constructors_test.go
@@ -1,0 +1,39 @@
+package errors
+
+import "testing"
+
+func TestConstructors(t *testing.T) {
+	tests := []struct {
+		name       string
+		build      func(string, string, string) *VoipbinError
+		wantStatus Status
+	}{
+		{"invalid_argument", InvalidArgument, StatusInvalidArgument},
+		{"unauthenticated", Unauthenticated, StatusUnauthenticated},
+		{"payment_required", PaymentRequired, StatusPaymentRequired},
+		{"permission_denied", PermissionDenied, StatusPermissionDenied},
+		{"not_found", NotFound, StatusNotFound},
+		{"already_exists", AlreadyExists, StatusAlreadyExists},
+		{"failed_precondition", FailedPrecondition, StatusFailedPrecondition},
+		{"resource_exhausted", ResourceExhausted, StatusResourceExhausted},
+		{"unavailable", Unavailable, StatusUnavailable},
+		{"internal", Internal, StatusInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := tt.build("d", "R", "m")
+			if e == nil {
+				t.Fatal("nil VoipbinError")
+			}
+			if e.Status != tt.wantStatus {
+				t.Errorf("wrong Status: got %q want %q", e.Status, tt.wantStatus)
+			}
+			if e.Domain != "d" || e.Reason != "R" || e.Message != "m" {
+				t.Errorf("wrong fields: %+v", e)
+			}
+			if e.Cause != nil {
+				t.Errorf("Cause should be nil by default")
+			}
+		})
+	}
+}

--- a/bin-common-handler/models/errors/constructors_test.go
+++ b/bin-common-handler/models/errors/constructors_test.go
@@ -3,7 +3,7 @@ package errors
 import (
 	"testing"
 
-	outline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/outline"
 )
 
 func TestConstructors(t *testing.T) {

--- a/bin-common-handler/models/errors/constructors_test.go
+++ b/bin-common-handler/models/errors/constructors_test.go
@@ -37,3 +37,9 @@ func TestConstructors(t *testing.T) {
 		})
 	}
 }
+
+func TestDataTypeVoipbinError(t *testing.T) {
+	if DataTypeVoipbinError != "voipbin_error" {
+		t.Errorf("DataTypeVoipbinError = %q, want %q", DataTypeVoipbinError, "voipbin_error")
+	}
+}

--- a/bin-common-handler/models/errors/datatype.go
+++ b/bin-common-handler/models/errors/datatype.go
@@ -1,0 +1,7 @@
+package errors
+
+// DataTypeVoipbinError is the sock.Response.DataType value used by
+// internal managers to signal that Data contains a JSON-serialized
+// VoipbinError. bin-api-manager's requesthandler inspects this to
+// decide whether to unmarshal the payload as a typed error.
+const DataTypeVoipbinError = "voipbin_error"

--- a/bin-common-handler/models/errors/datatype.go
+++ b/bin-common-handler/models/errors/datatype.go
@@ -4,4 +4,10 @@ package errors
 // internal managers to signal that Data contains a JSON-serialized
 // VoipbinError. bin-api-manager's requesthandler inspects this to
 // decide whether to unmarshal the payload as a typed error.
+//
+// Wire-format contract: once this DataType is in use on main, the
+// JSON shape is locked. Changes must be ADDITIVE-ONLY (new fields
+// with omitempty). Removing or renaming a field requires bumping to a
+// new DataType (e.g., "voipbin_error_v2") so old consumers continue
+// to parse old payloads.
 const DataTypeVoipbinError = "voipbin_error"

--- a/bin-common-handler/models/errors/rpc.go
+++ b/bin-common-handler/models/errors/rpc.go
@@ -8,9 +8,18 @@ import (
 )
 
 // FromResponse extracts a typed *VoipbinError from a sock.Response if
-// the response signals one (StatusCode >= 400 AND DataType ==
-// DataTypeVoipbinError AND Data unmarshals cleanly). Returns nil
-// otherwise — callers should apply their own fallback.
+// the response signals one: StatusCode >= 400 AND DataType ==
+// DataTypeVoipbinError AND Data unmarshals cleanly.
+//
+// Returns nil in three cases, none of which are distinguished:
+//   - success response (StatusCode < 400)
+//   - legacy error without typed body (DataType != DataTypeVoipbinError)
+//   - typed body present but JSON unmarshal failed
+//
+// Callers should treat nil as "not a typed error" and apply their own
+// fallback — for api-manager this means passing the raw error into
+// the translator, which runs sentinel-matching, transport-error
+// detection, and substring fallback before defaulting to INTERNAL.
 func FromResponse(resp *sock.Response) *VoipbinError {
 	if resp == nil || resp.StatusCode < 400 || resp.DataType != DataTypeVoipbinError || len(resp.Data) == 0 {
 		return nil

--- a/bin-common-handler/models/errors/rpc.go
+++ b/bin-common-handler/models/errors/rpc.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"monorepo/bin-common-handler/models/sock"
 )
@@ -19,4 +20,51 @@ func FromResponse(resp *sock.Response) *VoipbinError {
 		return nil
 	}
 	return out
+}
+
+// ToResponse encodes a VoipbinError into a sock.Response carrying the
+// JSON-serialized error in Data and the canonical HTTP status code.
+// Returns an error if e is nil or marshaling fails — neither is
+// expected in normal operation.
+func ToResponse(e *VoipbinError) (*sock.Response, error) {
+	if e == nil {
+		return nil, fmt.Errorf("cannot marshal nil VoipbinError")
+	}
+	body, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("marshal VoipbinError: %w", err)
+	}
+	return &sock.Response{
+		StatusCode: httpStatusFor(e.Status),
+		DataType:   DataTypeVoipbinError,
+		Data:       body,
+	}, nil
+}
+
+// httpStatusFor maps a canonical Status to an HTTP status code. This
+// mapping is the single source of truth for the RPC→HTTP layer;
+// bin-api-manager's abortWithError uses it too.
+func httpStatusFor(s Status) int {
+	switch s {
+	case StatusInvalidArgument:
+		return 400
+	case StatusUnauthenticated:
+		return 401
+	case StatusPaymentRequired:
+		return 402
+	case StatusPermissionDenied:
+		return 403
+	case StatusNotFound:
+		return 404
+	case StatusAlreadyExists, StatusFailedPrecondition:
+		return 409
+	case StatusResourceExhausted:
+		return 429
+	case StatusUnavailable:
+		return 503
+	case StatusInternal:
+		return 500
+	default:
+		return 500
+	}
 }

--- a/bin-common-handler/models/errors/rpc.go
+++ b/bin-common-handler/models/errors/rpc.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+)
+
+// FromResponse extracts a typed *VoipbinError from a sock.Response if
+// the response signals one (StatusCode >= 400 AND DataType ==
+// DataTypeVoipbinError AND Data unmarshals cleanly). Returns nil
+// otherwise — callers should apply their own fallback.
+func FromResponse(resp *sock.Response) *VoipbinError {
+	if resp == nil || resp.StatusCode < 400 || resp.DataType != DataTypeVoipbinError || len(resp.Data) == 0 {
+		return nil
+	}
+	out := &VoipbinError{}
+	if err := json.Unmarshal(resp.Data, out); err != nil {
+		return nil
+	}
+	return out
+}

--- a/bin-common-handler/models/errors/rpc.go
+++ b/bin-common-handler/models/errors/rpc.go
@@ -35,16 +35,15 @@ func ToResponse(e *VoipbinError) (*sock.Response, error) {
 		return nil, fmt.Errorf("marshal VoipbinError: %w", err)
 	}
 	return &sock.Response{
-		StatusCode: httpStatusFor(e.Status),
+		StatusCode: HTTPStatusFor(e.Status),
 		DataType:   DataTypeVoipbinError,
 		Data:       body,
 	}, nil
 }
 
-// httpStatusFor maps a canonical Status to an HTTP status code. This
-// mapping is the single source of truth for the RPC→HTTP layer;
-// bin-api-manager's abortWithError uses it too.
-func httpStatusFor(s Status) int {
+// HTTPStatusFor maps a canonical Status to an HTTP status code.
+// This is the single source of truth for the Status-to-HTTP mapping.
+func HTTPStatusFor(s Status) int {
 	switch s {
 	case StatusInvalidArgument:
 		return 400

--- a/bin-common-handler/models/errors/rpc.go
+++ b/bin-common-handler/models/errors/rpc.go
@@ -9,17 +9,16 @@ import (
 
 // FromResponse extracts a typed *VoipbinError from a sock.Response if
 // the response signals one: StatusCode >= 400 AND DataType ==
-// DataTypeVoipbinError AND Data unmarshals cleanly.
+// DataTypeVoipbinError AND Data is non-empty AND Data unmarshals
+// cleanly.
 //
-// Returns nil in three cases, none of which are distinguished:
-//   - success response (StatusCode < 400)
-//   - legacy error without typed body (DataType != DataTypeVoipbinError)
-//   - typed body present but JSON unmarshal failed
-//
-// Callers should treat nil as "not a typed error" and apply their own
-// fallback — for api-manager this means passing the raw error into
-// the translator, which runs sentinel-matching, transport-error
-// detection, and substring fallback before defaulting to INTERNAL.
+// Returns nil when any of those conditions fail (nil response, success
+// status, wrong DataType, empty Data, or unmarshal failure) — none of
+// the failure modes are distinguished. Callers should treat nil as
+// "not a typed error" and apply their own fallback. For api-manager
+// this means passing the raw error into the translator, which runs
+// sentinel-matching, transport-error detection, and substring fallback
+// before defaulting to INTERNAL.
 func FromResponse(resp *sock.Response) *VoipbinError {
 	if resp == nil || resp.StatusCode < 400 || resp.DataType != DataTypeVoipbinError || len(resp.Data) == 0 {
 		return nil

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -129,3 +129,29 @@ func TestToResponseNil(t *testing.T) {
 		t.Errorf("ToResponse(nil) must return an error")
 	}
 }
+
+func TestHTTPStatusFor(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   int
+	}{
+		{StatusInvalidArgument, 400},
+		{StatusUnauthenticated, 401},
+		{StatusPaymentRequired, 402},
+		{StatusPermissionDenied, 403},
+		{StatusNotFound, 404},
+		{StatusAlreadyExists, 409},
+		{StatusFailedPrecondition, 409},
+		{StatusResourceExhausted, 429},
+		{StatusUnavailable, 503},
+		{StatusInternal, 500},
+		{Status("UNKNOWN"), 500},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if got := HTTPStatusFor(tt.status); got != tt.want {
+				t.Errorf("got %d want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -73,3 +73,59 @@ func TestFromResponseNil(t *testing.T) {
 		t.Errorf("nil response must return nil, got %+v", got)
 	}
 }
+
+func TestToResponse(t *testing.T) {
+	e := NotFound("call-manager", "CALL_NOT_FOUND", "The call was not found.")
+	resp, err := ToResponse(e)
+	if err != nil {
+		t.Fatalf("ToResponse returned error: %v", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("wrong StatusCode: %d", resp.StatusCode)
+	}
+	if resp.DataType != DataTypeVoipbinError {
+		t.Errorf("wrong DataType: %s", resp.DataType)
+	}
+
+	// Round-trip: FromResponse must recover the original.
+	got := FromResponse(resp)
+	if got == nil || got.Status != StatusNotFound || got.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("round-trip failed: %+v", got)
+	}
+}
+
+func TestToResponseAllStatuses(t *testing.T) {
+	tests := []struct {
+		status Status
+		http   int
+	}{
+		{StatusInvalidArgument, 400},
+		{StatusUnauthenticated, 401},
+		{StatusPaymentRequired, 402},
+		{StatusPermissionDenied, 403},
+		{StatusNotFound, 404},
+		{StatusAlreadyExists, 409},
+		{StatusFailedPrecondition, 409},
+		{StatusResourceExhausted, 429},
+		{StatusUnavailable, 503},
+		{StatusInternal, 500},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			e := &VoipbinError{Status: tt.status, Reason: "X", Domain: "d", Message: "m"}
+			resp, err := ToResponse(e)
+			if err != nil {
+				t.Fatalf("ToResponse failed: %v", err)
+			}
+			if resp.StatusCode != tt.http {
+				t.Errorf("wrong StatusCode for %s: got %d want %d", tt.status, resp.StatusCode, tt.http)
+			}
+		})
+	}
+}
+
+func TestToResponseNil(t *testing.T) {
+	if _, err := ToResponse(nil); err == nil {
+		t.Errorf("ToResponse(nil) must return an error")
+	}
+}

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	outline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 )
 
@@ -75,7 +76,7 @@ func TestFromResponseNil(t *testing.T) {
 }
 
 func TestToResponse(t *testing.T) {
-	e := NotFound("call-manager", "CALL_NOT_FOUND", "The call was not found.")
+	e := NotFound(outline.ServiceNameCallManager, "CALL_NOT_FOUND", "The call was not found.")
 	resp, err := ToResponse(e)
 	if err != nil {
 		t.Fatalf("ToResponse returned error: %v", err)

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	outline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 )
 
@@ -162,6 +162,7 @@ func TestHTTPStatusFor(t *testing.T) {
 		{StatusResourceExhausted, 429},
 		{StatusUnavailable, 503},
 		{StatusInternal, 500},
+		{Status(""), 500},
 		{Status("UNKNOWN"), 500},
 	}
 	for _, tt := range tests {

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -1,0 +1,75 @@
+package errors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+)
+
+func TestFromResponseTypedError(t *testing.T) {
+	payload := &VoipbinError{
+		Status:  StatusNotFound,
+		Reason:  "CALL_NOT_FOUND",
+		Domain:  "call-manager",
+		Message: "The call was not found.",
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal setup: %v", err)
+	}
+	resp := &sock.Response{
+		StatusCode: 404,
+		DataType:   DataTypeVoipbinError,
+		Data:       data,
+	}
+
+	got := FromResponse(resp)
+	if got == nil {
+		t.Fatal("FromResponse returned nil for a typed error response")
+	}
+	if got.Status != StatusNotFound || got.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("wrong VoipbinError: %+v", got)
+	}
+}
+
+func TestFromResponseSuccess(t *testing.T) {
+	resp := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       json.RawMessage(`{"ok":true}`),
+	}
+	if got := FromResponse(resp); got != nil {
+		t.Errorf("FromResponse on success should return nil, got %+v", got)
+	}
+}
+
+func TestFromResponseErrorWithoutTypedDataType(t *testing.T) {
+	// Legacy manager — error code but no typed body.
+	resp := &sock.Response{
+		StatusCode: 500,
+		DataType:   "application/json",
+		Data:       json.RawMessage(`{"message":"legacy"}`),
+	}
+	if got := FromResponse(resp); got != nil {
+		t.Errorf("FromResponse without DataTypeVoipbinError must return nil, got %+v", got)
+	}
+}
+
+func TestFromResponseMalformedData(t *testing.T) {
+	resp := &sock.Response{
+		StatusCode: 500,
+		DataType:   DataTypeVoipbinError,
+		Data:       json.RawMessage(`{not json`),
+	}
+	// Must not panic and must fall back to nil so the caller uses its own fallback path.
+	if got := FromResponse(resp); got != nil {
+		t.Errorf("malformed Data must return nil, got %+v", got)
+	}
+}
+
+func TestFromResponseNil(t *testing.T) {
+	if got := FromResponse(nil); got != nil {
+		t.Errorf("nil response must return nil, got %+v", got)
+	}
+}

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -90,8 +90,20 @@ func TestToResponse(t *testing.T) {
 
 	// Round-trip: FromResponse must recover the original.
 	got := FromResponse(resp)
-	if got == nil || got.Status != StatusNotFound || got.Reason != "CALL_NOT_FOUND" {
-		t.Errorf("round-trip failed: %+v", got)
+	if got == nil {
+		t.Fatal("round-trip returned nil")
+	}
+	if got.Status != StatusNotFound {
+		t.Errorf("round-trip Status: got %q want %q", got.Status, StatusNotFound)
+	}
+	if got.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("round-trip Reason: got %q want %q", got.Reason, "CALL_NOT_FOUND")
+	}
+	if got.Domain != "call-manager" {
+		t.Errorf("round-trip Domain: got %q want %q", got.Domain, "call-manager")
+	}
+	if got.Message != "The call was not found." {
+		t.Errorf("round-trip Message: got %q want %q", got.Message, "The call was not found.")
 	}
 }
 
@@ -120,6 +132,10 @@ func TestToResponseAllStatuses(t *testing.T) {
 			}
 			if resp.StatusCode != tt.http {
 				t.Errorf("wrong StatusCode for %s: got %d want %d", tt.status, resp.StatusCode, tt.http)
+			}
+			// Verify the body always round-trips back through FromResponse.
+			if got := FromResponse(resp); got == nil {
+				t.Errorf("round-trip returned nil for %s; ToResponse must produce a body FromResponse recognizes", tt.status)
 			}
 		})
 	}

--- a/bin-common-handler/models/errors/rpc_test.go
+++ b/bin-common-handler/models/errors/rpc_test.go
@@ -75,6 +75,32 @@ func TestFromResponseNil(t *testing.T) {
 	}
 }
 
+func TestFromResponseEmptyData(t *testing.T) {
+	// DataType matches DataTypeVoipbinError and StatusCode is error,
+	// but Data is absent (e.g., a manager set DataType then failed
+	// to marshal the body). FromResponse must return nil, not panic,
+	// and not attempt to unmarshal an empty payload.
+	tests := []struct {
+		name string
+		data json.RawMessage
+	}{
+		{"nil_data", nil},
+		{"empty_data", json.RawMessage{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &sock.Response{
+				StatusCode: 500,
+				DataType:   DataTypeVoipbinError,
+				Data:       tt.data,
+			}
+			if got := FromResponse(resp); got != nil {
+				t.Errorf("FromResponse with %s must return nil, got %+v", tt.name, got)
+			}
+		})
+	}
+}
+
 func TestToResponse(t *testing.T) {
 	e := NotFound(outline.ServiceNameCallManager, "CALL_NOT_FOUND", "The call was not found.")
 	resp, err := ToResponse(e)

--- a/bin-common-handler/models/errors/status.go
+++ b/bin-common-handler/models/errors/status.go
@@ -1,10 +1,26 @@
 // Package errors defines the shared VoipbinError type used across the
-// VoIPbin monorepo for external API error responses.
+// VoIPbin monorepo for external API error responses and for typed
+// errors on the RabbitMQ RPC channel.
+//
+// Import alias: this package shadows stdlib "errors". Most callers
+// import it as "cerrors" alongside the standard library:
+//
+//	import (
+//	    stderrors "errors"
+//	    cerrors "monorepo/bin-common-handler/models/errors"
+//	)
+//
+// Admission-rule note: this package currently has one day-1 consumer
+// (bin-api-manager). The monorepo admission rule normally requires
+// three consumers for bin-common-handler residency. Exception
+// justification: VoipbinError is the shared RPC contract that every
+// internal manager can emit via sock.Response.Data, so its cross-
+// service consumer count will grow as managers migrate.
 package errors
 
 // Status is the canonical error status. It maps 1:1 to an HTTP status
-// code (see bin-api-manager for the mapping). The set is intentionally
-// closed — extending it requires a coordinated schema update.
+// code via HTTPStatusFor. The set is intentionally closed — extending
+// it requires a coordinated schema update across every consumer.
 type Status string
 
 const (

--- a/bin-common-handler/models/errors/status.go
+++ b/bin-common-handler/models/errors/status.go
@@ -1,0 +1,21 @@
+// Package errors defines the shared VoipbinError type used across the
+// VoIPbin monorepo for external API error responses.
+package errors
+
+// Status is the canonical error status. It maps 1:1 to an HTTP status
+// code (see bin-api-manager for the mapping). The set is intentionally
+// closed — extending it requires a coordinated schema update.
+type Status string
+
+const (
+	StatusInvalidArgument    Status = "INVALID_ARGUMENT"
+	StatusUnauthenticated    Status = "UNAUTHENTICATED"
+	StatusPaymentRequired    Status = "PAYMENT_REQUIRED"
+	StatusPermissionDenied   Status = "PERMISSION_DENIED"
+	StatusNotFound           Status = "NOT_FOUND"
+	StatusAlreadyExists      Status = "ALREADY_EXISTS"
+	StatusFailedPrecondition Status = "FAILED_PRECONDITION"
+	StatusResourceExhausted  Status = "RESOURCE_EXHAUSTED"
+	StatusUnavailable        Status = "UNAVAILABLE"
+	StatusInternal           Status = "INTERNAL"
+)

--- a/bin-common-handler/models/errors/status_test.go
+++ b/bin-common-handler/models/errors/status_test.go
@@ -1,0 +1,29 @@
+package errors
+
+import "testing"
+
+func TestStatusConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant Status
+		expected string
+	}{
+		{"invalid_argument", StatusInvalidArgument, "INVALID_ARGUMENT"},
+		{"unauthenticated", StatusUnauthenticated, "UNAUTHENTICATED"},
+		{"payment_required", StatusPaymentRequired, "PAYMENT_REQUIRED"},
+		{"permission_denied", StatusPermissionDenied, "PERMISSION_DENIED"},
+		{"not_found", StatusNotFound, "NOT_FOUND"},
+		{"already_exists", StatusAlreadyExists, "ALREADY_EXISTS"},
+		{"failed_precondition", StatusFailedPrecondition, "FAILED_PRECONDITION"},
+		{"resource_exhausted", StatusResourceExhausted, "RESOURCE_EXHAUSTED"},
+		{"unavailable", StatusUnavailable, "UNAVAILABLE"},
+		{"internal", StatusInternal, "INTERNAL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.constant) != tt.expected {
+				t.Errorf("got %q want %q", string(tt.constant), tt.expected)
+			}
+		})
+	}
+}

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -1,0 +1,13 @@
+package errors
+
+// VoipbinError is the canonical error shape returned from the external
+// VoIPbin API and (eventually) over RPC between internal managers.
+// The Cause field is for server-side logging only and is never
+// serialized to clients.
+type VoipbinError struct {
+	Status  Status `json:"status"`
+	Reason  string `json:"reason"`
+	Domain  string `json:"domain"`
+	Message string `json:"message"`
+	Cause   error  `json:"-"`
+}

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -3,9 +3,17 @@ package errors
 import "fmt"
 
 // VoipbinError is the canonical error shape returned from the external
-// VoIPbin API and (eventually) over RPC between internal managers.
-// The Cause field is for server-side logging only and is never
-// serialized to clients.
+// VoIPbin API and over RPC between internal managers.
+//
+// Wire contract:
+//   - Status, Reason, Domain, Message are emitted to clients and to
+//     internal RPC consumers.
+//   - Details is reserved for future structured detail; omitempty.
+//   - Cause is server-side only (json:"-"); it is included by Error()
+//     for server logs but MUST NOT be written into HTTP response
+//     bodies. Call json.Marshal(e) or construct a response envelope
+//     from fields directly — do not use e.Error() as a user-visible
+//     message.
 type VoipbinError struct {
 	Status  Status `json:"status"`
 	Reason  string `json:"reason"`

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -1,5 +1,7 @@
 package errors
 
+import "fmt"
+
 // VoipbinError is the canonical error shape returned from the external
 // VoIPbin API and (eventually) over RPC between internal managers.
 // The Cause field is for server-side logging only and is never
@@ -10,4 +12,21 @@ type VoipbinError struct {
 	Domain  string `json:"domain"`
 	Message string `json:"message"`
 	Cause   error  `json:"-"`
+}
+
+// Error satisfies the error interface. Format:
+//
+//	<domain>: <reason>: <message>[: <cause>]
+//
+// The cause is included when non-nil so server-side logs see the
+// underlying error without any extra call at the log site.
+func (e *VoipbinError) Error() string {
+	if e == nil {
+		return "<nil VoipbinError>"
+	}
+	base := fmt.Sprintf("%s: %s: %s", e.Domain, e.Reason, e.Message)
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %s", base, e.Cause.Error())
+	}
+	return base
 }

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -57,10 +57,16 @@ func (e *VoipbinError) Unwrap() error {
 }
 
 // Wrap returns a shallow copy of the VoipbinError with Cause set to
-// the given error. Callers can chain: Internal(...).Wrap(err). Wrap
-// does NOT mutate the receiver — this prevents aliasing surprises if
-// the receiver has been stored in a package-level variable or passed
-// to another goroutine.
+// the given error. Callers can chain: Internal(...).Wrap(err).
+//
+// Wrap does NOT mutate the receiver's Cause field — string, Status,
+// Reason, Domain, and Message are independently copied. However, the
+// Details slice is a shallow copy: mutating an existing Details entry
+// on the returned value will also mutate the receiver's same entry
+// (they share the backing array). In practice this is never an issue
+// because Wrap is called immediately after construction, before
+// Details is populated — but do not mutate Details entries after
+// calling Wrap if you intend to reuse the receiver.
 //
 // The cause is only used in server-side logs (Error() includes it);
 // JSON serialization still excludes it via the json:"-" tag.

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -11,7 +11,15 @@ type VoipbinError struct {
 	Reason  string `json:"reason"`
 	Domain  string `json:"domain"`
 	Message string `json:"message"`
-	Cause   error  `json:"-"`
+	// Details is reserved for future per-field or structured error
+	// detail (e.g., BadRequest field violations). Optional; may be
+	// omitted. New detail shapes must be additive-only so existing
+	// consumers tolerate unknown keys.
+	Details []map[string]any `json:"details,omitempty"`
+	// Cause is for server-side logging only — never serialized to
+	// clients. WARNING: Error() DOES include Cause.Error() in its
+	// return value. Never use err.Error() as an HTTP response body.
+	Cause error `json:"-"`
 }
 
 // Error satisfies the error interface. Format:

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -39,3 +39,15 @@ func (e *VoipbinError) Unwrap() error {
 	}
 	return e.Cause
 }
+
+// Wrap attaches an underlying cause to the VoipbinError and returns
+// the receiver so callers can chain: Internal(...).Wrap(err).
+// The cause is only used in server-side logs (Error() includes it);
+// JSON serialization still excludes it.
+func (e *VoipbinError) Wrap(cause error) *VoipbinError {
+	if e == nil {
+		return nil
+	}
+	e.Cause = cause
+	return e
+}

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -30,3 +30,12 @@ func (e *VoipbinError) Error() string {
 	}
 	return base
 }
+
+// Unwrap returns the underlying cause so errors.Is and errors.As
+// can walk the chain across fmt.Errorf("%w", VoipbinError) wraps.
+func (e *VoipbinError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/bin-common-handler/models/errors/voipbin_error.go
+++ b/bin-common-handler/models/errors/voipbin_error.go
@@ -40,14 +40,19 @@ func (e *VoipbinError) Unwrap() error {
 	return e.Cause
 }
 
-// Wrap attaches an underlying cause to the VoipbinError and returns
-// the receiver so callers can chain: Internal(...).Wrap(err).
+// Wrap returns a shallow copy of the VoipbinError with Cause set to
+// the given error. Callers can chain: Internal(...).Wrap(err). Wrap
+// does NOT mutate the receiver — this prevents aliasing surprises if
+// the receiver has been stored in a package-level variable or passed
+// to another goroutine.
+//
 // The cause is only used in server-side logs (Error() includes it);
-// JSON serialization still excludes it.
+// JSON serialization still excludes it via the json:"-" tag.
 func (e *VoipbinError) Wrap(cause error) *VoipbinError {
 	if e == nil {
 		return nil
 	}
-	e.Cause = cause
-	return e
+	out := *e
+	out.Cause = cause
+	return &out
 }

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"encoding/json"
 	stderrors "errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -99,5 +100,31 @@ func TestVoipbinErrorErrorMethodNilReceiver(t *testing.T) {
 	want := "<nil VoipbinError>"
 	if got != want {
 		t.Errorf("Error() on nil = %q, want %q", got, want)
+	}
+}
+
+func TestVoipbinErrorUnwrap(t *testing.T) {
+	inner := stderrors.New("inner failure")
+	e := &VoipbinError{
+		Status:  StatusInternal,
+		Reason:  "INTERNAL",
+		Domain:  "api-manager",
+		Message: "wrap test",
+		Cause:   inner,
+	}
+
+	// errors.Is walks the chain via Unwrap.
+	if !stderrors.Is(e, inner) {
+		t.Fatalf("errors.Is did not find wrapped cause")
+	}
+
+	// errors.As on a wrapped VoipbinError finds it.
+	wrapped := fmt.Errorf("context: %w", e)
+	var target *VoipbinError
+	if !stderrors.As(wrapped, &target) {
+		t.Fatalf("errors.As did not recover VoipbinError from wrapped chain")
+	}
+	if target.Reason != "INTERNAL" {
+		t.Errorf("errors.As returned wrong VoipbinError: %v", target)
 	}
 }

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"encoding/json"
 	stderrors "errors"
+	"strings"
 	"testing"
 )
 
@@ -52,22 +53,13 @@ func TestVoipbinErrorJSONExcludesCause(t *testing.T) {
 		`"domain":"call-manager"`,
 		`"message":"The call was not found."`,
 	} {
-		if !contains(s, want) {
+		if !strings.Contains(s, want) {
 			t.Errorf("expected %q in JSON %q", want, s)
 		}
 	}
 	for _, forbidden := range []string{"cause", "connection refused", "DB driver"} {
-		if contains(s, forbidden) {
+		if strings.Contains(s, forbidden) {
 			t.Errorf("forbidden token %q leaked into JSON %q", forbidden, s)
 		}
 	}
-}
-
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -159,3 +159,38 @@ func TestVoipbinErrorWrapNilReceiver(t *testing.T) {
 		t.Errorf("Wrap on nil receiver = %v, want nil", got)
 	}
 }
+
+func TestVoipbinErrorDetailsOmitempty(t *testing.T) {
+	// Without details — field must be absent from JSON.
+	e := &VoipbinError{Status: StatusInternal, Reason: "X", Domain: "d", Message: "m"}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "details") {
+		t.Errorf("details should be omitted when empty, got: %s", string(b))
+	}
+
+	// With details — field must round-trip through JSON.
+	e.Details = []map[string]any{
+		{"field": "phone_number", "issue": "not E.164"},
+	}
+	b, err = json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal with details: %v", err)
+	}
+	if !strings.Contains(string(b), `"details"`) {
+		t.Errorf("details should be present when set, got: %s", string(b))
+	}
+	if !strings.Contains(string(b), "phone_number") {
+		t.Errorf("details content missing: %s", string(b))
+	}
+
+	var round VoipbinError
+	if err := json.Unmarshal(b, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(round.Details) != 1 {
+		t.Fatalf("round-trip lost details: %+v", round.Details)
+	}
+}

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -92,3 +92,12 @@ func TestVoipbinErrorErrorMethodWithCause(t *testing.T) {
 		t.Errorf("Error() = %q, want %q", got, want)
 	}
 }
+
+func TestVoipbinErrorErrorMethodNilReceiver(t *testing.T) {
+	var e *VoipbinError
+	got := e.Error()
+	want := "<nil VoipbinError>"
+	if got != want {
+		t.Errorf("Error() on nil = %q, want %q", got, want)
+	}
+}

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -63,3 +63,32 @@ func TestVoipbinErrorJSONExcludesCause(t *testing.T) {
 		}
 	}
 }
+
+func TestVoipbinErrorErrorMethod(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusPermissionDenied,
+		Reason:  "BILLING_ACCESS_DENIED",
+		Domain:  "billing-manager",
+		Message: "Not allowed.",
+	}
+	got := e.Error()
+	want := "billing-manager: BILLING_ACCESS_DENIED: Not allowed."
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestVoipbinErrorErrorMethodWithCause(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusInternal,
+		Reason:  "INTERNAL",
+		Domain:  "api-manager",
+		Message: "Something went wrong.",
+		Cause:   stderrors.New("pq: connection refused"),
+	}
+	got := e.Error()
+	want := "api-manager: INTERNAL: Something went wrong.: pq: connection refused"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -134,11 +134,21 @@ func TestVoipbinErrorWrap(t *testing.T) {
 	inner := stderrors.New("boom")
 	out := e.Wrap(inner)
 
-	if out != e {
-		t.Errorf("Wrap should return the receiver for chaining")
+	if out == nil {
+		t.Fatal("Wrap returned nil")
 	}
-	if e.Cause != inner {
-		t.Errorf("Wrap did not set Cause: %v", e.Cause)
+	if out.Cause != inner {
+		t.Errorf("Wrap did not set Cause on returned value: %v", out.Cause)
+	}
+	if e.Cause != nil {
+		t.Errorf("Wrap must NOT mutate the receiver; e.Cause = %v", e.Cause)
+	}
+	if out == e {
+		t.Error("Wrap must return a copy, not the receiver")
+	}
+	// Also verify all other fields are copied correctly.
+	if out.Status != e.Status || out.Reason != e.Reason || out.Domain != e.Domain || out.Message != e.Message {
+		t.Errorf("Wrap copy lost fields: out=%+v e=%+v", out, e)
 	}
 }
 

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -1,0 +1,73 @@
+package errors
+
+import (
+	"encoding/json"
+	stderrors "errors"
+	"testing"
+)
+
+func TestVoipbinErrorFields(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusNotFound,
+		Reason:  "CALL_NOT_FOUND",
+		Domain:  "call-manager",
+		Message: "The call was not found.",
+		Cause:   stderrors.New("underlying"),
+	}
+	if e.Status != StatusNotFound {
+		t.Errorf("wrong Status: %v", e.Status)
+	}
+	if e.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("wrong Reason: %v", e.Reason)
+	}
+	if e.Domain != "call-manager" {
+		t.Errorf("wrong Domain: %v", e.Domain)
+	}
+	if e.Message != "The call was not found." {
+		t.Errorf("wrong Message: %v", e.Message)
+	}
+	if e.Cause == nil || e.Cause.Error() != "underlying" {
+		t.Errorf("wrong Cause: %v", e.Cause)
+	}
+}
+
+func TestVoipbinErrorJSONExcludesCause(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusNotFound,
+		Reason:  "CALL_NOT_FOUND",
+		Domain:  "call-manager",
+		Message: "The call was not found.",
+		Cause:   stderrors.New("DB driver error: connection refused"),
+	}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	s := string(b)
+	for _, want := range []string{
+		`"status":"NOT_FOUND"`,
+		`"reason":"CALL_NOT_FOUND"`,
+		`"domain":"call-manager"`,
+		`"message":"The call was not found."`,
+	} {
+		if !contains(s, want) {
+			t.Errorf("expected %q in JSON %q", want, s)
+		}
+	}
+	for _, forbidden := range []string{"cause", "connection refused", "DB driver"} {
+		if contains(s, forbidden) {
+			t.Errorf("forbidden token %q leaked into JSON %q", forbidden, s)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -128,3 +128,16 @@ func TestVoipbinErrorUnwrap(t *testing.T) {
 		t.Errorf("errors.As returned wrong VoipbinError: %v", target)
 	}
 }
+
+func TestVoipbinErrorWrap(t *testing.T) {
+	e := &VoipbinError{Status: StatusInternal, Reason: "INTERNAL", Domain: "api-manager", Message: "x"}
+	inner := stderrors.New("boom")
+	out := e.Wrap(inner)
+
+	if out != e {
+		t.Errorf("Wrap should return the receiver for chaining")
+	}
+	if e.Cause != inner {
+		t.Errorf("Wrap did not set Cause: %v", e.Cause)
+	}
+}

--- a/bin-common-handler/models/errors/voipbin_error_test.go
+++ b/bin-common-handler/models/errors/voipbin_error_test.go
@@ -141,3 +141,11 @@ func TestVoipbinErrorWrap(t *testing.T) {
 		t.Errorf("Wrap did not set Cause: %v", e.Cause)
 	}
 }
+
+func TestVoipbinErrorWrapNilReceiver(t *testing.T) {
+	var e *VoipbinError
+	got := e.Wrap(stderrors.New("x"))
+	if got != nil {
+		t.Errorf("Wrap on nil receiver = %v, want nil", got)
+	}
+}

--- a/bin-common-handler/models/sock/message.go
+++ b/bin-common-handler/models/sock/message.go
@@ -9,7 +9,13 @@ type Request struct {
 	Publisher string          `json:"publisher"`
 	DataType  string          `json:"data_type"`
 	Data      json.RawMessage `json:"data,omitempty"`
-	RequestID string          `json:"request_id,omitempty"`
+	// RequestID is an optional request correlation ID propagated from
+	// the inbound HTTP request through api-manager into downstream
+	// RPC calls. See the design doc (docs/plans/2026-04-24-api-error-
+	// response-codes-design.md §5.2) for the propagation chain.
+	// Clients and managers receive it via logrus fields so inbound
+	// and outbound log lines can be joined by the same ID.
+	RequestID string `json:"request_id,omitempty"`
 }
 
 // Response struct

--- a/bin-common-handler/models/sock/message.go
+++ b/bin-common-handler/models/sock/message.go
@@ -9,6 +9,7 @@ type Request struct {
 	Publisher string          `json:"publisher"`
 	DataType  string          `json:"data_type"`
 	Data      json.RawMessage `json:"data,omitempty"`
+	RequestID string          `json:"request_id,omitempty"`
 }
 
 // Response struct

--- a/bin-common-handler/models/sock/message_test.go
+++ b/bin-common-handler/models/sock/message_test.go
@@ -2,6 +2,7 @@ package sock
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -147,5 +148,38 @@ func TestResponseStatusCodes(t *testing.T) {
 				t.Errorf("Response.StatusCode = %v, expected %v", r.StatusCode, tt.statusCode)
 			}
 		})
+	}
+}
+
+func TestRequestRequestIDField(t *testing.T) {
+	r := Request{
+		URI:       "/v1/calls/1",
+		Method:    RequestMethodGet,
+		RequestID: "req_01hxyz12345",
+	}
+	if r.RequestID != "req_01hxyz12345" {
+		t.Errorf("RequestID not set: %q", r.RequestID)
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"request_id":"req_01hxyz12345"`) {
+		t.Errorf("request_id missing from JSON: %s", string(b))
+	}
+}
+
+func TestRequestRequestIDOmitempty(t *testing.T) {
+	r := Request{
+		URI:    "/v1/calls",
+		Method: RequestMethodPost,
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "request_id") {
+		t.Errorf("request_id should be omitted when empty, got: %s", string(b))
 	}
 }

--- a/docs/plans/2026-04-24-api-error-response-codes-design.md
+++ b/docs/plans/2026-04-24-api-error-response-codes-design.md
@@ -271,7 +271,7 @@ components:
 
 ### 10.2 PR 0b — `bin-api-manager` infrastructure
 
-- `abortWithError` / `abortWithServiceError` / `httpStatusFor` / `assertErrorResponse` helpers + tests.
+- `abortWithError` / `abortWithServiceError` / `assertErrorResponse` helpers + tests (reuses `cerrors.HTTPStatusFor` from bin-common-handler).
 - Request-ID middleware registered in `cmd/api-manager/main.go`.
 - Migrate `ratelimit.go` and `authenticate.go` middleware.
 - OpenAPI `ErrorBody` / `ErrorResponse` / named responses components added.

--- a/docs/plans/2026-04-24-api-error-response-codes-design.md
+++ b/docs/plans/2026-04-24-api-error-response-codes-design.md
@@ -366,3 +366,15 @@ During PR #799 self-review, six refinement commits tightened the API before merg
 - Typed the constructor `domain` parameter as `outline.ServiceName` to catch service-name typos at compile time.
 - Expanded `ToResponse` round-trip tests to assert all four wire fields; added per-status `FromResponse` round-trip assertion.
 - Documentation: package godoc states the cerrors import alias convention and admission-rule justification; `DataTypeVoipbinError` documents additive-only wire-format contract; Error() documented as non-client-safe; sock.Request.RequestID doc points to the design's propagation chain.
+
+### Round 2 refinements
+
+- `Wrap()` doc comment extended to acknowledge the shallow-copy aliasing semantics of the Details slice backing array.
+- `TestHTTPStatusFor` now covers the empty-string Status case (zero-value safety).
+- Removed the redundant `outline` import alias across `constructors.go`, `constructors_test.go`, and `rpc_test.go`.
+- `FromResponse` godoc corrected to enumerate all four nil-return guards (nil response / success status / wrong DataType / empty Data / unmarshal failure).
+
+### Round 3 refinements
+
+- Design doc §10.2 updated to no longer reference the private `httpStatusFor`; PR 0b's `abortWithError` reuses the exported `cerrors.HTTPStatusFor`.
+- `TestFromResponseEmptyData` added to cover the DataType-matches-but-Data-empty branch with both `nil` and empty-slice inputs.

--- a/docs/plans/2026-04-24-api-error-response-codes-design.md
+++ b/docs/plans/2026-04-24-api-error-response-codes-design.md
@@ -58,6 +58,7 @@ type VoipbinError struct {
     Reason  string `json:"reason"`   // UPPER_SNAKE, domain-scoped
     Domain  string `json:"domain"`   // e.g. "call-manager"
     Message string `json:"message"`
+    Details []map[string]any `json:"details,omitempty"` // reserved for future per-field detail
     Cause   error  `json:"-"`        // server-side only, never serialized
 }
 
@@ -65,20 +66,22 @@ func (e *VoipbinError) Error() string
 func (e *VoipbinError) Unwrap() error           // supports errors.Is / errors.As
 func (e *VoipbinError) Wrap(cause error) *VoipbinError
 
-// Constructors — one per canonical status
-func InvalidArgument(domain, reason, message string) *VoipbinError
-func Unauthenticated(domain, reason, message string) *VoipbinError
-func PaymentRequired(domain, reason, message string) *VoipbinError
-func PermissionDenied(domain, reason, message string) *VoipbinError
-func NotFound(domain, reason, message string) *VoipbinError
-func AlreadyExists(domain, reason, message string) *VoipbinError
-func FailedPrecondition(domain, reason, message string) *VoipbinError
-func ResourceExhausted(domain, reason, message string) *VoipbinError
-func Unavailable(domain, reason, message string) *VoipbinError
-func Internal(domain, reason, message string) *VoipbinError
+// Constructors — one per canonical status. The `domain` parameter
+// is typed as outline.ServiceName for compile-time rejection of
+// service-name typos; the struct field stays string on the wire.
+func InvalidArgument(domain outline.ServiceName, reason, message string) *VoipbinError
+func Unauthenticated(domain outline.ServiceName, reason, message string) *VoipbinError
+func PaymentRequired(domain outline.ServiceName, reason, message string) *VoipbinError
+func PermissionDenied(domain outline.ServiceName, reason, message string) *VoipbinError
+func NotFound(domain outline.ServiceName, reason, message string) *VoipbinError
+func AlreadyExists(domain outline.ServiceName, reason, message string) *VoipbinError
+func FailedPrecondition(domain outline.ServiceName, reason, message string) *VoipbinError
+func ResourceExhausted(domain outline.ServiceName, reason, message string) *VoipbinError
+func Unavailable(domain outline.ServiceName, reason, message string) *VoipbinError
+func Internal(domain outline.ServiceName, reason, message string) *VoipbinError
 ```
 
-**Domain naming:** uses `commonoutline.ServiceName*` constants (`"call-manager"`, `"billing-manager"`, `"api-manager"`, etc.). Add `ServiceNameApiManager = "api-manager"` if not already present.
+**Domain naming:** uses `commonoutline.ServiceName*` constants (`"call-manager"`, `"billing-manager"`, `"api-manager"`, etc.).
 
 ### 5.1 RPC carrier contract (additive, non-breaking)
 
@@ -122,10 +125,11 @@ Add optional `RequestID string \`json:"request_id,omitempty"\`` to `sock.Request
 ```go
 func abortWithError(c *gin.Context, err *cerrors.VoipbinError)
 func abortWithServiceError(c *gin.Context, err error)   // runs translator
-func httpStatusFor(s cerrors.Status) int                 // 10-entry switch
 func assertErrorResponse(t *testing.T, w *httptest.ResponseRecorder,
                           status cerrors.Status, reason string)  // test helper
 ```
+
+The Status-to-HTTP mapping lives in `bin-common-handler/models/errors` as the exported `HTTPStatusFor(cerrors.Status) int` (10-entry switch) so it can be reused by both the RPC carrier (`ToResponse`) and this abort helper without duplication.
 
 ### 7.2 Request-ID middleware (`lib/middleware/request_id.go`)
 
@@ -262,6 +266,7 @@ components:
 - `VoipbinError` type + constructors + `Error()`/`Unwrap()`/`Wrap()` + tests.
 - `sock.Request.RequestID` optional field.
 - RPC-response unmarshal helpers for `DataType = "voipbin_error"`.
+- Exported `HTTPStatusFor(Status) int` — single source of truth for the canonical-status → HTTP-status mapping, consumed by both `ToResponse` (RPC) and bin-api-manager's abort helper (HTTP).
 - Must land before any api-manager work depends on it.
 
 ### 10.2 PR 0b — `bin-api-manager` infrastructure
@@ -350,3 +355,14 @@ Seven rounds of self-review were run against this design. Issue counts per round
 - Reason-code catalog RST page added.
 - api-validator companion PRs scoped per migration PR.
 - Frontend-client audit added as blocking pre-flight for PR 1.
+
+### Round 1 implementation refinements (post-design, pre-merge)
+
+During PR #799 self-review, six refinement commits tightened the API before merge:
+
+- Exported `HTTPStatusFor` (was private `httpStatusFor`) so bin-api-manager can reuse the mapping without duplication.
+- `Wrap()` now returns a shallow copy instead of mutating the receiver, eliminating aliasing surprises when error pointers are memoized or passed across goroutines.
+- Added reserved `Details []map[string]any` field with `omitempty` so per-field validation detail can land later without a breaking schema change.
+- Typed the constructor `domain` parameter as `outline.ServiceName` to catch service-name typos at compile time.
+- Expanded `ToResponse` round-trip tests to assert all four wire fields; added per-status `FromResponse` round-trip assertion.
+- Documentation: package godoc states the cerrors import alias convention and admission-rule justification; `DataTypeVoipbinError` documents additive-only wire-format contract; Error() documented as non-client-safe; sock.Request.RequestID doc points to the design's propagation chain.

--- a/docs/plans/2026-04-24-api-error-response-codes-design.md
+++ b/docs/plans/2026-04-24-api-error-response-codes-design.md
@@ -1,0 +1,352 @@
+# VoIPbin API Error Response Codes — Design
+
+- **Date:** 2026-04-24
+- **Author:** pchero
+- **Status:** Design approved (self-review: 7 rounds, 35 fixes folded in)
+- **Target service:** `bin-api-manager` (with shared types in `bin-common-handler`)
+
+---
+
+## 1. Problem statement
+
+Today `bin-api-manager` returns `HTTP 400` with an empty body for ~1047 error sites across 66 handler files. Clients cannot distinguish permission failures, not-found, validation errors, or server failures from each other. Server-side log correlation with client-reported errors is ad-hoc.
+
+## 2. Goal & scope
+
+Replace the current pattern with:
+- A proper HTTP status code per error class.
+- A JSON response body carrying a VoIPbin reason code, originating domain, human-readable message, and a request correlation ID.
+
+**In scope:** every external HTTP endpoint served by `bin-api-manager`. WebSocket pre-upgrade errors (before the socket handshake completes).
+
+**Out of scope:** WebSocket post-upgrade frame errors (use WebSocket close codes). Internal-manager RPC behavior (hybrid plan allows indefinite coexistence).
+
+## 3. Design decisions (user-validated)
+
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | HTTP status codes | Fix to proper codes (401/403/404/409/503 + 402/429) **and** add error body |
+| Q2 | Error code naming scheme | Google-style flat `UPPER_SNAKE` `reason` with `domain` metadata |
+| Q3 | Error origination | Hybrid — shared `VoipbinError` type, api-manager adopts immediately, internal managers migrate gradually |
+| Q4 | Response body shape | Minimal envelope: `{error: {status, reason, domain, message, request_id}}` + reserved `details` |
+| Q5 | Rollout | Incremental by resource group (~9 migration PRs after foundation) |
+
+## 4. Architecture overview
+
+A shared `VoipbinError` type lives in `bin-common-handler`. `bin-api-manager` uses it for all local errors (permission, validation, auth) starting day one. For RPC errors from internal managers, `bin-api-manager` runs a translator: if the incoming error is already a `VoipbinError` (manager has migrated), pass it through; otherwise fall back through sentinel matching → transport-failure detection → substring matching → `INTERNAL`. A Gin middleware generates a `request_id`, attaches it to the logger and response, and propagates it to downstream RPC. A single `abortWithServiceError` helper replaces all 1047 `c.AbortWithStatus(400)` sites incrementally across 9 resource-grouped PRs plus a foundation split into 0a/0b.
+
+## 5. Shared error type (`bin-common-handler/models/errors`)
+
+```go
+type Status string
+
+const (
+    StatusInvalidArgument     Status = "INVALID_ARGUMENT"
+    StatusUnauthenticated     Status = "UNAUTHENTICATED"
+    StatusPaymentRequired     Status = "PAYMENT_REQUIRED"
+    StatusPermissionDenied    Status = "PERMISSION_DENIED"
+    StatusNotFound            Status = "NOT_FOUND"
+    StatusAlreadyExists       Status = "ALREADY_EXISTS"
+    StatusFailedPrecondition  Status = "FAILED_PRECONDITION"
+    StatusResourceExhausted   Status = "RESOURCE_EXHAUSTED"
+    StatusUnavailable         Status = "UNAVAILABLE"
+    StatusInternal            Status = "INTERNAL"
+)
+
+type VoipbinError struct {
+    Status  Status `json:"status"`
+    Reason  string `json:"reason"`   // UPPER_SNAKE, domain-scoped
+    Domain  string `json:"domain"`   // e.g. "call-manager"
+    Message string `json:"message"`
+    Cause   error  `json:"-"`        // server-side only, never serialized
+}
+
+func (e *VoipbinError) Error() string
+func (e *VoipbinError) Unwrap() error           // supports errors.Is / errors.As
+func (e *VoipbinError) Wrap(cause error) *VoipbinError
+
+// Constructors — one per canonical status
+func InvalidArgument(domain, reason, message string) *VoipbinError
+func Unauthenticated(domain, reason, message string) *VoipbinError
+func PaymentRequired(domain, reason, message string) *VoipbinError
+func PermissionDenied(domain, reason, message string) *VoipbinError
+func NotFound(domain, reason, message string) *VoipbinError
+func AlreadyExists(domain, reason, message string) *VoipbinError
+func FailedPrecondition(domain, reason, message string) *VoipbinError
+func ResourceExhausted(domain, reason, message string) *VoipbinError
+func Unavailable(domain, reason, message string) *VoipbinError
+func Internal(domain, reason, message string) *VoipbinError
+```
+
+**Domain naming:** uses `commonoutline.ServiceName*` constants (`"call-manager"`, `"billing-manager"`, `"api-manager"`, etc.). Add `ServiceNameApiManager = "api-manager"` if not already present.
+
+### 5.1 RPC carrier contract (additive, non-breaking)
+
+`sock.Response` already has `{StatusCode, DataType, Data}`. When an internal manager returns an error:
+
+- Set `StatusCode >= 400`.
+- Set `DataType = "voipbin_error"`.
+- Set `Data = json.Marshal(VoipbinError)`.
+
+`api-manager`'s RPC wrapper detects `DataType == "voipbin_error"` and unmarshals into a typed `*VoipbinError`. Managers that haven't migrated simply don't set this DataType; the fallback path handles them.
+
+### 5.2 Request correlation via `sock.Request.RequestID`
+
+Add optional `RequestID string \`json:"request_id,omitempty"\`` to `sock.Request`. The api-manager middleware stores the ID in `context.WithValue`, the RPC wrapper reads it, populates `sock.Request.RequestID`, and downstream services add it to their logrus fields so inbound/outbound log lines correlate by the same ID.
+
+## 6. Canonical status → HTTP mapping
+
+| Status | HTTP | When |
+|---|---|---|
+| `INVALID_ARGUMENT` | 400 | malformed request, invalid field, unparseable id |
+| `UNAUTHENTICATED` | 401 | missing/invalid JWT or access key |
+| `PAYMENT_REQUIRED` | 402 | insufficient balance, suspended billing account |
+| `PERMISSION_DENIED` | 403 | authenticated but not authorized |
+| `NOT_FOUND` | 404 | resource doesn't exist or belongs to another customer |
+| `ALREADY_EXISTS` | 409 | duplicate create (explicit construction only) |
+| `FAILED_PRECONDITION` | 409 | resource in wrong state (409 tie-breaker default) |
+| `RESOURCE_EXHAUSTED` | 429 | rate limit, quota |
+| `UNAVAILABLE` | 503 | upstream manager RPC timeout, RabbitMQ unreachable |
+| `INTERNAL` | 500 | unclassified failures, panic recovery |
+
+**409 tie-breaker:** when the translator receives a 409-equivalent failure with no typed error, default to `FAILED_PRECONDITION`. `ALREADY_EXISTS` is only emitted on explicit construction (e.g., duplicate-create handlers).
+
+**Enum is intentionally closed.** New statuses require a coordinated schema bump across consumers. `reason` is open-ended for per-domain extensibility.
+
+**Reason code catalog:** maintained at `bin-api-manager/docsdev/source/restful_api_errors.rst`. Each migration PR appends newly emitted reasons to the table. Reviewers reject PRs that introduce new reasons without cataloguing.
+
+## 7. `bin-api-manager` server-layer changes
+
+### 7.1 Helpers (`server/error.go`)
+
+```go
+func abortWithError(c *gin.Context, err *cerrors.VoipbinError)
+func abortWithServiceError(c *gin.Context, err error)   // runs translator
+func httpStatusFor(s cerrors.Status) int                 // 10-entry switch
+func assertErrorResponse(t *testing.T, w *httptest.ResponseRecorder,
+                          status cerrors.Status, reason string)  // test helper
+```
+
+### 7.2 Request-ID middleware (`lib/middleware/request_id.go`)
+
+- Generates `req_` + 26-char Crockford-ULID = 30 chars total.
+- Echoes inbound `X-Request-Id` if the client sends one.
+- Stored in `gin.Context`, `c.Request.Context()`, and logrus fields.
+- Always emitted as response header `X-Request-Id`.
+
+### 7.3 Existing middleware migrated in foundation
+
+- `lib/middleware/ratelimit.go` → `ResourceExhausted("api-manager", "RATE_LIMIT_EXCEEDED", ...)`.
+- `lib/middleware/authenticate.go` → `Unauthenticated(...)` and `PermissionDenied(...)` paths — replaces bare `c.AbortWithStatus(401)` and the existing `c.AbortWithStatusJSON(403, gin.H{...})`.
+
+### 7.4 Handler pattern (before → after)
+
+```go
+// Before (1047 sites)
+if err != nil {
+    log.Errorf("Could not ...: %v", err)
+    c.AbortWithStatus(400)
+    return
+}
+
+// After
+if err != nil {
+    abortWithServiceError(c, err)
+    return
+}
+```
+
+Per-site `log.Errorf` calls are removed — the translator emits a single structured log line per error.
+
+### 7.5 Response envelope
+
+```json
+{
+  "error": {
+    "status": "PERMISSION_DENIED",
+    "reason": "BILLING_ACCESS_DENIED",
+    "domain": "billing-manager",
+    "message": "You do not have permission to access this billing account.",
+    "request_id": "req_01hxyz..."
+  }
+}
+```
+
+## 8. Translator (`server/error_translate.go`)
+
+Priority chain — first match wins:
+
+1. **Typed passthrough:** `errors.As(err, &*VoipbinError)` → use directly.
+2. **Sentinel match:** `errors.Is(err, shandlererrors.ErrX)` → convert with a canned generic message. Sentinels live at `bin-api-manager/pkg/serviceerrors/sentinels.go` (parallel to `servicehandler/`, not nested).
+3. **Transport failure detection:** `errors.Is(err, context.Canceled)` → log-only, no body (client is gone). `errors.Is(err, context.DeadlineExceeded)` or RabbitMQ transport errors → `Unavailable("api-manager", "UPSTREAM_UNAVAILABLE", ...)`.
+4. **Substring fallback (shrinks over time):** small set of stable legacy patterns — `"no permission"` → `PermissionDenied`, `"not found"` → `NotFound`, `"authentication required"` → `Unauthenticated`, `"unavailable"` → `Unavailable`.
+5. **Default:** `Internal("api-manager", "INTERNAL", "An internal error occurred.").Wrap(err)`. Original error wrapped for server-side logs only, never serialized to client.
+
+**Defense:** the entire translator runs inside `defer recover()` — a panic produces a safe `INTERNAL` fallback rather than dropping the response.
+
+**Logging:** one structured line per error with `request_id`, `status`, `reason`, `domain`, `route`, and `cause` (server-side only).
+
+### 8.1 Construction guidance (preference order)
+
+1. **Preferred** — servicehandler constructs typed errors with rich context:
+   `cerrors.PermissionDenied("ai-manager", "KNOWLEDGE_BASE_FOREIGN", "Knowledge base does not belong to this customer.")`
+2. **Acceptable** — return a sentinel when there's no context to add.
+3. **Deprecated** — `fmt.Errorf("...")` legacy; caught by substring fallback. Migration target.
+
+### 8.2 Message-quality rule
+
+Messages may echo the client's own resource IDs and parameter names. Messages must NOT include internal DB IDs, tokens, other customers' IDs, stack traces, internal hostnames, or PII from other users. Code-review checklist item.
+
+## 9. OpenAPI schema (`bin-openapi-manager/openapi/openapi.yaml`)
+
+```yaml
+components:
+  schemas:
+    ErrorBody:
+      type: object
+      required: [status, reason, domain, message, request_id]
+      properties:
+        status:
+          type: string
+          enum: [INVALID_ARGUMENT, UNAUTHENTICATED, PAYMENT_REQUIRED,
+                 PERMISSION_DENIED, NOT_FOUND, ALREADY_EXISTS,
+                 FAILED_PRECONDITION, RESOURCE_EXHAUSTED, UNAVAILABLE, INTERNAL]
+          description: Canonical error status. Maps 1:1 to HTTP status code.
+        reason:
+          type: string
+          description: Specific VoIPbin reason code (UPPER_SNAKE). Open-ended.
+          example: CALL_NOT_FOUND
+        domain:
+          type: string
+          description: Originating manager service.
+          example: call-manager
+        message:
+          type: string
+          description: Human-readable message for debugging.
+        request_id:
+          type: string
+          description: Request correlation ID. Include in support tickets.
+          example: req_01hxyz...
+        details:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Reserved for future per-field or structured error detail. May be omitted.
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error: { $ref: '#/components/schemas/ErrorBody' }
+
+  responses:
+    BadRequest:       { description: "Invalid request (INVALID_ARGUMENT).",      content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    Unauthenticated:  { description: "Authentication required (UNAUTHENTICATED).", content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    PaymentRequired:  { description: "Payment required (PAYMENT_REQUIRED).",     content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    PermissionDenied: { description: "Insufficient permission (PERMISSION_DENIED).", content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    NotFound:         { description: "Resource not found (NOT_FOUND).",          content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    Conflict:         { description: "State conflict (ALREADY_EXISTS or FAILED_PRECONDITION).", content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    TooManyRequests:  { description: "Rate or quota exceeded (RESOURCE_EXHAUSTED).", content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    Unavailable:      { description: "Upstream unavailable (UNAVAILABLE).",      content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+    InternalError:    { description: "Internal error (INTERNAL).",               content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+```
+
+**Per-endpoint:** each path references only the error responses it actually emits. Default set: 400/401/403/404/500. Billing endpoints add 402. Write endpoints add 409. Rate-limited paths add 429. RPC-heavy paths add 503.
+
+**`details` is reserved (optional) from day one** so field-level validation can be added later without a breaking schema change.
+
+## 10. Rollout
+
+### 10.1 PR 0a — `bin-common-handler` foundation
+
+- `VoipbinError` type + constructors + `Error()`/`Unwrap()`/`Wrap()` + tests.
+- `sock.Request.RequestID` optional field.
+- RPC-response unmarshal helpers for `DataType = "voipbin_error"`.
+- Must land before any api-manager work depends on it.
+
+### 10.2 PR 0b — `bin-api-manager` infrastructure
+
+- `abortWithError` / `abortWithServiceError` / `httpStatusFor` / `assertErrorResponse` helpers + tests.
+- Request-ID middleware registered in `cmd/api-manager/main.go`.
+- Migrate `ratelimit.go` and `authenticate.go` middleware.
+- OpenAPI `ErrorBody` / `ErrorResponse` / named responses components added.
+- Update `restful_api.rst` with the new envelope + HTTP-status table. Create `restful_api_errors.rst` catalog page. Rebuild + commit Sphinx HTML.
+- **Spike:** wire error responses into ONE trivial endpoint (e.g., `GET /v1.0/ping`), regenerate `gens/openapi_server/gen.go`, confirm `oapi-codegen` output is compatible with the `abortWithError` pattern. If incompatible, pivot to keeping components available for docs-only (no per-path wiring) and document the pivot.
+- **Audit:** verify current managers' `Response.StatusCode` usage. Document invariant that `StatusCode >= 400` implies error semantics. Fix violators in cleanup PRs before their migration.
+
+### 10.3 Pre-flight before PR 1 (blocking)
+
+Audit `admin.voipbin.net` and `talk.voipbin.net` frontend repos for hardcoded `status === 400` branches. Coordinate deployment so clients tolerate 401/403/404/409/429/503 before api-manager PR 1 rolls out.
+
+### 10.4 PRs 1–9 — handler migration, grouped by resource
+
+| # | Group | Files (approx) |
+|---|---|---|
+| 1 | Auth & identity | `auth_*`, `me`, `customer`, `service_agents_*` auth if separate codepath |
+| 2 | Calls | `calls`, `groupcalls`, `recordings`, `recordingfiles`, `transfers` |
+| 3 | Flows & activeflows | `flows`, `activeflows` |
+| 4 | Numbers & providers | `numbers`, `available_numbers`, `providers`, `providercalls`, `trunks`, `routes` |
+| 5 | Billing | `billings`, `billing_account`, `billing_accounts` (exercises 402) |
+| 6 | Messaging & conversations | `messages`, `emails`, `conversations`, `conversation_accounts` |
+| 7 | AI, transcription, speaking | `ais`, `aicalls`, `aimessages`, `aisummaries`, `transcribes`, `transcripts`, `speakings` |
+| 8 | Agents, queues, conferences, campaigns | `agents`, `queues`, `queuecalls`, `conferences`, `conferencecalls`, `campaigns`, `campaigncalls`, `outplans`, `outdials` |
+| 9 | Storage, extensions, misc | `storage_*`, `extensions`, `tags`, `teams`, `timelines*`, `aggregated_events`, `contacts`, `service_agents_*` (remaining), `ws`, `accesskeys`, `rags` |
+
+Each migration PR:
+
+- Migrates server handler files to `abortWithServiceError`.
+- Adds/converts sentinels or constructs typed errors in servicehandler for that resource group.
+- Adds OpenAPI `responses` refs to the group's paths, appends new reason codes to the catalog RST.
+- Updates handler tests using `assertErrorResponse`.
+- Updates `*_overview.rst`, `*_tutorial.rst`, `*_troubleshooting.rst` per AI-native RST rules (cause+fix pairs).
+- Companion PR in `monorepo-monitoring` updating api-validator tests for the migrated endpoints.
+
+### 10.5 PR N+1 — shrink fallback
+
+Remove the substring fallback from the translator. Any unmatched error produces a clean `INTERNAL`. Unmatched = bug.
+
+### 10.6 Per-PR verification (mandatory)
+
+```bash
+cd bin-openapi-manager && go generate ./... && go mod tidy && go mod vendor && go test ./... && golangci-lint run -v --timeout 5m
+cd bin-api-manager    && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+cd bin-api-manager/docsdev && rm -rf build && python3 -m sphinx -M html source build && git add -f build
+```
+
+## 11. Out of scope
+
+1. **Field-level validation details** — envelope is forward-compatible via the reserved `details` array.
+2. **Internal-manager adoption of `VoipbinError`** — hybrid plan allows indefinite coexistence.
+3. **Rate-limit infrastructure** — vocabulary exists (`RESOURCE_EXHAUSTED`/429); no new middleware in this effort.
+4. **Reason-code versioning** — reasons are append-only; rename/remove requires a future deprecation process.
+5. **`doc_url` field** — RST anchor stability not guaranteed.
+6. **WebSocket post-upgrade errors** — use WebSocket close codes, not this envelope.
+7. **Expanding the canonical enum beyond 10** — closed set; future expansion requires coordinated schema bump.
+
+## 12. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `oapi-codegen` produces incompatible typed response variants | PR 0b spike with one endpoint; pivot to docs-only components if needed |
+| Frontend clients break on HTTP status change | Pre-flight audit of admin & agent repos blocks PR 1 |
+| Manager `Response.StatusCode` inconsistencies | Audit + cleanup during PR 0a |
+| Translator panic | `defer recover()` fallback + unit tests |
+| Test churn across 66 handler files | `assertErrorResponse` helper reduces boilerplate; per-PR scope keeps it manageable |
+| Reason-code drift | Central RST catalog + code-review checklist |
+| PR 0a ↔ 0b coupling forces joint iteration | Expect some rework of 0a when 0b review surfaces type-design issues |
+
+## 13. Self-review audit trail
+
+Seven rounds of self-review were run against this design. Issue counts per round: 14 → 9 → 5 → 4 → 2 → 2 → 0. Notable structural changes made during review:
+
+- Foundation PR split into 0a (`bin-common-handler`) and 0b (`bin-api-manager`) to decouple dependency ordering.
+- RPC carrier contract made concrete via `sock.Response.DataType = "voipbin_error"` (additive, non-breaking).
+- Sentinel-vs-typed-construction guidance added (preference for typed construction with context).
+- `request_id` propagation to downstream RPC via `sock.Request.RequestID`.
+- Existing `ratelimit.go` + `authenticate.go` middleware added to PR 0b scope (they emit HTTP errors too).
+- Translator includes `defer recover()` for panic safety.
+- `context.Canceled` / `context.DeadlineExceeded` explicitly handled.
+- `details` field reserved in OpenAPI schema for forward compatibility.
+- Reason-code catalog RST page added.
+- api-validator companion PRs scoped per migration PR.
+- Frontend-client audit added as blocking pre-flight for PR 1.

--- a/docs/plans/2026-04-24-api-error-response-codes-plan.md
+++ b/docs/plans/2026-04-24-api-error-response-codes-plan.md
@@ -1,0 +1,1246 @@
+# VoIPbin API Error Response Codes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Each code task follows TDD per @superpowers:test-driven-development — write the failing test first, watch it fail for the right reason, then implement.
+
+**Goal:** Ship the foundation for VoIPbin's structured API error responses (status + reason + domain + message + request_id) as a series of small, independently-verifiable PRs. This plan details PR 0a to execution-ready granularity; later PRs are scoped at a higher level.
+
+**Architecture:** `VoipbinError` type in `bin-common-handler/models/errors` → consumed by `bin-api-manager` server layer and (eventually) internal managers via the existing `sock.Response` RPC envelope. See the companion design doc: `docs/plans/2026-04-24-api-error-response-codes-design.md`.
+
+**Tech Stack:** Go, standard `testing` (table-driven, no testify), `github.com/gin-gonic/gin`, `github.com/oklog/ulid/v2`, `github.com/sirupsen/logrus`, `github.com/deepmap/oapi-codegen` (OpenAPI code generation).
+
+---
+
+## Preconditions
+
+- Worktree exists at `~/gitvoipbin/monorepo/.worktrees/NOJIRA-api-error-response-codes` on branch `NOJIRA-api-error-response-codes`.
+- Branch is based on latest `origin/main`.
+- Design doc committed at `docs/plans/2026-04-24-api-error-response-codes-design.md`.
+- `ServiceNameAPIManager` constant already exists in `bin-common-handler/models/outline/servicename.go` — no need to add.
+
+## Known constraint flag for review
+
+**`bin-common-handler` admission rule challenge.** The monorepo rule says a package must be used by 3+ services to live in `bin-common-handler`. The new `models/errors` package will have only `bin-api-manager` as a day-1 consumer. Defensible exception: the type becomes part of the shared RPC contract (`sock.Response.Data`) and `requesthandler` RPC wrappers will use it for typed unmarshal. If reviewers push back, fallback is to place `VoipbinError` in `bin-api-manager/pkg/errors/` initially and promote to `bin-common-handler` when the first internal manager adopts it. Call this out in the PR description so reviewers can decide.
+
+---
+
+## PR 0a — `bin-common-handler` foundation (execution-ready)
+
+**Scope:** introduce the `VoipbinError` type, canonical statuses, marshal/unmarshal helpers, and the `sock.Request.RequestID` field. Zero api-manager changes. Tests only — no production integration yet.
+
+**Target files:**
+- Create: `bin-common-handler/models/errors/status.go`
+- Create: `bin-common-handler/models/errors/status_test.go`
+- Create: `bin-common-handler/models/errors/voipbin_error.go`
+- Create: `bin-common-handler/models/errors/voipbin_error_test.go`
+- Create: `bin-common-handler/models/errors/constructors.go`
+- Create: `bin-common-handler/models/errors/constructors_test.go`
+- Create: `bin-common-handler/models/errors/datatype.go`
+- Create: `bin-common-handler/models/errors/rpc.go`
+- Create: `bin-common-handler/models/errors/rpc_test.go`
+- Modify: `bin-common-handler/models/sock/message.go` (add `RequestID` field)
+- Modify: `bin-common-handler/models/sock/message_test.go` (extend existing tests)
+
+**Verification cadence:** run `go test ./...` after each task. Run the full 5-step verification workflow (`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`) from `bin-common-handler/` before the final PR push.
+
+---
+
+### Task 1: Define the `Status` type and the 10 canonical constants
+
+**Files:**
+- Create: `bin-common-handler/models/errors/status.go`
+- Create: `bin-common-handler/models/errors/status_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// bin-common-handler/models/errors/status_test.go
+package errors
+
+import "testing"
+
+func TestStatusConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant Status
+		expected string
+	}{
+		{"invalid_argument", StatusInvalidArgument, "INVALID_ARGUMENT"},
+		{"unauthenticated", StatusUnauthenticated, "UNAUTHENTICATED"},
+		{"payment_required", StatusPaymentRequired, "PAYMENT_REQUIRED"},
+		{"permission_denied", StatusPermissionDenied, "PERMISSION_DENIED"},
+		{"not_found", StatusNotFound, "NOT_FOUND"},
+		{"already_exists", StatusAlreadyExists, "ALREADY_EXISTS"},
+		{"failed_precondition", StatusFailedPrecondition, "FAILED_PRECONDITION"},
+		{"resource_exhausted", StatusResourceExhausted, "RESOURCE_EXHAUSTED"},
+		{"unavailable", StatusUnavailable, "UNAVAILABLE"},
+		{"internal", StatusInternal, "INTERNAL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.constant) != tt.expected {
+				t.Errorf("got %q want %q", string(tt.constant), tt.expected)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestStatusConstants -v
+```
+
+Expected: compile error — `Status` and constants undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// bin-common-handler/models/errors/status.go
+// Package errors defines the shared VoipbinError type used across the
+// VoIPbin monorepo for external API error responses.
+package errors
+
+// Status is the canonical error status. It maps 1:1 to an HTTP status
+// code (see bin-api-manager for the mapping). The set is intentionally
+// closed — extending it requires a coordinated schema update.
+type Status string
+
+const (
+	StatusInvalidArgument    Status = "INVALID_ARGUMENT"
+	StatusUnauthenticated    Status = "UNAUTHENTICATED"
+	StatusPaymentRequired    Status = "PAYMENT_REQUIRED"
+	StatusPermissionDenied   Status = "PERMISSION_DENIED"
+	StatusNotFound           Status = "NOT_FOUND"
+	StatusAlreadyExists      Status = "ALREADY_EXISTS"
+	StatusFailedPrecondition Status = "FAILED_PRECONDITION"
+	StatusResourceExhausted  Status = "RESOURCE_EXHAUSTED"
+	StatusUnavailable        Status = "UNAVAILABLE"
+	StatusInternal           Status = "INTERNAL"
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestStatusConstants -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-api-error-response-codes
+git add bin-common-handler/models/errors/status.go bin-common-handler/models/errors/status_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Add canonical Status type and constants for the shared VoipbinError vocabulary.
+
+- bin-common-handler: Add models/errors package with Status type and 10 canonical status constants"
+```
+
+---
+
+### Task 2: Define the `VoipbinError` struct with JSON tags
+
+**Files:**
+- Create: `bin-common-handler/models/errors/voipbin_error.go`
+- Create: `bin-common-handler/models/errors/voipbin_error_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// bin-common-handler/models/errors/voipbin_error_test.go
+package errors
+
+import (
+	stderrors "errors"
+	"encoding/json"
+	"testing"
+)
+
+func TestVoipbinErrorFields(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusNotFound,
+		Reason:  "CALL_NOT_FOUND",
+		Domain:  "call-manager",
+		Message: "The call was not found.",
+		Cause:   stderrors.New("underlying"),
+	}
+	if e.Status != StatusNotFound {
+		t.Errorf("wrong Status: %v", e.Status)
+	}
+	if e.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("wrong Reason: %v", e.Reason)
+	}
+	if e.Domain != "call-manager" {
+		t.Errorf("wrong Domain: %v", e.Domain)
+	}
+	if e.Message != "The call was not found." {
+		t.Errorf("wrong Message: %v", e.Message)
+	}
+	if e.Cause == nil || e.Cause.Error() != "underlying" {
+		t.Errorf("wrong Cause: %v", e.Cause)
+	}
+}
+
+func TestVoipbinErrorJSONExcludesCause(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusNotFound,
+		Reason:  "CALL_NOT_FOUND",
+		Domain:  "call-manager",
+		Message: "The call was not found.",
+		Cause:   stderrors.New("DB driver error: connection refused"),
+	}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	s := string(b)
+	for _, want := range []string{
+		`"status":"NOT_FOUND"`,
+		`"reason":"CALL_NOT_FOUND"`,
+		`"domain":"call-manager"`,
+		`"message":"The call was not found."`,
+	} {
+		if !contains(s, want) {
+			t.Errorf("expected %q in JSON %q", want, s)
+		}
+	}
+	for _, forbidden := range []string{"cause", "connection refused", "DB driver"} {
+		if contains(s, forbidden) {
+			t.Errorf("forbidden token %q leaked into JSON %q", forbidden, s)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinError -v
+```
+
+Expected: compile error — `VoipbinError` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// bin-common-handler/models/errors/voipbin_error.go
+package errors
+
+// VoipbinError is the canonical error shape returned from the external
+// VoIPbin API and (eventually) over RPC between internal managers.
+// The Cause field is for server-side logging only and is never
+// serialized to clients.
+type VoipbinError struct {
+	Status  Status `json:"status"`
+	Reason  string `json:"reason"`
+	Domain  string `json:"domain"`
+	Message string `json:"message"`
+	Cause   error  `json:"-"`
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinError -v
+```
+
+Expected: PASS (both tests).
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/voipbin_error.go bin-common-handler/models/errors/voipbin_error_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Introduce VoipbinError struct with fields Status/Reason/Domain/Message/Cause.
+Cause is excluded from JSON to avoid leaking server-side detail to clients.
+
+- bin-common-handler: Add VoipbinError struct and JSON serialization contract"
+```
+
+---
+
+### Task 3: Implement `Error()` method
+
+**Files:**
+- Modify: `bin-common-handler/models/errors/voipbin_error.go`
+- Modify: `bin-common-handler/models/errors/voipbin_error_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// Append to voipbin_error_test.go
+func TestVoipbinErrorErrorMethod(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusPermissionDenied,
+		Reason:  "BILLING_ACCESS_DENIED",
+		Domain:  "billing-manager",
+		Message: "Not allowed.",
+	}
+	got := e.Error()
+	want := "billing-manager: BILLING_ACCESS_DENIED: Not allowed."
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestVoipbinErrorErrorMethodWithCause(t *testing.T) {
+	e := &VoipbinError{
+		Status:  StatusInternal,
+		Reason:  "INTERNAL",
+		Domain:  "api-manager",
+		Message: "Something went wrong.",
+		Cause:   stderrors.New("pq: connection refused"),
+	}
+	got := e.Error()
+	want := "api-manager: INTERNAL: Something went wrong.: pq: connection refused"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinErrorError -v
+```
+
+Expected: compile error — `(*VoipbinError).Error` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// Append to voipbin_error.go
+import "fmt"
+
+func (e *VoipbinError) Error() string {
+	if e == nil {
+		return "<nil VoipbinError>"
+	}
+	base := fmt.Sprintf("%s: %s: %s", e.Domain, e.Reason, e.Message)
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %s", base, e.Cause.Error())
+	}
+	return base
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinErrorError -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/voipbin_error.go bin-common-handler/models/errors/voipbin_error_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Implement the error interface for VoipbinError so it composes with fmt.Errorf / errors.Is / errors.As.
+
+- bin-common-handler: Implement Error() on VoipbinError"
+```
+
+---
+
+### Task 4: Implement `Unwrap()` method for `errors.Is` / `errors.As`
+
+**Files:**
+- Modify: `bin-common-handler/models/errors/voipbin_error.go`
+- Modify: `bin-common-handler/models/errors/voipbin_error_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// Append to voipbin_error_test.go
+func TestVoipbinErrorUnwrap(t *testing.T) {
+	inner := stderrors.New("inner failure")
+	e := &VoipbinError{
+		Status:  StatusInternal,
+		Reason:  "INTERNAL",
+		Domain:  "api-manager",
+		Message: "wrap test",
+		Cause:   inner,
+	}
+
+	// errors.Is walks the chain via Unwrap.
+	if !stderrors.Is(e, inner) {
+		t.Fatalf("errors.Is did not find wrapped cause")
+	}
+
+	// errors.As on a wrapped VoipbinError finds it.
+	wrapped := fmt.Errorf("context: %w", e)
+	var target *VoipbinError
+	if !stderrors.As(wrapped, &target) {
+		t.Fatalf("errors.As did not recover VoipbinError from wrapped chain")
+	}
+	if target.Reason != "INTERNAL" {
+		t.Errorf("errors.As returned wrong VoipbinError: %v", target)
+	}
+}
+```
+
+(You will need to add `"fmt"` to the test file imports.)
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinErrorUnwrap -v
+```
+
+Expected: FAIL — `errors.Is` returns false because `Unwrap` isn't defined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// Append to voipbin_error.go
+func (e *VoipbinError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinErrorUnwrap -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/voipbin_error.go bin-common-handler/models/errors/voipbin_error_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Support errors.Is and errors.As traversal so callers can walk wrapped VoipbinError chains.
+
+- bin-common-handler: Add Unwrap() to VoipbinError"
+```
+
+---
+
+### Task 5: Implement `Wrap(cause)` fluent method
+
+**Files:**
+- Modify: `bin-common-handler/models/errors/voipbin_error.go`
+- Modify: `bin-common-handler/models/errors/voipbin_error_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// Append to voipbin_error_test.go
+func TestVoipbinErrorWrap(t *testing.T) {
+	e := &VoipbinError{Status: StatusInternal, Reason: "INTERNAL", Domain: "api-manager", Message: "x"}
+	inner := stderrors.New("boom")
+	out := e.Wrap(inner)
+
+	if out != e {
+		t.Errorf("Wrap should return the receiver for chaining")
+	}
+	if e.Cause != inner {
+		t.Errorf("Wrap did not set Cause: %v", e.Cause)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinErrorWrap -v
+```
+
+Expected: compile error — `Wrap` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// Append to voipbin_error.go
+func (e *VoipbinError) Wrap(cause error) *VoipbinError {
+	if e == nil {
+		return nil
+	}
+	e.Cause = cause
+	return e
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestVoipbinErrorWrap -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/voipbin_error.go bin-common-handler/models/errors/voipbin_error_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Add a fluent Wrap(cause) method so constructors can chain underlying errors without an extra statement.
+
+- bin-common-handler: Add Wrap(cause) to VoipbinError"
+```
+
+---
+
+### Task 6: Add the 10 constructor functions
+
+**Files:**
+- Create: `bin-common-handler/models/errors/constructors.go`
+- Create: `bin-common-handler/models/errors/constructors_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// bin-common-handler/models/errors/constructors_test.go
+package errors
+
+import "testing"
+
+func TestConstructors(t *testing.T) {
+	tests := []struct {
+		name       string
+		build      func(string, string, string) *VoipbinError
+		wantStatus Status
+	}{
+		{"invalid_argument", InvalidArgument, StatusInvalidArgument},
+		{"unauthenticated", Unauthenticated, StatusUnauthenticated},
+		{"payment_required", PaymentRequired, StatusPaymentRequired},
+		{"permission_denied", PermissionDenied, StatusPermissionDenied},
+		{"not_found", NotFound, StatusNotFound},
+		{"already_exists", AlreadyExists, StatusAlreadyExists},
+		{"failed_precondition", FailedPrecondition, StatusFailedPrecondition},
+		{"resource_exhausted", ResourceExhausted, StatusResourceExhausted},
+		{"unavailable", Unavailable, StatusUnavailable},
+		{"internal", Internal, StatusInternal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := tt.build("d", "R", "m")
+			if e == nil {
+				t.Fatal("nil VoipbinError")
+			}
+			if e.Status != tt.wantStatus {
+				t.Errorf("wrong Status: got %q want %q", e.Status, tt.wantStatus)
+			}
+			if e.Domain != "d" || e.Reason != "R" || e.Message != "m" {
+				t.Errorf("wrong fields: %+v", e)
+			}
+			if e.Cause != nil {
+				t.Errorf("Cause should be nil by default")
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestConstructors -v
+```
+
+Expected: compile error — constructors undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// bin-common-handler/models/errors/constructors.go
+package errors
+
+func newVoipbinError(s Status, domain, reason, message string) *VoipbinError {
+	return &VoipbinError{Status: s, Domain: domain, Reason: reason, Message: message}
+}
+
+func InvalidArgument(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusInvalidArgument, domain, reason, message)
+}
+func Unauthenticated(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusUnauthenticated, domain, reason, message)
+}
+func PaymentRequired(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusPaymentRequired, domain, reason, message)
+}
+func PermissionDenied(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusPermissionDenied, domain, reason, message)
+}
+func NotFound(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusNotFound, domain, reason, message)
+}
+func AlreadyExists(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusAlreadyExists, domain, reason, message)
+}
+func FailedPrecondition(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusFailedPrecondition, domain, reason, message)
+}
+func ResourceExhausted(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusResourceExhausted, domain, reason, message)
+}
+func Unavailable(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusUnavailable, domain, reason, message)
+}
+func Internal(domain, reason, message string) *VoipbinError {
+	return newVoipbinError(StatusInternal, domain, reason, message)
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestConstructors -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/constructors.go bin-common-handler/models/errors/constructors_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Add one typed constructor per canonical Status so callers construct VoipbinError without exposing the raw struct literal.
+
+- bin-common-handler: Add 10 VoipbinError constructors"
+```
+
+---
+
+### Task 7: Add `DataTypeVoipbinError` constant
+
+**Files:**
+- Create: `bin-common-handler/models/errors/datatype.go`
+- Modify: `bin-common-handler/models/errors/constructors_test.go` (append to existing file)
+
+**Step 1: Write the failing test**
+
+```go
+// Append to constructors_test.go
+func TestDataTypeVoipbinError(t *testing.T) {
+	if DataTypeVoipbinError != "voipbin_error" {
+		t.Errorf("DataTypeVoipbinError = %q, want %q", DataTypeVoipbinError, "voipbin_error")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestDataTypeVoipbinError -v
+```
+
+Expected: compile error — `DataTypeVoipbinError` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// bin-common-handler/models/errors/datatype.go
+package errors
+
+// DataTypeVoipbinError is the sock.Response.DataType value used by
+// internal managers to signal that Data contains a JSON-serialized
+// VoipbinError. bin-api-manager's requesthandler inspects this to
+// decide whether to unmarshal the payload as a typed error.
+const DataTypeVoipbinError = "voipbin_error"
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestDataTypeVoipbinError -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/datatype.go bin-common-handler/models/errors/constructors_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Reserve the sock.Response.DataType value used to carry typed errors across the RPC boundary.
+
+- bin-common-handler: Add DataTypeVoipbinError constant"
+```
+
+---
+
+### Task 8: Add `FromResponse` helper (unmarshal `VoipbinError` from `sock.Response`)
+
+**Files:**
+- Create: `bin-common-handler/models/errors/rpc.go`
+- Create: `bin-common-handler/models/errors/rpc_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// bin-common-handler/models/errors/rpc_test.go
+package errors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+)
+
+func TestFromResponseTypedError(t *testing.T) {
+	payload := &VoipbinError{
+		Status:  StatusNotFound,
+		Reason:  "CALL_NOT_FOUND",
+		Domain:  "call-manager",
+		Message: "The call was not found.",
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal setup: %v", err)
+	}
+	resp := &sock.Response{
+		StatusCode: 404,
+		DataType:   DataTypeVoipbinError,
+		Data:       data,
+	}
+
+	got := FromResponse(resp)
+	if got == nil {
+		t.Fatal("FromResponse returned nil for a typed error response")
+	}
+	if got.Status != StatusNotFound || got.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("wrong VoipbinError: %+v", got)
+	}
+}
+
+func TestFromResponseSuccess(t *testing.T) {
+	resp := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       json.RawMessage(`{"ok":true}`),
+	}
+	if got := FromResponse(resp); got != nil {
+		t.Errorf("FromResponse on success should return nil, got %+v", got)
+	}
+}
+
+func TestFromResponseErrorWithoutTypedDataType(t *testing.T) {
+	// Legacy manager — error code but no typed body.
+	resp := &sock.Response{
+		StatusCode: 500,
+		DataType:   "application/json",
+		Data:       json.RawMessage(`{"message":"legacy"}`),
+	}
+	if got := FromResponse(resp); got != nil {
+		t.Errorf("FromResponse without DataTypeVoipbinError must return nil, got %+v", got)
+	}
+}
+
+func TestFromResponseMalformedData(t *testing.T) {
+	resp := &sock.Response{
+		StatusCode: 500,
+		DataType:   DataTypeVoipbinError,
+		Data:       json.RawMessage(`{not json`),
+	}
+	// Must not panic and must fall back to nil so the caller uses its own fallback path.
+	if got := FromResponse(resp); got != nil {
+		t.Errorf("malformed Data must return nil, got %+v", got)
+	}
+}
+
+func TestFromResponseNil(t *testing.T) {
+	if got := FromResponse(nil); got != nil {
+		t.Errorf("nil response must return nil, got %+v", got)
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestFromResponse -v
+```
+
+Expected: compile error — `FromResponse` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// bin-common-handler/models/errors/rpc.go
+package errors
+
+import (
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+)
+
+// FromResponse extracts a typed *VoipbinError from a sock.Response if
+// the response signals one (StatusCode >= 400 AND DataType ==
+// DataTypeVoipbinError AND Data unmarshals cleanly). Returns nil
+// otherwise — callers should apply their own fallback.
+func FromResponse(resp *sock.Response) *VoipbinError {
+	if resp == nil || resp.StatusCode < 400 || resp.DataType != DataTypeVoipbinError || len(resp.Data) == 0 {
+		return nil
+	}
+	out := &VoipbinError{}
+	if err := json.Unmarshal(resp.Data, out); err != nil {
+		return nil
+	}
+	return out
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestFromResponse -v
+```
+
+Expected: PASS (all five tests).
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/rpc.go bin-common-handler/models/errors/rpc_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Add FromResponse helper. api-manager and internal managers use it to detect typed errors without growing a new RPC field.
+
+- bin-common-handler: Add FromResponse helper to extract VoipbinError from sock.Response"
+```
+
+---
+
+### Task 9: Add `ToResponse` helper (encode `VoipbinError` into `sock.Response`)
+
+**Files:**
+- Modify: `bin-common-handler/models/errors/rpc.go`
+- Modify: `bin-common-handler/models/errors/rpc_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// Append to rpc_test.go
+func TestToResponse(t *testing.T) {
+	e := NotFound("call-manager", "CALL_NOT_FOUND", "The call was not found.")
+	resp, err := ToResponse(e)
+	if err != nil {
+		t.Fatalf("ToResponse returned error: %v", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("wrong StatusCode: %d", resp.StatusCode)
+	}
+	if resp.DataType != DataTypeVoipbinError {
+		t.Errorf("wrong DataType: %s", resp.DataType)
+	}
+
+	// Round-trip: FromResponse must recover the original.
+	got := FromResponse(resp)
+	if got == nil || got.Status != StatusNotFound || got.Reason != "CALL_NOT_FOUND" {
+		t.Errorf("round-trip failed: %+v", got)
+	}
+}
+
+func TestToResponseAllStatuses(t *testing.T) {
+	tests := []struct {
+		status Status
+		http   int
+	}{
+		{StatusInvalidArgument, 400},
+		{StatusUnauthenticated, 401},
+		{StatusPaymentRequired, 402},
+		{StatusPermissionDenied, 403},
+		{StatusNotFound, 404},
+		{StatusAlreadyExists, 409},
+		{StatusFailedPrecondition, 409},
+		{StatusResourceExhausted, 429},
+		{StatusUnavailable, 503},
+		{StatusInternal, 500},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			e := &VoipbinError{Status: tt.status, Reason: "X", Domain: "d", Message: "m"}
+			resp, err := ToResponse(e)
+			if err != nil {
+				t.Fatalf("ToResponse failed: %v", err)
+			}
+			if resp.StatusCode != tt.http {
+				t.Errorf("wrong StatusCode for %s: got %d want %d", tt.status, resp.StatusCode, tt.http)
+			}
+		})
+	}
+}
+
+func TestToResponseNil(t *testing.T) {
+	if _, err := ToResponse(nil); err == nil {
+		t.Errorf("ToResponse(nil) must return an error")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestToResponse -v
+```
+
+Expected: compile error — `ToResponse` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// Append to rpc.go
+import "errors" as stderrors  // NOTE: adjust imports; the file already
+// imports encoding/json and monorepo/bin-common-handler/models/sock.
+// Actually we'll use the "fmt" package for the error below, so import fmt.
+
+func ToResponse(e *VoipbinError) (*sock.Response, error) {
+	if e == nil {
+		return nil, fmt.Errorf("cannot marshal nil VoipbinError")
+	}
+	body, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("marshal VoipbinError: %w", err)
+	}
+	return &sock.Response{
+		StatusCode: httpStatusFor(e.Status),
+		DataType:   DataTypeVoipbinError,
+		Data:       body,
+	}, nil
+}
+
+// httpStatusFor maps a canonical Status to an HTTP status code.
+// This mapping is the single source of truth for the RPC→HTTP layer.
+func httpStatusFor(s Status) int {
+	switch s {
+	case StatusInvalidArgument:
+		return 400
+	case StatusUnauthenticated:
+		return 401
+	case StatusPaymentRequired:
+		return 402
+	case StatusPermissionDenied:
+		return 403
+	case StatusNotFound:
+		return 404
+	case StatusAlreadyExists, StatusFailedPrecondition:
+		return 409
+	case StatusResourceExhausted:
+		return 429
+	case StatusUnavailable:
+		return 503
+	case StatusInternal:
+		return 500
+	default:
+		return 500
+	}
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/errors/... -run TestToResponse -v
+```
+
+Expected: PASS (all three tests).
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/errors/rpc.go bin-common-handler/models/errors/rpc_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Add ToResponse helper that encodes VoipbinError into a sock.Response, plus the canonical Status-to-HTTP-status mapping that both sides of the RPC share.
+
+- bin-common-handler: Add ToResponse helper and canonical Status-to-HTTP mapping"
+```
+
+---
+
+### Task 10: Add `RequestID` field to `sock.Request`
+
+**Files:**
+- Modify: `bin-common-handler/models/sock/message.go`
+- Modify: `bin-common-handler/models/sock/message_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// Append to bin-common-handler/models/sock/message_test.go
+func TestRequestRequestIDField(t *testing.T) {
+	r := Request{
+		URI:       "/v1/calls/1",
+		Method:    RequestMethodGet,
+		RequestID: "req_01hxyz12345",
+	}
+	if r.RequestID != "req_01hxyz12345" {
+		t.Errorf("RequestID not set: %q", r.RequestID)
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"request_id":"req_01hxyz12345"`) {
+		t.Errorf("request_id missing from JSON: %s", string(b))
+	}
+}
+
+func TestRequestRequestIDOmitempty(t *testing.T) {
+	r := Request{
+		URI:    "/v1/calls",
+		Method: RequestMethodPost,
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "request_id") {
+		t.Errorf("request_id should be omitted when empty, got: %s", string(b))
+	}
+}
+```
+
+Add `"strings"` to the test file's imports.
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd bin-common-handler && go test ./models/sock/... -run TestRequestRequestID -v
+```
+
+Expected: compile error — `Request` has no `RequestID` field.
+
+**Step 3: Write minimal implementation**
+
+```go
+// Modify bin-common-handler/models/sock/message.go
+type Request struct {
+	URI       string          `json:"uri"`
+	Method    RequestMethod   `json:"method"`
+	Publisher string          `json:"publisher"`
+	DataType  string          `json:"data_type"`
+	Data      json.RawMessage `json:"data,omitempty"`
+	RequestID string          `json:"request_id,omitempty"`
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd bin-common-handler && go test ./models/sock/... -v
+```
+
+Expected: PASS — including all pre-existing tests (confirms the addition is backward-compatible).
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/sock/message.go bin-common-handler/models/sock/message_test.go
+git commit -m "NOJIRA-api-error-response-codes
+
+Add optional RequestID so request correlation IDs propagate from api-manager through RPC to internal managers for log correlation.
+
+- bin-common-handler: Add RequestID field to sock.Request"
+```
+
+---
+
+### Task 11: Run the full verification workflow
+
+**No new files. Confirms the package compiles, tests pass, lint is clean, and go.sum is in sync.**
+
+**Step 1: Run the workflow**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-api-error-response-codes/bin-common-handler
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all five steps pass. If `go mod tidy` or `go generate` mutated tracked files, stage and commit them.
+
+**Step 2: Commit any tidy/generate changes (if any)**
+
+```bash
+git status
+# If go.mod / go.sum / generated mocks changed:
+git add bin-common-handler/go.mod bin-common-handler/go.sum bin-common-handler/pkg/*/mock_*.go 2>/dev/null
+git diff --cached --quiet || git commit -m "NOJIRA-api-error-response-codes
+
+Bring go.mod/go.sum and generated mocks in sync after introducing the new errors package.
+
+- bin-common-handler: go mod tidy and mock regeneration sync"
+```
+
+(If nothing changed, skip the commit.)
+
+---
+
+### Task 12: Push the branch and open PR 0a
+
+**Step 1: Verify remote tracking and pull main for conflict check**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-api-error-response-codes
+git fetch origin main
+git log --oneline HEAD..origin/main
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)" || echo "no conflicts"
+```
+
+Expected: "no conflicts". If conflicts exist, rebase onto latest main, resolve, and re-run Task 11's verification workflow before pushing.
+
+**Step 2: Push**
+
+```bash
+git push -u origin NOJIRA-api-error-response-codes
+```
+
+**Step 3: Open PR**
+
+```bash
+gh pr create --title "NOJIRA-api-error-response-codes" --body "$(cat <<'EOF'
+Foundation for VoIPbin API structured error responses (PR 0a of N). Introduces the shared VoipbinError vocabulary and RPC request correlation, without wiring any callers yet. This PR changes only bin-common-handler so it can land independently before api-manager work begins.
+
+See design doc: docs/plans/2026-04-24-api-error-response-codes-design.md
+See implementation plan: docs/plans/2026-04-24-api-error-response-codes-plan.md
+
+- bin-common-handler: Add models/errors package with Status type, VoipbinError struct (Error/Unwrap/Wrap), 10 constructors, DataTypeVoipbinError, FromResponse/ToResponse helpers
+- bin-common-handler: Add optional RequestID field to sock.Request for cross-service log correlation
+
+Reviewer note: this introduces a new models/errors package with only bin-api-manager as the day-1 consumer. The admission-rule threshold is 3 services. Defensible exception: VoipbinError is part of the shared RPC contract (sock.Response.Data) and will be consumed by requesthandler typed-unmarshal in PR 0b and by each internal manager that later migrates. If the committee prefers stricter adherence, the fallback is to put VoipbinError in bin-api-manager/pkg/errors/ and promote when a second consumer appears.
+EOF
+)"
+```
+
+---
+
+### PR 0a success criteria
+
+- [ ] All 12 tasks committed.
+- [ ] `go test ./...` passes inside `bin-common-handler`.
+- [ ] `golangci-lint run -v --timeout 5m` is clean.
+- [ ] `go.mod` / `go.sum` / vendor are consistent; no uncommitted changes after verification.
+- [ ] No changes outside `bin-common-handler` (zero api-manager or other-manager modifications).
+- [ ] PR description explicitly flags the admission-rule exception for reviewers.
+
+---
+
+## Subsequent PRs (scoped at high level)
+
+These need their own execution-ready plans before implementation. Below are the rough shape and per-PR scope so reviewers and future authors share the same mental model.
+
+### PR 0b — bin-api-manager infrastructure
+
+**Scope (from design §10.2):**
+- `server/error.go`: `abortWithError`, `abortWithServiceError`, `httpStatusFor`, `assertErrorResponse` test helper.
+- `server/error_translate.go`: translator (typed-passthrough → sentinel → transport → substring → INTERNAL) with `defer recover()` panic safety.
+- `lib/middleware/request_id.go`: 30-char ULID middleware, echoes inbound `X-Request-Id`, stores in `gin.Context`, `c.Request.Context()`, logrus fields. Registered in `cmd/api-manager/main.go`.
+- `pkg/serviceerrors/sentinels.go`: initial sentinel set (`ErrPermissionDenied`, `ErrNotFound`, `ErrAuthenticationRequired`, `ErrDirectAccessNotSupported`).
+- Migrate `lib/middleware/ratelimit.go` (swap flat error shape for `abortWithError`).
+- Migrate `lib/middleware/authenticate.go` (bare 401 + non-envelope 403 → typed errors).
+- **Spike:** wire error responses into `GET /v1/ping` only, regenerate `gens/openapi_server/gen.go`, confirm `oapi-codegen` output is compatible. If not, pivot (document in PR).
+- **Audit:** survey `Response.StatusCode` usage across manager callers.
+- OpenAPI components in `bin-openapi-manager/openapi/openapi.yaml`: `ErrorBody` (with reserved `details` array), `ErrorResponse`, named responses. No per-endpoint wiring yet (except the spike endpoint).
+- RST: update `bin-api-manager/docsdev/source/restful_api.rst` with envelope + status table; create empty `restful_api_errors.rst` catalog with table header; clean-rebuild and commit HTML.
+
+**Verification:** full workflow for both `bin-openapi-manager` and `bin-api-manager`. RST HTML rebuild + `git add -f docsdev/build/`.
+
+**Blocker:** depends on PR 0a being merged.
+
+### PR 1 — Auth & identity migration
+
+**Scope:** handler files `auth_*`, `me`, `customer`, plus `service_agents_*` auth if separate codepath. Convert `c.AbortWithStatus(…)` and legacy `c.AbortWithStatusJSON` to `abortWithServiceError`. Add sentinels or typed constructors in `servicehandler` counterparts. Wire the group's OpenAPI paths to reference named error responses. Append any new reasons to `restful_api_errors.rst`. Update handler tests via `assertErrorResponse`. Update `*_tutorial.rst` / `*_troubleshooting.rst` per AI-native docs Rule 5. Companion PR in `monorepo-monitoring/api-validator/`.
+
+**Pre-flight blocker:** frontend client audit complete — `admin.voipbin.net` and `talk.voipbin.net` must tolerate 401/403/404/409/429/503 before this PR rolls out.
+
+### PR 2 — Calls group
+
+`calls`, `groupcalls`, `recordings`, `recordingfiles`, `transfers`. Same pattern as PR 1.
+
+### PR 3 — Flows & activeflows
+
+`flows`, `activeflows`.
+
+### PR 4 — Numbers & providers
+
+`numbers`, `available_numbers`, `providers`, `providercalls`, `trunks`, `routes`.
+
+### PR 5 — Billing (exercises 402)
+
+`billings`, `billing_account`, `billing_accounts`. First PR to emit `PAYMENT_REQUIRED` / 402. Verify the full 402 code path end-to-end.
+
+### PR 6 — Messaging & conversations
+
+`messages`, `emails`, `conversations`, `conversation_accounts`.
+
+### PR 7 — AI, transcription, speaking
+
+`ais`, `aicalls`, `aimessages`, `aisummaries`, `transcribes`, `transcripts`, `speakings`.
+
+### PR 8 — Agents, queues, conferences, campaigns
+
+`agents`, `queues`, `queuecalls`, `conferences`, `conferencecalls`, `campaigns`, `campaigncalls`, `outplans`, `outdials`.
+
+### PR 9 — Storage, extensions, remainder
+
+`storage_*`, `extensions`, `tags`, `teams`, `timelines*`, `aggregated_events`, `contacts`, remaining `service_agents_*`, `ws`, `accesskeys`, `rags`. Final sweep.
+
+### PR N+1 — Shrink the translator fallback
+
+Remove the substring-fallback cases from `server/error_translate.go`. Any error not caught by typed passthrough, sentinel, or transport detection returns clean `INTERNAL`. Add a test that asserts an unknown error hits the INTERNAL default with the original error in `Cause` (server-side only) and a generic client-visible message.
+
+---
+
+## Per-PR checklist (applies to every PR in this plan)
+
+For each PR from 0a onward:
+
+- [ ] Branch name matches `NOJIRA-api-error-response-codes` (single long-lived branch across PRs — use sub-branches per PR only if the team prefers; otherwise land in-sequence).
+- [ ] Commits squashed into one on merge (project rule: all merges squash-merged).
+- [ ] Full verification workflow run for each touched service (`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`).
+- [ ] Pulled latest `origin/main` and verified no merge conflicts before pushing or merging.
+- [ ] If RST source changed: clean-rebuilt Sphinx HTML (`rm -rf build && python3 -m sphinx -M html source build`) and force-added `docsdev/build/`.
+- [ ] PR title matches branch name.
+- [ ] PR body narrates what and lists `- project-name: change` bullets.
+- [ ] No AI attribution in commit messages or PR bodies.
+- [ ] No merge until the user explicitly authorizes it.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/plans/2026-04-24-api-error-response-codes-plan.md`. Two execution options:
+
+**1. Subagent-driven (this session)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Uses @superpowers:subagent-driven-development.
+
+**2. Parallel session (separate)** — Open a new session in this worktree, it uses @superpowers:executing-plans for batched execution with checkpoints.
+
+Which approach?


### PR DESCRIPTION
Foundation for VoIPbin API structured error responses (PR 0a of N). Introduces the shared VoipbinError vocabulary and RPC request correlation, without wiring any callers yet. This PR changes only bin-common-handler so it can land independently before api-manager work begins.

See design doc: docs/plans/2026-04-24-api-error-response-codes-design.md
See implementation plan: docs/plans/2026-04-24-api-error-response-codes-plan.md

- bin-common-handler: Add models/errors package with Status type, VoipbinError struct (Error/Unwrap/Wrap), 10 constructors, DataTypeVoipbinError, FromResponse/ToResponse helpers
- bin-common-handler: Add optional RequestID field to sock.Request for cross-service log correlation

Reviewer note: this introduces a new models/errors package with only bin-api-manager as the day-1 consumer. The admission-rule threshold is 3 services. Defensible exception: VoipbinError is part of the shared RPC contract (sock.Response.Data) and will be consumed by requesthandler typed-unmarshal in PR 0b and by each internal manager that later migrates. If the committee prefers stricter adherence, the fallback is to put VoipbinError in bin-api-manager/pkg/errors/ and promote when a second consumer appears.