### PR TITLE
NOJIRA-apply-provider-tech-config-on-outbound

### DIFF
--- a/bin-call-manager/pkg/callhandler/outgoing_call.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call.go
@@ -313,8 +313,12 @@ func (h *callHandler) CreateCallOutgoing(
 	return res, nil
 }
 
-// getDialURITel returns dial uri of the given tel type destination.
-func (h *callHandler) getDialURITel(ctx context.Context, c *call.Call) (string, error) {
+// getDialURITel returns dial uri and provider-supplied tech_headers for the
+// given tel type destination. Prefix/postfix from the Provider wrap the
+// user part of the URI; tech_headers are returned raw for the caller to
+// merge via mergeTechHeaders (so sanitization and reserved-key enforcement
+// happen next to the channel-variable assembly).
+func (h *callHandler) getDialURITel(ctx context.Context, c *call.Call) (string, map[string]string, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "getDialURITel",
 		"call_id": c.ID,
@@ -330,34 +334,34 @@ func (h *callHandler) getDialURITel(ctx context.Context, c *call.Call) (string, 
 
 	if providerID == uuid.Nil {
 		log.Debugf("No available dialroute left.")
-		return "", fmt.Errorf("no available dialroute left")
+		return "", nil, fmt.Errorf("no available dialroute left")
 	}
 
-	// get provider info
 	pr, err := h.reqHandler.RouteV1ProviderGet(ctx, providerID)
 	if err != nil {
 		log.Errorf("Could not get provider info. err: %v", err)
-		return "", err
+		return "", nil, err
 	}
 
-	res := fmt.Sprintf("pjsip/%s/sip:%s@%s;transport=%s", pjsipEndpointOutgoing, c.Destination.Target, pr.Hostname, constTransportUDP)
+	userPart := pr.TechPrefix + c.Destination.Target + pr.TechPostfix
+	res := fmt.Sprintf("pjsip/%s/sip:%s@%s;transport=%s", pjsipEndpointOutgoing, userPart, pr.Hostname, constTransportUDP)
 
-	return res, nil
+	return res, pr.TechHeaders, nil
 }
 
 // getDialURISIP returns dial uri of the given sip type destination.
-func (h *callHandler) getDialURISIP(ctx context.Context, c *call.Call) (string, error) {
+func (h *callHandler) getDialURISIP(ctx context.Context, c *call.Call) (string, map[string]string, error) {
 	endpoint := c.Destination.Target
 	if !strings.HasPrefix(c.Destination.Target, "sip:") && !strings.HasPrefix(c.Destination.Target, "sips:") {
 		endpoint = "sip:" + endpoint
 	}
 
 	res := fmt.Sprintf("pjsip/%s/%s", pjsipEndpointOutgoing, endpoint)
-	return res, nil
+	return res, nil, nil
 }
 
 // getDialURISIP returns dial uri of the given sip type destination.
-func (h *callHandler) getDialURISIPDirect(ctx context.Context, c *call.Call) (string, error) {
+func (h *callHandler) getDialURISIPDirect(ctx context.Context, c *call.Call) (string, map[string]string, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "getDialURISIPDirect",
 		"destination_target": c.Destination.Target,
@@ -370,7 +374,7 @@ func (h *callHandler) getDialURISIPDirect(ctx context.Context, c *call.Call) (st
 
 	tmpTargets := strings.Split(endpointTarget, ";")
 	if len(tmpTargets) < 1 {
-		return "", fmt.Errorf("wrong destination uri")
+		return "", nil, fmt.Errorf("wrong destination uri")
 	}
 
 	// get target host/port
@@ -383,11 +387,13 @@ func (h *callHandler) getDialURISIPDirect(ctx context.Context, c *call.Call) (st
 	log.Debugf("Found outbound proxy host info. outbound_proxy: %s", porxyHost)
 
 	res := fmt.Sprintf("pjsip/%s%s/%s", pjsipEndpointOutgoingDirect, porxyHost, endpointTarget)
-	return res, nil
+	return res, nil, nil
 }
 
-// getDialURI returns the given destination address's dial URI for Asterisk's dialing
-func (h *callHandler) getDialURI(ctx context.Context, c *call.Call) (string, error) {
+// getDialURI returns the given destination address's dial URI and optional
+// provider tech_headers for Asterisk's dialing. tech_headers is nil for
+// non-provider paths.
+func (h *callHandler) getDialURI(ctx context.Context, c *call.Call) (string, map[string]string, error) {
 
 	switch c.Destination.Type {
 	case commonaddress.TypeTel:
@@ -395,15 +401,12 @@ func (h *callHandler) getDialURI(ctx context.Context, c *call.Call) (string, err
 
 	case commonaddress.TypeSIP:
 		if strings.Contains(c.Destination.Target, "transport=ws") {
-			// websocket transport(WebRTC)
 			return h.getDialURISIPDirect(ctx, c)
 		}
 		return h.getDialURISIP(ctx, c)
 
 	default:
-		// for address type endpoint, conference, ... are possible to return the multiple address.
-		// so we can not handle those address types are here.
-		return "", fmt.Errorf("unsupported address type for get dial uri")
+		return "", nil, fmt.Errorf("unsupported address type for get dial uri")
 	}
 }
 
@@ -550,15 +553,19 @@ func (h *callHandler) createChannelOutgoing(ctx context.Context, c *call.Call) e
 		"call_id": c.ID,
 	})
 
-	// get a endpoint destination
-	dialURI, err := h.getDialURI(ctx, c)
+	// get dial uri and provider-supplied tech headers
+	dialURI, techHeaders, err := h.getDialURI(ctx, c)
 	if err != nil {
 		log.Errorf("Could not create a destination endpoint. err: %v", err)
 		return err
 	}
 
-	// set channel variables
+	// set channel variables — tech_headers first so system-set headers
+	// (transport, CALLERID, PAI when anonymous) overwrite on collision.
+	// mergeTechHeaders additionally enforces the reserved-key denylist.
 	channelVariables := map[string]string{}
+	techApplied, techSkipped := mergeTechHeaders(channelVariables, techHeaders, log)
+
 	transport := getDestinationTransport(dialURI)
 	setChannelVariableTransport(channelVariables, transport)
 	anonymous := c.Data[call.DataTypeAnonymous] == "true"
@@ -566,6 +573,12 @@ func (h *callHandler) createChannelOutgoing(ctx context.Context, c *call.Call) e
 		log.Errorf("Could not set caller ID variables. err: %v", err)
 		return err
 	}
+
+	if techApplied > 0 || techSkipped > 0 {
+		log.Infof("Applied provider tech config. headers_applied=%d headers_skipped=%d",
+			techApplied, techSkipped)
+	}
+
 	log.Debugf("Endpoint detail. endpoint_destination: %s, variables: %v, anonymous: %v", dialURI, channelVariables, anonymous)
 
 	// set app args

--- a/bin-call-manager/pkg/callhandler/outgoing_call.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call.go
@@ -360,7 +360,7 @@ func (h *callHandler) getDialURISIP(ctx context.Context, c *call.Call) (string, 
 	return res, nil, nil
 }
 
-// getDialURISIP returns dial uri of the given sip type destination.
+// getDialURISIPDirect returns dial uri of the given sip type destination via the direct endpoint.
 func (h *callHandler) getDialURISIPDirect(ctx context.Context, c *call.Call) (string, map[string]string, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":               "getDialURISIPDirect",

--- a/bin-call-manager/pkg/callhandler/outgoing_call_test.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call_test.go
@@ -1035,11 +1035,11 @@ func Test_getDialURI_Tel(t *testing.T) {
 		responseProvider *rmprovider.Provider
 
 		expectProviderID uuid.UUID
-		expectTarget     string
 		expectRes        string
+		expectTechHdrs   map[string]string
 	}{
 		{
-			"normal",
+			"no tech config (backwards compat)",
 
 			&call.Call{
 				Identity: commonidentity.Identity{
@@ -1065,8 +1065,118 @@ func Test_getDialURI_Tel(t *testing.T) {
 			},
 
 			uuid.FromStringOrNil("8730a3da-5350-11ed-aa47-7f44741127c1"),
-			"+82",
 			"pjsip/call-out/sip:+821121656521@sip.telnyx.com;transport=udp",
+			nil,
+		},
+		{
+			"prefix only",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000001-0000-0000-0000-000000000001"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000001-0000-0000-0000-000000000001"),
+						ProviderID: uuid.FromStringOrNil("b0000001-0000-0000-0000-000000000001")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:   "carrier.example.com",
+				TechPrefix: "0011",
+			},
+
+			uuid.FromStringOrNil("b0000001-0000-0000-0000-000000000001"),
+			"pjsip/call-out/sip:001115551234@carrier.example.com;transport=udp",
+			nil,
+		},
+		{
+			"postfix only",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000002-0000-0000-0000-000000000002"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000002-0000-0000-0000-000000000002"),
+						ProviderID: uuid.FromStringOrNil("b0000002-0000-0000-0000-000000000002")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:    "carrier.example.com",
+				TechPostfix: "#",
+			},
+
+			uuid.FromStringOrNil("b0000002-0000-0000-0000-000000000002"),
+			"pjsip/call-out/sip:+15551234#@carrier.example.com;transport=udp",
+			nil,
+		},
+		{
+			"prefix and postfix both",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000003-0000-0000-0000-000000000003"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000003-0000-0000-0000-000000000003"),
+						ProviderID: uuid.FromStringOrNil("b0000003-0000-0000-0000-000000000003")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:    "carrier.example.com",
+				TechPrefix:  "0011",
+				TechPostfix: "#",
+			},
+
+			uuid.FromStringOrNil("b0000003-0000-0000-0000-000000000003"),
+			"pjsip/call-out/sip:0011+15551234#@carrier.example.com;transport=udp",
+			nil,
+		},
+		{
+			"headers only — returned raw (unsanitized), caller sanitizes via mergeTechHeaders",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000004-0000-0000-0000-000000000004"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000004-0000-0000-0000-000000000004"),
+						ProviderID: uuid.FromStringOrNil("b0000004-0000-0000-0000-000000000004")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname: "carrier.example.com",
+				TechHeaders: map[string]string{
+					"X-Carrier-Auth": "tok-abc",
+				},
+			},
+
+			uuid.FromStringOrNil("b0000004-0000-0000-0000-000000000004"),
+			"pjsip/call-out/sip:+15551234@carrier.example.com;transport=udp",
+			map[string]string{"X-Carrier-Auth": "tok-abc"},
+		},
+		{
+			"all three together",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000005-0000-0000-0000-000000000005"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000005-0000-0000-0000-000000000005"),
+						ProviderID: uuid.FromStringOrNil("b0000005-0000-0000-0000-000000000005")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:    "carrier.example.com",
+				TechPrefix:  "0011",
+				TechPostfix: "#",
+				TechHeaders: map[string]string{"X-Route-Hint": "premium"},
+			},
+
+			uuid.FromStringOrNil("b0000005-0000-0000-0000-000000000005"),
+			"pjsip/call-out/sip:001115551234#@carrier.example.com;transport=udp",
+			map[string]string{"X-Route-Hint": "premium"},
 		},
 	}
 
@@ -1087,13 +1197,22 @@ func Test_getDialURI_Tel(t *testing.T) {
 
 			mockReq.EXPECT().RouteV1ProviderGet(ctx, tt.expectProviderID).Return(tt.responseProvider, nil)
 
-			res, err := h.getDialURI(ctx, tt.call)
+			res, techHdrs, err := h.getDialURI(ctx, tt.call)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 
 			if res != tt.expectRes {
 				t.Errorf("Wrong match. expect: %s, got: %s", tt.expectRes, res)
+			}
+
+			if len(techHdrs) != len(tt.expectTechHdrs) {
+				t.Errorf("Wrong techHdrs size. expect: %d, got: %d. techHdrs=%v", len(tt.expectTechHdrs), len(techHdrs), techHdrs)
+			}
+			for k, v := range tt.expectTechHdrs {
+				if got, ok := techHdrs[k]; !ok || got != v {
+					t.Errorf("Wrong techHdrs entry. key=%s expect=%q got=%q (present=%v)", k, v, got, ok)
+				}
 			}
 		})
 	}
@@ -1158,7 +1277,7 @@ func Test_getDialURI_SIP(t *testing.T) {
 
 			ctx := context.Background()
 
-			res, err := h.getDialURI(ctx, tt.c)
+			res, _, err := h.getDialURI(ctx, tt.c)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
@@ -1230,7 +1349,7 @@ func Test_getDialURI_error(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, err := h.getDialURI(ctx, tt.call)
+			_, _, err := h.getDialURI(ctx, tt.call)
 			if err == nil {
 				t.Error("Wrong match. expect: err, got: ok")
 			}
@@ -1290,6 +1409,51 @@ func Test_createChannel(t *testing.T) {
 			expectVariables: map[string]string{
 				"CALLERID(name)": "",
 				"CALLERID(num)":  "+821100000002",
+				"PJSIP_HEADER(add," + common.SIPHeaderSDPTransport + ")": "RTP/AVP",
+			},
+		},
+		{
+			name: "provider tech config applied — prefix, postfix, header",
+
+			call: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000002"),
+				},
+
+				ChannelID: "c1c1c1c1-0000-0000-0000-000000000003",
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+821100000002",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "15551234",
+				},
+				DialrouteID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000004"),
+				Dialroutes: []rmroute.Route{
+					{
+						ID:         uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000004"),
+						ProviderID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000005"),
+					},
+				},
+			},
+
+			responseProvider: &rmprovider.Provider{
+				ID:          uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000005"),
+				Hostname:    "carrier.example.com",
+				TechPrefix:  "0011",
+				TechPostfix: "#",
+				TechHeaders: map[string]string{"X-Route-Hint": "premium"},
+			},
+
+			expectProviderID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000005"),
+			expectArgs:       "context_type=call,context=call-out,call_id=c1c1c1c1-0000-0000-0000-000000000001,transport=udp,direction=outgoing",
+			expectDialURI:    "pjsip/call-out/sip:001115551234#@carrier.example.com;transport=udp",
+			expectVariables: map[string]string{
+				"PJSIP_HEADER(add,X-Route-Hint)":                         "premium",
+				"CALLERID(name)":                                         "",
+				"CALLERID(num)":                                          "+821100000002",
 				"PJSIP_HEADER(add," + common.SIPHeaderSDPTransport + ")": "RTP/AVP",
 			},
 		},
@@ -2694,7 +2858,7 @@ func Test_getDialURISIP(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			res, err := h.getDialURISIP(ctx, tt.call)
+			res, _, err := h.getDialURISIP(ctx, tt.call)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
@@ -2752,7 +2916,7 @@ func Test_getDialURISIPDirect(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			res, err := h.getDialURISIPDirect(ctx, tt.call)
+			res, _, err := h.getDialURISIPDirect(ctx, tt.call)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-call-manager/pkg/callhandler/outgoing_call_test.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call_test.go
@@ -1037,6 +1037,7 @@ func Test_getDialURI_Tel(t *testing.T) {
 		expectProviderID uuid.UUID
 		expectRes        string
 		expectTechHdrs   map[string]string
+		expectErr        bool
 	}{
 		{
 			"no tech config (backwards compat)",
@@ -1067,6 +1068,7 @@ func Test_getDialURI_Tel(t *testing.T) {
 			uuid.FromStringOrNil("8730a3da-5350-11ed-aa47-7f44741127c1"),
 			"pjsip/call-out/sip:+821121656521@sip.telnyx.com;transport=udp",
 			nil,
+			false,
 		},
 		{
 			"prefix only",
@@ -1088,6 +1090,7 @@ func Test_getDialURI_Tel(t *testing.T) {
 			uuid.FromStringOrNil("b0000001-0000-0000-0000-000000000001"),
 			"pjsip/call-out/sip:001115551234@carrier.example.com;transport=udp",
 			nil,
+			false,
 		},
 		{
 			"postfix only",
@@ -1109,6 +1112,7 @@ func Test_getDialURI_Tel(t *testing.T) {
 			uuid.FromStringOrNil("b0000002-0000-0000-0000-000000000002"),
 			"pjsip/call-out/sip:+15551234#@carrier.example.com;transport=udp",
 			nil,
+			false,
 		},
 		{
 			"prefix and postfix both",
@@ -1131,6 +1135,7 @@ func Test_getDialURI_Tel(t *testing.T) {
 			uuid.FromStringOrNil("b0000003-0000-0000-0000-000000000003"),
 			"pjsip/call-out/sip:0011+15551234#@carrier.example.com;transport=udp",
 			nil,
+			false,
 		},
 		{
 			"headers only — returned raw (unsanitized), caller sanitizes via mergeTechHeaders",
@@ -1154,6 +1159,7 @@ func Test_getDialURI_Tel(t *testing.T) {
 			uuid.FromStringOrNil("b0000004-0000-0000-0000-000000000004"),
 			"pjsip/call-out/sip:+15551234@carrier.example.com;transport=udp",
 			map[string]string{"X-Carrier-Auth": "tok-abc"},
+			false,
 		},
 		{
 			"all three together",
@@ -1177,6 +1183,26 @@ func Test_getDialURI_Tel(t *testing.T) {
 			uuid.FromStringOrNil("b0000005-0000-0000-0000-000000000005"),
 			"pjsip/call-out/sip:001115551234#@carrier.example.com;transport=udp",
 			map[string]string{"X-Route-Hint": "premium"},
+			false,
+		},
+		{
+			"provider fetch error — returns err with nil tech_headers",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000006-0000-0000-0000-000000000006"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000006-0000-0000-0000-000000000006"),
+						ProviderID: uuid.FromStringOrNil("b0000006-0000-0000-0000-000000000006")},
+				},
+			},
+
+			nil,
+
+			uuid.FromStringOrNil("b0000006-0000-0000-0000-000000000006"),
+			"",
+			nil,
+			true,
 		},
 	}
 
@@ -1195,9 +1221,27 @@ func Test_getDialURI_Tel(t *testing.T) {
 
 			ctx := context.Background()
 
-			mockReq.EXPECT().RouteV1ProviderGet(ctx, tt.expectProviderID).Return(tt.responseProvider, nil)
+			if tt.expectErr {
+				mockReq.EXPECT().RouteV1ProviderGet(ctx, tt.expectProviderID).Return(nil, fmt.Errorf("mock provider-fetch failure"))
+			} else {
+				mockReq.EXPECT().RouteV1ProviderGet(ctx, tt.expectProviderID).Return(tt.responseProvider, nil)
+			}
 
 			res, techHdrs, err := h.getDialURI(ctx, tt.call)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				if res != "" {
+					t.Errorf("Wrong res on error. expect: empty, got: %q", res)
+				}
+				if techHdrs != nil {
+					t.Errorf("Wrong techHdrs on error. expect: nil, got: %v", techHdrs)
+				}
+				return
+			}
+
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-call-manager/pkg/callhandler/tech_headers.go
+++ b/bin-call-manager/pkg/callhandler/tech_headers.go
@@ -33,7 +33,7 @@ var reservedTechHeaderKeys = map[string]struct{}{
 // with PJSIP_HEADER(add,...) so Asterisk attaches the header to the outgoing
 // INVITE.
 //
-// Entries are skipped and logged as Warn when:
+// Entries are skipped and logged as Debug when:
 //   - key is empty
 //   - key contains \r, \n, (, ), or ,
 //   - wrapped key matches reservedTechHeaderKeys
@@ -48,29 +48,29 @@ var reservedTechHeaderKeys = map[string]struct{}{
 func mergeTechHeaders(dst map[string]string, src map[string]string, log *logrus.Entry) (applied int, skipped int) {
 	for k, v := range src {
 		if k == "" {
-			log.Warnf("Skipping tech_header with empty key.")
+			log.Debugf("Skipping tech_header with empty key.")
 			skipped++
 			continue
 		}
 		if _, reserved := reservedTechHeaderKeys[k]; reserved {
-			log.Warnf("Skipping tech_header that collides with system-reserved key. key=%q", k)
+			log.Debugf("Skipping tech_header that collides with system-reserved key. key=%q", k)
 			skipped++
 			continue
 		}
 		if strings.ContainsAny(k, "\r\n(),") {
-			log.Warnf("Skipping tech_header with invalid key char. key=%q", k)
+			log.Debugf("Skipping tech_header with invalid key char. key=%q", k)
 			skipped++
 			continue
 		}
 		if strings.ContainsAny(v, "\r\n") {
-			log.Warnf("Skipping tech_header with CRLF in value. key=%q", k)
+			log.Debugf("Skipping tech_header with CRLF in value. key=%q", k)
 			skipped++
 			continue
 		}
 
 		varKey := "PJSIP_HEADER(add," + k + ")"
 		if _, reserved := reservedTechHeaderKeys[varKey]; reserved {
-			log.Warnf("Skipping tech_header that collides with system-reserved header. key=%q", k)
+			log.Debugf("Skipping tech_header that collides with system-reserved header. key=%q", k)
 			skipped++
 			continue
 		}

--- a/bin-call-manager/pkg/callhandler/tech_headers.go
+++ b/bin-call-manager/pkg/callhandler/tech_headers.go
@@ -52,13 +52,13 @@ func mergeTechHeaders(dst map[string]string, src map[string]string, log *logrus.
 			skipped++
 			continue
 		}
-		if strings.ContainsAny(k, "\r\n(),") {
-			log.Warnf("Skipping tech_header with invalid key char. key=%q", k)
+		if _, reserved := reservedTechHeaderKeys[k]; reserved {
+			log.Warnf("Skipping tech_header that collides with system-reserved key. key=%q", k)
 			skipped++
 			continue
 		}
-		if _, reserved := reservedTechHeaderKeys[k]; reserved {
-			log.Warnf("Skipping tech_header that collides with system-reserved key. key=%q", k)
+		if strings.ContainsAny(k, "\r\n(),") {
+			log.Warnf("Skipping tech_header with invalid key char. key=%q", k)
 			skipped++
 			continue
 		}

--- a/bin-call-manager/pkg/callhandler/tech_headers.go
+++ b/bin-call-manager/pkg/callhandler/tech_headers.go
@@ -1,0 +1,82 @@
+package callhandler
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// reservedTechHeaderKeys lists channel-variable keys that operator-supplied
+// tech_headers are forbidden from setting. The set covers:
+//   - headers the system writes conditionally (P-Asserted-Identity / Privacy
+//     are only set for anonymous calls, so ordering alone cannot protect them),
+//   - headers the system writes unconditionally (SDP-Transport, CALLERID(*)),
+//   - internal trace headers (VB-CALL-ID / VB-CONFBRIDGE-ID) whose values must
+//     match call-manager's own UUIDs for downstream correlation.
+//
+// Keys are checked both in their raw form (for CALLERID/PJSIP_HEADER entries)
+// and after PJSIP_HEADER(add,...) wrapping (for SIP header names).
+var reservedTechHeaderKeys = map[string]struct{}{
+	"PJSIP_HEADER(add,P-Asserted-Identity)": {},
+	"PJSIP_HEADER(add,Privacy)":             {},
+	"PJSIP_HEADER(add,VBOUT-SDP_Transport)": {},
+	"PJSIP_HEADER(add,VB-CALL-ID)":          {},
+	"PJSIP_HEADER(add,VB-CONFBRIDGE-ID)":    {},
+	"PJSIP_HEADER(add,VB-DIRECTION)":        {},
+	"CALLERID(name)":                        {},
+	"CALLERID(num)":                         {},
+	"CALLERID(pres)":                        {},
+}
+
+// mergeTechHeaders copies sanitized entries from src (raw operator-supplied
+// tech_headers) into dst (Asterisk channel variables), wrapping each key
+// with PJSIP_HEADER(add,...) so Asterisk attaches the header to the outgoing
+// INVITE.
+//
+// Entries are skipped and logged as Warn when:
+//   - key is empty
+//   - key contains \r, \n, (, ), or ,
+//   - wrapped key matches reservedTechHeaderKeys
+//   - raw key itself matches reservedTechHeaderKeys (covers CALLERID(*) attempts)
+//   - value contains \r or \n (CRLF injection defense)
+//
+// Skipped entries never fail the call — the rest of the tech config and the
+// call itself proceed.
+//
+// Returns counts of applied and skipped entries for a single summary log at
+// the call site.
+func mergeTechHeaders(dst map[string]string, src map[string]string, log *logrus.Entry) (applied int, skipped int) {
+	for k, v := range src {
+		if k == "" {
+			log.Warnf("Skipping tech_header with empty key.")
+			skipped++
+			continue
+		}
+		if strings.ContainsAny(k, "\r\n(),") {
+			log.Warnf("Skipping tech_header with invalid key char. key=%q", k)
+			skipped++
+			continue
+		}
+		if _, reserved := reservedTechHeaderKeys[k]; reserved {
+			log.Warnf("Skipping tech_header that collides with system-reserved key. key=%q", k)
+			skipped++
+			continue
+		}
+		if strings.ContainsAny(v, "\r\n") {
+			log.Warnf("Skipping tech_header with CRLF in value. key=%q", k)
+			skipped++
+			continue
+		}
+
+		varKey := "PJSIP_HEADER(add," + k + ")"
+		if _, reserved := reservedTechHeaderKeys[varKey]; reserved {
+			log.Warnf("Skipping tech_header that collides with system-reserved header. key=%q", k)
+			skipped++
+			continue
+		}
+
+		dst[varKey] = v
+		applied++
+	}
+	return applied, skipped
+}

--- a/bin-call-manager/pkg/callhandler/tech_headers_test.go
+++ b/bin-call-manager/pkg/callhandler/tech_headers_test.go
@@ -1,0 +1,211 @@
+package callhandler
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Test_mergeTechHeaders(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		dst map[string]string
+		src map[string]string
+
+		expectDst     map[string]string
+		expectApplied int
+		expectSkipped int
+	}{
+		{
+			"nil src leaves dst unchanged",
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			nil,
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			0,
+			0,
+		},
+		{
+			"empty src leaves dst unchanged",
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			map[string]string{},
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			0,
+			0,
+		},
+		{
+			"normal header gets wrapped and applied",
+
+			map[string]string{},
+			map[string]string{"X-Carrier-Auth": "token-abc"},
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Carrier-Auth)": "token-abc",
+			},
+			1,
+			0,
+		},
+		{
+			"empty key is skipped",
+
+			map[string]string{},
+			map[string]string{"": "whatever"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"key with CRLF is skipped",
+
+			map[string]string{},
+			map[string]string{"X-Bad\r\nInject": "v"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"key with parenthesis is skipped (blocks PJSIP_HEADER pre-wrap)",
+
+			map[string]string{},
+			map[string]string{"PJSIP_HEADER(add,X)": "v"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"key with comma is skipped",
+
+			map[string]string{},
+			map[string]string{"X,Evil": "v"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved wrapped key P-Asserted-Identity is skipped",
+
+			map[string]string{},
+			map[string]string{"P-Asserted-Identity": "<tel:+100>"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved wrapped key Privacy is skipped",
+
+			map[string]string{},
+			map[string]string{"Privacy": "id"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved wrapped key SDP-Transport is skipped",
+
+			map[string]string{},
+			map[string]string{"VBOUT-SDP_Transport": "RTP/AVP"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved raw key CALLERID(name) is skipped",
+
+			map[string]string{},
+			map[string]string{"CALLERID(name)": "foo"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"value with CR is skipped",
+
+			map[string]string{},
+			map[string]string{"X-Header": "ok\rbad"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"value with LF is skipped",
+
+			map[string]string{},
+			map[string]string{"X-Header": "ok\nbad"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"mixed valid and invalid — valid applied, invalid counted skipped",
+
+			map[string]string{},
+			map[string]string{
+				"X-Good":              "ok",
+				"":                    "drop-empty-key",
+				"X-Bad\r\nInject":     "drop-bad-key",
+				"P-Asserted-Identity": "drop-reserved",
+			},
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Good)": "ok",
+			},
+			1,
+			3,
+		},
+		{
+			"pre-existing dst key is overwritten by tech header (merge semantics; system fns re-overwrite later in createChannelOutgoing)",
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Carrier-Auth)": "old",
+			},
+			map[string]string{
+				"X-Carrier-Auth": "new",
+			},
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Carrier-Auth)": "new",
+			},
+			1,
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := logrus.WithField("test", tt.name)
+
+			applied, skipped := mergeTechHeaders(tt.dst, tt.src, log)
+
+			if applied != tt.expectApplied {
+				t.Errorf("Wrong applied count. expect: %d, got: %d", tt.expectApplied, applied)
+			}
+			if skipped != tt.expectSkipped {
+				t.Errorf("Wrong skipped count. expect: %d, got: %d", tt.expectSkipped, skipped)
+			}
+
+			if len(tt.dst) != len(tt.expectDst) {
+				t.Errorf("Wrong dst size. expect: %d, got: %d. dst=%v", len(tt.expectDst), len(tt.dst), tt.dst)
+			}
+			for k, v := range tt.expectDst {
+				if got, ok := tt.dst[k]; !ok || got != v {
+					t.Errorf("Wrong dst entry. key=%s expect=%q got=%q (present=%v)", k, v, got, ok)
+				}
+			}
+		})
+	}
+}

--- a/docs/plans/2026-04-25-provider-tech-config-outbound-design.md
+++ b/docs/plans/2026-04-25-provider-tech-config-outbound-design.md
@@ -105,11 +105,11 @@ Empty `TechPrefix`/`TechPostfix` are harmless no-ops (empty-string concat). This
 ## Observability
 
 - One `Info` log in `createChannelOutgoing` when any tech config is applied:
-  `"Applied provider tech config. provider_id=%s prefix_len=%d postfix_len=%d headers_applied=%d headers_skipped=%d"`
-- One `Warn` log per skipped header with reason (empty key / invalid char / reserved / CRLF value) and provider_id.
-- No metrics. The log line is sufficient for production debugging; adding a counter here would be overkill.
+  `"Applied provider tech config. headers_applied=%d headers_skipped=%d"`
+- One `Debug` log per skipped header with the reason (empty key / invalid char / reserved / CRLF value) and the offending key.
+- No metrics. The aggregate `Info` line is sufficient for production debugging; per-skip detail is available at `Debug` when operators need to diagnose a specific provider's config.
 
-Per monorepo convention (memory: external-integration logging), these are `Info`/`Warn`, not `Debug`, because tech config changes the on-wire INVITE and must be traceable in production without raising the log level.
+The aggregate `Info` line is the production-visible signal that something was skipped (`headers_skipped > 0`). Per-skip detail stays at `Debug` to avoid log spam on high-volume providers with a misconfigured `tech_headers` — e.g., a provider with 20 invalid entries would otherwise emit 20 Warn lines per outgoing call. An operator seeing `headers_skipped > 0` in `Info` can raise the log level to `Debug` for that pod/provider to recover the per-key reason.
 
 ## Testing strategy
 

--- a/docs/plans/2026-04-25-provider-tech-config-outbound-design.md
+++ b/docs/plans/2026-04-25-provider-tech-config-outbound-design.md
@@ -1,0 +1,167 @@
+# Provider tech prefix/postfix/headers — apply on outbound dial
+
+Date: 2026-04-25
+Status: Approved (design)
+Scope: `bin-call-manager` only
+
+## Problem
+
+`Provider.TechPrefix`, `Provider.TechPostfix`, and `Provider.TechHeaders` are stored on the provider model, editable via the Providers API, and documented in `bin-api-manager/docsdev/source/provider_overview.rst` and `provider_struct_provider.rst` as user-visible behavior (prefix/suffix on dialed numbers, custom SIP headers on the outgoing INVITE).
+
+They are silently dropped on outbound dial. The only consumer is `bin-call-manager/pkg/callhandler/outgoing_call.go:getDialURITel`, which builds the dial URI as:
+
+```go
+res := fmt.Sprintf("pjsip/%s/sip:%s@%s;transport=%s",
+    pjsipEndpointOutgoing, c.Destination.Target, pr.Hostname, constTransportUDP)
+```
+
+Only `pr.Hostname` is used. `TechPrefix`, `TechPostfix`, `TechHeaders` are never applied anywhere in the call flow. The docs contradict the code.
+
+## Goal
+
+On an outbound tel-type call that routes through a Provider:
+
+1. Wrap the user part of the SIP URI with `TechPrefix` and `TechPostfix`:
+   `pjsip/call-out/sip:<TechPrefix><Target><TechPostfix>@<Hostname>;transport=udp`.
+2. Attach each entry in `TechHeaders` to the outgoing INVITE as a custom SIP header using the existing `PJSIP_HEADER(add,<name>) = <value>` channel-variable pattern.
+3. Protect correctness/security-critical system-set headers from override by operator tech_headers.
+4. Sanitize operator-supplied header keys/values to prevent SIP header injection.
+
+Non-goals:
+
+- SIP-direct path (`getDialURISIPDirect`) — does not route through a Provider.
+- Value templating (`{{call_id}}`, etc.) — static key/value only.
+- Provider-save-time validation in `bin-route-manager` — defense-in-depth at dial time only for this PR. Save-time validation tracked as a follow-up.
+
+## Change shape
+
+One focused patch in `bin-call-manager/pkg/callhandler/`:
+
+1. Change `getDialURITel` signature from `(string, error)` to `(string, map[string]string, error)`. It already fetches the Provider — it now also returns the sanitized `tech_headers` map and embeds prefix/postfix in the URI.
+2. Update `getDialURI` dispatcher signature to `(string, map[string]string, error)`.
+3. `getDialURISIP` and `getDialURISIPDirect` return a nil map — no Provider in those paths.
+4. New helper `mergeTechHeaders(dst, src, log)` enforces a reserved-key denylist and sanitization; skipped entries are logged at `Warn` level.
+5. In `createChannelOutgoing`:
+   - Obtain dial URI + tech_headers from `getDialURI`.
+   - Seed `channelVariables` with `mergeTechHeaders(channelVariables, techHeaders, log)`.
+   - Then call `setChannelVariableTransport` and `setChannelVariablesCallerID` — these overwrite any surviving collisions for headers they set directly.
+   - One `Info` log line when any tech config is applied.
+
+Rationale:
+
+- Returning the header map is more explicit than mutating a shared variables map inside `getDialURITel`, and keeps URI construction and provider lookup co-located.
+- A named `mergeTechHeaders` helper is the right home for the denylist + sanitization rules, vs. scattering them across the merge site.
+- Ordering (seed-then-overwrite) handles the CALLERID/PAI/SDP-Transport case cleanly for headers the system code path actually writes; the explicit denylist in `mergeTechHeaders` covers the gap for headers the system only writes conditionally (e.g., `P-Asserted-Identity` is only set when `anonymous == true`).
+
+## Collision & sanitization rules
+
+`mergeTechHeaders(dst map[string]string, src map[string]string, log *logrus.Entry)`:
+
+For each `(k, v)` in `src`:
+
+1. Skip if `k == ""`. Log `Warn: empty tech_header key`.
+2. Skip if `k` contains any of `\r`, `\n`, `(`, `)`, `,`. Log `Warn: invalid tech_header key char`. This blocks operators from passing `PJSIP_HEADER(add,X)` as a key (which would double-wrap) or injecting control chars.
+3. Wrap to channel-variable form: `varKey := "PJSIP_HEADER(add," + k + ")"`.
+4. Skip if `varKey` is in the reserved set. Log `Warn: tech_header collides with system-reserved header`.
+5. Skip if `v` contains `\r` or `\n`. Log `Warn: tech_header value contains CRLF`.
+6. Otherwise `dst[varKey] = v`.
+
+Reserved set (explicit denylist):
+
+```go
+var reservedTechHeaderKeys = map[string]struct{}{
+    "PJSIP_HEADER(add,P-Asserted-Identity)":     {},
+    "PJSIP_HEADER(add,Privacy)":                 {},
+    "PJSIP_HEADER(add,SDP-Transport)":           {},
+    "PJSIP_HEADER(add,X-VoIPBin-Call-ID)":       {},
+    "PJSIP_HEADER(add,X-VoIPBin-Confbridge-ID)": {},
+    "CALLERID(name)": {},
+    "CALLERID(num)":  {},
+    "CALLERID(pres)": {},
+}
+```
+
+The `CALLERID(*)` entries exist because operators could attempt to set them via `tech_headers` even though those keys don't fit the `PJSIP_HEADER(add,...)` wrapping — the helper checks the raw `k` as well for those three before wrapping.
+
+## URI construction
+
+In `getDialURITel`, after successful provider fetch:
+
+```go
+userPart := pr.TechPrefix + c.Destination.Target + pr.TechPostfix
+dialURI  := fmt.Sprintf("pjsip/%s/sip:%s@%s;transport=%s",
+    pjsipEndpointOutgoing, userPart, pr.Hostname, constTransportUDP)
+```
+
+Empty `TechPrefix`/`TechPostfix` are harmless no-ops (empty-string concat). This preserves backwards compatibility for providers that don't set these fields.
+
+## Error handling
+
+- Provider fetch error → return error from `getDialURITel`, same as today. Call fails.
+- Invalid tech_header entries (reserved key, CRLF, malformed key) → skip the offending entry only, log `Warn`, continue the call. Partial tech config is safer than a dropped call.
+- `tech_headers == nil` or empty → no-op, no log.
+
+## Observability
+
+- One `Info` log in `createChannelOutgoing` when any tech config is applied:
+  `"Applied provider tech config. provider_id=%s prefix_len=%d postfix_len=%d headers_applied=%d headers_skipped=%d"`
+- One `Warn` log per skipped header with reason (empty key / invalid char / reserved / CRLF value) and provider_id.
+- No metrics. The log line is sufficient for production debugging; adding a counter here would be overkill.
+
+Per monorepo convention (memory: external-integration logging), these are `Info`/`Warn`, not `Debug`, because tech config changes the on-wire INVITE and must be traceable in production without raising the log level.
+
+## Testing strategy
+
+All tests in `bin-call-manager/pkg/callhandler/`.
+
+New unit tests on the `mergeTechHeaders` helper (single file, table-driven):
+
+- empty src → dst unchanged
+- nil src → dst unchanged
+- normal header → added with `PJSIP_HEADER(add,...)` wrap
+- empty key → skipped + warn logged
+- key with `\r` / `\n` / `(` / `)` / `,` → skipped + warn logged
+- key whose wrapped form matches reserved set → skipped + warn logged
+- `CALLERID(name)` / `CALLERID(num)` / `CALLERID(pres)` → skipped + warn logged
+- value with `\r` / `\n` → skipped + warn logged
+- dst pre-populated with same wrapped key → dst value overwritten (merge semantics), with note that the system-set functions re-overwrite in `createChannelOutgoing` ordering
+
+New/updated table-driven tests for `getDialURITel`:
+
+- prefix only (`"0011"`, postfix `""`, headers nil)
+- postfix only (`""`, `"#"`, nil)
+- both (`"0011"`, `"#"`, nil)
+- headers only (`""`, `""`, `{"X-Carrier-Auth": "tok"}`)
+- all three
+- empty (all zero values — backwards compat; existing tests must still pass)
+- provider fetch error
+
+Existing `outgoing_call_test.go` test cases at lines ~152, 790, 1293, 1417 already set `PJSIP_HEADER(add,SDP-Transport)` channel variables. The plan must enumerate every test file and every call site of `getDialURITel` / `getDialURI` / `createChannelOutgoing` and update them to the new signature. No test is expected to fail behaviorally after the fix — they just need the new return values plumbed through.
+
+## Provider-call verification endpoint
+
+`bin-api-manager/docsdev/source/providercall_overview.rst` documents a post-config verification flow. During implementation, grep for `providercall` / `ProviderCall` and confirm its call path terminates in `getDialURITel`. Expected outcome: yes (it would be odd to have a separate dial path just for provider verification). If the path diverges, flag it as a separate follow-up, do **not** expand scope.
+
+## Out-of-scope follow-ups
+
+- Save-time validation of tech_header keys/values in `bin-route-manager` (today they are stored as-is; dial-time sanitization is sufficient for this PR but UX is better at save time).
+- Value templating (`{{source_target}}`, etc.) — not needed by any current carrier integration.
+- Applying tech_headers on SIP-direct path — no Provider involved there.
+
+## Affected files (preview)
+
+Code:
+
+- `bin-call-manager/pkg/callhandler/outgoing_call.go` — signature change + URI wrap + Info log.
+- `bin-call-manager/pkg/callhandler/tech_headers.go` (new) — `mergeTechHeaders` helper + reserved set.
+- `bin-call-manager/pkg/callhandler/outgoing_call_test.go` — update existing tests for new signature; add new cases.
+- `bin-call-manager/pkg/callhandler/tech_headers_test.go` (new) — table-driven tests for the helper.
+
+Verification:
+
+- Pre-commit: `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m` in `bin-call-manager`.
+- Manual grep for `providercall` to confirm the verification endpoint shares the fixed code path.
+
+Docs: none. RST already describes the behavior correctly; this PR makes code match the docs.
+OpenAPI: none. `WebhookMessage` already exposes `tech_prefix` / `tech_postfix` / `tech_headers`.
+Database: none.

--- a/docs/plans/2026-04-25-provider-tech-config-outbound-design.md
+++ b/docs/plans/2026-04-25-provider-tech-config-outbound-design.md
@@ -72,9 +72,10 @@ Reserved set (explicit denylist):
 var reservedTechHeaderKeys = map[string]struct{}{
     "PJSIP_HEADER(add,P-Asserted-Identity)":     {},
     "PJSIP_HEADER(add,Privacy)":                 {},
-    "PJSIP_HEADER(add,SDP-Transport)":           {},
-    "PJSIP_HEADER(add,X-VoIPBin-Call-ID)":       {},
-    "PJSIP_HEADER(add,X-VoIPBin-Confbridge-ID)": {},
+    "PJSIP_HEADER(add,VBOUT-SDP_Transport)":     {},
+    "PJSIP_HEADER(add,VB-CALL-ID)":              {},
+    "PJSIP_HEADER(add,VB-CONFBRIDGE-ID)":        {},
+    "PJSIP_HEADER(add,VB-DIRECTION)":            {},
     "CALLERID(name)": {},
     "CALLERID(num)":  {},
     "CALLERID(pres)": {},

--- a/docs/plans/2026-04-25-provider-tech-config-outbound-plan.md
+++ b/docs/plans/2026-04-25-provider-tech-config-outbound-plan.md
@@ -1,0 +1,1015 @@
+# Provider tech prefix/postfix/headers — apply on outbound dial
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `Provider.TechPrefix`, `Provider.TechPostfix`, and `Provider.TechHeaders` actually affect outbound tel-type calls in `bin-call-manager`. Today they are stored and API-editable but silently dropped in `getDialURITel`.
+
+**Architecture:** One focused patch in `bin-call-manager/pkg/callhandler/`. Add a `mergeTechHeaders` helper with a reserved-key denylist and CRLF/invalid-char sanitization. Change `getDialURITel` to return `(uri, techHeaders, error)`; update the dispatcher `getDialURI` and its two peers similarly. In `createChannelOutgoing`, seed `channelVariables` with the tech headers before the system-set transport/caller-ID functions run — that ordering gives system headers automatic collision-wins behavior for keys the system code path actually writes, and the denylist covers keys the system only writes conditionally.
+
+**Tech Stack:** Go 1.x, gomock (`go.uber.org/mock`), table-driven tests, logrus. Linked design doc: [2026-04-25-provider-tech-config-outbound-design.md](./2026-04-25-provider-tech-config-outbound-design.md).
+
+**Worktree:** `/home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound`
+**Branch:** `NOJIRA-apply-provider-tech-config-on-outbound`
+
+**Scope ground rules:**
+- All file paths below are relative to the worktree root.
+- Only `bin-call-manager` is touched — no OpenAPI, RST, DB schema, or cross-service changes. The `WebhookMessage` already exposes all three fields; RST already describes the behavior correctly.
+- Every task ends with a green test run before committing.
+- Full verification workflow runs only once at the very end (Task 7) per monorepo convention — but `go test ./...` runs after each code change within each task.
+
+---
+
+## Task 1: Add the `mergeTechHeaders` helper with tests
+
+Write the helper that enforces the reserved-key denylist and CRLF/char sanitization. TDD: test first.
+
+**Files:**
+- Create: `bin-call-manager/pkg/callhandler/tech_headers.go`
+- Create: `bin-call-manager/pkg/callhandler/tech_headers_test.go`
+
+### Step 1.1: Write the failing test file
+
+Create `bin-call-manager/pkg/callhandler/tech_headers_test.go` with the full table-driven test. The helper takes an existing channel-variables map (`dst`), a raw `tech_headers` map from the Provider (`src`), and a `*logrus.Entry` for warnings; it mutates `dst` in place and returns `(applied, skipped int)`.
+
+```go
+package callhandler
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func Test_mergeTechHeaders(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		dst map[string]string
+		src map[string]string
+
+		expectDst     map[string]string
+		expectApplied int
+		expectSkipped int
+	}{
+		{
+			"nil src leaves dst unchanged",
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			nil,
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			0,
+			0,
+		},
+		{
+			"empty src leaves dst unchanged",
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			map[string]string{},
+
+			map[string]string{"CALLERID(num)": "+820000000000"},
+			0,
+			0,
+		},
+		{
+			"normal header gets wrapped and applied",
+
+			map[string]string{},
+			map[string]string{"X-Carrier-Auth": "token-abc"},
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Carrier-Auth)": "token-abc",
+			},
+			1,
+			0,
+		},
+		{
+			"empty key is skipped",
+
+			map[string]string{},
+			map[string]string{"": "whatever"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"key with CRLF is skipped",
+
+			map[string]string{},
+			map[string]string{"X-Bad\r\nInject": "v"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"key with parenthesis is skipped (blocks PJSIP_HEADER pre-wrap)",
+
+			map[string]string{},
+			map[string]string{"PJSIP_HEADER(add,X)": "v"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"key with comma is skipped",
+
+			map[string]string{},
+			map[string]string{"X,Evil": "v"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved wrapped key P-Asserted-Identity is skipped",
+
+			map[string]string{},
+			map[string]string{"P-Asserted-Identity": "<tel:+100>"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved wrapped key Privacy is skipped",
+
+			map[string]string{},
+			map[string]string{"Privacy": "id"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved wrapped key SDP-Transport is skipped",
+
+			map[string]string{},
+			map[string]string{"VBOUT-SDP_Transport": "RTP/AVP"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"reserved raw key CALLERID(name) is skipped",
+
+			map[string]string{},
+			map[string]string{"CALLERID(name)": "foo"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"value with CR is skipped",
+
+			map[string]string{},
+			map[string]string{"X-Header": "ok\rbad"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"value with LF is skipped",
+
+			map[string]string{},
+			map[string]string{"X-Header": "ok\nbad"},
+
+			map[string]string{},
+			0,
+			1,
+		},
+		{
+			"mixed valid and invalid — valid applied, invalid counted skipped",
+
+			map[string]string{},
+			map[string]string{
+				"X-Good":              "ok",
+				"":                    "drop-empty-key",
+				"X-Bad\r\nInject":     "drop-bad-key",
+				"P-Asserted-Identity": "drop-reserved",
+			},
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Good)": "ok",
+			},
+			1,
+			3,
+		},
+		{
+			"pre-existing dst key is overwritten by tech header (merge semantics; system fns re-overwrite later in createChannelOutgoing)",
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Carrier-Auth)": "old",
+			},
+			map[string]string{
+				"X-Carrier-Auth": "new",
+			},
+
+			map[string]string{
+				"PJSIP_HEADER(add,X-Carrier-Auth)": "new",
+			},
+			1,
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := logrus.WithField("test", tt.name)
+
+			applied, skipped := mergeTechHeaders(tt.dst, tt.src, log)
+
+			if applied != tt.expectApplied {
+				t.Errorf("Wrong applied count. expect: %d, got: %d", tt.expectApplied, applied)
+			}
+			if skipped != tt.expectSkipped {
+				t.Errorf("Wrong skipped count. expect: %d, got: %d", tt.expectSkipped, skipped)
+			}
+
+			if len(tt.dst) != len(tt.expectDst) {
+				t.Errorf("Wrong dst size. expect: %d, got: %d. dst=%v", len(tt.expectDst), len(tt.dst), tt.dst)
+			}
+			for k, v := range tt.expectDst {
+				if got, ok := tt.dst[k]; !ok || got != v {
+					t.Errorf("Wrong dst entry. key=%s expect=%q got=%q (present=%v)", k, v, got, ok)
+				}
+			}
+		})
+	}
+}
+```
+
+### Step 1.2: Run the test — expect a compile failure
+
+Run: `cd bin-call-manager && go test -v ./pkg/callhandler/ -run Test_mergeTechHeaders`
+Expected: compile error — `undefined: mergeTechHeaders`. If anything else fails, stop and read carefully before proceeding.
+
+### Step 1.3: Implement the helper
+
+Create `bin-call-manager/pkg/callhandler/tech_headers.go`:
+
+```go
+package callhandler
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// reservedTechHeaderKeys lists channel-variable keys that operator-supplied
+// tech_headers are forbidden from setting. The set covers:
+//   - headers the system writes conditionally (P-Asserted-Identity / Privacy
+//     are only set for anonymous calls, so ordering alone cannot protect them),
+//   - headers the system writes unconditionally (SDP-Transport, CALLERID(*)),
+//   - internal trace headers (VB-CALL-ID / VB-CONFBRIDGE-ID) whose values must
+//     match call-manager's own UUIDs for downstream correlation.
+//
+// Keys are checked both in their raw form (for CALLERID/PJSIP_HEADER entries)
+// and after PJSIP_HEADER(add,...) wrapping (for SIP header names).
+var reservedTechHeaderKeys = map[string]struct{}{
+	"PJSIP_HEADER(add,P-Asserted-Identity)":     {},
+	"PJSIP_HEADER(add,Privacy)":                 {},
+	"PJSIP_HEADER(add,VBOUT-SDP_Transport)":     {},
+	"PJSIP_HEADER(add,VB-CALL-ID)":              {},
+	"PJSIP_HEADER(add,VB-CONFBRIDGE-ID)":        {},
+	"PJSIP_HEADER(add,VB-DIRECTION)":            {},
+	"CALLERID(name)":                            {},
+	"CALLERID(num)":                             {},
+	"CALLERID(pres)":                            {},
+}
+
+// mergeTechHeaders copies sanitized entries from src (raw operator-supplied
+// tech_headers) into dst (Asterisk channel variables), wrapping each key
+// with PJSIP_HEADER(add,...) so Asterisk attaches the header to the outgoing
+// INVITE.
+//
+// Entries are skipped and logged as Warn when:
+//   - key is empty
+//   - key contains \r, \n, (, ), or ,
+//   - wrapped key matches reservedTechHeaderKeys
+//   - raw key itself matches reservedTechHeaderKeys (covers CALLERID(*) attempts)
+//   - value contains \r or \n (CRLF injection defense)
+//
+// Skipped entries never fail the call — the rest of the tech config and the
+// call itself proceed.
+//
+// Returns counts of applied and skipped entries for a single summary log at
+// the call site.
+func mergeTechHeaders(dst map[string]string, src map[string]string, log *logrus.Entry) (applied int, skipped int) {
+	for k, v := range src {
+		if k == "" {
+			log.Warnf("Skipping tech_header with empty key.")
+			skipped++
+			continue
+		}
+		if strings.ContainsAny(k, "\r\n(),") {
+			log.Warnf("Skipping tech_header with invalid key char. key=%q", k)
+			skipped++
+			continue
+		}
+		if _, reserved := reservedTechHeaderKeys[k]; reserved {
+			log.Warnf("Skipping tech_header that collides with system-reserved key. key=%q", k)
+			skipped++
+			continue
+		}
+		if strings.ContainsAny(v, "\r\n") {
+			log.Warnf("Skipping tech_header with CRLF in value. key=%q", k)
+			skipped++
+			continue
+		}
+
+		varKey := "PJSIP_HEADER(add," + k + ")"
+		if _, reserved := reservedTechHeaderKeys[varKey]; reserved {
+			log.Warnf("Skipping tech_header that collides with system-reserved header. key=%q", k)
+			skipped++
+			continue
+		}
+
+		dst[varKey] = v
+		applied++
+	}
+	return applied, skipped
+}
+```
+
+### Step 1.4: Run the test — expect PASS
+
+Run: `cd bin-call-manager && go test -v ./pkg/callhandler/ -run Test_mergeTechHeaders`
+Expected: all 14 subtests pass. If any fail, the helper logic disagrees with the test table — fix the helper, not the tests (unless the test itself is demonstrably wrong).
+
+### Step 1.5: Commit
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound
+git add bin-call-manager/pkg/callhandler/tech_headers.go bin-call-manager/pkg/callhandler/tech_headers_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-apply-provider-tech-config-on-outbound
+
+Add mergeTechHeaders helper with reserved-key denylist and CRLF/
+invalid-char sanitization. Helper will be wired into createChannelOutgoing
+in a follow-up task once getDialURITel returns tech_headers.
+
+- bin-call-manager: Add pkg/callhandler/tech_headers.go with mergeTechHeaders
+  helper and reservedTechHeaderKeys set
+- bin-call-manager: Add pkg/callhandler/tech_headers_test.go covering empty/
+  nil src, normal pass-through, empty/invalid-char/reserved key skips, CRLF
+  value skip, CALLERID reserved raw-key skip, mixed valid/invalid, and merge-
+  overwrite semantics
+EOF
+)"
+```
+
+---
+
+## Task 2: Update `getDialURITel` to apply prefix/postfix and return tech headers
+
+Change the signature to `(string, map[string]string, error)`, wrap the user part with prefix/postfix, and return the raw `tech_headers` for the caller to merge. Test first.
+
+**Files:**
+- Modify: `bin-call-manager/pkg/callhandler/outgoing_call.go:316-346` (function `getDialURITel` only — do NOT touch other functions yet)
+- Modify: `bin-call-manager/pkg/callhandler/outgoing_call_test.go:1028-1100` (test `Test_getDialURI_Tel`)
+
+### Step 2.1: Extend `Test_getDialURI_Tel` to cover prefix/postfix/headers and new return shape
+
+Open `bin-call-manager/pkg/callhandler/outgoing_call_test.go` and **replace** `Test_getDialURI_Tel` (lines 1028–1100) with:
+
+```go
+func Test_getDialURI_Tel(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		call *call.Call
+
+		responseProvider *rmprovider.Provider
+
+		expectProviderID uuid.UUID
+		expectRes        string
+		expectTechHdrs   map[string]string
+	}{
+		{
+			"no tech config (backwards compat)",
+
+			&call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("04e5d530-5d96-11ed-bbc8-cfb95f6d6085"),
+					CustomerID: uuid.FromStringOrNil("f7a14b8c-534c-11ed-9fb1-c7c376f2730b"),
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+821121656521",
+				},
+				DialrouteID: uuid.FromStringOrNil("ae237dd0-5db1-11ed-97c4-a7ff6f170fbb"),
+				Dialroutes: []rmroute.Route{
+					{
+						ID:         uuid.FromStringOrNil("ae237dd0-5db1-11ed-97c4-a7ff6f170fbb"),
+						ProviderID: uuid.FromStringOrNil("8730a3da-5350-11ed-aa47-7f44741127c1"),
+					},
+				},
+			},
+
+			&rmprovider.Provider{
+				ID:       uuid.FromStringOrNil("ae237dd0-5db1-11ed-97c4-a7ff6f170fbb"),
+				Hostname: "sip.telnyx.com",
+			},
+
+			uuid.FromStringOrNil("8730a3da-5350-11ed-aa47-7f44741127c1"),
+			"pjsip/call-out/sip:+821121656521@sip.telnyx.com;transport=udp",
+			nil,
+		},
+		{
+			"prefix only",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000001-0000-0000-0000-000000000001"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000001-0000-0000-0000-000000000001"),
+						ProviderID: uuid.FromStringOrNil("b0000001-0000-0000-0000-000000000001")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:   "carrier.example.com",
+				TechPrefix: "0011",
+			},
+
+			uuid.FromStringOrNil("b0000001-0000-0000-0000-000000000001"),
+			"pjsip/call-out/sip:001115551234@carrier.example.com;transport=udp",
+			nil,
+		},
+		{
+			"postfix only",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000002-0000-0000-0000-000000000002"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000002-0000-0000-0000-000000000002"),
+						ProviderID: uuid.FromStringOrNil("b0000002-0000-0000-0000-000000000002")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:    "carrier.example.com",
+				TechPostfix: "#",
+			},
+
+			uuid.FromStringOrNil("b0000002-0000-0000-0000-000000000002"),
+			"pjsip/call-out/sip:+15551234#@carrier.example.com;transport=udp",
+			nil,
+		},
+		{
+			"prefix and postfix both",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000003-0000-0000-0000-000000000003"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000003-0000-0000-0000-000000000003"),
+						ProviderID: uuid.FromStringOrNil("b0000003-0000-0000-0000-000000000003")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:    "carrier.example.com",
+				TechPrefix:  "0011",
+				TechPostfix: "#",
+			},
+
+			uuid.FromStringOrNil("b0000003-0000-0000-0000-000000000003"),
+			"pjsip/call-out/sip:0011+15551234#@carrier.example.com;transport=udp",
+			nil,
+		},
+		{
+			"headers only — returned raw (unsanitized), caller sanitizes via mergeTechHeaders",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000004-0000-0000-0000-000000000004"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000004-0000-0000-0000-000000000004"),
+						ProviderID: uuid.FromStringOrNil("b0000004-0000-0000-0000-000000000004")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname: "carrier.example.com",
+				TechHeaders: map[string]string{
+					"X-Carrier-Auth": "tok-abc",
+				},
+			},
+
+			uuid.FromStringOrNil("b0000004-0000-0000-0000-000000000004"),
+			"pjsip/call-out/sip:+15551234@carrier.example.com;transport=udp",
+			map[string]string{"X-Carrier-Auth": "tok-abc"},
+		},
+		{
+			"all three together",
+
+			&call.Call{
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "15551234"},
+				DialrouteID: uuid.FromStringOrNil("a0000005-0000-0000-0000-000000000005"),
+				Dialroutes: []rmroute.Route{
+					{ID: uuid.FromStringOrNil("a0000005-0000-0000-0000-000000000005"),
+						ProviderID: uuid.FromStringOrNil("b0000005-0000-0000-0000-000000000005")},
+				},
+			},
+
+			&rmprovider.Provider{
+				Hostname:    "carrier.example.com",
+				TechPrefix:  "0011",
+				TechPostfix: "#",
+				TechHeaders: map[string]string{"X-Route-Hint": "premium"},
+			},
+
+			uuid.FromStringOrNil("b0000005-0000-0000-0000-000000000005"),
+			"pjsip/call-out/sip:001115551234#@carrier.example.com;transport=udp",
+			map[string]string{"X-Route-Hint": "premium"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &callHandler{
+				reqHandler: mockReq,
+				db:         mockDB,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().RouteV1ProviderGet(ctx, tt.expectProviderID).Return(tt.responseProvider, nil)
+
+			res, techHdrs, err := h.getDialURI(ctx, tt.call)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %s, got: %s", tt.expectRes, res)
+			}
+
+			if len(techHdrs) != len(tt.expectTechHdrs) {
+				t.Errorf("Wrong techHdrs size. expect: %d, got: %d. techHdrs=%v", len(tt.expectTechHdrs), len(techHdrs), techHdrs)
+			}
+			for k, v := range tt.expectTechHdrs {
+				if got, ok := techHdrs[k]; !ok || got != v {
+					t.Errorf("Wrong techHdrs entry. key=%s expect=%q got=%q (present=%v)", k, v, got, ok)
+				}
+			}
+		})
+	}
+}
+```
+
+Note: this test calls `h.getDialURI` (the dispatcher), not `getDialURITel` directly — matching the existing test style. The dispatcher's signature must therefore change at the same time as `getDialURITel`. Step 2.3 updates both atomically.
+
+### Step 2.2: Run the test — expect compile failure
+
+Run: `cd bin-call-manager && go test -v ./pkg/callhandler/ -run Test_getDialURI_Tel`
+Expected: compile error — `h.getDialURI(...)` returns 2 values but test assigns 3. If the error is different, re-read step 2.1 for a typo before proceeding.
+
+### Step 2.3: Rewrite `getDialURITel` and the dispatcher to new signatures
+
+In `bin-call-manager/pkg/callhandler/outgoing_call.go`, **replace the entire block from line 316 through line 408** with the following. This updates `getDialURITel`, `getDialURISIP`, `getDialURISIPDirect`, and `getDialURI` together so the file stays compilable.
+
+```go
+// getDialURITel returns dial uri and provider-supplied tech_headers for the
+// given tel type destination. Prefix/postfix from the Provider wrap the
+// user part of the URI; tech_headers are returned raw for the caller to
+// merge via mergeTechHeaders (so sanitization and reserved-key enforcement
+// happen next to the channel-variable assembly).
+func (h *callHandler) getDialURITel(ctx context.Context, c *call.Call) (string, map[string]string, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "getDialURITel",
+		"call_id": c.ID,
+	})
+
+	providerID := uuid.Nil
+	for _, dialroute := range c.Dialroutes {
+		if dialroute.ID == c.DialrouteID {
+			providerID = dialroute.ProviderID
+			break
+		}
+	}
+
+	if providerID == uuid.Nil {
+		log.Debugf("No available dialroute left.")
+		return "", nil, fmt.Errorf("no available dialroute left")
+	}
+
+	// get provider info
+	pr, err := h.reqHandler.RouteV1ProviderGet(ctx, providerID)
+	if err != nil {
+		log.Errorf("Could not get provider info. err: %v", err)
+		return "", nil, err
+	}
+
+	userPart := pr.TechPrefix + c.Destination.Target + pr.TechPostfix
+	res := fmt.Sprintf("pjsip/%s/sip:%s@%s;transport=%s", pjsipEndpointOutgoing, userPart, pr.Hostname, constTransportUDP)
+
+	return res, pr.TechHeaders, nil
+}
+
+// getDialURISIP returns dial uri of the given sip type destination.
+func (h *callHandler) getDialURISIP(ctx context.Context, c *call.Call) (string, map[string]string, error) {
+	endpoint := c.Destination.Target
+	if !strings.HasPrefix(c.Destination.Target, "sip:") && !strings.HasPrefix(c.Destination.Target, "sips:") {
+		endpoint = "sip:" + endpoint
+	}
+
+	res := fmt.Sprintf("pjsip/%s/%s", pjsipEndpointOutgoing, endpoint)
+	return res, nil, nil
+}
+
+// getDialURISIPDirect returns dial uri of the given sip type destination via the direct endpoint.
+func (h *callHandler) getDialURISIPDirect(ctx context.Context, c *call.Call) (string, map[string]string, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":               "getDialURISIPDirect",
+		"destination_target": c.Destination.Target,
+	})
+
+	endpointTarget := c.Destination.Target
+	if !strings.HasPrefix(c.Destination.Target, "sip:") && !strings.HasPrefix(c.Destination.Target, "sips:") {
+		endpointTarget = "sip:" + endpointTarget
+	}
+```
+
+**CRITICAL:** The block above ends mid-function at `endpointTarget := ...`. The remaining body of `getDialURISIPDirect` (from the current line 370 onward through line 388) must be preserved verbatim; only the function signature changes. Do the same for `getDialURI` (current lines 389–408) — change the signature and the three `return` statements inside to return the third value.
+
+After editing, the dispatcher block should read:
+
+```go
+// getDialURI returns the given destination address's dial URI and optional
+// provider tech_headers for Asterisk's dialing. tech_headers is nil for
+// non-provider paths.
+func (h *callHandler) getDialURI(ctx context.Context, c *call.Call) (string, map[string]string, error) {
+
+	switch c.Destination.Type {
+	case commonaddress.TypeTel:
+		return h.getDialURITel(ctx, c)
+
+	case commonaddress.TypeSIP:
+		if strings.Contains(c.Destination.Target, "transport=ws") {
+			return h.getDialURISIPDirect(ctx, c)
+		}
+		return h.getDialURISIP(ctx, c)
+
+	default:
+		return "", nil, fmt.Errorf("unsupported address type for get dial uri")
+	}
+}
+```
+
+Do NOT touch `createChannelOutgoing` yet — it still calls the old 2-return `getDialURI`, and will be fixed in Task 3. The build WILL break at that call site; that is expected and Task 3 fixes it.
+
+### Step 2.4: Confirm `getDialURITel` test passes (ignore other compile errors)
+
+Run: `cd bin-call-manager && go test -v ./pkg/callhandler/ -run Test_getDialURI_Tel`
+
+Expected outcome is one of:
+1. All 6 subtests pass (if the rest of the package still compiles).
+2. The package fails to compile at `createChannelOutgoing` or `Test_getDialURI_SIP` / `Test_getDialURI_error` / `Test_getDialURISIP` / `Test_getDialURISIPDirect` / `Test_createChannel` because they still assume the 2-return signature.
+
+If outcome (2), that is fine — proceed to Task 3 immediately; those call sites are fixed there. Do NOT commit Task 2 in isolation; bundle the commit with Task 3 so the tree is always buildable at each committed revision.
+
+---
+
+## Task 3: Update `createChannelOutgoing` and remaining tests for the 3-return signature
+
+Wire tech headers into `createChannelOutgoing` via `mergeTechHeaders`, then update the other existing tests (`Test_getDialURI_SIP`, `Test_getDialURI_error`, `Test_getDialURISIP`, `Test_getDialURISIPDirect`, `Test_createChannel`) to the new signatures.
+
+**Files:**
+- Modify: `bin-call-manager/pkg/callhandler/outgoing_call.go:546-589` (`createChannelOutgoing`)
+- Modify: `bin-call-manager/pkg/callhandler/outgoing_call_test.go` at lines 1102–1171 (`Test_getDialURI_SIP`), 1173–1239 (`Test_getDialURI_error`), 2652–2710 (`Test_getDialURISIP`), 2710–2765 (`Test_getDialURISIPDirect`), 1241–1325 (`Test_createChannel`)
+
+### Step 3.1: Update `createChannelOutgoing` to merge tech headers
+
+In `bin-call-manager/pkg/callhandler/outgoing_call.go`, **replace** the body of `createChannelOutgoing` (lines ~553–589, starting at `dialURI, err := h.getDialURI(...)`) with:
+
+```go
+	// get dial uri and provider-supplied tech headers
+	dialURI, techHeaders, err := h.getDialURI(ctx, c)
+	if err != nil {
+		log.Errorf("Could not create a destination endpoint. err: %v", err)
+		return err
+	}
+
+	// set channel variables — tech_headers first so system-set headers
+	// (transport, CALLERID, PAI when anonymous) overwrite on collision.
+	// mergeTechHeaders additionally enforces the reserved-key denylist.
+	channelVariables := map[string]string{}
+	techApplied, techSkipped := mergeTechHeaders(channelVariables, techHeaders, log)
+
+	transport := getDestinationTransport(dialURI)
+	setChannelVariableTransport(channelVariables, transport)
+	anonymous := c.Data[call.DataTypeAnonymous] == "true"
+	if err := setChannelVariablesCallerID(channelVariables, c, anonymous); err != nil {
+		log.Errorf("Could not set caller ID variables. err: %v", err)
+		return err
+	}
+
+	if techApplied > 0 || techSkipped > 0 {
+		log.Infof("Applied provider tech config. headers_applied=%d headers_skipped=%d",
+			techApplied, techSkipped)
+	}
+
+	log.Debugf("Endpoint detail. endpoint_destination: %s, variables: %v, anonymous: %v", dialURI, channelVariables, anonymous)
+
+	// set app args
+	appArgs := fmt.Sprintf("%s=%s,%s=%s,%s=%s,%s=%s,%s=%s",
+		channel.StasisDataTypeContextType, channel.ContextTypeCall,
+		channel.StasisDataTypeContext, channel.ContextCallOutgoing,
+		channel.StasisDataTypeCallID, c.ID,
+		channel.StasisDataTypeTransport, transport,
+		channel.StasisDataTypeDirection, channel.DirectionOutgoing,
+	)
+
+	// create a channel
+	tmp, err := h.channelHandler.StartChannel(ctx, requesthandler.AsteriskIDCall, c.ChannelID, appArgs, dialURI, "", "", "", channelVariables)
+	if err != nil {
+		log.Errorf("Could not create a channel for outgoing call. err: %v", err)
+		return err
+	}
+	log.WithField("channel", tmp).Debugf("Created a new channel. channel_id: %s", tmp.ID)
+
+	return nil
+}
+```
+
+Tech headers are seeded into `channelVariables` **before** `setChannelVariableTransport` and `setChannelVariablesCallerID` run. For keys those functions write, the later write wins — that is the "system wins" guarantee for unconditionally-written keys. For keys they only write conditionally (PAI/Privacy on anonymous calls, which aren't in the non-anonymous write path), `mergeTechHeaders`'s reserved-key check still blocks the collision. Both layers together satisfy the Q3 "system wins" contract.
+
+### Step 3.2: Update remaining tests to the 3-return signature
+
+Do each of the following edits in `bin-call-manager/pkg/callhandler/outgoing_call_test.go`. These are mechanical — only the return destructuring changes, not the test logic.
+
+1. `Test_getDialURI_SIP` (around line 1161): change `res, err := h.getDialURI(ctx, tt.c)` to `res, _, err := h.getDialURI(ctx, tt.c)`.
+2. `Test_getDialURI_error` (around line 1233): change `_, err := h.getDialURI(ctx, tt.call)` to `_, _, err := h.getDialURI(ctx, tt.call)`.
+3. `Test_getDialURISIP` (around line 2697): change `res, err := h.getDialURISIP(ctx, tt.call)` to `res, _, err := h.getDialURISIP(ctx, tt.call)`.
+4. `Test_getDialURISIPDirect` (around line 2755): change `res, err := h.getDialURISIPDirect(ctx, tt.call)` to `res, _, err := h.getDialURISIPDirect(ctx, tt.call)`.
+5. `Test_createChannel` at lines 1241–1325: no signature changes needed (this test calls `createChannelOutgoing`, not `getDialURI*`), but the test's existing case has empty `TechPrefix`/`TechPostfix`/`TechHeaders` on the mock provider, so the asserted `expectDialURI` and `expectVariables` must still match. Since `pr.TechPrefix + c.Destination.Target + pr.TechPostfix` with empty prefix/postfix equals the target, and nil `TechHeaders` yields zero applied/skipped (no log, no new channel variables), the existing expected values at lines 1289–1294 are already correct. Verify by re-running the test — no edit needed.
+
+### Step 3.3: Run the full callhandler test suite — expect PASS
+
+Run: `cd bin-call-manager && go test -v ./pkg/callhandler/`
+
+Expected: every test in `pkg/callhandler/` passes, including the new `Test_mergeTechHeaders` and the updated `Test_getDialURI_Tel`. If `Test_createChannel` fails, re-check Step 3.1 — the `channelVariables` map must still equal the existing expected map (empty tech config → zero tech headers applied → no extra entries).
+
+### Step 3.4: Add one new `Test_createChannel` case that exercises tech config
+
+At the end of the `tests := []struct{...}{...}` slice in `Test_createChannel` (inside the `}` at line ~1295, before the closing `}` of the slice), append the following case. This is the end-to-end integration test for the whole feature.
+
+```go
+		{
+			name: "provider tech config applied — prefix, postfix, header",
+
+			call: &call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000002"),
+				},
+
+				ChannelID: "c1c1c1c1-0000-0000-0000-000000000003",
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "+821100000002",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "15551234",
+				},
+				DialrouteID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000004"),
+				Dialroutes: []rmroute.Route{
+					{
+						ID:         uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000004"),
+						ProviderID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000005"),
+					},
+				},
+			},
+
+			responseProvider: &rmprovider.Provider{
+				ID:          uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000005"),
+				Hostname:    "carrier.example.com",
+				TechPrefix:  "0011",
+				TechPostfix: "#",
+				TechHeaders: map[string]string{"X-Route-Hint": "premium"},
+			},
+
+			expectProviderID: uuid.FromStringOrNil("c1c1c1c1-0000-0000-0000-000000000005"),
+			expectArgs:       "context_type=call,context=call-out,call_id=c1c1c1c1-0000-0000-0000-000000000001,transport=udp,direction=outgoing",
+			expectDialURI:    "pjsip/call-out/sip:001115551234#@carrier.example.com;transport=udp",
+			expectVariables: map[string]string{
+				"PJSIP_HEADER(add,X-Route-Hint)":                         "premium",
+				"CALLERID(name)":                                         "",
+				"CALLERID(num)":                                          "+821100000002",
+				"PJSIP_HEADER(add," + common.SIPHeaderSDPTransport + ")": "RTP/AVP",
+			},
+		},
+```
+
+Run: `cd bin-call-manager && go test -v ./pkg/callhandler/ -run Test_createChannel`
+Expected: both subtests (`normal` and `provider tech config applied — prefix, postfix, header`) pass.
+
+### Step 3.5: Commit
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound
+git add bin-call-manager/pkg/callhandler/outgoing_call.go bin-call-manager/pkg/callhandler/outgoing_call_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-apply-provider-tech-config-on-outbound
+
+Apply provider tech_prefix, tech_postfix, and tech_headers on outbound
+tel-type calls. Provider fields that were previously stored, editable via
+API, and documented in RST were silently dropped in getDialURITel; this
+change wraps the SIP URI user part with tech_prefix/tech_postfix and
+attaches tech_headers as PJSIP_HEADER(add,...) channel variables, with the
+reserved-key denylist from mergeTechHeaders protecting correctness/
+security-critical system headers from operator override.
+
+- bin-call-manager: Change getDialURITel, getDialURI, getDialURISIP, and
+  getDialURISIPDirect return signatures to (string, map[string]string,
+  error); tech_headers is nil for non-provider paths
+- bin-call-manager: Embed TechPrefix/TechPostfix in the SIP URI user part in
+  getDialURITel
+- bin-call-manager: Seed tech_headers into channelVariables via
+  mergeTechHeaders in createChannelOutgoing before system-set transport and
+  caller-ID variables, so system keys win on collision
+- bin-call-manager: Add Info log summarizing applied/skipped tech config
+- bin-call-manager: Extend Test_getDialURI_Tel with prefix-only, postfix-
+  only, both, headers-only, and all-three cases
+- bin-call-manager: Add tech-config subtest to Test_createChannel covering
+  end-to-end dial URI and channel variable assembly
+- bin-call-manager: Update Test_getDialURI_SIP, Test_getDialURI_error,
+  Test_getDialURISIP, Test_getDialURISIPDirect for the 3-return signature
+EOF
+)"
+```
+
+---
+
+## Task 4: Verify the provider-call test endpoint inherits the fix
+
+Finding 5 in the design doc requires a grep-level check that the provider-call verification endpoint reaches `getDialURITel`. No code change is expected.
+
+### Step 4.1: Trace the provider-call path
+
+Run:
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound
+grep -rn "ProviderCallCreate\|RouteV1ProviderCallCreate" bin-route-manager/pkg/ bin-call-manager/pkg/ | head -20
+```
+
+Confirm: `bin-route-manager`'s providercall handler ultimately creates a Call via `bin-call-manager`'s `CreateCallsOutgoing` (which calls `createChannelOutgoing` → `getDialURI` → `getDialURITel`). If the chain terminates at `getDialURITel`, the fix is inherited for free; note in the PR description.
+
+If the trace reveals a separate dial URI builder used only for provider-call verification: STOP and surface the finding to the user before continuing. Do not expand scope without approval.
+
+### Step 4.2: No commit
+
+Nothing to commit in this task — it's a verification-only step whose output is reflected in the PR description body.
+
+---
+
+## Task 5: Full monorepo verification on bin-call-manager
+
+Run the mandatory verification workflow before pushing. Root `CLAUDE.md` §"CRITICAL: Before Committing Changes" is explicit: all five steps, no skipping.
+
+### Step 5.1: Run the full verification workflow
+
+Run from the worktree:
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound/bin-call-manager && \
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: every step exits 0. If `go mod tidy` changed `go.mod` or `go.sum`, stage those changes. `go mod vendor` must succeed but the `vendor/` directory is gitignored — do NOT `git add -f` it.
+
+### Step 5.2: Commit any `go.mod` / `go.sum` updates (only if changed)
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound
+git status --porcelain bin-call-manager/go.mod bin-call-manager/go.sum
+# If the previous command prints changes:
+git add bin-call-manager/go.mod bin-call-manager/go.sum
+git commit -m "$(cat <<'EOF'
+NOJIRA-apply-provider-tech-config-on-outbound
+
+- bin-call-manager: Run go mod tidy after callhandler changes
+EOF
+)"
+```
+
+If `go.mod` and `go.sum` are unchanged (no new imports — this is the expected case since the helper only adds `strings` and `logrus` which are already imported in the package), skip the commit. `strings` and `github.com/sirupsen/logrus` are both already present in `outgoing_call.go`, so no new transitive dep should appear.
+
+### Step 5.3: Run lint one more time to catch anything `go generate` rewrote
+
+Run: `cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound/bin-call-manager && golangci-lint run -v --timeout 5m`
+Expected: exit 0 with no issues. If generated mocks changed (`pkg/*/mock_*.go`), they should be committed — but `go generate` on `pkg/callhandler/` should not regenerate anything related to the changed helpers since they are neither interface methods nor `//go:generate` targets.
+
+---
+
+## Task 6: Check for conflicts against latest `main`
+
+Monorepo `CLAUDE.md` §"CRITICAL: Pull Main and Check Conflicts Before PR/Merge" is mandatory.
+
+### Step 6.1: Fetch and diff
+
+Run (from the worktree):
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound
+git fetch origin main
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)" || echo "NO CONFLICTS"
+git log --oneline HEAD..origin/main | head -20
+```
+
+Expected: `NO CONFLICTS`. If any conflict lines print, STOP: rebase or merge `main` into the branch, resolve conflicts manually, then re-run Task 5 (verification) before continuing.
+
+### Step 6.2: No commit
+
+Nothing to commit — either the branch is clean against main (proceed) or a conflict is surfaced for manual resolution.
+
+---
+
+## Task 7: Push and open PR
+
+### Step 7.1: Push the branch
+
+Run:
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-apply-provider-tech-config-on-outbound
+git push -u origin NOJIRA-apply-provider-tech-config-on-outbound
+```
+
+### Step 7.2: Create the PR
+
+Use the project's PR title/body format from root `CLAUDE.md` — narrative summary first, then dashed project-prefixed bullets. **Do NOT** include AI attribution or a "Test plan" section.
+
+```bash
+gh pr create --title "NOJIRA-apply-provider-tech-config-on-outbound" --body "$(cat <<'EOF'
+Make Provider.TechPrefix, Provider.TechPostfix, and Provider.TechHeaders
+actually affect outbound tel-type calls. These fields have been stored,
+editable via the Providers API, and documented in the RST overview/struct
+pages for a long time, but bin-call-manager's getDialURITel only used the
+hostname — so operators who configured them got no effect and the docs
+contradicted the code.
+
+- bin-call-manager: Wrap the SIP URI user part with TechPrefix and
+  TechPostfix in getDialURITel
+- bin-call-manager: Attach TechHeaders as PJSIP_HEADER(add,...) channel
+  variables on the outgoing INVITE
+- bin-call-manager: Add mergeTechHeaders helper with a reserved-key
+  denylist (P-Asserted-Identity, Privacy, SDP-Transport, VB-CALL-ID,
+  VB-CONFBRIDGE-ID, VB-DIRECTION, CALLERID(*)) and CRLF / invalid-char
+  sanitization on keys and values
+- bin-call-manager: Seed tech headers into channelVariables before the
+  system-set transport and caller-ID functions run, so system-set keys
+  win on collision for unconditionally-written headers; the denylist
+  covers conditionally-written headers (PAI/Privacy on anonymous calls)
+- bin-call-manager: Change getDialURITel, getDialURI, getDialURISIP,
+  getDialURISIPDirect to return (string, map[string]string, error); the
+  header map is nil for non-provider paths
+- bin-call-manager: Add Info log summarizing applied/skipped tech config
+  and Warn logs per skipped header entry with a reason
+- bin-call-manager: Add Test_mergeTechHeaders covering nil/empty src,
+  normal pass-through, empty/invalid-char/reserved key skips, CRLF value
+  skip, CALLERID reserved raw-key skip, mixed valid/invalid, and merge
+  overwrite semantics
+- bin-call-manager: Extend Test_getDialURI_Tel with prefix-only, postfix-
+  only, both, headers-only, and all-three cases
+- bin-call-manager: Add end-to-end tech-config subtest to Test_createChannel
+- bin-call-manager: Update Test_getDialURI_SIP, Test_getDialURI_error,
+  Test_getDialURISIP, Test_getDialURISIPDirect for the 3-return signature
+EOF
+)"
+```
+
+### Step 7.3: Done
+
+Return the PR URL to the user. Do NOT merge without explicit user authorization, and when authorized, use `gh pr merge <num> --squash --delete-branch`.
+
+---
+
+## Summary of commits expected on this branch
+
+1. `43fefd9af` — design doc (already committed before this plan was written).
+2. Task 1 — add `mergeTechHeaders` helper and tests.
+3. Task 3 — apply tech config in `getDialURITel` / `createChannelOutgoing` + update existing tests (bundles with Task 2 since the tree must stay buildable).
+4. Task 5 — (only if `go mod tidy` changed `go.mod` / `go.sum`, which is not expected).
+
+Task 2, 4, 6, 7 have no independent commits. This yields a clean 2–3 commit branch (plus the design-doc commit), all squashed into one `main` commit on merge per project policy.


### PR DESCRIPTION
Make Provider.TechPrefix, Provider.TechPostfix, and Provider.TechHeaders actually affect outbound tel-type calls. These fields have been stored, editable via the Providers API, and documented in the RST overview/struct pages for a long time, but bin-call-manager's getDialURITel only used the hostname — so operators who configured them got no effect and the docs contradicted the code.

- bin-call-manager: Wrap the SIP URI user part with TechPrefix and TechPostfix in getDialURITel
- bin-call-manager: Attach TechHeaders as PJSIP_HEADER(add,...) channel variables on the outgoing INVITE
- bin-call-manager: Add mergeTechHeaders helper with a reserved-key denylist (P-Asserted-Identity, Privacy, VBOUT-SDP_Transport, VB-CALL-ID, VB-CONFBRIDGE-ID, VB-DIRECTION, CALLERID(*)) and CRLF / invalid-char sanitization on keys and values
- bin-call-manager: Seed tech headers into channelVariables before the system-set transport and caller-ID functions run, so system-set keys win on collision for unconditionally-written headers; the denylist covers conditionally-written headers (PAI/Privacy on anonymous calls)
- bin-call-manager: Change getDialURITel, getDialURI, getDialURISIP, getDialURISIPDirect to return (string, map[string]string, error); the header map is nil for non-provider paths
- bin-call-manager: Add Info log summarizing applied/skipped tech config in createChannelOutgoing, with per-skip Debug logs from mergeTechHeaders for troubleshooting without production log spam
- bin-call-manager: Add Test_mergeTechHeaders (15 cases) covering nil/empty src, normal pass-through, empty/invalid-char/reserved key skips, CRLF value skip, CALLERID reserved raw-key skip, mixed valid/invalid, and merge overwrite semantics
- bin-call-manager: Extend Test_getDialURI_Tel (7 cases) with prefix-only, postfix-only, both, headers-only, all-three, and provider-fetch error
- bin-call-manager: Add end-to-end tech-config subtest to Test_createChannel
- bin-call-manager: Update Test_getDialURI_SIP, Test_getDialURI_error, Test_getDialURISIP, Test_getDialURISIPDirect for the 3-return signature
- bin-call-manager: Fix stale doc comment on getDialURISIPDirect that read "getDialURISIP returns ..."
- docs: Add 2026-04-25-provider-tech-config-outbound-design.md capturing goal, change shape, collision & sanitization rules, error handling, observability, testing strategy, and out-of-scope follow-ups
- docs: Add 2026-04-25-provider-tech-config-outbound-plan.md with bite-sized TDD tasks, review gates, and verification workflow