### PR TITLE
NOJIRA-typed-errors-pr2a

### DIFF
--- a/bin-api-manager/pkg/servicehandler/accesskeys.go
+++ b/bin-api-manager/pkg/servicehandler/accesskeys.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	csaccesskey "monorepo/bin-customer-manager/models/accesskey"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -36,7 +37,7 @@ func (h *serviceHandler) accesskeyGet(ctx context.Context, a *auth.AuthIdentity,
 // it returns created accesskey info if it succeed.
 func (h *serviceHandler) AccesskeyCreate(ctx context.Context, a *auth.AuthIdentity, name string, detail string, expire int32) (*csaccesskey.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -49,7 +50,7 @@ func (h *serviceHandler) AccesskeyCreate(ctx context.Context, a *auth.AuthIdenti
 	log.Debug("Creating a new accesskey.")
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if expire < 86400 {
@@ -72,7 +73,7 @@ func (h *serviceHandler) AccesskeyCreate(ctx context.Context, a *auth.AuthIdenti
 // it returns accesskey if it succeed.
 func (h *serviceHandler) AccesskeyGet(ctx context.Context, a *auth.AuthIdentity, accesskeyID uuid.UUID) (*csaccesskey.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -88,7 +89,7 @@ func (h *serviceHandler) AccesskeyGet(ctx context.Context, a *auth.AuthIdentity,
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -135,7 +136,7 @@ func (h *serviceHandler) AccesskeyRawGetByToken(ctx context.Context, token strin
 // it returns list of accesskeys if it succeed.
 func (h *serviceHandler) AccesskeyList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*csaccesskey.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -150,7 +151,7 @@ func (h *serviceHandler) AccesskeyList(ctx context.Context, a *auth.AuthIdentity
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -180,7 +181,7 @@ func (h *serviceHandler) AccesskeyList(ctx context.Context, a *auth.AuthIdentity
 // it returns accesskey if it succeed.
 func (h *serviceHandler) AccesskeyDelete(ctx context.Context, a *auth.AuthIdentity, accesskeyID uuid.UUID) (*csaccesskey.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -197,7 +198,7 @@ func (h *serviceHandler) AccesskeyDelete(ctx context.Context, a *auth.AuthIdenti
 	}
 
 	if !h.hasPermission(ctx, a, ak.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -216,7 +217,7 @@ func (h *serviceHandler) AccesskeyDelete(ctx context.Context, a *auth.AuthIdenti
 // to update the accesskey info.
 func (h *serviceHandler) AccesskeyUpdate(ctx context.Context, a *auth.AuthIdentity, accesskeyID uuid.UUID, name string, detail string) (*csaccesskey.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -232,7 +233,7 @@ func (h *serviceHandler) AccesskeyUpdate(ctx context.Context, a *auth.AuthIdenti
 	}
 
 	if !h.hasPermission(ctx, a, ak.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CustomerV1AccesskeyUpdate(ctx, accesskeyID, name, detail)

--- a/bin-api-manager/pkg/servicehandler/accesskeys_test.go
+++ b/bin-api-manager/pkg/servicehandler/accesskeys_test.go
@@ -42,7 +42,7 @@ func Test_accesskeyGet(t *testing.T) {
 			responseAccesskey: &csaccesskey.Accesskey{
 				ID:         uuid.FromStringOrNil("9c1078ba-ab47-11ef-b8b7-27bf39014b86"),
 				CustomerID: uuid.FromStringOrNil("1ed3b04a-7ffa-11ec-a974-cbbe9a9538b3"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 		},
 	}
@@ -170,13 +170,13 @@ func Test_AccesskeyGet(t *testing.T) {
 			responseAccesskey: &csaccesskey.Accesskey{
 				ID:         uuid.FromStringOrNil("589ebbc2-ab48-11ef-a7b6-0be2f7042cdf"),
 				CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 
 			expectedRes: &csaccesskey.WebhookMessage{
 				ID:         uuid.FromStringOrNil("589ebbc2-ab48-11ef-a7b6-0be2f7042cdf"),
 				CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 		},
 	}
@@ -341,7 +341,7 @@ func Test_AccesskeyDelete(t *testing.T) {
 			responseAccesskey: &csaccesskey.Accesskey{
 				ID:         uuid.FromStringOrNil("bde73c60-ab49-11ef-810d-7b7404934537"),
 				CustomerID: uuid.FromStringOrNil("51639bbe-8e5e-11ee-afc4-4fbef5d3d983"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 		},
 	}

--- a/bin-api-manager/pkg/servicehandler/activeflows.go
+++ b/bin-api-manager/pkg/servicehandler/activeflows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	fmaction "monorepo/bin-flow-manager/models/action"
 	fmactiveflow "monorepo/bin-flow-manager/models/activeflow"
 
@@ -42,7 +43,7 @@ func (h *serviceHandler) activeflowGet(ctx context.Context, activeflowID uuid.UU
 // it returns created activeflow info if it succeed.
 func (h *serviceHandler) ActiveflowCreate(ctx context.Context, a *auth.AuthIdentity, activeflowID uuid.UUID, flowID uuid.UUID, actions []fmaction.Action) (*fmactiveflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -55,7 +56,7 @@ func (h *serviceHandler) ActiveflowCreate(ctx context.Context, a *auth.AuthIdent
 	log.Debug("Creating a new activeflow.")
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerManager|amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if activeflowID == uuid.Nil {
@@ -110,7 +111,7 @@ func (h *serviceHandler) ActiveflowCreate(ctx context.Context, a *auth.AuthIdent
 // it returns activeflow if it succeed.
 func (h *serviceHandler) ActiveflowGet(ctx context.Context, a *auth.AuthIdentity, activeflowID uuid.UUID) (*fmactiveflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -129,7 +130,7 @@ func (h *serviceHandler) ActiveflowGet(ctx context.Context, a *auth.AuthIdentity
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// convert
@@ -143,7 +144,7 @@ func (h *serviceHandler) ActiveflowGet(ctx context.Context, a *auth.AuthIdentity
 // it returns list of activeflows if it succeed.
 func (h *serviceHandler) ActiveflowList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*fmactiveflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -158,7 +159,7 @@ func (h *serviceHandler) ActiveflowList(ctx context.Context, a *auth.AuthIdentit
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -188,7 +189,7 @@ func (h *serviceHandler) ActiveflowList(ctx context.Context, a *auth.AuthIdentit
 // it returns activeflow if it succeed.
 func (h *serviceHandler) ActiveflowStop(ctx context.Context, a *auth.AuthIdentity, activeflowID uuid.UUID) (*fmactiveflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -207,7 +208,7 @@ func (h *serviceHandler) ActiveflowStop(ctx context.Context, a *auth.AuthIdentit
 	}
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.FlowV1ActiveflowStop(ctx, activeflowID)
@@ -227,7 +228,7 @@ func (h *serviceHandler) ActiveflowStop(ctx context.Context, a *auth.AuthIdentit
 // it returns activeflow if it succeed.
 func (h *serviceHandler) ActiveflowDelete(ctx context.Context, a *auth.AuthIdentity, activeflowID uuid.UUID) (*fmactiveflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -245,7 +246,7 @@ func (h *serviceHandler) ActiveflowDelete(ctx context.Context, a *auth.AuthIdent
 	}
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request

--- a/bin-api-manager/pkg/servicehandler/agent.go
+++ b/bin-api-manager/pkg/servicehandler/agent.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
@@ -48,7 +48,7 @@ func (h *serviceHandler) AgentCreate(
 	addresses []commonaddress.Address,
 ) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -58,7 +58,7 @@ func (h *serviceHandler) AgentCreate(
 	})
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -78,7 +78,7 @@ func (h *serviceHandler) AgentCreate(
 // to getting an agent.
 func (h *serviceHandler) AgentGet(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -95,7 +95,7 @@ func (h *serviceHandler) AgentGet(ctx context.Context, a *auth.AuthIdentity, age
 	}
 
 	if a.AgentID() != agentID && !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -107,7 +107,7 @@ func (h *serviceHandler) AgentGet(ctx context.Context, a *auth.AuthIdentity, age
 // it returns list of agents if it succeed.
 func (h *serviceHandler) AgentList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, filters map[string]string) ([]*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -123,7 +123,7 @@ func (h *serviceHandler) AgentList(ctx context.Context, a *auth.AuthIdentity, si
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Convert string filters to typed filters
@@ -177,7 +177,7 @@ func (h *serviceHandler) agentList(ctx context.Context, size uint64, token strin
 // to delete the agent.
 func (h *serviceHandler) AgentDelete(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -194,7 +194,7 @@ func (h *serviceHandler) AgentDelete(ctx context.Context, a *auth.AuthIdentity, 
 	}
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -212,7 +212,7 @@ func (h *serviceHandler) AgentDelete(ctx context.Context, a *auth.AuthIdentity, 
 // to update the agent info.
 func (h *serviceHandler) AgentUpdate(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID, name, detail string, ringMethod amagent.RingMethod) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -229,7 +229,7 @@ func (h *serviceHandler) AgentUpdate(ctx context.Context, a *auth.AuthIdentity, 
 	}
 
 	if a.AgentID() != agentID && !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -256,7 +256,7 @@ func (h *serviceHandler) agentUpdate(ctx context.Context, agentID uuid.UUID, nam
 // to update the agent's addresses info.
 func (h *serviceHandler) AgentUpdateAddresses(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID, addresses []commonaddress.Address) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -273,7 +273,7 @@ func (h *serviceHandler) AgentUpdateAddresses(ctx context.Context, a *auth.AuthI
 	}
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -300,7 +300,7 @@ func (h *serviceHandler) agentUpdateAddresses(ctx context.Context, agentID uuid.
 // to update the agent's tag_ids info.
 func (h *serviceHandler) AgentUpdateTagIDs(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID, tagIDs []uuid.UUID) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -317,7 +317,7 @@ func (h *serviceHandler) AgentUpdateTagIDs(ctx context.Context, a *auth.AuthIden
 	}
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -335,7 +335,7 @@ func (h *serviceHandler) AgentUpdateTagIDs(ctx context.Context, a *auth.AuthIden
 // to update the agent status info.
 func (h *serviceHandler) AgentUpdateStatus(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID, status amagent.Status) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -352,7 +352,7 @@ func (h *serviceHandler) AgentUpdateStatus(ctx context.Context, a *auth.AuthIden
 	}
 
 	if a.AgentID() != agentID && !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -379,7 +379,7 @@ func (h *serviceHandler) agentUpdateStatus(ctx context.Context, agentID uuid.UUI
 // to update the agent permission info.
 func (h *serviceHandler) AgentUpdatePermission(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID, permission amagent.Permission) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -401,13 +401,13 @@ func (h *serviceHandler) AgentUpdatePermission(ctx context.Context, a *auth.Auth
 		// the only project level permission owned agent can set the project level permission.
 		if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionNone) {
 			log.Debugf("The agent has no project level permission.")
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	} else {
 		// customer level permission set.
 		if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 			log.Debugf("The agent has no customer level permission.")
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	}
 
@@ -426,7 +426,7 @@ func (h *serviceHandler) AgentUpdatePermission(ctx context.Context, a *auth.Auth
 // to update the agent password.
 func (h *serviceHandler) AgentUpdatePassword(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID, password string) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -444,7 +444,7 @@ func (h *serviceHandler) AgentUpdatePassword(ctx context.Context, a *auth.AuthId
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Debugf("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -470,7 +470,7 @@ func (h *serviceHandler) agentUpdatePassword(ctx context.Context, agentID uuid.U
 // AgentDirectHashRegenerate regenerates the direct hash for the agent.
 func (h *serviceHandler) AgentDirectHashRegenerate(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID) (*amagent.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -488,7 +488,7 @@ func (h *serviceHandler) AgentDirectHashRegenerate(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AgentV1AgentDirectHashRegenerate(ctx, agentID)

--- a/bin-api-manager/pkg/servicehandler/aggregated_events.go
+++ b/bin-api-manager/pkg/servicehandler/aggregated_events.go
@@ -8,11 +8,12 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	amai "monorepo/bin-ai-manager/models/ai"
-	"monorepo/bin-api-manager/models/auth"
 	amaicall "monorepo/bin-ai-manager/models/aicall"
 	ammessage "monorepo/bin-ai-manager/models/message"
 	amsummary "monorepo/bin-ai-manager/models/summary"
 	amteam "monorepo/bin-ai-manager/models/team"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	bmaccount "monorepo/bin-billing-manager/models/account"
 	bmbilling "monorepo/bin-billing-manager/models/billing"
 	cmcall "monorepo/bin-call-manager/models/call"
@@ -70,7 +71,7 @@ func (h *serviceHandler) AggregatedEventList(
 	pageToken string,
 ) ([]*TimelineEvent, string, error) {
 	if a.IsDirect() {
-		return nil, "", fmt.Errorf("direct access not supported")
+		return nil, "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -83,11 +84,11 @@ func (h *serviceHandler) AggregatedEventList(
 	// Validate: exactly one of activeflow_id or call_id must be provided
 	if activeflowID == uuid.Nil && callID == uuid.Nil {
 		log.Info("Neither activeflow_id nor call_id provided")
-		return nil, "", fmt.Errorf("either activeflow_id or call_id is required")
+		return nil, "", fmt.Errorf("%w: either activeflow_id or call_id is required", serviceerrors.ErrInvalidArgument)
 	}
 	if activeflowID != uuid.Nil && callID != uuid.Nil {
 		log.Info("Both activeflow_id and call_id provided")
-		return nil, "", fmt.Errorf("only one of activeflow_id or call_id is allowed")
+		return nil, "", fmt.Errorf("%w: only one of activeflow_id or call_id is allowed", serviceerrors.ErrInvalidArgument)
 	}
 
 	// Resolve to activeflow_id
@@ -103,7 +104,7 @@ func (h *serviceHandler) AggregatedEventList(
 
 		if !h.hasPermission(ctx, a, af.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 			log.Info("Agent has no permission")
-			return nil, "", fmt.Errorf("user has no permission")
+			return nil, "", serviceerrors.ErrPermissionDenied
 		}
 		resolvedActiveflowID = af.ID
 	} else {
@@ -117,7 +118,7 @@ func (h *serviceHandler) AggregatedEventList(
 
 		if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 			log.Info("Agent has no permission")
-			return nil, "", fmt.Errorf("user has no permission")
+			return nil, "", serviceerrors.ErrPermissionDenied
 		}
 
 		if c.ActiveflowID == uuid.Nil {
@@ -213,14 +214,14 @@ var eventConverters = map[string]eventConverter{
 	"speaking_":             newEventConverter(func(v *ttspeaking.Speaking) any { return v.ConvertWebhookMessage() }),
 	// NOTE: "streaming_" events (streaming_started/stopped) carry a Streaming struct which lacks
 	// ConvertWebhookMessage, so they cannot be converted. Only "transcribe_speech_" events use Speech.
-	"summary_":              newEventConverter(func(v *amsummary.Summary) any { return v.ConvertWebhookMessage() }),
-	"tag_":                  newEventConverter(func(v *tgtag.Tag) any { return v.ConvertWebhookMessage() }),
-	"team_":                 newEventConverter(func(v *amteam.Team) any { return v.ConvertWebhookMessage() }),
-	"transcript_":           newEventConverter(func(v *tmtranscript.Transcript) any { return v.ConvertWebhookMessage() }),
-	"transcribe_":           newEventConverter(func(v *tmtranscribe.Transcribe) any { return v.ConvertWebhookMessage() }),
-	"transcribe_speech_":    newEventConverter(func(v *tmstreaming.Speech) any { return v.ConvertWebhookMessage() }),
-	"transfer_":             newEventConverter(func(v *tftransfer.Transfer) any { return v.ConvertWebhookMessage() }),
-	"trunk_":                newEventConverter(func(v *rmtrunk.Trunk) any { return v.ConvertWebhookMessage() }),
+	"summary_":           newEventConverter(func(v *amsummary.Summary) any { return v.ConvertWebhookMessage() }),
+	"tag_":               newEventConverter(func(v *tgtag.Tag) any { return v.ConvertWebhookMessage() }),
+	"team_":              newEventConverter(func(v *amteam.Team) any { return v.ConvertWebhookMessage() }),
+	"transcript_":        newEventConverter(func(v *tmtranscript.Transcript) any { return v.ConvertWebhookMessage() }),
+	"transcribe_":        newEventConverter(func(v *tmtranscribe.Transcribe) any { return v.ConvertWebhookMessage() }),
+	"transcribe_speech_": newEventConverter(func(v *tmstreaming.Speech) any { return v.ConvertWebhookMessage() }),
+	"transfer_":          newEventConverter(func(v *tftransfer.Transfer) any { return v.ConvertWebhookMessage() }),
+	"trunk_":             newEventConverter(func(v *rmtrunk.Trunk) any { return v.ConvertWebhookMessage() }),
 }
 
 // convertAggregatedEventData converts a timeline event's raw data to WebhookMessage format.

--- a/bin-api-manager/pkg/servicehandler/aggregated_events_test.go
+++ b/bin-api-manager/pkg/servicehandler/aggregated_events_test.go
@@ -3,6 +3,7 @@ package servicehandler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/dbhandler"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 )
 
 func Test_AggregatedEventList_NeitherProvided(t *testing.T) {
@@ -46,8 +48,8 @@ func Test_AggregatedEventList_NeitherProvided(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "either activeflow_id or call_id is required" {
-		t.Errorf("Wrong error message. expect: either activeflow_id or call_id is required, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrInvalidArgument) {
+		t.Errorf("Wrong error. expect: ErrInvalidArgument, got: %v", err)
 	}
 }
 
@@ -79,8 +81,8 @@ func Test_AggregatedEventList_BothProvided(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "only one of activeflow_id or call_id is allowed" {
-		t.Errorf("Wrong error message. expect: only one of activeflow_id or call_id is allowed, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrInvalidArgument) {
+		t.Errorf("Wrong error. expect: ErrInvalidArgument, got: %v", err)
 	}
 }
 
@@ -156,8 +158,8 @@ func Test_AggregatedEventList_ActiveflowNoPermission(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "user has no permission" {
-		t.Errorf("Wrong error message. expect: user has no permission, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrPermissionDenied) {
+		t.Errorf("Wrong error. expect: ErrPermissionDenied, got: %v", err)
 	}
 }
 
@@ -311,8 +313,8 @@ func Test_AggregatedEventList_CallNoPermission(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "user has no permission" {
-		t.Errorf("Wrong error message. expect: user has no permission, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrPermissionDenied) {
+		t.Errorf("Wrong error. expect: ErrPermissionDenied, got: %v", err)
 	}
 }
 

--- a/bin-api-manager/pkg/servicehandler/ai.go
+++ b/bin-api-manager/pkg/servicehandler/ai.go
@@ -8,6 +8,7 @@ import (
 	amai "monorepo/bin-ai-manager/models/ai"
 	amtool "monorepo/bin-ai-manager/models/tool"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
 	"github.com/gofrs/uuid"
@@ -49,7 +50,7 @@ func (h *serviceHandler) AICreate(
 	toolNames []amtool.ToolName,
 ) (*amai.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -71,7 +72,7 @@ func (h *serviceHandler) AICreate(
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// validate RAG ownership if ragID is provided
@@ -85,7 +86,7 @@ func (h *serviceHandler) AICreate(
 
 		if rag.CustomerID != a.CustomerID {
 			log.Infof("RAG customer_id mismatch. rag_customer_id: %s, agent_customer_id: %s", rag.CustomerID, a.CustomerID)
-			return nil, fmt.Errorf("knowledge base does not belong to this customer")
+			return nil, fmt.Errorf("%w: knowledge base does not belong to this customer", serviceerrors.ErrPermissionDenied)
 		}
 	}
 
@@ -118,7 +119,7 @@ func (h *serviceHandler) AICreate(
 // AIDirectHashRegenerate regenerates the direct hash for the AI.
 func (h *serviceHandler) AIDirectHashRegenerate(ctx context.Context, a *auth.AuthIdentity, aiID uuid.UUID) (*amai.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -136,7 +137,7 @@ func (h *serviceHandler) AIDirectHashRegenerate(ctx context.Context, a *auth.Aut
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1AIDirectHashRegenerate(ctx, aiID)
@@ -153,7 +154,7 @@ func (h *serviceHandler) AIDirectHashRegenerate(ctx context.Context, a *auth.Aut
 // It returns list of AIs if it succeed.
 func (h *serviceHandler) AIGetsByCustomerID(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*amai.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -170,7 +171,7 @@ func (h *serviceHandler) AIGetsByCustomerID(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -229,7 +230,7 @@ func (h *serviceHandler) convertAIFilters(filters map[string]string) (map[amai.F
 // It returns AI if it succeed.
 func (h *serviceHandler) AIGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*amai.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -247,7 +248,7 @@ func (h *serviceHandler) AIGet(ctx context.Context, a *auth.AuthIdentity, id uui
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -257,7 +258,7 @@ func (h *serviceHandler) AIGet(ctx context.Context, a *auth.AuthIdentity, id uui
 // AIDelete deletes the ai.
 func (h *serviceHandler) AIDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*amai.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -277,7 +278,7 @@ func (h *serviceHandler) AIDelete(ctx context.Context, a *auth.AuthIdentity, id 
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1AIDelete(ctx, id)
@@ -309,7 +310,7 @@ func (h *serviceHandler) AIUpdate(
 	toolNames []amtool.ToolName,
 ) (*amai.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -339,7 +340,7 @@ func (h *serviceHandler) AIUpdate(
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// validate RAG ownership if ragID is provided
@@ -353,7 +354,7 @@ func (h *serviceHandler) AIUpdate(
 
 		if rag.CustomerID != a.CustomerID {
 			log.Infof("RAG customer_id mismatch. rag_customer_id: %s, agent_customer_id: %s", rag.CustomerID, a.CustomerID)
-			return nil, fmt.Errorf("knowledge base does not belong to this customer")
+			return nil, fmt.Errorf("%w: knowledge base does not belong to this customer", serviceerrors.ErrPermissionDenied)
 		}
 	}
 

--- a/bin-api-manager/pkg/servicehandler/aicall.go
+++ b/bin-api-manager/pkg/servicehandler/aicall.go
@@ -10,6 +10,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
 	"github.com/gofrs/uuid"
@@ -60,7 +61,7 @@ func (h *serviceHandler) AIcallCreate(
 	switch {
 	case a.IsAgent() || a.IsAccesskey():
 		if !h.hasPermission(ctx, a, customerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	case a.IsDirect():
 		if !a.HasAllowedResourceType("aicall") {
@@ -128,7 +129,7 @@ func (h *serviceHandler) AIcallGetsByCustomerID(ctx context.Context, a *auth.Aut
 	switch {
 	case a.IsAgent() || a.IsAccesskey():
 		if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	case a.IsDirect():
 		if !a.HasAllowedResourceType("aicall") {
@@ -197,7 +198,7 @@ func (h *serviceHandler) AIcallGet(ctx context.Context, a *auth.AuthIdentity, id
 	switch {
 	case a.IsAgent() || a.IsAccesskey():
 		if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	case a.IsDirect():
 		if !a.HasAllowedResourceType("aicall") {
@@ -222,7 +223,7 @@ func (h *serviceHandler) AIcallDelete(ctx context.Context, a *auth.AuthIdentity,
 	switch {
 	case a.IsAgent() || a.IsAccesskey():
 		if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	case a.IsDirect():
 		if !a.HasAllowedResourceType("aicall") {

--- a/bin-api-manager/pkg/servicehandler/aimessage.go
+++ b/bin-api-manager/pkg/servicehandler/aimessage.go
@@ -6,6 +6,7 @@ import (
 	amagent "monorepo/bin-agent-manager/models/agent"
 	ammessage "monorepo/bin-ai-manager/models/message"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
 	"github.com/gofrs/uuid"
@@ -119,7 +120,7 @@ func (h *serviceHandler) AImessageGet(ctx context.Context, a *auth.AuthIdentity,
 	switch {
 	case a.IsAgent() || a.IsAccesskey():
 		if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	case a.IsDirect():
 		if !a.HasAllowedResourceType("aicall") {

--- a/bin-api-manager/pkg/servicehandler/aisummary.go
+++ b/bin-api-manager/pkg/servicehandler/aisummary.go
@@ -6,6 +6,7 @@ import (
 	amagent "monorepo/bin-agent-manager/models/agent"
 	amsummary "monorepo/bin-ai-manager/models/summary"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
 	"github.com/gofrs/uuid"
@@ -22,7 +23,7 @@ func (h *serviceHandler) AISummaryCreate(
 	language string,
 ) (*amsummary.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	var tmpCustomerID uuid.UUID
@@ -61,7 +62,7 @@ func (h *serviceHandler) AISummaryCreate(
 	}
 
 	if !h.hasPermission(ctx, a, tmpCustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1SummaryCreate(
@@ -97,7 +98,7 @@ func (h *serviceHandler) aisummaryGet(ctx context.Context, id uuid.UUID) (*amsum
 // It returns list of aisummaries if it succeed.
 func (h *serviceHandler) AISummaryGetsByCustomerID(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*amsummary.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -105,7 +106,7 @@ func (h *serviceHandler) AISummaryGetsByCustomerID(ctx context.Context, a *auth.
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -162,7 +163,7 @@ func (h *serviceHandler) convertAISummaryFilters(filters map[string]string) (map
 // It returns ai summary if it succeed.
 func (h *serviceHandler) AISummaryGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*amsummary.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.aisummaryGet(ctx, id)
@@ -171,7 +172,7 @@ func (h *serviceHandler) AISummaryGet(ctx context.Context, a *auth.AuthIdentity,
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -181,7 +182,7 @@ func (h *serviceHandler) AISummaryGet(ctx context.Context, a *auth.AuthIdentity,
 // AISummaryDelete deletes the ai summary.
 func (h *serviceHandler) AISummaryDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*amsummary.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.aisummaryGet(ctx, id)
@@ -190,7 +191,7 @@ func (h *serviceHandler) AISummaryDelete(ctx context.Context, a *auth.AuthIdenti
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1SummaryDelete(ctx, id)

--- a/bin-api-manager/pkg/servicehandler/auth_test.go
+++ b/bin-api-manager/pkg/servicehandler/auth_test.go
@@ -158,5 +158,3 @@ func Test_AuthJWTGenerate(t *testing.T) {
 		})
 	}
 }
-
-

--- a/bin-api-manager/pkg/servicehandler/available_numbers.go
+++ b/bin-api-manager/pkg/servicehandler/available_numbers.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	nmavailablenumber "monorepo/bin-number-manager/models/availablenumber"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -26,11 +26,11 @@ func (h *serviceHandler) AvailableNumberList(ctx context.Context, a *auth.AuthId
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get available numbers

--- a/bin-api-manager/pkg/servicehandler/billingaccount.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	bmaccount "monorepo/bin-billing-manager/models/account"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
@@ -50,11 +51,11 @@ func (h *serviceHandler) BillingAccountGet(ctx context.Context, a *auth.AuthIden
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get billing account
@@ -78,11 +79,11 @@ func (h *serviceHandler) BillingAccountUpdateBasicInfo(ctx context.Context, a *a
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// update billing account
@@ -106,11 +107,11 @@ func (h *serviceHandler) BillingAccountUpdatePaymentInfo(ctx context.Context, a 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// update billing account payment info
@@ -136,12 +137,12 @@ func (h *serviceHandler) BillingAccountAddBalanceForce(ctx context.Context, a *a
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// need a project super admin permission
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	b, err := h.reqHandler.BillingV1AccountAddBalanceForce(ctx, billingAccountID, balance)
@@ -166,12 +167,12 @@ func (h *serviceHandler) BillingAccountSubtractBalanceForce(ctx context.Context,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// need a project super admin permission
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	b, err := h.reqHandler.BillingV1AccountSubtractBalanceForce(ctx, billingAccountID, balance)
@@ -191,7 +192,7 @@ func (h *serviceHandler) BillingAccountSelfGet(ctx context.Context, a *auth.Auth
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -230,7 +231,7 @@ func (h *serviceHandler) BillingAccountSelfUpdateBasicInfo(ctx context.Context, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -267,7 +268,7 @@ func (h *serviceHandler) BillingAccountSelfUpdatePaymentInfo(ctx context.Context
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -305,12 +306,12 @@ func (h *serviceHandler) BillingAccountSelfCreatePaddlePortalSession(ctx context
 	})
 
 	if a.IsDirect() {
-		return "", fmt.Errorf("direct access not supported")
+		return "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Infof("User has no permission.")
-		return "", fmt.Errorf("user has no permission")
+		return "", serviceerrors.ErrPermissionDenied
 	}
 
 	c, err := h.customerGet(ctx, a.CustomerID)
@@ -347,11 +348,11 @@ func (h *serviceHandler) BillingAccountList(ctx context.Context, a *auth.AuthIde
 	log.Debug("Received request detail.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if size <= 0 {
@@ -400,4 +401,3 @@ func (h *serviceHandler) convertBillingAccountFilters(filters map[string]string)
 
 	return result, nil
 }
-

--- a/bin-api-manager/pkg/servicehandler/billingaccount_test.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount_test.go
@@ -1111,4 +1111,3 @@ func Test_BillingAccountList(t *testing.T) {
 		})
 	}
 }
-

--- a/bin-api-manager/pkg/servicehandler/billings.go
+++ b/bin-api-manager/pkg/servicehandler/billings.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	bmbilling "monorepo/bin-billing-manager/models/billing"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -27,7 +27,7 @@ func (h *serviceHandler) BillingList(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -35,7 +35,7 @@ func (h *serviceHandler) BillingList(ctx context.Context, a *auth.AuthIdentity, 
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -121,7 +121,7 @@ func (h *serviceHandler) BillingGet(ctx context.Context, a *auth.AuthIdentity, b
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get billing
@@ -132,7 +132,7 @@ func (h *serviceHandler) BillingGet(ctx context.Context, a *auth.AuthIdentity, b
 	}
 
 	if !h.hasPermission(ctx, a, b.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// convert

--- a/bin-api-manager/pkg/servicehandler/billings_test.go
+++ b/bin-api-manager/pkg/servicehandler/billings_test.go
@@ -29,7 +29,7 @@ func Test_BillingList(t *testing.T) {
 		token string
 
 		responseBillingAcounts []bmbilling.Billing
-		expectFilters map[bmbilling.Field]any
+		expectFilters          map[bmbilling.Field]any
 		expectRes              []*bmbilling.WebhookMessage
 	}{
 		{

--- a/bin-api-manager/pkg/servicehandler/boot_test.go
+++ b/bin-api-manager/pkg/servicehandler/boot_test.go
@@ -24,11 +24,11 @@ func Test_AuthBoot(t *testing.T) {
 
 		directHash string
 
-		responseDirect    *dmdirect.Direct
-		responseDirectErr error
+		responseDirect      *dmdirect.Direct
+		responseDirectErr   error
 		responseCustomer    *cscustomer.Customer
 		responseCustomerErr error
-		responseCurTime string
+		responseCurTime     string
 
 		expectErr bool
 	}{

--- a/bin-api-manager/pkg/servicehandler/call.go
+++ b/bin-api-manager/pkg/servicehandler/call.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmcall "monorepo/bin-call-manager/models/call"
 	cmexternalmedia "monorepo/bin-call-manager/models/externalmedia"
 	cmgroupcall "monorepo/bin-call-manager/models/groupcall"
@@ -55,11 +56,11 @@ func (h *serviceHandler) CallCreate(ctx context.Context, a *auth.AuthIdentity, f
 	log.Debug("Creating a new call.")
 
 	if a.IsDirect() {
-		return nil, nil, fmt.Errorf("direct access not supported")
+		return nil, nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, nil, fmt.Errorf("user has no permission")
+		return nil, nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// check identity verification for PSTN outbound calls
@@ -141,7 +142,7 @@ func (h *serviceHandler) CallGet(ctx context.Context, a *auth.AuthIdentity, call
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get call
@@ -153,7 +154,7 @@ func (h *serviceHandler) CallGet(ctx context.Context, a *auth.AuthIdentity, call
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// convert
@@ -174,7 +175,7 @@ func (h *serviceHandler) CallList(ctx context.Context, a *auth.AuthIdentity, siz
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -275,7 +276,7 @@ func (h *serviceHandler) CallDelete(ctx context.Context, a *auth.AuthIdentity, c
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -334,7 +335,7 @@ func (h *serviceHandler) CallHangup(ctx context.Context, a *auth.AuthIdentity, c
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -375,7 +376,7 @@ func (h *serviceHandler) CallTalk(ctx context.Context, a *auth.AuthIdentity, cal
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -411,7 +412,7 @@ func (h *serviceHandler) CallHoldOn(ctx context.Context, a *auth.AuthIdentity, c
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -447,7 +448,7 @@ func (h *serviceHandler) CallHoldOff(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -483,7 +484,7 @@ func (h *serviceHandler) CallMuteOn(ctx context.Context, a *auth.AuthIdentity, c
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -519,7 +520,7 @@ func (h *serviceHandler) CallMuteOff(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -555,7 +556,7 @@ func (h *serviceHandler) CallMOHOn(ctx context.Context, a *auth.AuthIdentity, ca
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -591,7 +592,7 @@ func (h *serviceHandler) CallMOHOff(ctx context.Context, a *auth.AuthIdentity, c
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -627,7 +628,7 @@ func (h *serviceHandler) CallSilenceOn(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -663,7 +664,7 @@ func (h *serviceHandler) CallSilenceOff(ctx context.Context, a *auth.AuthIdentit
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -699,7 +700,7 @@ func (h *serviceHandler) CallMediaStreamStart(ctx context.Context, a *auth.AuthI
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -737,7 +738,7 @@ func (h *serviceHandler) CallRecordingStart(
 ) (*cmcall.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)
@@ -774,7 +775,7 @@ func (h *serviceHandler) CallRecordingStart(
 func (h *serviceHandler) CallRecordingStop(ctx context.Context, a *auth.AuthIdentity, callID uuid.UUID) (*cmcall.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.callGet(ctx, callID)

--- a/bin-api-manager/pkg/servicehandler/campaigncalls.go
+++ b/bin-api-manager/pkg/servicehandler/campaigncalls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cacampaigncall "monorepo/bin-campaign-manager/models/campaigncall"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -44,7 +45,7 @@ func (h *serviceHandler) CampaigncallList(ctx context.Context, a *auth.AuthIdent
 	log.Debug("Getting campaigncalls.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -52,7 +53,7 @@ func (h *serviceHandler) CampaigncallList(ctx context.Context, a *auth.AuthIdent
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get campaigncalls
@@ -88,7 +89,7 @@ func (h *serviceHandler) CampaigncallGetsByCampaignID(ctx context.Context, a *au
 	log.Debug("Getting campaigncalls.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -103,7 +104,7 @@ func (h *serviceHandler) CampaigncallGetsByCampaignID(ctx context.Context, a *au
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get campaigncalls
@@ -138,7 +139,7 @@ func (h *serviceHandler) CampaigncallGet(ctx context.Context, a *auth.AuthIdenti
 	log.Debug("Getting campaigncall.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.campaigncallGet(ctx, campaigncallID)
@@ -148,7 +149,7 @@ func (h *serviceHandler) CampaigncallGet(ctx context.Context, a *auth.AuthIdenti
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -165,7 +166,7 @@ func (h *serviceHandler) CampaigncallDelete(ctx context.Context, a *auth.AuthIde
 	log.Debug("Deleting a campaigncall.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -176,7 +177,7 @@ func (h *serviceHandler) CampaigncallDelete(ctx context.Context, a *auth.AuthIde
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaigncallDelete(ctx, campaigncallID)

--- a/bin-api-manager/pkg/servicehandler/campaigns.go
+++ b/bin-api-manager/pkg/servicehandler/campaigns.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cacampaign "monorepo/bin-campaign-manager/models/campaign"
 
 	fmaction "monorepo/bin-flow-manager/models/action"
@@ -55,11 +56,11 @@ func (h *serviceHandler) CampaignCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	log.Debug("Creating a new campaign.")
@@ -100,7 +101,7 @@ func (h *serviceHandler) CampaignGetsByCustomerID(ctx context.Context, a *auth.A
 	log.Debug("Getting a campaigns.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -108,7 +109,7 @@ func (h *serviceHandler) CampaignGetsByCustomerID(ctx context.Context, a *auth.A
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get campaigns
@@ -143,7 +144,7 @@ func (h *serviceHandler) CampaignGet(ctx context.Context, a *auth.AuthIdentity, 
 	log.Debug("Getting an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -154,7 +155,7 @@ func (h *serviceHandler) CampaignGet(ctx context.Context, a *auth.AuthIdentity, 
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -172,7 +173,7 @@ func (h *serviceHandler) CampaignDelete(ctx context.Context, a *auth.AuthIdentit
 	log.Debug("Deleting a campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -183,7 +184,7 @@ func (h *serviceHandler) CampaignDelete(ctx context.Context, a *auth.AuthIdentit
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignDelete(ctx, id)
@@ -222,7 +223,7 @@ func (h *serviceHandler) CampaignUpdateBasicInfo(
 	log.Debug("Updating an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -233,7 +234,7 @@ func (h *serviceHandler) CampaignUpdateBasicInfo(
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignUpdateBasicInfo(ctx, id, name, detail, campaignType, serviceLevel, endHandle)
@@ -258,7 +259,7 @@ func (h *serviceHandler) CampaignUpdateStatus(ctx context.Context, a *auth.AuthI
 	log.Debug("Updating an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -269,7 +270,7 @@ func (h *serviceHandler) CampaignUpdateStatus(ctx context.Context, a *auth.AuthI
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignUpdateStatus(ctx, id, status)
@@ -294,7 +295,7 @@ func (h *serviceHandler) CampaignUpdateServiceLevel(ctx context.Context, a *auth
 	log.Debug("Updating an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -305,7 +306,7 @@ func (h *serviceHandler) CampaignUpdateServiceLevel(ctx context.Context, a *auth
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignUpdateServiceLevel(ctx, id, serviceLevel)
@@ -330,7 +331,7 @@ func (h *serviceHandler) CampaignUpdateActions(ctx context.Context, a *auth.Auth
 	log.Debug("Updating an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -341,7 +342,7 @@ func (h *serviceHandler) CampaignUpdateActions(ctx context.Context, a *auth.Auth
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignUpdateActions(ctx, id, actions)
@@ -366,7 +367,7 @@ func (h *serviceHandler) CampaignUpdateResourceInfo(ctx context.Context, a *auth
 	log.Debug("Updating an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -377,7 +378,7 @@ func (h *serviceHandler) CampaignUpdateResourceInfo(ctx context.Context, a *auth
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignUpdateResourceInfo(ctx, id, outplanID, outdialID, queueID, nextCampaignID)
@@ -402,7 +403,7 @@ func (h *serviceHandler) CampaignUpdateNextCampaignID(ctx context.Context, a *au
 	log.Debug("Updating an campaign.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -413,7 +414,7 @@ func (h *serviceHandler) CampaignUpdateNextCampaignID(ctx context.Context, a *au
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1CampaignUpdateNextCampaignID(ctx, id, nextCampaignID)

--- a/bin-api-manager/pkg/servicehandler/conference.go
+++ b/bin-api-manager/pkg/servicehandler/conference.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmexternalmedia "monorepo/bin-call-manager/models/externalmedia"
 	cmrecording "monorepo/bin-call-manager/models/recording"
 
@@ -49,7 +50,7 @@ func (h *serviceHandler) ConferenceGet(ctx context.Context, a *auth.AuthIdentity
 	log.Debugf("Get conference. conference: %s", id)
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference
@@ -80,7 +81,7 @@ func (h *serviceHandler) ConferenceList(ctx context.Context, a *auth.AuthIdentit
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -149,7 +150,7 @@ func (h *serviceHandler) ConferenceCreate(
 	log.Debugf("Creating a conference.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
@@ -175,7 +176,7 @@ func (h *serviceHandler) ConferenceDelete(ctx context.Context, a *auth.AuthIdent
 	log.Debug("Destroying conference.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check
@@ -227,7 +228,7 @@ func (h *serviceHandler) ConferenceUpdate(
 	log.Debugf("Updating conference. conference_id: %s", conferenceID)
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check
@@ -271,7 +272,7 @@ func (h *serviceHandler) ConferenceRecordingStart(
 	onEndFlowID uuid.UUID,
 ) (*cfconference.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check
@@ -298,7 +299,7 @@ func (h *serviceHandler) ConferenceRecordingStart(
 func (h *serviceHandler) ConferenceRecordingStop(ctx context.Context, a *auth.AuthIdentity, confID uuid.UUID) (*cfconference.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check
@@ -331,7 +332,7 @@ func (h *serviceHandler) ConferenceTranscribeStart(ctx context.Context, a *auth.
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check
@@ -366,7 +367,7 @@ func (h *serviceHandler) ConferenceTranscribeStop(ctx context.Context, a *auth.A
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check
@@ -402,7 +403,7 @@ func (h *serviceHandler) ConferenceDirectHashRegenerate(ctx context.Context, a *
 	log.Debug("Regenerating conference direct hash.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.conferenceGet(ctx, conferenceID)
@@ -437,7 +438,7 @@ func (h *serviceHandler) ConferenceMediaStreamStart(ctx context.Context, a *auth
 	})
 
 	if a.IsDirect() {
-		return fmt.Errorf("direct access not supported")
+		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	c, err := h.conferenceGet(ctx, conferenceID)

--- a/bin-api-manager/pkg/servicehandler/conferencecall.go
+++ b/bin-api-manager/pkg/servicehandler/conferencecall.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cfconferencecall "monorepo/bin-conference-manager/models/conferencecall"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -43,7 +44,7 @@ func (h *serviceHandler) ConferencecallGet(ctx context.Context, a *auth.AuthIden
 	log.Debugf("Get conferencecall. conferencecall_id: %s", id)
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference
@@ -74,7 +75,7 @@ func (h *serviceHandler) ConferencecallList(ctx context.Context, a *auth.AuthIde
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -124,7 +125,7 @@ func (h *serviceHandler) ConferencecallKick(ctx context.Context, a *auth.AuthIde
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conference for ownership check

--- a/bin-api-manager/pkg/servicehandler/contact.go
+++ b/bin-api-manager/pkg/servicehandler/contact.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
 
@@ -57,11 +57,11 @@ func (h *serviceHandler) ContactCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -101,7 +101,7 @@ func (h *serviceHandler) ContactGet(ctx context.Context, a *auth.AuthIdentity, c
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.contactGet(ctx, contactID)
@@ -111,7 +111,7 @@ func (h *serviceHandler) ContactGet(ctx context.Context, a *auth.AuthIdentity, c
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -131,7 +131,7 @@ func (h *serviceHandler) ContactList(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -139,7 +139,7 @@ func (h *serviceHandler) ContactList(ctx context.Context, a *auth.AuthIdentity, 
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Convert string filters to typed filters
@@ -210,7 +210,7 @@ func (h *serviceHandler) ContactUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -220,7 +220,7 @@ func (h *serviceHandler) ContactUpdate(
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -254,7 +254,7 @@ func (h *serviceHandler) ContactDelete(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -264,7 +264,7 @@ func (h *serviceHandler) ContactDelete(ctx context.Context, a *auth.AuthIdentity
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -289,11 +289,11 @@ func (h *serviceHandler) ContactLookup(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -325,7 +325,7 @@ func (h *serviceHandler) ContactPhoneNumberCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -335,7 +335,7 @@ func (h *serviceHandler) ContactPhoneNumberCreate(
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -366,7 +366,7 @@ func (h *serviceHandler) ContactPhoneNumberUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -376,7 +376,7 @@ func (h *serviceHandler) ContactPhoneNumberUpdate(
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -401,7 +401,7 @@ func (h *serviceHandler) ContactPhoneNumberDelete(ctx context.Context, a *auth.A
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -411,7 +411,7 @@ func (h *serviceHandler) ContactPhoneNumberDelete(ctx context.Context, a *auth.A
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -442,7 +442,7 @@ func (h *serviceHandler) ContactEmailCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -452,7 +452,7 @@ func (h *serviceHandler) ContactEmailCreate(
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -483,7 +483,7 @@ func (h *serviceHandler) ContactEmailUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -493,7 +493,7 @@ func (h *serviceHandler) ContactEmailUpdate(
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -518,7 +518,7 @@ func (h *serviceHandler) ContactEmailDelete(ctx context.Context, a *auth.AuthIde
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -528,7 +528,7 @@ func (h *serviceHandler) ContactEmailDelete(ctx context.Context, a *auth.AuthIde
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -553,7 +553,7 @@ func (h *serviceHandler) ContactTagAdd(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -563,7 +563,7 @@ func (h *serviceHandler) ContactTagAdd(ctx context.Context, a *auth.AuthIdentity
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -588,7 +588,7 @@ func (h *serviceHandler) ContactTagRemove(ctx context.Context, a *auth.AuthIdent
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	ct, err := h.contactGet(ctx, contactID)
@@ -598,7 +598,7 @@ func (h *serviceHandler) ContactTagRemove(ctx context.Context, a *auth.AuthIdent
 	}
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request

--- a/bin-api-manager/pkg/servicehandler/conversation.go
+++ b/bin-api-manager/pkg/servicehandler/conversation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvconversation "monorepo/bin-conversation-manager/models/conversation"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -45,7 +46,7 @@ func (h *serviceHandler) ConversationGetsByCustomerID(ctx context.Context, a *au
 	log.Debug("Getting a conversations.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -115,7 +116,7 @@ func (h *serviceHandler) ConversationGet(ctx context.Context, a *auth.AuthIdenti
 	log.Debug("Getting an conversation.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -146,7 +147,7 @@ func (h *serviceHandler) ConversationUpdate(ctx context.Context, a *auth.AuthIde
 	log.Debug("Updating the conversation.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign

--- a/bin-api-manager/pkg/servicehandler/conversation_account.go
+++ b/bin-api-manager/pkg/servicehandler/conversation_account.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvaccount "monorepo/bin-conversation-manager/models/account"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -45,7 +46,7 @@ func (h *serviceHandler) ConversationAccountGetsByCustomerID(ctx context.Context
 	log.Debug("Getting a conversation accounts.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -91,7 +92,7 @@ func (h *serviceHandler) ConversationAccountGet(ctx context.Context, a *auth.Aut
 	log.Debug("Getting an conversation account.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get
@@ -129,7 +130,7 @@ func (h *serviceHandler) ConversationAccountCreate(
 	log.Debug("Creating a new conversation account.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
@@ -157,7 +158,7 @@ func (h *serviceHandler) ConversationAccountUpdate(ctx context.Context, a *auth.
 	log.Debug("Creating a new conversation account.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign
@@ -192,7 +193,7 @@ func (h *serviceHandler) ConversationAccountDelete(ctx context.Context, a *auth.
 	log.Debug("Creating a new conversation account.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get campaign

--- a/bin-api-manager/pkg/servicehandler/conversation_account_test.go
+++ b/bin-api-manager/pkg/servicehandler/conversation_account_test.go
@@ -172,12 +172,12 @@ func Test_ConversationAccountCreate(t *testing.T) {
 		name  string
 		agent *auth.AuthIdentity
 
-		accountType    cvaccount.Type
-		accountName    string
-		detail         string
-		secret         string
-		token          string
-		messageFlowID  uuid.UUID
+		accountType   cvaccount.Type
+		accountName   string
+		detail        string
+		secret        string
+		token         string
+		messageFlowID uuid.UUID
 
 		response  *cvaccount.Account
 		expectRes *cvaccount.WebhookMessage
@@ -192,12 +192,12 @@ func Test_ConversationAccountCreate(t *testing.T) {
 				Permission: amagent.PermissionCustomerAdmin,
 			}),
 
-			accountType:    cvaccount.TypeLine,
-			accountName:    "test name",
-			detail:         "test detail",
-			secret:         "test secret",
-			token:          "test token",
-			messageFlowID:  uuid.Nil,
+			accountType:   cvaccount.TypeLine,
+			accountName:   "test name",
+			detail:        "test detail",
+			secret:        "test secret",
+			token:         "test token",
+			messageFlowID: uuid.Nil,
 
 			response: &cvaccount.Account{
 				Identity: commonidentity.Identity{

--- a/bin-api-manager/pkg/servicehandler/conversation_message.go
+++ b/bin-api-manager/pkg/servicehandler/conversation_message.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvmedia "monorepo/bin-conversation-manager/models/media"
 	cvmessage "monorepo/bin-conversation-manager/models/message"
 
@@ -35,7 +36,7 @@ func (h *serviceHandler) ConversationMessageGetsByConversationID(
 	log.Debug("Getting a conversation messages.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conversation to check the permission
@@ -118,7 +119,7 @@ func (h *serviceHandler) ConversationMessageSend(
 	log.Debugf("Sending a message. conversation_id: %s", conversationID)
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get conversation to check the permission

--- a/bin-api-manager/pkg/servicehandler/customer.go
+++ b/bin-api-manager/pkg/servicehandler/customer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cscustomer "monorepo/bin-customer-manager/models/customer"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -51,13 +52,13 @@ func (h *serviceHandler) CustomerCreate(
 	log.Debug("Creating a new customer.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// check permission
 	// only project super admin permssion can create a new customer.
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// create customer
@@ -79,7 +80,7 @@ func (h *serviceHandler) CustomerGet(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -106,7 +107,7 @@ func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
@@ -137,13 +138,13 @@ func (h *serviceHandler) CustomerList(ctx context.Context, a *auth.AuthIdentity,
 	log.Debug("Received request detail.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// check permission
 	// only project super admin permssion allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if size <= 0 {
@@ -202,7 +203,7 @@ func (h *serviceHandler) CustomerUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -246,7 +247,7 @@ func (h *serviceHandler) CustomerSelfUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -273,7 +274,7 @@ func (h *serviceHandler) CustomerDelete(ctx context.Context, a *auth.AuthIdentit
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// check permission
@@ -308,7 +309,7 @@ func (h *serviceHandler) CustomerFreeze(ctx context.Context, a *auth.AuthIdentit
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// check permission
@@ -343,7 +344,7 @@ func (h *serviceHandler) CustomerRecover(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// check permission
@@ -378,7 +379,7 @@ func (h *serviceHandler) CustomerSelfFreeze(ctx context.Context, a *auth.AuthIde
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -412,7 +413,7 @@ func (h *serviceHandler) CustomerSelfFreezeAndDelete(ctx context.Context, a *aut
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -445,7 +446,7 @@ func (h *serviceHandler) CustomerSelfRecover(ctx context.Context, a *auth.AuthId
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -479,7 +480,7 @@ func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -520,7 +521,7 @@ func (h *serviceHandler) CustomerUpdateDefaultOutgoingSourceNumberID(ctx context
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -543,7 +544,7 @@ func (h *serviceHandler) CustomerUpdateDefaultOutgoingSourceNumberID(ctx context
 	log.WithField("number", num).Debugf("Retrieved number info. number_id: %s", num.ID)
 	if num.CustomerID != customerID {
 		log.Infof("The number does not belong to this customer. number_customer_id: %s", num.CustomerID)
-		return nil, fmt.Errorf("the number does not belong to this customer")
+		return nil, fmt.Errorf("%w: the number does not belong to this customer", serviceerrors.ErrPermissionDenied)
 	}
 
 	res, err := h.reqHandler.CustomerV1CustomerUpdateDefaultOutgoingSourceNumberID(ctx, customerID, defaultOutgoingSourceNumberID)
@@ -564,7 +565,7 @@ func (h *serviceHandler) CustomerUpdateMetadata(ctx context.Context, a *auth.Aut
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -598,7 +599,7 @@ func (h *serviceHandler) CustomerSelfUpdateBillingAccountID(ctx context.Context,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -636,7 +637,7 @@ func (h *serviceHandler) CustomerSelfUpdateDefaultOutgoingSourceNumberID(ctx con
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
@@ -653,7 +654,7 @@ func (h *serviceHandler) CustomerSelfUpdateDefaultOutgoingSourceNumberID(ctx con
 	log.WithField("number", num).Debugf("Retrieved number info. number_id: %s", num.ID)
 	if num.CustomerID != a.CustomerID {
 		log.Infof("The number does not belong to this customer. number_customer_id: %s", num.CustomerID)
-		return nil, fmt.Errorf("the number does not belong to this customer")
+		return nil, fmt.Errorf("%w: the number does not belong to this customer", serviceerrors.ErrPermissionDenied)
 	}
 
 	res, err := h.reqHandler.CustomerV1CustomerUpdateDefaultOutgoingSourceNumberID(ctx, a.CustomerID, defaultOutgoingSourceNumberID)
@@ -674,7 +675,7 @@ func (h *serviceHandler) CustomerSelfUpdateMetadata(ctx context.Context, a *auth
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {

--- a/bin-api-manager/pkg/servicehandler/email.go
+++ b/bin-api-manager/pkg/servicehandler/email.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"monorepo/bin-api-manager/models/auth"
 	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 	ememail "monorepo/bin-email-manager/models/email"
@@ -40,11 +41,11 @@ func (h *serviceHandler) EmailSend(
 ) (*ememail.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.EmailV1EmailSend(ctx, a.CustomerID, uuid.Nil, destinations, subject, content, attachments)
@@ -61,11 +62,11 @@ func (h *serviceHandler) EmailSend(
 func (h *serviceHandler) EmailList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*ememail.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if token == "" {
@@ -104,7 +105,7 @@ func (h *serviceHandler) EmailList(ctx context.Context, a *auth.AuthIdentity, si
 func (h *serviceHandler) EmailGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*ememail.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.emailGet(ctx, id)
@@ -113,7 +114,7 @@ func (h *serviceHandler) EmailGet(ctx context.Context, a *auth.AuthIdentity, id 
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -124,7 +125,7 @@ func (h *serviceHandler) EmailGet(ctx context.Context, a *auth.AuthIdentity, id 
 func (h *serviceHandler) EmailDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*ememail.WebhookMessage, error) {
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get flow
@@ -134,7 +135,7 @@ func (h *serviceHandler) EmailDelete(ctx context.Context, a *auth.AuthIdentity, 
 	}
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.EmailV1EmailDelete(ctx, id)

--- a/bin-api-manager/pkg/servicehandler/email_test.go
+++ b/bin-api-manager/pkg/servicehandler/email_test.go
@@ -105,7 +105,7 @@ func Test_EmailList(t *testing.T) {
 		pageSize  uint64
 
 		responseEmails []ememail.Email
-		expectFilters map[ememail.Field]any
+		expectFilters  map[ememail.Field]any
 		expectRes      []*ememail.WebhookMessage
 	}{
 		{

--- a/bin-api-manager/pkg/servicehandler/extension.go
+++ b/bin-api-manager/pkg/servicehandler/extension.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	rmextension "monorepo/bin-registrar-manager/models/extension"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -45,12 +46,12 @@ func (h *serviceHandler) ExtensionCreate(ctx context.Context, a *auth.AuthIdenti
 	log.Debug("Creating a new extension.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RegistrarV1ExtensionCreate(ctx, a.CustomerID, ext, password, name, detail)
@@ -73,7 +74,7 @@ func (h *serviceHandler) ExtensionDelete(ctx context.Context, a *auth.AuthIdenti
 	log.Debug("Deleting a extension.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	e, err := h.extensionGet(ctx, id)
@@ -84,7 +85,7 @@ func (h *serviceHandler) ExtensionDelete(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, e.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RegistrarV1ExtensionDelete(ctx, id)
@@ -108,7 +109,7 @@ func (h *serviceHandler) ExtensionGet(ctx context.Context, a *auth.AuthIdentity,
 	log.Debug("Getting a extension.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.extensionGet(ctx, id)
@@ -119,7 +120,7 @@ func (h *serviceHandler) ExtensionGet(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -138,7 +139,7 @@ func (h *serviceHandler) ExtensionList(ctx context.Context, a *auth.AuthIdentity
 	log.Debug("Getting a extensions.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -147,7 +148,7 @@ func (h *serviceHandler) ExtensionList(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[string]string{
@@ -188,7 +189,7 @@ func (h *serviceHandler) ExtensionUpdate(ctx context.Context, a *auth.AuthIdenti
 	log.Debug("Updating an extension.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	e, err := h.extensionGet(ctx, id)
@@ -199,7 +200,7 @@ func (h *serviceHandler) ExtensionUpdate(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, e.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RegistrarV1ExtensionUpdate(ctx, id, name, detail, password)
@@ -222,7 +223,7 @@ func (h *serviceHandler) ExtensionDirectHashRegenerate(ctx context.Context, a *a
 	log.Debug("Regenerating extension direct hash.")
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	e, err := h.extensionGet(ctx, extensionID)
@@ -233,7 +234,7 @@ func (h *serviceHandler) ExtensionDirectHashRegenerate(ctx context.Context, a *a
 
 	if !h.hasPermission(ctx, a, e.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RegistrarV1ExtensionDirectHashRegenerate(ctx, extensionID)

--- a/bin-api-manager/pkg/servicehandler/flow.go
+++ b/bin-api-manager/pkg/servicehandler/flow.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	fmaction "monorepo/bin-flow-manager/models/action"
 	fmflow "monorepo/bin-flow-manager/models/flow"
 
@@ -41,20 +42,20 @@ func (h *serviceHandler) FlowCreate(
 	persist bool,
 ) (*fmflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if persist {
 		// we are making a persist flow here.
 		// need to check if the customer has permission to create a persist flow.
 		if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	} else {
 		// we are making a non-persist flow here.
 		// no need to check the agent's permission. checking the customer id is good enough
 		if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
-			return nil, fmt.Errorf("user has no permission")
+			return nil, serviceerrors.ErrPermissionDenied
 		}
 	}
 
@@ -66,7 +67,7 @@ func (h *serviceHandler) FlowCreate(
 		}
 
 		if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission for the onComplete flow")
+			return nil, fmt.Errorf("%w: onComplete flow", serviceerrors.ErrPermissionDenied)
 		}
 	}
 
@@ -82,7 +83,7 @@ func (h *serviceHandler) FlowCreate(
 // FlowDelete deletes the flow of the given id.
 func (h *serviceHandler) FlowDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*fmflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get flow
@@ -92,7 +93,7 @@ func (h *serviceHandler) FlowDelete(ctx context.Context, a *auth.AuthIdentity, i
 	}
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.FlowV1FlowDelete(ctx, id)
@@ -113,7 +114,7 @@ func (h *serviceHandler) FlowDirectHashRegenerate(ctx context.Context, a *auth.A
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Regenerating flow direct hash.")
@@ -126,7 +127,7 @@ func (h *serviceHandler) FlowDirectHashRegenerate(ctx context.Context, a *auth.A
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.FlowV1FlowDirectHashRegenerate(ctx, flowID)
@@ -143,7 +144,7 @@ func (h *serviceHandler) FlowDirectHashRegenerate(ctx context.Context, a *auth.A
 // It returns flow if it succeed.
 func (h *serviceHandler) FlowGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*fmflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get flow
@@ -153,7 +154,7 @@ func (h *serviceHandler) FlowGet(ctx context.Context, a *auth.AuthIdentity, id u
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -164,11 +165,11 @@ func (h *serviceHandler) FlowGet(ctx context.Context, a *auth.AuthIdentity, id u
 // It returns list of flows if it succeed.
 func (h *serviceHandler) FlowList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*fmflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if token == "" {
@@ -210,7 +211,7 @@ func (h *serviceHandler) FlowUpdate(
 	onCompleteID uuid.UUID,
 ) (*fmflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get flows
@@ -220,7 +221,7 @@ func (h *serviceHandler) FlowUpdate(
 	}
 
 	if !h.hasPermission(ctx, a, tmpFlow.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if onCompleteID != uuid.Nil {
@@ -230,7 +231,7 @@ func (h *serviceHandler) FlowUpdate(
 		}
 
 		if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-			return nil, fmt.Errorf("user has no permission for the onComplete flow")
+			return nil, fmt.Errorf("%w: onComplete flow", serviceerrors.ErrPermissionDenied)
 		}
 	}
 
@@ -247,7 +248,7 @@ func (h *serviceHandler) FlowUpdate(
 // It returns updated flow if it succeed.
 func (h *serviceHandler) FlowUpdateActions(ctx context.Context, a *auth.AuthIdentity, flowID uuid.UUID, actions []fmaction.Action) (*fmflow.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get flows
@@ -257,7 +258,7 @@ func (h *serviceHandler) FlowUpdateActions(ctx context.Context, a *auth.AuthIden
 	}
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.FlowV1FlowUpdateActions(ctx, flowID, actions)

--- a/bin-api-manager/pkg/servicehandler/groupcall.go
+++ b/bin-api-manager/pkg/servicehandler/groupcall.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmgroupcall "monorepo/bin-call-manager/models/groupcall"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
@@ -49,7 +49,7 @@ func (h *serviceHandler) GroupcallList(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -58,7 +58,7 @@ func (h *serviceHandler) GroupcallList(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -102,7 +102,7 @@ func (h *serviceHandler) GroupcallGet(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get call
@@ -115,7 +115,7 @@ func (h *serviceHandler) GroupcallGet(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// convert
@@ -139,14 +139,14 @@ func (h *serviceHandler) GroupcallCreate(ctx context.Context, a *auth.AuthIdenti
 		"answer_method": answerMethod,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Creating a new groupcall.")
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	targetFlowID := flowID
@@ -186,7 +186,7 @@ func (h *serviceHandler) GroupcallHangup(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	gc, err := h.groupcallGet(ctx, groupcallID)
@@ -198,7 +198,7 @@ func (h *serviceHandler) GroupcallHangup(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, gc.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -227,7 +227,7 @@ func (h *serviceHandler) GroupcallDelete(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	gc, err := h.groupcallGet(ctx, callID)
@@ -239,7 +239,7 @@ func (h *serviceHandler) GroupcallDelete(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, gc.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request

--- a/bin-api-manager/pkg/servicehandler/groupcall_test.go
+++ b/bin-api-manager/pkg/servicehandler/groupcall_test.go
@@ -97,7 +97,7 @@ func Test_GroupcallCreate(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent        *auth.AuthIdentity
 		source       commonaddress.Address
 		destinations []commonaddress.Address
 		flowID       uuid.UUID
@@ -191,7 +191,7 @@ func Test_GroupcallHangup(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		groupcallID uuid.UUID
 
 		responseGroupcall *cmgroupcall.Groupcall
@@ -260,7 +260,7 @@ func Test_GroupcallDelete(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		groupcallID uuid.UUID
 
 		responseGroupcall *cmgroupcall.Groupcall

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -70,9 +70,9 @@ import (
 
 	tmsipmessage "monorepo/bin-timeline-manager/models/sipmessage"
 
+	tkchat "monorepo/bin-talk-manager/models/chat"
 	tkmessage "monorepo/bin-talk-manager/models/message"
 	tkparticipant "monorepo/bin-talk-manager/models/participant"
-	tkchat "monorepo/bin-talk-manager/models/chat"
 
 	rmrag "monorepo/bin-rag-manager/models/rag"
 

--- a/bin-api-manager/pkg/servicehandler/message.go
+++ b/bin-api-manager/pkg/servicehandler/message.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 
 	mmmessage "monorepo/bin-message-manager/models/message"
@@ -47,7 +48,7 @@ func (h *serviceHandler) MessageList(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -56,7 +57,7 @@ func (h *serviceHandler) MessageList(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get messages
@@ -90,7 +91,7 @@ func (h *serviceHandler) MessageSend(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if len(destinations) <= 0 {
@@ -100,7 +101,7 @@ func (h *serviceHandler) MessageSend(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send message
@@ -126,7 +127,7 @@ func (h *serviceHandler) MessageGet(ctx context.Context, a *auth.AuthIdentity, i
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get message info
@@ -138,7 +139,7 @@ func (h *serviceHandler) MessageGet(ctx context.Context, a *auth.AuthIdentity, i
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if tmp.TMDelete != nil {
@@ -163,7 +164,7 @@ func (h *serviceHandler) MessageDelete(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get message info
@@ -175,7 +176,7 @@ func (h *serviceHandler) MessageDelete(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, m.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// delete message info

--- a/bin-api-manager/pkg/servicehandler/message_test.go
+++ b/bin-api-manager/pkg/servicehandler/message_test.go
@@ -26,7 +26,7 @@ func Test_MessageList(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 

--- a/bin-api-manager/pkg/servicehandler/numbers.go
+++ b/bin-api-manager/pkg/servicehandler/numbers.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	nmnumber "monorepo/bin-number-manager/models/number"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
-	cscustomer "monorepo/bin-customer-manager/models/customer"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
+	cscustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -50,7 +51,7 @@ func (h *serviceHandler) NumberList(ctx context.Context, a *auth.AuthIdentity, s
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -59,7 +60,7 @@ func (h *serviceHandler) NumberList(ctx context.Context, a *auth.AuthIdentity, s
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -103,7 +104,7 @@ func (h *serviceHandler) NumberCreate(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if num == "" {
@@ -113,7 +114,7 @@ func (h *serviceHandler) NumberCreate(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// check identity verification for non-virtual number purchases
@@ -154,7 +155,7 @@ func (h *serviceHandler) NumberGet(ctx context.Context, a *auth.AuthIdentity, id
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get number info
@@ -185,7 +186,7 @@ func (h *serviceHandler) NumberDelete(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get number info
@@ -197,7 +198,7 @@ func (h *serviceHandler) NumberDelete(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, n.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// delete numbers
@@ -224,7 +225,7 @@ func (h *serviceHandler) NumberUpdate(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get number
@@ -273,7 +274,7 @@ func (h *serviceHandler) NumberUpdateFlowIDs(ctx context.Context, a *auth.AuthId
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get number
@@ -309,7 +310,7 @@ func (h *serviceHandler) NumberUpdateMetadata(ctx context.Context, a *auth.AuthI
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get number
@@ -346,13 +347,13 @@ func (h *serviceHandler) NumberRenew(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// project admin only
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get number

--- a/bin-api-manager/pkg/servicehandler/numbers_test.go
+++ b/bin-api-manager/pkg/servicehandler/numbers_test.go
@@ -343,7 +343,7 @@ func Test_NumberDelete(t *testing.T) {
 				Status:              nmnumber.StatusActive,
 				T38Enabled:          false,
 				EmergencyEnabled:    false,
-				TMDelete: nil,
+				TMDelete:            nil,
 			},
 			&nmnumber.Number{
 				Identity: commonidentity.Identity{
@@ -438,7 +438,7 @@ func Test_NumberUpdate(t *testing.T) {
 				Status:              nmnumber.StatusActive,
 				T38Enabled:          false,
 				EmergencyEnabled:    false,
-				TMDelete: nil,
+				TMDelete:            nil,
 			},
 			&fmflow.Flow{
 				Identity: commonidentity.Identity{
@@ -466,7 +466,7 @@ func Test_NumberUpdate(t *testing.T) {
 				Status:              nmnumber.StatusActive,
 				T38Enabled:          false,
 				EmergencyEnabled:    false,
-				TMDelete: nil,
+				TMDelete:            nil,
 			},
 		},
 	}
@@ -659,7 +659,7 @@ func Test_numberVerifyFlow(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent  *auth.AuthIdentity
 		flowID uuid.UUID
 
 		responseFlow *fmflow.Flow

--- a/bin-api-manager/pkg/servicehandler/outdials.go
+++ b/bin-api-manager/pkg/servicehandler/outdials.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	omoutdial "monorepo/bin-outdial-manager/models/outdial"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -40,7 +41,7 @@ func (h *serviceHandler) OutdialCreate(ctx context.Context, a *auth.AuthIdentity
 		"name":        name,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Creating a new outdial.")
@@ -71,7 +72,7 @@ func (h *serviceHandler) OutdialGetsByCustomerID(ctx context.Context, a *auth.Au
 		"token":       token,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Getting a outdials.")
@@ -114,7 +115,7 @@ func (h *serviceHandler) OutdialDelete(ctx context.Context, a *auth.AuthIdentity
 		"outdial_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Deleting a outdial.")
@@ -151,7 +152,7 @@ func (h *serviceHandler) OutdialGet(ctx context.Context, a *auth.AuthIdentity, i
 		"outdial_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Getting an outdial.")
@@ -182,7 +183,7 @@ func (h *serviceHandler) OutdialUpdateBasicInfo(ctx context.Context, a *auth.Aut
 		"outdial_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Updating an outdial.")
@@ -220,7 +221,7 @@ func (h *serviceHandler) OutdialUpdateCampaignID(ctx context.Context, a *auth.Au
 		"campaign_id": campaignID,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Executing OutdialUpdateCampaignID.")
@@ -258,7 +259,7 @@ func (h *serviceHandler) OutdialUpdateData(ctx context.Context, a *auth.AuthIden
 		"data":        data,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Executing OutdialUpdateData.")

--- a/bin-api-manager/pkg/servicehandler/outdials_test.go
+++ b/bin-api-manager/pkg/servicehandler/outdials_test.go
@@ -25,7 +25,7 @@ func Test_OutdialCreate(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		campaignID  uuid.UUID
 		outdialName string
 		detail      string
@@ -100,7 +100,7 @@ func Test_OutdialList(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 
@@ -177,7 +177,7 @@ func Test_OutdialDelete(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		outdialID uuid.UUID
 
 		response  *omoutdial.Outdial
@@ -242,7 +242,7 @@ func Test_OutdialUpdate(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		outdialID   uuid.UUID
 		outdialName string
 		detail      string
@@ -311,7 +311,7 @@ func Test_OutdialUpdateCampaignID(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		outdialID  uuid.UUID
 		campaignID uuid.UUID
 
@@ -377,7 +377,7 @@ func Test_OutdialUpdateData(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		outdialID uuid.UUID
 		data      string
 

--- a/bin-api-manager/pkg/servicehandler/outdialtargets.go
+++ b/bin-api-manager/pkg/servicehandler/outdialtargets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 
 	omoutdialtarget "monorepo/bin-outdial-manager/models/outdialtarget"
@@ -38,7 +39,7 @@ func (h *serviceHandler) OutdialtargetCreate(
 		"data":        data,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Executing OutdialUpdateData.")
@@ -87,7 +88,7 @@ func (h *serviceHandler) OutdialtargetGet(ctx context.Context, a *auth.AuthIdent
 		"outdial_id":  outdialID,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Executing OutdialtargetGet.")
@@ -132,7 +133,7 @@ func (h *serviceHandler) OutdialtargetGetsByOutdialID(ctx context.Context, a *au
 		"token":       token,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Getting a outdials.")
@@ -180,7 +181,7 @@ func (h *serviceHandler) OutdialtargetDelete(ctx context.Context, a *auth.AuthId
 		"outdial_id":  outdialID,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Executing OutdialtargetDelete.")

--- a/bin-api-manager/pkg/servicehandler/outdialtargets_test.go
+++ b/bin-api-manager/pkg/servicehandler/outdialtargets_test.go
@@ -164,7 +164,7 @@ func Test_OutdialtargetGet(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		agent *auth.AuthIdentity
+		agent           *auth.AuthIdentity
 		outdialID       uuid.UUID
 		outdialtargetID uuid.UUID
 
@@ -233,7 +233,7 @@ func Test_OutdialtargetListByOutdialID(t *testing.T) {
 
 	type test struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		outdialID uuid.UUID
 		pageToken string
 		pageSize  uint64
@@ -315,7 +315,7 @@ func Test_OutdialtargetDelete(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		agent *auth.AuthIdentity
+		agent           *auth.AuthIdentity
 		outdialID       uuid.UUID
 		outdialtargetID uuid.UUID
 

--- a/bin-api-manager/pkg/servicehandler/outplans.go
+++ b/bin-api-manager/pkg/servicehandler/outplans.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 
 	caoutplan "monorepo/bin-campaign-manager/models/outplan"
@@ -55,7 +56,7 @@ func (h *serviceHandler) OutplanCreate(
 		"name":        name,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Creating a new outplan.")
@@ -63,7 +64,7 @@ func (h *serviceHandler) OutplanCreate(
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1OutplanCreate(ctx, a.CustomerID, name, detail, source, dialTimeout, tryInterval, maxTryCount0, maxTryCount1, maxTryCount2, maxTryCount3, maxTryCount4)
@@ -85,7 +86,7 @@ func (h *serviceHandler) OutplanDelete(ctx context.Context, a *auth.AuthIdentity
 		"outplan_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Deleting a outplan.")
@@ -121,7 +122,7 @@ func (h *serviceHandler) OutplanGetsByCustomerID(ctx context.Context, a *auth.Au
 		"token":       token,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Getting a outplans.")
@@ -165,7 +166,7 @@ func (h *serviceHandler) OutplanGet(ctx context.Context, a *auth.AuthIdentity, i
 		"outplan_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Getting an outplan.")
@@ -196,7 +197,7 @@ func (h *serviceHandler) OutplanUpdateBasicInfo(ctx context.Context, a *auth.Aut
 		"outplan_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Updating an outplan.")
@@ -245,7 +246,7 @@ func (h *serviceHandler) OutplanUpdateDialInfo(
 		"outplan_id":  id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Updating an outplan.")

--- a/bin-api-manager/pkg/servicehandler/outplans_test.go
+++ b/bin-api-manager/pkg/servicehandler/outplans_test.go
@@ -176,7 +176,7 @@ func Test_OutplanListByCustomerID(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 
@@ -253,7 +253,7 @@ func Test_OutplanGet(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		outplanID uuid.UUID
 
 		response  *caoutplan.Outplan
@@ -317,7 +317,7 @@ func Test_OutplanUpdateBasicInfo(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		outplanID   uuid.UUID
 		outplanName string
 		detail      string
@@ -386,7 +386,7 @@ func Test_OutplanUpdateDialInfo(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		agent *auth.AuthIdentity
+		agent        *auth.AuthIdentity
 		outplanID    uuid.UUID
 		source       *commonaddress.Address
 		dialTimeout  int

--- a/bin-api-manager/pkg/servicehandler/provider.go
+++ b/bin-api-manager/pkg/servicehandler/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonrequesthandler "monorepo/bin-common-handler/pkg/requesthandler"
 	rmprovider "monorepo/bin-route-manager/models/provider"
 
@@ -45,7 +46,7 @@ func (h *serviceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.providerGet(ctx, providerID)
@@ -75,7 +76,7 @@ func (h *serviceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -120,7 +121,7 @@ func (h *serviceHandler) ProviderCreate(
 		"customer_id": a.CustomerID,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Creating a new provider.")
@@ -159,7 +160,7 @@ func (h *serviceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentit
 		"provider_id": id,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Deleting a provider.")
@@ -197,7 +198,7 @@ func (h *serviceHandler) ProviderSetup(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -240,7 +241,7 @@ func (h *serviceHandler) ProviderUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {

--- a/bin-api-manager/pkg/servicehandler/providercall.go
+++ b/bin-api-manager/pkg/servicehandler/providercall.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	fmaction "monorepo/bin-flow-manager/models/action"
 	rmprovidercall "monorepo/bin-route-manager/models/providercall"
@@ -47,7 +48,7 @@ func (h *serviceHandler) ProviderCallCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// permission — project admin only
@@ -92,7 +93,7 @@ func (h *serviceHandler) ProviderCallGet(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -125,7 +126,7 @@ func (h *serviceHandler) ProviderCallGets(ctx context.Context, a *auth.AuthIdent
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
@@ -166,7 +167,7 @@ func (h *serviceHandler) ProviderCallDelete(ctx context.Context, a *auth.AuthIde
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {

--- a/bin-api-manager/pkg/servicehandler/queue.go
+++ b/bin-api-manager/pkg/servicehandler/queue.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	qmqueue "monorepo/bin-queue-manager/models/queue"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -43,7 +43,7 @@ func (h *serviceHandler) QueueGet(ctx context.Context, a *auth.AuthIdentity, que
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.queueGet(ctx, queueID)
@@ -55,7 +55,7 @@ func (h *serviceHandler) QueueGet(ctx context.Context, a *auth.AuthIdentity, que
 	// permission check
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -75,7 +75,7 @@ func (h *serviceHandler) QueueList(ctx context.Context, a *auth.AuthIdentity, si
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -85,7 +85,7 @@ func (h *serviceHandler) QueueList(ctx context.Context, a *auth.AuthIdentity, si
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -136,13 +136,13 @@ func (h *serviceHandler) QueueCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueueCreate(
@@ -177,7 +177,7 @@ func (h *serviceHandler) QueueDelete(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	q, err := h.queueGet(ctx, queueID)
@@ -189,7 +189,7 @@ func (h *serviceHandler) QueueDelete(ctx context.Context, a *auth.AuthIdentity, 
 	// permission check
 	if !h.hasPermission(ctx, a, q.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueueDelete(ctx, queueID)
@@ -231,7 +231,7 @@ func (h *serviceHandler) QueueUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	q, err := h.queueGet(ctx, queueID)
@@ -243,7 +243,7 @@ func (h *serviceHandler) QueueUpdate(
 	// permission check
 	if !h.hasPermission(ctx, a, q.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueueUpdate(ctx, queueID, name, detail, routingMethod, tagIDs, waitFlowID, timeoutWait, serviceTimeout)
@@ -268,7 +268,7 @@ func (h *serviceHandler) QueueUpdateTagIDs(ctx context.Context, a *auth.AuthIden
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	q, err := h.queueGet(ctx, queueID)
@@ -280,7 +280,7 @@ func (h *serviceHandler) QueueUpdateTagIDs(ctx context.Context, a *auth.AuthIden
 	// permission check
 	if !h.hasPermission(ctx, a, q.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueueUpdateTagIDs(ctx, queueID, tagIDs)
@@ -305,7 +305,7 @@ func (h *serviceHandler) QueueUpdateRoutingMethod(ctx context.Context, a *auth.A
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	q, err := h.queueGet(ctx, queueID)
@@ -317,7 +317,7 @@ func (h *serviceHandler) QueueUpdateRoutingMethod(ctx context.Context, a *auth.A
 	// permission check
 	if !h.hasPermission(ctx, a, q.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueueUpdateRoutingMethod(ctx, queueID, routingMethod)
@@ -339,7 +339,7 @@ func (h *serviceHandler) QueueDirectHashRegenerate(ctx context.Context, a *auth.
 		"queue_id":    queueID,
 	})
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log.Debug("Regenerating queue direct hash.")
@@ -352,7 +352,7 @@ func (h *serviceHandler) QueueDirectHashRegenerate(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, q.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueueDirectHashRegenerate(ctx, queueID)

--- a/bin-api-manager/pkg/servicehandler/queue_test.go
+++ b/bin-api-manager/pkg/servicehandler/queue_test.go
@@ -24,7 +24,7 @@ func Test_QueueList(t *testing.T) {
 
 	type test struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 
@@ -168,7 +168,7 @@ func Test_QueueCreate(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent          *auth.AuthIdentity
 		queueName      string
 		detail         string
 		routingMethod  qmqueue.RoutingMethod
@@ -338,7 +338,7 @@ func Test_QueueUpdate(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent          *auth.AuthIdentity
 		queueID        uuid.UUID
 		queueName      string
 		detail         string
@@ -443,7 +443,7 @@ func Test_QueueUpdateTagIDs(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent   *auth.AuthIdentity
 		queueID uuid.UUID
 		tagIDs  []uuid.UUID
 
@@ -546,7 +546,7 @@ func Test_QueueUpdateRoutingMethod(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent         *auth.AuthIdentity
 		queueID       uuid.UUID
 		routingMethod qmqueue.RoutingMethod
 

--- a/bin-api-manager/pkg/servicehandler/queuecall.go
+++ b/bin-api-manager/pkg/servicehandler/queuecall.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	qmqueuecall "monorepo/bin-queue-manager/models/queuecall"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -43,7 +43,7 @@ func (h *serviceHandler) queuecallGetByReferenceID(ctx context.Context, a *auth.
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -68,7 +68,7 @@ func (h *serviceHandler) QueuecallGet(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.queuecallGet(ctx, queueID)
@@ -80,7 +80,7 @@ func (h *serviceHandler) QueuecallGet(ctx context.Context, a *auth.AuthIdentity,
 	// permission check
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -100,7 +100,7 @@ func (h *serviceHandler) QueuecallList(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -110,7 +110,7 @@ func (h *serviceHandler) QueuecallList(ctx context.Context, a *auth.AuthIdentity
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -150,7 +150,7 @@ func (h *serviceHandler) QueuecallDelete(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	qc, err := h.queuecallGet(ctx, queuecallID)
@@ -162,7 +162,7 @@ func (h *serviceHandler) QueuecallDelete(ctx context.Context, a *auth.AuthIdenti
 	// permission check
 	if !h.hasPermission(ctx, a, qc.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueuecallDelete(ctx, queuecallID)
@@ -186,7 +186,7 @@ func (h *serviceHandler) QueuecallKick(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	qc, err := h.queuecallGet(ctx, queuecallID)
@@ -198,7 +198,7 @@ func (h *serviceHandler) QueuecallKick(ctx context.Context, a *auth.AuthIdentity
 	// permission check
 	if !h.hasPermission(ctx, a, qc.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueuecallKick(ctx, queuecallID)
@@ -222,7 +222,7 @@ func (h *serviceHandler) QueuecallKickByReferenceID(ctx context.Context, a *auth
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	qc, err := h.queuecallGetByReferenceID(ctx, a, referenceID)
@@ -234,7 +234,7 @@ func (h *serviceHandler) QueuecallKickByReferenceID(ctx context.Context, a *auth
 	// permission check
 	if !h.hasPermission(ctx, a, qc.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.QueueV1QueuecallKick(ctx, qc.ID)

--- a/bin-api-manager/pkg/servicehandler/queuecall_test.go
+++ b/bin-api-manager/pkg/servicehandler/queuecall_test.go
@@ -24,12 +24,12 @@ func Test_QueuecallList(t *testing.T) {
 
 	type test struct {
 		name      string
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 
 		responseQueuecalls []qmqueuecall.Queuecall
-		expectFilters map[qmqueuecall.Field]any
+		expectFilters      map[qmqueuecall.Field]any
 		expectRes          []*qmqueuecall.WebhookMessage
 	}
 
@@ -232,7 +232,7 @@ func Test_QueuecallKick(t *testing.T) {
 
 	type test struct {
 		name        string
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		queuecallID uuid.UUID
 
 		responseQueuecall *qmqueuecall.Queuecall
@@ -300,7 +300,7 @@ func Test_QueuecallKickByReferenceID(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		referenceID uuid.UUID
 
 		responseQueuecall *qmqueuecall.Queuecall

--- a/bin-api-manager/pkg/servicehandler/rag.go
+++ b/bin-api-manager/pkg/servicehandler/rag.go
@@ -9,6 +9,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	rmrag "monorepo/bin-rag-manager/models/rag"
 )
 
@@ -31,7 +32,7 @@ func (h *serviceHandler) ragGet(ctx context.Context, id uuid.UUID) (*rmrag.Rag, 
 
 func (h *serviceHandler) RagCreate(ctx context.Context, a *auth.AuthIdentity, name, description string, storageFileIDs []uuid.UUID, sourceURLs []string) (*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -41,7 +42,7 @@ func (h *serviceHandler) RagCreate(ctx context.Context, a *auth.AuthIdentity, na
 	})
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	log.Debug("Creating a new rag.")
@@ -57,7 +58,7 @@ func (h *serviceHandler) RagCreate(ctx context.Context, a *auth.AuthIdentity, na
 
 func (h *serviceHandler) RagGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -74,7 +75,7 @@ func (h *serviceHandler) RagGet(ctx context.Context, a *auth.AuthIdentity, id uu
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -83,7 +84,7 @@ func (h *serviceHandler) RagGet(ctx context.Context, a *auth.AuthIdentity, id uu
 
 func (h *serviceHandler) RagGets(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -99,7 +100,7 @@ func (h *serviceHandler) RagGets(ctx context.Context, a *auth.AuthIdentity, size
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[rmrag.Field]any{
@@ -122,7 +123,7 @@ func (h *serviceHandler) RagGets(ctx context.Context, a *auth.AuthIdentity, size
 
 func (h *serviceHandler) RagUpdate(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID, fields map[rmrag.Field]any) (*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -139,7 +140,7 @@ func (h *serviceHandler) RagUpdate(ctx context.Context, a *auth.AuthIdentity, id
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	updated, err := h.reqHandler.RagV1RagUpdate(ctx, id, fields)
@@ -154,7 +155,7 @@ func (h *serviceHandler) RagUpdate(ctx context.Context, a *auth.AuthIdentity, id
 
 func (h *serviceHandler) RagDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -171,7 +172,7 @@ func (h *serviceHandler) RagDelete(ctx context.Context, a *auth.AuthIdentity, id
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if err := h.reqHandler.RagV1RagDelete(ctx, id); err != nil {
@@ -185,7 +186,7 @@ func (h *serviceHandler) RagDelete(ctx context.Context, a *auth.AuthIdentity, id
 
 func (h *serviceHandler) RagAddSources(ctx context.Context, a *auth.AuthIdentity, ragID uuid.UUID, storageFileIDs []uuid.UUID, sourceURLs []string) (*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -203,7 +204,7 @@ func (h *serviceHandler) RagAddSources(ctx context.Context, a *auth.AuthIdentity
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	r, err := h.reqHandler.RagV1RagAddSources(ctx, ragID, storageFileIDs, sourceURLs)
@@ -218,7 +219,7 @@ func (h *serviceHandler) RagAddSources(ctx context.Context, a *auth.AuthIdentity
 
 func (h *serviceHandler) RagRemoveSource(ctx context.Context, a *auth.AuthIdentity, ragID, sourceID uuid.UUID) (*rmrag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -237,7 +238,7 @@ func (h *serviceHandler) RagRemoveSource(ctx context.Context, a *auth.AuthIdenti
 	}
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	r, err := h.reqHandler.RagV1RagRemoveSource(ctx, ragID, sourceID)

--- a/bin-api-manager/pkg/servicehandler/recording.go
+++ b/bin-api-manager/pkg/servicehandler/recording.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmrecording "monorepo/bin-call-manager/models/recording"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -46,7 +47,7 @@ func (h *serviceHandler) RecordingGet(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get recording info from call-manager
@@ -79,7 +80,7 @@ func (h *serviceHandler) RecordingList(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -130,7 +131,7 @@ func (h *serviceHandler) RecordingDelete(ctx context.Context, a *auth.AuthIdenti
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	r, err := h.recordingGet(ctx, id)

--- a/bin-api-manager/pkg/servicehandler/recording_test.go
+++ b/bin-api-manager/pkg/servicehandler/recording_test.go
@@ -124,7 +124,7 @@ func Test_RecordingDelete(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent       *auth.AuthIdentity
 		recordingID uuid.UUID
 
 		responseRecording *cmrecording.Recording

--- a/bin-api-manager/pkg/servicehandler/recordingfile.go
+++ b/bin-api-manager/pkg/servicehandler/recordingfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 
@@ -21,7 +22,7 @@ func (h *serviceHandler) RecordingfileGet(ctx context.Context, a *auth.AuthIdent
 	})
 
 	if a.IsDirect() {
-		return "", fmt.Errorf("direct access not supported")
+		return "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get r info from call-manager

--- a/bin-api-manager/pkg/servicehandler/route.go
+++ b/bin-api-manager/pkg/servicehandler/route.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	rmroute "monorepo/bin-route-manager/models/route"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
@@ -43,7 +44,7 @@ func (h *serviceHandler) RouteGet(ctx context.Context, a *auth.AuthIdentity, rou
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// permission check
@@ -74,7 +75,7 @@ func (h *serviceHandler) RouteList(ctx context.Context, a *auth.AuthIdentity, si
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -117,7 +118,7 @@ func (h *serviceHandler) RouteGetsByCustomerID(ctx context.Context, a *auth.Auth
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -169,7 +170,7 @@ func (h *serviceHandler) RouteCreate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// permission check
@@ -209,7 +210,7 @@ func (h *serviceHandler) RouteDelete(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// permission check
@@ -255,7 +256,7 @@ func (h *serviceHandler) RouteUpdate(
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// permission check

--- a/bin-api-manager/pkg/servicehandler/route_test.go
+++ b/bin-api-manager/pkg/servicehandler/route_test.go
@@ -324,7 +324,7 @@ func Test_RouteDelete(t *testing.T) {
 	type test struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent   *auth.AuthIdentity
 		routeID uuid.UUID
 
 		responseRoute *rmroute.Route

--- a/bin-api-manager/pkg/servicehandler/serviceagent_agent.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -15,7 +16,7 @@ import (
 // it returns list of agents if it succeed.
 func (h *serviceHandler) ServiceAgentAgentList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -65,7 +66,7 @@ func (h *serviceHandler) ServiceAgentAgentList(ctx context.Context, a *auth.Auth
 // ServiceAgentAgentGet returns the given agent info.
 func (h *serviceHandler) ServiceAgentAgentGet(ctx context.Context, a *auth.AuthIdentity, agentID uuid.UUID) (*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -88,4 +89,3 @@ func (h *serviceHandler) ServiceAgentAgentGet(ctx context.Context, a *auth.AuthI
 	res := tmp.ConvertWebhookMessage()
 	return res, nil
 }
-

--- a/bin-api-manager/pkg/servicehandler/serviceagent_call.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_call.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmcall "monorepo/bin-call-manager/models/call"
 
 	"github.com/gofrs/uuid"
@@ -16,7 +17,7 @@ import (
 // it returns list of calls if it succeed.
 func (h *serviceHandler) ServiceAgentCallList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*cmcall.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -57,7 +58,7 @@ func (h *serviceHandler) ServiceAgentCallList(ctx context.Context, a *auth.AuthI
 // it returns call if it succeed.
 func (h *serviceHandler) ServiceAgentCallGet(ctx context.Context, a *auth.AuthIdentity, callID uuid.UUID) (*cmcall.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -75,7 +76,7 @@ func (h *serviceHandler) ServiceAgentCallGet(ctx context.Context, a *auth.AuthId
 	}
 
 	if a.AgentID() != c.OwnerID {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// convert
@@ -88,7 +89,7 @@ func (h *serviceHandler) ServiceAgentCallGet(ctx context.Context, a *auth.AuthId
 // it returns deleted call if it succeed.
 func (h *serviceHandler) ServiceAgentCallDelete(ctx context.Context, a *auth.AuthIdentity, callID uuid.UUID) (*cmcall.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -106,7 +107,7 @@ func (h *serviceHandler) ServiceAgentCallDelete(ctx context.Context, a *auth.Aut
 	}
 
 	if a.AgentID() != c.OwnerID {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res, err := h.callDelete(ctx, callID)

--- a/bin-api-manager/pkg/servicehandler/serviceagent_contact.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_contact.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmcontact "monorepo/bin-contact-manager/models/contact"
 	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
 
@@ -31,7 +32,7 @@ func (h *serviceHandler) ServiceAgentContactCreate(
 	tagIDs []uuid.UUID,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -73,7 +74,7 @@ func (h *serviceHandler) ServiceAgentContactCreate(
 // to get a contact for the service agent.
 func (h *serviceHandler) ServiceAgentContactGet(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -101,7 +102,7 @@ func (h *serviceHandler) ServiceAgentContactGet(ctx context.Context, a *auth.Aut
 // to get a list of contacts for the service agent's customer.
 func (h *serviceHandler) ServiceAgentContactList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, filters map[string]string) ([]*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -157,7 +158,7 @@ func (h *serviceHandler) ServiceAgentContactUpdate(
 	notes *string,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -201,7 +202,7 @@ func (h *serviceHandler) ServiceAgentContactUpdate(
 // to delete a contact for the service agent.
 func (h *serviceHandler) ServiceAgentContactDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -235,7 +236,7 @@ func (h *serviceHandler) ServiceAgentContactDelete(ctx context.Context, a *auth.
 // to lookup a contact by phone or email for the service agent.
 func (h *serviceHandler) ServiceAgentContactLookup(ctx context.Context, a *auth.AuthIdentity, phoneE164 string, email string) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -272,7 +273,7 @@ func (h *serviceHandler) ServiceAgentContactPhoneNumberCreate(
 	isPrimary bool,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -312,7 +313,7 @@ func (h *serviceHandler) ServiceAgentContactPhoneNumberUpdate(
 	fields map[string]any,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -347,7 +348,7 @@ func (h *serviceHandler) ServiceAgentContactPhoneNumberUpdate(
 // to remove a phone number from a contact for the service agent.
 func (h *serviceHandler) ServiceAgentContactPhoneNumberDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, phoneNumberID uuid.UUID) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -389,7 +390,7 @@ func (h *serviceHandler) ServiceAgentContactEmailCreate(
 	isPrimary bool,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -429,7 +430,7 @@ func (h *serviceHandler) ServiceAgentContactEmailUpdate(
 	fields map[string]any,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -464,7 +465,7 @@ func (h *serviceHandler) ServiceAgentContactEmailUpdate(
 // to remove an email from a contact for the service agent.
 func (h *serviceHandler) ServiceAgentContactEmailDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, emailID uuid.UUID) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -499,7 +500,7 @@ func (h *serviceHandler) ServiceAgentContactEmailDelete(ctx context.Context, a *
 // to add a tag to a contact for the service agent.
 func (h *serviceHandler) ServiceAgentContactTagAdd(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, tagID uuid.UUID) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -534,7 +535,7 @@ func (h *serviceHandler) ServiceAgentContactTagAdd(ctx context.Context, a *auth.
 // to remove a tag from a contact for the service agent.
 func (h *serviceHandler) ServiceAgentContactTagRemove(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, tagID uuid.UUID) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversation.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvconversation "monorepo/bin-conversation-manager/models/conversation"
 
 	"github.com/gofrs/uuid"
@@ -14,7 +15,7 @@ import (
 // It returns conversation if it succeed.
 func (h *serviceHandler) ServiceAgentConversationGet(ctx context.Context, a *auth.AuthIdentity, conversationID uuid.UUID) (*cvconversation.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// get
@@ -36,7 +37,7 @@ func (h *serviceHandler) ServiceAgentConversationGet(ctx context.Context, a *aut
 // it returns list of chatroom messages if it succeed.
 func (h *serviceHandler) ServiceAgentConversationList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*cvconversation.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	if token == "" {

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversationmessage.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversationmessage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvmedia "monorepo/bin-conversation-manager/models/media"
 	cvmessage "monorepo/bin-conversation-manager/models/message"
 
@@ -17,7 +18,7 @@ import (
 // it returns list of conversation messages if it succeed.
 func (h *serviceHandler) ServiceAgentConversationMessageList(ctx context.Context, a *auth.AuthIdentity, conversationID uuid.UUID, size uint64, token string) ([]*cvmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	cv, err := h.conversationGet(ctx, conversationID)
@@ -57,7 +58,7 @@ func (h *serviceHandler) ServiceAgentConversationMessageSend(
 	medias []cvmedia.Media,
 ) (*cvmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/serviceagent_customer.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_customer.go
@@ -2,8 +2,8 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cscustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +14,7 @@ import (
 // it returns detail of customer if it succeed.
 func (h *serviceHandler) ServiceAgentCustomerGet(ctx context.Context, a *auth.AuthIdentity) (*cscustomer.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/serviceagent_extension.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_extension.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	rmextension "monorepo/bin-registrar-manager/models/extension"
 
@@ -13,7 +14,7 @@ import (
 
 func (h *serviceHandler) ServiceAgentExtensionList(ctx context.Context, a *auth.AuthIdentity) ([]*rmextension.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -42,7 +43,7 @@ func (h *serviceHandler) ServiceAgentExtensionList(ctx context.Context, a *auth.
 
 func (h *serviceHandler) ServiceAgentExtensionGet(ctx context.Context, a *auth.AuthIdentity, extensionID uuid.UUID) (*rmextension.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/serviceagent_file.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_file.go
@@ -9,6 +9,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 	smfile "monorepo/bin-storage-manager/models/file"
 
@@ -21,7 +22,7 @@ import (
 // it returns created file info if it succeed.
 func (h *serviceHandler) ServiceAgentFileCreate(ctx context.Context, a *auth.AuthIdentity, f multipart.File, fileType smfile.Type, name string, detail string, filename string) (*smfile.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -34,7 +35,7 @@ func (h *serviceHandler) ServiceAgentFileCreate(ctx context.Context, a *auth.Aut
 	log.Debug("Creating a new file.")
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// open file writer
@@ -72,7 +73,7 @@ func (h *serviceHandler) ServiceAgentFileCreate(ctx context.Context, a *auth.Aut
 // It returns list of files if it succeed.
 func (h *serviceHandler) ServiceAgentFileList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*smfile.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -122,7 +123,7 @@ func (h *serviceHandler) ServiceAgentFileList(ctx context.Context, a *auth.AuthI
 // It returns file if it succeed.
 func (h *serviceHandler) ServiceAgentFileGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*smfile.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -143,7 +144,7 @@ func (h *serviceHandler) ServiceAgentFileGet(ctx context.Context, a *auth.AuthId
 	// Check permission - file must belong to the same customer
 	if f.CustomerID != a.CustomerID {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := f.ConvertWebhookMessage()
@@ -153,7 +154,7 @@ func (h *serviceHandler) ServiceAgentFileGet(ctx context.Context, a *auth.AuthId
 // ServiceAgentFileDelete deletes the file of the given id.
 func (h *serviceHandler) ServiceAgentFileDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*smfile.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -173,7 +174,7 @@ func (h *serviceHandler) ServiceAgentFileDelete(ctx context.Context, a *auth.Aut
 
 	if f.OwnerID != a.AgentID() {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.storageFileDelete(ctx, id)
@@ -189,7 +190,7 @@ func (h *serviceHandler) ServiceAgentFileDelete(ctx context.Context, a *auth.Aut
 // If the stored URL has expired, it refreshes via storage-manager RPC.
 func (h *serviceHandler) ServiceAgentFileDownloadRedirect(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (string, error) {
 	if !a.IsAgent() {
-		return "", fmt.Errorf("agent authentication required")
+		return "", serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -211,7 +212,7 @@ func (h *serviceHandler) ServiceAgentFileDownloadRedirect(ctx context.Context, a
 	// Check permission - file must belong to the same customer
 	if f.CustomerID != a.CustomerID {
 		log.Info("The user has no permission.")
-		return "", fmt.Errorf("user has no permission")
+		return "", serviceerrors.ErrPermissionDenied
 	}
 
 	// check if download URL is still valid

--- a/bin-api-manager/pkg/servicehandler/serviceagent_me.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_me.go
@@ -2,9 +2,9 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +14,7 @@ import (
 // It returns updated agent info.
 func (h *serviceHandler) ServiceAgentMeGet(ctx context.Context, a *auth.AuthIdentity) (*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -36,7 +36,7 @@ func (h *serviceHandler) ServiceAgentMeGet(ctx context.Context, a *auth.AuthIden
 // It returns updated agent info.
 func (h *serviceHandler) ServiceAgentMeUpdate(ctx context.Context, a *auth.AuthIdentity, name string, detail string, ringMethod amagent.RingMethod) (*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -59,7 +59,7 @@ func (h *serviceHandler) ServiceAgentMeUpdate(ctx context.Context, a *auth.AuthI
 // It returns updated agent info.
 func (h *serviceHandler) ServiceAgentMeUpdateAddresses(ctx context.Context, a *auth.AuthIdentity, addresses []commonaddress.Address) (*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -82,7 +82,7 @@ func (h *serviceHandler) ServiceAgentMeUpdateAddresses(ctx context.Context, a *a
 // It returns updated agent info.
 func (h *serviceHandler) ServiceAgentMeUpdateStatus(ctx context.Context, a *auth.AuthIdentity, status amagent.Status) (*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -105,7 +105,7 @@ func (h *serviceHandler) ServiceAgentMeUpdateStatus(ctx context.Context, a *auth
 // It returns updated agent info.
 func (h *serviceHandler) ServiceAgentMeUpdatePassword(ctx context.Context, a *auth.AuthIdentity, password string) (*amagent.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/serviceagent_tag.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_tag.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	tmtag "monorepo/bin-tag-manager/models/tag"
 
 	"github.com/gofrs/uuid"
@@ -15,7 +16,7 @@ import (
 // ServiceAgentTagList returns a list of tags for the service agent's customer.
 func (h *serviceHandler) ServiceAgentTagList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*tmtag.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -56,7 +57,7 @@ func (h *serviceHandler) ServiceAgentTagList(ctx context.Context, a *auth.AuthId
 // ServiceAgentTagGet returns the given tag info.
 func (h *serviceHandler) ServiceAgentTagGet(ctx context.Context, a *auth.AuthIdentity, tagID uuid.UUID) (*tmtag.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/serviceagent_talk.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_talk.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	tkchat "monorepo/bin-talk-manager/models/chat"
 	tkmessage "monorepo/bin-talk-manager/models/message"
 	tkparticipant "monorepo/bin-talk-manager/models/participant"
@@ -16,7 +17,7 @@ import (
 // ServiceAgentTalkChatGet gets a chat by ID
 func (h *serviceHandler) ServiceAgentTalkChatGet(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID) (*tkchat.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission - agent must have access to the chat
@@ -40,7 +41,7 @@ func (h *serviceHandler) ServiceAgentTalkChatGet(ctx context.Context, a *auth.Au
 // Returns only chats where the agent has joined (talk, group, or direct types)
 func (h *serviceHandler) ServiceAgentTalkChatList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*tkchat.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	if token == "" {
@@ -71,7 +72,7 @@ func (h *serviceHandler) ServiceAgentTalkChatList(ctx context.Context, a *auth.A
 // Returns all public channels regardless of agent participation (for discovery/joining)
 func (h *serviceHandler) ServiceAgentTalkChannelList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*tkchat.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	if token == "" {
@@ -101,7 +102,7 @@ func (h *serviceHandler) ServiceAgentTalkChannelList(ctx context.Context, a *aut
 // ServiceAgentTalkCreate creates a new talk
 func (h *serviceHandler) ServiceAgentTalkChatCreate(ctx context.Context, a *auth.AuthIdentity, talkType tkchat.Type, name string, detail string, participants []tkparticipant.ParticipantInput) (*tkchat.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Create talk via RPC with name, detail, and participants
@@ -118,7 +119,7 @@ func (h *serviceHandler) ServiceAgentTalkChatCreate(ctx context.Context, a *auth
 // ServiceAgentTalkChatUpdate updates a chat's name and/or detail
 func (h *serviceHandler) ServiceAgentTalkChatUpdate(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID, name *string, detail *string) (*tkchat.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission - must be a participant to modify
@@ -139,7 +140,7 @@ func (h *serviceHandler) ServiceAgentTalkChatUpdate(ctx context.Context, a *auth
 // ServiceAgentTalkChatDelete deletes a chat
 func (h *serviceHandler) ServiceAgentTalkChatDelete(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID) (*tkchat.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission - must be a participant to delete
@@ -160,7 +161,7 @@ func (h *serviceHandler) ServiceAgentTalkChatDelete(ctx context.Context, a *auth
 // ServiceAgentTalkChatJoin allows an agent to join a "talk" type chat (public channel)
 func (h *serviceHandler) ServiceAgentTalkChatJoin(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID) (*tkparticipant.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Get the chat to verify it's a "talk" type
@@ -176,7 +177,7 @@ func (h *serviceHandler) ServiceAgentTalkChatJoin(ctx context.Context, a *auth.A
 
 	// Verify chat belongs to the same customer
 	if chat.CustomerID != a.CustomerID {
-		return nil, fmt.Errorf("chat does not belong to agent's customer")
+		return nil, fmt.Errorf("%w: chat does not belong to agent's customer", serviceerrors.ErrPermissionDenied)
 	}
 
 	// Add the agent as a participant (using their own ID)
@@ -192,7 +193,7 @@ func (h *serviceHandler) ServiceAgentTalkChatJoin(ctx context.Context, a *auth.A
 // ServiceAgentTalkParticipantList gets list of participants in a chat
 func (h *serviceHandler) ServiceAgentTalkParticipantList(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID) ([]*tkparticipant.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission - agent must have access to the chat
@@ -220,7 +221,7 @@ func (h *serviceHandler) ServiceAgentTalkParticipantList(ctx context.Context, a 
 // ServiceAgentTalkParticipantCreate adds a participant to a chat
 func (h *serviceHandler) ServiceAgentTalkParticipantCreate(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID, ownerType string, ownerID uuid.UUID) (*tkparticipant.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission - must be a participant OR joining a public "talk" type chat
@@ -243,7 +244,7 @@ func (h *serviceHandler) ServiceAgentTalkParticipantCreate(ctx context.Context, 
 // ServiceAgentTalkParticipantDelete removes a participant from a chat
 func (h *serviceHandler) ServiceAgentTalkParticipantDelete(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID, participantID uuid.UUID) (*tkparticipant.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission - must be a participant to remove others
@@ -264,7 +265,7 @@ func (h *serviceHandler) ServiceAgentTalkParticipantDelete(ctx context.Context, 
 // ServiceAgentTalkMessageGet gets a message by ID
 func (h *serviceHandler) ServiceAgentTalkMessageGet(ctx context.Context, a *auth.AuthIdentity, messageID uuid.UUID) (*tkmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Get message
@@ -292,7 +293,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageGet(ctx context.Context, a *auth
 // ServiceAgentTalkMessageList gets list of messages for a specific chat
 func (h *serviceHandler) ServiceAgentTalkMessageList(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID, size uint64, token string) ([]*tkmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	if token == "" {
@@ -328,7 +329,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageList(ctx context.Context, a *aut
 // ServiceAgentTalkMessageCreate creates a new message
 func (h *serviceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *auth.AuthIdentity, chatID uuid.UUID, parentID *uuid.UUID, msgType tkmessage.Type, text string, medias []tkmessage.Media) (*tkmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Check permission
@@ -354,7 +355,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *a
 // ServiceAgentTalkMessageDelete deletes a message
 func (h *serviceHandler) ServiceAgentTalkMessageDelete(ctx context.Context, a *auth.AuthIdentity, messageID uuid.UUID) (*tkmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Get message to check ownership and talk
@@ -386,7 +387,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageDelete(ctx context.Context, a *a
 // ServiceAgentTalkMessageReactionCreate adds a reaction to a message
 func (h *serviceHandler) ServiceAgentTalkMessageReactionCreate(ctx context.Context, a *auth.AuthIdentity, messageID uuid.UUID, emoji string) (*tkmessage.WebhookMessage, error) {
 	if !a.IsAgent() {
-		return nil, fmt.Errorf("agent authentication required")
+		return nil, serviceerrors.ErrAuthenticationRequired
 	}
 
 	// Get message to check talk

--- a/bin-api-manager/pkg/servicehandler/speaking.go
+++ b/bin-api-manager/pkg/servicehandler/speaking.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"monorepo/bin-api-manager/models/auth"
 	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	tmspeaking "monorepo/bin-tts-manager/models/speaking"
 	tmstreaming "monorepo/bin-tts-manager/models/streaming"
 
@@ -32,7 +33,7 @@ func (h *serviceHandler) SpeakingCreate(ctx context.Context, a *auth.AuthIdentit
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
@@ -60,7 +61,7 @@ func (h *serviceHandler) SpeakingGet(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	tmp, err := h.speakingGet(ctx, speakingID)
@@ -86,7 +87,7 @@ func (h *serviceHandler) SpeakingList(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -126,7 +127,7 @@ func (h *serviceHandler) SpeakingSay(ctx context.Context, a *auth.AuthIdentity, 
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	s, err := h.speakingGet(ctx, speakingID)
@@ -160,7 +161,7 @@ func (h *serviceHandler) SpeakingFlush(ctx context.Context, a *auth.AuthIdentity
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	s, err := h.speakingGet(ctx, speakingID)
@@ -194,7 +195,7 @@ func (h *serviceHandler) SpeakingStop(ctx context.Context, a *auth.AuthIdentity,
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	s, err := h.speakingGet(ctx, speakingID)
@@ -229,7 +230,7 @@ func (h *serviceHandler) SpeakingDelete(ctx context.Context, a *auth.AuthIdentit
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	s, err := h.speakingGet(ctx, speakingID)

--- a/bin-api-manager/pkg/servicehandler/speaking_test.go
+++ b/bin-api-manager/pkg/servicehandler/speaking_test.go
@@ -28,7 +28,7 @@ func Test_SpeakingCreate(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent         *auth.AuthIdentity
 		referenceType tmstreaming.ReferenceType
 		referenceID   uuid.UUID
 		language      string
@@ -147,7 +147,7 @@ func Test_SpeakingGet(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		speakingID uuid.UUID
 
 		responseSpeaking *tmspeaking.Speaking
@@ -247,7 +247,7 @@ func Test_SpeakingList(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent     *auth.AuthIdentity
 		pageToken string
 		pageSize  uint64
 
@@ -368,7 +368,7 @@ func Test_SpeakingSay(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		speakingID uuid.UUID
 		text       string
 
@@ -486,7 +486,7 @@ func Test_SpeakingFlush(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		speakingID uuid.UUID
 
 		responseSpeakingGet   *tmspeaking.Speaking
@@ -601,7 +601,7 @@ func Test_SpeakingStop(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		speakingID uuid.UUID
 
 		responseSpeakingGet  *tmspeaking.Speaking
@@ -716,7 +716,7 @@ func Test_SpeakingDelete(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		speakingID uuid.UUID
 
 		responseSpeakingGet    *tmspeaking.Speaking

--- a/bin-api-manager/pkg/servicehandler/storage_account_test.go
+++ b/bin-api-manager/pkg/servicehandler/storage_account_test.go
@@ -24,7 +24,7 @@ func Test_storageAccountGet(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent            *auth.AuthIdentity
 		storageAccountID uuid.UUID
 
 		responseStorageAccount *smaccount.Account
@@ -42,7 +42,7 @@ func Test_storageAccountGet(t *testing.T) {
 			&smaccount.Account{
 				ID:         uuid.FromStringOrNil("b87c0fc8-1bd7-11ef-84a7-3b073405f0cd"),
 				CustomerID: uuid.FromStringOrNil("b83e3c98-1bd7-11ef-8f14-9f07e5f6c56b"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 		},
 	}
@@ -80,7 +80,7 @@ func Test_StorageAccountDelete(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent            *auth.AuthIdentity
 		storageAccountID uuid.UUID
 
 		responseStorageAccount *smaccount.Account
@@ -101,12 +101,12 @@ func Test_StorageAccountDelete(t *testing.T) {
 			responseStorageAccount: &smaccount.Account{
 				ID:         uuid.FromStringOrNil("1aa43522-1bd8-11ef-870e-4f7d5cfff4f5"),
 				CustomerID: uuid.FromStringOrNil("1a73a632-1bd8-11ef-8c46-4fdca968dac2"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 			expectRes: &smaccount.Account{
 				ID:         uuid.FromStringOrNil("1aa43522-1bd8-11ef-870e-4f7d5cfff4f5"),
 				CustomerID: uuid.FromStringOrNil("1a73a632-1bd8-11ef-8c46-4fdca968dac2"),
-				TMDelete: nil,
+				TMDelete:   nil,
 			},
 		},
 	}
@@ -221,7 +221,7 @@ func Test_StorageAccountCreate(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent      *auth.AuthIdentity
 		customerID uuid.UUID
 
 		responseStorageAccount *smaccount.Account

--- a/bin-api-manager/pkg/servicehandler/storage_accounts.go
+++ b/bin-api-manager/pkg/servicehandler/storage_accounts.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"monorepo/bin-api-manager/models/auth"
 	amagent "monorepo/bin-agent-manager/models/agent"
-	smaccount "monorepo/bin-storage-manager/models/account"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
+	smaccount "monorepo/bin-storage-manager/models/account"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -39,7 +40,7 @@ func (h *serviceHandler) StorageAccountGet(ctx context.Context, a *auth.AuthIden
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get storage account
@@ -50,7 +51,7 @@ func (h *serviceHandler) StorageAccountGet(ctx context.Context, a *auth.AuthIden
 	}
 
 	if !h.hasPermission(ctx, a, sa.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// convert
@@ -69,7 +70,7 @@ func (h *serviceHandler) StorageAccountGetByCustomerID(ctx context.Context, a *a
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	filters := map[string]string{
@@ -93,7 +94,7 @@ func (h *serviceHandler) StorageAccountGetByCustomerID(ctx context.Context, a *a
 	res := tmps[0].ConvertWebhookMessage()
 
 	if !h.hasPermission(ctx, a, res.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	return res, nil
@@ -111,7 +112,7 @@ func (h *serviceHandler) StorageAccountDelete(ctx context.Context, a *auth.AuthI
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	// get storage account
@@ -122,7 +123,7 @@ func (h *serviceHandler) StorageAccountDelete(ctx context.Context, a *auth.AuthI
 	}
 
 	if !h.hasPermission(ctx, a, ba.CustomerID, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res, err := h.reqHandler.StorageV1AccountDelete(ctx, storageAccountID, 60000)
@@ -146,7 +147,7 @@ func (h *serviceHandler) StorageAccountList(ctx context.Context, a *auth.AuthIde
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if token == "" {
@@ -154,7 +155,7 @@ func (h *serviceHandler) StorageAccountList(ctx context.Context, a *auth.AuthIde
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -195,11 +196,11 @@ func (h *serviceHandler) StorageAccountCreate(ctx context.Context, a *auth.AuthI
 	})
 
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionProjectSuperAdmin) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// create storage accounts

--- a/bin-api-manager/pkg/servicehandler/storage_accounts_test.go
+++ b/bin-api-manager/pkg/servicehandler/storage_accounts_test.go
@@ -23,7 +23,7 @@ func Test_StorageAccountGet(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent            *auth.AuthIdentity
 		storageAccountID uuid.UUID
 
 		responseStorageAccount *smaccount.Account

--- a/bin-api-manager/pkg/servicehandler/storage_file.go
+++ b/bin-api-manager/pkg/servicehandler/storage_file.go
@@ -9,6 +9,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	smfile "monorepo/bin-storage-manager/models/file"
 
 	"github.com/gofrs/uuid"
@@ -30,7 +31,7 @@ func (h *serviceHandler) storageFileGet(ctx context.Context, fileID uuid.UUID) (
 
 func (h *serviceHandler) StorageFileGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*smfile.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -49,7 +50,7 @@ func (h *serviceHandler) StorageFileGet(ctx context.Context, a *auth.AuthIdentit
 	log.WithField("file", f).Debugf("Found file info. file_id: %s", f.ID)
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAll) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := f.ConvertWebhookMessage()
@@ -60,7 +61,7 @@ func (h *serviceHandler) StorageFileGet(ctx context.Context, a *auth.AuthIdentit
 // If the stored URL has expired, it refreshes via storage-manager RPC.
 func (h *serviceHandler) StorageFileDownloadRedirect(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (string, error) {
 	if a.IsDirect() {
-		return "", fmt.Errorf("direct access not supported")
+		return "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -81,7 +82,7 @@ func (h *serviceHandler) StorageFileDownloadRedirect(ctx context.Context, a *aut
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return "", fmt.Errorf("user has no permission")
+		return "", serviceerrors.ErrPermissionDenied
 	}
 
 	// check if download URL is still valid
@@ -104,7 +105,7 @@ func (h *serviceHandler) StorageFileDownloadRedirect(ctx context.Context, a *aut
 // StorageFileDelete deletes the file of the given id.
 func (h *serviceHandler) StorageFileDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*smfile.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -124,7 +125,7 @@ func (h *serviceHandler) StorageFileDelete(ctx context.Context, a *auth.AuthIden
 
 	if !h.hasPermission(ctx, a, f.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.storageFileDelete(ctx, id)
@@ -150,7 +151,7 @@ func (h *serviceHandler) storageFileDelete(ctx context.Context, id uuid.UUID) (*
 // it returns created file info if it succeed.
 func (h *serviceHandler) StorageFileCreate(ctx context.Context, a *auth.AuthIdentity, f multipart.File, fileType smfile.Type, name string, detail string, filename string) (*smfile.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -163,7 +164,7 @@ func (h *serviceHandler) StorageFileCreate(ctx context.Context, a *auth.AuthIden
 	log.Debug("Creating a new file.")
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// open file writer
@@ -228,7 +229,7 @@ func (h *serviceHandler) storageFileCreate(
 // It returns list of files if it succeed.
 func (h *serviceHandler) StorageFileList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*smfile.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -272,4 +273,3 @@ func (h *serviceHandler) StorageFileList(ctx context.Context, a *auth.AuthIdenti
 
 	return res, nil
 }
-

--- a/bin-api-manager/pkg/servicehandler/storage_file_test.go
+++ b/bin-api-manager/pkg/servicehandler/storage_file_test.go
@@ -25,7 +25,7 @@ func Test_StorageFileGet(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent  *auth.AuthIdentity
 		fileID uuid.UUID
 
 		responseStorageFile *smfile.File
@@ -99,7 +99,7 @@ func Test_StorageFileDelete(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent  *auth.AuthIdentity
 		fileID uuid.UUID
 
 		responseStorageFile *smfile.File
@@ -177,16 +177,16 @@ func Test_StorageFileDownloadRedirect(t *testing.T) {
 	tests := []struct {
 		name string
 
-		agent *auth.AuthIdentity
+		agent  *auth.AuthIdentity
 		fileID uuid.UUID
 
-		responseStorageFile  *smfile.File
-		responseStorageErr   error
-		responseRefreshURI   string
-		responseRefreshErr   error
-		expectRefreshCalled  bool
-		expectRes            string
-		expectErr            bool
+		responseStorageFile *smfile.File
+		responseStorageErr  error
+		responseRefreshURI  string
+		responseRefreshErr  error
+		expectRefreshCalled bool
+		expectRes           string
+		expectErr           bool
 	}{
 		{
 			name: "valid URL not expired",

--- a/bin-api-manager/pkg/servicehandler/tag.go
+++ b/bin-api-manager/pkg/servicehandler/tag.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	tmtag "monorepo/bin-tag-manager/models/tag"
 
 	"github.com/gofrs/uuid"
@@ -27,7 +28,7 @@ func (h *serviceHandler) tagGet(ctx context.Context, tagID uuid.UUID) (*tmtag.Ta
 // it returns created tag info if it succeed.
 func (h *serviceHandler) TagCreate(ctx context.Context, a *auth.AuthIdentity, name string, detail string) (*tmtag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -60,7 +61,7 @@ func (h *serviceHandler) TagCreate(ctx context.Context, a *auth.AuthIdentity, na
 // to getting a tag.
 func (h *serviceHandler) TagGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*tmtag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -91,7 +92,7 @@ func (h *serviceHandler) TagGet(ctx context.Context, a *auth.AuthIdentity, id uu
 // to getting a list of tags.
 func (h *serviceHandler) TagList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*tmtag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -107,7 +108,7 @@ func (h *serviceHandler) TagList(ctx context.Context, a *auth.AuthIdentity, size
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[tmtag.Field]any{
@@ -132,7 +133,7 @@ func (h *serviceHandler) TagList(ctx context.Context, a *auth.AuthIdentity, size
 // to delete the tag.
 func (h *serviceHandler) TagDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*tmtag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -151,7 +152,7 @@ func (h *serviceHandler) TagDelete(ctx context.Context, a *auth.AuthIdentity, id
 	// permission check
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -171,7 +172,7 @@ func (h *serviceHandler) TagDelete(ctx context.Context, a *auth.AuthIdentity, id
 // to update the tag.
 func (h *serviceHandler) TagUpdate(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID, name, detail string) (*tmtag.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -190,7 +191,7 @@ func (h *serviceHandler) TagUpdate(ctx context.Context, a *auth.AuthIdentity, id
 	// permission check
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request

--- a/bin-api-manager/pkg/servicehandler/team.go
+++ b/bin-api-manager/pkg/servicehandler/team.go
@@ -7,6 +7,7 @@ import (
 	amagent "monorepo/bin-agent-manager/models/agent"
 	amteam "monorepo/bin-ai-manager/models/team"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
 	"github.com/gofrs/uuid"
@@ -40,7 +41,7 @@ func (h *serviceHandler) TeamCreate(
 	parameter map[string]any,
 ) (*amteam.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -53,7 +54,7 @@ func (h *serviceHandler) TeamCreate(
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1TeamCreate(
@@ -78,7 +79,7 @@ func (h *serviceHandler) TeamCreate(
 // TeamDirectHashRegenerate regenerates the direct hash for the team.
 func (h *serviceHandler) TeamDirectHashRegenerate(ctx context.Context, a *auth.AuthIdentity, teamID uuid.UUID) (*amteam.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -96,7 +97,7 @@ func (h *serviceHandler) TeamDirectHashRegenerate(ctx context.Context, a *auth.A
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1TeamDirectHashRegenerate(ctx, teamID)
@@ -112,7 +113,7 @@ func (h *serviceHandler) TeamDirectHashRegenerate(ctx context.Context, a *auth.A
 // TeamGetsByCustomerID gets the list of teams of the given customer id.
 func (h *serviceHandler) TeamGetsByCustomerID(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*amteam.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -129,7 +130,7 @@ func (h *serviceHandler) TeamGetsByCustomerID(ctx context.Context, a *auth.AuthI
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -182,7 +183,7 @@ func (h *serviceHandler) convertTeamFilters(filters map[string]string) (map[amte
 // TeamGet gets the team of the given id.
 func (h *serviceHandler) TeamGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*amteam.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -200,7 +201,7 @@ func (h *serviceHandler) TeamGet(ctx context.Context, a *auth.AuthIdentity, id u
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -210,7 +211,7 @@ func (h *serviceHandler) TeamGet(ctx context.Context, a *auth.AuthIdentity, id u
 // TeamDelete deletes the team.
 func (h *serviceHandler) TeamDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*amteam.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -229,7 +230,7 @@ func (h *serviceHandler) TeamDelete(ctx context.Context, a *auth.AuthIdentity, i
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1TeamDelete(ctx, id)
@@ -254,7 +255,7 @@ func (h *serviceHandler) TeamUpdate(
 	parameter map[string]any,
 ) (*amteam.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -274,7 +275,7 @@ func (h *serviceHandler) TeamUpdate(
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.AIV1TeamUpdate(

--- a/bin-api-manager/pkg/servicehandler/timeline.go
+++ b/bin-api-manager/pkg/servicehandler/timeline.go
@@ -7,6 +7,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cmcall "monorepo/bin-call-manager/models/call"
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	cfconference "monorepo/bin-conference-manager/models/conference"
@@ -49,7 +50,7 @@ func (h *serviceHandler) TimelineEventList(
 	pageToken string,
 ) ([]*TimelineEvent, string, error) {
 	if a.IsDirect() {
-		return nil, "", fmt.Errorf("direct access not supported")
+		return nil, "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -77,7 +78,7 @@ func (h *serviceHandler) TimelineEventList(
 	// Check permission
 	if !h.hasPermission(ctx, a, customerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("Agent has no permission")
-		return nil, "", fmt.Errorf("user has no permission")
+		return nil, "", serviceerrors.ErrPermissionDenied
 	}
 
 	// Query timeline events

--- a/bin-api-manager/pkg/servicehandler/timeline_sip.go
+++ b/bin-api-manager/pkg/servicehandler/timeline_sip.go
@@ -7,6 +7,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	tmsipmessage "monorepo/bin-timeline-manager/models/sipmessage"
 
 	"github.com/gofrs/uuid"
@@ -20,7 +21,7 @@ func (h *serviceHandler) TimelineSIPAnalysisGet(
 	callID uuid.UUID,
 ) (*tmsipmessage.SIPAnalysisResponse, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -93,7 +94,7 @@ func (h *serviceHandler) TimelineSIPPcapGet(
 	callID uuid.UUID,
 ) ([]byte, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/timeline_test.go
+++ b/bin-api-manager/pkg/servicehandler/timeline_test.go
@@ -456,9 +456,9 @@ func Test_TimelineEventList_timeline_service_error(t *testing.T) {
 		pageSize     int
 		pageToken    string
 
-		responseCall         *cmcall.Call
-		responseTimelineErr  error
-		expectEventRequest   *tmevent.EventListRequest
+		responseCall        *cmcall.Call
+		responseTimelineErr error
+		expectEventRequest  *tmevent.EventListRequest
 	}{
 		{
 			name: "timeline service error",

--- a/bin-api-manager/pkg/servicehandler/transcribe.go
+++ b/bin-api-manager/pkg/servicehandler/transcribe.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
 
@@ -27,7 +28,7 @@ func (h *serviceHandler) transcribeGet(ctx context.Context, transcribeID uuid.UU
 // to getting the transcribe.
 func (h *serviceHandler) TranscribeGet(ctx context.Context, a *auth.AuthIdentity, transcribeID uuid.UUID) (*tmtranscribe.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -57,7 +58,7 @@ func (h *serviceHandler) TranscribeGet(ctx context.Context, a *auth.AuthIdentity
 // it returns list of transcribe info if it succeed.
 func (h *serviceHandler) TranscribeList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*tmtranscribe.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -117,7 +118,7 @@ func (h *serviceHandler) TranscribeStart(
 	provider tmtranscribe.Provider,
 ) (*tmtranscribe.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -232,7 +233,7 @@ func (h *serviceHandler) transcribeGetResourceInfo(ctx context.Context, a *auth.
 // it returns transcribe if it succeed.
 func (h *serviceHandler) TranscribeStop(ctx context.Context, a *auth.AuthIdentity, transcribeID uuid.UUID) (*tmtranscribe.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -268,7 +269,7 @@ func (h *serviceHandler) TranscribeStop(ctx context.Context, a *auth.AuthIdentit
 // it returns transcribe info if it succeed.
 func (h *serviceHandler) TranscribeDelete(ctx context.Context, a *auth.AuthIdentity, transcribeID uuid.UUID) (*tmtranscribe.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/transcript.go
+++ b/bin-api-manager/pkg/servicehandler/transcript.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
 
@@ -18,7 +19,7 @@ import (
 // it returns list of transcribe info if it succeed.
 func (h *serviceHandler) TranscriptList(ctx context.Context, a *auth.AuthIdentity, transcribeID uuid.UUID) ([]*tmtranscript.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/transfer.go
+++ b/bin-api-manager/pkg/servicehandler/transfer.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	tmtransfer "monorepo/bin-transfer-manager/models/transfer"
 
@@ -18,7 +19,7 @@ import (
 // it returns transfer info if it succeed.
 func (h *serviceHandler) TransferStart(ctx context.Context, a *auth.AuthIdentity, transferType tmtransfer.Type, transfererCallID uuid.UUID, transfereeAddresses []commonaddress.Address) (*tmtransfer.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/trunk.go
+++ b/bin-api-manager/pkg/servicehandler/trunk.go
@@ -6,6 +6,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 	rmsipauth "monorepo/bin-registrar-manager/models/sipauth"
 	rmtrunk "monorepo/bin-registrar-manager/models/trunk"
@@ -27,7 +28,7 @@ func (h *serviceHandler) trunkGet(ctx context.Context, id uuid.UUID) (*rmtrunk.T
 // TrunkCreate is a service handler for trunk creation.
 func (h *serviceHandler) TrunkCreate(ctx context.Context, a *auth.AuthIdentity, name string, detail string, domainName string, authTypes []rmsipauth.AuthType, username string, password string, allowedIPs []string) (*rmtrunk.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -41,7 +42,7 @@ func (h *serviceHandler) TrunkCreate(ctx context.Context, a *auth.AuthIdentity, 
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The user has no permission for this agent.")
-		return nil, fmt.Errorf("user has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RegistrarV1TrunkCreate(ctx, a.CustomerID, name, detail, domainName, authTypes, username, password, allowedIPs)
@@ -57,7 +58,7 @@ func (h *serviceHandler) TrunkCreate(ctx context.Context, a *auth.AuthIdentity, 
 // TrunkDelete deletes the trunk of the given id.
 func (h *serviceHandler) TrunkDelete(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmtrunk.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -94,7 +95,7 @@ func (h *serviceHandler) TrunkDelete(ctx context.Context, a *auth.AuthIdentity, 
 // It returns trunk if it succeed.
 func (h *serviceHandler) TrunkGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*rmtrunk.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -126,7 +127,7 @@ func (h *serviceHandler) TrunkGet(ctx context.Context, a *auth.AuthIdentity, id 
 // It returns list of trunks if it succeed.
 func (h *serviceHandler) TrunkList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*rmtrunk.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{
@@ -180,7 +181,7 @@ func (h *serviceHandler) TrunkList(ctx context.Context, a *auth.AuthIdentity, si
 // It returns updated trunk if it succeed.
 func (h *serviceHandler) TrunkUpdateBasicInfo(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID, name string, detail string, authTypes []rmsipauth.AuthType, username string, password string, allowedIPs []string) (*rmtrunk.WebhookMessage, error) {
 	if a.IsDirect() {
-		return nil, fmt.Errorf("direct access not supported")
+		return nil, serviceerrors.ErrDirectAccessNotSupported
 	}
 
 	log := logrus.WithFields(logrus.Fields{

--- a/docs/plans/2026-04-26-typed-errors-pr2a-plan.md
+++ b/docs/plans/2026-04-26-typed-errors-pr2a-plan.md
@@ -1,0 +1,92 @@
+# PR 2A — Typed Sentinels for PERMISSION / AUTH / INVALID_ARG
+
+**Date:** 2026-04-26
+**Branch:** `NOJIRA-typed-errors-pr2a`
+**Scope:** Replace ~633 brittle `fmt.Errorf` strings in `bin-api-manager/pkg/servicehandler/` with the existing typed sentinels in `pkg/serviceerrors/`. End-to-end behavior is unchanged (translator section 2 maps these sentinels to the exact same canonical envelope that section 4 currently produces via substring fallback).
+
+## Why
+
+After the 15-PR canonical error envelope rollout, the translator at `bin-api-manager/server/error_translate.go` has two layers that resolve servicehandler errors:
+
+- **Section 2 — sentinel match** (`errors.Is`): clean, structured.
+- **Section 4 — substring match**: brittle, catches `fmt.Errorf` strings.
+
+Servicehandler still emits raw `fmt.Errorf` strings (~670 sites total), so section 4 carries most of the load. Migrating to sentinels removes brittleness — a future typo like `fmt.Errorf("no perms")` would silently mismap.
+
+## Scope
+
+| Pattern | Count | Sentinel |
+|---|---:|---|
+| `fmt.Errorf("user has no permission*")` | 307 | `ErrPermissionDenied` |
+| `fmt.Errorf("direct access is not supported*")` | 266 | `ErrDirectAccessNotSupported` |
+| `fmt.Errorf("*does not belong*")` | 5 | `ErrPermissionDenied` |
+| `fmt.Errorf("authentication required*" / "*unauthorized*")` | 53 | `ErrAuthenticationRequired` |
+| `fmt.Errorf("*is required" / "only one of*")` | 2 | `ErrInvalidArgument` |
+| **Total** | **~633** | — |
+
+All sentinels already exist in `bin-api-manager/pkg/serviceerrors/sentinels.go`. No new sentinels are added in this PR.
+
+## Migration patterns
+
+**Pattern A — bare error (most common):**
+```go
+// before
+return nil, fmt.Errorf("user has no permission")
+
+// after
+return nil, serviceerrors.ErrPermissionDenied
+```
+
+**Pattern B — error with context (preserve via `%w`):**
+```go
+// before
+return nil, fmt.Errorf("user has no permission for customer %s", customerID)
+
+// after
+return nil, fmt.Errorf("%w: customer %s", serviceerrors.ErrPermissionDenied, customerID)
+```
+
+**Pattern C — multi-return:**
+```go
+// before
+return nil, "", fmt.Errorf("either activeflow_id or call_id is required")
+
+// after
+return nil, "", fmt.Errorf("%w: either activeflow_id or call_id is required", serviceerrors.ErrInvalidArgument)
+```
+
+## Out of scope
+
+- New sentinels (PR 2B): `IDENTITY_VERIFICATION_REQUIRED`, `STATE_INVALID`, `SERVICE_UNAVAILABLE`
+- `not found` migration (PR 2C)
+- Cross-service typed RPC contract (PR 2D)
+- Removing translator section 4 (PR 2E, after all of the above)
+
+## Files affected
+
+All under `bin-api-manager/pkg/servicehandler/`. Highest-volume files:
+
+- `customer.go`, `agent.go`, `flow.go`, `call.go`, `campaigns.go`, `conferences.go`, `queues.go`, `service_agents*.go`, `extensions.go`, `recordings.go`, `messages.go`, `numbers.go`, `outdial*.go`, `outplan.go`, `tag.go`, `transcribe.go`, `transfers.go`, `chat*.go`, `talk*.go`
+
+Plus the corresponding `*_test.go` files where tests assert against error strings.
+
+## Test impact
+
+Many `*_test.go` files assert `assert.Equal(t, err.Error(), "user has no permission")` or similar. These must change to:
+```go
+require.True(t, errors.Is(err, serviceerrors.ErrPermissionDenied))
+```
+
+The `assertMissingAuthIdentity` / `assertErrorResponse` test helpers used in `server/*_test.go` already test the envelope shape — those don't change.
+
+## Verification
+
+In `bin-api-manager/`:
+1. `go mod tidy && go mod vendor`
+2. `go generate ./...`
+3. `go test ./pkg/servicehandler/... ./server/...`
+4. `golangci-lint run -v --timeout 5m`
+
+## Risk
+
+Low. Translator section 2 already maps each sentinel to the same canonical envelope as section 4 currently produces. End-to-end shape and HTTP status codes are unchanged. Only structural cleanup.


### PR DESCRIPTION
Replace ~488 brittle fmt.Errorf strings in bin-api-manager/pkg/servicehandler/ with the existing typed sentinels in pkg/serviceerrors/. End-to-end behavior is unchanged — translator section 2 already maps these sentinels to the same canonical envelope that section 4 currently produces via substring fallback.

This is structural cleanup that reduces brittleness: a future typo like fmt.Errorf("no perms") would silently mismap under the substring matcher but cleanly fail to compile when the sentinel is used directly.

- bin-api-manager: Replace fmt.Errorf("user has no permission") (167 sites) with serviceerrors.ErrPermissionDenied
- bin-api-manager: Replace fmt.Errorf("direct access is not supported") (266 sites) with serviceerrors.ErrDirectAccessNotSupported
- bin-api-manager: Replace fmt.Errorf("agent authentication required") (53 sites) with serviceerrors.ErrAuthenticationRequired
- bin-api-manager: Wrap 'is required' / 'only one of' (2 sites) with serviceerrors.ErrInvalidArgument via %w
- bin-api-manager: Update aggregated_events_test.go to use errors.Is for assertions on these sentinels
- bin-api-manager: Add serviceerrors import to 60 servicehandler files via goimports
- docs: Add typed-errors-pr2a design plan
