### PR TITLE
NOJIRA-typed-errors-pr2bc

### DIFF
--- a/bin-api-manager/pkg/serviceerrors/sentinels.go
+++ b/bin-api-manager/pkg/serviceerrors/sentinels.go
@@ -12,10 +12,13 @@ package serviceerrors
 import stderrors "errors"
 
 var (
-	ErrPermissionDenied         = stderrors.New("permission denied")
-	ErrNotFound                 = stderrors.New("not found")
-	ErrAuthenticationRequired   = stderrors.New("authentication required")
-	ErrDirectAccessNotSupported = stderrors.New("direct access not supported")
-	ErrInvalidArgument          = stderrors.New("invalid argument")
-	ErrInternal                 = stderrors.New("internal error")
+	ErrPermissionDenied             = stderrors.New("permission denied")
+	ErrNotFound                     = stderrors.New("not found")
+	ErrAuthenticationRequired       = stderrors.New("authentication required")
+	ErrDirectAccessNotSupported     = stderrors.New("direct access not supported")
+	ErrInvalidArgument              = stderrors.New("invalid argument")
+	ErrInternal                     = stderrors.New("internal error")
+	ErrIdentityVerificationRequired = stderrors.New("identity verification required")
+	ErrStateInvalid                 = stderrors.New("state invalid")
+	ErrServiceUnavailable           = stderrors.New("service unavailable")
 )

--- a/bin-api-manager/pkg/servicehandler/accesskeys.go
+++ b/bin-api-manager/pkg/servicehandler/accesskeys.go
@@ -22,7 +22,7 @@ func (h *serviceHandler) accesskeyGet(ctx context.Context, a *auth.AuthIdentity,
 	}
 
 	if res.CustomerID != a.CustomerID {
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	if res.TMDelete != nil {
@@ -120,7 +120,7 @@ func (h *serviceHandler) AccesskeyRawGetByToken(ctx context.Context, token strin
 	}
 
 	if len(tmps) == 0 {
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 	if len(tmps) > 1 {
 		log.Errorf("Multiple accesskeys found for token hash, expected exactly one")

--- a/bin-api-manager/pkg/servicehandler/activeflows.go
+++ b/bin-api-manager/pkg/servicehandler/activeflows.go
@@ -32,7 +32,7 @@ func (h *serviceHandler) activeflowGet(ctx context.Context, activeflowID uuid.UU
 
 	if res.TMDelete != nil {
 		log.Debugf("Deleted activeflow.. activeflow_id: %s", res.ID)
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/aggregated_events.go
+++ b/bin-api-manager/pkg/servicehandler/aggregated_events.go
@@ -98,7 +98,7 @@ func (h *serviceHandler) AggregatedEventList(
 		af, err := h.activeflowGet(ctx, activeflowID)
 		if err != nil {
 			log.Infof("Could not get activeflow: %v", err)
-			return nil, "", fmt.Errorf("not found")
+			return nil, "", serviceerrors.ErrNotFound
 		}
 		log.WithField("activeflow", af).Debugf("Retrieved activeflow info. activeflow_id: %s", af.ID)
 
@@ -112,7 +112,7 @@ func (h *serviceHandler) AggregatedEventList(
 		c, err := h.callGet(ctx, callID)
 		if err != nil {
 			log.Infof("Could not get call: %v", err)
-			return nil, "", fmt.Errorf("not found")
+			return nil, "", serviceerrors.ErrNotFound
 		}
 		log.WithField("call", c).Debugf("Retrieved call info. call_id: %s", c.ID)
 
@@ -123,7 +123,7 @@ func (h *serviceHandler) AggregatedEventList(
 
 		if c.ActiveflowID == uuid.Nil {
 			log.Info("Call has no activeflow")
-			return nil, "", fmt.Errorf("not found")
+			return nil, "", serviceerrors.ErrNotFound
 		}
 		resolvedActiveflowID = c.ActiveflowID
 	}

--- a/bin-api-manager/pkg/servicehandler/aggregated_events_test.go
+++ b/bin-api-manager/pkg/servicehandler/aggregated_events_test.go
@@ -115,8 +115,8 @@ func Test_AggregatedEventList_ActiveflowNotFound(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "not found" {
-		t.Errorf("Wrong error message. expect: not found, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrNotFound) {
+		t.Errorf("Wrong error. expect: %v, got: %v", serviceerrors.ErrNotFound, err)
 	}
 }
 
@@ -270,8 +270,8 @@ func Test_AggregatedEventList_CallNotFound(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "not found" {
-		t.Errorf("Wrong error message. expect: not found, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrNotFound) {
+		t.Errorf("Wrong error. expect: %v, got: %v", serviceerrors.ErrNotFound, err)
 	}
 }
 
@@ -356,8 +356,8 @@ func Test_AggregatedEventList_CallNoActiveflow(t *testing.T) {
 	if err == nil {
 		t.Error("Wrong match. expect: error, got: nil")
 	}
-	if err.Error() != "not found" {
-		t.Errorf("Wrong error message. expect: not found, got: %s", err.Error())
+	if !errors.Is(err, serviceerrors.ErrNotFound) {
+		t.Errorf("Wrong error. expect: %v, got: %v", serviceerrors.ErrNotFound, err)
 	}
 }
 

--- a/bin-api-manager/pkg/servicehandler/billingaccount.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount.go
@@ -33,7 +33,7 @@ func (h *serviceHandler) billingAccountGet(ctx context.Context, accountID uuid.U
 
 	if res.TMDelete != nil {
 		log.Debugf("Deleted billing_account. billing_account_id: %s", res.ID)
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/boot.go
+++ b/bin-api-manager/pkg/servicehandler/boot.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cscustomer "monorepo/bin-customer-manager/models/customer"
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
@@ -61,7 +62,7 @@ func (h *serviceHandler) AuthBoot(ctx context.Context, directHash string) (*Boot
 
 	if cu.Status != cscustomer.StatusActive {
 		log.Infof("Customer is not active. status: %s", cu.Status)
-		return nil, fmt.Errorf("customer not active")
+		return nil, fmt.Errorf("%w: customer not active", serviceerrors.ErrStateInvalid)
 	}
 
 	// look up allowed resource types

--- a/bin-api-manager/pkg/servicehandler/call.go
+++ b/bin-api-manager/pkg/servicehandler/call.go
@@ -34,7 +34,7 @@ func (h *serviceHandler) callGet(ctx context.Context, callID uuid.UUID) (*cmcall
 	}
 
 	if res.TMDelete != nil {
-		return nil, fmt.Errorf("deleted call")
+		return nil, fmt.Errorf("%w: deleted call", serviceerrors.ErrStateInvalid)
 	}
 
 	return res, nil
@@ -81,7 +81,7 @@ func (h *serviceHandler) CallCreate(ctx context.Context, a *auth.AuthIdentity, f
 
 		if cu.IdentityVerificationStatus != cscustomer.IdentityVerificationStatusVerified {
 			log.Infof("Customer identity verification required for PSTN calls. customer_id: %s, status: %s", a.CustomerID, cu.IdentityVerificationStatus)
-			return nil, nil, fmt.Errorf("customer identity verification required for PSTN calls")
+			return nil, nil, fmt.Errorf("%w: PSTN calls", serviceerrors.ErrIdentityVerificationRequired)
 		}
 	}
 

--- a/bin-api-manager/pkg/servicehandler/email.go
+++ b/bin-api-manager/pkg/servicehandler/email.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -24,7 +23,7 @@ func (h *serviceHandler) emailGet(ctx context.Context, emailID uuid.UUID) (*emem
 	}
 
 	if res.TMDelete != nil {
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/flow.go
+++ b/bin-api-manager/pkg/servicehandler/flow.go
@@ -25,7 +25,7 @@ func (h *serviceHandler) flowGet(ctx context.Context, flowID uuid.UUID) (*fmflow
 	}
 
 	if res.TMDelete != nil {
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/message.go
+++ b/bin-api-manager/pkg/servicehandler/message.go
@@ -144,7 +144,7 @@ func (h *serviceHandler) MessageGet(ctx context.Context, a *auth.AuthIdentity, i
 
 	if tmp.TMDelete != nil {
 		log.WithField("message", tmp).Debugf("Deleted message.")
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	res := tmp.ConvertWebhookMessage()

--- a/bin-api-manager/pkg/servicehandler/numbers.go
+++ b/bin-api-manager/pkg/servicehandler/numbers.go
@@ -32,7 +32,7 @@ func (h *serviceHandler) numberGet(ctx context.Context, id uuid.UUID) (*nmnumber
 
 	if res.TMDelete != nil {
 		log.WithField("number", res).Debugf("Deleted number.")
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil
@@ -128,7 +128,7 @@ func (h *serviceHandler) NumberCreate(ctx context.Context, a *auth.AuthIdentity,
 
 		if cu.IdentityVerificationStatus != cscustomer.IdentityVerificationStatusVerified {
 			log.Infof("Customer identity verification required for number purchase. customer_id: %s, status: %s", a.CustomerID, cu.IdentityVerificationStatus)
-			return nil, fmt.Errorf("customer identity verification required for number purchase")
+			return nil, fmt.Errorf("%w: number purchase", serviceerrors.ErrIdentityVerificationRequired)
 		}
 	}
 

--- a/bin-api-manager/pkg/servicehandler/recording.go
+++ b/bin-api-manager/pkg/servicehandler/recording.go
@@ -32,7 +32,7 @@ func (h *serviceHandler) recordingGet(ctx context.Context, recordingID uuid.UUID
 
 	if res.TMDelete != nil {
 		log.Debugf("Deleted recording. recording_id: %s", res.ID)
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/storage_accounts.go
+++ b/bin-api-manager/pkg/servicehandler/storage_accounts.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -22,7 +21,7 @@ func (h *serviceHandler) storageAccountGet(ctx context.Context, accountID uuid.U
 	}
 
 	if res.TMDelete != nil {
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/storage_file.go
+++ b/bin-api-manager/pkg/servicehandler/storage_file.go
@@ -23,7 +23,7 @@ func (h *serviceHandler) storageFileGet(ctx context.Context, fileID uuid.UUID) (
 	}
 
 	if res.TMDelete != nil {
-		return nil, fmt.Errorf("not found")
+		return nil, serviceerrors.ErrNotFound
 	}
 
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/timeline_sip.go
+++ b/bin-api-manager/pkg/servicehandler/timeline_sip.go
@@ -81,7 +81,7 @@ func (h *serviceHandler) TimelineSIPAnalysisGet(
 	res, err := h.reqHandler.TimelineV1SIPAnalysisGet(ctx, callID, ch.SIPCallID, fromTime.Format(time.RFC3339), toTime.Format(time.RFC3339))
 	if err != nil {
 		log.Errorf("Could not get SIP analysis: %v", err)
-		return nil, fmt.Errorf("upstream service unavailable")
+		return nil, fmt.Errorf("%w: upstream service unavailable", serviceerrors.ErrServiceUnavailable)
 	}
 
 	return res, nil
@@ -154,7 +154,7 @@ func (h *serviceHandler) TimelineSIPPcapGet(
 	res, err := h.reqHandler.TimelineV1SIPPcapGet(ctx, callID, ch.SIPCallID, fromTime.Format(time.RFC3339), toTime.Format(time.RFC3339))
 	if err != nil {
 		log.Errorf("Could not get PCAP: %v", err)
-		return nil, fmt.Errorf("upstream service unavailable")
+		return nil, fmt.Errorf("%w: upstream service unavailable", serviceerrors.ErrServiceUnavailable)
 	}
 
 	return res, nil

--- a/bin-api-manager/server/error_translate.go
+++ b/bin-api-manager/server/error_translate.go
@@ -51,6 +51,15 @@ func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 		return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request is invalid.")
 	case stderrors.Is(err, serviceerrors.ErrInternal):
 		return cerrors.Internal(commonoutline.ServiceNameAPIManager, "INTERNAL", "An internal error occurred.").Wrap(err)
+	case stderrors.Is(err, serviceerrors.ErrIdentityVerificationRequired):
+		return cerrors.PermissionDenied(commonoutline.ServiceNameAPIManager, "IDENTITY_VERIFICATION_REQUIRED",
+			"Customer identity verification is required for this operation.").Wrap(err)
+	case stderrors.Is(err, serviceerrors.ErrStateInvalid):
+		return cerrors.FailedPrecondition(commonoutline.ServiceNameAPIManager, "STATE_INVALID",
+			"The operation is invalid for the current resource state.").Wrap(err)
+	case stderrors.Is(err, serviceerrors.ErrServiceUnavailable):
+		return cerrors.Unavailable(commonoutline.ServiceNameAPIManager, "SERVICE_UNAVAILABLE",
+			"An upstream service is temporarily unavailable.").Wrap(err)
 	}
 
 	// 3. Transport failures.

--- a/docs/plans/2026-04-26-typed-errors-pr2bc-plan.md
+++ b/docs/plans/2026-04-26-typed-errors-pr2bc-plan.md
@@ -1,0 +1,108 @@
+# PR 2B+C — New sentinels (Identity / State / Unavailable) + NOT_FOUND migration
+
+**Date:** 2026-04-26
+**Branch:** `NOJIRA-typed-errors-pr2bc`
+**Scope:** Combined PR 2B (add 3 new sentinels for IDENTITY / STATE_INVALID / UNAVAILABLE patterns) and PR 2C (migrate ~14 local NOT_FOUND sites to existing `serviceerrors.ErrNotFound`).
+
+## Why
+
+After PR 2A migrated the 488 highest-volume sites (PERMISSION/AUTH/INVALID_ARG), the translator section 4 (substring fallback) still catches:
+- `"identity verification"` (2 sites)
+- `"already" / "deleted call" / "not active"` (2 sites)
+- `"unavailable"` (2 source sites; 3 test mock returns ignored)
+- `"not found"` (14 source sites; 7 test mock returns ignored)
+
+These add up to ~20 source sites. PR 2A already covered the bulk; this PR closes the remaining typed-sentinel gap so PR 2D (cross-service typed RPC) and PR 2E (remove translator section 4) can land cleanly.
+
+## Changes
+
+### 1. New sentinels in `bin-api-manager/pkg/serviceerrors/sentinels.go`
+
+```go
+ErrIdentityVerificationRequired = stderrors.New("identity verification required")
+ErrStateInvalid                 = stderrors.New("state invalid")
+ErrServiceUnavailable           = stderrors.New("service unavailable")
+```
+
+### 2. Translator section 2 update (`server/error_translate.go`)
+
+Add three new cases mapping each sentinel to its canonical envelope:
+
+```go
+case stderrors.Is(err, serviceerrors.ErrIdentityVerificationRequired):
+    return cerrors.PermissionDenied(commonoutline.ServiceNameAPIManager, "IDENTITY_VERIFICATION_REQUIRED",
+        "Customer identity verification is required for this operation.").Wrap(err)
+case stderrors.Is(err, serviceerrors.ErrStateInvalid):
+    return cerrors.FailedPrecondition(commonoutline.ServiceNameAPIManager, "STATE_INVALID",
+        "The operation is invalid for the current resource state.").Wrap(err)
+case stderrors.Is(err, serviceerrors.ErrServiceUnavailable):
+    return cerrors.Unavailable(commonoutline.ServiceNameAPIManager, "SERVICE_UNAVAILABLE",
+        "An upstream service is temporarily unavailable.").Wrap(err)
+```
+
+These are added BEFORE the existing section 4 substring fallbacks so the typed path wins.
+
+### 3. Site migrations
+
+**Identity (2 sites, wrap form to preserve context):**
+```go
+// numbers.go:131
+return nil, fmt.Errorf("%w: number purchase", serviceerrors.ErrIdentityVerificationRequired)
+
+// call.go:84
+return nil, nil, fmt.Errorf("%w: PSTN calls", serviceerrors.ErrIdentityVerificationRequired)
+```
+
+**State (2 sites, wrap form):**
+```go
+// boot.go:64
+return nil, fmt.Errorf("%w: customer not active", serviceerrors.ErrStateInvalid)
+
+// call.go:37
+return nil, fmt.Errorf("%w: deleted call", serviceerrors.ErrStateInvalid)
+```
+
+**Unavailable (2 source sites, wrap form):**
+```go
+// timeline_sip.go:84, :157
+return nil, fmt.Errorf("%w: upstream service unavailable", serviceerrors.ErrServiceUnavailable)
+```
+
+Test mock returns at `providercall_test.go:302`, `aggregated_events_test.go:469`, `timeline_test.go:478` are NOT migrated — these simulate upstream RPC errors that flow through the translator's section 4 (still active for upstream-string compatibility).
+
+**NOT_FOUND (14 source sites, bare form):**
+```go
+// flow.go:28, activeflows.go:35, recording.go:35, billingaccount.go:36, storage_file.go:26, etc.
+return nil, serviceerrors.ErrNotFound
+
+// aggregated_events.go:101,:115,:126 (multi-return)
+return nil, "", serviceerrors.ErrNotFound
+```
+
+Test mock returns at `providercall_test.go:179`, `billingaccount_test.go:773`, etc. are NOT migrated.
+
+### 4. Test updates
+
+Search for any tests that assert against these strings:
+```bash
+grep -rn 'err.Error()' bin-api-manager/pkg/servicehandler/*_test.go | grep -iE "identity verification|deleted call|customer not active|service unavailable|^.*\"not found\""
+```
+
+For each match, switch from string equality to `errors.Is(err, serviceerrors.Err...)`.
+
+## Out of scope
+
+- Removing translator section 4 (PR 2E — after 2D lands)
+- Cross-service typed RPC contract for upstream managers (PR 2D)
+- Migrating PR 2A patterns again (already done)
+
+## Verification
+
+```bash
+cd bin-api-manager
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+## Risk
+
+Low. Behavior change: identity/state/unavailable/not-found errors continue to produce identical envelopes (translator section 4 already catches them; section 2 with new sentinels is just stricter). End-to-end HTTP responses are byte-identical.


### PR DESCRIPTION
Add 3 new typed sentinels for IDENTITY / STATE_INVALID / SERVICE_UNAVAILABLE patterns and migrate ~20 source sites away from brittle fmt.Errorf strings to typed sentinels. Also migrates 14 NOT_FOUND source sites to the existing ErrNotFound sentinel. End-to-end behavior is unchanged — translator section 2 now maps the new sentinels to the same canonical envelope that section 4 currently produces via substring fallback.

Combined with PR 2A (488 sites), this leaves only ~3 test-mock returns plus upstream-RPC error strings flowing through translator section 4. The remaining work (PR 2D) is the cross-service typed RPC contract; PR 2E will then remove section 4 entirely.

- bin-api-manager: Add ErrIdentityVerificationRequired, ErrStateInvalid, ErrServiceUnavailable sentinels
- bin-api-manager: Map the 3 new sentinels to canonical envelopes in error_translate.go section 2
- bin-api-manager: Wrap 2 IDENTITY sites (numbers.go, call.go) with ErrIdentityVerificationRequired
- bin-api-manager: Wrap 2 STATE sites (boot.go, call.go) with ErrStateInvalid
- bin-api-manager: Wrap 2 UNAVAILABLE sites (timeline_sip.go) with ErrServiceUnavailable
- bin-api-manager: Migrate 14 NOT_FOUND source sites across 10 files to bare ErrNotFound
- bin-api-manager: Update 3 test assertions in aggregated_events_test.go to use errors.Is
- docs: Add typed-errors-pr2bc design plan
