### PR TITLE
NOJIRA-typed-rpc-pr1-billing-pilot

### DIFF
--- a/bin-billing-manager/pkg/accounthandler/account.go
+++ b/bin-billing-manager/pkg/accounthandler/account.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-billing-manager/models/account"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // Create creates a new account and return the created account.
@@ -94,7 +96,14 @@ func (h *accountHandler) SetStatus(ctx context.Context, id uuid.UUID, status acc
 	case account.StatusActive, account.StatusFrozen, account.StatusDeleted:
 		// valid
 	default:
-		return nil, fmt.Errorf("invalid status: %s", status)
+		// SetStatus is only invoked from the billing-control CLI and from internal
+		// paddle webhook handlers — the public API never reaches this code path.
+		// An unrecognized value here is a programmer error, not user input.
+		return nil, cerrors.Internal(
+			commonoutline.ServiceNameBillingManager,
+			"INVALID_ACCOUNT_STATUS",
+			fmt.Sprintf("The account status %q is not valid. Allowed: active, frozen, deleted.", string(status)),
+		)
 	}
 
 	if err := h.db.AccountSetStatus(ctx, id, status); err != nil {

--- a/bin-billing-manager/pkg/accounthandler/balance.go
+++ b/bin-billing-manager/pkg/accounthandler/balance.go
@@ -10,6 +10,8 @@ import (
 
 	"monorepo/bin-billing-manager/models/account"
 	"monorepo/bin-billing-manager/models/billing"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	cmcustomer "monorepo/bin-customer-manager/models/customer"
 )
 
@@ -127,7 +129,11 @@ func (h *accountHandler) IsValidBalance(ctx context.Context, accountID uuid.UUID
 
 	default:
 		log.Errorf("Unsupported billing type. billing_type: %s", billingType)
-		return false, fmt.Errorf("unsupported billing type")
+		return false, cerrors.InvalidArgument(
+			commonoutline.ServiceNameBillingManager,
+			"UNSUPPORTED_BILLING_TYPE",
+			fmt.Sprintf("The billing type %q is not supported.", string(billingType)),
+		)
 	}
 
 	log.Infof("The account has not enough balance or tokens. balance_credit: %d, balance_token: %d", a.BalanceCredit, a.BalanceToken)

--- a/bin-billing-manager/pkg/accounthandler/db.go
+++ b/bin-billing-manager/pkg/accounthandler/db.go
@@ -2,13 +2,17 @@ package accounthandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-billing-manager/models/account"
+	"monorepo/bin-billing-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // dbCreate creates a new account and return the created account.
@@ -47,6 +51,11 @@ func (h *accountHandler) dbCreate(ctx context.Context, customerID uuid.UUID, nam
 }
 
 // Get returns a account.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As. Other DB errors flow
+// through as plain wrapped errors and become INTERNAL via the default path.
 func (h *accountHandler) Get(ctx context.Context, id uuid.UUID) (*account.Account, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "Get",
@@ -56,6 +65,13 @@ func (h *accountHandler) Get(ctx context.Context, id uuid.UUID) (*account.Accoun
 	res, err := h.db.AccountGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get account. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameBillingManager,
+				"BILLING_ACCOUNT_NOT_FOUND",
+				"The billing account was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get account info")
 	}
 
@@ -275,7 +291,20 @@ func (h *accountHandler) Delete(ctx context.Context, id uuid.UUID) (*account.Acc
 
 	res, err := h.Get(ctx, id)
 	if err != nil {
+		// h.Get() now emits cerrors.NotFound on dbhandler.ErrNotFound. The
+		// soft-delete preserves the row, so a not-found here means a transient
+		// cache/DB hiccup, NOT that the delete failed. Re-classify as INTERNAL
+		// so the caller doesn't receive a misleading 404 after a successful
+		// delete — the delete itself succeeded.
 		log.Errorf("Could not get deleted account. err: %v", err)
+		var ve *cerrors.VoipbinError
+		if stderrors.As(err, &ve) && ve.Status == cerrors.StatusNotFound {
+			return nil, cerrors.Internal(
+				commonoutline.ServiceNameBillingManager,
+				"POST_DELETE_LOOKUP_FAILED",
+				"The account was deleted but a transient lookup failed when re-fetching it.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get deleted account")
 	}
 

--- a/bin-billing-manager/pkg/accounthandler/paddle.go
+++ b/bin-billing-manager/pkg/accounthandler/paddle.go
@@ -2,6 +2,7 @@ package accounthandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
@@ -25,7 +26,7 @@ func (h *accountHandler) checkPaddleIdempotency(ctx context.Context, eventID str
 	if err == nil {
 		return true, nil // Already processed
 	}
-	if err == dbhandler.ErrNotFound {
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
 		return false, nil // Not processed yet
 	}
 	return false, fmt.Errorf("could not check idempotency: %w", err)

--- a/bin-billing-manager/pkg/accounthandler/resource_limit.go
+++ b/bin-billing-manager/pkg/accounthandler/resource_limit.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-billing-manager/models/account"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // IsValidResourceLimitByCustomerID checks if the given customer has not exceeded its plan limit for the given resource type.
@@ -58,8 +60,15 @@ func (h *accountHandler) IsValidResourceLimit(ctx context.Context, accountID uui
 
 	planLimits, ok := account.PlanLimitMap[a.PlanType]
 	if !ok {
+		// a.PlanType is loaded from the DB. An unrecognized value here means
+		// the database has a corrupt or out-of-date enum — not user input.
+		// Classify as INTERNAL so operations sees it, not as a 400 to the caller.
 		log.Errorf("Unknown plan type. plan_type: %s", a.PlanType)
-		return false, fmt.Errorf("unknown plan type: %s", a.PlanType)
+		return false, cerrors.Internal(
+			commonoutline.ServiceNameBillingManager,
+			"UNKNOWN_PLAN_TYPE",
+			fmt.Sprintf("The account plan type %q is not recognized.", string(a.PlanType)),
+		)
 	}
 
 	limit := planLimits.GetLimit(resourceType)
@@ -102,6 +111,10 @@ func (h *accountHandler) getResourceCount(ctx context.Context, customerID uuid.U
 	case account.ResourceTypeVirtualNumber:
 		return h.reqHandler.NumberV1VirtualNumberCountByCustomerID(ctx, customerID)
 	default:
-		return 0, fmt.Errorf("unsupported resource type: %s", resourceType)
+		return 0, cerrors.InvalidArgument(
+			commonoutline.ServiceNameBillingManager,
+			"UNSUPPORTED_RESOURCE_TYPE",
+			fmt.Sprintf("The resource type %q is not supported.", string(resourceType)),
+		)
 	}
 }

--- a/bin-billing-manager/pkg/billinghandler/billing.go
+++ b/bin-billing-manager/pkg/billinghandler/billing.go
@@ -2,10 +2,13 @@ package billinghandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	cmcustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
@@ -44,7 +47,7 @@ func (h *billingHandler) BillingStart(
 
 	// idempotency check — return early if billing already exists for this reference
 	existing, err := h.db.BillingGetByReferenceTypeAndID(ctx, referenceType, referenceID)
-	if err != nil && err != dbhandler.ErrNotFound {
+	if err != nil && !stderrors.Is(err, dbhandler.ErrNotFound) {
 		// real DB error (connection timeout, etc.) — do NOT fall through to create
 		return errors.Wrap(err, "could not check for existing billing")
 	}
@@ -81,8 +84,15 @@ func (h *billingHandler) BillingStart(
 	case billing.ReferenceTypeNumber, billing.ReferenceTypeNumberRenew:
 		flagEnd = true
 	default:
+		// Reached only for an unrecognized internal enum (BillingStart is invoked
+		// by the event subscriber, not by an external caller). Classify as
+		// INTERNAL — the API caller did not supply this value.
 		log.Errorf("Unsupported reference type. reference_type: %s", referenceType)
-		return fmt.Errorf("unsupported reference type")
+		return cerrors.Internal(
+			commonoutline.ServiceNameBillingManager,
+			"UNSUPPORTED_REFERENCE_TYPE",
+			fmt.Sprintf("The billing reference type %q is not supported.", string(referenceType)),
+		)
 	}
 
 	tmp, err := h.Create(ctx, a.CustomerID, a.ID, referenceType, referenceID, costType, tmBillingStart)
@@ -154,8 +164,15 @@ func (h *billingHandler) BillingEnd(
 		usageDuration = 0
 		billableUnits = 1
 	default:
+		// Reached only for an unrecognized internal enum (BillingEnd is invoked
+		// by the event subscriber on a billing record we constructed). Classify
+		// as INTERNAL — this is not user input.
 		log.Errorf("Unsupported billing reference type. reference_type: %s", bill.ReferenceType)
-		return fmt.Errorf("unsupported billing reference type. reference_type: %s", bill.ReferenceType)
+		return cerrors.Internal(
+			commonoutline.ServiceNameBillingManager,
+			"UNSUPPORTED_REFERENCE_TYPE",
+			fmt.Sprintf("The billing reference type %q is not supported.", string(bill.ReferenceType)),
+		)
 	}
 
 	// Use atomic consume-and-record transaction

--- a/bin-billing-manager/pkg/billinghandler/db.go
+++ b/bin-billing-manager/pkg/billinghandler/db.go
@@ -2,6 +2,7 @@ package billinghandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-billing-manager/models/billing"
+	"monorepo/bin-billing-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // Create creates a new billing and return the created billing.
@@ -70,6 +74,10 @@ func (h *billingHandler) Create(
 }
 
 // Get returns a billing.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *billingHandler) Get(ctx context.Context, id uuid.UUID) (*billing.Billing, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "Get",
@@ -79,6 +87,13 @@ func (h *billingHandler) Get(ctx context.Context, id uuid.UUID) (*billing.Billin
 	res, err := h.db.BillingGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get billing. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameBillingManager,
+				"BILLING_NOT_FOUND",
+				"The billing record was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get billing")
 	}
 

--- a/bin-billing-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-billing-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,111 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-billing-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+// Test_errorResponse_typed verifies that a *cerrors.VoipbinError is encoded
+// via cerrors.ToResponse — the api-manager edge will recover the typed error
+// from the resulting sock.Response via FromResponse.
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.InvalidArgument(
+		commonoutline.ServiceNameBillingManager,
+		"UNSUPPORTED_BILLING_TYPE",
+		"The billing type is not supported.",
+	)
+
+	resp := errorResponse(ve)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode mismatch. expected: %d, got: %d", http.StatusBadRequest, resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+	if len(resp.Data) == 0 {
+		t.Errorf("expected non-empty Data containing JSON-encoded VoipbinError")
+	}
+}
+
+// Test_errorResponse_typedThroughPkgErrorsWrap verifies that errors.As walks
+// the pkg/errors.Wrapf chain — the standard wrapping idiom in business
+// handlers — and recovers the typed error.
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.InvalidArgument(
+		commonoutline.ServiceNameBillingManager,
+		"INVALID_ACCOUNT_STATUS",
+		"The account status is not valid.",
+	)
+	wrapped := pkgerrors.Wrap(ve, "outer context")
+
+	resp := errorResponse(wrapped)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode mismatch. expected: %d, got: %d", http.StatusBadRequest, resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+// Test_errorResponse_legacyNotFound verifies that dbhandler.ErrNotFound
+// (wrapped via pkg/errors) preserves the legacy 404 mapping for code paths
+// that have not yet been migrated to typed errors.
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	wrapped := pkgerrors.Wrap(dbhandler.ErrNotFound, "could not get account info")
+
+	resp := errorResponse(wrapped)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != "" {
+		t.Errorf("DataType should be empty for legacy 404, got: %s", resp.DataType)
+	}
+	// stderrors.Is should still walk through pkg/errors wrap
+	if !stderrors.Is(wrapped, dbhandler.ErrNotFound) {
+		t.Errorf("stderrors.Is should walk pkg/errors chain to find ErrNotFound")
+	}
+}
+
+// Test_errorResponse_unclassifiedError verifies that any unknown error
+// (e.g., a DB connection failure) falls through to 500 — becomes INTERNAL
+// at the api-manager translator default branch.
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	plain := fmt.Errorf("connection refused")
+
+	resp := errorResponse(plain)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+// Test_errorResponse_nilError defensive test — calling with nil should not
+// crash and should return 500.
+func Test_errorResponse_nilError(t *testing.T) {
+	resp := errorResponse(nil)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}

--- a/bin-billing-manager/pkg/listenhandler/main.go
+++ b/bin-billing-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -15,6 +18,7 @@ import (
 
 	"monorepo/bin-billing-manager/pkg/accounthandler"
 	"monorepo/bin-billing-manager/pkg/billinghandler"
+	"monorepo/bin-billing-manager/pkg/dbhandler"
 	"monorepo/bin-billing-manager/pkg/paddlehandler"
 )
 
@@ -98,6 +102,40 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order:
+//  1. Typed *cerrors.VoipbinError → encoded via cerrors.ToResponse so the
+//     api-manager edge recovers domain/reason/message via errors.As over RPC.
+//  2. Legacy dbhandler.ErrNotFound (wrapped via pkg/errors) → simpleResponse(404)
+//     so account-not-found behavior is preserved for not-yet-migrated code paths.
+//  3. Anything else → simpleResponse(500). Plain DB/marshal errors become
+//     INTERNAL via the api-manager translator's default branch.
+//
+// errorResponse should never be called with a nil error — every call site
+// gates on `if err != nil`. If nil is passed defensively log a loud warning
+// so the misuse is visible, then return 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		// fall through if marshal fails — should not happen for a valid VoipbinError
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface

--- a/bin-billing-manager/pkg/listenhandler/v1_accounts.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_accounts.go
@@ -53,12 +53,13 @@ func (h *listenHandler) processV1AccountsGet(ctx context.Context, m *sock.Reques
 	as, err := h.accountHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get accounts info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(as)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal accounts response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -87,12 +88,13 @@ func (h *listenHandler) processV1AccountsIDGet(ctx context.Context, m *sock.Requ
 	c, err := h.accountHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get account info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(c)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal account response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -125,13 +127,14 @@ func (h *listenHandler) processV1AccountsIDPut(ctx context.Context, m *sock.Requ
 
 	c, err := h.accountHandler.UpdateBasicInfo(ctx, id, req.Name, req.Detail)
 	if err != nil {
-		log.Errorf("Could not get account info. err: %v", err)
-		return simpleResponse(404), nil
+		log.Errorf("Could not update account basic info. err: %v", err)
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(c)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal account response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -165,12 +168,13 @@ func (h *listenHandler) processV1AccountsIDBalanceAddForcePost(ctx context.Conte
 	c, err := h.accountHandler.AddBalance(ctx, id, req.Balance)
 	if err != nil {
 		log.Errorf("Could not add the balance. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(c)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal account response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -203,13 +207,14 @@ func (h *listenHandler) processV1AccountsIDBalanceSubtractForcePost(ctx context.
 
 	c, err := h.accountHandler.SubtractBalance(ctx, id, req.Balance)
 	if err != nil {
-		log.Errorf("Could not get call info. err: %v", err)
-		return simpleResponse(404), nil
+		log.Errorf("Could not subtract the balance. err: %v", err)
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(c)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal account response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -243,7 +248,7 @@ func (h *listenHandler) processV1AccountsIDIsValidBalancePost(ctx context.Contex
 	valid, err := h.accountHandler.IsValidBalance(ctx, accountID, billing.ReferenceType(req.BillingType), req.Country, req.Count)
 	if err != nil {
 		log.Errorf("Could not validate the account's balance info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	tmp := &response.V1ResponseAccountsIDIsValidBalance{
@@ -252,7 +257,8 @@ func (h *listenHandler) processV1AccountsIDIsValidBalancePost(ctx context.Contex
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal balance validation response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -286,7 +292,7 @@ func (h *listenHandler) processV1AccountsIDIsValidResourceLimitPost(ctx context.
 	valid, err := h.accountHandler.IsValidResourceLimit(ctx, accountID, account.ResourceType(req.ResourceType))
 	if err != nil {
 		log.Errorf("Could not validate the account's resource limit. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	tmp := &response.V1ResponseAccountsIDIsValidResourceLimit{
@@ -295,7 +301,8 @@ func (h *listenHandler) processV1AccountsIDIsValidResourceLimitPost(ctx context.
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal resource limit validation response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -324,7 +331,7 @@ func (h *listenHandler) processV1AccountsIsValidBalanceByCustomerIDPost(ctx cont
 	valid, err := h.accountHandler.IsValidBalanceByCustomerID(ctx, customerID, billing.ReferenceType(req.BillingType), req.Country, req.Count)
 	if err != nil {
 		log.Errorf("Could not validate the account's balance info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	tmp := &response.V1ResponseAccountsIDIsValidBalance{
@@ -333,7 +340,8 @@ func (h *listenHandler) processV1AccountsIsValidBalanceByCustomerIDPost(ctx cont
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal balance validation response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -362,7 +370,7 @@ func (h *listenHandler) processV1AccountsIsValidResourceLimitByCustomerIDPost(ct
 	valid, err := h.accountHandler.IsValidResourceLimitByCustomerID(ctx, customerID, account.ResourceType(req.ResourceType))
 	if err != nil {
 		log.Errorf("Could not validate the account's resource limit. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	tmp := &response.V1ResponseAccountsIDIsValidResourceLimit{
@@ -371,7 +379,8 @@ func (h *listenHandler) processV1AccountsIsValidResourceLimitByCustomerIDPost(ct
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal resource limit validation response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -405,12 +414,13 @@ func (h *listenHandler) processV1AccountsIDPaymentInfoPut(ctx context.Context, m
 	tmp, err := h.accountHandler.UpdatePaymentInfo(ctx, accountID, req.PaymentType, req.PaymentMethod)
 	if err != nil {
 		log.Errorf("Could not update the account's payment info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal payment info response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{

--- a/bin-billing-manager/pkg/listenhandler/v1_billing.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_billing.go
@@ -43,7 +43,7 @@ func (h *listenHandler) processV1BillingGet(ctx context.Context, m *sock.Request
 	billing, err := h.billingHandler.Get(ctx, billingID)
 	if err != nil {
 		log.Errorf("Could not get billing. billing_id: %s, err: %v", billingID, err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(billing)

--- a/bin-billing-manager/pkg/listenhandler/v1_billings.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_billings.go
@@ -48,12 +48,13 @@ func (h *listenHandler) processV1BillingsGet(ctx context.Context, m *sock.Reques
 	as, err := h.billingHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get billings info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(as)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal billings response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{

--- a/docs/plans/2026-04-26-typed-rpc-design.md
+++ b/docs/plans/2026-04-26-typed-rpc-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Author:** Sungtae Kim
-**Date:** 2026-04-26
+**Date:** 2026-04-26 (last updated 2026-04-26 with PR1+PR2 combination)
 **Related:** Follows the 18-PR `bin-api-manager` structured-error-envelope migration. Eliminates the substring-fallback in the api-manager translator by making upstream managers emit typed errors over RPC.
 
 ---
@@ -18,17 +18,17 @@ Eliminate `bin-api-manager/server/error_translate.go` section 4 (substring fallb
 3. A true transport failure: `context.Canceled` or `context.DeadlineExceeded` (translator section 3).
 4. An unclassified internal error caught by the section-5 `INTERNAL` safety net.
 
-Section 4 (substring matching against `http.StatusText`-derived strings) is removed. The substring rules in section 4 have always been a leaky abstraction — they match strings that the api-manager's own `requesthandler` synthesized from status codes, not strings that upstream managers actually emit. They are infrastructure pretending to be domain logic, and they swallow real bugs (an internal error containing the word "unavailable" gets misclassified as a SERVICE_UNAVAILABLE response).
+Section 4 (substring matching against `http.StatusText`-derived strings) is removed.
 
 ### Non-goals
 
 - **Replacing every `fmt.Errorf` in the codebase.** Only errors with a user-visible classification get migrated. Examples that get migrated: `NOT_FOUND`, `INVALID_ARGUMENT`, `FAILED_PRECONDITION`, `PAYMENT_REQUIRED`, `PERMISSION_DENIED`, `RESOURCE_EXHAUSTED`, `ALREADY_EXISTS`. Examples that stay as plain `fmt.Errorf` (and ride the default `INTERNAL` path): DB connection failures, JSON marshal errors, programmer-error invariant violations.
-- **Manager-to-manager protocol changes** beyond what `cerrors.ToResponse`/`FromResponse` already do. The wire is backward-compatible: a non-migrated client just ignores `DataTypeVoipbinError` and treats the response the same way it always has.
+- **Manager-to-manager protocol changes** beyond what `cerrors.ToResponse`/`FromResponse` already do. Backward-compatible: a non-migrated client just ignores `DataTypeVoipbinError` and treats the response the same as before.
 - **Touching api-manager-local error logic.** Sections 1–3 and 5 of the translator stay as-is.
 
 ---
 
-## 2. Current state (confirmed in scoping)
+## 2. Current state (PR0 confirmed it)
 
 ```
 [manager business handler]
@@ -51,11 +51,10 @@ Section 4 (substring matching against `http.StatusText`-derived strings) is remo
 [bin-api-manager/server/error_translate.go]
    strings.ToLower(err.Error()) → contains "not found" → NotFound envelope
                                   ↑
-                          section 4 — substring-matches the canned sentinel string,
-                          NOT manager-emitted text
+                          section 4 — substring-matches the canned sentinel string
 ```
 
-**Key insight from scoping**: section 4 isn't matching upstream service text. It's matching `http.StatusText` strings synthesized inside `bin-common-handler/pkg/requesthandler/common.go` from status codes. That means the fix lives in `requesthandler`, not just per-manager.
+**Key insight:** section 4 isn't matching upstream service text. It's matching `http.StatusText` strings synthesized inside `bin-common-handler/pkg/requesthandler/common.go` from status codes.
 
 ---
 
@@ -68,44 +67,32 @@ Section 4 (substring matching against `http.StatusText`-derived strings) is remo
        │
        ▼
 [manager listenHandler]
-   if errors.As(err, &ve) { return cerrors.ToResponse(ve) }
-       ← StatusCode=404, DataType=DataTypeVoipbinError, body=JSON
+   errorResponse(err)   ← detects typed VoipbinError, emits via cerrors.ToResponse
        │
        ▼
-[requesthandler.parseResponse]
+[requesthandler.parseResponse (PR0)]
    if ve := cerrors.FromResponse(resp); ve != nil { return ve }
-       ← typed *VoipbinError flows through
-       │
-       ▼
-[api-manager servicehandler]
-   return fmt.Errorf("...: %w", err)   ← still wraps; the cause is typed
        │
        ▼
 [error_translate.go section 1]
    errors.As(err, &ve) → return ve     ← passthrough, no string matching
 ```
 
-Section 4 deleted. Section 5 (default `INTERNAL`) catches the rare case of an un-classified error.
+Section 4 deleted. Section 5 (default `INTERNAL`) catches the rare un-classified case.
 
 ---
 
-## 4. Audit findings (pre-implementation scoping)
+## 4. PR0 audit findings (recap)
 
-### 4.1 `errors.Is`/`errors.Cause` consumers of `requesthandler.Err*` (production-only)
+### 4.1 Legacy sentinel callers (3 production sites — fixed in PR0)
 
-Three production sites depend on the legacy sentinels. They will silently regress when their upstream starts emitting typed errors, because `*VoipbinError` is a different concrete type and won't match `errors.Is(err, requesthandler.ErrNotFound)`.
-
-| File | Pattern | Behavior at risk |
+| File | Pattern | Mitigation in PR0 |
 |------|---------|------------------|
-| `bin-call-manager/pkg/channelhandler/hangup.go:46` | `errors.Cause(errHangup) == requesthandler.ErrNotFound` | "Channel already gone" silently treated as success. Regression: the typed 404 falls through to error propagation, hangup looks like a real failure. |
-| `bin-api-manager/pkg/servicehandler/provider.go:212` | `errors.Is(err, commonrequesthandler.ErrUnprocessableEntity)` | "Carrier rejected key" → `CARRIER_CREDENTIALS_REJECTED`. Regression: typed 422 falls through, returns generic error to client. |
-| `bin-api-manager/server/providers.go:213` | Same as above (HTTP-handler-layer duplicate guard) | Same. |
+| `bin-call-manager/pkg/channelhandler/hangup.go:46` | `errors.Cause(errHangup) == requesthandler.ErrNotFound` | Added parallel typed-error guard. |
+| `bin-api-manager/pkg/servicehandler/provider.go` | `errors.Is(err, ErrUnprocessableEntity)` | Added typed-error pass-through. |
+| `bin-api-manager/server/providers.go` | Same as above | Added typed-error pass-through. |
 
-**Mitigation**: PR0 patches all three with parallel typed-error guards alongside the legacy check. Both branches stay until the relevant upstream is migrated. Cleanup of legacy guards happens in the per-manager PRs as the upstream is migrated.
-
-### 4.2 Manager scope
-
-All 28 managers with a `pkg/listenhandler/` (RPC entry point) are in scope:
+### 4.2 Manager scope — all 28 with `pkg/listenhandler/`
 
 ```
 agent, ai, billing (pilot), call, campaign, conference, contact,
@@ -116,174 +103,107 @@ transcribe, transfer, tts, webhook
 
 Excluded: `dbscheme-manager`, `openapi-manager`, `sentinel-manager` (no listenhandler / not RPC entry points).
 
-### 4.3 api-validator framework
+### 4.3 api-validator framework — ready
 
-`monorepo-monitoring/api-validator/tests/helpers/assertions.py:assert_error_envelope()` already supports the per-domain assertion needed for end-to-end verification (`domain="billing-manager"` etc.). All 10 canonical statuses are in `CANONICAL_STATUSES`. Existing per-resource error scenarios in `tests/scenarios/test_*_errors.py` are the targets for adding domain assertions per migrated manager.
-
-No framework work needed. Per-manager PR adds scenarios.
+`monorepo-monitoring/api-validator/tests/helpers/assertions.py:assert_error_envelope()` accepts `domain="..."` for per-service assertions. No framework work needed.
 
 ---
 
-## 5. Migration plan (30 PRs)
+## 5. Migration plan (29 PRs)
 
-### PR0 — Wire unwrap path `[bin-common-handler + 3 callers]`
+### PR0 — Wire unwrap path `[bin-common-handler + 3 callers]` ✅ MERGED 2026-04-26
 
-**Scope:**
-
-1. **`bin-common-handler/pkg/requesthandler/common.go:parseResponse`** — add typed-error detection ahead of the legacy `HttpStatusErrorMap` path:
-
-    ```go
-    func parseResponse(resp *sock.Response, out any) error {
-        if resp == nil {
-            return nil
-        }
-
-        // NEW: typed VoipbinError takes precedence over canned sentinel.
-        if ve := cerrors.FromResponse(resp); ve != nil {
-            return ve
-        }
-
-        if errStatus := getResponseStatusCodeError(resp.StatusCode); errStatus != nil {
-            return errStatus
-        }
-        // ... existing path unchanged
-    }
-    ```
-
-    Behavior: if upstream sets `DataType=DataTypeVoipbinError`, the typed `*VoipbinError` flows up; otherwise legacy path fires. Wire-compatible with all non-migrated managers.
-
-2. **Patch 3 production callers** that depend on the legacy sentinel match. Add a parallel typed guard:
-
-    ```go
-    // call-manager hangup.go:
-    var ve *cerrors.VoipbinError
-    if errors.As(errHangup, &ve) && ve.Status == cerrors.StatusNotFound {
-        return nil
-    }
-    if errors.Cause(errHangup) == requesthandler.ErrNotFound {
-        return nil
-    }
-    ```
-
-3. **Unit tests** in `bin-common-handler/pkg/requesthandler/`:
-   - `parseResponse` with `DataType=DataTypeVoipbinError` and valid body → returns `*VoipbinError`.
-   - `parseResponse` with status 404 and no DataType → returns legacy `ErrNotFound`.
-   - `parseResponse` with `DataType=DataTypeVoipbinError` and malformed JSON → falls through to legacy path.
-   - `parseResponse` with 200 status → no error, unchanged behavior.
-
-**Verify:** all 28+ services that depend on `bin-common-handler`. Mostly mechanical (no service-side code changes; just rebuild + test). Use the standard verification:
-`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`
-
-**Branch:** `NOJIRA-typed-rpc-pr0-wire-unwrap`
+`parseResponse` now returns `*VoipbinError` ahead of the legacy `HttpStatusErrorMap` path. Logs warn when `DataType=DataTypeVoipbinError` but unmarshal fails. Three production callers patched with parallel typed-error guards. Squash-merged at commit `9fb2ee8e`.
 
 ---
 
-### PR1 — Pilot listenHandler integration `[bin-billing-manager]`
+### PR1 — Pilot: bin-billing-manager (combined listenHandler + business-handler migration)
 
-**Scope:**
+**Combined scope** (originally PR1 + PR2 in the v1 plan; combined to avoid the 404→500 regression that would result from migrating only the listenHandler). The pilot ships both layers in one PR so semantics are preserved end-to-end.
 
-- Add `errorResponse(err error) *sock.Response` helper in `bin-billing-manager/pkg/listenhandler/`:
+**Changes:**
 
-    ```go
-    func errorResponse(err error) *sock.Response {
-        var ve *cerrors.VoipbinError
-        if errors.As(err, &ve) {
-            if resp, e := cerrors.ToResponse(ve); e == nil {
-                return resp
-            }
-        }
-        return simpleResponse(http.StatusInternalServerError)
-    }
-    ```
+1. **`bin-billing-manager/pkg/listenhandler/main.go`** — add `errorResponse(err)` helper:
+   - If `errors.As(err, *cerrors.VoipbinError)` → return `cerrors.ToResponse(ve)`.
+   - Else if `errors.Is(err, dbhandler.ErrNotFound)` → return `simpleResponse(404)` (preserves legacy not-found-via-DB-sentinel behavior).
+   - Else → return `simpleResponse(500)`.
 
-- Replace `simpleResponse(4xx)` call sites in the dispatcher with `errorResponse(err)` where the error originates from a business handler.
-- **No business-logic changes.** Existing `fmt.Errorf` paths still produce a 500 via the helper's fallback.
+2. **`bin-billing-manager/pkg/listenhandler/v1_*.go`** — replace business-handler error sites:
+   - `simpleResponse(404)` (the kludge that returned 404 for ANY error) → `errorResponse(err)` so the helper picks the right code.
+   - JSON-marshal failures stay as `simpleResponse(500)` (programmer error, not user-visible).
+   - Paddle-webhook handlers (`v1_hooks_paddle.go`, `v1_accounts_paddle.go`) are out of scope.
+
+3. **Business handlers — typed errors for the user-visible `fmt.Errorf` sites:**
+   - `accounthandler/account.go:97` — `invalid status: %s` → `cerrors.InvalidArgument`.
+   - `accounthandler/balance.go:130` — `unsupported billing type` → `cerrors.InvalidArgument`.
+   - `accounthandler/resource_limit.go:62` — `unknown plan type` → `cerrors.InvalidArgument`.
+   - `accounthandler/resource_limit.go:105` — `unsupported resource type` → `cerrors.InvalidArgument`.
+   - `billinghandler/billing.go:85` — `unsupported reference type` → `cerrors.InvalidArgument`.
+   - `billinghandler/billing.go:158` — `unsupported billing reference type` → `cerrors.InvalidArgument`.
+   - DB-failure-wrapping `fmt.Errorf` sites stay as plain errors (INTERNAL via default).
+
+4. **Tests** — update string-asserts in `accounthandler/*_test.go`, `billinghandler/*_test.go`, `listenhandler/v1_*_test.go` to use `errors.Is` / `errors.As`.
+
+5. **api-validator** — extend `monorepo-monitoring/api-validator/tests/scenarios/test_billing_e2e.py` (or `test_accesskey_errors.py` if billing is hard to trigger) with a scenario that asserts `domain="billing-manager"` for at least one user-visible error path.
 
 **Verify:** bin-billing-manager + bin-api-manager.
 
-**Branch:** `NOJIRA-typed-rpc-pr1-billing-listenhandler`
+**Branch:** `NOJIRA-typed-rpc-pr1-billing-pilot`
 
 ---
 
-### PR2 — Pilot business-handler migration `[bin-billing-manager]`
+### PR2..N-1 — Replicate per remaining manager `[one PR per manager]`
 
-**Scope:** migrate user-visible errors in `accounthandler/`, `billinghandler/`. Mapping:
-
-| Current | New |
-|---------|-----|
-| `fmt.Errorf("invalid status: %s", status)` | `cerrors.InvalidArgument(svc, "INVALID_STATUS", "...")` |
-| `fmt.Errorf("unsupported billing type")` | `cerrors.InvalidArgument(svc, "UNSUPPORTED_BILLING_TYPE", "...")` |
-| `fmt.Errorf("insufficient balance")` (production sites) | `cerrors.PaymentRequired(svc, "INSUFFICIENT_BALANCE", "...")` |
-| Account/billing not-found from DB | `cerrors.NotFound(svc, "RESOURCE_NOT_FOUND", "...")` |
-| DB connection / marshal failures | **stay as `fmt.Errorf`** → `INTERNAL` via default |
-
-Update tests asserting on error strings to use `errors.Is` / `errors.As`.
-
-**End-to-end check via api-validator:** trigger `INSUFFICIENT_BALANCE` and confirm:
-- HTTP 402.
-- Body shape `{"error": {"status": "PAYMENT_REQUIRED", "reason": "INSUFFICIENT_BALANCE", "domain": "billing-manager", ...}}`.
-- `domain` field reads `billing-manager`, **not** `api-manager`. This proves the typed envelope flowed end-to-end and didn't get re-synthesized by api-manager's translator.
-
-**Verify:** bin-billing-manager + bin-api-manager + monorepo-monitoring api-validator (add error-envelope assertions for billing endpoints).
-
-**Branch:** `NOJIRA-typed-rpc-pr2-billing-handlers`
-
----
-
-### PR3..N — Replicate per remaining manager `[one PR per manager]`
-
-Each follows the compressed pattern (listenHandler integration + business-handler migration in one PR), since the pilot proves the wiring.
+Each follows the combined pilot pattern.
 
 **Order** (priority by api-manager exposure × error-semantic complexity):
 
 | Tier | PR | Manager | Branch |
 |------|-----|---------|--------|
-| 1 | PR3 | bin-call-manager | `NOJIRA-typed-rpc-pr3-call` |
-| 1 | PR4 | bin-flow-manager | `NOJIRA-typed-rpc-pr4-flow` |
-| 1 | PR5 | bin-conference-manager | `NOJIRA-typed-rpc-pr5-conference` |
-| 1 | PR6 | bin-conversation-manager | `NOJIRA-typed-rpc-pr6-conversation` |
-| 1 | PR7 | bin-customer-manager | `NOJIRA-typed-rpc-pr7-customer` |
-| 1 | PR8 | bin-agent-manager | `NOJIRA-typed-rpc-pr8-agent` |
-| 2 | PR9 | bin-number-manager | `NOJIRA-typed-rpc-pr9-number` |
-| 2 | PR10 | bin-message-manager | `NOJIRA-typed-rpc-pr10-message` |
-| 2 | PR11 | bin-email-manager | `NOJIRA-typed-rpc-pr11-email` |
-| 2 | PR12 | bin-campaign-manager | `NOJIRA-typed-rpc-pr12-campaign` |
-| 2 | PR13 | bin-outdial-manager | `NOJIRA-typed-rpc-pr13-outdial` |
-| 2 | PR14 | bin-queue-manager | `NOJIRA-typed-rpc-pr14-queue` |
-| 2 | PR15 | bin-ai-manager | `NOJIRA-typed-rpc-pr15-ai` |
-| 3 | PR16 | bin-rag-manager | `NOJIRA-typed-rpc-pr16-rag` |
-| 3 | PR17 | bin-tts-manager | `NOJIRA-typed-rpc-pr17-tts` |
-| 3 | PR18 | bin-transcribe-manager | `NOJIRA-typed-rpc-pr18-transcribe` |
-| 3 | PR19 | bin-storage-manager | `NOJIRA-typed-rpc-pr19-storage` |
-| 3 | PR20 | bin-pipecat-manager | `NOJIRA-typed-rpc-pr20-pipecat` |
-| 4 | PR21 | bin-webhook-manager | `NOJIRA-typed-rpc-pr21-webhook` |
-| 4 | PR22 | bin-hook-manager | `NOJIRA-typed-rpc-pr22-hook` |
-| 4 | PR23 | bin-timeline-manager | `NOJIRA-typed-rpc-pr23-timeline` |
-| 4 | PR24 | bin-tag-manager | `NOJIRA-typed-rpc-pr24-tag` |
-| 4 | PR25 | bin-contact-manager | `NOJIRA-typed-rpc-pr25-contact` |
-| 4 | PR26 | bin-direct-manager | `NOJIRA-typed-rpc-pr26-direct` |
-| 4 | PR27 | bin-talk-manager | `NOJIRA-typed-rpc-pr27-talk` |
-| 4 | PR28 | bin-transfer-manager | `NOJIRA-typed-rpc-pr28-transfer` |
-| 4 | PR29 | bin-route-manager | `NOJIRA-typed-rpc-pr29-route` |
-| 4 | PR30 | bin-registrar-manager | `NOJIRA-typed-rpc-pr30-registrar` |
+| 1 | PR2 | bin-call-manager | `NOJIRA-typed-rpc-pr2-call` |
+| 1 | PR3 | bin-flow-manager | `NOJIRA-typed-rpc-pr3-flow` |
+| 1 | PR4 | bin-conference-manager | `NOJIRA-typed-rpc-pr4-conference` |
+| 1 | PR5 | bin-conversation-manager | `NOJIRA-typed-rpc-pr5-conversation` |
+| 1 | PR6 | bin-customer-manager | `NOJIRA-typed-rpc-pr6-customer` |
+| 1 | PR7 | bin-agent-manager | `NOJIRA-typed-rpc-pr7-agent` |
+| 2 | PR8 | bin-number-manager | `NOJIRA-typed-rpc-pr8-number` |
+| 2 | PR9 | bin-message-manager | `NOJIRA-typed-rpc-pr9-message` |
+| 2 | PR10 | bin-email-manager | `NOJIRA-typed-rpc-pr10-email` |
+| 2 | PR11 | bin-campaign-manager | `NOJIRA-typed-rpc-pr11-campaign` |
+| 2 | PR12 | bin-outdial-manager | `NOJIRA-typed-rpc-pr12-outdial` |
+| 2 | PR13 | bin-queue-manager | `NOJIRA-typed-rpc-pr13-queue` |
+| 2 | PR14 | bin-ai-manager | `NOJIRA-typed-rpc-pr14-ai` |
+| 3 | PR15 | bin-rag-manager | `NOJIRA-typed-rpc-pr15-rag` |
+| 3 | PR16 | bin-tts-manager | `NOJIRA-typed-rpc-pr16-tts` |
+| 3 | PR17 | bin-transcribe-manager | `NOJIRA-typed-rpc-pr17-transcribe` |
+| 3 | PR18 | bin-storage-manager | `NOJIRA-typed-rpc-pr18-storage` |
+| 3 | PR19 | bin-pipecat-manager | `NOJIRA-typed-rpc-pr19-pipecat` |
+| 4 | PR20 | bin-webhook-manager | `NOJIRA-typed-rpc-pr20-webhook` |
+| 4 | PR21 | bin-hook-manager | `NOJIRA-typed-rpc-pr21-hook` |
+| 4 | PR22 | bin-timeline-manager | `NOJIRA-typed-rpc-pr22-timeline` |
+| 4 | PR23 | bin-tag-manager | `NOJIRA-typed-rpc-pr23-tag` |
+| 4 | PR24 | bin-contact-manager | `NOJIRA-typed-rpc-pr24-contact` |
+| 4 | PR25 | bin-direct-manager | `NOJIRA-typed-rpc-pr25-direct` |
+| 4 | PR26 | bin-talk-manager | `NOJIRA-typed-rpc-pr26-talk` |
+| 4 | PR27 | bin-transfer-manager | `NOJIRA-typed-rpc-pr27-transfer` |
+| 4 | PR28 | bin-route-manager | `NOJIRA-typed-rpc-pr28-route` |
+| 4 | PR29 | bin-registrar-manager | `NOJIRA-typed-rpc-pr29-registrar` |
 
 ---
 
-### Final PR — Remove translator section 4 `[bin-api-manager]`
+### Final PR (PR30) — Remove translator section 4 `[bin-api-manager]`
 
 After all in-scope managers are migrated AND api-validator error-envelope tests run green for at least one CI cycle:
 
 - Delete section 4 from `error_translate.go`.
-- Update `error_translate_test.go`: drop section-4 cases, beef up sections 1–3 + 5 if any gaps.
+- Update `error_translate_test.go`: drop section-4 cases.
 - Keep section 5 (default `INTERNAL`) as the safety net.
-
-If a regression appears post-merge, revert is one PR.
 
 **Branch:** `NOJIRA-typed-rpc-final-kill-section4`
 
 ---
 
-## 6. Per-manager migration template (PR3..N)
+## 6. Per-manager migration template (PR2..PR29)
 
 For each manager:
 
@@ -304,12 +224,10 @@ For each manager:
 
 | Risk | Mitigation |
 |------|------------|
-| PR0 changes `parseResponse` behavior subtly for callers using legacy sentinels on responses that *will be* migrated post-PR0 | Pre-implementation audit identified 3 sites; PR0 patches each with a parallel typed guard. Both branches stay until upstream is migrated. |
-| Breaking changes in error-message text for clients matching on it | Out of scope. Clients should be using HTTP status code and envelope `reason`, not message strings. If api-validator catches text-matching, fix the test. |
+| listenHandler-only migration would regress 404 → 500 | Combined pilot pattern: ship listenHandler integration + business-handler migration together. The `errorResponse` helper also detects legacy `dbhandler.ErrNotFound` to preserve not-found behavior for non-migrated DB code paths. |
+| Breaking changes in error-message text for clients matching on it | Out of scope. Clients should be using HTTP status code and envelope `reason`. |
 | Accidentally migrating an internal error to a user-visible classification | Code-review checkpoint per PR. Heuristic: if an operator (not the user) needs to debug it, it's `INTERNAL`. |
-| 28-service blast-radius PR0 verification fatigue | PR0 is a no-op for service code; verification is `go test`/lint passing, not "review every diff." |
-| api-validator coverage gap masks a regression | Each per-manager PR adds at least one domain-asserting scenario. Stricter coverage tracked across the rollout. |
-| Pre-existing `errors.Is(err, requesthandler.Err*)` callers in pending feature work (worktrees) regress when those features land post-PR0 | Worktree work is not in scope. Feature owners must update their callers using the same dual-guard pattern when their features merge. |
+| api-validator coverage gap masks a regression | Each per-manager PR adds at least one domain-asserting scenario. |
 
 ---
 
@@ -318,7 +236,7 @@ For each manager:
 Every PR is independently revertable:
 
 - **PR0** — revert restores legacy-only path. Migrated managers' typed responses become canned sentinels again — degraded but functional.
-- **PR1..N** — revert restores `fmt.Errorf` + `simpleResponse(4xx)` path. Translator's section 4 still catches it (until the final PR lands).
+- **PR1..N-1** — revert restores `fmt.Errorf` + `simpleResponse(4xx)` path. Translator's section 4 still catches it (until the final PR lands).
 - **Final PR** — revert restores section 4.
 
 No schema changes, no migrations, no irreversible state.
@@ -327,8 +245,8 @@ No schema changes, no migrations, no irreversible state.
 
 ## 9. Verification strategy
 
-- **PR0**: full monorepo verify (28+ services). Mechanical — `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m` per service. Plus new unit tests in `bin-common-handler/pkg/requesthandler` covering the typed-passthrough and legacy-fallback paths. Plus `bin-call-manager` and `bin-api-manager` verification for the 3 patched callers.
-- **PR1..N**: per-manager verify + bin-api-manager verify + api-validator scenarios for at least one error path with `domain=<service-name>` assertion.
+- **PR0**: full monorepo verify (28+ services). Mechanical — no service-side code changes.
+- **PR1..N-1**: per-manager verify + bin-api-manager verify + api-validator scenarios for at least one error path with `domain=<service-name>` assertion.
 - **Final PR**: bin-api-manager verify + full api-validator error-envelope suite green.
 
 Code review (review-and-fix loop) runs before every merge — no shortcuts based on PR size.


### PR DESCRIPTION
Combined pilot PR for the typed-RPC-error-envelope migration. Migrates bin-billing-manager listenHandler and business handlers to emit typed *cerrors.VoipbinError end-to-end. After this lands, GET /v1/billing-accounts/{nonexistent} returns an envelope with domain=\"billing-manager\" instead of the api-manager translator's hand-rolled string-matched envelope, proving end-to-end typed-error flow from PR0's parseResponse unwrap.

PR1 originally split listenHandler integration (PR1) and business-handler migration (PR2) into separate PRs; combined to avoid the 404→500 regression that would result from migrating only the listenHandler (errorResponse helper's typed branch is dormant until business handlers emit typed errors). Total PR count drops from 30 → 29.

- bin-billing-manager: Add errorResponse(err) helper in listenhandler/main.go. Resolution order: typed *VoipbinError → ToResponse; legacy dbhandler.ErrNotFound → simpleResponse(404); else → simpleResponse(500). Defensive nil-guard logs warn and returns 500.
- bin-billing-manager: Migrate listenhandler v1_accounts.go, v1_billings.go, v1_billing.go simpleResponse(404) sites after business-handler calls to errorResponse(err). JSON marshal failures correctly use simpleResponse(500) (was buggy 404). Paddle webhook handlers out of scope.
- bin-billing-manager: accounthandler.Get and billinghandler.Get emit typed cerrors.NotFound when underlying DB returns dbhandler.ErrNotFound, so api-manager edge recovers BILLING_ACCOUNT_NOT_FOUND / BILLING_NOT_FOUND reasons via errors.As.
- bin-billing-manager: Migrate accounthandler/balance.go (UNSUPPORTED_BILLING_TYPE → InvalidArgument) and resource_limit.go:getResourceCount (UNSUPPORTED_RESOURCE_TYPE → InvalidArgument) — these come from API request body. Migrate accounthandler/account.go:SetStatus (INVALID_ACCOUNT_STATUS → Internal), resource_limit.go:62 plan-type (UNKNOWN_PLAN_TYPE → Internal), billinghandler/billing.go:BillingStart+BillingEnd (UNSUPPORTED_REFERENCE_TYPE → Internal) — these come from internal enums or DB-loaded values, not user input.
- bin-billing-manager: accounthandler.Delete re-classifies a typed NotFound from the post-delete re-fetch as Internal (POST_DELETE_LOOKUP_FAILED) — the delete itself succeeded; a 404 would be misleading.
- bin-billing-manager: Migrate two identity comparisons (\`err == ErrNotFound\`) to \`stderrors.Is\` in billinghandler/billing.go and accounthandler/paddle.go to be safe across future error wrapping.
- bin-billing-manager: 5 new tests in listenhandler/error_response_test.go cover typed pass-through, pkg/errors.Wrapf chain unwrap, legacy ErrNotFound preservation, unclassified-error fallthrough, and nil-error defensive path.
- docs: Update typed-RPC design doc to reflect combined-PR1 sequencing (PR1+PR2 merged) and renumber subsequent per-manager PRs accordingly.

Follow-up after this deploys: extend monorepo-monitoring/api-validator/tests/scenarios/test_billing*.py with a scenario that asserts domain=\"billing-manager\" for GET /v1/billing-accounts/{nonexistent} — confirms typed envelope flowed end-to-end. Deferred because the api-validator runs against deployed services.