### PR TITLE
NOJIRA-typed-rpc-pr2-call

### DIFF
--- a/bin-call-manager/pkg/callhandler/db.go
+++ b/bin-call-manager/pkg/callhandler/db.go
@@ -2,11 +2,14 @@ package callhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	fmaction "monorepo/bin-flow-manager/models/action"
 
@@ -17,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-call-manager/models/call"
+	"monorepo/bin-call-manager/pkg/dbhandler"
 )
 
 // Create creates a call record.
@@ -148,9 +152,20 @@ func (h *callHandler) List(ctx context.Context, size uint64, token string, filte
 }
 
 // Get returns call.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *callHandler) Get(ctx context.Context, id uuid.UUID) (*call.Call, error) {
 	res, err := h.db.CallGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"CALL_NOT_FOUND",
+				"The call was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "Could not get call.")
 	}
 

--- a/bin-call-manager/pkg/channelhandler/db.go
+++ b/bin-call-manager/pkg/channelhandler/db.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -96,6 +99,12 @@ func (h *channelHandler) get(ctx context.Context, id string) (*channel.Channel, 
 }
 
 // Get returns call.
+//
+// When `getWithTimeout` exhausts `defaultExistTimeout` without the channel
+// appearing, Get returns a typed *cerrors.VoipbinError (Status=NotFound).
+// From the caller's perspective the channel is not present — Asterisk has
+// not announced it within the retry window — and the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *channelHandler) Get(ctx context.Context, id string) (*channel.Channel, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "Get",
@@ -109,7 +118,11 @@ func (h *channelHandler) Get(ctx context.Context, id string) (*channel.Channel, 
 	res, err := h.getWithTimeout(ctx, id, defaultExistTimeout)
 	if err != nil {
 		log.Errorf("Could not get channel. err: %v", err)
-		return nil, err
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameCallManager,
+			"CHANNEL_NOT_FOUND",
+			"The channel was not found.",
+		).Wrap(err)
 	}
 
 	return res, nil

--- a/bin-call-manager/pkg/confbridgehandler/db.go
+++ b/bin-call-manager/pkg/confbridgehandler/db.go
@@ -2,6 +2,7 @@ package confbridgehandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-call-manager/models/confbridge"
+	"monorepo/bin-call-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // Create is handy function for creating a confbridge.
@@ -63,10 +67,21 @@ func (h *confbridgeHandler) Create(
 	return res, nil
 }
 
-// Get returns confbridge
+// Get returns confbridge.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *confbridgeHandler) Get(ctx context.Context, id uuid.UUID) (*confbridge.Confbridge, error) {
 	res, err := h.db.ConfbridgeGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"CONFBRIDGE_NOT_FOUND",
+				"The conference was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get the confbridge. id: %s", id)
 	}
 

--- a/bin-call-manager/pkg/externalmediahandler/db.go
+++ b/bin-call-manager/pkg/externalmediahandler/db.go
@@ -2,11 +2,15 @@ package externalmediahandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
 	"monorepo/bin-call-manager/models/externalmedia"
+	"monorepo/bin-call-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // Create creates a new external media
@@ -67,10 +71,21 @@ func (h *externalMediaHandler) Create(
 	return extMedia, nil
 }
 
-// Get returns external media info
+// Get returns external media info.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *externalMediaHandler) Get(ctx context.Context, id uuid.UUID) (*externalmedia.ExternalMedia, error) {
 	res, err := h.db.ExternalMediaGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"EXTERNAL_MEDIA_NOT_FOUND",
+				"The external media was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get external media with id: %s", id)
 	}
 

--- a/bin-call-manager/pkg/groupcallhandler/db.go
+++ b/bin-call-manager/pkg/groupcallhandler/db.go
@@ -2,15 +2,19 @@ package groupcallhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-call-manager/models/groupcall"
+	"monorepo/bin-call-manager/pkg/dbhandler"
 )
 
 // Create creates a new groupcall.
@@ -99,9 +103,20 @@ func (h *groupcallHandler) Create(
 }
 
 // Get returns a groupcall of the given id.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *groupcallHandler) Get(ctx context.Context, id uuid.UUID) (*groupcall.Groupcall, error) {
 	res, err := h.db.GroupcallGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"GROUPCALL_NOT_FOUND",
+				"The group call was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "Could not get groupcall.")
 	}
 

--- a/bin-call-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-call-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,136 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-call-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+// Test_errorResponse_typed verifies that a *cerrors.VoipbinError is encoded
+// via cerrors.ToResponse — the api-manager edge will recover the typed error
+// from the resulting sock.Response via FromResponse.
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(
+		commonoutline.ServiceNameCallManager,
+		"CALL_NOT_FOUND",
+		"The call was not found.",
+	)
+
+	resp := errorResponse(ve)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+	if len(resp.Data) == 0 {
+		t.Errorf("expected non-empty Data containing JSON-encoded VoipbinError")
+	}
+}
+
+// Test_errorResponse_typedThroughPkgErrorsWrap verifies that errors.As walks
+// the pkg/errors.Wrapf chain — the standard wrapping idiom in business
+// handlers — and recovers the typed error.
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(
+		commonoutline.ServiceNameCallManager,
+		"CONFBRIDGE_NOT_FOUND",
+		"The conference was not found.",
+	)
+	wrapped := pkgerrors.Wrap(ve, "outer context")
+
+	resp := errorResponse(wrapped)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+// Test_errorResponse_legacyNotFound verifies that dbhandler.ErrNotFound
+// (wrapped via pkg/errors) preserves the legacy 404 mapping for code paths
+// that have not yet been migrated to typed errors.
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	wrapped := pkgerrors.Wrap(dbhandler.ErrNotFound, "could not find resource")
+
+	resp := errorResponse(wrapped)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != "" {
+		t.Errorf("DataType should be empty for legacy 404, got: %s", resp.DataType)
+	}
+}
+
+// Test_errorResponse_unclassifiedError verifies that any unknown error
+// (e.g., a DB connection failure) falls through to 500 — becomes INTERNAL
+// at the api-manager translator default branch.
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	plain := fmt.Errorf("connection refused")
+
+	resp := errorResponse(plain)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+// Test_errorResponse_nilError defensive test — calling with nil should not
+// crash and should return 500.
+func Test_errorResponse_nilError(t *testing.T) {
+	resp := errorResponse(nil)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+// Test_errorResponse_typedNotFoundFromBusinessHandler verifies the end-to-end
+// path: a business handler returns the exact typed error pattern this PR
+// introduces, and errorResponse correctly encodes it.
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	// simulate callHandler.Get returning typed NotFound on dbhandler.ErrNotFound
+	dbErr := dbhandler.ErrNotFound
+	typed := cerrors.NotFound(
+		commonoutline.ServiceNameCallManager,
+		"CALL_NOT_FOUND",
+		"The call was not found.",
+	).Wrap(dbErr)
+
+	resp := errorResponse(typed)
+	if resp == nil {
+		t.Fatalf("expected response, got nil")
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+
+	// Cause chain still walks: errors.Is can find dbhandler.ErrNotFound
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("errors.Is should walk VoipbinError.Unwrap chain to find ErrNotFound")
+	}
+}

--- a/bin-call-manager/pkg/listenhandler/main.go
+++ b/bin-call-manager/pkg/listenhandler/main.go
@@ -4,12 +4,15 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
 	"monorepo/bin-call-manager/models/common"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -21,6 +24,7 @@ import (
 	"monorepo/bin-call-manager/pkg/callhandler"
 	"monorepo/bin-call-manager/pkg/channelhandler"
 	"monorepo/bin-call-manager/pkg/confbridgehandler"
+	"monorepo/bin-call-manager/pkg/dbhandler"
 	"monorepo/bin-call-manager/pkg/externalmediahandler"
 	"monorepo/bin-call-manager/pkg/groupcallhandler"
 	"monorepo/bin-call-manager/pkg/recordinghandler"
@@ -145,6 +149,45 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order:
+//  1. Typed *cerrors.VoipbinError → encoded via cerrors.ToResponse so the
+//     api-manager edge recovers domain/reason/message via errors.As over RPC.
+//  2. Legacy dbhandler.ErrNotFound (wrapped via pkg/errors) → simpleResponse(404)
+//     so resource-not-found behavior is preserved for not-yet-migrated paths.
+//  3. Anything else → simpleResponse(500). Plain DB/marshal errors become
+//     INTERNAL via the api-manager translator's default branch.
+//
+// errorResponse should never be called with a nil error — every call site
+// gates on `if err != nil`. If nil is passed defensively log a loud warning
+// so the misuse is visible, then return 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		// ToResponse should not fail for a well-formed VoipbinError (no
+		// channels, funcs, or cycles in the struct). If it ever does,
+		// fall to a clean 500 — silently legacy-pathing here would mask
+		// the issue and mis-report the wire status.
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface

--- a/bin-call-manager/pkg/listenhandler/main_test.go
+++ b/bin-call-manager/pkg/listenhandler/main_test.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -768,16 +770,34 @@ func Test_processRequest_errorPaths(t *testing.T) {
 		expectCode int
 	}{
 		{
-			name: "GET /v1/calls/<id> returns 404 on error",
+			// callHandler.Get now emits typed *VoipbinError (Status=NotFound)
+			// when the underlying DB returns ErrNotFound. The listenHandler's
+			// errorResponse helper detects the typed error and emits a 404.
+			name: "GET /v1/calls/<id> returns 404 on typed NotFound error",
 			request: &sock.Request{
 				URI:    "/v1/calls/638769c2-620d-11eb-bd1f-6b576e26b4e6",
 				Method: sock.RequestMethodGet,
 			},
 			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
 				mockCall := h.callHandler.(*callhandler.MockCallHandler)
-				mockCall.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("638769c2-620d-11eb-bd1f-6b576e26b4e6")).Return(nil, fmt.Errorf("not found"))
+				typedErr := cerrors.NotFound(commonoutline.ServiceNameCallManager, "CALL_NOT_FOUND", "The call was not found.")
+				mockCall.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("638769c2-620d-11eb-bd1f-6b576e26b4e6")).Return(nil, typedErr)
 			},
 			expectCode: 404,
+		},
+		{
+			// Generic (non-typed, non-ErrNotFound) errors now correctly become 500
+			// instead of being mis-classified as 404.
+			name: "GET /v1/calls/<id> returns 500 on generic error",
+			request: &sock.Request{
+				URI:    "/v1/calls/638769c2-620d-11eb-bd1f-6b576e26b4e6",
+				Method: sock.RequestMethodGet,
+			},
+			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
+				mockCall := h.callHandler.(*callhandler.MockCallHandler)
+				mockCall.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("638769c2-620d-11eb-bd1f-6b576e26b4e6")).Return(nil, fmt.Errorf("connection refused"))
+			},
+			expectCode: 500,
 		},
 		{
 			name: "GET /v1/confbridges/<id> returns 400 on error",
@@ -792,28 +812,29 @@ func Test_processRequest_errorPaths(t *testing.T) {
 			expectCode: 400,
 		},
 		{
-			name: "GET /v1/recordings/<id> returns 404 on error",
+			name: "GET /v1/recordings/<id> returns 404 on typed NotFound error",
 			request: &sock.Request{
 				URI:    "/v1/recordings/68e9edd8-3609-11ec-ad76-b72fa8f57f23",
 				Method: sock.RequestMethodGet,
 			},
 			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
 				mockRecording := h.recordingHandler.(*recordinghandler.MockRecordingHandler)
-				mockRecording.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("not found"))
+				typedErr := cerrors.NotFound(commonoutline.ServiceNameCallManager, "RECORDING_NOT_FOUND", "The recording was not found.")
+				mockRecording.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, typedErr)
 			},
 			expectCode: 404,
 		},
 		{
-			name: "GET /v1/external-medias/<id> returns 404 on error",
+			name: "GET /v1/external-medias/<id> returns 500 on generic error",
 			request: &sock.Request{
 				URI:    "/v1/external-medias/68e9edd8-3609-11ec-ad76-b72fa8f57f23",
 				Method: sock.RequestMethodGet,
 			},
 			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
 				mockExternalMedia := h.externalMediaHandler.(*externalmediahandler.MockExternalMediaHandler)
-				mockExternalMedia.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("not found"))
+				mockExternalMedia.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("connection refused"))
 			},
-			expectCode: 404,
+			expectCode: 500,
 		},
 		{
 			name: "GET /v1/groupcalls/<id> returns 500 on error",
@@ -824,6 +845,42 @@ func Test_processRequest_errorPaths(t *testing.T) {
 			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
 				mockGroupcall := h.groupcallHandler.(*groupcallhandler.MockGroupcallHandler)
 				mockGroupcall.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("not found"))
+			},
+			expectCode: 500,
+		},
+		{
+			name: "DELETE /v1/recordings/<id> returns 500 on generic error",
+			request: &sock.Request{
+				URI:    "/v1/recordings/68e9edd8-3609-11ec-ad76-b72fa8f57f23",
+				Method: sock.RequestMethodDelete,
+			},
+			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
+				mockRecording := h.recordingHandler.(*recordinghandler.MockRecordingHandler)
+				mockRecording.EXPECT().Delete(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("delete error"))
+			},
+			expectCode: 500,
+		},
+		{
+			name: "DELETE /v1/external-medias/<id> returns 500 on generic error",
+			request: &sock.Request{
+				URI:    "/v1/external-medias/68e9edd8-3609-11ec-ad76-b72fa8f57f23",
+				Method: sock.RequestMethodDelete,
+			},
+			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
+				mockExternalMedia := h.externalMediaHandler.(*externalmediahandler.MockExternalMediaHandler)
+				mockExternalMedia.EXPECT().Stop(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("stop error"))
+			},
+			expectCode: 500,
+		},
+		{
+			name: "POST /v1/recordings/<id>/stop returns 500 on generic error",
+			request: &sock.Request{
+				URI:    "/v1/recordings/68e9edd8-3609-11ec-ad76-b72fa8f57f23/stop",
+				Method: sock.RequestMethodPost,
+			},
+			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
+				mockRecording := h.recordingHandler.(*recordinghandler.MockRecordingHandler)
+				mockRecording.EXPECT().Stop(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("stop error"))
 			},
 			expectCode: 500,
 		},

--- a/bin-call-manager/pkg/listenhandler/v1_calls.go
+++ b/bin-call-manager/pkg/listenhandler/v1_calls.go
@@ -92,12 +92,13 @@ func (h *listenHandler) processV1CallsIDGet(ctx context.Context, m *sock.Request
 	c, err := h.callHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get call info. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(c)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal call response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -350,7 +351,7 @@ func (h *listenHandler) processV1CallsIDActionTimeoutPost(ctx context.Context, m
 
 	if err := h.callHandler.ActionTimeout(ctx, id, action); err != nil {
 		log.Debugf("Could not handle the action timeout request. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	res := &sock.Response{
@@ -381,7 +382,7 @@ func (h *listenHandler) processV1CallsIDActionNextPost(ctx context.Context, m *s
 	c, err := h.callHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get call info from the database. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	// we run the go runc() here.

--- a/bin-call-manager/pkg/listenhandler/v1_channels.go
+++ b/bin-call-manager/pkg/listenhandler/v1_channels.go
@@ -30,7 +30,7 @@ func (h *listenHandler) processV1ChannelsIDGet(ctx context.Context, m *sock.Requ
 	res, err := h.channelHandler.Get(ctx, channelID)
 	if err != nil {
 		log.Errorf("Could not get channel. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(res)

--- a/bin-call-manager/pkg/listenhandler/v1_external_medias.go
+++ b/bin-call-manager/pkg/listenhandler/v1_external_medias.go
@@ -133,12 +133,13 @@ func (h *listenHandler) processV1ExternalMediasIDGet(ctx context.Context, m *soc
 	tmp, err := h.externalMediaHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get external media. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal external media response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -167,12 +168,13 @@ func (h *listenHandler) processV1ExternalMediasIDDelete(ctx context.Context, m *
 	tmp, err := h.externalMediaHandler.Stop(ctx, id)
 	if err != nil {
 		log.Errorf("Could not stop the extneral media. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal external media response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{

--- a/bin-call-manager/pkg/listenhandler/v1_recordings.go
+++ b/bin-call-manager/pkg/listenhandler/v1_recordings.go
@@ -120,12 +120,13 @@ func (h *listenHandler) processV1RecordingsIDGet(ctx context.Context, m *sock.Re
 	tmp, err := h.recordingHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get recording. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal recording response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -154,12 +155,13 @@ func (h *listenHandler) processV1RecordingsIDDelete(ctx context.Context, m *sock
 	tmp, err := h.recordingHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete the recording. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal recording response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -188,12 +190,13 @@ func (h *listenHandler) processV1RecordingsIDStopPost(ctx context.Context, m *so
 	tmp, err := h.recordingHandler.Stop(ctx, id)
 	if err != nil {
 		log.Errorf("Could not stop the recording: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		log.Errorf("Could not marshal recording response. err: %v", err)
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{

--- a/bin-call-manager/pkg/recordinghandler/db.go
+++ b/bin-call-manager/pkg/recordinghandler/db.go
@@ -2,13 +2,17 @@ package recordinghandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-call-manager/models/recording"
+	"monorepo/bin-call-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	smfile "monorepo/bin-storage-manager/models/file"
 )
 
@@ -96,7 +100,11 @@ func (h *recordingHandler) List(ctx context.Context, size uint64, token string, 
 	return res, nil
 }
 
-// Get returns the recording info
+// Get returns the recording info.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *recordingHandler) Get(ctx context.Context, id uuid.UUID) (*recording.Recording, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":         "Get",
@@ -106,6 +114,13 @@ func (h *recordingHandler) Get(ctx context.Context, id uuid.UUID) (*recording.Re
 	res, err := h.db.RecordingGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get recording info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"RECORDING_NOT_FOUND",
+				"The recording was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Migrates bin-call-manager to emit typed *cerrors.VoipbinError end-to-end, following the bin-billing-manager pilot pattern (PR1). The largest blast radius service in the migration: 5 entry-point Get methods migrated, 17 listenhandler simpleResponse(404) sites converted to errorResponse(err), and several pre-existing bug fixes (404→500 for non-NotFound errors).

After this lands, GET /v1/calls/{nonexistent} (and the matching channel, confbridge, recording, external-media, groupcall endpoints) returns an envelope with domain=\"call-manager\" instead of api-manager's hand-rolled string-matched envelope, completing tier-1 of the typed-RPC migration.

- bin-call-manager: Add errorResponse(err) helper in listenhandler/main.go with the same resolution order as billing-manager: typed *VoipbinError → ToResponse; legacy dbhandler.ErrNotFound → simpleResponse(404); else → simpleResponse(500). ToResponse failure on a typed error logs and returns 500 (no silent fallthrough). Defensive nil-guard logs warn and returns 500.
- bin-call-manager: Migrate 5 entry-point Get methods to emit typed cerrors.NotFound on dbhandler.ErrNotFound: callhandler/db.go:Get (CALL_NOT_FOUND), channelhandler/db.go:Get (CHANNEL_NOT_FOUND — timeout from getWithTimeout also wrapped, since Asterisk-not-announcing-channel = \"not present\" from caller's perspective), confbridgehandler/db.go:Get (CONFBRIDGE_NOT_FOUND), recordinghandler/db.go:Get (RECORDING_NOT_FOUND), groupcallhandler/db.go:Get (GROUPCALL_NOT_FOUND).
- bin-call-manager: Migrate externalmediahandler/db.go:Get to emit typed cerrors.NotFound (EXTERNAL_MEDIA_NOT_FOUND) on dbhandler.ErrNotFound, preventing a 404→500 regression on GET /v1/external-medias/{id}.
- bin-call-manager: Replace 17 simpleResponse(404) sites in listenhandler v1_calls.go, v1_recordings.go, v1_external_medias.go, v1_channels.go with errorResponse(err). JSON marshal failures correctly use simpleResponse(500) (was buggy 404). The change preserves 404 for legitimate not-found cases via both the typed-error path and the legacy dbhandler.ErrNotFound fallback.
- bin-call-manager: 6 new tests in listenhandler/error_response_test.go covering typed pass-through, pkg/errors.Wrapf chain unwrap, legacy ErrNotFound preservation, unclassified-error 500 fallthrough, nil-error defensive path, and end-to-end VoipbinError.Wrap(dbhandler.ErrNotFound) with errors.Is chain walking.
- bin-call-manager: Update 4 existing test cases in main_test.go that previously asserted \"any business-handler error returns 404\" (a buggy catch-all). Now they correctly assert \"typed cerrors.NotFound → 404, generic error → 500\" — bug fix for the API contract. Add 3 new test cases verifying generic errors on Delete/Stop endpoints emit 500.