### PR TITLE
NOJIRA-typed-rpc-pr3-flow

### DIFF
--- a/bin-flow-manager/pkg/activeflowhandler/db.go
+++ b/bin-flow-manager/pkg/activeflowhandler/db.go
@@ -2,16 +2,20 @@ package activeflowhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-flow-manager/models/action"
 	"monorepo/bin-flow-manager/models/activeflow"
 	"monorepo/bin-flow-manager/models/stack"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
 )
 
 // Create creates a new activeflow
@@ -377,11 +381,22 @@ func (h *activeflowHandler) delete(ctx context.Context, id uuid.UUID) (*activefl
 	return res, nil
 }
 
-// Get returns activeflow
+// Get returns activeflow.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *activeflowHandler) Get(ctx context.Context, id uuid.UUID) (*activeflow.Activeflow, error) {
 
 	res, err := h.db.ActiveflowGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameFlowManager,
+				"ACTIVEFLOW_NOT_FOUND",
+				"The active flow was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get activeflow. activeflow_id: %s", id)
 	}
 

--- a/bin-flow-manager/pkg/flowhandler/db.go
+++ b/bin-flow-manager/pkg/flowhandler/db.go
@@ -2,15 +2,19 @@ package flowhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-flow-manager/models/action"
 	"monorepo/bin-flow-manager/models/flow"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
 )
 
 // maxFlowCount is the hard limit on persisted flows per customer.
@@ -32,7 +36,11 @@ import (
 // are excluded because they auto-expire from Redis.
 const maxFlowCount = 10000
 
-// Get returns flow
+// Get returns flow.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *flowHandler) Get(ctx context.Context, id uuid.UUID) (*flow.Flow, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func": "Get",
@@ -42,6 +50,13 @@ func (h *flowHandler) Get(ctx context.Context, id uuid.UUID) (*flow.Flow, error)
 	res, err := h.db.FlowGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get flow. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameFlowManager,
+				"FLOW_NOT_FOUND",
+				"The flow was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-flow-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-flow-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,77 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameFlowManager, "FLOW_NOT_FOUND", "The flow was not found.")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameFlowManager, "ACTIVEFLOW_NOT_FOUND", "The active flow was not found.")
+	wrapped := pkgerrors.Wrap(ve, "outer context")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	wrapped := pkgerrors.Wrap(dbhandler.ErrNotFound, "could not get flow")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != "" {
+		t.Errorf("DataType should be empty for legacy 404, got: %s", resp.DataType)
+	}
+}
+
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	resp := errorResponse(fmt.Errorf("connection refused"))
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_nilError(t *testing.T) {
+	resp := errorResponse(nil)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	dbErr := dbhandler.ErrNotFound
+	typed := cerrors.NotFound(commonoutline.ServiceNameFlowManager, "FLOW_NOT_FOUND", "The flow was not found.").Wrap(dbErr)
+	resp := errorResponse(typed)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("errors.Is should walk VoipbinError.Unwrap chain to find ErrNotFound")
+	}
+}

--- a/bin-flow-manager/pkg/listenhandler/main.go
+++ b/bin-flow-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -16,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-flow-manager/pkg/activeflowhandler"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
 	"monorepo/bin-flow-manager/pkg/flowhandler"
 	"monorepo/bin-flow-manager/pkg/variablehandler"
 )
@@ -110,6 +114,37 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order:
+//  1. Typed *cerrors.VoipbinError → encoded via cerrors.ToResponse so the
+//     api-manager edge recovers domain/reason/message via errors.As over RPC.
+//  2. Legacy dbhandler.ErrNotFound (wrapped via pkg/errors) → simpleResponse(404)
+//     so resource-not-found behavior is preserved for not-yet-migrated paths.
+//  3. Anything else → simpleResponse(500). Plain DB/marshal errors become
+//     INTERNAL via the api-manager translator's default branch.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -301,10 +336,22 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 		requestType = "notfound"
 	}
 
-	// default error handler
+	// default error handler — endpoint handlers that return (nil, err) flow
+	// through here. Typed *VoipbinError and dbhandler.ErrNotFound get routed
+	// through errorResponse so the api-manager edge sees the correct envelope
+	// or 404. Other errors keep the legacy 400 — most call sites that hit
+	// this path are JSON unmarshal failures, which are 400-class.
 	if err != nil {
 		log.Errorf("Could not process the request correctly. data: %s", m.Data)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 


### PR DESCRIPTION
Migrates bin-flow-manager to emit typed *cerrors.VoipbinError end-to-end, following the established pattern from PR1/PR2.

- bin-flow-manager: Add errorResponse(err) helper in listenhandler/main.go with the standard resolution order (typed *VoipbinError → ToResponse; legacy dbhandler.ErrNotFound → 404; else → 500). Defensive nil-guard logs warn and returns 500. ToResponse failure on a typed error logs and returns 500 (no silent fallthrough).
- bin-flow-manager: Update dispatcher's default error handler to route typed errors and dbhandler.ErrNotFound through errorResponse, while preserving the legacy simpleResponse(400) for plain errors (JSON unmarshal failures hit this path and remain 400-class).
- bin-flow-manager: Migrate flowhandler/db.go:Get and activeflowhandler/db.go:Get to emit typed cerrors.NotFound (FLOW_NOT_FOUND, ACTIVEFLOW_NOT_FOUND) on dbhandler.ErrNotFound, so api-manager edge recovers domain="flow-manager" via errors.As.
- bin-flow-manager: 6 new tests in listenhandler/error_response_test.go covering typed pass-through, pkg/errors.Wrapf chain unwrap, legacy ErrNotFound preservation, unclassified-error 500 fallthrough, nil-error defensive path, and end-to-end VoipbinError.Wrap(dbhandler.ErrNotFound).