### PR TITLE
NOJIRA-typed-rpc-pr4-conference

### DIFF
--- a/bin-conference-manager/pkg/conferencecallhandler/db.go
+++ b/bin-conference-manager/pkg/conferencecallhandler/db.go
@@ -2,13 +2,17 @@ package conferencecallhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-conference-manager/models/conferencecall"
+	"monorepo/bin-conference-manager/pkg/dbhandler"
 )
 
 // Create is handy function for creating a conference.
@@ -81,6 +85,10 @@ func (h *conferencecallHandler) List(ctx context.Context, size uint64, token str
 }
 
 // Get is handy function for getting a conferencecall.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *conferencecallHandler) Get(ctx context.Context, id uuid.UUID) (*conferencecall.Conferencecall, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":              "Get",
@@ -90,6 +98,13 @@ func (h *conferencecallHandler) Get(ctx context.Context, id uuid.UUID) (*confere
 	res, err := h.db.ConferencecallGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get conferencecall info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameConferenceManager,
+				"CONFERENCECALL_NOT_FOUND",
+				"The conference call was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-conference-manager/pkg/conferencehandler/conference.go
+++ b/bin-conference-manager/pkg/conferencehandler/conference.go
@@ -2,12 +2,15 @@ package conferencehandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"fmt"
 
 	bmaccount "monorepo/bin-billing-manager/models/account"
 	cmconfbridge "monorepo/bin-call-manager/models/confbridge"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
 	"github.com/gofrs/uuid"
@@ -15,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-conference-manager/models/conference"
+	"monorepo/bin-conference-manager/pkg/dbhandler"
 )
 
 const defaultConferenceTimeout = 86400
@@ -156,9 +160,20 @@ func (h *conferenceHandler) List(ctx context.Context, size uint64, token string,
 }
 
 // Get returns conference.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *conferenceHandler) Get(ctx context.Context, id uuid.UUID) (*conference.Conference, error) {
 	res, err := h.db.ConferenceGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameConferenceManager,
+				"CONFERENCE_NOT_FOUND",
+				"The conference was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "Could not get conference.")
 	}
 

--- a/bin-conference-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-conference-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,71 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-conference-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameConferenceManager, "CONFERENCE_NOT_FOUND", "The conference was not found.")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameConferenceManager, "CONFERENCECALL_NOT_FOUND", "The conference call was not found.")
+	wrapped := pkgerrors.Wrap(ve, "outer context")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	wrapped := pkgerrors.Wrap(dbhandler.ErrNotFound, "could not get conference")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	resp := errorResponse(fmt.Errorf("connection refused"))
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_nilError(t *testing.T) {
+	resp := errorResponse(nil)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	dbErr := dbhandler.ErrNotFound
+	typed := cerrors.NotFound(commonoutline.ServiceNameConferenceManager, "CONFERENCE_NOT_FOUND", "The conference was not found.").Wrap(dbErr)
+	resp := errorResponse(typed)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("errors.Is should walk VoipbinError.Unwrap chain to find ErrNotFound")
+	}
+}

--- a/bin-conference-manager/pkg/listenhandler/main.go
+++ b/bin-conference-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -15,6 +18,7 @@ import (
 
 	"monorepo/bin-conference-manager/pkg/conferencecallhandler"
 	"monorepo/bin-conference-manager/pkg/conferencehandler"
+	"monorepo/bin-conference-manager/pkg/dbhandler"
 )
 
 // pagination parameters
@@ -95,6 +99,35 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order:
+//  1. Typed *cerrors.VoipbinError → encoded via cerrors.ToResponse so the
+//     api-manager edge recovers domain/reason/message via errors.As over RPC.
+//  2. Legacy dbhandler.ErrNotFound (wrapped via pkg/errors) → simpleResponse(404).
+//  3. Anything else → simpleResponse(500).
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -272,10 +305,21 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed *VoipbinError and dbhandler.ErrNotFound
+	// flow through errorResponse so the api-manager edge sees the right
+	// envelope or 404. Other errors keep the legacy 400 (most are JSON
+	// unmarshal failures, which are 400-class).
 	if err != nil {
 		log.Errorf("Could not process the request correctly. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 


### PR DESCRIPTION
Migrates bin-conference-manager to emit typed *cerrors.VoipbinError end-to-end, following the established pattern from PR1/PR2/PR3.

- bin-conference-manager: Add errorResponse(err) helper with standard resolution order (typed → ToResponse; legacy ErrNotFound → 404; else → 500).
- bin-conference-manager: Update dispatcher to route typed/ErrNotFound errors through errorResponse while preserving 400 for unmarshal failures.
- bin-conference-manager: Migrate conferenceHandler.Get (CONFERENCE_NOT_FOUND) and conferencecallHandler.Get (CONFERENCECALL_NOT_FOUND) to emit typed errors on dbhandler.ErrNotFound.
- bin-conference-manager: 6 standard error-response tests.