### PR TITLE
NOJIRA-typed-rpc-pr6-customer

### DIFF
--- a/bin-customer-manager/pkg/accesskeyhandler/db.go
+++ b/bin-customer-manager/pkg/accesskeyhandler/db.go
@@ -2,13 +2,17 @@ package accesskeyhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-customer-manager/models/accesskey"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
 )
 
 // List returns list of accesskeys
@@ -42,12 +46,23 @@ func (h *accesskeyHandler) GetsByCustomerID(ctx context.Context, size uint64, to
 }
 
 // Get returns accesskey info.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *accesskeyHandler) Get(ctx context.Context, id uuid.UUID) (*accesskey.Accesskey, error) {
 	log := logrus.WithField("func", "Get")
 
 	res, err := h.db.AccesskeyGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get accesskey info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCustomerManager,
+				"ACCESSKEY_NOT_FOUND",
+				"The access key was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-customer-manager/pkg/customerhandler/db.go
+++ b/bin-customer-manager/pkg/customerhandler/db.go
@@ -2,12 +2,16 @@ package customerhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-customer-manager/models/customer"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
 )
 
 // List returns list of customers
@@ -24,12 +28,23 @@ func (h *customerHandler) List(ctx context.Context, size uint64, token string, f
 }
 
 // Get returns customer info.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *customerHandler) Get(ctx context.Context, id uuid.UUID) (*customer.Customer, error) {
 	log := logrus.WithField("func", "Get")
 
 	res, err := h.db.CustomerGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get customer info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCustomerManager,
+				"CUSTOMER_NOT_FOUND",
+				"The customer was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-customer-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-customer-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,68 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameCustomerManager, "CUSTOMER_NOT_FOUND", "The customer was not found.")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameCustomerManager, "ACCESSKEY_NOT_FOUND", "Not found.")
+	wrapped := pkgerrors.Wrap(ve, "outer")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	wrapped := pkgerrors.Wrap(dbhandler.ErrNotFound, "x")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	resp := errorResponse(fmt.Errorf("connection refused"))
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_nilError(t *testing.T) {
+	resp := errorResponse(nil)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	dbErr := dbhandler.ErrNotFound
+	typed := cerrors.NotFound(commonoutline.ServiceNameCustomerManager, "CUSTOMER_NOT_FOUND", "Not found.").Wrap(dbErr)
+	resp := errorResponse(typed)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("errors.Is should walk VoipbinError.Unwrap chain to find ErrNotFound")
+	}
+}

--- a/bin-customer-manager/pkg/listenhandler/main.go
+++ b/bin-customer-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -17,6 +20,7 @@ import (
 
 	"monorepo/bin-customer-manager/pkg/accesskeyhandler"
 	"monorepo/bin-customer-manager/pkg/customerhandler"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
 	"monorepo/bin-customer-manager/pkg/metricshandler"
 )
 
@@ -71,6 +75,35 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order:
+//  1. Typed *cerrors.VoipbinError → encoded via cerrors.ToResponse so the
+//     api-manager edge recovers domain/reason/message via errors.As over RPC.
+//  2. Legacy dbhandler.ErrNotFound (wrapped via pkg/errors) → simpleResponse(404).
+//  3. Anything else → simpleResponse(500).
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -238,7 +271,18 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 
 	if err != nil {
 		log.Errorf("Could not find corresponded message handler. method: %s, uri: %s", m.Method, m.URI)
-		response = simpleResponse(400)
+		// Typed *VoipbinError and dbhandler.ErrNotFound flow through errorResponse
+		// so the api-manager edge sees the right envelope or 404. Other errors
+		// keep the legacy 400.
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	} else {
 		log.WithFields(


### PR DESCRIPTION
Migrates bin-customer-manager to typed errors.

- bin-customer-manager: Add errorResponse helper, route typed/ErrNotFound through dispatcher.
- bin-customer-manager: Migrate customerHandler.Get (CUSTOMER_NOT_FOUND) and accesskeyHandler.Get (ACCESSKEY_NOT_FOUND).
- bin-customer-manager: 6 standard error-response tests.