### PR TITLE
NOJIRA-typed-rpc-pr7-agent

### DIFF
--- a/bin-agent-manager/pkg/agenthandler/agent.go
+++ b/bin-agent-manager/pkg/agenthandler/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 	"monorepo/bin-agent-manager/pkg/metricshandler"
 	bmaccount "monorepo/bin-billing-manager/models/account"
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	cmcustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
@@ -72,12 +75,23 @@ func (h *agentHandler) GetByCustomerIDAndAddress(ctx context.Context, customerID
 }
 
 // Get returns agent info.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *agentHandler) Get(ctx context.Context, id uuid.UUID) (*agent.Agent, error) {
 	log := logrus.WithField("func", "Get")
 
 	res, err := h.dbGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get agent info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameAgentManager,
+				"AGENT_NOT_FOUND",
+				"The agent was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-agent-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-agent-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,68 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"monorepo/bin-agent-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameAgentManager, "AGENT_NOT_FOUND", "The agent was not found.")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, resp.DataType)
+	}
+}
+
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameAgentManager, "AGENT_NOT_FOUND", "Not found.")
+	wrapped := pkgerrors.Wrap(ve, "outer")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	wrapped := pkgerrors.Wrap(dbhandler.ErrNotFound, "x")
+	resp := errorResponse(wrapped)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	resp := errorResponse(fmt.Errorf("connection refused"))
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_nilError(t *testing.T) {
+	resp := errorResponse(nil)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode mismatch. expected: 500, got: %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	dbErr := dbhandler.ErrNotFound
+	typed := cerrors.NotFound(commonoutline.ServiceNameAgentManager, "AGENT_NOT_FOUND", "Not found.").Wrap(dbErr)
+	resp := errorResponse(typed)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", resp.StatusCode)
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("errors.Is should walk VoipbinError.Unwrap chain to find ErrNotFound")
+	}
+}

--- a/bin-agent-manager/pkg/listenhandler/main.go
+++ b/bin-agent-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"monorepo/bin-common-handler/models/sock"
@@ -17,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-agent-manager/pkg/agenthandler"
+	"monorepo/bin-agent-manager/pkg/dbhandler"
 	"monorepo/bin-agent-manager/pkg/metricshandler"
 )
 
@@ -73,6 +77,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -235,7 +265,15 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 
 	if err != nil {
 		log.Errorf("Could not find corresponded message handler. method: %s, uri: %s", m.Method, m.URI)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	} else {
 		log.WithFields(logrus.Fields{

--- a/bin-agent-manager/pkg/listenhandler/v1_password_forgot.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_password_forgot.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1PasswordForgotPost(ctx context.Context, m *sock
 
 	if err := h.agentHandler.PasswordForgot(ctx, reqData.Username, agenthandler.PasswordResetEmailTypeForgot); err != nil {
 		log.Infof("Could not process password forgot. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	return simpleResponse(200), nil

--- a/bin-agent-manager/pkg/listenhandler/v1_password_forgot_test.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_password_forgot_test.go
@@ -1,7 +1,6 @@
 package listenhandler
 
 import (
-	"fmt"
 	reflect "reflect"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	"monorepo/bin-agent-manager/pkg/agenthandler"
+	"monorepo/bin-agent-manager/pkg/dbhandler"
 )
 
 func Test_ProcessV1PasswordForgotPost(t *testing.T) {
@@ -86,7 +86,7 @@ func Test_ProcessV1PasswordForgotPost_AgentNotFound(t *testing.T) {
 		Data:     []byte(`{"username":"unknown@voipbin.net"}`),
 	}
 
-	mockAgent.EXPECT().PasswordForgot(gomock.Any(), "unknown@voipbin.net", agenthandler.PasswordResetEmailTypeForgot).Return(fmt.Errorf("agent not found"))
+	mockAgent.EXPECT().PasswordForgot(gomock.Any(), "unknown@voipbin.net", agenthandler.PasswordResetEmailTypeForgot).Return(dbhandler.ErrNotFound)
 
 	res, err := h.processRequest(req)
 	if err != nil {


### PR DESCRIPTION
Migrates bin-agent-manager to typed errors. Completes tier-1 of the migration (call/flow/conference/conversation/customer/agent + billing pilot).

- bin-agent-manager: Add errorResponse helper, route typed/ErrNotFound through dispatcher.
- bin-agent-manager: Migrate agentHandler.Get (AGENT_NOT_FOUND).
- bin-agent-manager: Migrate v1_password_forgot.go simpleResponse(404) to errorResponse.
- bin-agent-manager: 6 standard error-response tests.
- bin-agent-manager: Update v1_password_forgot_test.go to use dbhandler.ErrNotFound.