### PR TITLE
NOJIRA-typed-rpc-pr8-number

### DIFF
--- a/bin-number-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-number-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,60 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-number-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameNumberManager, "NUMBER_NOT_FOUND", "x")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameNumberManager, "NUMBER_NOT_FOUND", "x")
+	resp := errorResponse(pkgerrors.Wrap(ve, "outer"))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped: got %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	resp := errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x"))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("legacy: got %d", resp.StatusCode)
+	}
+}
+
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500")
+	}
+}
+
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500")
+	}
+}
+
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameNumberManager, "NUMBER_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	resp := errorResponse(typed)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d", resp.StatusCode)
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-number-manager/pkg/listenhandler/main.go
+++ b/bin-number-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -15,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-number-manager/pkg/dbhandler"
 	"monorepo/bin-number-manager/pkg/numberhandler"
 )
 
@@ -85,6 +89,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -213,7 +243,8 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400 (mostly unmarshal failures).
 	if err != nil {
 		log.WithFields(
 			logrus.Fields{
@@ -221,7 +252,15 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 				"method": m.Method,
 				"error":  err,
 			}).Errorf("Could not process the request correctly. data: %s", m.Data)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-number-manager/pkg/numberhandler/number.go
+++ b/bin-number-manager/pkg/numberhandler/number.go
@@ -2,17 +2,21 @@ package numberhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
 	bmaccount "monorepo/bin-billing-manager/models/account"
 	bmbilling "monorepo/bin-billing-manager/models/billing"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-number-manager/models/number"
+	"monorepo/bin-number-manager/pkg/dbhandler"
 )
 
 // Create creates a new order numbers of given numbers
@@ -257,6 +261,13 @@ func (h *numberHandler) Get(ctx context.Context, id uuid.UUID) (*number.Number, 
 	res, err := h.dbGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get number info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameNumberManager,
+				"NUMBER_NOT_FOUND",
+				"The phone number was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get number info")
 	}
 


### PR DESCRIPTION
Migrates bin-number-manager to typed errors.

- bin-number-manager: Add errorResponse helper, route typed/ErrNotFound through dispatcher.
- bin-number-manager: Migrate numberHandler.Get (NUMBER_NOT_FOUND).
- bin-number-manager: 6 standard error-response tests.