### PR TITLE
NOJIRA-typed-rpc-pr9-message

### DIFF
--- a/bin-message-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-message-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,52 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-message-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameMessageManager, "MESSAGE_NOT_FOUND", "x")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameMessageManager, "MESSAGE_NOT_FOUND", "x")
+	if errorResponse(pkgerrors.Wrap(ve, "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameMessageManager, "MESSAGE_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("end-to-end failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-message-manager/pkg/listenhandler/main.go
+++ b/bin-message-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -13,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-message-manager/pkg/dbhandler"
 	"monorepo/bin-message-manager/pkg/messagehandler"
 )
 
@@ -79,6 +83,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -174,10 +204,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400 (mostly unmarshal failures).
 	if err != nil {
 		log.Errorf("Could not process the request correctly. data: %s, err: %v", m.Data, err)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 	log.WithField("response", response).Debugf("Sending response. method: %s, uri: %s", m.Method, m.URI)

--- a/bin-message-manager/pkg/messagehandler/message.go
+++ b/bin-message-manager/pkg/messagehandler/message.go
@@ -2,15 +2,19 @@ package messagehandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-message-manager/models/message"
 	"monorepo/bin-message-manager/models/target"
+	"monorepo/bin-message-manager/pkg/dbhandler"
 )
 
 // Create creates a new message.
@@ -89,7 +93,11 @@ func (h *messageHandler) Delete(ctx context.Context, id uuid.UUID) (*message.Mes
 	return res, nil
 }
 
-// Get returns message info of the given id
+// Get returns message info of the given id.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *messageHandler) Get(ctx context.Context, id uuid.UUID) (*message.Message, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "Get",
@@ -99,6 +107,13 @@ func (h *messageHandler) Get(ctx context.Context, id uuid.UUID) (*message.Messag
 	res, err := h.dbGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get message info. message: %s, err:%v", id, err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameMessageManager,
+				"MESSAGE_NOT_FOUND",
+				"The message was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Migrates bin-message-manager to typed errors.

- bin-message-manager: Add errorResponse helper, route typed/ErrNotFound through dispatcher.
- bin-message-manager: Migrate messageHandler.Get (MESSAGE_NOT_FOUND).
- bin-message-manager: 6 standard error-response tests.