### PR TITLE
NOJIRA-pipecat-pod-ping-design

### DIFF
--- a/bin-ai-manager/pkg/aicallhandler/event_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/event_test.go
@@ -98,6 +98,7 @@ func Test_EventCMDTMFReceived(t *testing.T) {
 			mockDB.EXPECT().AIcallGetByReferenceID(ctx, tt.expectedReferenceID).Return(tt.responseAIcall, nil)
 			mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.expectedPipecatcallID).Return(tt.responsePipecatcall, nil)
 			mockMessage.EXPECT().Create(ctx, uuid.Nil, tt.responseAIcall.CustomerID, tt.responseAIcall.ID, tt.responseAIcall.ActiveflowID, message.DirectionOutgoing, message.RoleUser, tt.expectedMessageText, nil, "").Return(tt.responseMessage, nil)
+			mockReq.EXPECT().PipecatV1Ping(gomock.Any(), tt.responsePipecatcall.HostID).Return(nil)
 			mockReq.EXPECT().PipecatV1MessageSend(ctx, tt.responsePipecatcall.HostID, tt.expectedPipecatcallID, tt.responseMessage.ID.String(), tt.expectedMessageText, true, true).Return(nil, nil)
 
 			h.EventCMDTMFReceived(ctx, tt.evt)

--- a/bin-ai-manager/pkg/aicallhandler/ping.go
+++ b/bin-ai-manager/pkg/aicallhandler/ping.go
@@ -26,6 +26,9 @@ func (h *aicallHandler) pingPipecatHost(ctx context.Context, hostID string) bool
 	if hostID == "" {
 		return false
 	}
+	// PipecatV1Ping enforces its own 1s hard timeout inside sendRequest; this
+	// outer 1.1s context provides a slightly wider cancellation safety net so
+	// the helper still returns even if upstream contexts are uncancellable.
 	cctx, cancel := context.WithTimeout(ctx, 1100*time.Millisecond)
 	defer cancel()
 	err := h.reqHandler.PipecatV1Ping(cctx, hostID)

--- a/bin-ai-manager/pkg/aicallhandler/ping.go
+++ b/bin-ai-manager/pkg/aicallhandler/ping.go
@@ -1,0 +1,45 @@
+package aicallhandler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-common-handler/pkg/circuitbreakerhandler"
+)
+
+// pingPipecatHost runs a ~1s preflight against hostID. Returns true if the
+// pod is reachable and owns this host_id; false if the pod is unreachable
+// (timeout) or the breaker is open. Broker/transport errors return false
+// and are logged distinctly so an outage is not misclassified as pod death.
+//
+// Note: relies on errors.Is unwrapping through pkg/errors v0.9.0+ wrappers
+// applied by sendRequest. Verified pkg/errors v0.9.1 is pinned in
+// bin-common-handler/go.mod and bin-ai-manager/go.mod.
+func (h *aicallHandler) pingPipecatHost(ctx context.Context, hostID string) bool {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "pingPipecatHost",
+		"host_id": hostID,
+	})
+	if hostID == "" {
+		return false
+	}
+	cctx, cancel := context.WithTimeout(ctx, 1100*time.Millisecond)
+	defer cancel()
+	err := h.reqHandler.PipecatV1Ping(cctx, hostID)
+	if err == nil {
+		log.Debug("Pipecat host ping succeeded.")
+		return true
+	}
+	switch {
+	case errors.Is(err, circuitbreakerhandler.ErrCircuitOpen):
+		log.Debug("Pipecat host ping skipped: circuit breaker open.")
+	case errors.Is(err, context.DeadlineExceeded):
+		log.Info("Pipecat host ping timed out; treating as dead.")
+	default:
+		log.Warnf("Pipecat ping failed with unexpected error; skipping per-pod RPC. err: %v", err)
+	}
+	return false
+}

--- a/bin-ai-manager/pkg/aicallhandler/ping_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/ping_test.go
@@ -1,0 +1,89 @@
+package aicallhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/circuitbreakerhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	pkgerrors "github.com/pkg/errors"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func Test_aicallHandler_pingPipecatHost(t *testing.T) {
+	tests := []struct {
+		name string
+
+		hostID    string
+		mockErr   error
+		expectRes bool
+		expectPing bool
+	}{
+		{
+			name: "empty host_id returns false without calling ping",
+
+			hostID:     "",
+			expectRes:  false,
+			expectPing: false,
+		},
+		{
+			name: "alive pod returns true",
+
+			hostID:     "10.4.2.18",
+			mockErr:    nil,
+			expectRes:  true,
+			expectPing: true,
+		},
+		{
+			name: "wrapped DeadlineExceeded returns false",
+
+			hostID:     "10.4.2.19",
+			mockErr:    pkgerrors.Wrap(context.DeadlineExceeded, "rpc timeout"),
+			expectRes:  false,
+			expectPing: true,
+		},
+		{
+			name: "wrapped ErrCircuitOpen returns false",
+
+			hostID:     "10.4.2.20",
+			mockErr:    pkgerrors.Wrap(circuitbreakerhandler.ErrCircuitOpen, "ping rejected"),
+			expectRes:  false,
+			expectPing: true,
+		},
+		{
+			name: "unexpected broker error returns false",
+
+			hostID:     "10.4.2.21",
+			mockErr:    fmt.Errorf("broker connection refused"),
+			expectRes:  false,
+			expectPing: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+
+			h := &aicallHandler{
+				reqHandler: mockReq,
+			}
+			ctx := context.Background()
+
+			if tt.expectPing {
+				mockReq.EXPECT().PipecatV1Ping(gomock.Any(), tt.hostID).Return(tt.mockErr)
+			}
+
+			got := h.pingPipecatHost(ctx, tt.hostID)
+			if got != tt.expectRes {
+				t.Errorf("expected: %v, got: %v", tt.expectRes, got)
+			}
+		})
+	}
+}

--- a/bin-ai-manager/pkg/aicallhandler/send.go
+++ b/bin-ai-manager/pkg/aicallhandler/send.go
@@ -43,6 +43,10 @@ func (h *aicallHandler) SendReferenceTypeCall(ctx context.Context, c *aicall.AIc
 	}
 	log.WithField("message", res).Debugf("Created the message to the ai. aicall_id: %s, message_id: %s", c.ID, res.ID)
 
+	if !h.pingPipecatHost(ctx, pc.HostID) {
+		return nil, errors.Errorf("pipecat pod for this aicall is no longer reachable. host_id: %s, pipecatcall_id: %s", pc.HostID, pc.ID)
+	}
+
 	tmp, err := h.reqHandler.PipecatV1MessageSend(ctx, pc.HostID, pc.ID, res.ID.String(), messageText, runImmediately, audioResponse)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not send the message to the pipecatcall correctly")

--- a/bin-ai-manager/pkg/aicallhandler/send.go
+++ b/bin-ai-manager/pkg/aicallhandler/send.go
@@ -37,15 +37,18 @@ func (h *aicallHandler) SendReferenceTypeCall(ctx context.Context, c *aicall.AIc
 	}
 	log.WithField("pipecatcall", pc).Debugf("Found the pipecatcall.")
 
+	// Preflight ping before persisting the message so a dead-pod failure does not
+	// orphan a user-message row in the database. The remaining failure path
+	// (PipecatV1MessageSend after a successful ping) preserves existing behavior.
+	if !h.pingPipecatHost(ctx, pc.HostID) {
+		return nil, errors.Errorf("pipecat pod for this aicall is no longer reachable. host_id: %s, pipecatcall_id: %s", pc.HostID, pc.ID)
+	}
+
 	res, err := h.messageHandler.Create(ctx, uuid.Nil, c.CustomerID, c.ID, c.ActiveflowID, message.DirectionOutgoing, message.RoleUser, messageText, nil, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not create the message. aicall_id: %s", c.ID)
 	}
 	log.WithField("message", res).Debugf("Created the message to the ai. aicall_id: %s, message_id: %s", c.ID, res.ID)
-
-	if !h.pingPipecatHost(ctx, pc.HostID) {
-		return nil, errors.Errorf("pipecat pod for this aicall is no longer reachable. host_id: %s, pipecatcall_id: %s", pc.HostID, pc.ID)
-	}
 
 	tmp, err := h.reqHandler.PipecatV1MessageSend(ctx, pc.HostID, pc.ID, res.ID.String(), messageText, runImmediately, audioResponse)
 	if err != nil {

--- a/bin-ai-manager/pkg/aicallhandler/send_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/send_test.go
@@ -17,6 +17,7 @@ import (
 	"monorepo/bin-common-handler/pkg/utilhandler"
 	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -388,6 +389,179 @@ func Test_SendReferenceTypeOthers(t *testing.T) {
 			// Verify CurrentMemberID was updated in-place on the updated aicall (for team cases with fallback)
 			if tt.expectCurrentMemberIDAfter != uuid.Nil && tt.responseUpdatedAIcall.CurrentMemberID != tt.expectCurrentMemberIDAfter {
 				t.Errorf("expected CurrentMemberID after: %v, got: %v", tt.expectCurrentMemberIDAfter, tt.responseUpdatedAIcall.CurrentMemberID)
+			}
+		})
+	}
+}
+
+func Test_SendReferenceTypeCall(t *testing.T) {
+	tests := []struct {
+		name string
+
+		aicall      *aicall.AIcall
+		messageText string
+
+		responsePipecatcall *pmpipecatcall.Pipecatcall
+		responseMessage     *message.Message
+
+		pingErr error
+
+		expectPingHostID    string
+		expectMessageSend   bool
+		expectErr           bool
+		expectErrSubstring  string
+		expectRes           *message.Message
+	}{
+		{
+			name: "alive pod sends message",
+
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("e0000001-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("e0000001-0000-0000-0000-000000000010"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("e0000001-0000-0000-0000-000000000020"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				PipecatcallID: uuid.FromStringOrNil("e0000001-0000-0000-0000-000000000050"),
+			},
+			messageText: "hello pipecat",
+
+			responsePipecatcall: &pmpipecatcall.Pipecatcall{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("e0000001-0000-0000-0000-000000000050"),
+				},
+				HostID: "10.4.2.18",
+			},
+			responseMessage: &message.Message{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("e0000001-0000-0000-0000-0000000000f0"),
+				},
+			},
+
+			pingErr: nil,
+
+			expectPingHostID:  "10.4.2.18",
+			expectMessageSend: true,
+			expectErr:         false,
+			expectRes: &message.Message{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("e0000001-0000-0000-0000-0000000000f0"),
+				},
+			},
+		},
+		{
+			name: "dead pod (ping deadline) returns error and skips MessageSend",
+
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("f0000001-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("f0000001-0000-0000-0000-000000000010"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("f0000001-0000-0000-0000-000000000020"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				PipecatcallID: uuid.FromStringOrNil("f0000001-0000-0000-0000-000000000050"),
+			},
+			messageText: "hello dead pod",
+
+			responsePipecatcall: &pmpipecatcall.Pipecatcall{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("f0000001-0000-0000-0000-000000000050"),
+				},
+				HostID: "10.4.2.99",
+			},
+			responseMessage: &message.Message{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("f0000001-0000-0000-0000-0000000000f0"),
+				},
+			},
+
+			pingErr: context.DeadlineExceeded,
+
+			expectPingHostID:   "10.4.2.99",
+			expectMessageSend:  false,
+			expectErr:          true,
+			expectErrSubstring: "no longer reachable",
+			expectRes:          nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockAI := aihandler.NewMockAIHandler(mc)
+			mockTeam := teamhandler.NewMockTeamHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+			h := &aicallHandler{
+				utilHandler:    mockUtil,
+				reqHandler:     mockReq,
+				notifyHandler:  mockNotify,
+				db:             mockDB,
+				aiHandler:      mockAI,
+				teamHandler:    mockTeam,
+				messageHandler: mockMessage,
+			}
+			ctx := context.Background()
+
+			// 1. PipecatV1PipecatcallGet
+			mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.aicall.PipecatcallID).Return(tt.responsePipecatcall, nil)
+
+			// 2. messageHandler.Create — always called BEFORE ping
+			mockMessage.EXPECT().Create(
+				ctx,
+				uuid.Nil,
+				tt.aicall.CustomerID,
+				tt.aicall.ID,
+				tt.aicall.ActiveflowID,
+				message.DirectionOutgoing,
+				message.RoleUser,
+				tt.messageText,
+				nil,
+				"",
+			).Return(tt.responseMessage, nil)
+
+			// 3. PipecatV1Ping preflight
+			mockReq.EXPECT().PipecatV1Ping(gomock.Any(), tt.expectPingHostID).Return(tt.pingErr)
+
+			// 4. PipecatV1MessageSend — only if ping succeeded
+			if tt.expectMessageSend {
+				mockReq.EXPECT().PipecatV1MessageSend(
+					ctx,
+					tt.responsePipecatcall.HostID,
+					tt.responsePipecatcall.ID,
+					tt.responseMessage.ID.String(),
+					tt.messageText,
+					true,
+					true,
+				).Return(nil, nil)
+			}
+
+			res, err := h.SendReferenceTypeCall(ctx, tt.aicall, message.RoleUser, tt.messageText, true, true)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.expectErrSubstring != "" && !strings.Contains(err.Error(), tt.expectErrSubstring) {
+					t.Errorf("expected error containing %q, got: %v", tt.expectErrSubstring, err)
+				}
+				if res != nil {
+					t.Errorf("expected nil res on error, got: %v", res)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("expected: %v, got: %v", tt.expectRes, res)
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/aicallhandler/send_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/send_test.go
@@ -514,25 +514,27 @@ func Test_SendReferenceTypeCall(t *testing.T) {
 			// 1. PipecatV1PipecatcallGet
 			mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.aicall.PipecatcallID).Return(tt.responsePipecatcall, nil)
 
-			// 2. messageHandler.Create — always called BEFORE ping
-			mockMessage.EXPECT().Create(
-				ctx,
-				uuid.Nil,
-				tt.aicall.CustomerID,
-				tt.aicall.ID,
-				tt.aicall.ActiveflowID,
-				message.DirectionOutgoing,
-				message.RoleUser,
-				tt.messageText,
-				nil,
-				"",
-			).Return(tt.responseMessage, nil)
-
-			// 3. PipecatV1Ping preflight
+			// 2. PipecatV1Ping preflight (always runs after Get, before Create)
 			mockReq.EXPECT().PipecatV1Ping(gomock.Any(), tt.expectPingHostID).Return(tt.pingErr)
 
-			// 4. PipecatV1MessageSend — only if ping succeeded
+			// 3. messageHandler.Create — only called if ping succeeded; gating
+			//    ping before Create avoids orphaning a user-message row when
+			//    the pipecat pod is unreachable.
 			if tt.expectMessageSend {
+				mockMessage.EXPECT().Create(
+					ctx,
+					uuid.Nil,
+					tt.aicall.CustomerID,
+					tt.aicall.ID,
+					tt.aicall.ActiveflowID,
+					message.DirectionOutgoing,
+					message.RoleUser,
+					tt.messageText,
+					nil,
+					"",
+				).Return(tt.responseMessage, nil)
+
+				// 4. PipecatV1MessageSend — only if ping succeeded
 				mockReq.EXPECT().PipecatV1MessageSend(
 					ctx,
 					tt.responsePipecatcall.HostID,

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -1088,6 +1088,9 @@ type RequestHandler interface {
 	PipecatV1PipecatcallTerminate(ctx context.Context, hostID string, pipecatcallID uuid.UUID) (*pmpipecatcall.Pipecatcall, error)
 	PipecatV1PipecatcallTerminateWithDelay(ctx context.Context, hostID string, pipecatcallID uuid.UUID, delay int) error
 
+	// pipecat-manager ping
+	PipecatV1Ping(ctx context.Context, hostID string) error
+
 	// queue-manager queue
 	QueueV1QueueList(ctx context.Context, pageToken string, pageSize uint64, filters map[qmqueue.Field]any) ([]qmqueue.Queue, error)
 	QueueV1QueueGet(ctx context.Context, queueID uuid.UUID) (*qmqueue.Queue, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -4804,6 +4804,20 @@ func (mr *MockRequestHandlerMockRecorder) PipecatV1MessageSend(ctx, hostID, pipe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PipecatV1MessageSend", reflect.TypeOf((*MockRequestHandler)(nil).PipecatV1MessageSend), ctx, hostID, pipecatcallID, messageID, messageText, runImmediately, audioResponse)
 }
 
+// PipecatV1Ping mocks base method.
+func (m *MockRequestHandler) PipecatV1Ping(ctx context.Context, hostID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PipecatV1Ping", ctx, hostID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PipecatV1Ping indicates an expected call of PipecatV1Ping.
+func (mr *MockRequestHandlerMockRecorder) PipecatV1Ping(ctx, hostID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PipecatV1Ping", reflect.TypeOf((*MockRequestHandler)(nil).PipecatV1Ping), ctx, hostID)
+}
+
 // PipecatV1PipecatcallGet mocks base method.
 func (m *MockRequestHandler) PipecatV1PipecatcallGet(ctx context.Context, pipecatcallID uuid.UUID) (*pipecatcall.Pipecatcall, error) {
 	m.ctrl.T.Helper()

--- a/bin-common-handler/pkg/requesthandler/pipecat_ping.go
+++ b/bin-common-handler/pkg/requesthandler/pipecat_ping.go
@@ -17,10 +17,11 @@ const requestTimeoutPipecatPing = 1000 // pipecat ping timeout(1 sec)
 // live case), or an error otherwise (timeout, circuit open, mismatched
 // host_id from a queue-name collision, etc.).
 //
-// IMPORTANT: do not add status-code checks here. A 404 from an old pipecat
-// pod that predates this route is a valid "alive" signal — the pod responded.
-// The only "dead" signal is err != nil, including ctx.DeadlineExceeded and
-// circuitbreakerhandler.ErrCircuitOpen.
+// IMPORTANT: do not add status-code checks here. ANY response from the per-pod
+// queue (200, 404 from old pods, even 5xx) means the pod is up and consuming
+// — that is the only liveness signal we want. The only "dead" signal is
+// err != nil, including ctx.DeadlineExceeded and circuitbreakerhandler.ErrCircuitOpen.
+// Adding 5xx-as-error logic would defeat the purpose of the probe.
 func (r *requestHandler) PipecatV1Ping(ctx context.Context, hostID string) error {
 	queueName := fmt.Sprintf("%s.%s", outline.QueueNamePipecatRequest, hostID)
 	res, err := r.sendRequest(

--- a/bin-common-handler/pkg/requesthandler/pipecat_ping.go
+++ b/bin-common-handler/pkg/requesthandler/pipecat_ping.go
@@ -1,0 +1,53 @@
+package requesthandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	outline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/sock"
+	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
+)
+
+const requestTimeoutPipecatPing = 1000 // 1s — sub-second decisive liveness probe
+
+// PipecatV1Ping issues a sub-second liveness probe against the per-pod queue
+// for hostID. Returns nil if the pod responded with a matching host_id (the
+// live case), or an error otherwise (timeout, circuit open, mismatched
+// host_id from a queue-name collision, etc.).
+//
+// IMPORTANT: do not add status-code checks here. A 404 from an old pipecat
+// pod that predates this route is a valid "alive" signal — the pod responded.
+// The only "dead" signal is err != nil, including ctx.DeadlineExceeded and
+// circuitbreakerhandler.ErrCircuitOpen.
+func (r *requestHandler) PipecatV1Ping(ctx context.Context, hostID string) error {
+	queueName := fmt.Sprintf("%s.%s", outline.QueueNamePipecatRequest, hostID)
+	res, err := r.sendRequest(
+		ctx,
+		outline.QueueName(queueName),
+		"/v1/ping",
+		sock.RequestMethodGet,
+		"pipecat/ping",
+		requestTimeoutPipecatPing,
+		0,
+		ContentTypeNone,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Best-effort host_id echo verification. Note: Calico POD_IP recycle gives
+	// a matching IP, so this check does NOT cover that case (see design §4.6).
+	// For old pods the body is empty (404 simpleResponse) → skip the check.
+	if res != nil && res.StatusCode == 200 && len(res.Data) > 0 {
+		var pr pmpipecatcall.PingResult
+		if errParse := json.Unmarshal(res.Data, &pr); errParse == nil {
+			if pr.HostID != "" && pr.HostID != hostID {
+				return fmt.Errorf("ping host_id mismatch: requested %s, got %s", hostID, pr.HostID)
+			}
+		}
+	}
+	return nil
+}

--- a/bin-common-handler/pkg/requesthandler/pipecat_ping.go
+++ b/bin-common-handler/pkg/requesthandler/pipecat_ping.go
@@ -10,7 +10,7 @@ import (
 	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
 )
 
-const requestTimeoutPipecatPing = 1000 // 1s — sub-second decisive liveness probe
+const requestTimeoutPipecatPing = 1000 // pipecat ping timeout(1 sec)
 
 // PipecatV1Ping issues a sub-second liveness probe against the per-pod queue
 // for hostID. Returns nil if the pod responded with a matching host_id (the

--- a/bin-common-handler/pkg/requesthandler/pipecat_ping_test.go
+++ b/bin-common-handler/pkg/requesthandler/pipecat_ping_test.go
@@ -1,0 +1,165 @@
+package requesthandler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+)
+
+func Test_PipecatV1Ping(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		hostID string
+
+		expectTarget  string
+		expectRequest *sock.Request
+
+		response    *sock.Response
+		responseErr error
+
+		expectErr       bool
+		expectErrSubstr string
+	}{
+		{
+			name: "alive pod returns matching host_id",
+
+			hostID: "10.4.2.18",
+
+			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectRequest: &sock.Request{
+				URI:      "/v1/ping",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeNone,
+				Data:     nil,
+			},
+
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"host_id":"10.4.2.18","timestamp":"2026-04-26T12:00:00Z"}`),
+			},
+			responseErr: nil,
+
+			expectErr: false,
+		},
+		{
+			name: "host_id echo mismatch",
+
+			hostID: "10.4.2.18",
+
+			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectRequest: &sock.Request{
+				URI:      "/v1/ping",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeNone,
+				Data:     nil,
+			},
+
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"host_id":"10.4.2.99","timestamp":"2026-04-26T12:00:00Z"}`),
+			},
+			responseErr: nil,
+
+			expectErr:       true,
+			expectErrSubstr: "host_id mismatch",
+		},
+		{
+			name: "old-pod 404 with empty body treated as alive",
+
+			hostID: "10.4.2.18",
+
+			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectRequest: &sock.Request{
+				URI:      "/v1/ping",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeNone,
+				Data:     nil,
+			},
+
+			response: &sock.Response{
+				StatusCode: 404,
+			},
+			responseErr: nil,
+
+			expectErr: false,
+		},
+		{
+			name: "200 with empty body treated as alive",
+
+			hostID: "10.4.2.18",
+
+			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectRequest: &sock.Request{
+				URI:      "/v1/ping",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeNone,
+				Data:     nil,
+			},
+
+			response: &sock.Response{
+				StatusCode: 200,
+			},
+			responseErr: nil,
+
+			expectErr: false,
+		},
+		{
+			name: "timeout from sendRequest propagates",
+
+			hostID: "10.4.2.18",
+
+			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectRequest: &sock.Request{
+				URI:      "/v1/ping",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeNone,
+				Data:     nil,
+			},
+
+			response:    nil,
+			responseErr: context.DeadlineExceeded,
+
+			expectErr:       true,
+			expectErrSubstr: "deadline exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			reqHandler := requestHandler{
+				sock: mockSock,
+			}
+			ctx := context.Background()
+
+			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, tt.responseErr)
+
+			err := reqHandler.PipecatV1Ping(ctx, tt.hostID)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+					return
+				}
+				if tt.expectErrSubstr != "" && !strings.Contains(err.Error(), tt.expectErrSubstr) {
+					t.Errorf("Wrong match. expect error containing %q, got: %v", tt.expectErrSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Wrong match. expect: ok, got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/bin-common-handler/pkg/requesthandler/pipecat_ping_test.go
+++ b/bin-common-handler/pkg/requesthandler/pipecat_ping_test.go
@@ -2,11 +2,13 @@ package requesthandler
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"go.uber.org/mock/gomock"
 
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 )
@@ -32,7 +34,7 @@ func Test_PipecatV1Ping(t *testing.T) {
 
 			hostID: "10.4.2.18",
 
-			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectTarget: fmt.Sprintf("%s.%s", commonoutline.QueueNamePipecatRequest, "10.4.2.18"),
 			expectRequest: &sock.Request{
 				URI:      "/v1/ping",
 				Method:   sock.RequestMethodGet,
@@ -54,7 +56,7 @@ func Test_PipecatV1Ping(t *testing.T) {
 
 			hostID: "10.4.2.18",
 
-			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectTarget: fmt.Sprintf("%s.%s", commonoutline.QueueNamePipecatRequest, "10.4.2.18"),
 			expectRequest: &sock.Request{
 				URI:      "/v1/ping",
 				Method:   sock.RequestMethodGet,
@@ -77,7 +79,7 @@ func Test_PipecatV1Ping(t *testing.T) {
 
 			hostID: "10.4.2.18",
 
-			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectTarget: fmt.Sprintf("%s.%s", commonoutline.QueueNamePipecatRequest, "10.4.2.18"),
 			expectRequest: &sock.Request{
 				URI:      "/v1/ping",
 				Method:   sock.RequestMethodGet,
@@ -97,7 +99,7 @@ func Test_PipecatV1Ping(t *testing.T) {
 
 			hostID: "10.4.2.18",
 
-			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectTarget: fmt.Sprintf("%s.%s", commonoutline.QueueNamePipecatRequest, "10.4.2.18"),
 			expectRequest: &sock.Request{
 				URI:      "/v1/ping",
 				Method:   sock.RequestMethodGet,
@@ -117,7 +119,7 @@ func Test_PipecatV1Ping(t *testing.T) {
 
 			hostID: "10.4.2.18",
 
-			expectTarget: "bin-manager.pipecat-manager.request.10.4.2.18",
+			expectTarget: fmt.Sprintf("%s.%s", commonoutline.QueueNamePipecatRequest, "10.4.2.18"),
 			expectRequest: &sock.Request{
 				URI:      "/v1/ping",
 				Method:   sock.RequestMethodGet,

--- a/bin-pipecat-manager/models/pipecatcall/ping.go
+++ b/bin-pipecat-manager/models/pipecatcall/ping.go
@@ -1,0 +1,12 @@
+package pipecatcall
+
+import "time"
+
+// PingResult is returned by the per-pod GET /v1/ping route.
+// HostID is the responding pod's POD_IP, used by the caller to verify the
+// queue is consumed by the expected pod (best-effort; does not detect Calico
+// POD_IP recycle).
+type PingResult struct {
+	HostID    string    `json:"host_id"`
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/bin-pipecat-manager/pkg/listenhandler/main.go
+++ b/bin-pipecat-manager/pkg/listenhandler/main.go
@@ -48,6 +48,9 @@ var (
 
 	// messages
 	regV1Messages = regexp.MustCompile(`/v1/messages$`)
+
+	// ping
+	regV1Ping = regexp.MustCompile(`/v1/ping$`)
 )
 
 var (
@@ -202,6 +205,14 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1Messages.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		response, err = h.processV1MessagesPost(ctx, m)
 		requestType = "/v1/messages"
+
+	////////////////////
+	// ping
+	////////////////////
+	// GET /v1/ping
+	case regV1Ping.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
+		response, err = h.processV1PingGet(ctx, m)
+		requestType = "/v1/ping"
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// No handler found

--- a/bin-pipecat-manager/pkg/listenhandler/v1_ping.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_ping.go
@@ -1,0 +1,37 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/sirupsen/logrus"
+)
+
+// processV1PingGet handles GET /v1/ping by returning the pod's PingResult.
+// This is the per-pod liveness probe used by ai-manager preflight.
+func (h *listenHandler) processV1PingGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "processV1PingGet",
+		"request": m,
+	})
+
+	res, err := h.pipecatcallHandler.Ping(ctx)
+	if err != nil {
+		log.Errorf("Could not get ping result. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		log.Errorf("Could not marshal ping result. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}, nil
+}

--- a/bin-pipecat-manager/pkg/listenhandler/v1_ping.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_ping.go
@@ -19,13 +19,13 @@ func (h *listenHandler) processV1PingGet(ctx context.Context, m *sock.Request) (
 
 	res, err := h.pipecatcallHandler.Ping(ctx)
 	if err != nil {
-		log.Errorf("Could not get ping result. err: %v", err)
+		log.Debugf("Could not get ping result. err: %v", err)
 		return simpleResponse(500), nil
 	}
 
 	data, err := json.Marshal(res)
 	if err != nil {
-		log.Errorf("Could not marshal ping result. err: %v", err)
+		log.Debugf("Could not marshal ping result. err: %v", err)
 		return simpleResponse(500), nil
 	}
 

--- a/bin-pipecat-manager/pkg/listenhandler/v1_ping_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_ping_test.go
@@ -1,0 +1,68 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+	"monorepo/bin-pipecat-manager/pkg/pipecatcallhandler"
+)
+
+func Test_processV1PingGet(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *sock.Request
+		mockPing       *pipecatcall.PingResult
+		expectedStatus int
+	}{
+		{
+			name: "GET /v1/ping returns 200 with PingResult body",
+			request: &sock.Request{
+				URI:    "/v1/ping",
+				Method: sock.RequestMethodGet,
+			},
+			mockPing:       &pipecatcall.PingResult{HostID: "10.4.2.18", Timestamp: time.Now().UTC()},
+			expectedStatus: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockPCH := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+			mockPCH.EXPECT().Ping(gomock.Any()).Return(tt.mockPing, nil)
+
+			h := &listenHandler{
+				sockHandler:        sockhandler.NewMockSockHandler(mc),
+				pipecatcallHandler: mockPCH,
+			}
+
+			res, err := h.processV1PingGet(context.Background(), tt.request)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.StatusCode != tt.expectedStatus {
+				t.Errorf("StatusCode = %d, want %d", res.StatusCode, tt.expectedStatus)
+			}
+			if res.DataType != "application/json" {
+				t.Errorf("DataType = %q, want application/json", res.DataType)
+			}
+			var got pipecatcall.PingResult
+			if err := json.Unmarshal(res.Data, &got); err != nil {
+				t.Fatalf("response body did not unmarshal as PingResult: %v", err)
+			}
+			if !reflect.DeepEqual(&got, tt.mockPing) {
+				t.Errorf("body = %+v, want %+v", got, tt.mockPing)
+			}
+		})
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/main.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/main.go
@@ -46,6 +46,8 @@ type PipecatcallHandler interface {
 	RunnerWebsocketHandle(id uuid.UUID, c *gin.Context) error
 	RunnerToolHandle(id uuid.UUID, c *gin.Context) error
 	RunnerMemberSwitchedHandle(id uuid.UUID, c *gin.Context) error
+
+	Ping(ctx context.Context) (*pipecatcall.PingResult, error)
 }
 
 // list of default external media channel options.

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/mock_main.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/mock_main.go
@@ -59,6 +59,21 @@ func (mr *MockPipecatcallHandlerMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPipecatcallHandler)(nil).Get), ctx, id)
 }
 
+// Ping mocks base method.
+func (m *MockPipecatcallHandler) Ping(ctx context.Context) (*pipecatcall.PingResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", ctx)
+	ret0, _ := ret[0].(*pipecatcall.PingResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockPipecatcallHandlerMockRecorder) Ping(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockPipecatcallHandler)(nil).Ping), ctx)
+}
+
 // RunnerMemberSwitchedHandle mocks base method.
 func (m *MockPipecatcallHandler) RunnerMemberSwitchedHandle(id uuid.UUID, c *gin.Context) error {
 	m.ctrl.T.Helper()

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/ping.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/ping.go
@@ -1,0 +1,18 @@
+package pipecatcallhandler
+
+import (
+	"context"
+	"time"
+
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+)
+
+// Ping returns this pod's identity for liveness verification by callers.
+// Returning error keeps the door open for forward-compatible drain semantics
+// (e.g., responding 503 during shutdown). v1 always returns nil.
+func (h *pipecatcallHandler) Ping(ctx context.Context) (*pipecatcall.PingResult, error) {
+	return &pipecatcall.PingResult{
+		HostID:    h.hostID,
+		Timestamp: time.Now().UTC(),
+	}, nil
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/ping_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/ping_test.go
@@ -1,0 +1,42 @@
+package pipecatcallhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func Test_pipecatcallHandler_Ping(t *testing.T) {
+	tests := []struct {
+		name   string
+		hostID string
+	}{
+		{"non-empty host id", "10.4.2.18"},
+		{"empty host id (defensive)", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &pipecatcallHandler{hostID: tt.hostID}
+			before := time.Now().UTC()
+
+			res, err := h.Ping(context.Background())
+
+			if err != nil {
+				t.Fatalf("Ping returned error: %v", err)
+			}
+			if res == nil {
+				t.Fatalf("Ping returned nil result")
+			}
+			if res.HostID != tt.hostID {
+				t.Errorf("HostID = %q, want %q", res.HostID, tt.hostID)
+			}
+			if res.Timestamp.Before(before) {
+				t.Errorf("Timestamp %v is before test start %v", res.Timestamp, before)
+			}
+			if time.Since(res.Timestamp) > 5*time.Second {
+				t.Errorf("Timestamp %v is too old", res.Timestamp)
+			}
+		})
+	}
+}

--- a/docs/plans/2026-04-26-pipecat-pod-ping-design.md
+++ b/docs/plans/2026-04-26-pipecat-pod-ping-design.md
@@ -1,0 +1,437 @@
+# Per-pod liveness ping for `bin-pipecat-manager`
+
+**Date:** 2026-04-26
+**Status:** Design (pre-implementation)
+**Owner:** ai-platform
+**Related:** Conversation-AI text chatbot (`bin-conversation-manager` ↔ `bin-ai-manager` ↔ `bin-pipecat-manager`); independent of and non-blocking for that v1 work.
+
+---
+
+## 1. Problem
+
+`bin-pipecat-manager` and `bin-ai-manager` run on Kubernetes with multiple replicas. Each pipecat session is pinned to a specific pipecat-manager pod via `pipecatcall.HostID`, which is set to that pod's `POD_IP` at session creation (`bin-pipecat-manager/cmd/pipecat-manager/main.go:116-120`). Per-pod RPCs (`PipecatV1MessageSend`, `PipecatV1PipecatcallTerminate`) target a per-pod RabbitMQ queue:
+
+```
+bin-manager.pipecat-manager.request.<host_id>
+```
+
+When a pipecat-manager pod restarts (rolling deploy, OOM kill, eviction, etc.), the new pod gets a new `POD_IP`. Any `pipecatcall` row whose `HostID` still points to the old IP is now permanently unreachable: the volatile per-pod queue is auto-deleted by RabbitMQ once the consumer disconnects (`pkg/listenhandler/main.go:125`), and the in-memory session state in the original pod is gone.
+
+Today, `bin-ai-manager` cannot tell whether a stored `HostID` is alive without firing a real RPC and waiting for it to time out. The default per-call RPC timeout is 3 seconds (`bin-common-handler/pkg/requesthandler/main.go:130`). On the conversation chat hot path (`pkg/aicallhandler/send.go:46`), this means a single user message stalls **3 seconds** before failing. Once the existing per-target circuit breaker in `bin-common-handler/pkg/circuitbreakerhandler/` records 5 consecutive failures (5 separate user messages in a 30s window — not 5 within one message), it opens for 30 seconds and subsequent calls fast-fail in microseconds. So the customer pain is roughly:
+- First user message after a pod restart: **3 s** stall, then error.
+- Next ≤4 user messages while CB is closed: **3 s** each, then error.
+- After CB opens: 30 seconds of µs-fast-fail; next attempt at T+30s probes again.
+
+This design adds a sub-second decisive liveness preflight on the chat hot path. The goal is to cut the per-call stall from **3 s → 1 s**, and to start that 30-second negative-cache window after far less wasted latency.
+
+## 2. Goals & non-goals
+
+### Goals
+- Give `bin-ai-manager` a sub-second decisive liveness signal for any `HostID` before issuing the per-pod chat-message RPC.
+- Cut wasted latency on the dead-pod chat path from 3 s → 1 s per call.
+- Reuse the existing `circuitbreakerhandler` so dead pods are fast-failed (~µs) for 30 seconds after the breaker trips, with no new CB code.
+- Be safe across rolling deploys (mixed old/new pipecat pods).
+
+### Non-goals
+- No DB schema change (no new column on `pipecatcall`).
+- No background heartbeat goroutine.
+- No pipecat-record reaper / cleanup process.
+- No new circuit-breaker code or threshold tuning in v1.
+- No changes to the Python pipecat side.
+- No automatic session recovery (creating a fresh pipecatcall when the old one's pod is dead) — v2 concern.
+- **No detection of POD_IP reuse by Calico CNI.** When K8s recycles an old IP for a new pod within minutes, the new pod will respond to the ping with a matching `host_id` echo but won't own the original session. In that edge case, behavior degrades to current behavior (real RPC sent and fails). Detecting this would require either a more durable pod identifier (e.g., `POD_UID`) stored in the `pipecatcall` row — which violates the no-DB-schema-change constraint — or a session-aware ping (out of v1 scope per §9 decisions).
+
+## 3. Constraints (from problem statement)
+
+- Lightweight ping/health RPC, routed via per-pod queue `bin-manager.pipecat-manager.request.<host_id>`.
+- Short timeout (target: 1 s).
+- Multi-pod safe; no leader election; no shared state beyond what already exists.
+- Backwards compatible during rolling deploys.
+
+## 4. Design
+
+### 4.1 Architecture
+
+```
+ai-manager                         pipecat-manager (per pod)
+─────────                          ────────────────────────
+                                   listens on:
+                                     bin-manager.pipecat-manager.request          (shared)
+                                     bin-manager.pipecat-manager.request.<POD_IP> (volatile, per-pod)
+
+PipecatV1Ping(hostID)
+  → r.sendRequest(
+       queue   = "...request.<hostID>",
+       uri     = "/v1/ping",
+       method  = GET,
+       timeout = 1s)
+  → cb.Allow(queue) ──[open? fast-fail with ErrCircuitOpen]
+  → RabbitMQ RPC ─────────────────────►   listenhandler routes /v1/ping
+                                            → pipecatcallHandler.Ping(ctx)
+                                            → returns {host_id: <POD_IP>, timestamp: now}
+  ◄────── response ────────────────────
+  → cb.RecordSuccess(queue)
+  → verify response.host_id == requested hostID; mismatch → return error
+  → return nil
+
+(timeout case)
+  → cb.RecordFailure(queue) → return error   // pod dead
+                                              // 5 consecutive failures trip CB → 30s fast-fail window
+```
+
+The ping uses the **same per-pod queue** as Send/Terminate, so they share the same circuit-breaker target. Failures from any source (ping or real call) move the same breaker.
+
+### 4.2 Why this leverages the existing infrastructure
+
+The `circuitbreakerhandler` in `bin-common-handler/pkg/circuitbreakerhandler/` is wired into every `r.sendRequest()` call (see `send_request.go:50-67`). It provides:
+
+- Per-target (per queue name) breaker state.
+- Default failure threshold: **5 consecutive failures** → `Closed → Open` (`option.go:9`).
+- Default open duration: **30 s** — `cb.Allow()` rejects immediately during this window (`option.go:10`).
+- Half-open probe after 30 s — one allowed request decides whether to close or re-open.
+- Free Prometheus metrics: `*_circuitbreaker_state{target=...}`, `*_circuitbreaker_state_transitions_total`, `*_circuitbreaker_rejected_total`.
+
+**Practical implication:** because the ping is just another `sendRequest` call against the per-pod queue, no new state, no new caches, and no new metrics need to be added in v1. The breaker provides the negative-cache effect (30 s of µs-fast-fail per dead `HostID`) for free, and exposes that state to Grafana.
+
+### 4.3 Components
+
+#### `bin-pipecat-manager` (server side)
+
+1. `pkg/pipecatcallhandler/main.go` — extend the `PipecatcallHandler` interface with:
+   ```go
+   Ping(ctx context.Context) (*pipecatcall.PingResult, error)
+   ```
+   Returning `error` keeps the door open for forward-compatible states like "drain mode" (responding `503` while the pod is shutting down). v1 always returns `nil`.
+2. `pkg/pipecatcallhandler/ping.go` (new) — implementation: `&PingResult{HostID: h.hostID, Timestamp: time.Now().UTC()}, nil`. No DB I/O, no mutex.
+3. `models/pipecatcall/ping.go` (new) — `PingResult` struct.
+4. `pkg/listenhandler/main.go` — register a new route:
+   ```go
+   regV1Ping = regexp.MustCompile(`/v1/ping$`)
+   ```
+   and a switch case for `GET /v1/ping`.
+5. `pkg/listenhandler/v1_ping.go` (new) — `processV1PingGet`: calls `h.pipecatcallHandler.Ping(ctx)`, marshals the `PingResult`, returns `200 application/json`. On non-nil error, returns `500` (v1 won't hit this path).
+6. Regenerate `pkg/pipecatcallhandler/mock_main.go` via the existing `//go:generate` directive.
+
+#### `bin-common-handler` (client side)
+
+1. `pkg/requesthandler/main.go` — add to the `RequestHandler` interface:
+   ```go
+   PipecatV1Ping(ctx context.Context, hostID string) error
+   ```
+2. `pkg/requesthandler/pipecat_ping.go` (new) — uses the same `outline` package alias as `pipecat_message.go`:
+   ```go
+   package requesthandler
+
+   import (
+       "context"
+       "encoding/json"
+       "fmt"
+
+       outline "monorepo/bin-common-handler/models/outline"
+       "monorepo/bin-common-handler/models/sock"
+       pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
+   )
+
+   const requestTimeoutPipecatPing = 1000  // 1s
+
+   // PipecatV1Ping issues a sub-second liveness probe against the per-pod queue
+   // for hostID. Returns nil if the pod responded with a matching host_id (the
+   // live case), or an error otherwise (timeout, circuit open, mismatched
+   // host_id from a queue-name collision, etc.).
+   //
+   // IMPORTANT: do not add status-code checks here. A 404 from an old pipecat
+   // pod that predates this route is a valid "alive" signal — the pod responded.
+   // The only "dead" signal is err != nil, including ctx.DeadlineExceeded and
+   // circuitbreakerhandler.ErrCircuitOpen.
+   func (r *requestHandler) PipecatV1Ping(ctx context.Context, hostID string) error {
+       queueName := fmt.Sprintf("%s.%s", outline.QueueNamePipecatRequest, hostID)
+       res, err := r.sendRequest(
+           ctx,
+           outline.QueueName(queueName),
+           "/v1/ping",
+           sock.RequestMethodGet,
+           "pipecat/ping",
+           requestTimeoutPipecatPing,
+           0,
+           ContentTypeNone,
+           nil,
+       )
+       if err != nil {
+           return err
+       }
+
+       // Best-effort host_id echo verification: catches the case where the
+       // queue is consumed by a pod with a different identity. Note: Calico
+       // POD_IP recycle gives a matching IP, so this check does NOT cover
+       // that case — see §4.6.
+       // For old pods (404) the body is empty → skip the check (the 404
+       // itself signals "alive but old code").
+       if res != nil && res.StatusCode == 200 && len(res.Data) > 0 {
+           var pr pmpipecatcall.PingResult
+           if errParse := json.Unmarshal(res.Data, &pr); errParse == nil {
+               if pr.HostID != "" && pr.HostID != hostID {
+                   return fmt.Errorf("ping host_id mismatch: requested %s, got %s", hostID, pr.HostID)
+               }
+           }
+       }
+       return nil
+   }
+   ```
+3. Regenerate `pkg/requesthandler/mock_main.go`.
+
+**Admission-rule note:** Per root CLAUDE.md, packages in `bin-common-handler` should serve 3+ services. `bin-common-handler/pkg/requesthandler/pipecat_*.go` already contains pipecat-specific RPCs (`PipecatV1PipecatcallStart`, `PipecatV1PipecatcallGet`, `PipecatV1PipecatcallTerminate`, `PipecatV1PipecatcallTerminateWithDelay`, `PipecatV1MessageSend`) consumed by a single service (`bin-ai-manager`). Adding `PipecatV1Ping` follows that established pattern. The alternative (a `pipecatpinghandler/` package in `bin-ai-manager` calling `r.SendRequest(...)` directly) would split pipecat client logic across two locations — net negative for clarity. Decision: keep alongside the existing pipecat methods.
+
+#### `bin-ai-manager` (preflight integration)
+
+1. `pkg/aicallhandler/ping.go` (new) — small private helper that distinguishes broker errors from dead-pod errors:
+   ```go
+   package aicallhandler
+
+   import (
+       "context"
+       "errors"
+       "time"
+
+       "github.com/sirupsen/logrus"
+
+       "monorepo/bin-common-handler/pkg/circuitbreakerhandler"
+   )
+
+   // pingPipecatHost runs a 1s preflight against hostID. Returns true if the
+   // pod is reachable and owns this host_id; false if the pod is unreachable
+   // (timeout) or the breaker is open. Broker/transport errors return false
+   // and are logged distinctly so an outage is not misclassified as pod death.
+   //
+   // Note: relies on errors.Is unwrapping through pkg/errors v0.9.0+ wrappers
+   // applied by sendRequest. Verified pkg/errors v0.9.1 is pinned in
+   // bin-common-handler/go.mod and bin-ai-manager/go.mod.
+   func (h *aicallHandler) pingPipecatHost(ctx context.Context, hostID string) bool {
+       log := logrus.WithFields(logrus.Fields{
+           "func":    "pingPipecatHost",
+           "host_id": hostID,
+       })
+       if hostID == "" {
+           return false
+       }
+       cctx, cancel := context.WithTimeout(ctx, 1100*time.Millisecond) // small slack over the RPC timeout
+       defer cancel()
+       err := h.reqHandler.PipecatV1Ping(cctx, hostID)
+       if err == nil {
+           log.Debug("Pipecat host ping succeeded.")
+           return true
+       }
+       switch {
+       case errors.Is(err, circuitbreakerhandler.ErrCircuitOpen):
+           log.Debug("Pipecat host ping skipped: circuit breaker open.")
+       case errors.Is(err, context.DeadlineExceeded):
+           log.Info("Pipecat host ping timed out; treating as dead.")
+       default:
+           log.Warnf("Pipecat ping failed with unexpected error; skipping per-pod RPC. err: %v", err)
+       }
+       return false
+   }
+   ```
+2. Edit existing call site — gate the per-pod RPC with a preflight ping at exactly **one** location:
+   - `pkg/aicallhandler/send.go:46` — `PipecatV1MessageSend` (the chat hot path).
+
+   On preflight failure: return an error to the caller (`api-manager` / activeflow), do not auto-restart in v1.
+
+3. Regenerate mocks (see §6 for full scope).
+
+**Call sites NOT gated, with justification:**
+
+| Call site | Why not gated |
+|---|---|
+| `pkg/aicallhandler/process.go:72` `PipecatV1PipecatcallTerminate` | Cleanup path. Code already log-and-continues on RPC error (lines 73-77). Gating saves 2 s on a non-customer-facing path; not worth the extra ping. |
+| `pkg/aicallhandler/start.go:210` `PipecatV1PipecatcallTerminateWithDelay` | Delayed RPC. `sendRequest` returns immediately for `delay > 0` (`send_request.go:41-47`); there is no 3 s wait to save. The delayed message is dropped silently if the per-pod queue dies before delivery. |
+| `pkg/aicallhandler/send.go:88` `PipecatV1PipecatcallTerminateWithDelay` | Same as above (delayed), and `pc` was just created via `startPipecatcall` on the same pod that just answered — `HostID` is freshly known to be alive. Pinging is pure waste. |
+
+If operational data later shows pain at these sites, gating is a small follow-up — but YAGNI for v1.
+
+### 4.4 Decision rule on the gated site
+
+For `pkg/aicallhandler/send.go:46` (`PipecatV1MessageSend` — the chat hot path): on ping success, proceed with the `PipecatV1MessageSend` RPC. On ping failure, return an error to the caller; do **not** auto-restart in v1.
+
+The message cannot be delivered to the bound session if the pod is dead, so the caller must know the operation failed. Auto-restart with a fresh pipecatcall is left as a v2 enhancement to keep v1 small (~10 lines of preflight, plus the new ping plumbing).
+
+### 4.5 Data flow
+
+#### Happy path: chat message to a live pod
+
+```
+api-manager → ai-manager.Send(aicall_id, "hello")
+  → SendReferenceTypeCall(c)
+    ├─ PipecatV1PipecatcallGet(c.PipecatcallID)        // shared queue, ~few ms
+    │   → pc{HostID: "10.4.2.18", ID: <uuid>}
+    ├─ messageHandler.Create(...)                       // DB write
+    ├─ pingPipecatHost("10.4.2.18")                     // NEW
+    │   → cb.Allow → ok
+    │   → RPC GET /v1/ping → response in ~few ms
+    │   → cb.RecordSuccess → host_id echo matches → returns true
+    └─ PipecatV1MessageSend(pc.HostID, pc.ID, ...)      // proceeds
+```
+
+Net added latency on the live path: **one RabbitMQ round-trip (~few ms)**.
+
+#### Dead-pod path: `HostID` points to a restarted pod
+
+```
+api-manager → ai-manager.Send(aicall_id, "hello")
+  → SendReferenceTypeCall(c)
+    ├─ PipecatV1PipecatcallGet(...) → pc{HostID: "10.4.2.18 (DEAD)"}
+    ├─ messageHandler.Create(...)
+    ├─ pingPipecatHost("10.4.2.18")
+    │   → cb.Allow → ok (not yet tripped)
+    │   → RPC GET /v1/ping → ctx deadline exceeded after 1 s
+    │   → cb.RecordFailure → returns false
+    └─ return errors.New("pipecat pod for this aicall is no longer reachable")
+```
+
+Per-call savings: **3 s → 1 s** on first failure. After **5 consecutive failed pings** (across separate user messages within 30 s) the breaker opens; subsequent calls within the next 30 s short-circuit at `cb.Allow()` in microseconds. At T+30 s the breaker enters half-open and admits one probe ping.
+
+#### Degraded-pod path (slow but alive)
+
+If the pod responds to ping in 950 ms but the real RPC then takes 3 s, the chat path eats **ping (≤1 s) + real RPC (≤3 s) = up to 4 s** vs 3 s today on the unhappy degraded path. This is the worst case the design accepts; degraded-but-not-dead pods are rare in practice (typically either healthy <50 ms or dead = full timeout).
+
+### 4.6 Edge cases
+
+| Case | Behavior | Justification |
+|---|---|---|
+| Old pipecat pod (no `/v1/ping` route) | `listenhandler` falls through to default 404. `sendRequest` returns `(*sock.Response{StatusCode: 404}, nil)`. Ping helper sees `err == nil` → returns `true` → preflight passes → real RPC proceeds normally. The host_id echo check skips because the response body is empty. | Rolling-deploy safety: old pods are alive, just unaware of the ping route. |
+| `pc.HostID == ""` (race during start) | `pingPipecatHost("")` returns `false` immediately, no RPC issued. | Defensive guard; should not happen in practice. |
+| RabbitMQ broker down | `sendRequest` errors out → CB records failure → preflight returns `false`. The error is logged distinctly (not as "pod dead"). | Broker-flap protection. |
+| Network partition: ping succeeds, real RPC then times out | Real RPC's own `sendRequest` path goes through the same CB target; a real timeout still records `RecordFailure`. CB eventually trips. | Ping doesn't promise the next RPC succeeds — only that the pod *was* reachable µs ago. |
+| Concurrent sends to the same dead `HostID` | Each independently calls ping; the first 5 each pay 1 s, then the CB opens for all subsequent calls in the 30-s window. Bounded blast radius: ≤5 × 1 s of ping waste per fresh dead host. | Acceptable. Tracked as test case in §6. |
+| Calico POD_IP reuse: new pod takes the dead pod's IP | Ping reaches the new pod; new pod responds with `host_id == requested hostID` (both equal POD_IP). Helper returns `true`. Real `PipecatV1MessageSend` is sent; the new pod's listenhandler returns 4xx because the session isn't in `mapPipecatcallSession`. ai-manager surfaces the error after one wasted RPC (~3 s). | Same outcome as today. v2 candidate: store `POD_UID` (immutable across IP reuse) in `pipecatcall` and verify it in the ping echo. Out of scope for v1 per non-goals. |
+| Pod alive, session lost (in-memory cleanup via `ConnAstDone` lifecycle monitor — see `bin-pipecat-manager/CLAUDE.md`) | Same as Calico IP reuse: ping passes, real RPC fails. Same v2 fix applies (session-aware ping). | Same outcome as today. |
+
+### 4.7 Logging
+
+Per the monorepo CLAUDE.md (`Debug Logging for Retrieved Data`, `External Event & Webhook Processing Logs`):
+
+- Ping success in ai-manager helper: **Debug** — high-frequency, not interesting alone.
+  ```go
+  log.WithField("host_id", hostID).Debug("Pipecat host ping succeeded.")
+  ```
+- Ping fail with `ErrCircuitOpen`: **Debug** — already known steady-state; the CB itself logs the open transition at Warn (`circuitbreakerhandler/main.go:96,115,127`).
+- Ping fail with `context.DeadlineExceeded`: **Info** — visible in production, useful for capacity planning and rolling-deploy diagnostics.
+  ```go
+  log.WithField("host_id", hostID).Infof("Pipecat host ping timed out; treating as dead.")
+  ```
+- Ping fail with other errors (broker/transport): **Warn**, distinguished from pod-death.
+  ```go
+  log.WithField("host_id", hostID).Warnf("Pipecat ping failed with unexpected error; skipping per-pod RPC. err: %v", err)
+  ```
+- The CB itself emits `log.Warnf` on state transitions (already present).
+
+### 4.8 What does NOT change
+
+- DB schema (no Alembic migration).
+- `pipecatcall` model fields.
+- Python pipecat side.
+- Existing public-facing API surface (`bin-api-manager` REST routes).
+- RST docs in `bin-api-manager/docsdev/source/` — `/v1/ping` is internal RPC, not public.
+- Conversation-AI v1 chatbot work — independent.
+
+## 5. Backwards compatibility, rollout, and rollback
+
+### Rollout
+
+The change is additive in `bin-common-handler` (new method, no signature changes) and `bin-pipecat-manager` (new route, new handler method). The behavioral change in `bin-ai-manager` only kicks in when `PipecatV1Ping` is wired into the call site.
+
+Rolling deploy order:
+
+1. **Deploy `bin-pipecat-manager` first** — wait for the new pods to be 100% rolled out. New pods serve `/v1/ping`; any still-running pre-rollout pod returns 404 (treated as alive — see edge cases).
+2. **Bump `bin-common-handler` library version** consumed by `bin-ai-manager` (no service deploy).
+3. **Deploy `bin-ai-manager`** — preflight pings activate. Mid-rollout, mixed old/new ai-manager replicas coexist; old replicas don't ping (current behavior), new replicas do (improved behavior). No coordination required.
+
+If step 1's rollout is paused mid-way, ai-manager (still on old code) is unaffected. Only step 3 introduces the new behavior, and by then step 1 should be complete.
+
+### Rollback
+
+The pipecat `/v1/ping` route is harmless dead code if unused. Two rollback paths:
+
+- **Forward rollback (preferred):** revert the `bin-ai-manager` PR only and redeploy. Reverting that commit removes the `PipecatV1Ping` call sites in ai-manager source; vendor regenerates from source on the next Docker build. (Monorepo uses local `replace` directives in `go.mod`, so there is no version pin to roll back separately.) ai-manager stops calling `PipecatV1Ping`; pipecat-manager's `/v1/ping` route remains but is unused. No coordinated rollback needed; no separate vendor surgery required.
+- **Full rollback:** revert all three commits in reverse order (ai-manager → common-handler → pipecat-manager).
+
+No feature flag needed in v1 — the gating is one helper call at one site, trivial to revert.
+
+## 6. Testing strategy
+
+### `bin-pipecat-manager`
+- `pkg/pipecatcallhandler/ping_test.go` (new): construct handler with a known `hostID`, call `Ping(ctx)`, assert `PingResult.HostID` and recent `Timestamp`.
+- `pkg/listenhandler/v1_ping_test.go` (new): mock `pipecatcallHandler.Ping`, assert `200 application/json` response and JSON body. Negative case: `POST /v1/ping` falls through to 404.
+
+### `bin-common-handler`
+- `pkg/requesthandler/pipecat_ping_test.go` (new), table-driven (mirrors `pipecat_message_test.go`):
+  - **Success, host_id matches**: mock `RequestPublish` returns 200 with body `{host_id: "X", ...}` for requested hostID `X` → `nil` error.
+  - **Success, host_id mismatch (Calico-reuse phantom case)**: mock returns 200 with body `{host_id: "Y", ...}` for requested hostID `X` → returns mismatch error.
+  - **Old-pod 404**: mock returns 404 with `nil` error → ping returns `nil` (alive). Body parsing must skip cleanly.
+  - **Empty body 200**: mock returns 200 with empty `Data` → `nil` error (no echo check possible; degrade gracefully).
+  - **Timeout**: mock blocks until ctx cancels; assert `context.DeadlineExceeded` propagates.
+  - **Circuit open**: mock the breaker into open state; assert `ErrCircuitOpen` propagates.
+  - **Queue-name regression**: assert exact queue name `bin-manager.pipecat-manager.request.<hostID>`.
+- Circuit-breaker integration is already covered by `send_request_test.go`; do not re-test.
+
+### `bin-ai-manager`
+- `pkg/aicallhandler/ping_test.go` (new):
+  - Alive → returns `true`.
+  - Empty `hostID` → returns `false` and no RPC issued.
+  - `ErrCircuitOpen` → returns `false`, debug-level log.
+  - `context.DeadlineExceeded` → returns `false`, info-level log.
+  - Other error → returns `false`, warn-level log.
+  - **Concurrency**: 10 parallel calls to `pingPipecatHost("dead-host")`; first 5 each pay ≤1 s, ≥6th onwards complete in <100 ms because CB opened. Use a fake clock if needed to keep the test under 6 s.
+- Extend existing `pkg/aicallhandler/send_test.go`:
+  - `Send_PipecatHostAlive_CallsMessageSend` — ping mock returns success → `PipecatV1MessageSend` mock asserted called once.
+  - `Send_PipecatHostDead_ReturnsErrorWithoutCallingMessageSend` — ping mock returns error → `PipecatV1MessageSend` mock asserted **never called**, `Send` returns non-nil error.
+- **No edits** needed to `process_test.go` or `start_test.go` — those call sites are not gated.
+
+### Mock-regen scope (operational note)
+
+Adding `PipecatV1Ping` to the `RequestHandler` interface means `bin-common-handler/pkg/requesthandler/mock_main.go` regenerates with a new mock method. Every consumer that already constructs a `MockRequestHandler` and uses strict expectations (rather than `EXPECT().AnyTimes()` defaults) will keep compiling unchanged because the new method is additive, but tests that explicitly enumerate "no other calls expected" patterns may need an update.
+
+In practice, only `bin-ai-manager`'s own `aicallhandler` tests need attention because they set explicit expectations. To keep the blast radius bounded, the `bin-ai-manager` PR should:
+1. Add `EXPECT().PipecatV1Ping(...).AnyTimes()` to existing per-pod test fixtures, or
+2. Add explicit positive expectations only for the new gated path, leaving other tests unchanged.
+
+This is mechanical, not architectural — call out in PR description so reviewers know to check.
+
+### Out of scope
+- End-to-end against a real RabbitMQ broker.
+- Re-testing the `circuitbreakerhandler` state machine.
+
+## 7. Verification workflow per service touched
+
+Per monorepo CLAUDE.md, before commit:
+
+```bash
+# 1. bin-common-handler
+cd bin-common-handler && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# 2. bin-pipecat-manager
+cd bin-pipecat-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# 3. bin-ai-manager
+cd bin-ai-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+No other services need verification — `bin-common-handler` adds one new method (additive only); no existing signatures change.
+
+## 8. Open questions / future work
+
+- **Lower CB threshold for per-pod queues.** Default `5` means up to 5 × 1 s = 5 s of pain (across separate user messages) per dead `HostID` before fast-fail. If metrics show this hurts, add an optional per-target threshold to `circuitbreakerhandler` (e.g., register per-pod queues with threshold `1`).
+- **Auto-recover on dead-pod-detected in `Send`.** Today: surface error. v2 candidate: spin up a fresh pipecatcall on the shared queue and resend. Requires care around message ordering and the `pipecatcall_id` rotation that already happens in `SendReferenceTypeOthers`.
+- **Session-aware ping.** Today's process-level ping doesn't catch Calico IP-reuse or in-memory session loss without IP change. v2 candidate: `Ping(ctx, pipecatcallID)` checks `mapPipecatcallSession` and returns 404 if the session isn't owned. Requires a small DB schema change (or POD_UID storage) only if we want to verify pod identity without trusting the responding pod's self-report.
+- **DB reaper for orphaned `pipecatcall` rows.** Independent cleanup task; out of scope here.
+- **Circuit-breaker map and Prometheus cardinality.** `breakers map[string]*breaker` in `circuitbreakerhandler` accumulates one entry per ever-seen per-pod queue name. Memory cost is small (~tens of bytes per entry), but Prometheus labels also accumulate one series per ever-seen `target` value. Over months of pod churn (POD_IP recycling) this is unbounded. Fix candidates: (a) TTL-evict breaker map entries that have been Closed and idle for >1 h; (b) strip the `<POD_IP>` from the metric label and aggregate at the queue-prefix level. Defer until profiling shows pressure.
+
+## 9. Decisions log
+
+- **Ping scope = process-level** (queue alive + pod responsive), not session-level. The failure mode in scope is "pod restarted with a new IP." Session-level would catch Calico IP reuse and in-memory session loss but adds DB or RPC complexity for v1.
+- **No caching in ai-manager.** The existing CB already provides 30-s negative caching for free per dead `HostID`. Adding a positive cache would shave a few ms in chat bursts at the cost of staleness; not worth it for v1.
+- **Single gated call site (`send.go:46`).** Other per-pod call sites either don't pay the 3-s timeout (delayed RPCs) or aren't on a customer hot path (cleanup terminate). Keep v1 minimal.
+- **Decision rule: send returns error.** Auto-restart is a v2 enhancement.
+- **Use existing CB unchanged.** Threshold tuning is a follow-up if data demands it.
+- **Keep `PipecatV1Ping` in `bin-common-handler`** alongside existing `PipecatV1*` methods, despite the 3-service admission rule — established precedent, and splitting pipecat client logic across two locations has worse ergonomics.
+- **`Ping(ctx) (*PingResult, error)` on the server interface** — error return enables future drain-mode / 503 semantics without an interface break.
+- **`host_id` echo verification on the client** — best-effort detection of queue-name collisions (low confidence on Calico IP reuse, high confidence on routing bugs).

--- a/docs/plans/2026-04-26-pipecat-pod-ping-plan.md
+++ b/docs/plans/2026-04-26-pipecat-pod-ping-plan.md
@@ -1,0 +1,1084 @@
+# Pipecat Pod Ping Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `/v1/ping` per-pod RPC route to `bin-pipecat-manager`, a 1-second client method `PipecatV1Ping` in `bin-common-handler`, and a preflight ping in `bin-ai-manager` before the chat-message RPC at `pkg/aicallhandler/send.go:46` — cutting dead-pod stalls from 3s → 1s without DB schema changes.
+
+**Architecture:** Process-level liveness ping routed through the existing per-pod RabbitMQ queue `bin-manager.pipecat-manager.request.<host_id>`. The ping is a normal `r.sendRequest()` call so it shares the existing per-target circuit breaker — five consecutive failures trip a 30s fast-fail window for free. Server returns `{host_id, timestamp}`; client verifies the echo. Old pods that 404 the route are treated as alive (rolling-deploy safe).
+
+**Tech Stack:** Go 1.22, RabbitMQ via `amqp091-go`, `github.com/pkg/errors` v0.9.1 (Unwrap-aware), `go.uber.org/mock` for mockgen, logrus, Prometheus. Verification per service: `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
+
+**Reference:** [`docs/plans/2026-04-26-pipecat-pod-ping-design.md`](./2026-04-26-pipecat-pod-ping-design.md)
+
+**Worktree:** `/home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design`
+**Branch:** `NOJIRA-pipecat-pod-ping-design` (already created; design doc already committed at `cfa75eb52`)
+
+---
+
+## Branch sync precheck (run before starting Task 1)
+
+**Step 0.1: Pull latest main into the worktree base for conflict detection**
+
+Run from the worktree:
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+git fetch origin main
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)" || echo "no conflicts"
+git log --oneline HEAD..origin/main | head -10
+```
+Expected: `no conflicts`. If conflicts, rebase onto `origin/main` and re-run; do not start implementation until clean.
+
+---
+
+## Task 1: Create `PingResult` model in bin-pipecat-manager
+
+**Files:**
+- Create: `bin-pipecat-manager/models/pipecatcall/ping.go`
+
+**Step 1.1: Write the model file**
+
+```go
+package pipecatcall
+
+import "time"
+
+// PingResult is returned by the per-pod GET /v1/ping route.
+// HostID is the responding pod's POD_IP, used by the caller to verify the
+// queue is consumed by the expected pod (best-effort; does not detect Calico
+// POD_IP recycle).
+type PingResult struct {
+	HostID    string    `json:"host_id"`
+	Timestamp time.Time `json:"timestamp"`
+}
+```
+
+**Step 1.2: Verify it compiles**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-pipecat-manager
+go build ./models/pipecatcall/...
+```
+Expected: no output, exit 0.
+
+---
+
+## Task 2: Add `Ping` to `PipecatcallHandler` interface and implement it
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/main.go` (add to interface)
+- Create: `bin-pipecat-manager/pkg/pipecatcallhandler/ping.go`
+- Create: `bin-pipecat-manager/pkg/pipecatcallhandler/ping_test.go`
+
+**Step 2.1: Write the failing test**
+
+`bin-pipecat-manager/pkg/pipecatcallhandler/ping_test.go`:
+
+```go
+package pipecatcallhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func Test_pipecatcallHandler_Ping(t *testing.T) {
+	tests := []struct {
+		name   string
+		hostID string
+	}{
+		{"non-empty host id", "10.4.2.18"},
+		{"empty host id (defensive)", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &pipecatcallHandler{hostID: tt.hostID}
+			before := time.Now().UTC()
+
+			res, err := h.Ping(context.Background())
+
+			if err != nil {
+				t.Fatalf("Ping returned error: %v", err)
+			}
+			if res == nil {
+				t.Fatalf("Ping returned nil result")
+			}
+			if res.HostID != tt.hostID {
+				t.Errorf("HostID = %q, want %q", res.HostID, tt.hostID)
+			}
+			if res.Timestamp.Before(before) {
+				t.Errorf("Timestamp %v is before test start %v", res.Timestamp, before)
+			}
+			if time.Since(res.Timestamp) > 5*time.Second {
+				t.Errorf("Timestamp %v is too old", res.Timestamp)
+			}
+		})
+	}
+}
+```
+
+**Step 2.2: Run the test — expect compile failure (Ping doesn't exist)**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-pipecat-manager
+go test ./pkg/pipecatcallhandler/ -run Test_pipecatcallHandler_Ping -v
+```
+Expected: FAIL with "h.Ping undefined" or similar build error.
+
+**Step 2.3: Add `Ping` to the interface**
+
+In `bin-pipecat-manager/pkg/pipecatcallhandler/main.go`, inside the `PipecatcallHandler` interface block (after the `RunnerMemberSwitchedHandle` method, before the closing brace):
+
+```go
+	Ping(ctx context.Context) (*pipecatcall.PingResult, error)
+```
+
+**Step 2.4: Implement `Ping` in a new file**
+
+`bin-pipecat-manager/pkg/pipecatcallhandler/ping.go`:
+
+```go
+package pipecatcallhandler
+
+import (
+	"context"
+	"time"
+
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+)
+
+// Ping returns this pod's identity for liveness verification by callers.
+// Returning error keeps the door open for forward-compatible drain semantics
+// (e.g., responding 503 during shutdown). v1 always returns nil.
+func (h *pipecatcallHandler) Ping(ctx context.Context) (*pipecatcall.PingResult, error) {
+	return &pipecatcall.PingResult{
+		HostID:    h.hostID,
+		Timestamp: time.Now().UTC(),
+	}, nil
+}
+```
+
+**Step 2.5: Run the test — expect pass**
+
+```bash
+go test ./pkg/pipecatcallhandler/ -run Test_pipecatcallHandler_Ping -v
+```
+Expected: PASS.
+
+---
+
+## Task 3: Regenerate the `pipecatcallhandler` mock
+
+**Files:**
+- Modify (regenerated): `bin-pipecat-manager/pkg/pipecatcallhandler/mock_main.go`
+
+**Step 3.1: Regenerate the mock**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-pipecat-manager
+go generate ./pkg/pipecatcallhandler/...
+```
+Expected: no output, exit 0.
+
+**Step 3.2: Verify the regenerated mock compiles and existing tests still pass**
+
+```bash
+go test ./pkg/pipecatcallhandler/...
+```
+Expected: PASS for all package tests.
+
+---
+
+## Task 4: Add `/v1/ping` route to listenhandler
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/listenhandler/main.go` (add regex + switch case)
+- Create: `bin-pipecat-manager/pkg/listenhandler/v1_ping.go`
+- Create: `bin-pipecat-manager/pkg/listenhandler/v1_ping_test.go`
+
+**Step 4.1: Write the failing test**
+
+`bin-pipecat-manager/pkg/listenhandler/v1_ping_test.go`:
+
+```go
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	mocksock "monorepo/bin-common-handler/pkg/sockhandler"
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+	"monorepo/bin-pipecat-manager/pkg/pipecatcallhandler"
+)
+
+func Test_processV1PingGet(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *sock.Request
+		mockPing       *pipecatcall.PingResult
+		expectedStatus int
+	}{
+		{
+			name: "GET /v1/ping returns 200 with PingResult body",
+			request: &sock.Request{
+				URI:    "/v1/ping",
+				Method: sock.RequestMethodGet,
+			},
+			mockPing:       &pipecatcall.PingResult{HostID: "10.4.2.18", Timestamp: time.Now().UTC()},
+			expectedStatus: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockPCH := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+			mockPCH.EXPECT().Ping(gomock.Any()).Return(tt.mockPing, nil)
+
+			h := &listenHandler{
+				sockHandler:        mocksock.NewMockSockHandler(mc),
+				pipecatcallHandler: mockPCH,
+			}
+
+			res, err := h.processV1PingGet(context.Background(), tt.request)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res.StatusCode != tt.expectedStatus {
+				t.Errorf("StatusCode = %d, want %d", res.StatusCode, tt.expectedStatus)
+			}
+			if res.DataType != "application/json" {
+				t.Errorf("DataType = %q, want application/json", res.DataType)
+			}
+			var got pipecatcall.PingResult
+			if err := json.Unmarshal(res.Data, &got); err != nil {
+				t.Fatalf("response body did not unmarshal as PingResult: %v", err)
+			}
+			if !reflect.DeepEqual(&got, tt.mockPing) {
+				t.Errorf("body = %+v, want %+v", got, tt.mockPing)
+			}
+		})
+	}
+}
+```
+
+**Step 4.2: Run the test — expect compile failure (`processV1PingGet` undefined)**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-pipecat-manager
+go test ./pkg/listenhandler/ -run Test_processV1PingGet -v
+```
+Expected: FAIL with "h.processV1PingGet undefined" or similar.
+
+**Step 4.3: Add the route regex and switch case in `main.go`**
+
+In `bin-pipecat-manager/pkg/listenhandler/main.go`:
+
+(a) Add to the `var (...)` block that defines route regexes (after `regV1Messages`):
+
+```go
+	// ping
+	regV1Ping = regexp.MustCompile(`/v1/ping$`)
+```
+
+(b) Add a switch case in `processRequest()` (place it after the `messages` block, before the `default:`):
+
+```go
+		////////////////////
+		// ping
+		////////////////////
+		// GET /v1/ping
+		case regV1Ping.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
+			response, err = h.processV1PingGet(ctx, m)
+			requestType = "/v1/ping"
+```
+
+**Step 4.4: Implement `processV1PingGet`**
+
+`bin-pipecat-manager/pkg/listenhandler/v1_ping.go`:
+
+```go
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/sirupsen/logrus"
+)
+
+// processV1PingGet handles GET /v1/ping by returning the pod's PingResult.
+// This is the per-pod liveness probe used by ai-manager preflight.
+func (h *listenHandler) processV1PingGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "processV1PingGet",
+		"request": m,
+	})
+
+	res, err := h.pipecatcallHandler.Ping(ctx)
+	if err != nil {
+		log.Errorf("Could not get ping result. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		log.Errorf("Could not marshal ping result. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}, nil
+}
+```
+
+**Step 4.5: Run the test — expect pass**
+
+```bash
+go test ./pkg/listenhandler/ -run Test_processV1PingGet -v
+```
+Expected: PASS.
+
+**Step 4.6: Run the full listenhandler package tests to verify no regressions**
+
+```bash
+go test ./pkg/listenhandler/...
+```
+Expected: PASS.
+
+---
+
+## Task 5: Verify and commit `bin-pipecat-manager` changes
+
+**Step 5.1: Run the full verification workflow for bin-pipecat-manager**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-pipecat-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+Expected: all 5 steps succeed; lint clean. **Do not skip any step**, even if "trivial" — `go mod tidy` may update `go.sum` even when no new imports are added. Vendor directory is gitignored — do **not** commit it.
+
+**Step 5.2: Stage and review the diff**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+git status
+git diff --stat bin-pipecat-manager/
+git diff bin-pipecat-manager/
+```
+Expected files changed:
+- `bin-pipecat-manager/models/pipecatcall/ping.go` (new)
+- `bin-pipecat-manager/pkg/pipecatcallhandler/main.go` (interface +1 line)
+- `bin-pipecat-manager/pkg/pipecatcallhandler/ping.go` (new)
+- `bin-pipecat-manager/pkg/pipecatcallhandler/ping_test.go` (new)
+- `bin-pipecat-manager/pkg/pipecatcallhandler/mock_main.go` (regenerated)
+- `bin-pipecat-manager/pkg/listenhandler/main.go` (regex + switch case)
+- `bin-pipecat-manager/pkg/listenhandler/v1_ping.go` (new)
+- `bin-pipecat-manager/pkg/listenhandler/v1_ping_test.go` (new)
+- `bin-pipecat-manager/go.mod`, `bin-pipecat-manager/go.sum` (possibly updated by `go mod tidy`)
+
+**Step 5.3: Commit (checkpoint commit on the feature branch — final squash on merge)**
+
+```bash
+git add bin-pipecat-manager/
+git status  # confirm no vendor/ files staged
+git commit -m "$(cat <<'EOF'
+NOJIRA-pipecat-pod-ping-design: add ping endpoint
+
+- bin-pipecat-manager: Add Ping method to PipecatcallHandler interface returning PingResult{host_id, timestamp}
+- bin-pipecat-manager: Add models/pipecatcall/ping.go with PingResult struct
+- bin-pipecat-manager: Add listenhandler route GET /v1/ping wired to PipecatcallHandler.Ping
+- bin-pipecat-manager: Regenerate pipecatcallhandler mock for new interface method
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `PipecatV1Ping` client method in bin-common-handler
+
+**Files:**
+- Modify: `bin-common-handler/pkg/requesthandler/main.go` (add to interface)
+- Create: `bin-common-handler/pkg/requesthandler/pipecat_ping.go`
+
+**Step 6.1: Add `PipecatV1Ping` to the `RequestHandler` interface**
+
+In `bin-common-handler/pkg/requesthandler/main.go`, find the existing pipecat method block (around line 1061-1090; look for `PipecatV1MessageSend` and `PipecatV1PipecatcallTerminateWithDelay`) and add at the end of that block:
+
+```go
+	// pipecat-manager ping
+	PipecatV1Ping(ctx context.Context, hostID string) error
+```
+
+**Step 6.2: Implement `PipecatV1Ping`**
+
+`bin-common-handler/pkg/requesthandler/pipecat_ping.go`:
+
+```go
+package requesthandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	outline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/sock"
+	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
+)
+
+const requestTimeoutPipecatPing = 1000 // 1s — sub-second decisive liveness probe
+
+// PipecatV1Ping issues a sub-second liveness probe against the per-pod queue
+// for hostID. Returns nil if the pod responded with a matching host_id (the
+// live case), or an error otherwise (timeout, circuit open, mismatched
+// host_id from a queue-name collision, etc.).
+//
+// IMPORTANT: do not add status-code checks here. A 404 from an old pipecat
+// pod that predates this route is a valid "alive" signal — the pod responded.
+// The only "dead" signal is err != nil, including ctx.DeadlineExceeded and
+// circuitbreakerhandler.ErrCircuitOpen.
+func (r *requestHandler) PipecatV1Ping(ctx context.Context, hostID string) error {
+	queueName := fmt.Sprintf("%s.%s", outline.QueueNamePipecatRequest, hostID)
+	res, err := r.sendRequest(
+		ctx,
+		outline.QueueName(queueName),
+		"/v1/ping",
+		sock.RequestMethodGet,
+		"pipecat/ping",
+		requestTimeoutPipecatPing,
+		0,
+		ContentTypeNone,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Best-effort host_id echo verification. Note: Calico POD_IP recycle gives
+	// a matching IP, so this check does NOT cover that case (see design §4.6).
+	// For old pods the body is empty (404 simpleResponse) → skip the check.
+	if res != nil && res.StatusCode == 200 && len(res.Data) > 0 {
+		var pr pmpipecatcall.PingResult
+		if errParse := json.Unmarshal(res.Data, &pr); errParse == nil {
+			if pr.HostID != "" && pr.HostID != hostID {
+				return fmt.Errorf("ping host_id mismatch: requested %s, got %s", hostID, pr.HostID)
+			}
+		}
+	}
+	return nil
+}
+```
+
+**Step 6.3: Verify it compiles**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-common-handler
+go build ./pkg/requesthandler/...
+```
+Expected: exit 0.
+
+---
+
+## Task 7: Write `pipecat_ping_test.go` (table-driven)
+
+**Files:**
+- Create: `bin-common-handler/pkg/requesthandler/pipecat_ping_test.go`
+
+**Step 7.1: Open `bin-common-handler/pkg/requesthandler/pipecat_message_test.go` for the test fixture pattern reference**
+
+Read the file end-to-end. The new ping test follows the same structure: gomock controller, mock `sockhandler`, table cases.
+
+**Step 7.2: Write the test file**
+
+`bin-common-handler/pkg/requesthandler/pipecat_ping_test.go`:
+
+```go
+package requesthandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
+)
+
+func Test_PipecatV1Ping(t *testing.T) {
+	tests := []struct {
+		name           string
+		hostID         string
+		expectQueue    string
+		mockResponse   *sock.Response
+		mockErr        error
+		expectErr      bool
+		expectErrSubstr string
+	}{
+		{
+			name:        "alive pod returns matching host_id",
+			hostID:      "10.4.2.18",
+			expectQueue: "bin-manager.pipecat-manager.request.10.4.2.18",
+			mockResponse: func() *sock.Response {
+				body, _ := json.Marshal(pmpipecatcall.PingResult{HostID: "10.4.2.18", Timestamp: time.Now().UTC()})
+				return &sock.Response{StatusCode: 200, DataType: "application/json", Data: body}
+			}(),
+			mockErr:   nil,
+			expectErr: false,
+		},
+		{
+			name:        "host_id echo mismatch returns error",
+			hostID:      "10.4.2.18",
+			expectQueue: "bin-manager.pipecat-manager.request.10.4.2.18",
+			mockResponse: func() *sock.Response {
+				body, _ := json.Marshal(pmpipecatcall.PingResult{HostID: "10.4.2.99", Timestamp: time.Now().UTC()})
+				return &sock.Response{StatusCode: 200, DataType: "application/json", Data: body}
+			}(),
+			mockErr:         nil,
+			expectErr:       true,
+			expectErrSubstr: "host_id mismatch",
+		},
+		{
+			name:        "old pod 404 with empty body treated as alive",
+			hostID:      "10.4.2.18",
+			expectQueue: "bin-manager.pipecat-manager.request.10.4.2.18",
+			mockResponse: &sock.Response{StatusCode: 404},
+			mockErr:     nil,
+			expectErr:   false,
+		},
+		{
+			name:        "200 with empty body treated as alive (no echo check possible)",
+			hostID:      "10.4.2.18",
+			expectQueue: "bin-manager.pipecat-manager.request.10.4.2.18",
+			mockResponse: &sock.Response{StatusCode: 200},
+			mockErr:     nil,
+			expectErr:   false,
+		},
+		{
+			name:            "timeout error from sendRequest is propagated",
+			hostID:          "10.4.2.18",
+			expectQueue:     "bin-manager.pipecat-manager.request.10.4.2.18",
+			mockResponse:    nil,
+			mockErr:         context.DeadlineExceeded,
+			expectErr:       true,
+			expectErrSubstr: "deadline exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			r := &requestHandler{
+				sock:      mockSock,
+				publisher: commonoutline.ServiceNameAIManager,
+			}
+			initPrometheusOnce(t)
+
+			mockSock.EXPECT().
+				RequestPublish(gomock.Any(), tt.expectQueue, gomock.Any()).
+				Return(tt.mockResponse, tt.mockErr)
+
+			err := r.PipecatV1Ping(context.Background(), tt.hostID)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.expectErrSubstr != "" && !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), tt.expectErrSubstr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.expectErrSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected nil, got: %v", err)
+				}
+			}
+		})
+	}
+}
+```
+
+**Note:** `initPrometheusOnce(t)` is a placeholder — check whether existing tests in this package use a helper to avoid duplicate Prometheus registration. Search:
+```bash
+grep -n "initPrometheus\|prometheus.MustRegister" bin-common-handler/pkg/requesthandler/*_test.go bin-common-handler/pkg/requesthandler/main_test.go 2>/dev/null
+```
+If existing tests use `r := newRequestHandlerForTest(...)` or similar, mirror that. If they construct `requestHandler{}` directly, drop the `initPrometheusOnce(t)` call. The exact wiring depends on the package's test-setup convention; verify before pasting blindly.
+
+**Step 7.3: Run the test — expect pass**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-common-handler
+go test ./pkg/requesthandler/ -run Test_PipecatV1Ping -v
+```
+Expected: PASS for all 5 subtests.
+
+---
+
+## Task 8: Regenerate `requesthandler` mock
+
+**Files:**
+- Modify (regenerated): `bin-common-handler/pkg/requesthandler/mock_main.go`
+
+**Step 8.1: Regenerate**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-common-handler
+go generate ./pkg/requesthandler/...
+```
+Expected: exit 0.
+
+**Step 8.2: Confirm `MockRequestHandler` now exposes `PipecatV1Ping`**
+
+```bash
+grep -n "PipecatV1Ping" pkg/requesthandler/mock_main.go | head -5
+```
+Expected: 4–6 matches (mocked method body + recorder + comment lines).
+
+---
+
+## Task 9: Verify and commit `bin-common-handler` changes
+
+**Step 9.1: Full verification workflow**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-common-handler
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+Expected: all 5 steps succeed.
+
+**Step 9.2: Stage and commit**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+git status
+git add bin-common-handler/
+git commit -m "$(cat <<'EOF'
+NOJIRA-pipecat-pod-ping-design: add PipecatV1Ping client method
+
+- bin-common-handler: Add PipecatV1Ping(ctx, hostID) to RequestHandler interface with 1s timeout
+- bin-common-handler: Add pipecat_ping.go implementation with best-effort host_id echo verification
+- bin-common-handler: Add pipecat_ping_test.go covering alive, mismatch, old-pod 404, empty body, and timeout cases
+- bin-common-handler: Regenerate requesthandler mock for new interface method
+EOF
+)"
+```
+
+---
+
+## Task 10: Add `pingPipecatHost` helper in bin-ai-manager
+
+**Files:**
+- Create: `bin-ai-manager/pkg/aicallhandler/ping.go`
+
+**Step 10.1: Verify pkg/errors v0.9.1 is pinned (Unwrap support)**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-ai-manager
+grep "pkg/errors" go.mod
+```
+Expected: `github.com/pkg/errors v0.9.1`. If older, the `errors.Is` chain through `sendRequest`'s wrapping will not work; halt and bump dependency.
+
+**Step 10.2: Implement the helper**
+
+`bin-ai-manager/pkg/aicallhandler/ping.go`:
+
+```go
+package aicallhandler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-common-handler/pkg/circuitbreakerhandler"
+)
+
+// pingPipecatHost runs a ~1s preflight against hostID. Returns true if the
+// pod is reachable and owns this host_id; false if the pod is unreachable
+// (timeout) or the breaker is open. Broker/transport errors return false
+// and are logged distinctly so an outage is not misclassified as pod death.
+//
+// Note: relies on errors.Is unwrapping through pkg/errors v0.9.0+ wrappers
+// applied by sendRequest. Verified pkg/errors v0.9.1 is pinned in
+// bin-common-handler/go.mod and bin-ai-manager/go.mod.
+func (h *aicallHandler) pingPipecatHost(ctx context.Context, hostID string) bool {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "pingPipecatHost",
+		"host_id": hostID,
+	})
+	if hostID == "" {
+		return false
+	}
+	cctx, cancel := context.WithTimeout(ctx, 1100*time.Millisecond)
+	defer cancel()
+	err := h.reqHandler.PipecatV1Ping(cctx, hostID)
+	if err == nil {
+		log.Debug("Pipecat host ping succeeded.")
+		return true
+	}
+	switch {
+	case errors.Is(err, circuitbreakerhandler.ErrCircuitOpen):
+		log.Debug("Pipecat host ping skipped: circuit breaker open.")
+	case errors.Is(err, context.DeadlineExceeded):
+		log.Info("Pipecat host ping timed out; treating as dead.")
+	default:
+		log.Warnf("Pipecat ping failed with unexpected error; skipping per-pod RPC. err: %v", err)
+	}
+	return false
+}
+```
+
+**Step 10.3: Verify it compiles**
+
+```bash
+go build ./pkg/aicallhandler/...
+```
+Expected: exit 0. (May fail because `bin-ai-manager`'s vendor doesn't yet have the new `PipecatV1Ping` method — Step 10.4 fixes that.)
+
+**Step 10.4: Re-vendor to pick up the new common-handler method**
+
+```bash
+go mod tidy && go mod vendor
+go build ./pkg/aicallhandler/...
+```
+Expected: exit 0.
+
+---
+
+## Task 11: Write `ping_test.go` for the helper
+
+**Files:**
+- Create: `bin-ai-manager/pkg/aicallhandler/ping_test.go`
+
+**Step 11.1: Read an existing aicallhandler test for the fixture pattern**
+
+```bash
+head -80 /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-ai-manager/pkg/aicallhandler/send_test.go
+```
+Use the constructor pattern from the existing test (likely `newAIcallHandlerForTest(t, mc)` or a direct struct literal — match it).
+
+**Step 11.2: Write the test**
+
+`bin-ai-manager/pkg/aicallhandler/ping_test.go`:
+
+```go
+package aicallhandler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/pkg/circuitbreakerhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+)
+
+func Test_aicallHandler_pingPipecatHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		hostID      string
+		mockErr     error
+		expectCall  bool
+		expectAlive bool
+	}{
+		{
+			name:        "empty hostID returns false without RPC",
+			hostID:      "",
+			mockErr:     nil,
+			expectCall:  false,
+			expectAlive: false,
+		},
+		{
+			name:        "alive pod returns true",
+			hostID:      "10.4.2.18",
+			mockErr:     nil,
+			expectCall:  true,
+			expectAlive: true,
+		},
+		{
+			name:        "deadline exceeded returns false",
+			hostID:      "10.4.2.18",
+			mockErr:     errors.Wrap(context.DeadlineExceeded, "could not send the request"),
+			expectCall:  true,
+			expectAlive: false,
+		},
+		{
+			name:        "circuit open returns false",
+			hostID:      "10.4.2.18",
+			mockErr:     errors.Wrap(circuitbreakerhandler.ErrCircuitOpen, "could not send the request"),
+			expectCall:  true,
+			expectAlive: false,
+		},
+		{
+			name:        "unexpected error returns false",
+			hostID:      "10.4.2.18",
+			mockErr:     fmt.Errorf("broker connection refused"),
+			expectCall:  true,
+			expectAlive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq}
+
+			if tt.expectCall {
+				mockReq.EXPECT().PipecatV1Ping(gomock.Any(), tt.hostID).Return(tt.mockErr)
+			}
+
+			got := h.pingPipecatHost(context.Background(), tt.hostID)
+			if got != tt.expectAlive {
+				t.Errorf("pingPipecatHost = %v, want %v", got, tt.expectAlive)
+			}
+		})
+	}
+}
+```
+
+**Note:** This file imports both stdlib `errors` and `github.com/pkg/errors`. The stdlib import is needed by `errors.Is` paths in the helper under test (already imported in `ping.go`). For the test, only `errors.Wrap` from pkg/errors is used. Resolve the alias collision by importing pkg/errors as `pkgerrors`:
+```go
+	"errors"
+
+	pkgerrors "github.com/pkg/errors"
+```
+Then change `errors.Wrap(...)` to `pkgerrors.Wrap(...)` in the table cases. Update accordingly.
+
+**Step 11.3: Run the test**
+
+```bash
+go test ./pkg/aicallhandler/ -run Test_aicallHandler_pingPipecatHost -v
+```
+Expected: PASS for all 5 subtests.
+
+---
+
+## Task 12: Gate `send.go:46` with the preflight ping
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/aicallhandler/send.go` (around line 46)
+- Modify: `bin-ai-manager/pkg/aicallhandler/send_test.go` (extend `SendReferenceTypeCall` cases)
+
+**Step 12.1: Read the current `SendReferenceTypeCall` to confirm line numbers**
+
+```bash
+grep -n "PipecatV1MessageSend\|SendReferenceTypeCall\|PipecatV1PipecatcallGet" /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-ai-manager/pkg/aicallhandler/send.go | head -10
+```
+Confirm `PipecatV1MessageSend` is still on the line near 46 (line numbers may shift after the package gains `ping.go`).
+
+**Step 12.2: Insert the preflight before `PipecatV1MessageSend`**
+
+In `bin-ai-manager/pkg/aicallhandler/send.go`, find this block in `SendReferenceTypeCall`:
+
+```go
+	res, err := h.messageHandler.Create(ctx, uuid.Nil, c.CustomerID, c.ID, c.ActiveflowID, message.DirectionOutgoing, message.RoleUser, messageText, nil, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create the message. aicall_id: %s", c.ID)
+	}
+	log.WithField("message", res).Debugf("Created the message to the ai. aicall_id: %s, message_id: %s", c.ID, res.ID)
+
+	tmp, err := h.reqHandler.PipecatV1MessageSend(ctx, pc.HostID, pc.ID, res.ID.String(), messageText, runImmediately, audioResponse)
+```
+
+Add a preflight check between the `log.Debugf` after message create and the `PipecatV1MessageSend` call:
+
+```go
+	res, err := h.messageHandler.Create(ctx, uuid.Nil, c.CustomerID, c.ID, c.ActiveflowID, message.DirectionOutgoing, message.RoleUser, messageText, nil, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create the message. aicall_id: %s", c.ID)
+	}
+	log.WithField("message", res).Debugf("Created the message to the ai. aicall_id: %s, message_id: %s", c.ID, res.ID)
+
+	if !h.pingPipecatHost(ctx, pc.HostID) {
+		return nil, errors.Errorf("pipecat pod for this aicall is no longer reachable. host_id: %s, pipecatcall_id: %s", pc.HostID, pc.ID)
+	}
+
+	tmp, err := h.reqHandler.PipecatV1MessageSend(ctx, pc.HostID, pc.ID, res.ID.String(), messageText, runImmediately, audioResponse)
+```
+
+**Step 12.3: Update existing `send_test.go` cases**
+
+Find existing `SendReferenceTypeCall` tests in `send_test.go`. For every test case that goes through the success path, add an `EXPECT().PipecatV1Ping(...).Return(nil)` expectation **before** the existing `PipecatV1MessageSend` expectation:
+
+```go
+mockReq.EXPECT().PipecatV1Ping(gomock.Any(), tt.pipecatcall.HostID).Return(nil)
+mockReq.EXPECT().PipecatV1MessageSend(gomock.Any(), tt.pipecatcall.HostID, tt.pipecatcall.ID, gomock.Any(), tt.messageText, tt.runImmediately, tt.audioResponse).Return(tt.expectMessage, nil)
+```
+
+If the existing tests use `.AnyTimes()` or wildcards that already accept any RPC, the failure mode is "method called but no expectation"; gomock will error. Add explicit `EXPECT().PipecatV1Ping(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()` to fixtures that need to remain permissive.
+
+**Step 12.4: Add a new test case for the dead-pod path**
+
+Add a new entry to the `SendReferenceTypeCall` table or a new `t.Run` covering:
+- Setup: `pc.HostID = "10.4.2.18"`.
+- Mock: `mockReq.EXPECT().PipecatV1Ping(gomock.Any(), "10.4.2.18").Return(context.DeadlineExceeded)`.
+- Mock: assert `PipecatV1MessageSend` is **never** called by NOT registering an expectation; gomock will fail if it is called.
+- Assert: `Send` returns non-nil error containing "no longer reachable".
+- Assert: `messageHandler.Create` IS called (the message row is persisted before the preflight).
+
+**Step 12.5: Run the test suite**
+
+```bash
+go test ./pkg/aicallhandler/...
+```
+Expected: PASS, including the new dead-pod case.
+
+---
+
+## Task 13: Verify and commit `bin-ai-manager` changes
+
+**Step 13.1: Full verification workflow**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design/bin-ai-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+Expected: all 5 steps succeed.
+
+**Step 13.2: Stage and commit**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+git status
+git add bin-ai-manager/
+git commit -m "$(cat <<'EOF'
+NOJIRA-pipecat-pod-ping-design: gate chat MessageSend with preflight ping
+
+- bin-ai-manager: Add aicallhandler.pingPipecatHost helper distinguishing ErrCircuitOpen, DeadlineExceeded, and other errors
+- bin-ai-manager: Gate PipecatV1MessageSend in SendReferenceTypeCall (send.go:46) with the preflight, returning a "no longer reachable" error on ping failure
+- bin-ai-manager: Add ping_test.go covering alive, dead, circuit-open, broker-error, and empty-hostID cases
+- bin-ai-manager: Update send_test.go fixtures and add a dead-pod regression case
+EOF
+)"
+```
+
+---
+
+## Task 14: Conflict precheck against latest main
+
+**Step 14.1: Re-run conflict check**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+git fetch origin main
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)" || echo "no conflicts"
+git log --oneline HEAD..origin/main | head
+```
+If conflicts exist: rebase on `origin/main`, resolve, and re-run the per-service verification workflows for any service whose files were touched by the merge before continuing.
+
+---
+
+## Task 15: Code review and fix loop
+
+Per saved feedback memory: ALWAYS run code review after finishing work; fix HIGH+ severity issues before commit/PR.
+
+**Step 15.1: Run a code review on the full diff**
+
+Dispatch the `code-reviewer` agent (or run `/code-review` if available) against the diff range:
+```bash
+git diff origin/main...HEAD
+```
+Capture HIGH and CRITICAL findings.
+
+**Step 15.2: Apply fixes for HIGH+ findings, re-verify each touched service, and amend or add commits.** Do not proceed to PR creation until reviewer reports no HIGH+ findings.
+
+---
+
+## Task 16: Push branch and open PR
+
+**Step 16.1: Push the branch**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+git push -u origin NOJIRA-pipecat-pod-ping-design
+```
+
+**Step 16.2: Create the PR**
+
+PR title MUST exactly match the branch name. Body uses the project-prefix bullet format with no markdown headers, no test plan section, no AI attribution. Use `gh pr create`:
+
+```bash
+gh pr create --title "NOJIRA-pipecat-pod-ping-design" --body "$(cat <<'EOF'
+Add a per-pod liveness preflight ping in bin-pipecat-manager, called from
+bin-ai-manager before the chat-message RPC at pkg/aicallhandler/send.go to
+skip the 3-second RabbitMQ timeout when the stored pipecatcall.HostID
+points to a now-dead pod. v1 reuses the existing per-target circuit
+breaker; no new caches, no DB schema change.
+
+- docs: Add design doc 2026-04-26-pipecat-pod-ping-design.md and implementation plan 2026-04-26-pipecat-pod-ping-plan.md
+- bin-pipecat-manager: Add Ping method to PipecatcallHandler interface returning PingResult{host_id, timestamp}
+- bin-pipecat-manager: Add models/pipecatcall/ping.go with PingResult struct
+- bin-pipecat-manager: Add listenhandler route GET /v1/ping wired to PipecatcallHandler.Ping
+- bin-pipecat-manager: Regenerate pipecatcallhandler mock for new interface method
+- bin-common-handler: Add PipecatV1Ping(ctx, hostID) to RequestHandler interface with 1s timeout
+- bin-common-handler: Add pipecat_ping.go implementation with best-effort host_id echo verification
+- bin-common-handler: Add pipecat_ping_test.go covering alive, mismatch, old-pod 404, empty body, and timeout cases
+- bin-common-handler: Regenerate requesthandler mock for new interface method
+- bin-ai-manager: Add aicallhandler.pingPipecatHost helper distinguishing ErrCircuitOpen, DeadlineExceeded, and other errors
+- bin-ai-manager: Gate PipecatV1MessageSend in SendReferenceTypeCall with the preflight, returning a "no longer reachable" error on ping failure
+- bin-ai-manager: Add ping_test.go covering alive, dead, circuit-open, broker-error, and empty-hostID cases
+- bin-ai-manager: Update send_test.go fixtures and add a dead-pod regression case
+EOF
+)"
+```
+
+**Step 16.3: Wait for explicit user authorization before merging.** Per saved feedback memory and CLAUDE.md, NEVER merge without explicit user request, and when authorized use squash merge: `gh pr merge <pr-number> --squash --delete-branch`.
+
+---
+
+## Post-merge cleanup
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo
+git pull origin main
+git worktree remove /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-pipecat-pod-ping-design
+```
+
+## Rollout deploy order (operations team)
+
+Per design doc §5: deploy `bin-pipecat-manager` to 100% first, then `bin-ai-manager`. Old pipecat pods 404 the route → safely treated as alive.


### PR DESCRIPTION
Add a per-pod liveness preflight ping in bin-pipecat-manager, called from
bin-ai-manager before the chat-message RPC at pkg/aicallhandler/send.go to
skip the 3-second RabbitMQ timeout when the stored pipecatcall.HostID
points to a now-dead pod. v1 reuses the existing per-target circuit
breaker; no new caches, no DB schema change.

The preflight runs BEFORE messageHandler.Create so a dead-pod failure
does not orphan a user-message row in the database. Old pipecat-manager
pods that pre-date the /v1/ping route return 404 and are correctly
treated as alive (rolling-deploy safe).

Known limitation: process-level liveness only. Calico POD_IP recycle
where the dead host's IP is reassigned to a different pipecat pod is
acknowledged in the design as the same outcome as today (one wasted
real RPC); session-aware ping is a v2 candidate.

- docs: Add design doc 2026-04-26-pipecat-pod-ping-design.md and implementation plan 2026-04-26-pipecat-pod-ping-plan.md
- bin-pipecat-manager: Add Ping method to PipecatcallHandler interface returning PingResult{host_id, timestamp}
- bin-pipecat-manager: Add models/pipecatcall/ping.go with PingResult struct
- bin-pipecat-manager: Add listenhandler route GET /v1/ping wired to PipecatcallHandler.Ping
- bin-pipecat-manager: Regenerate pipecatcallhandler mock for new interface method
- bin-common-handler: Add PipecatV1Ping(ctx, hostID) to RequestHandler interface with 1s timeout
- bin-common-handler: Add pipecat_ping.go implementation with best-effort host_id echo verification; explicit comment forbids future status-code checks (any response = alive)
- bin-common-handler: Add pipecat_ping_test.go covering alive, mismatch, old-pod 404, empty body, and timeout cases; queue name uses commonoutline.QueueNamePipecatRequest constant for rename safety
- bin-common-handler: Regenerate requesthandler mock for new interface method
- bin-ai-manager: Add aicallhandler.pingPipecatHost helper distinguishing ErrCircuitOpen, DeadlineExceeded, and other errors via errors.Is unwrapping (relies on pkg/errors v0.9.1+ Unwrap support, pinned in both go.mod files)
- bin-ai-manager: Gate PipecatV1MessageSend in SendReferenceTypeCall with the preflight, returning a "no longer reachable" error on ping failure; preflight runs BEFORE messageHandler.Create to avoid orphaning user-message rows on dead-pod
- bin-ai-manager: Add ping_test.go covering alive, dead-deadline, dead-circuit-open, broker-error, and empty-hostID cases
- bin-ai-manager: Update send_test.go fixtures with PipecatV1Ping expectation on the success path; add a dead-pod regression case asserting messageHandler.Create and PipecatV1MessageSend are NEVER called when ping fails
- bin-ai-manager: Update event_test.go to add PipecatV1Ping expectation on Test_EventCMDTMFReceived which transitively calls SendReferenceTypeCall