### PR TITLE
NOJIRA-typed-rpc-pr11-campaign

### DIFF
--- a/bin-campaign-manager/pkg/campaigncallhandler/campaigncall.go
+++ b/bin-campaign-manager/pkg/campaigncallhandler/campaigncall.go
@@ -2,14 +2,18 @@ package campaigncallhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-campaign-manager/models/campaigncall"
+	"monorepo/bin-campaign-manager/pkg/dbhandler"
 )
 
 // Create creates a new campaigncall
@@ -100,6 +104,13 @@ func (h *campaigncallHandler) Get(ctx context.Context, id uuid.UUID) (*campaignc
 	res, err := h.db.CampaigncallGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get campaigncall. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCampaignManager,
+				"CAMPAIGNCALL_NOT_FOUND",
+				"The campaign call was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-campaign-manager/pkg/campaignhandler/campaign.go
+++ b/bin-campaign-manager/pkg/campaignhandler/campaign.go
@@ -2,9 +2,12 @@ package campaignhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	fmaction "monorepo/bin-flow-manager/models/action"
 	fmflow "monorepo/bin-flow-manager/models/flow"
 
@@ -12,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-campaign-manager/models/campaign"
+	"monorepo/bin-campaign-manager/pkg/dbhandler"
 )
 
 // Create creates a new campaign
@@ -153,7 +157,11 @@ func (h *campaignHandler) Delete(ctx context.Context, id uuid.UUID) (*campaign.C
 	return res, nil
 }
 
-// Get returns campaign
+// Get returns campaign.
+//
+// When the underlying DB layer returns dbhandler.ErrNotFound, Get returns a
+// typed *cerrors.VoipbinError (Status=NotFound) so the api-manager edge can
+// recover the upstream domain/reason via errors.As.
 func (h *campaignHandler) Get(ctx context.Context, id uuid.UUID) (*campaign.Campaign, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "Get",
@@ -162,6 +170,13 @@ func (h *campaignHandler) Get(ctx context.Context, id uuid.UUID) (*campaign.Camp
 	res, err := h.db.CampaignGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get campaign. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCampaignManager,
+				"CAMPAIGN_NOT_FOUND",
+				"The campaign was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-campaign-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-campaign-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,52 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"monorepo/bin-campaign-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameCampaignManager, "CAMPAIGN_NOT_FOUND", "x")
+	resp := errorResponse(ve)
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	ve := cerrors.NotFound(commonoutline.ServiceNameCampaignManager, "CAMPAIGN_NOT_FOUND", "x")
+	if errorResponse(pkgerrors.Wrap(ve, "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameCampaignManager, "CAMPAIGN_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("end-to-end failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-campaign-manager/pkg/listenhandler/main.go
+++ b/bin-campaign-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -14,6 +17,7 @@ import (
 
 	"monorepo/bin-campaign-manager/pkg/campaigncallhandler"
 	"monorepo/bin-campaign-manager/pkg/campaignhandler"
+	"monorepo/bin-campaign-manager/pkg/dbhandler"
 	"monorepo/bin-campaign-manager/pkg/outplanhandler"
 )
 
@@ -88,6 +92,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -260,7 +290,8 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		logrus.WithFields(
 			logrus.Fields{
@@ -268,7 +299,15 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 				"method": m.Method,
 				"error":  err,
 			}).Errorf("Could not process the request correctly. data: %s", m.Data)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-campaign-manager/pkg/outplanhandler/outplan.go
+++ b/bin-campaign-manager/pkg/outplanhandler/outplan.go
@@ -2,14 +2,18 @@ package outplanhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-campaign-manager/models/outplan"
+	"monorepo/bin-campaign-manager/pkg/dbhandler"
 )
 
 // Create creates a new outplan
@@ -81,6 +85,13 @@ func (h *outplanHandler) Get(ctx context.Context, id uuid.UUID) (*outplan.Outpla
 	res, err := h.db.OutplanGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get outplan. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameCampaignManager,
+				"OUTPLAN_NOT_FOUND",
+				"The outplan was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Migrates bin-campaign-manager to typed errors.

- bin-campaign-manager: Add errorResponse helper, route typed/ErrNotFound through dispatcher.
- bin-campaign-manager: Migrate 3 entry-point Get methods (campaign, campaigncall, outplan) to emit typed NotFound.
- bin-campaign-manager: 6 standard error-response tests.