### PR TITLE
NOJIRA-typed-rpc-pr12-outdial

### DIFF
--- a/bin-outdial-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-outdial-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-outdial-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameOutdialManager, "OUTDIAL_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameOutdialManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameOutdialManager, "OUTDIAL_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-outdial-manager/pkg/listenhandler/main.go
+++ b/bin-outdial-manager/pkg/listenhandler/main.go
@@ -2,16 +2,20 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-outdial-manager/pkg/dbhandler"
 	"monorepo/bin-outdial-manager/pkg/outdialhandler"
 	"monorepo/bin-outdial-manager/pkg/outdialtargethandler"
 )
@@ -80,6 +84,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -213,7 +243,8 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		logrus.WithFields(
 			logrus.Fields{
@@ -221,7 +252,15 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 				"method": m.Method,
 				"error":  err,
 			}).Errorf("Could not process the request correctly. data: %s", m.Data)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-outdial-manager/pkg/outdialhandler/outdial.go
+++ b/bin-outdial-manager/pkg/outdialhandler/outdial.go
@@ -2,13 +2,17 @@ package outdialhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-outdial-manager/models/outdial"
+	"monorepo/bin-outdial-manager/pkg/dbhandler"
 )
 
 // Create creates a new outdial
@@ -93,6 +97,13 @@ func (h *outdialHandler) Get(ctx context.Context, id uuid.UUID) (*outdial.Outdia
 	res, err := h.db.OutdialGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get outdial. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameOutdialManager,
+				"OUTDIAL_NOT_FOUND",
+				"The outdial was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-outdial-manager/pkg/outdialtargethandler/outdialtarget.go
+++ b/bin-outdial-manager/pkg/outdialtargethandler/outdialtarget.go
@@ -2,14 +2,18 @@ package outdialtargethandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-outdial-manager/models/outdialtarget"
+	"monorepo/bin-outdial-manager/pkg/dbhandler"
 )
 
 // Create creates a new outdial
@@ -86,6 +90,13 @@ func (h *outdialTargetHandler) Get(ctx context.Context, id uuid.UUID) (*outdialt
 	res, err := h.db.OutdialTargetGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not create the outdial. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameOutdialManager,
+				"OUTDIAL_TARGET_NOT_FOUND",
+				"The outdial target was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Migrates bin-outdial-manager to typed errors.

- bin-outdial-manager: Add errorResponse helper, route typed/ErrNotFound through dispatcher.
- bin-outdial-manager: Migrate 2 entry-point Get methods (outdial, outdialtarget) to emit typed NotFound.
- bin-outdial-manager: 6 standard error-response tests.