### PR TITLE
NOJIRA-typed-rpc-pr14-ai

### DIFF
--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -2,6 +2,7 @@ package aicallhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -10,7 +11,10 @@ import (
 
 	"monorepo/bin-ai-manager/models/ai"
 	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // Create is creating a new aicall.
@@ -163,6 +167,13 @@ func (h *aicallHandler) Get(ctx context.Context, id uuid.UUID) (*aicall.AIcall, 
 	res, err := h.db.AIcallGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get aicall info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameAIManager,
+				"AICALL_NOT_FOUND",
+				"The AI call was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-ai-manager/pkg/aihandler/db.go
+++ b/bin-ai-manager/pkg/aihandler/db.go
@@ -2,18 +2,22 @@ package aihandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
 	"monorepo/bin-ai-manager/models/ai"
 	"monorepo/bin-ai-manager/models/tool"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 )
 
 // Create creates a new ai record.
@@ -101,6 +105,13 @@ func (h *aiHandler) dbCreate(
 func (h *aiHandler) Get(ctx context.Context, id uuid.UUID) (*ai.AI, error) {
 	res, err := h.db.AIGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameAIManager,
+				"AI_NOT_FOUND",
+				"The AI was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get ai")
 	}
 

--- a/bin-ai-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-ai-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameAIManager, "AI_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameAIManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameAIManager, "AI_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-ai-manager/pkg/listenhandler/main.go
+++ b/bin-ai-manager/pkg/listenhandler/main.go
@@ -4,7 +4,9 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
@@ -13,10 +15,12 @@ import (
 
 	"monorepo/bin-ai-manager/pkg/aicallhandler"
 	"monorepo/bin-ai-manager/pkg/aihandler"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-ai-manager/pkg/messagehandler"
 	"monorepo/bin-ai-manager/pkg/summaryhandler"
 	"monorepo/bin-ai-manager/pkg/teamhandler"
 	"monorepo/bin-ai-manager/pkg/toolhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -120,6 +124,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -371,9 +401,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.Errorf("Could not handle the requested message correctly. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-ai-manager/pkg/messagehandler/db.go
+++ b/bin-ai-manager/pkg/messagehandler/db.go
@@ -2,8 +2,13 @@ package messagehandler
 
 import (
 	"context"
+	stderrors "errors"
+
 	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -63,6 +68,13 @@ func (h *messageHandler) Create(
 func (h *messageHandler) Get(ctx context.Context, id uuid.UUID) (*message.Message, error) {
 	res, err := h.db.MessageGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameAIManager,
+				"MESSAGE_NOT_FOUND",
+				"The message was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get data")
 	}
 

--- a/bin-ai-manager/pkg/summaryhandler/db.go
+++ b/bin-ai-manager/pkg/summaryhandler/db.go
@@ -2,9 +2,14 @@ package summaryhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+
 	"monorepo/bin-ai-manager/models/summary"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -66,6 +71,13 @@ func (h *summaryHandler) Get(ctx context.Context, id uuid.UUID) (*summary.Summar
 
 	res, err := h.db.SummaryGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameAIManager,
+				"SUMMARY_NOT_FOUND",
+				"The summary was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get data")
 	}
 

--- a/bin-ai-manager/pkg/teamhandler/handler.go
+++ b/bin-ai-manager/pkg/teamhandler/handler.go
@@ -2,17 +2,21 @@ package teamhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
 	"monorepo/bin-ai-manager/models/team"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 )
 
 // Create creates a new team record.
@@ -85,6 +89,13 @@ func (h *teamHandler) Get(ctx context.Context, id uuid.UUID) (*team.Team, error)
 
 	res, err := h.db.TeamGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameAIManager,
+				"TEAM_NOT_FOUND",
+				"The team was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get team")
 	}
 	log.WithField("team", res).Debugf("Retrieved team info. team_id: %s", res.ID)


### PR DESCRIPTION
Migrate bin-ai-manager to emit typed *cerrors.VoipbinError over RabbitMQ
RPC for not-found responses, eliminating reliance on api-manager substring
fallback for AI, AIcall, message, summary, and team errors.

- bin-ai-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-ai-manager: Update dispatcher catch-all in processRequest to route
  typed errors and ErrNotFound through errorResponse while preserving the
  legacy 400 for unclassified errors
- bin-ai-manager: Migrate aiHandler.Get, aicallHandler.Get,
  messageHandler.Get, summaryHandler.Get, and teamHandler.Get to wrap
  dbhandler.ErrNotFound with cerrors.NotFound (AI_NOT_FOUND,
  AICALL_NOT_FOUND, MESSAGE_NOT_FOUND, SUMMARY_NOT_FOUND, TEAM_NOT_FOUND)
- bin-ai-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases