### PR TITLE
NOJIRA-typed-rpc-pr15-rag

### DIFF
--- a/bin-rag-manager/pkg/dbhandler/document.go
+++ b/bin-rag-manager/pkg/dbhandler/document.go
@@ -3,6 +3,7 @@ package dbhandler
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -193,6 +194,9 @@ func (h *handler) DocumentGet(ctx context.Context, id uuid.UUID) (*document.Docu
 	row := h.db.QueryRowContext(ctx, sqlStr, args...)
 	d, err := scanDocument(row)
 	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
 		return nil, fmt.Errorf("could not scan document: %w", err)
 	}
 
@@ -332,6 +336,13 @@ func (h *handler) DocumentDeleteByRagID(ctx context.Context, ragID uuid.UUID) er
 // DocumentClaimForProcessing atomically sets a pending document to processing status.
 // It increments retry_count and sets tm_processing for heartbeat tracking.
 // Returns the updated document or an error if the document is not in pending status.
+//
+// NOTE: this method intentionally does NOT translate sql.ErrNoRows into
+// dbhandler.ErrNotFound. A "no rows" outcome here means the document is not
+// claimable (already claimed, processing, deleted, or never existed) — a race
+// condition signal, not an external "not found" semantic. Callers must not
+// match against ErrNotFound for claim outcomes; treat any error as
+// "could not claim" and fall through to the worker's retry/skip logic.
 func (h *handler) DocumentClaimForProcessing(ctx context.Context, id uuid.UUID) (*document.Document, error) {
 	now := h.utilHandler.TimeNow()
 

--- a/bin-rag-manager/pkg/dbhandler/main.go
+++ b/bin-rag-manager/pkg/dbhandler/main.go
@@ -5,6 +5,7 @@ package dbhandler
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -15,6 +16,11 @@ import (
 	"monorepo/bin-rag-manager/models/document"
 	"monorepo/bin-rag-manager/models/rag"
 )
+
+// ErrNotFound is returned when a requested record does not exist.
+// Translated from sql.ErrNoRows by single-row Get methods so callers can
+// match with errors.Is regardless of the underlying driver detail.
+var ErrNotFound = errors.New("record not found")
 
 // psql is a squirrel StatementBuilder configured for PostgreSQL dollar placeholders.
 // Shared across all dbhandler files (rag.go, document.go, chunk.go).

--- a/bin-rag-manager/pkg/dbhandler/rag.go
+++ b/bin-rag-manager/pkg/dbhandler/rag.go
@@ -3,6 +3,7 @@ package dbhandler
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
@@ -132,6 +133,9 @@ func (h *handler) RagGet(ctx context.Context, id uuid.UUID) (*rag.Rag, error) {
 
 	r, err := ragScanRow(row)
 	if err != nil {
+		if stderrors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
 		return nil, fmt.Errorf("could not scan rag row: %w", err)
 	}
 

--- a/bin-rag-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-rag-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-rag-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameRagManager, "RAG_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameRagManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameRagManager, "RAG_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-rag-manager/pkg/listenhandler/main.go
+++ b/bin-rag-manager/pkg/listenhandler/main.go
@@ -5,13 +5,17 @@ package listenhandler
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
+	"monorepo/bin-rag-manager/pkg/dbhandler"
 	"monorepo/bin-rag-manager/pkg/raghandler"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -141,9 +145,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 		requestType = "notfound"
 	}
 
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 500.
 	if err != nil {
 		log.Errorf("Could not process request. err: %v", err)
-		response = simpleResponse(500)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(500)
+		}
 	}
 
 	elapsed := time.Since(start)
@@ -156,6 +170,32 @@ func simpleResponse(statusCode int) *sock.Response {
 	return &sock.Response{
 		StatusCode: statusCode,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 func jsonResponse(statusCode int, data any) *sock.Response {

--- a/bin-rag-manager/pkg/raghandler/document.go
+++ b/bin-rag-manager/pkg/raghandler/document.go
@@ -2,6 +2,7 @@ package raghandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,9 +14,13 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	dbchunk "monorepo/bin-rag-manager/models/chunk"
 	"monorepo/bin-rag-manager/models/document"
 	"monorepo/bin-rag-manager/pkg/chunker"
+	"monorepo/bin-rag-manager/pkg/dbhandler"
 )
 
 const (
@@ -35,6 +40,13 @@ func (h *ragHandler) DocumentGet(ctx context.Context, id uuid.UUID) (*document.D
 	d, err := h.dbHandler.DocumentGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get document. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRagManager,
+				"DOCUMENT_NOT_FOUND",
+				"The document was not found.",
+			).Wrap(err)
+		}
 		return nil, fmt.Errorf("could not get document: %w", err)
 	}
 	log.WithField("document", d).Debugf("Retrieved document. document_id: %s", d.ID)

--- a/bin-rag-manager/pkg/raghandler/rag.go
+++ b/bin-rag-manager/pkg/raghandler/rag.go
@@ -2,14 +2,19 @@ package raghandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	"monorepo/bin-rag-manager/models/document"
 	"monorepo/bin-rag-manager/models/rag"
+	"monorepo/bin-rag-manager/pkg/dbhandler"
 )
 
 func (h *ragHandler) RagCreate(ctx context.Context, customerID uuid.UUID, name, description string, storageFileIDs []uuid.UUID, sourceURLs []string) (*rag.Rag, error) {
@@ -60,6 +65,13 @@ func (h *ragHandler) RagGet(ctx context.Context, id uuid.UUID) (*rag.Rag, error)
 	r, err := h.dbHandler.RagGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get rag. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRagManager,
+				"RAG_NOT_FOUND",
+				"The RAG was not found.",
+			).Wrap(err)
+		}
 		return nil, fmt.Errorf("could not get rag: %w", err)
 	}
 	log.WithField("rag", r).Debugf("Retrieved rag. rag_id: %s", r.ID)


### PR DESCRIPTION
Migrate bin-rag-manager to emit typed *cerrors.VoipbinError over RabbitMQ
RPC for not-found responses, eliminating reliance on api-manager substring
fallback for RAG and document errors.

- bin-rag-manager: Introduce dbhandler.ErrNotFound sentinel and translate
  sql.ErrNoRows in RagGet and DocumentGet so handlers can match on
  ErrNotFound. DocumentClaimForProcessing keeps the raw sql.ErrNoRows
  semantic for race-condition signaling, with an explanatory comment so
  callers don't mistake it for a not-found case.
- bin-rag-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-rag-manager: Update dispatcher catch-all in processRequest to route
  typed errors and ErrNotFound through errorResponse while preserving the
  legacy 500 for unclassified errors
- bin-rag-manager: Migrate ragHandler.RagGet and ragHandler.DocumentGet to
  wrap dbhandler.ErrNotFound with cerrors.NotFound (RAG_NOT_FOUND,
  DOCUMENT_NOT_FOUND)
- bin-rag-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases