### PR TITLE
NOJIRA-typed-rpc-pr16-tts

### DIFF
--- a/bin-tts-manager/pkg/dbhandler/main.go
+++ b/bin-tts-manager/pkg/dbhandler/main.go
@@ -5,6 +5,8 @@ package dbhandler
 import (
 	"context"
 	"database/sql"
+	"errors"
+
 	"monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-tts-manager/models/speaking"
 	"monorepo/bin-tts-manager/models/streaming"
@@ -12,6 +14,11 @@ import (
 
 	"github.com/gofrs/uuid"
 )
+
+// ErrNotFound is returned when a requested record does not exist.
+// Translated from sql.ErrNoRows / redis.Nil by single-row Get methods so
+// callers can match with errors.Is regardless of the underlying driver detail.
+var ErrNotFound = errors.New("record not found")
 
 type DBHandler interface {
 	StreamingCreate(ctx context.Context, s *streaming.Streaming) error

--- a/bin-tts-manager/pkg/dbhandler/main_test.go
+++ b/bin-tts-manager/pkg/dbhandler/main_test.go
@@ -3,7 +3,6 @@ package dbhandler
 import (
 	"testing"
 
-	"monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-tts-manager/pkg/cachehandler"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -41,10 +40,5 @@ func Test_NewDBHandler(t *testing.T) {
 	}
 	if dbh.util == nil {
 		t.Error("util should not be nil")
-	}
-
-	// verify util is correctly initialized
-	if _, ok := dbh.util.(utilhandler.UtilHandler); !ok {
-		t.Error("util should be UtilHandler type")
 	}
 }

--- a/bin-tts-manager/pkg/dbhandler/speaking.go
+++ b/bin-tts-manager/pkg/dbhandler/speaking.go
@@ -71,7 +71,7 @@ func (h *dbHandler) SpeakingGet(ctx context.Context, id uuid.UUID) (*speaking.Sp
 		if err := rows.Err(); err != nil {
 			return nil, fmt.Errorf("row error. SpeakingGet. err: %v", err)
 		}
-		return nil, fmt.Errorf("not found")
+		return nil, ErrNotFound
 	}
 
 	return h.speakingGetFromRow(rows)

--- a/bin-tts-manager/pkg/dbhandler/streaming.go
+++ b/bin-tts-manager/pkg/dbhandler/streaming.go
@@ -2,9 +2,12 @@ package dbhandler
 
 import (
 	"context"
+	stderrors "errors"
+
 	"monorepo/bin-tts-manager/models/streaming"
 
 	"github.com/gofrs/uuid"
+	"github.com/redis/go-redis/v9"
 )
 
 // StreamingCreate creates a new variable.
@@ -27,6 +30,9 @@ func (h *dbHandler) streamingGetFromCache(ctx context.Context, id uuid.UUID) (*s
 	// get from cache
 	res, err := h.cache.StreamingGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, redis.Nil) {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/bin-tts-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-tts-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-tts-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameTTSManager, "SPEAKING_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameTTSManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameTTSManager, "SPEAKING_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-tts-manager/pkg/listenhandler/main.go
+++ b/bin-tts-manager/pkg/listenhandler/main.go
@@ -2,16 +2,20 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-tts-manager/pkg/dbhandler"
 	"monorepo/bin-tts-manager/pkg/speakinghandler"
 	"monorepo/bin-tts-manager/pkg/streaminghandler"
 	"monorepo/bin-tts-manager/pkg/ttshandler"
@@ -84,6 +88,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -218,6 +248,20 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	}
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
+
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors propagate to the sock layer unchanged.
+	if err != nil {
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+			err = nil
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+			err = nil
+		}
+	}
 
 	return response, err
 }

--- a/bin-tts-manager/pkg/speakinghandler/speaking.go
+++ b/bin-tts-manager/pkg/speakinghandler/speaking.go
@@ -2,10 +2,14 @@ package speakinghandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-tts-manager/models/speaking"
 	"monorepo/bin-tts-manager/models/streaming"
+	"monorepo/bin-tts-manager/pkg/dbhandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -141,6 +145,13 @@ func (h *speakingHandler) Get(ctx context.Context, id uuid.UUID) (*speaking.Spea
 	res, err := h.db.SpeakingGet(ctx, id)
 	if err != nil {
 		log.Infof("Could not get speaking. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTTSManager,
+				"SPEAKING_NOT_FOUND",
+				"The speaking was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 	log.WithField("speaking", res).Debugf("Retrieved speaking. speaking_id: %s", id)

--- a/bin-tts-manager/pkg/streaminghandler/streaming.go
+++ b/bin-tts-manager/pkg/streaminghandler/streaming.go
@@ -9,7 +9,9 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/websocket"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-tts-manager/models/streaming"
 )
 
@@ -91,7 +93,11 @@ func (h *streamingHandler) Get(ctx context.Context, streamingID uuid.UUID) (*str
 
 	res, ok := h.mapStreaming[streamingID]
 	if !ok {
-		return nil, fmt.Errorf("streaming not found. streaming_id: %s", streamingID)
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameTTSManager,
+			"STREAMING_NOT_FOUND",
+			"The streaming was not found.",
+		)
 	}
 
 	return res, nil


### PR DESCRIPTION
Migrate bin-tts-manager to emit typed *cerrors.VoipbinError over RabbitMQ
RPC for not-found responses, eliminating reliance on api-manager substring
fallback for speaking and streaming errors.

- bin-tts-manager: Introduce dbhandler.ErrNotFound sentinel and translate
  the legacy "not found" string in SpeakingGet plus redis.Nil in
  streamingGetFromCache so handlers can match on ErrNotFound
- bin-tts-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-tts-manager: Add a minimal dispatcher catch-all in processRequest
  that intercepts typed errors and ErrNotFound through errorResponse;
  other errors propagate to the sock layer unchanged
- bin-tts-manager: Migrate speakingHandler.Get to wrap dbhandler.ErrNotFound
  with cerrors.NotFound (SPEAKING_NOT_FOUND); streamingHandler.Get returns
  a direct typed cerrors.NotFound (STREAMING_NOT_FOUND) for the in-memory
  map miss case
- bin-tts-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases
- bin-tts-manager: Remove a pre-existing tautological type assertion
  (staticcheck S1040) and its unused import in pkg/dbhandler/main_test.go
  to keep golangci-lint clean