### PR TITLE
NOJIRA-typed-rpc-pr17-transcribe

### DIFF
--- a/bin-transcribe-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-transcribe-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-transcribe-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameTranscribeManager, "TRANSCRIBE_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameTranscribeManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameTranscribeManager, "TRANSCRIBE_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-transcribe-manager/pkg/listenhandler/main.go
+++ b/bin-transcribe-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -15,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-transcribe-manager/pkg/dbhandler"
 	"monorepo/bin-transcribe-manager/pkg/transcribehandler"
 	"monorepo/bin-transcribe-manager/pkg/transcripthandler"
 )
@@ -86,6 +90,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -248,14 +278,23 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"uri":    m.URI,
 			"method": m.Method,
 			"error":  err,
 		}).Errorf("Could not process the request correctly. data: %s", m.Data)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-transcribe-manager/pkg/streaminghandler/streaming.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/streaming.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-transcribe-manager/models/streaming"
 	"monorepo/bin-transcribe-manager/models/transcript"
 )
@@ -44,7 +46,11 @@ func (h *streamingHandler) Get(ctx context.Context, streamingID uuid.UUID) (*str
 
 	res, ok := h.mapStreaming[streamingID]
 	if !ok {
-		return nil, fmt.Errorf("streaming not found. streaming_id: %s", streamingID)
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameTranscribeManager,
+			"STREAMING_NOT_FOUND",
+			"The streaming was not found.",
+		)
 	}
 
 	return res, nil

--- a/bin-transcribe-manager/pkg/transcribehandler/transcribe.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/transcribe.go
@@ -2,20 +2,31 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-transcribe-manager/models/transcribe"
 	"monorepo/bin-transcribe-manager/models/transcript"
+	"monorepo/bin-transcribe-manager/pkg/dbhandler"
 )
 
 // Get returns transcribe
 func (h *transcribeHandler) Get(ctx context.Context, id uuid.UUID) (*transcribe.Transcribe, error) {
 	res, err := h.db.TranscribeGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTranscribeManager,
+				"TRANSCRIBE_NOT_FOUND",
+				"The transcribe was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get transcribe info. transcribe_id: %s", id)
 	}
 
@@ -26,6 +37,13 @@ func (h *transcribeHandler) Get(ctx context.Context, id uuid.UUID) (*transcribe.
 func (h *transcribeHandler) GetByReferenceIDAndLanguage(ctx context.Context, referenceID uuid.UUID, language string) (*transcribe.Transcribe, error) {
 	res, err := h.db.TranscribeGetByReferenceIDAndLanguage(ctx, referenceID, language)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTranscribeManager,
+				"TRANSCRIBE_NOT_FOUND",
+				"The transcribe was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get transcribe info. reference_id: %s, language: %s", referenceID, language)
 	}
 


### PR DESCRIPTION
Migrate bin-transcribe-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for transcribe and streaming errors.

- bin-transcribe-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-transcribe-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-transcribe-manager: Migrate transcribeHandler.Get and
  transcribeHandler.GetByReferenceIDAndLanguage to wrap dbhandler.ErrNotFound
  with cerrors.NotFound (TRANSCRIBE_NOT_FOUND)
- bin-transcribe-manager: Migrate streamingHandler.Get to return a direct
  typed cerrors.NotFound (STREAMING_NOT_FOUND) for the in-memory map miss
- bin-transcribe-manager: Add 6 standard error_response tests covering
  typed, pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and
  end-to-end cases