### PR TITLE
NOJIRA-typed-rpc-pr18-storage

### DIFF
--- a/bin-storage-manager/pkg/accounthandler/account.go
+++ b/bin-storage-manager/pkg/accounthandler/account.go
@@ -2,8 +2,13 @@ package accounthandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-storage-manager/models/account"
+	"monorepo/bin-storage-manager/pkg/dbhandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -53,6 +58,13 @@ func (h *accountHandler) Create(ctx context.Context, customerID uuid.UUID) (*acc
 func (h *accountHandler) Get(ctx context.Context, id uuid.UUID) (*account.Account, error) {
 	res, err := h.db.AccountGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameStorageManager,
+				"ACCOUNT_NOT_FOUND",
+				"The account was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get file info")
 	}
 

--- a/bin-storage-manager/pkg/filehandler/file.go
+++ b/bin-storage-manager/pkg/filehandler/file.go
@@ -2,10 +2,15 @@ package filehandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
-	commonidentity "monorepo/bin-common-handler/models/identity"
-	"monorepo/bin-storage-manager/models/file"
 	"time"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-storage-manager/models/file"
+	"monorepo/bin-storage-manager/pkg/dbhandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -133,6 +138,13 @@ func (h *fileHandler) Create(
 func (h *fileHandler) Get(ctx context.Context, id uuid.UUID) (*file.File, error) {
 	res, err := h.db.FileGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameStorageManager,
+				"FILE_NOT_FOUND",
+				"The file was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get file info")
 	}
 

--- a/bin-storage-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-storage-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-storage-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameStorageManager, "FILE_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameStorageManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameStorageManager, "FILE_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-storage-manager/pkg/listenhandler/main.go
+++ b/bin-storage-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -14,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-storage-manager/pkg/accounthandler"
+	"monorepo/bin-storage-manager/pkg/dbhandler"
 	"monorepo/bin-storage-manager/pkg/storagehandler"
 )
 
@@ -83,6 +87,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -198,6 +228,20 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	}
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
+
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors propagate to the sock layer unchanged.
+	if err != nil {
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+			err = nil
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+			err = nil
+		}
+	}
 
 	return response, err
 }


### PR DESCRIPTION
Migrate bin-storage-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for file and account errors.

- bin-storage-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-storage-manager: Add a minimal dispatcher catch-all in processRequest
  that intercepts typed errors and ErrNotFound through errorResponse;
  other errors propagate to the sock layer unchanged
- bin-storage-manager: Migrate fileHandler.Get and accountHandler.Get to
  wrap dbhandler.ErrNotFound with cerrors.NotFound (FILE_NOT_FOUND,
  ACCOUNT_NOT_FOUND)
- bin-storage-manager: Add 6 standard error_response tests covering
  typed, pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and
  end-to-end cases