### PR TITLE
NOJIRA-typed-rpc-pr19-pipecat

### DIFF
--- a/bin-pipecat-manager/models/message/main_test.go
+++ b/bin-pipecat-manager/models/message/main_test.go
@@ -35,12 +35,10 @@ func TestMessage_Struct(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.msg.ID != tt.msg.ID {
-				t.Errorf("ID mismatch")
-			}
-			if tt.msg.Text != tt.msg.Text {
-				t.Errorf("Text mismatch")
-			}
+			// Ensure the Message struct is constructable with the given fields.
+			// The struct has no behavior to validate beyond field presence, so
+			// just round-trip the value to confirm the test compiles and runs.
+			_ = tt.msg
 		})
 	}
 }

--- a/bin-pipecat-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-pipecat-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNamePipecatManager, "PIPECATCALL_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNamePipecatManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNamePipecatManager, "PIPECATCALL_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-pipecat-manager/pkg/listenhandler/main.go
+++ b/bin-pipecat-manager/pkg/listenhandler/main.go
@@ -2,13 +2,17 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
+	"monorepo/bin-pipecat-manager/pkg/dbhandler"
 	"monorepo/bin-pipecat-manager/pkg/pipecatcallhandler"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -80,6 +84,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -229,14 +259,23 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"uri":    m.URI,
 			"method": m.Method,
 			"error":  err,
 		}).Errorf("Could not process the request correctly. data: %s", m.Data)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-pipecat-manager/pkg/listenhandler/models/request/main_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/models/request/main_test.go
@@ -34,12 +34,10 @@ func TestPagination_Struct(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.p.PageSize != tt.p.PageSize {
-				t.Errorf("PageSize mismatch")
-			}
-			if tt.p.PageToken != tt.p.PageToken {
-				t.Errorf("PageToken mismatch")
-			}
+			// Ensure the Pagination struct is constructable with the given
+			// fields. The struct has no behavior to validate beyond field
+			// presence, so just round-trip the value.
+			_ = tt.p
 		})
 	}
 }

--- a/bin-pipecat-manager/pkg/listenhandler/models/request/v1_messages_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/models/request/v1_messages_test.go
@@ -36,21 +36,10 @@ func TestV1DataMessagesPost_Struct(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.req.PipecatcallID != tt.req.PipecatcallID {
-				t.Errorf("PipecatcallID mismatch")
-			}
-			if tt.req.MessageID != tt.req.MessageID {
-				t.Errorf("MessageID mismatch")
-			}
-			if tt.req.MessageText != tt.req.MessageText {
-				t.Errorf("MessageText mismatch")
-			}
-			if tt.req.RunImmediately != tt.req.RunImmediately {
-				t.Errorf("RunImmediately mismatch")
-			}
-			if tt.req.AudioResponse != tt.req.AudioResponse {
-				t.Errorf("AudioResponse mismatch")
-			}
+			// Ensure the V1DataMessagesPost struct is constructable with the
+			// given fields. The struct has no behavior to validate beyond
+			// field presence, so just round-trip the value.
+			_ = tt.req
 		})
 	}
 }

--- a/bin-pipecat-manager/pkg/listenhandler/models/request/v1_pipecatcalls_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/models/request/v1_pipecatcalls_test.go
@@ -50,39 +50,10 @@ func TestV1DataPipecatcallsPost_Struct(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.req.ID != tt.req.ID {
-				t.Errorf("ID mismatch")
-			}
-			if tt.req.CustomerID != tt.req.CustomerID {
-				t.Errorf("CustomerID mismatch")
-			}
-			if tt.req.ActiveflowID != tt.req.ActiveflowID {
-				t.Errorf("ActiveflowID mismatch")
-			}
-			if tt.req.ReferenceType != tt.req.ReferenceType {
-				t.Errorf("ReferenceType mismatch")
-			}
-			if tt.req.ReferenceID != tt.req.ReferenceID {
-				t.Errorf("ReferenceID mismatch")
-			}
-			if tt.req.LLMType != tt.req.LLMType {
-				t.Errorf("LLMType mismatch")
-			}
-			if tt.req.STTType != tt.req.STTType {
-				t.Errorf("STTType mismatch")
-			}
-			if tt.req.STTLanguage != tt.req.STTLanguage {
-				t.Errorf("STTLanguage mismatch")
-			}
-			if tt.req.TTSType != tt.req.TTSType {
-				t.Errorf("TTSType mismatch")
-			}
-			if tt.req.TTSLanguage != tt.req.TTSLanguage {
-				t.Errorf("TTSLanguage mismatch")
-			}
-			if tt.req.TTSVoiceID != tt.req.TTSVoiceID {
-				t.Errorf("TTSVoiceID mismatch")
-			}
+			// Ensure the request struct is constructable with the given
+			// fields. The struct has no behavior to validate beyond field
+			// presence, so just round-trip the value.
+			_ = tt.req
 		})
 	}
 }

--- a/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
@@ -77,7 +77,10 @@ func (h *listenHandler) processV1PipecatcallsIDGet(ctx context.Context, m *sock.
 	c, err := h.pipecatcallHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get resource. err: %v", err)
-		return simpleResponse(404), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed PIPECATCALL_NOT_FOUND surfaces to the
+		// caller. Other errors fall back to the legacy 400.
+		return nil, err
 	}
 
 	data, err := json.Marshal(c)

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/pipecatcall.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/pipecatcall.go
@@ -2,9 +2,13 @@ package pipecatcallhandler
 
 import (
 	"context"
+	stderrors "errors"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
+	"monorepo/bin-pipecat-manager/pkg/dbhandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -63,6 +67,13 @@ func (h *pipecatcallHandler) Create(
 func (h *pipecatcallHandler) Get(ctx context.Context, id uuid.UUID) (*pipecatcall.Pipecatcall, error) {
 	res, err := h.db.PipecatcallGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNamePipecatManager,
+				"PIPECATCALL_NOT_FOUND",
+				"The pipecat call was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not get pipecatcall from db")
 	}
 


### PR DESCRIPTION
Migrate bin-pipecat-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for pipecatcall errors.

- bin-pipecat-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-pipecat-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-pipecat-manager: Migrate pipecatcallHandler.Get to wrap
  dbhandler.ErrNotFound with cerrors.NotFound (PIPECATCALL_NOT_FOUND)
- bin-pipecat-manager: Update processV1PipecatcallsIDGet to propagate the
  Get error to the dispatcher instead of swallowing it as a bare 404, so
  the typed PIPECATCALL_NOT_FOUND surfaces to the caller
- bin-pipecat-manager: Add 6 standard error_response tests covering
  typed, pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and
  end-to-end cases
- bin-pipecat-manager: Remove pre-existing tautological self-comparisons
  (staticcheck SA4000) in 4 model/request struct tests; replace with
  round-trip pattern to keep golangci-lint clean