### PR TITLE
NOJIRA-typed-rpc-pr20-webhook

### DIFF
--- a/bin-webhook-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-webhook-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-webhook-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameWebhookManager, "WEBHOOK_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameWebhookManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameWebhookManager, "WEBHOOK_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-webhook-manager/pkg/listenhandler/main.go
+++ b/bin-webhook-manager/pkg/listenhandler/main.go
@@ -3,16 +3,20 @@ package listenhandler
 //go:generate mockgen -package listenhandler -destination ./mock_listenhandler.go -source main.go -build_flags=-mod=mod
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-webhook-manager/pkg/dbhandler"
 	"monorepo/bin-webhook-manager/pkg/webhookhandler"
 )
 
@@ -73,6 +77,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -156,10 +186,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.Errorf("Could not process the request correctly. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 


### PR DESCRIPTION
Add typed-error RPC plumbing to bin-webhook-manager so future Get methods
route through errorResponse correctly. The service has no current Get-by-ID
RPC entry points, so this PR only sets up the helper, dispatcher catch-all,
and six standard tests; no handler-level Get migration is required today.

- bin-webhook-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-webhook-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-webhook-manager: Add 6 standard error_response tests covering
  typed, pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and
  end-to-end cases