### PR TITLE
NOJIRA-typed-rpc-pr23-tag

### DIFF
--- a/bin-tag-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-tag-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-tag-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameTagManager, "TAG_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameTagManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameTagManager, "TAG_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-tag-manager/pkg/listenhandler/main.go
+++ b/bin-tag-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -15,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-tag-manager/pkg/dbhandler"
 	"monorepo/bin-tag-manager/pkg/taghandler"
 )
 
@@ -73,6 +77,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -168,9 +198,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
-		log.Errorf("Could not find corresponded message handler. method: %s, uri: %s", m.Method, m.URI)
-		response = simpleResponse(400)
+		log.Errorf("Could not handle the message correctly. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	} else {
 		log.WithFields(

--- a/bin-tag-manager/pkg/listenhandler/v1_tags.go
+++ b/bin-tag-manager/pkg/listenhandler/v1_tags.go
@@ -90,7 +90,10 @@ func (h *listenHandler) processV1TagsIDGet(ctx context.Context, m *sock.Request)
 	tmp, err := h.tagHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get an tag info. err: %v", err)
-		return simpleResponse(500), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed TAG_NOT_FOUND surfaces to the caller.
+		// Other errors fall back to the legacy 400.
+		return nil, err
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-tag-manager/pkg/listenhandler/v1_tags_error_test.go
+++ b/bin-tag-manager/pkg/listenhandler/v1_tags_error_test.go
@@ -158,6 +158,17 @@ func TestProcessV1TagsIDGet_Error(t *testing.T) {
 			}
 
 			res, err := h.processV1TagsIDGet(context.Background(), tt.request)
+
+			// "handler_error" propagates the underlying error so the dispatcher
+			// can route typed errors / ErrNotFound through errorResponse.
+			// "invalid_uri" is a request-shape problem and returns a 400 inline.
+			if tt.name == "handler_error" {
+				if err == nil {
+					t.Errorf("processV1TagsIDGet should propagate handler error, got nil")
+				}
+				return
+			}
+
 			if err != nil {
 				t.Errorf("processV1TagsIDGet should not return error, got: %v", err)
 			}

--- a/bin-tag-manager/pkg/taghandler/tag.go
+++ b/bin-tag-manager/pkg/taghandler/tag.go
@@ -2,12 +2,16 @@ package taghandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-tag-manager/models/tag"
+	"monorepo/bin-tag-manager/pkg/dbhandler"
 )
 
 // List returns tags
@@ -38,6 +42,13 @@ func (h *tagHandler) Get(ctx context.Context, id uuid.UUID) (*tag.Tag, error) {
 	res, err := h.dbGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get tag info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTagManager,
+				"TAG_NOT_FOUND",
+				"The tag was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Migrate bin-tag-manager to emit typed *cerrors.VoipbinError over RabbitMQ
RPC for not-found responses, eliminating reliance on api-manager substring
fallback for tag errors.

- bin-tag-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-tag-manager: Update dispatcher catch-all in processRequest to route
  typed errors and ErrNotFound through errorResponse while preserving the
  legacy 400 for unclassified errors
- bin-tag-manager: Migrate tagHandler.Get to wrap dbhandler.ErrNotFound
  with cerrors.NotFound (TAG_NOT_FOUND)
- bin-tag-manager: Update processV1TagsIDGet to propagate the Get error
  to the dispatcher instead of swallowing it as a bare 500, so the typed
  TAG_NOT_FOUND surfaces to the caller; update the matching error test
  to assert the propagated handler error
- bin-tag-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases