### PR TITLE
NOJIRA-typed-rpc-pr24-contact

### DIFF
--- a/bin-contact-manager/pkg/contacthandler/contact.go
+++ b/bin-contact-manager/pkg/contacthandler/contact.go
@@ -2,6 +2,7 @@ package contacthandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -9,7 +10,10 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
 
 // normalizeE164 normalizes a phone number to E.164 format by stripping
@@ -128,6 +132,13 @@ func (h *contactHandler) Create(ctx context.Context, c *contact.Contact) (*conta
 func (h *contactHandler) Get(ctx context.Context, id uuid.UUID) (*contact.Contact, error) {
 	res, err := h.db.ContactGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"CONTACT_NOT_FOUND",
+				"The contact was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 
@@ -199,14 +210,36 @@ func (h *contactHandler) Delete(ctx context.Context, id uuid.UUID) (*contact.Con
 
 // LookupByPhone finds a contact by phone number (E.164 format)
 func (h *contactHandler) LookupByPhone(ctx context.Context, customerID uuid.UUID, phoneE164 string) (*contact.Contact, error) {
-	return h.db.ContactLookupByPhone(ctx, customerID, phoneE164)
+	res, err := h.db.ContactLookupByPhone(ctx, customerID, phoneE164)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"CONTACT_NOT_FOUND",
+				"The contact was not found.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // LookupByEmail finds a contact by email address
 func (h *contactHandler) LookupByEmail(ctx context.Context, customerID uuid.UUID, email string) (*contact.Contact, error) {
 	// Normalize email to lowercase
 	email = strings.ToLower(strings.TrimSpace(email))
-	return h.db.ContactLookupByEmail(ctx, customerID, email)
+	res, err := h.db.ContactLookupByEmail(ctx, customerID, email)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"CONTACT_NOT_FOUND",
+				"The contact was not found.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // AddPhoneNumber adds a phone number to a contact

--- a/bin-contact-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-contact-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameContactManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -16,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-contact-manager/pkg/contacthandler"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
 
 // pagination parameters
@@ -85,6 +89,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -234,9 +264,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.Errorf("Could not process request. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	} else {
 		log.WithFields(

--- a/bin-contact-manager/pkg/listenhandler/v1_contacts.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contacts.go
@@ -162,7 +162,10 @@ func (h *listenHandler) processV1ContactsIDGet(ctx context.Context, m *sock.Requ
 	tmp, err := h.contactHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get a contact info. err: %v", err)
-		return simpleResponse(500), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed CONTACT_NOT_FOUND surfaces to the caller.
+		// Other errors fall back to the legacy 400.
+		return nil, err
 	}
 
 	data, err := json.Marshal(tmp)
@@ -318,7 +321,10 @@ func (h *listenHandler) processV1ContactsLookupGet(ctx context.Context, req *soc
 
 	if err != nil {
 		log.Errorf("Could not lookup contact. err: %v", err)
-		return simpleResponse(404), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed CONTACT_NOT_FOUND surfaces to the caller.
+		// Other errors fall back to the legacy 400.
+		return nil, err
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-contact-manager/pkg/listenhandler/v1_contacts_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contacts_test.go
@@ -1092,8 +1092,11 @@ func TestProcessV1ContactsIDGet_GetError(t *testing.T) {
 	if err != nil {
 		t.Errorf("processRequest() error = %v", err)
 	}
-	if res.StatusCode != 500 {
-		t.Errorf("processRequest() StatusCode = %v, want 500", res.StatusCode)
+	// Unclassified errors propagate to the dispatcher and are mapped to the
+	// legacy 400 (typed errors and dbhandler.ErrNotFound get 404 via
+	// errorResponse; everything else stays on the legacy 400 path).
+	if res.StatusCode != 400 {
+		t.Errorf("processRequest() StatusCode = %v, want 400", res.StatusCode)
 	}
 }
 
@@ -1262,8 +1265,11 @@ func TestProcessV1ContactsLookupGet_LookupError(t *testing.T) {
 	if err != nil {
 		t.Errorf("processRequest() error = %v", err)
 	}
-	if res.StatusCode != 404 {
-		t.Errorf("processRequest() StatusCode = %v, want 404", res.StatusCode)
+	// Unclassified lookup errors propagate to the dispatcher and are mapped
+	// to the legacy 400. A typed CONTACT_NOT_FOUND (from contactHandler
+	// wrapping dbhandler.ErrNotFound) would map to 404 instead.
+	if res.StatusCode != 400 {
+		t.Errorf("processRequest() StatusCode = %v, want 400", res.StatusCode)
 	}
 }
 
@@ -2002,8 +2008,11 @@ func TestProcessV1ContactsLookupGet_ByEmail_Error(t *testing.T) {
 	if err != nil {
 		t.Errorf("processRequest() error = %v", err)
 	}
-	if res.StatusCode != 404 {
-		t.Errorf("processRequest() StatusCode = %v, want 404", res.StatusCode)
+	// Unclassified lookup errors propagate to the dispatcher and are mapped
+	// to the legacy 400. A typed CONTACT_NOT_FOUND (from contactHandler
+	// wrapping dbhandler.ErrNotFound) would map to 404 instead.
+	if res.StatusCode != 400 {
+		t.Errorf("processRequest() StatusCode = %v, want 400", res.StatusCode)
 	}
 }
 


### PR DESCRIPTION
Migrate bin-contact-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for contact errors.

- bin-contact-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-contact-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-contact-manager: Migrate contactHandler.Get, LookupByPhone, and
  LookupByEmail to wrap dbhandler.ErrNotFound with cerrors.NotFound
  (CONTACT_NOT_FOUND)
- bin-contact-manager: Update processV1ContactsIDGet and
  processV1ContactsLookupGet to propagate handler errors to the dispatcher
  instead of swallowing them with bare 500/404, so the typed
  CONTACT_NOT_FOUND surfaces to the caller
- bin-contact-manager: Update 3 listenhandler tests to assert the new
  unclassified-error behavior (legacy 400) with comments explaining
  CONTACT_NOT_FOUND maps to 404 via errorResponse
- bin-contact-manager: Add 6 standard error_response tests covering
  typed, pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and
  end-to-end cases