### PR TITLE
NOJIRA-typed-rpc-pr25-direct

### DIFF
--- a/bin-direct-manager/pkg/directhandler/handler.go
+++ b/bin-direct-manager/pkg/directhandler/handler.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"monorepo/bin-direct-manager/models/direct"
+	"monorepo/bin-direct-manager/pkg/dbhandler"
 )
 
 // generateHash generates a unique direct hash using crypto/rand.
@@ -86,6 +90,13 @@ func (h *directHandler) Get(ctx context.Context, id uuid.UUID) (*direct.Direct, 
 	res, err := h.dbGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get direct info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameDirectManager,
+				"DIRECT_NOT_FOUND",
+				"The direct was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 
@@ -110,6 +121,13 @@ func (h *directHandler) GetByHash(ctx context.Context, hash string) (*direct.Dir
 	res, err = h.dbGetByHash(ctx, hash)
 	if err != nil {
 		log.Errorf("Could not get direct by hash. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameDirectManager,
+				"DIRECT_NOT_FOUND",
+				"The direct was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-direct-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-direct-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-direct-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameDirectManager, "DIRECT_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameDirectManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameDirectManager, "DIRECT_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-direct-manager/pkg/listenhandler/main.go
+++ b/bin-direct-manager/pkg/listenhandler/main.go
@@ -4,10 +4,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -15,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-direct-manager/pkg/dbhandler"
 	"monorepo/bin-direct-manager/pkg/directhandler"
 )
 
@@ -75,6 +79,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -175,9 +205,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
-		log.Errorf("Could not find corresponded message handler. method: %s, uri: %s", m.Method, m.URI)
-		response = simpleResponse(400)
+		log.Errorf("Could not handle the message correctly. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	} else {
 		log.WithFields(

--- a/bin-direct-manager/pkg/listenhandler/v1_directs.go
+++ b/bin-direct-manager/pkg/listenhandler/v1_directs.go
@@ -90,7 +90,9 @@ func (h *listenHandler) processV1DirectsIDGet(ctx context.Context, m *sock.Reque
 	tmp, err := h.directHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get a direct info. err: %v", err)
-		return simpleResponse(500), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed DIRECT_NOT_FOUND surfaces to the caller.
+		return nil, err
 	}
 
 	data, err := json.Marshal(tmp)
@@ -126,7 +128,9 @@ func (h *listenHandler) processV1DirectsByHashGet(ctx context.Context, m *sock.R
 	tmp, err := h.directHandler.GetByHash(ctx, hash)
 	if err != nil {
 		log.Errorf("Could not get a direct by hash. err: %v", err)
-		return simpleResponse(500), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed DIRECT_NOT_FOUND surfaces to the caller.
+		return nil, err
 	}
 
 	data, err := json.Marshal(tmp)


### PR DESCRIPTION
Migrate bin-direct-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for direct errors.

- bin-direct-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-direct-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-direct-manager: Migrate directHandler.Get and directHandler.GetByHash
  to wrap dbhandler.ErrNotFound with cerrors.NotFound (DIRECT_NOT_FOUND)
- bin-direct-manager: Update processV1DirectsIDGet and
  processV1DirectsByHashGet to propagate handler errors to the dispatcher
  instead of swallowing them with bare 500, so the typed DIRECT_NOT_FOUND
  surfaces to the caller
- bin-direct-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases