### PR TITLE
NOJIRA-typed-rpc-pr26-talk

### DIFF
--- a/bin-talk-manager/pkg/chathandler/chat.go
+++ b/bin-talk-manager/pkg/chathandler/chat.go
@@ -2,15 +2,19 @@ package chathandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"monorepo/bin-talk-manager/models/chat"
 	"monorepo/bin-talk-manager/models/participant"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
 )
 
 // ChatCreate creates a new talk
@@ -174,6 +178,13 @@ func (h *chatHandler) ChatGet(ctx context.Context, id uuid.UUID) (*chat.Chat, er
 	t, err := h.dbHandler.ChatGet(ctx, id)
 	if err != nil {
 		log.Errorf("Failed to get talk. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTalkManager,
+				"CHAT_NOT_FOUND",
+				"The chat was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "failed to get talk")
 	}
 

--- a/bin-talk-manager/pkg/dbhandler/chat.go
+++ b/bin-talk-manager/pkg/dbhandler/chat.go
@@ -2,7 +2,6 @@ package dbhandler
 
 import (
 	"context"
-	"database/sql"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/gofrs/uuid"
@@ -69,7 +68,7 @@ func (h *dbHandler) ChatGet(ctx context.Context, id uuid.UUID) (*chat.Chat, erro
 	}()
 
 	if !rows.Next() {
-		return nil, sql.ErrNoRows
+		return nil, ErrNotFound
 	}
 
 	var t chat.Chat

--- a/bin-talk-manager/pkg/dbhandler/main.go
+++ b/bin-talk-manager/pkg/dbhandler/main.go
@@ -5,6 +5,7 @@ package dbhandler
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/gofrs/uuid"
@@ -14,6 +15,11 @@ import (
 	"monorepo/bin-talk-manager/models/chat"
 	commonutil "monorepo/bin-common-handler/pkg/utilhandler"
 )
+
+// ErrNotFound is returned when a requested record does not exist.
+// Translated from sql.ErrNoRows by single-row Get methods so callers can
+// match with errors.Is regardless of the underlying driver detail.
+var ErrNotFound = errors.New("record not found")
 
 // DBHandler defines database operations interface
 type DBHandler interface {

--- a/bin-talk-manager/pkg/dbhandler/message.go
+++ b/bin-talk-manager/pkg/dbhandler/message.go
@@ -2,7 +2,6 @@ package dbhandler
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 
 	sq "github.com/Masterminds/squirrel"
@@ -85,7 +84,7 @@ func (h *dbHandler) MessageGet(ctx context.Context, id uuid.UUID) (*message.Mess
 	}()
 
 	if !rows.Next() {
-		return nil, sql.ErrNoRows
+		return nil, ErrNotFound
 	}
 
 	var m message.Message

--- a/bin-talk-manager/pkg/dbhandler/participant.go
+++ b/bin-talk-manager/pkg/dbhandler/participant.go
@@ -2,7 +2,6 @@ package dbhandler
 
 import (
 	"context"
-	"database/sql"
 	"strings"
 
 	sq "github.com/Masterminds/squirrel"
@@ -116,7 +115,7 @@ func (h *dbHandler) ParticipantGet(ctx context.Context, id uuid.UUID) (*particip
 	}()
 
 	if !rows.Next() {
-		return nil, sql.ErrNoRows
+		return nil, ErrNotFound
 	}
 
 	var p participant.Participant

--- a/bin-talk-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-talk-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameTalkManager, "CHAT_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameTalkManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameTalkManager, "CHAT_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-talk-manager/pkg/listenhandler/main.go
+++ b/bin-talk-manager/pkg/listenhandler/main.go
@@ -5,14 +5,18 @@ package listenhandler
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
+	"net/http"
 	"regexp"
 
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-talk-manager/pkg/chathandler"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
 	"monorepo/bin-talk-manager/pkg/messagehandler"
 	"monorepo/bin-talk-manager/pkg/participanthandler"
 	"monorepo/bin-talk-manager/pkg/reactionhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	commonsock "monorepo/bin-common-handler/models/sock"
 	commonsockhandler "monorepo/bin-common-handler/pkg/sockhandler"
@@ -156,9 +160,19 @@ func (h *listenHandler) processRequest(m *commonsock.Request) (*commonsock.Respo
 		return simpleResponse(404), nil
 	}
 
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 500.
 	if err != nil {
 		logrus.Errorf("Request failed: %v", err)
-		return simpleResponse(500), err
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			return errorResponse(err), nil
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			return errorResponse(err), nil
+		default:
+			return simpleResponse(500), err
+		}
 	}
 
 	return response, nil
@@ -171,4 +185,30 @@ func simpleResponse(statusCode int) *commonsock.Response {
 		DataType:   "application/json",
 		Data:       json.RawMessage("{}"),
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *commonsock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }

--- a/bin-talk-manager/pkg/listenhandler/v1_chats.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats.go
@@ -106,7 +106,9 @@ func (h *listenHandler) v1ChatsIDGet(ctx context.Context, m commonsock.Request) 
 
 	t, err := h.chatHandler.ChatGet(ctx, chatID)
 	if err != nil {
-		return simpleResponse(404), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed CHAT_NOT_FOUND surfaces to the caller.
+		return nil, err
 	}
 
 	data, _ := json.Marshal(t)

--- a/bin-talk-manager/pkg/listenhandler/v1_chats_participants.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats_participants.go
@@ -59,7 +59,9 @@ func (h *listenHandler) v1ChatsIDParticipantsGet(ctx context.Context, m commonso
 	chat, err := h.chatHandler.ChatGet(ctx, chatID)
 	if err != nil {
 		logrus.Errorf("Failed to get chat: %v", err)
-		return simpleResponse(404), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed CHAT_NOT_FOUND surfaces to the caller.
+		return nil, err
 	}
 
 	participants, err := h.participantHandler.ParticipantList(ctx, chat.CustomerID, chatID)
@@ -89,7 +91,9 @@ func (h *listenHandler) v1ChatsIDParticipantsIDDelete(ctx context.Context, m com
 	chat, err := h.chatHandler.ChatGet(ctx, chatID)
 	if err != nil {
 		logrus.Errorf("Failed to get chat: %v", err)
-		return simpleResponse(404), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed CHAT_NOT_FOUND surfaces to the caller.
+		return nil, err
 	}
 
 	err = h.participantHandler.ParticipantRemove(ctx, chat.CustomerID, participantID)

--- a/bin-talk-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_messages.go
@@ -115,7 +115,9 @@ func (h *listenHandler) v1MessagesIDGet(ctx context.Context, m commonsock.Reques
 	msg, err := h.messageHandler.MessageGet(ctx, messageID)
 	if err != nil {
 		log.Errorf("Could not get the message. err: %v", err)
-		return simpleResponse(404), nil
+		// Let the dispatcher route typed errors and ErrNotFound through
+		// errorResponse so the typed MESSAGE_NOT_FOUND surfaces to the caller.
+		return nil, err
 	}
 
 	data, _ := json.Marshal(msg)

--- a/bin-talk-manager/pkg/messagehandler/message.go
+++ b/bin-talk-manager/pkg/messagehandler/message.go
@@ -2,13 +2,17 @@ package messagehandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-talk-manager/models/message"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
 )
 
 // MessageCreate creates a new message with threading validation
@@ -141,7 +145,18 @@ func (h *messageHandler) MessageCreate(ctx context.Context, req MessageCreateReq
 
 // MessageGet retrieves a message by ID
 func (h *messageHandler) MessageGet(ctx context.Context, id uuid.UUID) (*message.Message, error) {
-	return h.dbHandler.MessageGet(ctx, id)
+	res, err := h.dbHandler.MessageGet(ctx, id)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTalkManager,
+				"MESSAGE_NOT_FOUND",
+				"The message was not found.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // MessageList retrieves messages with filters and pagination

--- a/bin-talk-manager/pkg/participanthandler/participant.go
+++ b/bin-talk-manager/pkg/participanthandler/participant.go
@@ -2,7 +2,7 @@ package participanthandler
 
 import (
 	"context"
-	"database/sql"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
@@ -10,6 +10,7 @@ import (
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-talk-manager/models/participant"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
 )
 
 // ParticipantAdd adds a participant to a talk
@@ -180,7 +181,7 @@ func (h *participantHandler) ParticipantRemove(ctx context.Context, customerID, 
 	p, err := h.dbHandler.ParticipantGet(ctx, participantID)
 	if err != nil {
 		// If participant doesn't exist, treat as successful deletion (idempotent)
-		if err == sql.ErrNoRows {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
 			log.Infof("Participant already removed (not found). participant_id: %s", participantID)
 			return nil
 		}
@@ -192,7 +193,7 @@ func (h *participantHandler) ParticipantRemove(ctx context.Context, customerID, 
 	err = h.dbHandler.ParticipantDelete(ctx, participantID)
 	if err != nil {
 		// If already deleted, treat as success (idempotent)
-		if err == sql.ErrNoRows {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
 			log.Infof("Participant already removed (delete). participant_id: %s", participantID)
 			return nil
 		}

--- a/bin-talk-manager/pkg/participanthandler/participant_test.go
+++ b/bin-talk-manager/pkg/participanthandler/participant_test.go
@@ -2,7 +2,6 @@ package participanthandler
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"reflect"
 	"testing"
@@ -791,7 +790,7 @@ func Test_ParticipantRemove_idempotent(t *testing.T) {
 			customerID:    uuid.FromStringOrNil("809656e2-305e-43cd-8d7b-ccb44373dddb"),
 			participantID: uuid.FromStringOrNil("af243cbc-de04-4705-ad2b-78350d0a4fba"),
 
-			getError: sql.ErrNoRows,
+			getError: dbhandler.ErrNotFound,
 		},
 	}
 
@@ -860,7 +859,7 @@ func Test_ParticipantRemove_idempotent_delete(t *testing.T) {
 	mockDB.EXPECT().ParticipantGet(ctx, participantID).Return(testParticipant, nil)
 
 	// Mock delete returning ErrNoRows (already deleted by another process)
-	mockDB.EXPECT().ParticipantDelete(ctx, participantID).Return(sql.ErrNoRows)
+	mockDB.EXPECT().ParticipantDelete(ctx, participantID).Return(dbhandler.ErrNotFound)
 
 	// Should succeed idempotently
 	err := h.ParticipantRemove(ctx, customerID, participantID)


### PR DESCRIPTION
Migrate bin-talk-manager to emit typed *cerrors.VoipbinError over RabbitMQ
RPC for not-found responses, eliminating reliance on api-manager substring
fallback for chat, message, and participant errors.

- bin-talk-manager: Introduce dbhandler.ErrNotFound sentinel and translate
  sql.ErrNoRows -> ErrNotFound in ChatGet, MessageGet, ParticipantGet so
  callers can match on a stable sentinel; remove now-unused database/sql
  imports
- bin-talk-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-talk-manager: Update dispatcher catch-all in processRequest to route
  typed errors and ErrNotFound through errorResponse while preserving the
  legacy 500 for unclassified errors
- bin-talk-manager: Migrate chatHandler.ChatGet and messageHandler.MessageGet
  to wrap dbhandler.ErrNotFound with cerrors.NotFound (CHAT_NOT_FOUND,
  MESSAGE_NOT_FOUND)
- bin-talk-manager: Update participantHandler.ParticipantRemove to use
  stderrors.Is(err, dbhandler.ErrNotFound) for idempotent-delete paths
  (replaces dead sql.ErrNoRows comparisons)
- bin-talk-manager: Update v1ChatsIDGet, v1MessagesIDGet,
  v1ChatsIDParticipantsGet, and v1ChatsIDParticipantsIDDelete to propagate
  handler errors to the dispatcher instead of swallowing them with bare
  404, so the typed CHAT_NOT_FOUND / MESSAGE_NOT_FOUND surfaces to the
  caller
- bin-talk-manager: Update participant_test.go to inject ErrNotFound
  instead of sql.ErrNoRows so the idempotent-delete test exercises the
  live path
- bin-talk-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases