### PR TITLE
NOJIRA-typed-rpc-pr27-transfer

### DIFF
--- a/bin-common-handler/models/outline/servicename.go
+++ b/bin-common-handler/models/outline/servicename.go
@@ -38,6 +38,7 @@ const (
 	ServiceNameTalkManager       ServiceName = "talk-manager"
 	ServiceNameTimelineManager   ServiceName = "timeline-manager"
 	ServiceNameTranscribeManager ServiceName = "transcribe-manager"
+	ServiceNameTransferManager   ServiceName = "transfer-manager"
 	ServiceNameTTSManager        ServiceName = "tts-manager"
 	ServiceNameWebhookManager    ServiceName = "webhook-manager"
 )

--- a/bin-transfer-manager/pkg/dbhandler/transfer_test.go
+++ b/bin-transfer-manager/pkg/dbhandler/transfer_test.go
@@ -159,7 +159,7 @@ func TestTransferGet(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 				if result.ID != tt.expectedTransfer.ID {
 					t.Errorf("Wrong ID. expect: %s, got: %s", tt.expectedTransfer.ID, result.ID)
@@ -225,7 +225,7 @@ func TestTransferGetByTransfererCallID(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 				if result.ID != tt.expectedTransferID {
 					t.Errorf("Wrong ID. expect: %s, got: %s", tt.expectedTransferID, result.ID)
@@ -291,7 +291,7 @@ func TestTransferGetByGroupcallID(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 				if result.ID != tt.expectedTransferID {
 					t.Errorf("Wrong ID. expect: %s, got: %s", tt.expectedTransferID, result.ID)

--- a/bin-transfer-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-transfer-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-transfer-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameTransferManager, "TRANSFER_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameTransferManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameTransferManager, "TRANSFER_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-transfer-manager/pkg/listenhandler/main.go
+++ b/bin-transfer-manager/pkg/listenhandler/main.go
@@ -2,16 +2,20 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-transfer-manager/pkg/dbhandler"
 	"monorepo/bin-transfer-manager/pkg/transferhandler"
 )
 
@@ -71,6 +75,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -152,10 +182,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.Errorf("Could not process the request correctly. method: %s, uri: %s, err: %v", m.Method, m.URI, err)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-transfer-manager/pkg/transferhandler/db.go
+++ b/bin-transfer-manager/pkg/transferhandler/db.go
@@ -2,15 +2,19 @@ package transferhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-transfer-manager/models/transfer"
+	"monorepo/bin-transfer-manager/pkg/dbhandler"
 )
 
 // Create is handy function for creating a transfer.
@@ -65,6 +69,13 @@ func (h *transferHandler) Get(ctx context.Context, id uuid.UUID) (*transfer.Tran
 	res, err := h.db.TransferGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get transfer. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTransferManager,
+				"TRANSFER_NOT_FOUND",
+				"The transfer was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get transfer")
 	}
 
@@ -75,6 +86,13 @@ func (h *transferHandler) Get(ctx context.Context, id uuid.UUID) (*transfer.Tran
 func (h *transferHandler) GetByGroupcallID(ctx context.Context, groupcallID uuid.UUID) (*transfer.Transfer, error) {
 	res, err := h.db.TransferGetByGroupcallID(ctx, groupcallID)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTransferManager,
+				"TRANSFER_NOT_FOUND",
+				"The transfer was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get transfer")
 	}
 
@@ -85,6 +103,13 @@ func (h *transferHandler) GetByGroupcallID(ctx context.Context, groupcallID uuid
 func (h *transferHandler) GetByTransfererCallID(ctx context.Context, transfererCallID uuid.UUID) (*transfer.Transfer, error) {
 	res, err := h.db.TransferGetByTransfererCallID(ctx, transfererCallID)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameTransferManager,
+				"TRANSFER_NOT_FOUND",
+				"The transfer was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "could not get transfer")
 	}
 

--- a/bin-transfer-manager/pkg/transferhandler/db_test.go
+++ b/bin-transfer-manager/pkg/transferhandler/db_test.go
@@ -105,7 +105,7 @@ func TestCreate(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 				if result.CustomerID != tt.customerID {
 					t.Errorf("Wrong CustomerID. expect: %s, got: %s", tt.customerID, result.CustomerID)
@@ -188,7 +188,7 @@ func TestGet(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 				if result.ID != tt.dbTransfer.ID {
 					t.Errorf("Wrong ID. expect: %s, got: %s", tt.dbTransfer.ID, result.ID)
@@ -259,7 +259,7 @@ func TestGetByGroupcallID(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 			}
 		})
@@ -327,7 +327,7 @@ func TestGetByTransfererCallID(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 			}
 		})
@@ -436,7 +436,7 @@ func Test_updateTransfereeCallID(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 				if result == nil {
-					t.Error("Expected transfer but got nil")
+					t.Fatal("Expected transfer but got nil")
 				}
 				if result.TransfereeCallID != tt.transfereeCallID {
 					t.Errorf("Wrong TransfereeCallID. expect: %s, got: %s", tt.transfereeCallID, result.TransfereeCallID)


### PR DESCRIPTION
Migrate bin-transfer-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for transfer errors.

- bin-common-handler: Add ServiceNameTransferManager constant in alpha
  order so transfer-manager (and any future caller) can construct typed
  cerrors.VoipbinError values without a custom ServiceName literal
- bin-transfer-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-transfer-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-transfer-manager: Migrate transferHandler.Get, GetByGroupcallID, and
  GetByTransfererCallID to wrap dbhandler.ErrNotFound with cerrors.NotFound
  (TRANSFER_NOT_FOUND)
- bin-transfer-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases
- bin-transfer-manager: Replace pre-existing t.Error("nil...") with t.Fatal
  in transfer_test.go and db_test.go (staticcheck SA5011) so the post-nil
  dereference can no longer panic, keeping golangci-lint clean