### PR TITLE
NOJIRA-typed-rpc-pr28-route

### DIFF
--- a/bin-route-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-route-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-route-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameRouteManager, "ROUTE_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameRouteManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameRouteManager, "ROUTE_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-route-manager/pkg/listenhandler/main.go
+++ b/bin-route-manager/pkg/listenhandler/main.go
@@ -4,16 +4,20 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"monorepo/bin-route-manager/pkg/dbhandler"
 	"monorepo/bin-route-manager/pkg/providercallhandler"
 	"monorepo/bin-route-manager/pkg/providerhandler"
 	"monorepo/bin-route-manager/pkg/routehandler"
@@ -88,6 +92,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -238,7 +268,8 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		logrus.WithFields(
 			logrus.Fields{
@@ -246,7 +277,15 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 				"method": m.Method,
 				"error":  err,
 			}).Errorf("Could not process the request correctly. data: %s", logData)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-route-manager/pkg/providercallhandler/providercall.go
+++ b/bin-route-manager/pkg/providercallhandler/providercall.go
@@ -2,9 +2,12 @@ package providercallhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	cmcall "monorepo/bin-call-manager/models/call"
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	fmaction "monorepo/bin-flow-manager/models/action"
 	fmflow "monorepo/bin-flow-manager/models/flow"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-route-manager/models/providercall"
+	"monorepo/bin-route-manager/pkg/dbhandler"
 )
 
 // Create orchestrates an admin-triggered provider call end-to-end inside
@@ -155,6 +159,13 @@ func (h *providerCallHandler) Get(ctx context.Context, id uuid.UUID) (*providerc
 	res, err := h.db.ProviderCallGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get providercall. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRouteManager,
+				"PROVIDERCALL_NOT_FOUND",
+				"The provider call was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 	log.WithField("providercall", res).Debugf("Retrieved providercall. id: %s", res.ID)

--- a/bin-route-manager/pkg/providerhandler/provider.go
+++ b/bin-route-manager/pkg/providerhandler/provider.go
@@ -2,12 +2,16 @@ package providerhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-route-manager/models/provider"
+	"monorepo/bin-route-manager/pkg/dbhandler"
 )
 
 // Get returns provider
@@ -20,6 +24,13 @@ func (h *providerHandler) Get(ctx context.Context, id uuid.UUID) (*provider.Prov
 	res, err := h.db.ProviderGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get provider. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRouteManager,
+				"PROVIDER_NOT_FOUND",
+				"The provider was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 

--- a/bin-route-manager/pkg/routehandler/route.go
+++ b/bin-route-manager/pkg/routehandler/route.go
@@ -2,12 +2,16 @@ package routehandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-route-manager/models/route"
+	"monorepo/bin-route-manager/pkg/dbhandler"
 )
 
 // Get returns route
@@ -20,6 +24,13 @@ func (h *routeHandler) Get(ctx context.Context, id uuid.UUID) (*route.Route, err
 	res, err := h.db.RouteGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get route. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRouteManager,
+				"ROUTE_NOT_FOUND",
+				"The route was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Migrate bin-route-manager to emit typed *cerrors.VoipbinError over RabbitMQ
RPC for not-found responses, eliminating reliance on api-manager substring
fallback for route, provider, and providercall errors.

- bin-route-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-route-manager: Update dispatcher catch-all in processRequest to route
  typed errors and ErrNotFound through errorResponse while preserving the
  legacy 400 for unclassified errors
- bin-route-manager: Migrate routeHandler.Get, providerHandler.Get, and
  providerCallHandler.Get to wrap dbhandler.ErrNotFound with cerrors.NotFound
  (ROUTE_NOT_FOUND, PROVIDER_NOT_FOUND, PROVIDERCALL_NOT_FOUND)
- bin-route-manager: Add 6 standard error_response tests covering typed,
  pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and end-to-end
  cases