### PR TITLE
NOJIRA-typed-rpc-pr29-registrar

### DIFF
--- a/bin-registrar-manager/pkg/extensionhandler/extension.go
+++ b/bin-registrar-manager/pkg/extensionhandler/extension.go
@@ -2,13 +2,16 @@ package extensionhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
 	bmaccount "monorepo/bin-billing-manager/models/account"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 	"monorepo/bin-registrar-manager/models/astaor"
 	"monorepo/bin-registrar-manager/models/astauth"
@@ -16,6 +19,7 @@ import (
 	"monorepo/bin-registrar-manager/models/common"
 	"monorepo/bin-registrar-manager/models/extension"
 	"monorepo/bin-registrar-manager/models/sipauth"
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
 )
 
 // Create creates a new extension
@@ -159,6 +163,13 @@ func (h *extensionHandler) Create(
 func (h *extensionHandler) Get(ctx context.Context, id uuid.UUID) (*extension.Extension, error) {
 	res, err := h.dbBin.ExtensionGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRegistrarManager,
+				"EXTENSION_NOT_FOUND",
+				"The extension was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 
@@ -167,7 +178,18 @@ func (h *extensionHandler) Get(ctx context.Context, id uuid.UUID) (*extension.Ex
 
 // GetByExtension gets a exists extension of the given endpoint
 func (h *extensionHandler) GetByExtension(ctx context.Context, customerID uuid.UUID, ext string) (*extension.Extension, error) {
-	return h.dbBin.ExtensionGetByExtension(ctx, customerID, ext)
+	res, err := h.dbBin.ExtensionGetByExtension(ctx, customerID, ext)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRegistrarManager,
+				"EXTENSION_NOT_FOUND",
+				"The extension was not found.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // List returns list of extensions

--- a/bin-registrar-manager/pkg/listenhandler/error_response_test.go
+++ b/bin-registrar-manager/pkg/listenhandler/error_response_test.go
@@ -1,0 +1,50 @@
+package listenhandler
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+func Test_errorResponse_typed(t *testing.T) {
+	resp := errorResponse(cerrors.NotFound(commonoutline.ServiceNameRegistrarManager, "TRUNK_NOT_FOUND", "x"))
+	if resp.StatusCode != http.StatusNotFound || resp.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("typed: got %d/%s", resp.StatusCode, resp.DataType)
+	}
+}
+func Test_errorResponse_typedThroughPkgErrorsWrap(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(cerrors.NotFound(commonoutline.ServiceNameRegistrarManager, "x", "x"), "outer")).StatusCode != http.StatusNotFound {
+		t.Errorf("wrapped failed")
+	}
+}
+func Test_errorResponse_legacyNotFound(t *testing.T) {
+	if errorResponse(pkgerrors.Wrap(dbhandler.ErrNotFound, "x")).StatusCode != http.StatusNotFound {
+		t.Errorf("legacy failed")
+	}
+}
+func Test_errorResponse_unclassifiedError(t *testing.T) {
+	if errorResponse(fmt.Errorf("x")).StatusCode != http.StatusInternalServerError {
+		t.Errorf("unclassified failed")
+	}
+}
+func Test_errorResponse_nilError(t *testing.T) {
+	if errorResponse(nil).StatusCode != http.StatusInternalServerError {
+		t.Errorf("nil failed")
+	}
+}
+func Test_errorResponse_typedNotFoundFromBusinessHandler(t *testing.T) {
+	typed := cerrors.NotFound(commonoutline.ServiceNameRegistrarManager, "TRUNK_NOT_FOUND", "x").Wrap(dbhandler.ErrNotFound)
+	if errorResponse(typed).StatusCode != http.StatusNotFound {
+		t.Errorf("e2e failed")
+	}
+	if !stderrors.Is(typed, dbhandler.ErrNotFound) {
+		t.Errorf("Is should walk")
+	}
+}

--- a/bin-registrar-manager/pkg/listenhandler/main.go
+++ b/bin-registrar-manager/pkg/listenhandler/main.go
@@ -2,10 +2,13 @@ package listenhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"time"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -15,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-registrar-manager/pkg/contacthandler"
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
 	"monorepo/bin-registrar-manager/pkg/extensionhandler"
 	"monorepo/bin-registrar-manager/pkg/trunkhandler"
 )
@@ -92,6 +96,32 @@ func simpleResponse(code int) *sock.Response {
 	return &sock.Response{
 		StatusCode: code,
 	}
+}
+
+// errorResponse maps a business-handler error to the appropriate sock.Response.
+// Resolution order: typed *cerrors.VoipbinError → ToResponse; legacy
+// dbhandler.ErrNotFound → 404; else → 500.
+func errorResponse(err error) *sock.Response {
+	if err == nil {
+		logrus.WithField("func", "errorResponse").Warn("errorResponse called with nil error — likely a caller bug; returning 500")
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		resp, e := cerrors.ToResponse(ve)
+		if e == nil {
+			return resp
+		}
+		logrus.WithField("func", "errorResponse").Errorf("cerrors.ToResponse failed for typed VoipbinError: %v", e)
+		return simpleResponse(http.StatusInternalServerError)
+	}
+
+	if stderrors.Is(err, dbhandler.ErrNotFound) {
+		return simpleResponse(http.StatusNotFound)
+	}
+
+	return simpleResponse(http.StatusInternalServerError)
 }
 
 // NewListenHandler return ListenHandler interface
@@ -245,12 +275,21 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	elapsed := time.Since(start)
 	promReceivedRequestProcessTime.WithLabelValues(requestType, string(m.Method)).Observe(float64(elapsed.Milliseconds()))
 
-	// default error handler
+	// default error handler — typed errors and ErrNotFound flow through
+	// errorResponse; other errors keep legacy 400.
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"error": err,
 		}).Errorf("Could not process the request correctly. method: %s, uri: %s", m.Method, m.URI)
-		response = simpleResponse(400)
+		var ve *cerrors.VoipbinError
+		switch {
+		case stderrors.As(err, &ve):
+			response = errorResponse(err)
+		case stderrors.Is(err, dbhandler.ErrNotFound):
+			response = errorResponse(err)
+		default:
+			response = simpleResponse(400)
+		}
 		err = nil
 	}
 

--- a/bin-registrar-manager/pkg/trunkhandler/trunk.go
+++ b/bin-registrar-manager/pkg/trunkhandler/trunk.go
@@ -2,6 +2,7 @@ package trunkhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
@@ -9,10 +10,13 @@ import (
 	"github.com/sirupsen/logrus"
 
 	bmaccount "monorepo/bin-billing-manager/models/account"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-registrar-manager/models/common"
 	"monorepo/bin-registrar-manager/models/sipauth"
 	"monorepo/bin-registrar-manager/models/trunk"
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
 )
 
 // Create creates a new trunk and returns a created trunk info
@@ -108,6 +112,13 @@ func (h *trunkHandler) Create(
 func (h *trunkHandler) Get(ctx context.Context, id uuid.UUID) (*trunk.Trunk, error) {
 	res, err := h.db.TrunkGet(ctx, id)
 	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRegistrarManager,
+				"TRUNK_NOT_FOUND",
+				"The trunk was not found.",
+			).Wrap(err)
+		}
 		return nil, err
 	}
 
@@ -124,6 +135,13 @@ func (h *trunkHandler) GetByDomainName(ctx context.Context, domainName string) (
 	res, err := h.db.TrunkGetByDomainName(ctx, domainName)
 	if err != nil {
 		log.Errorf("Could not get trunk info. err: %v", err)
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameRegistrarManager,
+				"TRUNK_NOT_FOUND",
+				"The trunk was not found.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrap(err, "Could not get trunk info")
 	}
 


### PR DESCRIPTION
Migrate bin-registrar-manager to emit typed *cerrors.VoipbinError over
RabbitMQ RPC for not-found responses, eliminating reliance on api-manager
substring fallback for trunk and extension errors.

- bin-registrar-manager: Add errorResponse helper in pkg/listenhandler/main.go
  mapping typed *cerrors.VoipbinError -> cerrors.ToResponse, legacy
  dbhandler.ErrNotFound -> 404, else -> 500
- bin-registrar-manager: Update dispatcher catch-all in processRequest to
  route typed errors and ErrNotFound through errorResponse while preserving
  the legacy 400 for unclassified errors
- bin-registrar-manager: Migrate trunkHandler.Get, trunkHandler.GetByDomainName,
  extensionHandler.Get, and extensionHandler.GetByExtension to wrap
  dbhandler.ErrNotFound with cerrors.NotFound (TRUNK_NOT_FOUND,
  EXTENSION_NOT_FOUND)
- bin-registrar-manager: Add 6 standard error_response tests covering
  typed, pkg/errors.Wrap, legacy ErrNotFound, unclassified, nil, and
  end-to-end cases