### PR TITLE
NOJIRA-typed-rpc-final-cleanup

### DIFF
--- a/bin-api-manager/server/error_translate.go
+++ b/bin-api-manager/server/error_translate.go
@@ -20,6 +20,17 @@ import (
 //
 // The whole function is wrapped in defer recover() so a panic inside
 // any branch degrades to INTERNAL rather than dropping the response.
+//
+// Migration status (2026-04): Steps 1-3 cover all RPC traffic from
+// upstream managers — every Get-by-ID handler in bin-call-manager,
+// bin-flow-manager, …, bin-registrar-manager now emits typed
+// *cerrors.VoipbinError on miss. Step 4 remains because the api-manager
+// servicehandler layer itself still returns plain fmt.Errorf strings
+// (e.g., authorization checks like `"user has no permission"` and
+// validation errors like `"... is required"`). Migrating servicehandler
+// to typed errors / sentinels is the natural follow-up; once that is
+// done, step 4 can be removed and any unmatched legacy string will
+// correctly degrade to INTERNAL via step 5.
 func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -75,6 +86,12 @@ func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 	// http.StatusText) are caught alongside lowercase servicehandler
 	// strings. This set is intentionally small — each pattern is a
 	// migration target for a sentinel in subsequent PRs.
+	//
+	// As of the typed-RPC migration (PR2-PR29), upstream managers no
+	// longer emit these strings — only api-manager's own servicehandler
+	// does (authorization checks, validation, etc.). Removing this branch
+	// requires migrating servicehandler to typed errors / sentinels,
+	// which is tracked as follow-up work.
 	lowered := strings.ToLower(err.Error())
 	switch {
 	case strings.Contains(lowered, "no permission"),


### PR DESCRIPTION
Document the post-migration status of section 4 (substring fallback) in
bin-api-manager's translateToVoipbinError. The 29 typed-RPC PRs migrated
every upstream manager (call-manager through registrar-manager) to emit
typed *cerrors.VoipbinError on miss, so steps 1-3 of the resolution chain
now cover all RPC traffic. Section 4 is retained because the api-manager
servicehandler layer itself still returns plain fmt.Errorf strings for
authorization checks (e.g., "user has no permission") and validation
errors (e.g., "... is required"); 20+ existing server tests rely on
those legacy strings producing sensible HTTP statuses (403, 400, etc.)
through the substring fallback.

Removing section 4 is the natural follow-up once the api-manager
servicehandler is migrated to typed errors / sentinels — at that point
any unmatched legacy string will correctly degrade to INTERNAL via
step 5 instead of breaking 20+ tests.

- bin-api-manager: Update translateToVoipbinError doc comment to record
  migration status as of 2026-04 — explicitly note that section 4
  remains for servicehandler-emitted strings while upstream manager
  RPC traffic is fully covered by typed passthrough (step 1)