### PR TITLE
NOJIRA-typed-rpc-svchandler-perm

### DIFF
--- a/bin-api-manager/pkg/servicehandler/billingaccount.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount.go
@@ -197,7 +197,7 @@ func (h *serviceHandler) BillingAccountSelfGet(ctx context.Context, a *auth.Auth
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get customer to resolve billing account ID
@@ -236,7 +236,7 @@ func (h *serviceHandler) BillingAccountSelfUpdateBasicInfo(ctx context.Context, 
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	c, err := h.customerGet(ctx, a.CustomerID)
@@ -273,7 +273,7 @@ func (h *serviceHandler) BillingAccountSelfUpdatePaymentInfo(ctx context.Context
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	c, err := h.customerGet(ctx, a.CustomerID)

--- a/bin-api-manager/pkg/servicehandler/call.go
+++ b/bin-api-manager/pkg/servicehandler/call.go
@@ -184,7 +184,7 @@ func (h *serviceHandler) CallList(ctx context.Context, a *auth.AuthIdentity, siz
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -288,7 +288,7 @@ func (h *serviceHandler) CallDelete(ctx context.Context, a *auth.AuthIdentity, c
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res, err := h.callDelete(ctx, callID)
@@ -347,7 +347,7 @@ func (h *serviceHandler) CallHangup(ctx context.Context, a *auth.AuthIdentity, c
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -388,7 +388,7 @@ func (h *serviceHandler) CallTalk(ctx context.Context, a *auth.AuthIdentity, cal
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -424,7 +424,7 @@ func (h *serviceHandler) CallHoldOn(ctx context.Context, a *auth.AuthIdentity, c
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -460,7 +460,7 @@ func (h *serviceHandler) CallHoldOff(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -496,7 +496,7 @@ func (h *serviceHandler) CallMuteOn(ctx context.Context, a *auth.AuthIdentity, c
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -532,7 +532,7 @@ func (h *serviceHandler) CallMuteOff(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -568,7 +568,7 @@ func (h *serviceHandler) CallMOHOn(ctx context.Context, a *auth.AuthIdentity, ca
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -604,7 +604,7 @@ func (h *serviceHandler) CallMOHOff(ctx context.Context, a *auth.AuthIdentity, c
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -640,7 +640,7 @@ func (h *serviceHandler) CallSilenceOn(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -676,7 +676,7 @@ func (h *serviceHandler) CallSilenceOff(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -712,7 +712,7 @@ func (h *serviceHandler) CallMediaStreamStart(ctx context.Context, a *auth.AuthI
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	if errRun := h.websockHandler.RunMediaStream(ctx, w, r, cmexternalmedia.ReferenceTypeCall, callID, encapsulation); errRun != nil {
@@ -747,7 +747,7 @@ func (h *serviceHandler) CallRecordingStart(
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -784,7 +784,7 @@ func (h *serviceHandler) CallRecordingStop(ctx context.Context, a *auth.AuthIden
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request

--- a/bin-api-manager/pkg/servicehandler/conference.go
+++ b/bin-api-manager/pkg/servicehandler/conference.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"monorepo/bin-api-manager/models/auth"
@@ -62,7 +61,7 @@ func (h *serviceHandler) ConferenceGet(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -90,7 +89,7 @@ func (h *serviceHandler) ConferenceList(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[string]string{
@@ -154,7 +153,7 @@ func (h *serviceHandler) ConferenceCreate(
 	}
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConferenceV1ConferenceCreate(ctx, conferenceID, a.CustomerID, confType, name, detail, data, timeout, preFlowID, postFlowID)
@@ -188,7 +187,7 @@ func (h *serviceHandler) ConferenceDelete(ctx context.Context, a *auth.AuthIdent
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// destroy
@@ -240,7 +239,7 @@ func (h *serviceHandler) ConferenceUpdate(
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConferenceV1ConferenceUpdate(
@@ -282,7 +281,7 @@ func (h *serviceHandler) ConferenceRecordingStart(
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// recording
@@ -309,7 +308,7 @@ func (h *serviceHandler) ConferenceRecordingStop(ctx context.Context, a *auth.Au
 	}
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// recording
@@ -344,7 +343,7 @@ func (h *serviceHandler) ConferenceTranscribeStart(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConferenceV1ConferenceTranscribeStart(ctx, conferenceID, language)
@@ -379,7 +378,7 @@ func (h *serviceHandler) ConferenceTranscribeStop(ctx context.Context, a *auth.A
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// recording
@@ -414,7 +413,7 @@ func (h *serviceHandler) ConferenceDirectHashRegenerate(ctx context.Context, a *
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConferenceV1ConferenceDirectHashRegenerate(ctx, conferenceID)
@@ -450,7 +449,7 @@ func (h *serviceHandler) ConferenceMediaStreamStart(ctx context.Context, a *auth
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return fmt.Errorf("agent has no permission")
+		return serviceerrors.ErrPermissionDenied
 	}
 
 	if errRun := h.websockHandler.RunMediaStream(ctx, w, r, cmexternalmedia.ReferenceTypeConfbridge, c.ConfbridgeID, encapsulation); errRun != nil {

--- a/bin-api-manager/pkg/servicehandler/conferencecall.go
+++ b/bin-api-manager/pkg/servicehandler/conferencecall.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -56,7 +55,7 @@ func (h *serviceHandler) ConferencecallGet(ctx context.Context, a *auth.AuthIden
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -84,7 +83,7 @@ func (h *serviceHandler) ConferencecallList(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[string]string{
@@ -137,7 +136,7 @@ func (h *serviceHandler) ConferencecallKick(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// kick the conferencecall from the conference

--- a/bin-api-manager/pkg/servicehandler/conversation.go
+++ b/bin-api-manager/pkg/servicehandler/conversation.go
@@ -55,7 +55,7 @@ func (h *serviceHandler) ConversationGetsByCustomerID(ctx context.Context, a *au
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[cvconversation.Field]any{
@@ -128,7 +128,7 @@ func (h *serviceHandler) ConversationGet(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -159,7 +159,7 @@ func (h *serviceHandler) ConversationUpdate(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConversationV1ConversationUpdate(ctx, conversationID, fields)

--- a/bin-api-manager/pkg/servicehandler/conversation_account.go
+++ b/bin-api-manager/pkg/servicehandler/conversation_account.go
@@ -55,7 +55,7 @@ func (h *serviceHandler) ConversationAccountGetsByCustomerID(ctx context.Context
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[cvaccount.Field]any{
@@ -104,7 +104,7 @@ func (h *serviceHandler) ConversationAccountGet(ctx context.Context, a *auth.Aut
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -135,7 +135,7 @@ func (h *serviceHandler) ConversationAccountCreate(
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConversationV1AccountCreate(ctx, a.CustomerID, accountType, name, detail, secret, token, messageFlowID)
@@ -170,7 +170,7 @@ func (h *serviceHandler) ConversationAccountUpdate(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, ca.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConversationV1AccountUpdate(ctx, accountID, fields)
@@ -205,7 +205,7 @@ func (h *serviceHandler) ConversationAccountDelete(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, ca.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ConversationV1AccountDelete(ctx, accountID)

--- a/bin-api-manager/pkg/servicehandler/conversation_message.go
+++ b/bin-api-manager/pkg/servicehandler/conversation_message.go
@@ -48,7 +48,7 @@ func (h *serviceHandler) ConversationMessageGetsByConversationID(
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmps, err := h.conversationMessageGetsByConversationID(ctx, a, conversationID, size, token)
@@ -131,7 +131,7 @@ func (h *serviceHandler) ConversationMessageSend(
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.conversationMessageSend(ctx, a, conversationID, text, medias)

--- a/bin-api-manager/pkg/servicehandler/customer.go
+++ b/bin-api-manager/pkg/servicehandler/customer.go
@@ -85,7 +85,7 @@ func (h *serviceHandler) CustomerGet(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.customerGet(ctx, customerID)
@@ -112,7 +112,7 @@ func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.customerGet(ctx, a.CustomerID)
@@ -208,7 +208,7 @@ func (h *serviceHandler) CustomerUpdate(
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	c, err := h.customerGet(ctx, id)
@@ -252,7 +252,7 @@ func (h *serviceHandler) CustomerSelfUpdate(
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res, err := h.reqHandler.CustomerV1CustomerUpdate(ctx, a.CustomerID, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
@@ -281,7 +281,7 @@ func (h *serviceHandler) CustomerDelete(ctx context.Context, a *auth.AuthIdentit
 	// only admin permssion allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, customerID)
@@ -316,7 +316,7 @@ func (h *serviceHandler) CustomerFreeze(ctx context.Context, a *auth.AuthIdentit
 	// only admin permission allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, customerID)
@@ -351,7 +351,7 @@ func (h *serviceHandler) CustomerRecover(ctx context.Context, a *auth.AuthIdenti
 	// only admin permission allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission for this agent.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, customerID)
@@ -384,7 +384,7 @@ func (h *serviceHandler) CustomerSelfFreeze(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, a.CustomerID)
@@ -418,7 +418,7 @@ func (h *serviceHandler) CustomerSelfFreezeAndDelete(ctx context.Context, a *aut
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, a.CustomerID)
@@ -451,7 +451,7 @@ func (h *serviceHandler) CustomerSelfRecover(ctx context.Context, a *auth.AuthId
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, a.CustomerID)
@@ -485,7 +485,7 @@ func (h *serviceHandler) CustomerUpdateBillingAccountID(ctx context.Context, a *
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, customerID)
@@ -526,7 +526,7 @@ func (h *serviceHandler) CustomerUpdateDefaultOutgoingSourceNumberID(ctx context
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.customerGet(ctx, customerID)
@@ -570,7 +570,7 @@ func (h *serviceHandler) CustomerUpdateMetadata(ctx context.Context, a *auth.Aut
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	c, err := h.customerGet(ctx, customerID)
@@ -604,7 +604,7 @@ func (h *serviceHandler) CustomerSelfUpdateBillingAccountID(ctx context.Context,
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	ba, err := h.billingAccountGet(ctx, billingAccountID)
@@ -615,7 +615,7 @@ func (h *serviceHandler) CustomerSelfUpdateBillingAccountID(ctx context.Context,
 
 	if !h.hasPermission(ctx, a, ba.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res, err := h.reqHandler.CustomerV1CustomerUpdateBillingAccountID(ctx, a.CustomerID, billingAccountID)
@@ -642,7 +642,7 @@ func (h *serviceHandler) CustomerSelfUpdateDefaultOutgoingSourceNumberID(ctx con
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// validate the number exists and belongs to the agent's customer
@@ -680,7 +680,7 @@ func (h *serviceHandler) CustomerSelfUpdateMetadata(ctx context.Context, a *auth
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res, err := h.reqHandler.CustomerV1CustomerUpdateMetadata(ctx, a.CustomerID, metadata)

--- a/bin-api-manager/pkg/servicehandler/numbers.go
+++ b/bin-api-manager/pkg/servicehandler/numbers.go
@@ -167,7 +167,7 @@ func (h *serviceHandler) NumberGet(ctx context.Context, a *auth.AuthIdentity, id
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -237,7 +237,7 @@ func (h *serviceHandler) NumberUpdate(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, n.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// check call flow
@@ -286,7 +286,7 @@ func (h *serviceHandler) NumberUpdateFlowIDs(ctx context.Context, a *auth.AuthId
 
 	if !h.hasPermission(ctx, a, n.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// update number
@@ -322,7 +322,7 @@ func (h *serviceHandler) NumberUpdateMetadata(ctx context.Context, a *auth.AuthI
 
 	if !h.hasPermission(ctx, a, n.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// update number metadata

--- a/bin-api-manager/pkg/servicehandler/outdials.go
+++ b/bin-api-manager/pkg/servicehandler/outdials.go
@@ -48,7 +48,7 @@ func (h *serviceHandler) OutdialCreate(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.OutdialV1OutdialCreate(ctx, a.CustomerID, campaignID, name, detail, data)
@@ -83,7 +83,7 @@ func (h *serviceHandler) OutdialGetsByCustomerID(ctx context.Context, a *auth.Au
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get outdials
@@ -129,7 +129,7 @@ func (h *serviceHandler) OutdialDelete(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.OutdialV1OutdialDelete(ctx, id)
@@ -166,7 +166,7 @@ func (h *serviceHandler) OutdialGet(ctx context.Context, a *auth.AuthIdentity, i
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -197,7 +197,7 @@ func (h *serviceHandler) OutdialUpdateBasicInfo(ctx context.Context, a *auth.Aut
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.OutdialV1OutdialUpdateBasicInfo(ctx, id, name, detail)
@@ -235,7 +235,7 @@ func (h *serviceHandler) OutdialUpdateCampaignID(ctx context.Context, a *auth.Au
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.OutdialV1OutdialUpdateCampaignID(ctx, id, campaignID)
@@ -273,7 +273,7 @@ func (h *serviceHandler) OutdialUpdateData(ctx context.Context, a *auth.AuthIden
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.OutdialV1OutdialUpdateData(ctx, id, data)

--- a/bin-api-manager/pkg/servicehandler/outdialtargets.go
+++ b/bin-api-manager/pkg/servicehandler/outdialtargets.go
@@ -53,7 +53,7 @@ func (h *serviceHandler) OutdialtargetCreate(
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// create
@@ -102,7 +102,7 @@ func (h *serviceHandler) OutdialtargetGet(ctx context.Context, a *auth.AuthIdent
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get outdialtarget
@@ -151,7 +151,7 @@ func (h *serviceHandler) OutdialtargetGetsByOutdialID(ctx context.Context, a *au
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get targets
@@ -195,7 +195,7 @@ func (h *serviceHandler) OutdialtargetDelete(ctx context.Context, a *auth.AuthId
 
 	if !h.hasPermission(ctx, a, od.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get outdialtarget

--- a/bin-api-manager/pkg/servicehandler/outplans.go
+++ b/bin-api-manager/pkg/servicehandler/outplans.go
@@ -99,7 +99,7 @@ func (h *serviceHandler) OutplanDelete(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, op.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1OutplanDelete(ctx, id)
@@ -133,7 +133,7 @@ func (h *serviceHandler) OutplanGetsByCustomerID(ctx context.Context, a *auth.Au
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get outplans
@@ -180,7 +180,7 @@ func (h *serviceHandler) OutplanGet(ctx context.Context, a *auth.AuthIdentity, i
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -211,7 +211,7 @@ func (h *serviceHandler) OutplanUpdateBasicInfo(ctx context.Context, a *auth.Aut
 
 	if !h.hasPermission(ctx, a, op.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1OutplanUpdateBasicInfo(ctx, id, name, detail)
@@ -260,7 +260,7 @@ func (h *serviceHandler) OutplanUpdateDialInfo(
 
 	if !h.hasPermission(ctx, a, op.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CampaignV1OutplanUpdateDialInfo(ctx, id, source, dialTimeout, tryInterval, maxTryCount0, maxTryCount1, maxTryCount2, maxTryCount3, maxTryCount4)

--- a/bin-api-manager/pkg/servicehandler/provider.go
+++ b/bin-api-manager/pkg/servicehandler/provider.go
@@ -58,7 +58,7 @@ func (h *serviceHandler) ProviderGet(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	return tmp.ConvertWebhookMessage(), nil
@@ -88,7 +88,7 @@ func (h *serviceHandler) ProviderList(ctx context.Context, a *auth.AuthIdentity,
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmps, err := h.reqHandler.RouteV1ProviderList(ctx, token, size)
@@ -131,7 +131,7 @@ func (h *serviceHandler) ProviderCreate(
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RouteV1ProviderCreate(
@@ -170,7 +170,7 @@ func (h *serviceHandler) ProviderDelete(ctx context.Context, a *auth.AuthIdentit
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get provider
@@ -204,7 +204,7 @@ func (h *serviceHandler) ProviderSetup(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RouteV1ProviderSetup(ctx, carrier, name, detail, apiKey)
@@ -260,7 +260,7 @@ func (h *serviceHandler) ProviderUpdate(
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.providerGet(ctx, providerID)

--- a/bin-api-manager/pkg/servicehandler/providercall.go
+++ b/bin-api-manager/pkg/servicehandler/providercall.go
@@ -54,7 +54,7 @@ func (h *serviceHandler) ProviderCallCreate(
 	// permission — project admin only
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// fail-fast provider existence check — avoids asking route-manager to
@@ -98,7 +98,7 @@ func (h *serviceHandler) ProviderCallGet(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RouteV1ProviderCallGet(ctx, id)
@@ -131,7 +131,7 @@ func (h *serviceHandler) ProviderCallGets(ctx context.Context, a *auth.AuthIdent
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if token == "" {
@@ -172,7 +172,7 @@ func (h *serviceHandler) ProviderCallDelete(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RouteV1ProviderCallDelete(ctx, id)

--- a/bin-api-manager/pkg/servicehandler/recording.go
+++ b/bin-api-manager/pkg/servicehandler/recording.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -60,7 +59,7 @@ func (h *serviceHandler) RecordingGet(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, rec.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := rec.ConvertWebhookMessage()
@@ -89,7 +88,7 @@ func (h *serviceHandler) RecordingList(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -143,7 +142,7 @@ func (h *serviceHandler) RecordingDelete(ctx context.Context, a *auth.AuthIdenti
 
 	if !h.hasPermission(ctx, a, r.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.CallV1RecordingDelete(ctx, id)

--- a/bin-api-manager/pkg/servicehandler/recordingfile.go
+++ b/bin-api-manager/pkg/servicehandler/recordingfile.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -36,7 +35,7 @@ func (h *serviceHandler) RecordingfileGet(ctx context.Context, a *auth.AuthIdent
 
 	if !h.hasPermission(ctx, a, r.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return "", fmt.Errorf("agent has no permission")
+		return "", serviceerrors.ErrPermissionDenied
 	}
 
 	// get download url from storage-manager

--- a/bin-api-manager/pkg/servicehandler/route.go
+++ b/bin-api-manager/pkg/servicehandler/route.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -51,7 +50,7 @@ func (h *serviceHandler) RouteGet(ctx context.Context, a *auth.AuthIdentity, rou
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.routeGet(ctx, routeID)
@@ -86,7 +85,7 @@ func (h *serviceHandler) RouteList(ctx context.Context, a *auth.AuthIdentity, si
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get all routes (no filtering for super admin)
@@ -129,7 +128,7 @@ func (h *serviceHandler) RouteGetsByCustomerID(ctx context.Context, a *auth.Auth
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[rmroute.Field]any{
@@ -177,7 +176,7 @@ func (h *serviceHandler) RouteCreate(
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.RouteV1RouteCreate(
@@ -217,7 +216,7 @@ func (h *serviceHandler) RouteDelete(ctx context.Context, a *auth.AuthIdentity, 
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.routeGet(ctx, routeID)
@@ -263,7 +262,7 @@ func (h *serviceHandler) RouteUpdate(
 	// only project admin allowed
 	if !h.hasPermission(ctx, a, uuid.Nil, amagent.PermissionProjectSuperAdmin) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	_, err := h.routeGet(ctx, routeID)

--- a/bin-api-manager/pkg/servicehandler/serviceagent_agent.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_agent.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -33,7 +32,7 @@ func (h *serviceHandler) ServiceAgentAgentList(ctx context.Context, a *auth.Auth
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters
@@ -83,7 +82,7 @@ func (h *serviceHandler) ServiceAgentAgentGet(ctx context.Context, a *auth.AuthI
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()

--- a/bin-api-manager/pkg/servicehandler/serviceagent_call.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_call.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -34,7 +33,7 @@ func (h *serviceHandler) ServiceAgentCallList(ctx context.Context, a *auth.AuthI
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// filters

--- a/bin-api-manager/pkg/servicehandler/serviceagent_contact.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_contact.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -42,7 +41,7 @@ func (h *serviceHandler) ServiceAgentContactCreate(
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1ContactCreate(
@@ -91,7 +90,7 @@ func (h *serviceHandler) ServiceAgentContactGet(ctx context.Context, a *auth.Aut
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -119,7 +118,7 @@ func (h *serviceHandler) ServiceAgentContactList(ctx context.Context, a *auth.Au
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	typedFilters, err := h.convertContactFilters(filters)
@@ -175,7 +174,7 @@ func (h *serviceHandler) ServiceAgentContactUpdate(
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1ContactUpdate(
@@ -219,7 +218,7 @@ func (h *serviceHandler) ServiceAgentContactDelete(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1ContactDelete(ctx, contactID)
@@ -248,7 +247,7 @@ func (h *serviceHandler) ServiceAgentContactLookup(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1ContactLookup(ctx, a.CustomerID, phoneE164, email)
@@ -290,7 +289,7 @@ func (h *serviceHandler) ServiceAgentContactPhoneNumberCreate(
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1PhoneNumberCreate(ctx, contactID, number, numberE164, phoneType, isPrimary)
@@ -331,7 +330,7 @@ func (h *serviceHandler) ServiceAgentContactPhoneNumberUpdate(
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1PhoneNumberUpdate(ctx, contactID, phoneNumberID, fields)
@@ -366,7 +365,7 @@ func (h *serviceHandler) ServiceAgentContactPhoneNumberDelete(ctx context.Contex
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1PhoneNumberDelete(ctx, contactID, phoneNumberID)
@@ -407,7 +406,7 @@ func (h *serviceHandler) ServiceAgentContactEmailCreate(
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1EmailCreate(ctx, contactID, address, emailType, isPrimary)
@@ -448,7 +447,7 @@ func (h *serviceHandler) ServiceAgentContactEmailUpdate(
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1EmailUpdate(ctx, contactID, emailID, fields)
@@ -483,7 +482,7 @@ func (h *serviceHandler) ServiceAgentContactEmailDelete(ctx context.Context, a *
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1EmailDelete(ctx, contactID, emailID)
@@ -518,7 +517,7 @@ func (h *serviceHandler) ServiceAgentContactTagAdd(ctx context.Context, a *auth.
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1TagAdd(ctx, contactID, tagID)
@@ -553,7 +552,7 @@ func (h *serviceHandler) ServiceAgentContactTagRemove(ctx context.Context, a *au
 
 	if !h.hasPermission(ctx, a, ct.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.ContactV1TagRemove(ctx, contactID, tagID)

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversation.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversation.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvconversation "monorepo/bin-conversation-manager/models/conversation"
@@ -25,7 +24,7 @@ func (h *serviceHandler) ServiceAgentConversationGet(ctx context.Context, a *aut
 	}
 
 	if tmp.OwnerID != a.AgentID() {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversationmessage.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversationmessage.go
@@ -27,7 +27,7 @@ func (h *serviceHandler) ServiceAgentConversationMessageList(ctx context.Context
 	}
 
 	if cv.OwnerID != a.AgentID() {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	if token == "" {
@@ -76,7 +76,7 @@ func (h *serviceHandler) ServiceAgentConversationMessageSend(
 	}
 
 	if c.OwnerID != a.AgentID() {
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.conversationMessageSend(ctx, a, conversationID, text, medias)

--- a/bin-api-manager/pkg/servicehandler/serviceagent_tag.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_tag.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -33,7 +32,7 @@ func (h *serviceHandler) ServiceAgentTagList(ctx context.Context, a *auth.AuthId
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[tmtag.Field]any{
@@ -76,7 +75,7 @@ func (h *serviceHandler) ServiceAgentTagGet(ctx context.Context, a *auth.AuthIde
 
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionAll) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := t.ConvertWebhookMessage()

--- a/bin-api-manager/pkg/servicehandler/serviceagent_talk.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_talk.go
@@ -24,7 +24,7 @@ func (h *serviceHandler) ServiceAgentTalkChatGet(ctx context.Context, a *auth.Au
 	// Public "talk" type chats are accessible to all agents in the customer
 	// For group/direct chats, agent must be a participant
 	if !h.canAccessChat(ctx, a.AgentID(), a.CustomerID, chatID) {
-		return nil, fmt.Errorf("agent has no permission to access this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Get chat
@@ -124,7 +124,7 @@ func (h *serviceHandler) ServiceAgentTalkChatUpdate(ctx context.Context, a *auth
 
 	// Check permission - must be a participant to modify
 	if !h.isParticipantOfTalk(ctx, a.AgentID(), chatID) {
-		return nil, fmt.Errorf("agent is not a participant of this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Update chat via RPC
@@ -145,7 +145,7 @@ func (h *serviceHandler) ServiceAgentTalkChatDelete(ctx context.Context, a *auth
 
 	// Check permission - must be a participant to delete
 	if !h.isParticipantOfTalk(ctx, a.AgentID(), chatID) {
-		return nil, fmt.Errorf("agent is not a participant of this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Delete chat via RPC
@@ -172,7 +172,7 @@ func (h *serviceHandler) ServiceAgentTalkChatJoin(ctx context.Context, a *auth.A
 
 	// Only allow joining "talk" type chats (public channels)
 	if chat.Type != tkchat.TypeTalk {
-		return nil, fmt.Errorf("can only join talk-type chats")
+		return nil, fmt.Errorf("%w: only talk-type chats can be joined", serviceerrors.ErrInvalidArgument)
 	}
 
 	// Verify chat belongs to the same customer
@@ -200,7 +200,7 @@ func (h *serviceHandler) ServiceAgentTalkParticipantList(ctx context.Context, a 
 	// Public "talk" type chats are accessible to all agents in the customer
 	// For group/direct chats, agent must be a participant
 	if !h.canAccessChat(ctx, a.AgentID(), a.CustomerID, chatID) {
-		return nil, fmt.Errorf("agent has no permission to access this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Get participants via RPC
@@ -228,7 +228,7 @@ func (h *serviceHandler) ServiceAgentTalkParticipantCreate(ctx context.Context, 
 	// For "talk" type chats (public channels): anyone in the customer can add themselves (join)
 	// For group/direct chats: only existing participants can add others
 	if !h.canAddParticipant(ctx, a, chatID, ownerType, ownerID) {
-		return nil, fmt.Errorf("agent is not a participant of this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Add participant via RPC
@@ -249,7 +249,7 @@ func (h *serviceHandler) ServiceAgentTalkParticipantDelete(ctx context.Context, 
 
 	// Check permission - must be a participant to remove others
 	if !h.isParticipantOfTalk(ctx, a.AgentID(), chatID) {
-		return nil, fmt.Errorf("agent is not a participant of this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Delete participant via RPC
@@ -278,7 +278,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageGet(ctx context.Context, a *auth
 	// Public "talk" type chats are accessible to all agents in the customer
 	// For group/direct chats, agent must be a participant
 	if !h.canAccessChat(ctx, a.AgentID(), a.CustomerID, tmp.ChatID) {
-		return nil, fmt.Errorf("agent has no permission to access this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Convert to WebhookMessage
@@ -304,7 +304,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageList(ctx context.Context, a *aut
 	// Public "talk" type chats are accessible to all agents in the customer
 	// For group/direct chats, agent must be a participant
 	if !h.canAccessChat(ctx, a.AgentID(), a.CustomerID, chatID) {
-		return nil, fmt.Errorf("agent is not a participant of this chat")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Get messages for this specific chat
@@ -334,7 +334,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageCreate(ctx context.Context, a *a
 
 	// Check permission
 	if !h.isParticipantOfTalk(ctx, a.AgentID(), chatID) {
-		return nil, fmt.Errorf("agent is not a participant of this talk")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Create message via RPC
@@ -366,7 +366,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageDelete(ctx context.Context, a *a
 
 	// Check permission - must own the message
 	if tmp.OwnerID != a.AgentID() {
-		return nil, fmt.Errorf("agent does not own this message")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Delete message via RPC
@@ -398,7 +398,7 @@ func (h *serviceHandler) ServiceAgentTalkMessageReactionCreate(ctx context.Conte
 
 	// Check permission - must be participant of the talk
 	if !h.isParticipantOfTalk(ctx, a.AgentID(), tmp.ChatID) {
-		return nil, fmt.Errorf("agent is not a participant of this talk")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Add reaction via RPC

--- a/bin-api-manager/pkg/servicehandler/speaking.go
+++ b/bin-api-manager/pkg/servicehandler/speaking.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -38,7 +37,7 @@ func (h *serviceHandler) SpeakingCreate(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.TTSV1SpeakingCreate(ctx, a.CustomerID, referenceType, referenceID, language, provider, voiceID, direction)
@@ -72,7 +71,7 @@ func (h *serviceHandler) SpeakingGet(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	return tmp.ConvertWebhookMessage(), nil
@@ -96,7 +95,7 @@ func (h *serviceHandler) SpeakingList(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[tmspeaking.Field]any{
@@ -139,7 +138,7 @@ func (h *serviceHandler) SpeakingSay(ctx context.Context, a *auth.AuthIdentity, 
 
 	if !h.hasPermission(ctx, a, s.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.TTSV1SpeakingSay(ctx, s.PodID, speakingID, text)
@@ -173,7 +172,7 @@ func (h *serviceHandler) SpeakingFlush(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, s.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.TTSV1SpeakingFlush(ctx, s.PodID, speakingID)
@@ -207,7 +206,7 @@ func (h *serviceHandler) SpeakingStop(ctx context.Context, a *auth.AuthIdentity,
 
 	if !h.hasPermission(ctx, a, s.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.TTSV1SpeakingStop(ctx, s.PodID, speakingID)
@@ -241,7 +240,7 @@ func (h *serviceHandler) SpeakingDelete(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, s.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Stop the streaming session first (pod-targeted) to ensure proper cleanup

--- a/bin-api-manager/pkg/servicehandler/tag.go
+++ b/bin-api-manager/pkg/servicehandler/tag.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -40,7 +39,7 @@ func (h *serviceHandler) TagCreate(ctx context.Context, a *auth.AuthIdentity, na
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request
@@ -80,7 +79,7 @@ func (h *serviceHandler) TagGet(ctx context.Context, a *auth.AuthIdentity, id uu
 	// permission check
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// create result

--- a/bin-api-manager/pkg/servicehandler/timeline_sip.go
+++ b/bin-api-manager/pkg/servicehandler/timeline_sip.go
@@ -41,7 +41,7 @@ func (h *serviceHandler) TimelineSIPAnalysisGet(
 	// Check permission
 	if !h.hasPermission(ctx, a, call.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("Agent has no permission")
-		return nil, fmt.Errorf("permission denied")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Get channel to retrieve SIP Call-ID
@@ -114,7 +114,7 @@ func (h *serviceHandler) TimelineSIPPcapGet(
 	// Check permission
 	if !h.hasPermission(ctx, a, call.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("Agent has no permission")
-		return nil, fmt.Errorf("permission denied")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// Get channel to retrieve SIP Call-ID

--- a/bin-api-manager/pkg/servicehandler/transcribe.go
+++ b/bin-api-manager/pkg/servicehandler/transcribe.go
@@ -46,7 +46,7 @@ func (h *serviceHandler) TranscribeGet(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -75,7 +75,7 @@ func (h *serviceHandler) TranscribeList(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[string]string{
@@ -134,7 +134,7 @@ func (h *serviceHandler) TranscribeStart(
 
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// get transcribe resource info
@@ -221,7 +221,7 @@ func (h *serviceHandler) transcribeGetResourceInfo(ctx context.Context, a *auth.
 	// check the ownership
 	if !h.hasPermission(ctx, a, tmpCustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return "", uuid.Nil, fmt.Errorf("agent has no permission")
+		return "", uuid.Nil, serviceerrors.ErrPermissionDenied
 	}
 
 	return resReferenceType, resReferenceID, nil
@@ -251,7 +251,7 @@ func (h *serviceHandler) TranscribeStop(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.TranscribeV1TranscribeStop(ctx, transcribeID)
@@ -287,7 +287,7 @@ func (h *serviceHandler) TranscribeDelete(ctx context.Context, a *auth.AuthIdent
 
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// send request

--- a/bin-api-manager/pkg/servicehandler/transcript.go
+++ b/bin-api-manager/pkg/servicehandler/transcript.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -37,7 +36,7 @@ func (h *serviceHandler) TranscriptList(ctx context.Context, a *auth.AuthIdentit
 
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[string]string{

--- a/bin-api-manager/pkg/servicehandler/transfer.go
+++ b/bin-api-manager/pkg/servicehandler/transfer.go
@@ -2,7 +2,6 @@ package servicehandler
 
 import (
 	"context"
-	"fmt"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -39,7 +38,7 @@ func (h *serviceHandler) TransferStart(ctx context.Context, a *auth.AuthIdentity
 
 	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	tmp, err := h.reqHandler.TransferV1TransferStart(ctx, transferType, transfererCallID, transfereeAddresses)

--- a/bin-api-manager/pkg/servicehandler/trunk.go
+++ b/bin-api-manager/pkg/servicehandler/trunk.go
@@ -78,7 +78,7 @@ func (h *serviceHandler) TrunkDelete(ctx context.Context, a *auth.AuthIdentity, 
 	// permission check
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// delete
@@ -116,7 +116,7 @@ func (h *serviceHandler) TrunkGet(ctx context.Context, a *auth.AuthIdentity, id 
 	// permission check
 	if !h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	res := tmp.ConvertWebhookMessage()
@@ -146,7 +146,7 @@ func (h *serviceHandler) TrunkList(ctx context.Context, a *auth.AuthIdentity, si
 	// permission check
 	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	filters := map[string]string{
@@ -202,7 +202,7 @@ func (h *serviceHandler) TrunkUpdateBasicInfo(ctx context.Context, a *auth.AuthI
 	// permission check
 	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		log.Info("The agent has no permission.")
-		return nil, fmt.Errorf("agent has no permission")
+		return nil, serviceerrors.ErrPermissionDenied
 	}
 
 	// update


### PR DESCRIPTION
Migrate permission-related fmt.Errorf strings in api-manager servicehandler
to typed sentinels (serviceerrors.ErrPermissionDenied / ErrInvalidArgument).
This is the first step in removing the substring-fallback in
server/error_translate.go (section 4) by making upstream emit typed errors
the dispatcher can recognize directly via errors.Is.

- bin-api-manager: Replace `fmt.Errorf("agent has no permission")` with
  `serviceerrors.ErrPermissionDenied` across 31 servicehandler files
- bin-api-manager: Replace `fmt.Errorf("permission denied")` with
  the same sentinel
- bin-api-manager: Replace serviceagent_talk.go participant/ownership
  checks with `serviceerrors.ErrPermissionDenied`
- bin-api-manager: Use `serviceerrors.ErrInvalidArgument` for the type-guard
  in `ServiceAgentTalkChatJoin` (chat.Type != TypeTalk is a 400, not 403)
- bin-api-manager: Clean up now-unused fmt imports via goimports