### PR TITLE
NOJIRA-typed-rpc-svchandler-notfound

### DIFF
--- a/bin-api-manager/pkg/servicehandler/billingaccount.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount.go
@@ -210,7 +210,7 @@ func (h *serviceHandler) BillingAccountSelfGet(ctx context.Context, a *auth.Auth
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Info("Customer has no billing account.")
-		return nil, fmt.Errorf("no billing account")
+		return nil, fmt.Errorf("%w: customer has no billing account configured", serviceerrors.ErrStateInvalid)
 	}
 
 	ba, err := h.billingAccountGet(ctx, c.BillingAccountID)
@@ -248,7 +248,7 @@ func (h *serviceHandler) BillingAccountSelfUpdateBasicInfo(ctx context.Context, 
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Info("Customer has no billing account.")
-		return nil, fmt.Errorf("no billing account")
+		return nil, fmt.Errorf("%w: customer has no billing account configured", serviceerrors.ErrStateInvalid)
 	}
 
 	tmp, err := h.reqHandler.BillingV1AccountUpdateBasicInfo(ctx, c.BillingAccountID, name, detail)
@@ -285,7 +285,7 @@ func (h *serviceHandler) BillingAccountSelfUpdatePaymentInfo(ctx context.Context
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Info("Customer has no billing account.")
-		return nil, fmt.Errorf("no billing account")
+		return nil, fmt.Errorf("%w: customer has no billing account configured", serviceerrors.ErrStateInvalid)
 	}
 
 	tmp, err := h.reqHandler.BillingV1AccountUpdatePaymentInfo(ctx, c.BillingAccountID, paymentType, paymentMethod)
@@ -323,7 +323,7 @@ func (h *serviceHandler) BillingAccountSelfCreatePaddlePortalSession(ctx context
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Infof("Customer has no billing account. customer_id: %s", c.ID)
-		return "", fmt.Errorf("no billing account")
+		return "", fmt.Errorf("%w: customer has no billing account configured", serviceerrors.ErrStateInvalid)
 	}
 
 	url, err := h.reqHandler.BillingV1AccountPaddlePortalSession(ctx, c.BillingAccountID)

--- a/bin-api-manager/pkg/servicehandler/boot.go
+++ b/bin-api-manager/pkg/servicehandler/boot.go
@@ -48,7 +48,7 @@ func (h *serviceHandler) AuthBoot(ctx context.Context, directHash string) (*Boot
 	d, err := h.reqHandler.DirectV1DirectGetByHash(ctx, directHash)
 	if err != nil {
 		log.Infof("Could not get direct by hash. err: %v", err)
-		return nil, fmt.Errorf("direct hash not found")
+		return nil, fmt.Errorf("%w: direct hash not found", serviceerrors.ErrNotFound)
 	}
 	log.WithField("direct", d).Debugf("Retrieved direct info. direct_id: %s", d.ID)
 
@@ -56,7 +56,7 @@ func (h *serviceHandler) AuthBoot(ctx context.Context, directHash string) (*Boot
 	cu, err := h.reqHandler.CustomerV1CustomerGet(ctx, d.CustomerID)
 	if err != nil {
 		log.Infof("Could not get customer. err: %v", err)
-		return nil, fmt.Errorf("customer not found")
+		return nil, fmt.Errorf("%w: customer not found", serviceerrors.ErrNotFound)
 	}
 	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 

--- a/bin-api-manager/pkg/servicehandler/providercall.go
+++ b/bin-api-manager/pkg/servicehandler/providercall.go
@@ -61,7 +61,7 @@ func (h *serviceHandler) ProviderCallCreate(
 	// create a Call record that would immediately fail at DialrouteList.
 	if _, err := h.reqHandler.RouteV1ProviderGet(ctx, providerID); err != nil {
 		log.Errorf("Could not find the provider. err: %v", err)
-		return nil, fmt.Errorf("provider not found. err: %v", err)
+		return nil, fmt.Errorf("%w: provider not found", serviceerrors.ErrNotFound)
 	}
 
 	// forward to route-manager for orchestration

--- a/bin-api-manager/pkg/servicehandler/timeline_sip.go
+++ b/bin-api-manager/pkg/servicehandler/timeline_sip.go
@@ -34,7 +34,7 @@ func (h *serviceHandler) TimelineSIPAnalysisGet(
 	call, err := h.callGet(ctx, callID)
 	if err != nil {
 		log.Infof("Could not get call: %v", err)
-		return nil, fmt.Errorf("call not found")
+		return nil, fmt.Errorf("%w: call not found", serviceerrors.ErrNotFound)
 	}
 	log.WithField("call", call).Debugf("Retrieved call info. call_id: %s", call.ID)
 
@@ -47,26 +47,26 @@ func (h *serviceHandler) TimelineSIPAnalysisGet(
 	// Get channel to retrieve SIP Call-ID
 	if call.ChannelID == "" {
 		log.Info("Call has no channel ID")
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 
 	ch, err := h.reqHandler.CallV1ChannelGet(ctx, call.ChannelID)
 	if err != nil {
 		log.Errorf("Could not get channel: %v", err)
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 	log.WithField("channel", ch).Debugf("Retrieved channel info. channel_id: %s", ch.ID)
 
 	if ch.SIPCallID == "" {
 		log.Info("Channel has no SIP Call-ID")
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 
 	// Determine time range from call timestamps
 	fromTime := call.TMCreate
 	if fromTime == nil {
 		log.Info("Call has no create timestamp")
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 	toTime := call.TMHangup
 	if toTime == nil {
@@ -107,7 +107,7 @@ func (h *serviceHandler) TimelineSIPPcapGet(
 	call, err := h.callGet(ctx, callID)
 	if err != nil {
 		log.Infof("Could not get call: %v", err)
-		return nil, fmt.Errorf("call not found")
+		return nil, fmt.Errorf("%w: call not found", serviceerrors.ErrNotFound)
 	}
 	log.WithField("call", call).Debugf("Retrieved call info. call_id: %s", call.ID)
 
@@ -120,26 +120,26 @@ func (h *serviceHandler) TimelineSIPPcapGet(
 	// Get channel to retrieve SIP Call-ID
 	if call.ChannelID == "" {
 		log.Info("Call has no channel ID")
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 
 	ch, err := h.reqHandler.CallV1ChannelGet(ctx, call.ChannelID)
 	if err != nil {
 		log.Errorf("Could not get channel: %v", err)
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 	log.WithField("channel", ch).Debugf("Retrieved channel info. channel_id: %s", ch.ID)
 
 	if ch.SIPCallID == "" {
 		log.Info("Channel has no SIP Call-ID")
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 
 	// Determine time range from call timestamps
 	fromTime := call.TMCreate
 	if fromTime == nil {
 		log.Info("Call has no create timestamp")
-		return nil, fmt.Errorf("no SIP data available for this call")
+		return nil, fmt.Errorf("%w: no SIP data available for this call", serviceerrors.ErrNotFound)
 	}
 	toTime := call.TMHangup
 	if toTime == nil {


### PR DESCRIPTION
Migrate not-found-style fmt.Errorf strings in api-manager servicehandler
to typed sentinels. Genuine \"resource not found\" cases wrap
\`serviceerrors.ErrNotFound\` (HTTP 404). The \"customer has no billing
account configured\" case (BillingAccountID == uuid.Nil) wraps
\`serviceerrors.ErrStateInvalid\` (HTTP 409) — the customer exists but
billing isn't yet set up, so 404 would be semantically wrong.

- bin-api-manager: Wrap \"direct hash not found\", \"customer not found\"
  in boot.go with \`serviceerrors.ErrNotFound\`
- bin-api-manager: Wrap \"provider not found\" in providercall.go with
  \`serviceerrors.ErrNotFound\` (upstream err already logged at Errorf;
  drop from response to keep client-visible body generic)
- bin-api-manager: Wrap \"call not found\" (×2) and \"no SIP data
  available for this call\" (×8) in timeline_sip.go with
  \`serviceerrors.ErrNotFound\`
- bin-api-manager: Map \"customer has no billing account configured\"
  (BillingAccountID == uuid.Nil, 4 sites) to
  \`serviceerrors.ErrStateInvalid\` so clients receive 409, not 404
- bin-api-manager: Leave billingaccount.go:36 (soft-deleted billing
  account by valid ID) as \`serviceerrors.ErrNotFound\` — that case is
  legitimately a 404