### PR TITLE
NOJIRA-wire-check-docs-hook

### DIFF
--- a/.claude/scripts/check-docs-size.sh
+++ b/.claude/scripts/check-docs-size.sh
@@ -17,9 +17,16 @@ if [[ -z "$FILE_PATH" ]]; then
     exit 0
 fi
 
-# Only run when root CLAUDE.md or any docs/ file is edited
+# Only run when ROOT CLAUDE.md or root docs/* is edited. Service-level
+# CLAUDE.md (e.g., bin-pipecat-manager/CLAUDE.md) and service-level docs are
+# explicitly out of scope — the cap applies to root CLAUDE.md only, and the
+# README check only reads root docs/<category>/README.md. Match both
+# absolute paths (Write tool) and repo-relative paths.
 case "$FILE_PATH" in
-    */CLAUDE.md|CLAUDE.md|*/docs/*|docs/*) ;;
+    # Reject service-level paths first
+    bin-*/CLAUDE.md|*/bin-*/CLAUDE.md|bin-*/docs/*|*/bin-*/docs/*) exit 0 ;;
+    # Accept root-level paths
+    CLAUDE.md|*/CLAUDE.md|docs/*|*/docs/*) ;;
     *) exit 0 ;;
 esac
 

--- a/.claude/scripts/check-docs-size.sh
+++ b/.claude/scripts/check-docs-size.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run scripts/check-docs.sh after edits to root CLAUDE.md or docs/*.
+# Used by Claude Code PostToolUse hook on Write|Edit.
+#
+# Reads the tool input JSON from stdin to extract the file path.
+# Exits 0 on pass; on fail, prints the script's error and exits 0
+# (warning rather than blocking — the cap is advisory at the hook layer
+# and CI will be the eventual enforcement point).
+
+set -euo pipefail
+
+# Read tool input from stdin
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.file // empty' 2>/dev/null || true)
+
+if [[ -z "$FILE_PATH" ]]; then
+    exit 0
+fi
+
+# Only run when root CLAUDE.md or any docs/ file is edited
+case "$FILE_PATH" in
+    */CLAUDE.md|CLAUDE.md|*/docs/*|docs/*) ;;
+    *) exit 0 ;;
+esac
+
+# Find the monorepo root (where scripts/check-docs.sh lives)
+SCRIPT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+if [[ ! -x "$SCRIPT_DIR/scripts/check-docs.sh" ]]; then
+    exit 0
+fi
+
+# Run the cap check
+OUTPUT=$("$SCRIPT_DIR/scripts/check-docs.sh" 2>&1) || {
+    echo ""
+    echo "[Hook] check-docs.sh failed for $FILE_PATH:"
+    echo "$OUTPUT" | sed 's/^/[Hook]   /'
+    echo "[Hook] Move detail to docs/<category>/<topic>.md, or run \`make lint-docs\` to re-verify."
+    echo ""
+    exit 0
+}
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,11 @@
             "type": "command",
             "command": "bash .claude/scripts/check-migration-table-names.sh",
             "description": "Verify Alembic migration table names exist in dbhandler code"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/check-docs-size.sh",
+            "description": "Run scripts/check-docs.sh after edits to root CLAUDE.md or docs/* to catch root CLAUDE.md regrowth and missing category READMEs"
           }
         ]
       }

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 # This Makefile is reserved for repo-wide checks that don't belong in any one
 # service.
 
+.DEFAULT_GOAL := lint-docs
+
 .PHONY: lint-docs
 
 lint-docs:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Top-level monorepo Makefile.
+# Per-service Go builds/tests live in each service's own toolchain — see
+# docs/workflows/development-guide.md and docs/workflows/verification-workflows.md.
+#
+# This Makefile is reserved for repo-wide checks that don't belong in any one
+# service.
+
+.PHONY: lint-docs
+
+lint-docs:
+	@./scripts/check-docs.sh

--- a/docs/workflows/verification-workflows.md
+++ b/docs/workflows/verification-workflows.md
@@ -59,3 +59,21 @@ golangci-lint run -v --timeout 5m
 - For regular code changes, only update dependencies if needed
 
 **Both workflows are MANDATORY before committing** - Do not skip any step. The monorepo's interdependencies require this to maintain consistency and catch issues early.
+
+## Documentation checks
+
+Repo-wide doc structure (root `CLAUDE.md` line cap, per-category README presence) is enforced by `scripts/check-docs.sh`. Three invocation points:
+
+```bash
+# Manual
+make lint-docs
+
+# Hook (automatic during AI work sessions)
+# Wired in .claude/settings.json → PostToolUse → check-docs-size.sh; fires on
+# Write|Edit of root CLAUDE.md or root docs/* and runs the script in advisory
+# mode (warns rather than blocking).
+
+# CI (follow-up enhancement, not yet wired)
+```
+
+Run `make lint-docs` after any edit to root `CLAUDE.md` or any file under root `docs/` to confirm the cap and per-category README invariants still hold.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -2,11 +2,12 @@
 # scripts/check-docs.sh — guards against root CLAUDE.md regrowth and missing category READMEs.
 # Run from the monorepo root.
 #
-# NOT YET WIRED INTO CI. v1 ships this as an advisory local check; the cap is enforced
-# only when a contributor remembers to run the script. Wiring it into .circleci/config.yml
-# (or a Makefile lint-docs target called from CI) is a follow-up — see the
-# 2026-04-27-claude-md-categorization design doc, "Open questions / future work".
-# Until then, run manually as part of the verification workflow.
+# Invocation points:
+#   - make lint-docs                                  (manual)
+#   - .claude/scripts/check-docs-size.sh              (Claude Code PostToolUse hook,
+#                                                      fires on Write|Edit of CLAUDE.md
+#                                                      or docs/* during AI work sessions)
+#   - CI integration is a follow-up enhancement.
 
 set -euo pipefail
 


### PR DESCRIPTION
Wire scripts/check-docs.sh into a top-level Makefile target (`make lint-docs`)
and a Claude Code PostToolUse hook that fires on Write|Edit of root CLAUDE.md
or root docs/* during AI work sessions. Follow-up to PR #859, which shipped
scripts/check-docs.sh as an advisory script with no automatic invocation.

The hook is advisory (warns rather than blocks) so it doesn't interfere with
the work session; CI integration remains a deferred follow-up per the original
design's Open Questions.

The path filter explicitly excludes service-level CLAUDE.md and service-level
docs paths (bin-*/CLAUDE.md, bin-*/docs/*) so editing a service file does not
trigger a check that only knows about root state.

- Makefile: Add top-level Makefile with lint-docs target wrapping scripts/check-docs.sh and .DEFAULT_GOAL := lint-docs so a bare make invocation runs the check; reserved for repo-wide checks that don't belong in any one service
- .claude/scripts: Add check-docs-size.sh PostToolUse hook script that filters Write|Edit events for root CLAUDE.md or root docs/* paths (rejecting bin-*/CLAUDE.md and bin-*/docs/* explicitly), runs scripts/check-docs.sh, and reports failures with [Hook]-prefixed messages; exits 0 even on failure (advisory)
- .claude: Wire check-docs-size.sh into .claude/settings.json PostToolUse hooks alongside the four existing hooks (check-magic-strings, check-rst-build, check-error-log-return, check-migration-table-names)
- scripts: Update check-docs.sh header comment to enumerate the three invocation points (make lint-docs, PostToolUse hook, CI as follow-up); drops the stale NOT YET WIRED note left over from the original v1 ship
- docs: Add a Documentation checks section to docs/workflows/verification-workflows.md describing the three invocation points so developers can find it when searching the docs after seeing a [Hook] warning