### PR TITLE
NOJIRA-audit-service-claude-md

### DIFF
--- a/bin-agent-manager/CLAUDE.md
+++ b/bin-agent-manager/CLAUDE.md
@@ -42,7 +42,7 @@ cmd/agent-manager/main.go
 - `pkg/listenhandler/`: RabbitMQ RPC request routing (REST-like paths: `/v1/agents`, `/v1/login`)
 - `pkg/subscribehandler/`: Event consumption from other services
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `POST /v1/agents` - Create agent
@@ -55,13 +55,13 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `PUT /v1/agents/<uuid>/tag_ids` - Update agent skill tags
 - `POST /v1/login` - Authenticate agent
 
-### Event Subscriptions
+## Event Subscriptions
 
 SubscribeHandler processes events from:
 - **call-manager**: `groupcall_created`, `groupcall_progressing` - Updates agent status when calls are routed
 - **customer-manager**: `customer_created`, `customer_deleted` - Creates/deletes guest agent on customer lifecycle
 
-### Configuration
+## Configuration
 
 Uses **Cobra + Viper** pattern (see `internal/config/`):
 - Command-line flags and environment variables (e.g., `--rabbitmq_address` or `RABBITMQ_ADDRESS`)

--- a/bin-agent-manager/CLAUDE.md
+++ b/bin-agent-manager/CLAUDE.md
@@ -11,6 +11,8 @@ This is the `bin-agent-manager` service, part of the VoIPbin monorepo. It manage
 - **Ring Method**: Strategy for routing calls to agents - "ringall" (all at once) or "linear" (sequential)
 - **Permission System**: Bitwise permission flags organized in levels (project: super admin; customer: agent/admin/manager)
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-agent-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern

--- a/bin-ai-manager/CLAUDE.md
+++ b/bin-ai-manager/CLAUDE.md
@@ -2,13 +2,22 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## Overview
 
-`bin-ai-manager` is a Go service within the VoipBin monorepo that manages AI-powered voice conversations. It orchestrates AI calls, processes messages through various LLM engines (OpenAI, Dialogflow, etc.), handles speech-to-text/text-to-speech operations, and integrates with the broader VoipBin telephony platform.
+`bin-ai-manager` is a Go service within the VoIPbin monorepo that manages AI-powered voice conversations. It orchestrates AI calls, processes messages through various LLM engines (OpenAI, Dialogflow, etc.), handles speech-to-text/text-to-speech operations, and integrates with the broader VoIPbin telephony platform.
+
+**Key Concepts:**
+- **AI**: Per-customer AI configuration (engine type, model, init prompt, TTS/STT settings).
+- **AIcall**: Active conversation session linking an AI configuration to a reference (call/conversation/task) with lifecycle status.
+- **Engine**: LLM provider integration (OpenAI, Dialogflow, Grok, Gemini, etc.); messages are routed to the configured engine handler.
+- **Tool**: Function-calling capability exposed to the LLM (`connect_call`, `send_email`, `set_variables`, etc.).
+- **Pipecat integration**: Real-time audio (STT → LLM → TTS) is delegated to `bin-pipecat-manager`; this service owns orchestration and persistence.
 
 This service operates as an event-driven microservice using RabbitMQ for message passing and Redis for caching.
 
-## Development Commands
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-ai-manager`.
+
+## Common Commands
 
 ### Testing
 ```bash
@@ -94,6 +103,13 @@ Uses same environment variables as ai-manager (`DATABASE_DSN`, `RABBITMQ_ADDRESS
 
 ## Architecture
 
+### Service Communication Pattern
+
+This service uses **RabbitMQ for event-driven RPC communication**:
+- **ListenHandler** (`pkg/listenhandler/`): Consumes RPC requests from queue `bin-manager.ai-manager.request` (routes: `/v1/ais`, `/v1/aicalls`, `/v1/messages`, `/v1/summaries`, `/v1/services`)
+- **SubscribeHandler** (`pkg/subscribehandler/`): Subscribes to call/transcribe/tts/pipecat events
+- **NotifyHandler**: Publishes AI lifecycle events to exchange `bin-manager.ai-manager.event`
+
 ### Core Components
 
 **Main Entry Point** (`cmd/ai-manager/main.go:30-178`)
@@ -159,17 +175,6 @@ Uses same environment variables as ai-manager (`DATABASE_DSN`, `RABBITMQ_ADDRESS
 - Individual message in a conversation
 - Supports tool calls for function calling capabilities
 - Direction: inbound/outbound, Role: system/user/assistant/tool
-
-### Integration Points
-
-**Monorepo Dependencies**
-This service depends on several sibling services in the monorepo:
-- `bin-common-handler`: Shared utilities (database, request/notify handlers, socket handling)
-- `bin-call-manager`: Telephony call management
-- `bin-pipecat-manager`: Real-time audio streaming with Pipecat framework
-- `bin-flow-manager`: Conversation flow orchestration
-
-All monorepo dependencies use `replace` directives in `go.mod` pointing to `../<service-name>`
 
 ### AI Manager and Pipecat Manager Relationship
 
@@ -273,6 +278,45 @@ Available tools:
 - Google Cloud Dialogflow API
 - OpenAI API (and other LLM providers)
 
+## Request Routing
+
+ListenHandler routes requests using regex patterns matching REST-like URIs (see `pkg/listenhandler/`):
+
+**AIs API (`/v1/ais/*`):**
+- `POST /v1/ais` — Create AI configuration
+- `GET /v1/ais?<filters>` — List AIs (pagination)
+- `GET /v1/ais/<uuid>` — Get AI configuration
+- `PUT /v1/ais/<uuid>` — Update AI configuration
+- `DELETE /v1/ais/<uuid>` — Delete AI configuration
+
+**AIcalls API (`/v1/aicalls/*`):**
+- `POST /v1/aicalls` — Start AI call session
+- `GET /v1/aicalls?<filters>` — List AI calls
+- `GET /v1/aicalls/<uuid>` — Get AI call
+- `POST /v1/aicalls/<uuid>/terminate` — Terminate AI call
+- `POST /v1/aicalls/<uuid>/pause` / `POST /v1/aicalls/<uuid>/resume` — Pause/resume
+
+**Messages API (`/v1/messages/*`):**
+- `POST /v1/messages` — Create message
+- `GET /v1/messages?<filters>` — List messages
+- `GET /v1/messages/<uuid>` — Get message
+
+**Summaries API (`/v1/summaries/*`):**
+- `POST /v1/summaries` — Create summary (async LLM)
+- `GET /v1/summaries/<uuid>` — Get summary
+- `GET /v1/summaries?<filters>` — List summaries
+
+**Services API (`/v1/services/*`):**
+- `POST /v1/services/type/aicall` — Create AI call service (used by flow-manager)
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.call-manager.event**: Call lifecycle events (hangup, conference join/leave) to drive AIcall state.
+- **bin-manager.transcribe-manager.event**: Transcription events for non-realtime AI flows.
+- **bin-manager.tts-manager.event**: TTS lifecycle events.
+- **bin-manager.pipecat-manager.event**: Pipecat session events (initialized, message arrived) — drives realtime conversation state.
+
 ### Event Flow Examples
 
 **Inbound AI Call Flow**
@@ -292,43 +336,49 @@ Available tools:
 4. Sends to OpenAI for summarization
 5. Updates summary record with result
 
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (database, request/notify handlers, socket handling)
+- `monorepo/bin-call-manager`: Telephony call management
+- `monorepo/bin-pipecat-manager`: Real-time audio streaming with Pipecat framework
+- `monorepo/bin-flow-manager`: Conversation flow orchestration
+
+`bin-ai-manager` is a per-pod-routing client of `bin-pipecat-manager`: follow-up RPCs target the Pipecat pod that owns the in-memory session via the per-pod queue convention. See `bin-pipecat-manager/CLAUDE.md` and [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md).
+
+Always run `go mod vendor` after changing dependencies.
+
 ## Testing Patterns
 
-- Tests use mockgen-generated mocks for dependencies
+Tests use **gomock** (go.uber.org/mock):
+- Mockgen-generated mocks for handler dependencies
 - Test files co-located with implementation: `<package>/<feature>_test.go`
 - Database operations tested with mock DBHandler
 - Example: `pkg/aicallhandler/start_test.go` tests AIcall creation with various scenarios
 
-## Configuration
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
 
-The service reads configuration from environment variables (though not explicitly shown in code, this is typical for the monorepo pattern):
-- Database DSN (MySQL connection string)
-- Redis address, password, database number
-- RabbitMQ address
-- Engine API keys (e.g., ChatGPT key)
-- Prometheus metrics endpoint
+## Key Implementation Details
 
-## Prometheus Metrics
-
-The service exports metrics on:
-- `ai_manager_aicall_create_total`: AIcalls created (by reference_type)
-- `ai_manager_aicall_end_total`: AIcalls ended (by reference_type)
-- `ai_manager_aicall_duration_seconds`: AIcall duration histogram (by reference_type)
-- `ai_manager_aicall_tool_execute_total`: Tool executions (by tool_name)
-- `ai_manager_message_create_total`: Messages created (by role)
-- `ai_manager_subscribe_event_process_time`: Event processing latency (by publisher and type)
-
-## CI/CD Pipeline
-
-See `.gitlab-ci.yml` for the full pipeline:
-- **ensure**: Download and vendor dependencies
-- **test**: Run linting (golint, golangci-lint), vet, and tests with coverage
-- **build**: Build Docker image and push to registry
-- **release**: Deploy to GKE using kustomize (manual trigger)
-
-## Common Patterns
-
-**Handler Pattern**
+### Handler Pattern
 All domain handlers follow this structure:
 ```go
 type FooHandler interface {
@@ -336,9 +386,8 @@ type FooHandler interface {
 }
 
 type fooHandler struct {
-    // dependencies injected
-    db DBHandler
-    reqHandler RequestHandler
+    db            DBHandler
+    reqHandler    RequestHandler
     notifyHandler NotifyHandler
 }
 
@@ -347,16 +396,53 @@ func NewFooHandler(...) FooHandler {
 }
 ```
 
-**Error Handling**
-- Errors are logged with logrus at the point of occurrence
-- Errors propagate up to the handler layer
-- HTTP-style status codes used in request/response even though transport is RabbitMQ
+### AIcall Lifecycle
+Status flow: `initiating` → `progressing` → (`pausing`/`resuming`) → `terminating` → `terminated`. Lifecycle is driven by RPC entrypoints and external events from `bin-pipecat-manager` and `bin-call-manager`.
 
-**Context Usage**
-- All public handler methods accept `context.Context` as first parameter
-- Used for cancellation and timeout propagation
-- Database and external API calls respect context
+### Engine Routing
+`MessageHandler` selects an engine handler based on the AI's `engine_type`:
+- `engine_openai_handler/`: OpenAI-compatible chat completions API (also used for Grok via base URL override).
+- `engine_dialogflow_handler/`: Google Dialogflow CX/ES.
 
-**UUID Usage**
-- All IDs are UUID v4 using `github.com/gofrs/uuid` package
-- Identity model from common-handler provides base ID/CustomerID fields
+### Tool Execution
+Tool definitions live in `pkg/toolhandler/definitions.go`; only tools enabled in the AI's `tool_names` field are exposed to the LLM. Pipecat invokes tools via HTTP POST to `AIcallHandler.ToolHandle()`, which dispatches to the appropriate manager.
+
+### Error Handling & Context
+- Errors are logged with logrus and propagated up to the handler layer
+- All public handler methods accept `context.Context` as the first parameter
+- IDs are UUID v4 (`github.com/gofrs/uuid`); identity model from `bin-common-handler` provides base `ID`/`CustomerID` fields
+
+## Configuration
+
+Uses **Viper + pflag** pattern (see `cmd/ai-manager/init.go`):
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `chatgpt_key` / `CHATGPT_KEY` | OpenAI API key | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+Engine-specific keys (Dialogflow service account, Grok/Gemini/Anthropic keys, etc.) are configured via the same env-var pattern.
+
+## Prometheus Metrics
+
+Service exports metrics on the configured endpoint (default `:2112/metrics`):
+- `ai_manager_aicall_create_total` — counter of AIcalls created (label `reference_type`)
+- `ai_manager_aicall_end_total` — counter of AIcalls ended (label `reference_type`)
+- `ai_manager_aicall_duration_seconds` — histogram of AIcall duration (label `reference_type`)
+- `ai_manager_aicall_tool_execute_total` — counter of tool executions (label `tool_name`)
+- `ai_manager_message_create_total` — counter of messages created (label `role`)
+- `ai_manager_subscribe_event_process_time` — histogram of event processing latency (labels `publisher`, `type`)
+
+## CI/CD Pipeline
+
+See `.gitlab-ci.yml` for the full pipeline:
+- **ensure**: Download and vendor dependencies
+- **test**: Run linting (golint, golangci-lint), vet, and tests with coverage
+- **build**: Build Docker image and push to registry
+- **release**: Deploy to GKE using kustomize (manual trigger)

--- a/bin-api-manager/CLAUDE.md
+++ b/bin-api-manager/CLAUDE.md
@@ -499,10 +499,14 @@ Runtime configuration via CLI flags (defined in `main.go`):
 - Middleware validates tokens on protected endpoints
 - Login endpoint: `/auth/login` generates JWT tokens
 
-### Testing Patterns
-- Mock generation using `go:generate` with `mockgen`
+## Testing Patterns
+
+- Mock generation using `go:generate` with `mockgen` (`gomock` / `go.uber.org/mock`)
 - Tests co-located with source files (`*_test.go`)
 - Mock files: `mock_*.go` in respective packages
+- Service handlers (`pkg/servicehandler/*`) use mocked `requesthandler` interfaces from `bin-common-handler` to assert RPC fan-out without real RabbitMQ
+- HTTP layer is generated from `bin-openapi-manager`'s OpenAPI spec via `oapi-codegen` (see `gens/openapi_server/gen.go`); tests target the service handlers, not the generated server bindings
+- Table-driven tests with struct slices are the dominant pattern; see [docs/conventions/testing.md](../docs/conventions/testing.md) for the canonical shape
 
 ## Authentication & Authorization
 

--- a/bin-api-manager/CLAUDE.md
+++ b/bin-api-manager/CLAUDE.md
@@ -4,9 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-`bin-api-manager` is a RESTful API gateway for the VoIPBIN platform that handles authentication, routing, and API requests to various backend managers. It's part of a Go monorepo architecture and serves as the public-facing API for the entire VoIPBIN system.
+`bin-api-manager` is a RESTful API gateway for the VoIPbin platform that handles authentication, routing, and API requests to various backend managers. It is the public-facing entrypoint for the entire VoIPbin system.
 
-## Build & Development Commands
+**Key Concepts:**
+- **API gateway, not a manager**: Owns authentication and authorization but defers all business logic to backend manager services via RabbitMQ RPC.
+- **OpenAPI-driven**: Server code is generated from `bin-openapi-manager/openapi/openapi.yaml`. The OpenAPI spec is the single source of truth for the public contract.
+- **WebhookMessage pattern**: All external responses return the `WebhookMessage` form of internal models (defined in each service's `models/<entity>/webhook.go`) to avoid leaking internal fields. See [docs/patterns/webhook-message.md](../docs/patterns/webhook-message.md) for details.
+- **Two-level handler pattern**: Private helpers (e.g., `callGet`) fetch resources without permission checks; public methods (e.g., `CallGet`) call the helper, run `hasPermission`, and return the converted `WebhookMessage`.
+- **RST docs co-located**: User-facing developer docs (`docsdev/`) are owned by this service. Built HTML is committed to git and served from production.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-api-manager`.
+
+## Common Commands
 
 ### Prerequisites
 The project requires ZMQ libraries for messaging:
@@ -622,29 +631,6 @@ if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin) {
 }
 ```
 
-## Git Workflow
-
-### Use Git Worktrees for Feature Development
-
-**CRITICAL: Never edit files directly in the main repository directory for feature work.**
-
-```bash
-# Create a worktree for your feature
-git worktree add ../worktrees/NOJIRA-feature-name -b NOJIRA-feature-name
-
-# Work in the worktree
-cd ../worktrees/NOJIRA-feature-name
-
-# When done, remove the worktree
-git worktree remove ../worktrees/NOJIRA-feature-name
-```
-
-**Why worktrees:**
-- Keeps main repository clean and always on `main` branch
-- Allows parallel work on multiple features
-- Easy to abandon work without affecting main workspace
-- Clear separation between exploration and implementation
-
 ## Common Workflows
 
 ### Adding a New API Endpoint
@@ -730,6 +716,89 @@ res, err := h.reqHandler.TimelineV1EventList(ctx, "call-manager", ...)
 
 ### Working with Database Changes
 Database operations go through `pkg/dbhandler/`. This wraps both MySQL and Redis caching. Don't bypass this abstraction.
+
+## Request Routing
+
+`bin-api-manager` exposes the public REST API. Endpoints are defined in `bin-openapi-manager/openapi/openapi.yaml`; server code is generated under `gens/openapi_server/`. Concrete handlers live in `server/` and delegate to `pkg/servicehandler/`.
+
+Top-level resource groups (each maps to a backend manager via RabbitMQ RPC):
+- `/v1.0/auth/*` — login, JWT issuance
+- `/v1.0/customer`, `/v1.0/customers/*` — customer profile (singular = self, plural = admin)
+- `/v1.0/agents/*`, `/v1.0/calls/*`, `/v1.0/conferences/*`, `/v1.0/flows/*`, `/v1.0/activeflows/*`
+- `/v1.0/recordings/*`, `/v1.0/transcribes/*`, `/v1.0/numbers/*`, `/v1.0/queues/*`
+- `/v1.0/conversations/*`, `/v1.0/messages/*`, `/v1.0/emails/*`
+- `/v1.0/billings/*`, `/v1.0/billing-accounts/*` — Admin only (CustomerAdmin)
+- `/v1.0/ais/*`, `/v1.0/aicalls/*`, `/v1.0/rags/*`
+- WebSocket endpoints: `/ws/*` (real-time event streaming)
+- Audio streaming endpoint on the audiosocket protocol (port 9000)
+
+See `bin-openapi-manager/openapi/openapi.yaml` for the authoritative endpoint list.
+
+## Event Subscriptions
+
+`bin-api-manager` consumes events from backend managers and re-emits them as customer-facing webhooks and WebSocket frames:
+- **Subscriber**: `pkg/subscribehandler/` — subscribes to event queues from call-manager, flow-manager, conversation-manager, message-manager, ai-manager, billing-manager, etc.
+- **WebSocket fan-out**: `pkg/websockhandler/` pushes events to authenticated WebSocket clients filtered by customer.
+- **Webhook delivery**: Events are forwarded to `bin-webhook-manager` for HTTP webhook delivery to customer endpoints.
+- **ZMQ pub/sub**: `pkg/zmqpubhandler/`, `pkg/zmqsubhandler/` for internal pub/sub events.
+
+## Monorepo Context
+
+`bin-api-manager` is the only service that depends on most of the monorepo. `go.mod` contains `replace` directives for ~20 sibling managers (call, flow, ai, storage, webhook, agent, billing, campaign, chat, conference, conversation, customer, email, hook, message, number, outdial, pipecat, queue, registrar, route, sentinel, storage, talk, tag, timeline, transcribe, transfer, tts, webhook).
+
+When models change in any backend service:
+1. Update the corresponding OpenAPI schema in `bin-openapi-manager/openapi/openapi.yaml` (compare against the backend service's `WebhookMessage` struct, not the internal model — see [docs/patterns/webhook-message.md](../docs/patterns/webhook-message.md)).
+2. Regenerate openapi types: `cd ../bin-openapi-manager && go generate ./...`
+3. Regenerate this service's server code: `cd ../bin-api-manager && go generate ./...`
+4. Run the verification workflow.
+
+**RST documentation lives here.** Updates to user-facing API behavior require updating `docsdev/source/*.rst` and rebuilding HTML — see [docs/workflows/special-cases.md](../docs/workflows/special-cases.md) for the full procedure.
+
+## Key Implementation Details
+
+### Two-Level Handler Pattern
+For every resource, define a private helper that fetches without permission checks, then a public method that calls the helper, runs `hasPermission`, and returns the `WebhookMessage`. See [docs/patterns/webhook-message.md](../docs/patterns/webhook-message.md) and the Authorization Check Pattern above.
+
+### OpenAPI-First Workflow
+Never modify api-manager handler code without first updating `bin-openapi-manager/openapi/openapi.yaml`. The generated types are the contract; hand-edited types drift and break clients.
+
+### WebhookMessage Conversion
+External responses MUST go through `.ConvertWebhookMessage()`. Returning the internal struct leaks fields like `PodID`, `Username`, `PermissionIDs`. RST struct docs (`*_struct_*.rst`) MUST match `WebhookMessage` fields, not the internal model.
+
+### Service Name Constants
+Use `commonoutline.ServiceName*` (from `bin-common-handler/models/outline/servicename.go`) instead of string literals. Compile-time checking prevents typos.
+
+### Audio Streaming
+Audio streaming uses the audiosocket protocol on port 9000 (see `pkg/streamhandler/`). Used by AI/Pipecat features.
+
+### SSL Certificates
+SSL certificates are passed as base64-encoded environment variables/flags (`-ssl_cert_base64`, `-ssl_private_base64`) and decoded at startup.
+
+## Configuration
+
+Runtime configuration via CLI flags / environment variables (defined in `cmd/api-manager/main.go`):
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `-dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `-rabbit_addr` / `RABBITMQ_ADDRESS` | RabbitMQ address | required |
+| `-redis_addr` / `REDIS_ADDRESS` | Redis address | required |
+| `-jwt_key` / `JWT_KEY` | JWT signing key | required |
+| `-gcp_project_id` / `GCP_PROJECT_ID` | GCP project for storage integration | optional |
+| `-gcp_bucket_name` / `GCP_BUCKET_NAME` | GCS bucket for media | optional |
+| `-ssl_cert_base64` / `SSL_CERT_BASE64` | Base64-encoded SSL certificate | optional |
+| `-ssl_private_base64` / `SSL_PRIVATE_BASE64` | Base64-encoded SSL private key | optional |
+| `-prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `-prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `api_manager_receive_request_process_time` — histogram of HTTP request processing time (labels: method, path)
+- `api_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)
+- `api_manager_websocket_connections` — gauge of active WebSocket connections
+
+This service also benefits from per-target circuit-breaker metrics that `bin-common-handler/pkg/requesthandler` registers under the `api_manager_*` namespace (see [docs/patterns/circuit-breaker.md](../docs/patterns/circuit-breaker.md)).
 
 ## Key Dependencies
 - **gin-gonic/gin**: HTTP router and middleware

--- a/bin-billing-manager/CLAUDE.md
+++ b/bin-billing-manager/CLAUDE.md
@@ -181,7 +181,7 @@ cmd/billing-manager/main.go
 - `pkg/listenhandler/`: RabbitMQ RPC request routing (REST-like paths: `/v1/accounts`, `/v1/billings`)
 - `pkg/subscribehandler/`: Event consumption from other services for billing triggers
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 
@@ -199,7 +199,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 **Billings:**
 - `GET /v1/billings?<filters>` - List billing records (pagination via page_size/page_token)
 
-### Event Subscriptions
+## Event Subscriptions
 
 SubscribeHandler processes events from:
 - **call-manager**: `call_progressing`, `call_hangup` - Creates/updates billing for calls
@@ -207,7 +207,7 @@ SubscribeHandler processes events from:
 - **customer-manager**: `customer_created`, `customer_deleted` - Creates/deletes billing accounts
 - **number-manager**: `number_created`, `number_renewed` - Creates billing for number purchases/renewals
 
-### Configuration
+## Configuration
 
 Uses **Viper + pflag** pattern (see `cmd/billing-manager/init.go`):
 - Command-line flags and environment variables (e.g., `--database_dsn` or `DATABASE_DSN`)

--- a/bin-billing-manager/CLAUDE.md
+++ b/bin-billing-manager/CLAUDE.md
@@ -4,11 +4,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-`bin-billing-manager` is a Go service within the VoIPBin monorepo that manages billing operations for telecommunications services. It tracks account balances, processes billing for calls/SMS/numbers, handles payment information, and publishes billing events to the platform.
+`bin-billing-manager` is a Go service within the VoIPbin monorepo that manages billing operations for telecommunications services. It tracks account balances, processes billing for calls/SMS/numbers, handles payment information (including Paddle webhooks), and publishes billing events to the platform.
+
+**Key Concepts:**
+- **Account**: Billing account per customer with balance, payment type, and plan (e.g., `unlimited` plans bypass balance checks).
+- **Billing**: A record for a billable event (call, SMS, number purchase, number renewal) with cost-per-unit and total cost.
+- **FailedEvent**: Persisted retry queue for billing operations that failed downstream (hard-deleted on success).
+- **Paddle integration**: Subscription and transaction webhooks drive plan upgrades, balance top-ups, and customer state.
 
 This service operates as an event-driven microservice using RabbitMQ for message passing and Redis for caching.
 
-## Development Commands
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-billing-manager`.
+
+## Common Commands
 
 ### Testing
 ```bash

--- a/bin-call-manager/CLAUDE.md
+++ b/bin-call-manager/CLAUDE.md
@@ -15,6 +15,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **External Media**: WebRTC or external media streams integrated into calls/conferences
 - **Group Call**: Multi-party call group managing multiple simultaneous calls
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-call-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern

--- a/bin-call-manager/CLAUDE.md
+++ b/bin-call-manager/CLAUDE.md
@@ -56,7 +56,7 @@ cmd/call-manager/main.go
 - `pkg/subscribehandler/`: Event consumption and processing
 - `pkg/arieventhandler/`: Asterisk ARI event processing (channel/bridge state changes)
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 
@@ -118,7 +118,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 **Recovery API**:
 - `POST /v1/recovery` - Recover call state from Homer SIP capture
 
-### Event Subscriptions
+## Event Subscriptions
 
 SubscribeHandler subscribes to these RabbitMQ queues:
 - **asterisk.all.event**: All Asterisk ARI events (channel/bridge state changes, DTMF, playback, recording)
@@ -133,7 +133,7 @@ Processes events including:
 - **Playback Events**: PlaybackStarted, PlaybackFinished
 - **Contact Events**: ContactStatusChange (SIP registration changes)
 
-### Configuration
+## Configuration
 
 Uses **Viper + pflag** pattern (see `cmd/call-manager/init.go:47-180`):
 - Command-line flags and environment variables (e.g., `--rabbitmq_address` or `RABBITMQ_ADDRESS`)

--- a/bin-campaign-manager/CLAUDE.md
+++ b/bin-campaign-manager/CLAUDE.md
@@ -288,6 +288,7 @@ Tests use **gomock** (go.uber.org/mock):
 - Generate mocks via `go generate ./...` before running tests
 - Tests should not require external services (use mocks)
 - Event handling tests verify proper event routing and handler invocation
+- Database tests use in-memory SQLite when possible (see `pkg/dbhandler/main_test.go`, which loads `github.com/mattn/go-sqlite3` and `file::memory:` to exercise dbhandler logic without a live MySQL)
 
 ```go
 tests := []struct {

--- a/bin-campaign-manager/CLAUDE.md
+++ b/bin-campaign-manager/CLAUDE.md
@@ -4,9 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-`bin-campaign-manager` is a Go microservice that manages outbound calling campaigns within a VoIP platform. It orchestrates campaign execution, manages individual calls, and coordinates with other microservices via RabbitMQ message broker.
+`bin-campaign-manager` is a Go microservice that manages outbound calling campaigns within a VoIP platform. It orchestrates campaign execution, manages individual calls, and coordinates with other microservices via the RabbitMQ message broker.
 
-## Development Commands
+**Key Concepts:**
+- **Campaign**: An outbound campaign linking an outplan (dial config), an outdial (target list), and optionally a queue, with status `stop`/`run`/`stopping`.
+- **Campaigncall**: A single call attempt within a campaign with up to 5 destination addresses and independent retry counts; references either a Call or an Activeflow.
+- **Outplan**: Dialing configuration (timeouts, retry intervals, max try counts, source address) shared across multiple campaigns.
+- **Service Level**: Percentage-based throttle on concurrent dialing based on queue agent availability.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-campaign-manager`.
+
+## Common Commands
 
 ### Build
 ```bash
@@ -150,12 +158,40 @@ All business logic is organized into handler packages with interface-first desig
 **ListenHandler** (`pkg/listenhandler/`): RabbitMQ RPC server
 - Processes incoming API requests from "campaign_request" queue
 - Routes to appropriate handler based on URI pattern and HTTP method
-- Endpoints: `/v1/campaigns`, `/v1/campaigncalls`, `/v1/outplans`
 
 **SubscribeHandler** (`pkg/subscribehandler/`): Event subscriber
 - Listens to events from call-manager and flow-manager
-- Processes: `call_hungup` and `activeflow_deleted` events
 - Updates campaigncall status and triggers campaign state changes
+
+## Request Routing
+
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
+
+**Campaigns API (`/v1/campaigns/*`):**
+- `POST /v1/campaigns` — Create campaign
+- `GET /v1/campaigns?<filters>` — List campaigns (pagination)
+- `GET /v1/campaigns/<uuid>` — Get campaign
+- `PUT /v1/campaigns/<uuid>` — Update campaign basic info
+- `PUT /v1/campaigns/<uuid>/status` — Update status (`run`/`stop`/`stopping`)
+- `DELETE /v1/campaigns/<uuid>` — Delete campaign
+
+**Campaigncalls API (`/v1/campaigncalls/*`):**
+- `GET /v1/campaigncalls?<filters>` — List campaigncalls
+- `GET /v1/campaigncalls/<uuid>` — Get campaigncall
+- `DELETE /v1/campaigncalls/<uuid>` — Delete campaigncall
+
+**Outplans API (`/v1/outplans/*`):**
+- `POST /v1/outplans` — Create outplan
+- `GET /v1/outplans?<filters>` — List outplans
+- `GET /v1/outplans/<uuid>` — Get outplan
+- `PUT /v1/outplans/<uuid>` — Update outplan
+- `DELETE /v1/outplans/<uuid>` — Delete outplan
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.call-manager.event**: `call_hangup` → marks campaigncall as done; drives campaign `run` → `stop` transitions when no more targets remain.
+- **bin-manager.flow-manager.event**: `activeflow_deleted` → marks campaigncall as done (for `TypeFlow` campaigns).
 
 ### Event-Driven Communication
 
@@ -199,21 +235,26 @@ All business logic is organized into handler packages with interface-first desig
 5. If no more targets or manual stop → Campaign transitions to Stop
 ```
 
-### Key Design Patterns
+## Key Implementation Details
 
-**Interface-Based Design**: All handlers are interfaces with mock implementations for testing (generated via `go generate`)
+### Interface-Based Design
+All handlers are interfaces with mock implementations for testing (generated via `go generate`).
 
-**Soft Deletes**: All models use `tm_delete` timestamp (default: "9999-01-01 00:00:000"). Deleted records are marked with actual deletion time.
+### Soft Deletes
+All models use `tm_delete` timestamp (default: `"9999-01-01 00:00:000"`). Deleted records are marked with actual deletion time.
 
-**Service Level Queuing**: Campaigns can limit concurrent dialing based on queue agent availability:
+### Service Level Queuing
+Campaigns can limit concurrent dialing based on queue agent availability:
 ```
 agent_capacity = (available_agents × service_level) / 100
 dialing_allowed = current_dialing_count < agent_capacity
 ```
 
-**Recursive Execution**: Campaign execute uses goroutine-based recursive scheduling rather than persistent job queue
+### Recursive Execution
+Campaign `Execute()` uses goroutine-based recursive scheduling (500 ms delay between iterations) rather than a persistent job queue.
 
-**Multi-Destination Retry Logic**: Each campaigncall supports 5 destination addresses with independent retry tracking (destination_0 through destination_4, try_count_0 through try_count_4)
+### Multi-Destination Retry Logic
+Each campaigncall supports 5 destination addresses with independent retry tracking (`destination_0` through `destination_4`, `try_count_0` through `try_count_4`).
 
 ## Configuration
 
@@ -240,13 +281,39 @@ When making changes that affect other services, coordinate changes across:
 - `bin-queue-manager`: Queue and agent tracking
 - `bin-common-handler`: Shared models and utilities
 
-## Testing Considerations
+## Testing Patterns
 
+Tests use **gomock** (go.uber.org/mock):
 - All handlers have interface definitions for mockability
 - Generate mocks via `go generate ./...` before running tests
 - Tests should not require external services (use mocks)
-- Database tests use in-memory SQLite when possible (see `dbhandler/main_test.go`)
 - Event handling tests verify proper event routing and handler invocation
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `campaign_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `campaign_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)
 
 ## Important Files
 

--- a/bin-conference-manager/CLAUDE.md
+++ b/bin-conference-manager/CLAUDE.md
@@ -50,7 +50,7 @@ cmd/conference-manager/main.go
 - `pkg/listenhandler/`: RabbitMQ RPC request routing (REST-like paths)
 - `pkg/subscribehandler/`: Event consumption from call-manager
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 
@@ -76,7 +76,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 **Services API**:
 - `POST /v1/services/type/conferencecall` - Create conferencecall service (used by flow-manager)
 
-### Event Subscriptions
+## Event Subscriptions
 
 SubscribeHandler subscribes to these RabbitMQ queues:
 - **bin-manager.call-manager.event**: Conference bridge join/leave events
@@ -85,7 +85,7 @@ Processes events including:
 - **confbridge_joined**: When a call joins a confbridge, updates conferencecall status to `joined`
 - **confbridge_leaved**: When a call leaves a confbridge, terminates the conferencecall
 
-### Conference-Call Relationship
+## Conference-Call Relationship
 
 The service manages a two-layer architecture:
 1. **Conference layer** (`pkg/conferencehandler`): High-level conference coordination
@@ -100,7 +100,7 @@ The service manages a two-layer architecture:
    - Performs health checks on participants
    - Auto-terminates based on conference type rules
 
-### Configuration
+## Configuration
 
 Uses **Viper + pflag** pattern (see `cmd/conference-manager/init.go`):
 - Command-line flags and environment variables (e.g., `--rabbitmq_address` or `RABBITMQ_ADDRESS`)

--- a/bin-conference-manager/CLAUDE.md
+++ b/bin-conference-manager/CLAUDE.md
@@ -15,6 +15,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `queue`: Special conference type for queue operations
 - **Confbridge**: The underlying Asterisk conference bridge managed by call-manager
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-conference-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern

--- a/bin-contact-manager/CLAUDE.md
+++ b/bin-contact-manager/CLAUDE.md
@@ -4,9 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-contact-manager is a Go microservice for managing CRM-style contact records in a VoIP system. It provides CRUD operations for contacts with support for multiple phone numbers, emails, and tag assignments. It also supports contact lookup by phone number (E.164) or email for caller ID enrichment.
+`bin-contact-manager` is a Go microservice for managing CRM-style contact records in a VoIP system. It provides CRUD operations for contacts with support for multiple phone numbers, emails, and tag assignments. It also supports contact lookup by phone number (E.164) or email for caller ID enrichment.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Contact**: A CRM record (first/last name, display name, company, job title, source, external_id, notes) belonging to a customer.
+- **PhoneNumber / Email**: 1:N child records on a contact for multi-number / multi-email support.
+- **Tag assignment**: Many-to-many link between contacts and tags managed in `bin-tag-manager`.
+- **Lookup**: O(1) lookup by E.164 phone or email for caller-ID enrichment in inbound flows.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-contact-manager`.
+
+## Common Commands
 
 ```bash
 # Build the service and CLI
@@ -112,63 +120,108 @@ Event Flow:
 RabbitMQ Event → subscribehandler → contacthandler → cleanup operations
 ```
 
-### Configuration
-
-Environment variables / flags:
-- `DATABASE_DSN` - MySQL connection string (default: `testid:testpassword@tcp(127.0.0.1:3306)/test`)
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (default: `amqp://guest:guest@localhost:5672`)
-- `REDIS_ADDRESS` - Redis server address (default: `127.0.0.1:6379`)
-- `REDIS_PASSWORD` - Redis password (default: empty)
-- `REDIS_DATABASE` - Redis database index (default: `1`)
-- `PROMETHEUS_ENDPOINT` - Metrics endpoint path (default: `/metrics`)
-- `PROMETHEUS_LISTEN_ADDRESS` - Metrics server address (default: `:2112`)
-
-### API Endpoints (via RabbitMQ RPC)
+## Request Routing
 
 The service handles REST-like requests through RabbitMQ with URI pattern matching:
 
-**Contacts:**
-- `GET /v1/contacts?<params>` - List contacts with pagination and filters
-- `POST /v1/contacts` - Create new contact (with optional phone numbers, emails, tags)
-- `GET /v1/contacts/{contact-id}` - Get specific contact
-- `PUT /v1/contacts/{contact-id}` - Update contact basic fields
-- `DELETE /v1/contacts/{contact-id}` - Soft delete contact
-- `GET /v1/contacts/lookup?customer_id=<uuid>&phone_e164=<e164>` - Lookup by phone
-- `GET /v1/contacts/lookup?customer_id=<uuid>&email=<email>` - Lookup by email
+**Contacts API (`/v1/contacts/*`):**
+- `GET /v1/contacts?<params>` — List contacts with pagination and filters
+- `POST /v1/contacts` — Create new contact (with optional phone numbers, emails, tags)
+- `GET /v1/contacts/{contact-id}` — Get specific contact
+- `PUT /v1/contacts/{contact-id}` — Update contact basic fields
+- `DELETE /v1/contacts/{contact-id}` — Soft delete contact
+- `GET /v1/contacts/lookup?customer_id=<uuid>&phone_e164=<e164>` — Lookup by phone
+- `GET /v1/contacts/lookup?customer_id=<uuid>&email=<email>` — Lookup by email
 
-**Phone Numbers:**
-- `POST /v1/contacts/{contact-id}/phone-numbers` - Add phone number to contact
-- `DELETE /v1/contacts/{contact-id}/phone-numbers/{phone-id}` - Remove phone number
+**Phone Numbers API:**
+- `POST /v1/contacts/{contact-id}/phone-numbers` — Add phone number to contact
+- `DELETE /v1/contacts/{contact-id}/phone-numbers/{phone-id}` — Remove phone number
 
-**Emails:**
-- `POST /v1/contacts/{contact-id}/emails` - Add email to contact
-- `DELETE /v1/contacts/{contact-id}/emails/{email-id}` - Remove email
+**Emails API:**
+- `POST /v1/contacts/{contact-id}/emails` — Add email to contact
+- `DELETE /v1/contacts/{contact-id}/emails/{email-id}` — Remove email
 
-**Tags:**
-- `POST /v1/contacts/{contact-id}/tags` - Add tag to contact
-- `DELETE /v1/contacts/{contact-id}/tags/{tag-id}` - Remove tag from contact
+**Tags API:**
+- `POST /v1/contacts/{contact-id}/tags` — Add tag to contact
+- `DELETE /v1/contacts/{contact-id}/tags/{tag-id}` — Remove tag from contact
 
-### Event Types Published
+**Events Published:**
+- `contact_created` — when a new contact is created
+- `contact_updated` — when contact information is updated
+- `contact_deleted` — when a contact is deleted
 
-- `contact_created` - When a new contact is created
-- `contact_updated` - When contact information is updated
-- `contact_deleted` - When a contact is deleted
+## Event Subscriptions
 
-### Database Tables
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: `customer_deleted` → cascading deletion of contacts owned by the deleted customer.
 
-- `contact_manager_contact` - Main contact records
-- `contact_manager_phone_number` - Phone numbers linked to contacts
-- `contact_manager_email` - Email addresses linked to contacts
-- `contact_manager_tag_assignment` - Tag assignments linking contacts to tags
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
+- `monorepo/bin-customer-manager`: Customer event models (cascading deletes)
+- `monorepo/bin-tag-manager`: Tag definitions used for contact tagging
+
+Contacts can be mapped to `commonaddress.Address` for call routing — mapping is done by consuming services.
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
 
 ### Cache Strategy
+Contacts are cached in Redis for fast lookups; cache is invalidated on updates and deletions. Uses `pkg/cachehandler` for all Redis operations.
 
-- Contacts are cached in Redis for fast lookups
-- Cache is invalidated on updates and deletions
-- Uses `pkg/cachehandler` for all Redis operations
+### Database Tables
+- `contact_manager_contact` — Main contact records
+- `contact_manager_phone_number` — Phone numbers linked to contacts
+- `contact_manager_email` — Email addresses linked to contacts
+- `contact_manager_tag_assignment` — Tag assignments linking contacts to tags
 
-### Integration with Other Services
+### Soft Deletes
+Records use `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records).
 
-- **bin-tag-manager**: Provides tag definitions used for contact tagging
-- **bin-customer-manager**: Provides customer context; contacts are cleaned up when customers are deleted
-- **commonaddress.Address**: Contacts can be mapped to addresses for call routing (mapping done by consuming services)
+## Configuration
+
+Environment variables / flags:
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | `testid:testpassword@tcp(127.0.0.1:3306)/test` |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | `amqp://guest:guest@localhost:5672` |
+| `redis_address` / `REDIS_ADDRESS` | Redis server | `127.0.0.1:6379` |
+| `redis_password` / `REDIS_PASSWORD` | Redis password | empty |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | `1` |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `contact_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `contact_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-conversation-manager/CLAUDE.md
+++ b/bin-conversation-manager/CLAUDE.md
@@ -12,6 +12,8 @@ This is the `bin-conversation-manager` service, part of the VoIPbin monorepo. It
 - **Account**: Platform-specific credentials (LINE channel secret/token, SMS provider credentials) for sending messages
 - **Dialog ID**: External platform conversation identifier (LINE chatroom ID, SMS thread ID)
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-conversation-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern

--- a/bin-conversation-manager/CLAUDE.md
+++ b/bin-conversation-manager/CLAUDE.md
@@ -53,7 +53,7 @@ cmd/conversation-manager/main.go
 - `pkg/listenhandler/`: RabbitMQ RPC request routing (REST-like paths)
 - `pkg/subscribehandler/`: Event consumption from message-manager
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 
@@ -82,12 +82,12 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `POST /v1/hooks` - Generic webhook endpoint
 - `POST /v1/setup` - Setup/configuration webhook
 
-### Event Subscriptions
+## Event Subscriptions
 
 SubscribeHandler processes events from:
 - **message-manager**: `message_created` - Creates conversation and message records when SMS/MMS received
 
-### Webhook Processing
+## Webhook Processing
 
 The service receives webhooks from external platforms:
 - **LINE**: Incoming messages via LINE Bot SDK webhook (parsed in `pkg/linehandler/hook.go`)
@@ -96,7 +96,7 @@ The service receives webhooks from external platforms:
   - Publishes conversation/message events
 - Hook URI pattern: `/v1.0/conversation/accounts/<account_id>`
 
-### Configuration
+## Configuration
 
 Uses **Viper + pflag** pattern (see `cmd/conversation-manager/init.go`):
 - Command-line flags and environment variables (e.g., `--rabbitmq_address` or `RABBITMQ_ADDRESS`)

--- a/bin-customer-manager/CLAUDE.md
+++ b/bin-customer-manager/CLAUDE.md
@@ -44,7 +44,7 @@ cmd/customer-manager/main.go
 - `pkg/cachehandler/`: Redis caching for customer/accesskey lookups (cache-first pattern)
 - `pkg/listenhandler/`: RabbitMQ RPC request routing with REST-like path patterns
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 
@@ -63,7 +63,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `PUT /v1/accesskeys/<id>` - Update access key basic info
 - `DELETE /v1/accesskeys/<id>` - Delete access key
 
-### Event Publishing
+## Event Publishing
 
 Customer operations publish events to `bin-manager.customer-manager.event`:
 - `customer_created`, `customer_updated`, `customer_deleted`

--- a/bin-customer-manager/CLAUDE.md
+++ b/bin-customer-manager/CLAUDE.md
@@ -12,6 +12,8 @@ This is the `bin-customer-manager` service, part of the VoIPbin monorepo. It man
 - **Soft Deletes**: Records use `tm_delete` timestamp (default `"9999-01-01 00:00:00.000000"` for active records)
 - **Webhook Events**: Customer changes trigger webhook notifications via RabbitMQ for async delivery
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-customer-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern
@@ -69,7 +71,11 @@ Customer operations publish events to `bin-manager.customer-manager.event`:
 
 Webhook notifications are created and queued for async delivery to customer webhook URIs.
 
-### Configuration
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler — customer state is driven entirely by inbound RPC.
+
+## Configuration
 
 Uses **Cobra + Viper** pattern (see `internal/config/`):
 - Command-line flags and environment variables (e.g., `--rabbitmq_address` or `RABBITMQ_ADDRESS`)

--- a/bin-dbscheme-manager/CLAUDE.md
+++ b/bin-dbscheme-manager/CLAUDE.md
@@ -4,14 +4,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Database schema management for VoIPBin using Alembic migrations. This repository manages two separate database schemas:
+`bin-dbscheme-manager` is the canonical home for database schema management in VoIPbin using Alembic migrations. This repository manages two separate database schemas:
 
-- **bin-manager** - VoIPBin core database (`voipbin` database)
-- **asterisk_config** - Asterisk-related database (`asterisk` database)
+- **bin-manager** — VoIPbin core database (`voipbin` database)
+- **asterisk_config** — Asterisk-related database (`asterisk` database)
 
 Each directory maintains its own Alembic migration history with separate `alembic.ini` configurations and `versions/` directories.
 
-## Database Architecture
+**Key Concepts:**
+- **Two independent migration streams** — `bin-manager/main/versions/` and `asterisk_config/config/versions/`. Never mix them.
+- **`alembic revision` is the only safe way to create migration files** — handpicked revision IDs collide.
+- **VPN required for production migrations** — staging and production database access is gated by VPN.
+- **Schema dumps baked into Docker image** — the production image has migrations applied during build, not at runtime.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, RST sync, the general "Database via Alembic only" rule) live in the root [CLAUDE.md](../CLAUDE.md). This file is the authoritative reference for Alembic-specific procedures.
+
+## Architecture
+
+### Database Architecture
 
 **Two Independent Migration Streams:**
 - `bin-manager/` → manages `voipbin` MySQL database
@@ -178,10 +188,49 @@ alembic -c alembic.ini revision -m "ai_aicalls add column current_member_id"
 2. Add your SQL to the `upgrade()` and `downgrade()` functions
 3. Verify with `alembic -c alembic.ini heads` — should show exactly one head
 
+## Request Routing
+
+N/A — schema-management tool, not a runtime service. No `cmd/` entrypoint, no listen queue.
+
+## Event Subscriptions
+
+N/A — runs as a Kubernetes Job, not a long-lived service. No SubscribeHandler.
+
+## Monorepo Context
+
+This repository is referenced by other services indirectly: every Go manager service that uses MySQL relies on the schema produced here. Changes to the schema do not require `replace` directives because there is no Go module dependency — the contract is the database itself.
+
+When adding a `db:` tag to a Go model, you MUST also create a corresponding Alembic migration here. Updating the schema in `scripts/database_scripts/table_*.sql` (used in tests) without a migration breaks production.
+
+## Testing Patterns
+
+- Migrations are validated against a temporary local MariaDB during the Docker build (see "Docker Build Process" above). If a migration is malformed or conflicts, the Docker build fails.
+- Verify locally with `alembic -c alembic.ini heads` — expect exactly one head per migration stream.
+- Run `alembic -c alembic.ini upgrade head` against a throwaway local database before pushing to confirm the migration applies cleanly.
+
+## Key Implementation Details
+
+### Migration File Generation
+ALWAYS use `alembic -c alembic.ini revision -m "<message>"` to generate migration files. Hand-picked revision IDs collide with existing migrations. See "CRITICAL: Never Manually Create Migration Files" above for the full rationale.
+
+### Collation Compatibility Patches
+The Docker build exports schema dumps with collation patches (`utf8mb4_uca1400_ai_ci` → `utf8mb4_general_ci`) to keep dumps importable by MySQL 8.0.
+
+### Two-Database Discipline
+Always work within the appropriate subdirectory (`bin-manager/` or `asterisk_config/`) when running Alembic commands. Each directory has its own independent migration chain — never mix them. The `-c alembic.ini` flag is required for all Alembic commands since the config file is in the subdirectory.
+
+## Configuration
+
+Configuration lives in the per-subdirectory `alembic.ini` files. Both files are gitignored — copy from `alembic.ini.sample` and set `sqlalchemy.url` to your database connection string. There are no environment-variable runtime configs because this is a schema tool, not a service.
+
+## Prometheus Metrics
+
+N/A — runs as a Kubernetes Job and exits after completing migrations. No metrics surface.
+
 ## Important Notes
 
 - Always work within the appropriate subdirectory (`bin-manager/` or `asterisk_config/`) when running Alembic commands
-- Each directory has its own independent migration chain - never mix them
+- Each directory has its own independent migration chain — never mix them
 - The `-c alembic.ini` flag is required for all Alembic commands since the config file is in the subdirectory
 - Migration files should include both `upgrade()` and `downgrade()` functions for rollback capability
 - VPN connection is mandatory for running migrations against remote databases

--- a/bin-email-manager/CLAUDE.md
+++ b/bin-email-manager/CLAUDE.md
@@ -12,6 +12,8 @@ This is the `bin-email-manager` service, part of the VoIPBin monorepo. It manage
 - **Webhook Integration**: Processes delivery status callbacks from providers to update email states
 - **Attachment Support**: Links to storage-manager for including recordings/files in emails
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-email-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern
@@ -74,12 +76,23 @@ Attachments reference files via `AttachmentReferenceType`:
 - Uses `requesthandler` to fetch file URLs from storage service
 - Attachments fetched and attached before sending via provider
 
-### Configuration
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler — provider delivery status is received via inbound `POST /v1/hooks` webhooks (proxied through `bin-hook-manager`).
+
+## Configuration
 
 Uses **pflag + Viper** pattern (see `cmd/email-manager/init.go`):
-- Command-line flags and environment variables (e.g., `--sendgrid_api_key` or `SENDGRID_API_KEY`)
-- Required: `database_dsn`, `rabbitmq_address`, `redis_address`, `prometheus_endpoint`
-- Provider-specific: `sendgrid_api_key`, `mailgun_api_key`
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `sendgrid_api_key` / `SENDGRID_API_KEY` | SendGrid API key | required |
+| `mailgun_api_key` / `MAILGUN_API_KEY` | Mailgun API key | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
 ## Common Commands
 

--- a/bin-email-manager/CLAUDE.md
+++ b/bin-email-manager/CLAUDE.md
@@ -46,7 +46,7 @@ cmd/email-manager/main.go
 - `pkg/cachehandler/`: Redis caching
 - `pkg/listenhandler/`: RabbitMQ RPC request routing (REST-like paths: `/v1/emails`, `/v1/hooks`)
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `POST /v1/emails` - Create and send email
@@ -55,7 +55,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `DELETE /v1/emails/<uuid>` - Delete email
 - `POST /v1/hooks` - Process webhook events from providers (query param: `?uri=/v1/hooks/sendgrid` or `?uri=/v1/hooks/mailgun`)
 
-### Provider Integration
+## Provider Integration
 
 **Multi-Provider Strategy:**
 - Emails attempt delivery via SendGrid first, then Mailgun if SendGrid fails
@@ -69,7 +69,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 - Also handles: `bounce`, `dropped`, `deferred`, `unsubscribe`, `spamreport`
 - See `pkg/emailhandler/hook.go` for webhook routing logic
 
-### Email Attachments
+## Email Attachments
 
 Attachments reference files via `AttachmentReferenceType`:
 - `recording`: Links to call recordings via `storage-manager` service

--- a/bin-flow-manager/CLAUDE.md
+++ b/bin-flow-manager/CLAUDE.md
@@ -2,11 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## Overview
 
-flow-manager is a Go microservice that manages call flows in a VoIP system. It orchestrates call actions (e.g., answer, play, talk, record) by coordinating with other microservices (call-manager, agent-manager, ai-manager, etc.) through RabbitMQ RPC.
+`bin-flow-manager` is a Go microservice that manages call flows in a VoIP system. It orchestrates call actions (e.g., answer, play, talk, record) by coordinating with other microservices (call-manager, agent-manager, ai-manager, etc.) through RabbitMQ RPC.
 
-## Development Commands
+**Key Concepts:**
+- **Flow**: A sequence of actions that defines call behavior (e.g., answer → play message → hangup). Flows are templates stored in the database.
+- **Activeflow**: A running instance of a Flow attached to a specific call/reference. Contains execution state (current action, stack, variables).
+- **Action**: An atomic operation in a flow, dispatched to the appropriate manager (call-manager, ai-manager, agent-manager, etc.) by type.
+- **Stack**: Activeflows use a stack structure to handle nested flows (e.g., when branching or calling sub-flows). Each stack contains its own action sequence.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-flow-manager`.
+
+## Common Commands
 
 ### Building
 ```bash
@@ -93,49 +101,16 @@ A command-line tool for managing flows directly via database/cache (bypasses Rab
 
 Uses same environment variables as flow-manager (`DATABASE_DSN`, `RABBITMQ_ADDRESS`, `REDIS_ADDRESS`, etc.).
 
-## Configuration
-
-Configuration is managed via the `internal/config` package using Cobra and Viper.
-
-**Configuration precedence (highest to lowest):**
-1. Command-line flags (e.g., `--database_dsn`)
-2. Environment variables (e.g., `DATABASE_DSN`)
-3. Default values
-
-**Available configuration:**
-- `--rabbitmq_address` / `RABBITMQ_ADDRESS`: RabbitMQ server address
-- `--database_dsn` / `DATABASE_DSN`: MySQL connection string
-- `--redis_address` / `REDIS_ADDRESS`: Redis server address
-- `--redis_password` / `REDIS_PASSWORD`: Redis password
-- `--redis_database` / `REDIS_DATABASE`: Redis database index
-- `--prometheus_endpoint` / `PROMETHEUS_ENDPOINT`: Prometheus metrics path
-- `--prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS`: Prometheus server address
-
-**Access config in code:**
-```go
-import "monorepo/bin-flow-manager/internal/config"
-
-// Access configuration
-dbDSN := config.Get().DatabaseDSN
-redisAddr := config.Get().RedisAddress
-```
-
 ## Architecture
 
-### Core Concepts
+### Action Dispatch by Manager
 
-**Flow**: A sequence of actions that defines call behavior (e.g., answer → play message → hangup). Flows are templates stored in the database.
-
-**Activeflow**: A running instance of a Flow attached to a specific call/reference. Contains execution state (current action, stack, variables).
-
-**Action**: An atomic operation in a flow. Actions are executed by different managers based on type:
+Actions are executed by different managers based on type:
 - `call-manager`: answer, play, talk, recording_start, dtmf_receive, hangup, etc.
 - `flow-manager`: connect, goto, branch, call, patch, block, etc.
 - `ai-manager`: ai_talk, ai_summary, ai_task
 - `agent-manager`: agent_call
 - Other managers: conference_join, queue_join, transcribe_start, etc.
-
-**Stack**: Activeflows use a stack structure to handle nested flows (e.g., when branching or calling sub-flows). Each stack contains its own action sequence.
 
 ### Component Structure
 
@@ -167,6 +142,36 @@ pkg/                      # Business logic packages
 - **Event Subscription**: Subscribes to `bin-manager.customer.event` for customer-related events.
 - **Delayed Messages**: Uses `bin-manager.delay` exchange for time-delayed operations.
 
+## Request Routing
+
+ListenHandler routes requests using regex patterns matching REST-like URIs (see `pkg/listenhandler/`):
+
+**Flows API (`/v1/flows/*`):**
+- `POST /v1/flows` — Create flow
+- `GET /v1/flows?<filters>` — List flows (pagination)
+- `GET /v1/flows/<uuid>` — Get flow details
+- `PUT /v1/flows/<uuid>` — Update flow
+- `PUT /v1/flows/<uuid>/actions` — Update flow actions
+- `DELETE /v1/flows/<uuid>` — Delete flow
+
+**Activeflows API (`/v1/activeflows/*`):**
+- `POST /v1/activeflows` — Create activeflow
+- `GET /v1/activeflows?<filters>` — List activeflows
+- `GET /v1/activeflows/<uuid>` — Get activeflow
+- `POST /v1/activeflows/<uuid>/execute` — Execute next action
+- `POST /v1/activeflows/<uuid>/stop` — Stop activeflow
+- `POST /v1/activeflows/<uuid>/push` — Push actions onto stack
+- `POST /v1/activeflows/<uuid>/variables` — Set activeflow variables
+
+**Variables API (`/v1/variables/*`):**
+- `GET /v1/variables/<uuid>` — Get variables for activeflow
+- `POST /v1/variables/<uuid>` — Set variables
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: Customer lifecycle events (e.g., customer deletion to clean up flows).
+
 ### Handler Pattern
 
 Each handler follows a consistent pattern:
@@ -184,7 +189,7 @@ Example dependency chain: `listenhandler` → `flowhandler` + `activeflowhandler
 - **Query Builder**: Uses Masterminds/squirrel for SQL query construction
 - DBHandler provides unified interface to both database and cache
 
-## Important Patterns
+## Key Implementation Details
 
 ### Action Execution Flow
 1. Request arrives at listenhandler (e.g., `/v1/activeflows/{id}/execute`)
@@ -211,29 +216,63 @@ Variables follow format: `${variable.key}` or `${voipbin.activeflow.id}`. Built-
 ### Stack Management
 Stacks enable nested flow execution. When pushing actions (e.g., via `patch_flow`), a new stack is created. When a stack completes, it pops back to the parent stack.
 
-## Flow Execution Pattern
+### Variable Substitution
 
-**Key Concepts:**
-1. **Flow** = template with action sequence (stored in database)
-2. **Activeflow** = running instance attached to call (contains execution state)
-3. **Actions dispatched to appropriate managers** via RabbitMQ (call-manager, ai-manager, etc.)
-4. **Stack-based execution** for nested flows (branch, call actions)
+Variable substitution happens automatically before actions are dispatched to target managers. The variablehandler replaces all `${variable.key}` placeholders with actual values from activeflow state and call data.
 
-**Variable Substitution:**
+## Configuration
 
-Variables use format `${variable.key}`:
-- `${voipbin.activeflow.id}` - Built-in activeflow metadata (ID, customer_id, reference_id, etc.)
-- `${voipbin.call.caller_id}` - Call information from call-manager (caller_id, callee_id, status, etc.)
-- Custom variables stored per activeflow (set via action options or external updates)
+Configuration is managed via the `internal/config` package using Cobra and Viper.
 
-**Variable substitution happens automatically** before actions are dispatched to target managers. The variablehandler replaces all `${variable.key}` placeholders with actual values from activeflow state and call data.
+**Configuration precedence (highest to lowest):**
+1. Command-line flags (e.g., `--database_dsn`)
+2. Environment variables (e.g., `DATABASE_DSN`)
+3. Default values
 
-## Testing
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server address | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis server address | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis password | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis database index | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+**Access config in code:**
+```go
+import "monorepo/bin-flow-manager/internal/config"
+
+dbDSN := config.Get().DatabaseDSN
+redisAddr := config.Get().RedisAddress
+```
+
+## Testing Patterns
 
 - Tests use `go.uber.org/mock` for mocking dependencies
-- Most tests follow table-driven pattern with subtests
+- Most tests follow the table-driven pattern with subtests
 - Tests cover: CRUD operations, action execution, variable substitution, stack operations, error handling
 - 34 test files total across the codebase
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
 
 ## Monorepo Context
 
@@ -242,3 +281,9 @@ This service is part of a larger monorepo (`monorepo/bin-*`). It depends on:
 - Other `bin-*-manager` services: Definitions for cross-service communication
 
 All inter-service communication happens via RabbitMQ RPC, not direct HTTP calls.
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `flow_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `flow_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-hook-manager/CLAUDE.md
+++ b/bin-hook-manager/CLAUDE.md
@@ -4,7 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-The hook-manager is a webhook gateway service that receives external webhook messages and forwards them to internal VoIPBIN services via RabbitMQ. It acts as a public-facing HTTPS endpoint that routes incoming webhooks to appropriate internal microservices.
+`bin-hook-manager` is a webhook gateway service that receives external webhook messages and forwards them to internal VoIPbin services via RabbitMQ. It acts as a public-facing HTTPS endpoint that routes incoming webhooks to appropriate internal microservices.
+
+**Key Concepts:**
+- **Public-facing HTTPS gateway**: Runs on both ports 80 and 443 with SSL certificates decoded from base64 environment variables.
+- **Thin proxy**: No business logic; transforms inbound HTTP webhook payloads into RabbitMQ messages forwarded to the right internal service.
+- **Routes by path**: URL path (e.g., `/v1.0/emails`, `/v1.0/messages`, `/v1.0/conversation`) determines the destination service.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-hook-manager`.
 
 ## Architecture
 
@@ -48,7 +55,7 @@ This service imports several sibling modules via `replace` directives in go.mod:
 
 When working with shared code, remember that changes to bin-common-handler affect multiple services.
 
-## Development Commands
+## Common Commands
 
 ### Building
 ```bash
@@ -119,6 +126,21 @@ The service runs on both HTTP (:80) and HTTPS (:443) simultaneously. SSL certifi
 - `POST /v1.0/conversation` → forwards to conversation-manager
 - `GET /ping` → health check endpoint
 
+## Request Routing
+
+Unlike most services in the monorepo, `bin-hook-manager` exposes its API over HTTP/HTTPS (Gin), not RabbitMQ RPC. There is no listenhandler. Endpoints are listed under "Webhook Endpoints" above.
+
+## Event Subscriptions
+
+This service does not subscribe to RabbitMQ events. There is no SubscribeHandler — it only publishes messages to other services.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (RabbitMQ via `requesthandler`, models)
+
+Always run `go mod vendor` after changing dependencies.
+
 ## Testing Patterns
 
 Tests use gomock-generated mocks of ServiceHandler interface:
@@ -126,9 +148,29 @@ Tests use gomock-generated mocks of ServiceHandler interface:
 - Tests verify that incoming HTTP requests correctly call service handler methods
 - Example pattern in `api/v1.0/emails/emails_test.go`
 
-## Important Notes
+## Key Implementation Details
 
-- The service initializes SSL certificates by decoding base64 strings to files in `/tmp/` - ensure proper permissions in containerized environments
-- Prometheus metrics are exposed on port 2112 at `/metrics` by default
-- All endpoints use CORS middleware allowing all origins (`AllowOrigins: ["*"]`)
-- The service uses structured logging with logrus + joonix formatter for Stackdriver compatibility
+### SSL Certificate Bootstrapping
+Certificates are passed in base64-encoded form via `SSL_CERT_BASE64` and `SSL_PRIVKEY_BASE64`, decoded at startup, and written to `/tmp/`. Ensure proper file permissions in containerized environments.
+
+### CORS
+All endpoints use CORS middleware allowing all origins (`AllowOrigins: ["*"]`) — appropriate because this is a public webhook receiver.
+
+### Logging
+The service uses structured logging with logrus + joonix formatter for Stackdriver compatibility.
+
+## Configuration
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string (currently connected but not used) | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server (`amqp://guest:guest@localhost:5672`) | required |
+| `ssl_cert_base64` / `SSL_CERT_BASE64` | Base64-encoded SSL certificate | required |
+| `ssl_privkey_base64` / `SSL_PRIVKEY_BASE64` | Base64-encoded SSL private key | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `hook_manager_receive_request_process_time` — histogram of HTTP request processing time (labels: type, method)

--- a/bin-message-manager/CLAUDE.md
+++ b/bin-message-manager/CLAUDE.md
@@ -46,7 +46,7 @@ cmd/message-manager/main.go
 - `pkg/requestexternal/`: HTTP clients for provider APIs (Telnyx, MessageBird)
 - `pkg/listenhandler/`: RabbitMQ RPC request routing (REST-like paths: `/v1/messages`, `/v1/hooks`)
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `POST /v1/messages` - Send message (checks billing balance, creates message, dispatches to provider)
@@ -55,7 +55,7 @@ ListenHandler routes requests using regex patterns matching REST-like URIs:
 - `DELETE /v1/messages/<uuid>` - Delete message
 - `POST /v1/hooks` - Process provider webhook (delivery status updates)
 
-### Provider Architecture
+## Provider Architecture
 
 Messages are sent asynchronously via goroutine after creation:
 1. Balance validation via `billing-manager` RPC call

--- a/bin-message-manager/CLAUDE.md
+++ b/bin-message-manager/CLAUDE.md
@@ -12,6 +12,8 @@ This is the `bin-message-manager` service, part of the VoIPbin monorepo. It hand
 - **Target**: Individual recipient with delivery status (queued/sent/delivered/failed)
 - **Hook**: Webhook endpoint receiving provider delivery status updates
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-message-manager`.
+
 ## Architecture
 
 ### Service Communication Pattern
@@ -72,12 +74,23 @@ Messages are sent asynchronously via goroutine after creation:
 - URI suffix determines provider (e.g., `/telnyx` → Telnyx webhook)
 - Payload parsed to extract delivery status and update message targets
 
-### Configuration
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler — provider delivery status is received via inbound `POST /v1/hooks` webhooks.
+
+## Configuration
 
 Uses **Cobra + Viper** pattern (`cmd/message-manager/init.go`):
-- Command-line flags and environment variables (e.g., `--rabbitmq_address` or `RABBITMQ_ADDRESS`)
-- Required: `database_dsn`, `rabbitmq_address`, `redis_address`, `authtoken_messagebird`, `authtoken_telnyx`
-- Prometheus metrics endpoint configurable (default `:2112/metrics`)
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `authtoken_messagebird` / `AUTHTOKEN_MESSAGEBIRD` | MessageBird auth token | required |
+| `authtoken_telnyx` / `AUTHTOKEN_TELNYX` | Telnyx auth token | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
 ## Common Commands
 

--- a/bin-number-manager/CLAUDE.md
+++ b/bin-number-manager/CLAUDE.md
@@ -4,9 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-number-manager is a Go microservice for telephone number management in a VoIP system. It handles purchasing, managing, and releasing phone numbers through external providers (Telnyx, Twilio).
+`bin-number-manager` is a Go microservice for telephone number management in a VoIP system. It handles purchasing, managing, and releasing phone numbers through external providers (Telnyx, Twilio).
 
-## Build and Test Commands
+**Key Concepts:**
+- **Number**: A purchased phone number with assigned call flow and/or message flow IDs.
+- **AvailableNumber**: A number available for purchase from a provider, queried by country code.
+- **ProviderNumber**: Internal mapping between a `Number` and the provider that owns it.
+- **Provider routing**: Both Telnyx and Twilio are supported; provider-specific subhandlers wrap the external APIs.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-number-manager`.
+
+## Common Commands
 
 ```bash
 # Build both number-manager daemon and number-control CLI
@@ -112,35 +120,94 @@ RabbitMQ Request → listenhandler (regex routing) → numberhandler → provide
                                                           dbhandler → MySQL/Redis
 ```
 
-### Configuration
+## Request Routing
 
-Environment variables / flags:
-- `DATABASE_DSN` - MySQL connection string
-- `RABBITMQ_ADDRESS` - RabbitMQ connection
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE` - Redis cache
-- `TELNYX_CONNECTION_ID`, `TELNYX_PROFILE_ID`, `TELNYX_TOKEN` - Telnyx credentials
-- `TWILIO_SID`, `TWILIO_TOKEN` - Twilio credentials
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
 
-### number-control CLI Tool
+**Numbers API (`/v1/numbers/*`):**
+- `POST /v1/numbers` — Create (purchase) number
+- `POST /v1/numbers/register` — Register existing number without going through a provider
+- `GET /v1/numbers?<filters>` — List numbers (pagination)
+- `GET /v1/numbers/<uuid>` — Get number
+- `PUT /v1/numbers/<uuid>` — Update number (call/message flow IDs, status)
+- `DELETE /v1/numbers/<uuid>` — Release number
 
-A command-line tool for managing phone numbers. **All output is JSON format** (stdout), logs go to stderr.
+**Available Numbers API (`/v1/available_numbers/*`):**
+- `GET /v1/available_numbers?country_code=<code>&limit=<n>` — Search provider for purchasable numbers
 
-```bash
-# Create number - returns created number JSON
-./bin/number-control number create --customer_id <uuid> --number "+15551234567" [--call_flow_id <uuid>] [--message_flow_id <uuid>] [--name] [--detail]
+## Event Subscriptions
 
-# Register number (manual registration without provider) - returns registered number JSON
-./bin/number-control number register --customer_id <uuid> --number "+15551234567" [--call_flow_id <uuid>] [--message_flow_id <uuid>] [--name] [--detail]
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: `customer_deleted` → release all numbers for the deleted customer.
+- **bin-manager.flow-manager.event**: `flow_deleted` → unset `call_flow_id`/`message_flow_id` references on affected numbers.
 
-# Get number - returns number JSON
-./bin/number-control number get --id <uuid>
+## Monorepo Context
 
-# List numbers - returns JSON array
-./bin/number-control number list --customer_id <uuid> [--limit 100] [--token]
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
+- `monorepo/bin-customer-manager`: Customer event models for cascading deletes
+- `monorepo/bin-flow-manager`: Flow event models for flow-deletion cleanup
 
-# Delete number - returns deleted number JSON
-./bin/number-control number delete --id <uuid>
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
 ```
 
-Uses same environment variables as number-manager (`DATABASE_DSN`, `RABBITMQ_ADDRESS`, `REDIS_ADDRESS`, etc.).
+## Key Implementation Details
+
+### Provider Strategy
+The numberhandler delegates to provider-specific sub-handlers (`numberhandlertelnyx`, `numberhandlertwilio`). Each provider implements the same interface for purchase, release, and listing operations.
+
+### Soft Deletes
+Records use `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records).
+
+### Cache Strategy
+Redis cache fronts MySQL for number lookups. Mutations invalidate the relevant Redis keys.
+
+## Configuration
+
+Environment variables / flags:
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `telnyx_connection_id` / `TELNYX_CONNECTION_ID` | Telnyx connection ID | required if Telnyx used |
+| `telnyx_profile_id` / `TELNYX_PROFILE_ID` | Telnyx messaging profile | required if Telnyx used |
+| `telnyx_token` / `TELNYX_TOKEN` | Telnyx API token | required if Telnyx used |
+| `twilio_sid` / `TWILIO_SID` | Twilio account SID | required if Twilio used |
+| `twilio_token` / `TWILIO_TOKEN` | Twilio auth token | required if Twilio used |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `number_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `number_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-openapi-manager/CLAUDE.md
+++ b/bin-openapi-manager/CLAUDE.md
@@ -11,6 +11,8 @@ This is the `bin-openapi-manager` service, part of the VoIPbin monorepo. It serv
 - Generates Go type definitions and models used by other services for type safety and consistency
 - Provides a modular structure for organizing API paths across multiple manager services
 
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-openapi-manager`.
+
 ## Architecture
 
 ### OpenAPI Structure
@@ -114,6 +116,14 @@ go mod vendor
 go get -u ./...
 go mod tidy
 ```
+
+## Request Routing
+
+N/A — schema-only library, not a runtime service. No `cmd/` entrypoint, no listen queue.
+
+## Event Subscriptions
+
+N/A — schema-only library, not a runtime service. No SubscribeHandler.
 
 ## Monorepo Context
 
@@ -449,6 +459,23 @@ externalDocs:
 ```
 
 API is documented at: https://api.voipbin.net/docs/
+
+## Testing Patterns
+
+Tests are minimal — this repository contains generated code only. Validation is done via:
+- `oapi-codegen` validating the spec on `go generate ./...`
+- Downstream consumers (`bin-api-manager` and other services) failing to compile if generated types break their code
+- Manual smoke testing of the generated client/server code from `bin-api-manager`
+
+There is no co-located unit test suite; verification happens cross-service after a regen.
+
+## Configuration
+
+N/A — schema-only library, not a runtime service. No environment variables or flags.
+
+## Prometheus Metrics
+
+N/A — schema-only library, no runtime metrics surface.
 
 ## Dependencies
 

--- a/bin-outdial-manager/CLAUDE.md
+++ b/bin-outdial-manager/CLAUDE.md
@@ -4,9 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-outdial-manager is a Go microservice for managing outbound dialing campaigns in a VoIP system. It manages outdials (campaign containers), outdial targets (individual call targets), and target call tracking.
+`bin-outdial-manager` is a Go microservice for managing outbound dialing campaigns in a VoIP system. It manages outdials (campaign containers), outdial targets (individual call targets), and target call tracking.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Outdial**: Container for an outbound dialing campaign — belongs to a customer and a campaign, holds custom JSON data.
+- **OutdialTarget**: Individual call target within an outdial; up to 5 destination numbers with independent try counts; status `idle` / `processing` / `done`.
+- **OutdialTargetCall**: Call attempt tracking for a single target.
+- Used by `bin-campaign-manager` to fetch available targets and update target status during campaign execution.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-outdial-manager`.
+
+## Common Commands
 
 ```bash
 # Build the daemon
@@ -111,27 +119,31 @@ RabbitMQ Request → listenhandler (regex routing) → outdial/target handlers �
                                                                         webhook event published
 ```
 
-### API Structure
+## Request Routing
 
-The listenhandler uses regex-based routing to handle REST-like RPC requests:
+ListenHandler uses regex-based routing to handle REST-like RPC requests:
 
-**Outdials:**
-- `POST /v1/outdials` - Create outdial
-- `GET /v1/outdials?customer_id=<uuid>` - List outdials by customer
-- `GET /v1/outdials/<outdial-id>` - Get outdial
-- `PUT /v1/outdials/<outdial-id>` - Update outdial basic info
-- `DELETE /v1/outdials/<outdial-id>` - Delete outdial
-- `PUT /v1/outdials/<outdial-id>/campaign_id` - Update campaign ID
-- `PUT /v1/outdials/<outdial-id>/data` - Update custom data
-- `GET /v1/outdials/<outdial-id>/available?try_count_0=N&...&limit=N` - Get available targets
-- `POST /v1/outdials/<outdial-id>/targets` - Create target
-- `GET /v1/outdials/<outdial-id>/targets?page_size=N&page_token=T` - List targets
+**Outdials API (`/v1/outdials/*`):**
+- `POST /v1/outdials` — Create outdial
+- `GET /v1/outdials?customer_id=<uuid>` — List outdials by customer
+- `GET /v1/outdials/<outdial-id>` — Get outdial
+- `PUT /v1/outdials/<outdial-id>` — Update outdial basic info
+- `DELETE /v1/outdials/<outdial-id>` — Delete outdial
+- `PUT /v1/outdials/<outdial-id>/campaign_id` — Update campaign ID
+- `PUT /v1/outdials/<outdial-id>/data` — Update custom data
+- `GET /v1/outdials/<outdial-id>/available?try_count_0=N&...&limit=N` — Get available targets
+- `POST /v1/outdials/<outdial-id>/targets` — Create target
+- `GET /v1/outdials/<outdial-id>/targets?page_size=N&page_token=T` — List targets
 
-**Outdial Targets:**
-- `GET /v1/outdialtargets/<target-id>` - Get target
-- `DELETE /v1/outdialtargets/<target-id>` - Delete target
-- `POST /v1/outdialtargets/<target-id>/progressing` - Mark target as in progress
-- `PUT /v1/outdialtargets/<target-id>/status` - Update target status
+**Outdial Targets API (`/v1/outdialtargets/*`):**
+- `GET /v1/outdialtargets/<target-id>` — Get target
+- `DELETE /v1/outdialtargets/<target-id>` — Delete target
+- `POST /v1/outdialtargets/<target-id>/progressing` — Mark target as in progress
+- `PUT /v1/outdialtargets/<target-id>/status` — Update target status
+
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler.
 
 ### Data Models
 
@@ -147,14 +159,62 @@ The listenhandler uses regex-based routing to handle REST-like RPC requests:
 
 **OutdialTargetCall** - Call attempt tracking for a target
 
-### Configuration
+## Monorepo Context
 
-Environment variables / flags:
-- `DATABASE_DSN` - MySQL connection string
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (amqp://user:pass@host:port)
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE` - Redis cache
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared handlers (sockhandler, requesthandler, notifyhandler, databasehandler, utilhandler)
+- `monorepo/bin-campaign-manager`: Campaign event models (consumed via the campaign manager's reverse direction)
 
-### Testing
+Always run `go mod vendor` after changing dependencies.
 
-Tests use SQLite in-memory databases with schema loaded from `scripts/database_scripts/*.sql`. The `TestMain` function in `pkg/dbhandler/main_test.go` sets up the shared test database using `github.com/smotes/purse` to load SQL files.
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock) plus SQLite in-memory databases:
+- Mock interfaces co-located with handlers
+- The `TestMain` in `pkg/dbhandler/main_test.go` sets up a shared SQLite test DB using `github.com/smotes/purse` to load schema from `scripts/database_scripts/*.sql`
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Multi-Destination Retry Tracking
+Each `OutdialTarget` carries 5 destination addresses (`destination_0` through `destination_4`) with independent try-count tracking. The `available` endpoint allows the campaign manager to filter targets by retry count thresholds.
+
+### Soft Deletes
+Records use the `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records).
+
+## Configuration
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server (`amqp://user:pass@host:port`) | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `outdial_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)

--- a/bin-queue-manager/CLAUDE.md
+++ b/bin-queue-manager/CLAUDE.md
@@ -2,7 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Build and Development Commands
+## Overview
+
+`bin-queue-manager` is a microservice in the VoIPbin monorepo that manages call queues and queue calls (calls waiting in queues). It routes calls to available agents using configurable routing methods and integrates with other services via RabbitMQ.
+
+**Key Concepts:**
+- **Queue**: A call queue with routing configuration, agent tags, wait/service timeouts, and lists of waiting and serviced queuecalls.
+- **Queuecall**: A single call sitting in a queue. Status flow: `initiating` → `waiting` → `connecting` → `service` → `done`/`abandoned`.
+- **Routing methods**: How callers are matched to agents (e.g., `random`).
+- **Wait timeout**: How long a queuecall may sit in the queue before timing out.
+- **Service timeout**: Maximum agent service duration before forced cleanup.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-queue-manager`.
+
+## Common Commands
 
 ### Building
 ```bash
@@ -84,9 +97,6 @@ Uses same environment variables as queue-manager (`DATABASE_DSN`, `RABBITMQ_ADDR
 
 ## Architecture
 
-### Service Overview
-`bin-queue-manager` is a microservice in a VoIP platform monorepo that manages call queues and queue calls (calls waiting in queues). It handles routing calls to available agents using configurable routing methods and integrates with other services via RabbitMQ.
-
 ### Core Domain Models
 
 - **Queue** (`models/queue/queue.go`): Represents a call queue with routing configuration, agent tags, wait/service timeouts, and lists of waiting/serviced queuecalls
@@ -146,31 +156,103 @@ The service uses a layered handler architecture where handlers are dependency-in
 4. `runListen()`: Starts RPC request listener
 5. `runSubscribe()`: Starts event subscription handlers
 
-### Monorepo Structure
+## Request Routing
 
-This service is part of a Go monorepo with `replace` directives in go.mod for local dependencies:
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
+
+**Queues API (`/v1/queues/*`):**
+- `POST /v1/queues` — Create queue
+- `GET /v1/queues?<filters>` — List queues (pagination)
+- `GET /v1/queues/<uuid>` — Get queue
+- `PUT /v1/queues/<uuid>` — Update queue
+- `PUT /v1/queues/<uuid>/tag_ids` — Update queue tag IDs
+- `PUT /v1/queues/<uuid>/routing_method` — Update routing method
+- `PUT /v1/queues/<uuid>/execute` — Update execute state (`run`/`stop`)
+- `DELETE /v1/queues/<uuid>` — Delete queue
+
+**Queuecalls API (`/v1/queuecalls/*`):**
+- `POST /v1/queuecalls` — Create queuecall (place a call into a queue)
+- `GET /v1/queuecalls?<filters>` — List queuecalls
+- `GET /v1/queuecalls/<uuid>` — Get queuecall
+- `POST /v1/queuecalls/<uuid>/health-check` — Health-check the queuecall
+- `DELETE /v1/queuecalls/<uuid>` — Remove a queuecall
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.call-manager.event**: `call_hangup`, `confbridge_joined`, `confbridge_leaved` — drives queuecall state transitions.
+- **bin-manager.agent-manager.event**: agent status changes — re-evaluates queue routing.
+- **bin-manager.conference-manager.event**: confbridge state events for queue-type conferences.
+- **bin-manager.customer-manager.event**: `customer_deleted` — cleans up queues owned by the deleted customer.
+
+## Monorepo Context
+
+This service is part of a Go monorepo with `replace` directives in `go.mod` for local dependencies:
 - `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
 - `monorepo/bin-call-manager`: Call management models/events
 - `monorepo/bin-agent-manager`: Agent models
 - `monorepo/bin-customer-manager`: Customer models/events
-- And many others...
+- `monorepo/bin-conference-manager`: Confbridge models for queue-type conferences
 
 When modifying code that affects other managers, check for cross-service impacts via event contracts.
 
-### Testing Patterns
+## Testing Patterns
 
 - Tests use `go.uber.org/mock` for mocking interfaces
-- Generate mocks with `//go:generate mockgen` directives (see handler main.go files)
+- Generate mocks with `//go:generate mockgen` directives (see handler `main.go` files)
 - Test files follow `*_test.go` naming convention
 - Mock files are named `mock_main.go` in each package
 - Database tests may use `scripts/database_scripts_test/` for test fixtures
 
-### Configuration
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Queuecall Status Lifecycle
+`initiating` → `waiting` → `connecting` → `service` → `done` / `abandoned`. Transitions are driven by RPC entrypoints and `bin-call-manager` events.
+
+### Timeouts
+Each queue has a `wait_timeout` (max time waiting before abandonment) and `service_timeout` (max agent service time). Both are enforced by background timer logic in `queuecallhandler`.
+
+### Soft Deletes
+Records use `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records).
+
+## Configuration
 
 All configuration uses environment variables or flags (via Viper):
-- `DATABASE_DSN`: MySQL connection string
-- `RABBITMQ_ADDRESS`: RabbitMQ connection URL
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE`: Redis connection
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS`: Metrics configuration
 
-See `cmd/queue-manager/init.go:42` for all configuration options and defaults.
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+See `cmd/queue-manager/init.go` for the authoritative list and defaults.
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `queue_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `queue_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-rag-manager/CLAUDE.md
+++ b/bin-rag-manager/CLAUDE.md
@@ -4,9 +4,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-rag-manager is a Go microservice that provides a multi-tenant knowledge base with Retrieval-Augmented Generation (RAG) for VoIPBin. It indexes documentation sources and customer-uploaded documents, embeds them using Google Gemini, stores embeddings in PostgreSQL with pgvector, and retrieves relevant chunks for queries. Answer generation is handled by ai-manager, not this service.
+`bin-rag-manager` is a Go microservice that provides a multi-tenant knowledge base with Retrieval-Augmented Generation (RAG) for VoIPbin. It indexes documentation sources and customer-uploaded documents, embeds them using Google Gemini, stores embeddings in PostgreSQL with pgvector, and retrieves relevant chunks for queries. Answer generation is handled by `bin-ai-manager`, not this service.
 
-## Build and Test Commands
+**Key Concepts:**
+- **RAG configuration**: Per-customer settings for the knowledge base.
+- **Document**: A source file (RST, Markdown, or OpenAPI YAML) parsed into chunks.
+- **Chunk**: A semantically meaningful slice of a document with an embedding vector.
+- **Embedding**: 768-dimension vector produced by Google Gemini `text-embedding-004`.
+- **pgvector**: PostgreSQL extension storing the embedding vectors and providing nearest-neighbor search.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-rag-manager`.
+
+## Architecture
+
+### Service Communication Pattern
+
+This service uses **RabbitMQ for RPC-style communication**:
+- **ListenHandler** (`pkg/listenhandler/`): Consumes RPC requests from queue `bin-manager.rag-manager.request` and routes to `raghandler` via regex-based URI matching.
+- **NotifyHandler**: Publishes RAG lifecycle events when configurations or documents change.
+
+### Service Layer Structure
+
+1. **cmd/rag-manager/** — Main daemon entry point (Cobra/Viper configuration)
+2. **pkg/listenhandler/** — RabbitMQ RPC request handler
+3. **pkg/raghandler/** — Core business logic orchestrating the RAG pipeline
+4. **pkg/chunker/** — Document parsers for RST, Markdown, and OpenAPI YAML
+5. **pkg/embedder/** — Google Gemini embedding client (`text-embedding-004`, 768 dimensions)
+6. **pkg/dbhandler/** — PostgreSQL operations (rags, documents, chunks with pgvector)
+
+### Request Flow
+
+```
+RabbitMQ Request -> listenhandler (regex routing) -> raghandler
+                                                       |
+                                                       +-> embedder (Google Gemini)
+                                                       +-> dbhandler -> PostgreSQL (pgvector)
+```
+
+## Common Commands
 
 ```bash
 # Build the service
@@ -28,42 +63,88 @@ golangci-lint run -v --timeout 5m
 go generate ./...
 ```
 
-## Architecture
+## Request Routing
 
-### Service Layer Structure
+Multi-tenant CRUD operations for RAG configurations, documents, and queries (see `pkg/listenhandler/main.go` for the authoritative regex patterns):
 
-1. **cmd/rag-manager/** - Main daemon entry point with configuration via pflag/Viper
-2. **pkg/listenhandler/** - RabbitMQ RPC request handler with regex-based URI routing
-3. **pkg/raghandler/** - Core business logic orchestrating the RAG pipeline
-4. **pkg/chunker/** - Document parsers for RST, Markdown, and OpenAPI YAML
-5. **pkg/embedder/** - Google Gemini embedding client (text-embedding-004, 768 dimensions)
-6. **pkg/dbhandler/** - PostgreSQL database operations (rags, documents, chunks with pgvector)
+**RAGs API (`/v1/rags/*`):**
+- `POST /v1/rags` — Create RAG configuration
+- `GET /v1/rags?<filters>` — List RAGs
+- `GET /v1/rags/<uuid>` — Get RAG
+- `DELETE /v1/rags/<uuid>` — Delete RAG
 
-### Request Flow
+**Documents API (`/v1/documents/*`):**
+- `POST /v1/documents` — Add document (parses, chunks, embeds, stores)
+- `GET /v1/documents?<filters>` — List documents
+- `DELETE /v1/documents/<uuid>` — Remove a document
 
+**Queries API (`/v1/queries/*`):**
+- `POST /v1/queries` — Embed query and return top-K relevant chunks
+
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock) plus pgvector-aware integration tests:
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
 ```
-RabbitMQ Request -> listenhandler (regex routing) -> raghandler
-                                                       |
-                                                       +-> embedder (Google Gemini)
-                                                       +-> dbhandler -> PostgreSQL (pgvector)
-```
 
-### API Endpoints (via RabbitMQ RPC)
+## Key Implementation Details
 
-Multi-tenant CRUD operations for RAG configurations, documents, and queries (endpoints TBD in Phase 2).
+### PostgreSQL with pgvector
+Unlike most services in the monorepo (which use MySQL), this service uses PostgreSQL with the pgvector extension to store and search 768-dimension embedding vectors. The DSN is provided via `POSTGRESQL_DSN`.
 
-### Configuration
+### GKE Workload Identity Auth
+Authentication to Google Vertex AI for embeddings uses GKE Workload Identity (Application Default Credentials) — no API keys required in production.
 
-Environment variables (sourced from `voipbin` k8s secret via `secretKeyRef`):
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (secret key: `RABBITMQ_ADDRESS`)
-- `GCP_PROJECT_ID` - GCP project ID for Vertex AI (secret key: `GCP_PROJECT_ID`)
-- `GCP_REGION` - GCP region for Vertex AI (secret key: `GCP_REGION`)
-- `POSTGRESQL_DSN` - PostgreSQL connection string (secret key: `DATABASE_DSN_POSTGRES`)
+### Document Parsers
+`pkg/chunker/` contains parsers for RST (Sphinx-style), Markdown, and OpenAPI YAML — each producing a stream of semantically coherent chunks before embedding.
 
-Hardcoded in deployment.yml:
-- `GOOGLE_EMBEDDING_MODEL` - Embedding model (default: text-embedding-004)
-- `RAG_TOP_K` - Chunks to retrieve (default: 5)
-- `PROMETHEUS_ENDPOINT` - Metrics endpoint (default: /metrics)
-- `PROMETHEUS_LISTEN_ADDRESS` - Metrics address (default: :2112)
+## Configuration
 
-Authentication uses GKE Workload Identity (Application Default Credentials) — no API keys required.
+Environment variables (sourced from the `voipbin` k8s secret via `secretKeyRef`):
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `GCP_PROJECT_ID` | GCP project ID for Vertex AI | required |
+| `GCP_REGION` | GCP region for Vertex AI | required |
+| `POSTGRESQL_DSN` | PostgreSQL connection (secret key: `DATABASE_DSN_POSTGRES`) | required |
+| `GOOGLE_EMBEDDING_MODEL` | Embedding model | `text-embedding-004` |
+| `RAG_TOP_K` | Chunks to retrieve per query | `5` |
+| `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `rag_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)

--- a/bin-registrar-manager/CLAUDE.md
+++ b/bin-registrar-manager/CLAUDE.md
@@ -2,11 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Service Overview
+## Overview
 
-**bin-registrar-manager** manages SIP registrations for VoIP extensions and trunks in the voipbin platform. It handles the lifecycle of Asterisk PJSIP endpoints, contacts, authentication, and Address of Record (AOR) configurations.
+`bin-registrar-manager` manages SIP registrations for VoIP extensions and trunks in the VoIPbin platform. It handles the lifecycle of Asterisk PJSIP endpoints, contacts, authentication, and Address of Record (AOR) configurations.
 
-This is part of a Go monorepo where services communicate via RabbitMQ message passing and share database access (both bin-manager and asterisk databases).
+**Key Concepts:**
+- **Extension**: SIP endpoint for an individual user within a customer account; backed by Asterisk `ps_endpoints`/`ps_aors`/`ps_auths` tables.
+- **Trunk**: SIP trunk for carrier/provider connections; supports basic (user/pass) and/or IP-based authentication.
+- **Contact**: An active SIP registration (read from Asterisk `ps_contacts`, cached in Redis).
+- **Two-database architecture**: Service connects to both the Asterisk DB (`ps_*` tables) and the bin-manager DB (extensions, trunks, sip_auth tables).
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-registrar-manager`.
 
 ## Architecture
 
@@ -65,6 +71,33 @@ RabbitMQ Request → ListenHandler.processRequest() → Domain Handler → DBHan
 RabbitMQ Event (e.g., customer.deleted) → SubscribeHandler → Domain Handler → Cleanup Resources
 ```
 
+## Request Routing
+
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs (see `pkg/listenhandler/main.go`):
+
+**Extensions API (`/v1/extensions/*`):**
+- `POST /v1/extensions` — Create extension
+- `GET /v1/extensions?<filters>` — List extensions
+- `GET /v1/extensions/<uuid>` — Get extension
+- `PUT /v1/extensions/<uuid>` — Update extension
+- `DELETE /v1/extensions/<uuid>` — Delete extension
+
+**Trunks API (`/v1/trunks/*`):**
+- `POST /v1/trunks` — Create trunk
+- `GET /v1/trunks?<filters>` — List trunks
+- `GET /v1/trunks/<uuid>` — Get trunk
+- `PUT /v1/trunks/<uuid>` — Update trunk
+- `DELETE /v1/trunks/<uuid>` — Delete trunk
+
+**Contacts API (`/v1/contacts/*`):**
+- `GET /v1/contacts?<filters>` — List active SIP contacts
+- `GET /v1/contacts/<uuid>` — Get contact details
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: `customer_deleted` → triggers cleanup of extensions/trunks owned by the deleted customer.
+
 ## Configuration
 
 The service uses **Cobra + Viper** for configuration management (migrated from flag-based config). Configuration is loaded via:
@@ -84,7 +117,7 @@ Key configuration parameters:
 
 Config singleton is accessed via `config.Get()`.
 
-## Development Commands
+## Common Commands
 
 ### Building
 ```bash
@@ -231,58 +264,72 @@ registrar-control trunk delete --id "<trunk-uuid>"
 **Required Flags:**
 All required flags must be provided via command line - no interactive prompts.
 
-## Code Patterns
+## Monorepo Context
 
-### Handler Interface Pattern
-Most business logic is defined as interfaces (e.g., `ExtensionHandler`, `TrunkHandler`) with mock implementations for testing. When adding new functionality:
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared handlers (database, request, notify, socket)
+- `monorepo/bin-customer-manager`: Customer event models
 
-1. Add method to interface in `main.go`
-2. Implement in same package (e.g., `extension.go`)
-3. Regenerate mocks with `go generate`
+When modifying these dependencies, remember that Go modules use `replace` directives in `go.mod` to point to local paths.
 
-### Database Pattern
-All database operations go through `DBHandler` interface. When adding new DB operations:
+## Testing Patterns
 
-1. Add method signature to `pkg/dbhandler/main.go` interface
-2. Implement in appropriate file (e.g., `ast_auth.go` for Asterisk auth, `extension.go` for extensions)
-3. Use `Masterminds/squirrel` for SQL building
-4. Handle `ErrNotFound` for missing records
-
-### Model Pattern
-Models are in `models/` directory with separate packages for each entity type. Each model may include:
-- Struct definition
-- Event types (e.g., `EventExtensionCreated`)
-- Webhook types
-- Helper methods
-
-### Testing Pattern
 Tests use:
 - `go.uber.org/mock` for mocking
 - Table-driven tests with `t.Run(name, func(t *testing.T){})`
 - In-memory SQLite for database tests (see `pkg/dbhandler/main_test.go`)
 
-## Monorepo Dependencies
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
 
-This service imports from sibling packages:
-- `monorepo/bin-common-handler` - Shared handlers (database, request, notify, socket)
-- `monorepo/bin-customer-manager` - Customer models for event handling
+## Key Implementation Details
 
-When modifying these dependencies, remember that Go modules use `replace` directives in `go.mod` to point to local paths.
+### Handler Interface Pattern
+Business logic is defined as interfaces (e.g., `ExtensionHandler`, `TrunkHandler`) with mock implementations. To add functionality: define the method on the interface in `main.go`, implement in the same package, regenerate mocks.
 
-## Observability
+### Database Pattern
+All database operations go through the `DBHandler` interface (defined in `pkg/dbhandler/main.go`). New operations belong in that interface; use `Masterminds/squirrel` for SQL building; handle `ErrNotFound` for missing records.
 
-### Prometheus Metrics
-Metrics are exposed on the configured prometheus endpoint (default `:2112/metrics`):
-- `registrar_manager_extension_create_total` - Total extensions created
-- `registrar_manager_extension_delete_total` - Total extensions deleted
-- `registrar_manager_trunk_create_total` - Total trunks created
-- `registrar_manager_trunk_delete_total` - Total trunks deleted
-- `registrar_manager_receive_request_process_time` - Request processing latency histogram
+### Models
+Models live in `models/` with separate packages per entity. Each model may include the struct definition, event types (e.g., `EventExtensionCreated`), webhook types, and helper methods.
+
+### Multi-Resource Atomicity
+Creating an Extension touches three Asterisk tables (`ps_endpoints`, `ps_aors`, `ps_auths`). Deletes must clean up all three. Wrap in a transaction where possible.
+
+### Domain Names
+Extensions and trunks must have valid domain names set via `common.SetBaseDomainNames()` during startup.
+
+### Contact Caching
+Asterisk contacts are cached in Redis for performance; always invalidate the cache when modifying endpoints.
 
 ### Logging
-- Uses `logrus` with structured fields
-- Joonix formatter for stackdriver-compatible JSON logs
-- Log level: Debug (configured in `config.initLog()`)
+Uses `logrus` with structured fields and the Joonix formatter for Stackdriver-compatible JSON logs. Log level: Debug (configured in `config.initLog()`).
+
+## Prometheus Metrics
+
+Metrics are exposed on the configured Prometheus endpoint (default `:2112/metrics`):
+- `registrar_manager_extension_create_total` — counter of extensions created
+- `registrar_manager_extension_delete_total` — counter of extensions deleted
+- `registrar_manager_trunk_create_total` — counter of trunks created
+- `registrar_manager_trunk_delete_total` — counter of trunks deleted
+- `registrar_manager_receive_request_process_time` — histogram of request processing latency
 
 ## Common Tasks
 

--- a/bin-route-manager/CLAUDE.md
+++ b/bin-route-manager/CLAUDE.md
@@ -4,9 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-route-manager is a Go microservice for call routing in a VoIP system. It manages routing providers and routes, providing route selection logic for outbound calls based on customer configuration and target destinations.
+`bin-route-manager` is a Go microservice for call routing in a VoIP system. It manages routing providers and routes, providing route selection logic for outbound calls based on customer configuration and target destinations.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Provider**: SIP trunk/gateway used for outbound call routing (hostname, tech prefix/postfix, custom SIP headers).
+- **Route**: Maps a customer destination (country code or `all`) to a provider with a priority order.
+- **Dialroute**: Effective merged route list for a (customer, target) pair — customer-specific routes override system defaults from `CustomerIDBasicRoute` (`00000000-0000-0000-0000-000000000001`).
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-route-manager`.
+
+## Common Commands
 
 ```bash
 # Build the route-manager daemon
@@ -108,65 +115,107 @@ RabbitMQ Request → listenhandler (regex routing) → route/provider handler �
                                                                    cache lookup/update
 ```
 
-### Configuration
+## Request Routing
+
+Handled via RabbitMQ RPC with regex routing in `pkg/listenhandler/main.go`:
+
+**Providers API (`/v1/providers/*`):**
+- `GET /v1/providers?page_size=N&page_token=T` — List providers with pagination
+- `POST /v1/providers` — Create provider
+- `GET /v1/providers/{id}` — Get single provider
+- `PUT /v1/providers/{id}` — Update provider
+- `DELETE /v1/providers/{id}` — Delete provider
+
+**Routes API (`/v1/routes/*`):**
+- `GET /v1/routes?page_size=N&page_token=T` — List routes with pagination
+- `POST /v1/routes` — Create route
+- `GET /v1/routes/{id}` — Get single route
+- `PUT /v1/routes/{id}` — Update route
+- `DELETE /v1/routes/{id}` — Delete route
+
+**Dialroute API (`/v1/dialroutes/*`):**
+- `GET /v1/dialroutes?customer_id={id}&target={target}` — Get effective routes for dialing (merges customer and default routes)
+
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared handlers (sockhandler, requesthandler, notifyhandler, databasehandler, utilhandler)
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Configuration
 
 Environment variables / flags (managed via Viper/pflag):
-- `DATABASE_DSN` - MySQL connection string (e.g., `user:password@tcp(localhost:3306)/dbname`)
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (e.g., `amqp://guest:guest@localhost:5672`)
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE` - Redis cache configuration
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint configuration
 
-## Core Concepts
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
-### Providers
+## Prometheus Metrics
 
-Providers represent SIP trunks/gateways for routing outbound calls. Each provider has:
-- Type (currently only "sip" is supported)
-- Hostname (SIP destination)
-- Tech prefix/postfix (dial string manipulation)
-- Tech headers (custom SIP headers)
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `route_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
 
-See models/provider/provider.go for the Provider struct.
-
-### Routes
-
-Routes map customer destinations to providers with priority ordering:
-- Each route belongs to a customer_id
-- Target can be a country code or "all" for default routing
-- Priority determines route order (lower = higher priority)
-- Basic route customer_id `00000000-0000-0000-0000-000000000001` provides system-wide defaults
-
-See models/route/route.go for the Route struct.
+## Key Implementation Details
 
 ### Dialroute Selection
-
-The dialroute logic (pkg/routehandler/dialroute.go:DialrouteGets) implements a fallback mechanism:
-1. First retrieves customer-specific routes for the target destination
-2. Then retrieves default routes (CustomerIDBasicRoute) for the same target
-3. Merges results, prioritizing customer routes while adding default routes that use providers not already in the customer routes
+`DialrouteGets` (in `pkg/routehandler/dialroute.go`) implements a fallback merge:
+1. First retrieves customer-specific routes for the target destination.
+2. Then retrieves default routes (`CustomerIDBasicRoute`) for the same target.
+3. Merges results, prioritizing customer routes while adding default routes that use providers not already used by customer routes.
 
 This allows customers to override specific providers while falling back to system defaults for others.
 
-## API Endpoints
+### Provider Model
+Providers represent SIP trunks/gateways for routing outbound calls. Each provider has type (currently only `sip`), hostname, tech prefix/postfix (dial string manipulation), and tech headers (custom SIP headers). See `models/provider/provider.go`.
 
-Handled via RabbitMQ RPC with regex routing in pkg/listenhandler/main.go:
+### Route Model
+Routes map customer destinations to providers with priority ordering:
+- Each route belongs to a `customer_id`
+- Target can be a country code or `all` for default routing
+- Priority determines route order (lower = higher priority)
+- The basic route `customer_id` `00000000-0000-0000-0000-000000000001` provides system-wide defaults
 
-### Providers
-- `GET /v1/providers?page_size=N&page_token=T` - List providers with pagination
-- `POST /v1/providers` - Create provider
-- `GET /v1/providers/{id}` - Get single provider
-- `PUT /v1/providers/{id}` - Update provider
-- `DELETE /v1/providers/{id}` - Delete provider
+See `models/route/route.go`.
 
-### Routes
-- `GET /v1/routes?page_size=N&page_token=T` - List routes with pagination
-- `POST /v1/routes` - Create route
-- `GET /v1/routes/{id}` - Get single route
-- `PUT /v1/routes/{id}` - Update route
-- `DELETE /v1/routes/{id}` - Delete route
-
-### Dialroute
-- `GET /v1/dialroutes?customer_id={id}&target={target}` - Get effective routes for dialing (merges customer and default routes)
+### Soft Deletes
+Both `providers` and `routes` tables use the `tm_delete` timestamp pattern.
 
 ## Database Schema
 

--- a/bin-sentinel-manager/CLAUDE.md
+++ b/bin-sentinel-manager/CLAUDE.md
@@ -4,9 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-sentinel-manager is a Kubernetes pod monitoring service for VoIP infrastructure. It watches pod lifecycle events in Kubernetes namespaces and publishes notifications to RabbitMQ for other services to consume.
+`bin-sentinel-manager` is a Kubernetes pod monitoring service for VoIP infrastructure. It watches pod lifecycle events in Kubernetes namespaces and publishes notifications to RabbitMQ for other services to consume.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Pod informer**: Uses `k8s.io/client-go` with label selectors to watch pods scoped to specific apps (`asterisk-call`, `asterisk-conference`, `asterisk-registrar`).
+- **In-cluster only**: Authenticates via `rest.InClusterConfig()`; cannot run outside a Kubernetes cluster.
+- **Publish, don't react**: Emits `pod_updated` and `pod_deleted` events; downstream services (e.g., `bin-call-manager`) decide what to do with them.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-sentinel-manager`.
+
+## Common Commands
 
 ```bash
 # Build the sentinel-manager daemon
@@ -78,19 +85,71 @@ bin-sentinel-manager runs as an in-cluster Kubernetes service that:
   - `pod.EventTypePodDeleted` - When pod is removed
 - **Monorepo structure**: All sibling services are referenced via `replace` directives in go.mod pointing to `../bin-*-manager` directories
 
-### Prometheus Metrics
+## Request Routing
 
-The service exposes metrics at `/metrics` (port 2112 by default):
-- `sentinel_manager_pod_state_change_total` - Counter with labels: namespace, pod app label, state (updated/deleted)
+N/A — `bin-sentinel-manager` is an event publisher only. It does not process RPC requests. There is no listenhandler.
 
-### Configuration
+## Event Subscriptions
+
+This service does not subscribe to RabbitMQ events. Its inputs come from the Kubernetes API via informers; outputs are published events.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (RabbitMQ via `notifyhandler`, models)
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### SharedIndexInformer
+Uses `cache.SharedIndexInformer` from `k8s.io/client-go/tools/cache`. Each (namespace, label-selector) pair runs in its own goroutine. `AddFunc` is intentionally empty (registration events aren't useful here); `UpdateFunc` handles state changes; `DeleteFunc` handles removals. No resync period (set to 0) for efficiency.
+
+### RBAC Requirements
+Requires a `pod-reader` Role with `get`/`list`/`watch` verbs on pods in the target namespace, bound via RoleBinding to the service account.
+
+## Configuration
 
 Environment variables / flags:
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (default: `amqp://guest:guest@localhost:5672`)
-- `PROMETHEUS_ENDPOINT` - Metrics endpoint path (default: `/metrics`)
-- `PROMETHEUS_LISTEN_ADDRESS` - Metrics server address (default: `:2112`)
 
-### Kubernetes Deployment
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | `amqp://guest:guest@localhost:5672` |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics at `/metrics` (port 2112 by default):
+- `sentinel_manager_pod_state_change_total` — counter (labels: `namespace`, pod `app` label, `state` ∈ `updated`/`deleted`)
+
+## Kubernetes Deployment
 
 The service requires specific RBAC permissions to watch pods:
 - **Role**: `pod-reader` in target namespace (`voip`) with verbs: `get`, `list`, `watch` on pods

--- a/bin-storage-manager/CLAUDE.md
+++ b/bin-storage-manager/CLAUDE.md
@@ -4,9 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-storage-manager is a Go microservice for managing file and media storage in a VoIP system. It handles file uploads, downloads, recordings, and compression operations using Google Cloud Storage (GCS). The service manages customer storage accounts with quota enforcement (10GB per customer) and integrates with other microservices via RabbitMQ.
+`bin-storage-manager` is a Go microservice for managing file and media storage in a VoIP system. It handles file uploads, downloads, recordings, and compression operations using Google Cloud Storage (GCS). The service manages customer storage accounts with quota enforcement (10 GB per customer) and integrates with other microservices via RabbitMQ.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Storage Account**: Per-customer storage record with a 10 GB quota.
+- **File**: An object stored in GCS with reference type (`normal` or `recording`) and metadata.
+- **Compressfile**: A zip archive built on-demand from multiple files (typically all recordings with the same `reference_id`).
+- **Two GCS buckets**: `gcp_bucket_name_media` (persistent recordings/files) and `gcp_bucket_name_tmp` (transient compressed archives).
+- **Signed URLs**: Downloads use GCS signed URLs (default 24 h expiration) with either local-key signing or IAM Credentials API signing.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-storage-manager`.
+
+## Common Commands
 
 ```bash
 # Build the daemon
@@ -132,45 +141,106 @@ RabbitMQ Request → listenhandler (regex routing) → storagehandler → fileha
    - Uses GCS signed URLs with configurable expiration (default 24 hours)
    - Supports local signing (with private key) or IAM Credentials API
 
-### API Endpoints (via RabbitMQ RPC)
+## Request Routing
 
 The service exposes REST-like endpoints through RabbitMQ:
 
-**Accounts**:
-- `POST /v1/accounts` - Create storage account
-- `GET /v1/accounts?page_size=X&page_token=Y` - List accounts
-- `GET /v1/accounts/<id>` - Get account details
-- `DELETE /v1/accounts/<id>` - Delete account
+**Accounts API (`/v1/accounts/*`):**
+- `POST /v1/accounts` — Create storage account
+- `GET /v1/accounts?page_size=X&page_token=Y` — List accounts
+- `GET /v1/accounts/<id>` — Get account details
+- `DELETE /v1/accounts/<id>` — Delete account
 
-**Files**:
-- `POST /v1/files` - Create file record
-- `GET /v1/files?page_size=X&page_token=Y` - List files
-- `GET /v1/files/<id>` - Get file with download URL
-- `DELETE /v1/files/<id>` - Delete file
+**Files API (`/v1/files/*`):**
+- `POST /v1/files` — Create file record
+- `GET /v1/files?page_size=X&page_token=Y` — List files
+- `GET /v1/files/<id>` — Get file with download URL
+- `DELETE /v1/files/<id>` — Delete file
 
-**Recordings**:
-- `GET /v1/recordings/<reference_id>` - Get compressed recording (creates zip of all files with reference_id)
-- `DELETE /v1/recordings/<reference_id>` - Delete all files for a recording
+**Recordings API (`/v1/recordings/*`):**
+- `GET /v1/recordings/<reference_id>` — Get compressed recording (creates zip of all files with `reference_id`)
+- `DELETE /v1/recordings/<reference_id>` — Delete all files for a recording
 
-**Compress Files**:
-- `POST /v1/compressfiles` - Create compressed archive from multiple files
+**Compressfiles API (`/v1/compressfiles/*`):**
+- `POST /v1/compressfiles` — Create compressed archive from multiple files
 
-### Configuration
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: `customer_deleted` → cascading deletion of all storage accounts and files for the deleted customer.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared handlers (sockhandler, requesthandler, notifyhandler, databasehandler)
+- `monorepo/bin-customer-manager`: Customer event models for cascading deletes
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Storage Quota
+Each customer account has a 10 GB storage limit (enforced in `accounthandler`).
+
+### Recording Compression
+Recordings sharing the same `reference_id` are automatically compressed into a single zip on download via `GET /v1/recordings/<reference_id>`. The zip lands in the tmp bucket; signed-URL expiration limits how long it stays accessible.
+
+### Cascading Deletions
+When `bin-customer-manager` publishes `customer_deleted`, all associated storage accounts and files are removed.
+
+### Cache Coordination
+File and account operations update both MySQL and Redis to keep cache consistent. Mutations invalidate the corresponding Redis keys.
+
+### Joonix Logging
+Uses logrus with the joonix formatter for Stackdriver-compatible JSON logs.
+
+## Configuration
 
 Environment variables / flags (via Viper binding):
-- `DATABASE_DSN` - MySQL connection string (format: `user:password@tcp(host:port)/dbname`)
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (format: `amqp://user:pass@host:port`)
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE` - Redis cache configuration
-- `GCP_PROJECT_ID` - Google Cloud project ID
-- `GCP_BUCKET_NAME_MEDIA` - GCS bucket for persistent media storage
-- `GCP_BUCKET_NAME_TMP` - GCS bucket for temporary files
-- `GOOGLE_APPLICATION_CREDENTIALS` - (optional) Path to service account JSON for local GCS authentication
-- `GOOGLE_SERVICE_ACCOUNT_EMAIL` - (optional) Service account email when not running on GCE
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint configuration
 
-### Important Constraints
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `gcp_project_id` / `GCP_PROJECT_ID` | Google Cloud project ID | required |
+| `gcp_bucket_name_media` / `GCP_BUCKET_NAME_MEDIA` | GCS bucket for persistent media | required |
+| `gcp_bucket_name_tmp` / `GCP_BUCKET_NAME_TMP` | GCS bucket for temporary files | required |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON for local GCS auth | optional |
+| `GOOGLE_SERVICE_ACCOUNT_EMAIL` | Service account email when not running on GCE | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
-- **Storage Quota**: Each customer account has a 10GB storage limit (enforced in accounthandler:17)
-- **Recording Compression**: Recordings with the same reference_id are automatically compressed into a single zip file on download
-- **Cascading Deletions**: When a customer is deleted, all associated accounts and files are automatically removed
-- **Cache Coordination**: File and account operations update both MySQL and Redis for consistency
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `storage_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `storage_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-tag-manager/CLAUDE.md
+++ b/bin-tag-manager/CLAUDE.md
@@ -4,9 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-tag-manager is a Go microservice for managing customer tags in a VoIP system. It provides CRUD operations for tags and handles event-driven cascading deletions when customers are removed.
+`bin-tag-manager` is a Go microservice for managing customer tags in a VoIP system. It provides CRUD operations for tags and handles event-driven cascading deletions when customers are removed.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Tag**: A customer-scoped label (name, optional detail) used by other services (e.g., `bin-contact-manager`, `bin-queue-manager`) to categorize records.
+- **Cascading deletes**: When a customer is deleted, all of that customer's tags are removed automatically.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-tag-manager`.
+
+## Common Commands
 
 ```bash
 # Build the service and CLI
@@ -107,35 +113,85 @@ Event Flow:
 RabbitMQ Event → subscribehandler → taghandler → cleanup operations
 ```
 
-### Configuration
-
-Environment variables / flags:
-- `DATABASE_DSN` - MySQL connection string (default: `testid:testpassword@tcp(127.0.0.1:3306)/test`)
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (default: `amqp://guest:guest@localhost:5672`)
-- `REDIS_ADDRESS` - Redis server address (default: `127.0.0.1:6379`)
-- `REDIS_PASSWORD` - Redis password (default: empty)
-- `REDIS_DATABASE` - Redis database index (default: `1`)
-- `PROMETHEUS_ENDPOINT` - Metrics endpoint path (default: `/metrics`)
-- `PROMETHEUS_LISTEN_ADDRESS` - Metrics server address (default: `:2112`)
-
-### API Endpoints (via RabbitMQ RPC)
+## Request Routing
 
 The service handles REST-like requests through RabbitMQ with URI pattern matching:
 
-- `GET /v1/tags?<params>` - List tags with pagination
-- `POST /v1/tags` - Create new tag
-- `GET /v1/tags/{tag-id}` - Get specific tag
-- `PUT /v1/tags/{tag-id}` - Update tag
-- `DELETE /v1/tags/{tag-id}` - Delete tag
+**Tags API (`/v1/tags/*`):**
+- `GET /v1/tags?<params>` — List tags with pagination
+- `POST /v1/tags` — Create new tag
+- `GET /v1/tags/{tag-id}` — Get specific tag
+- `PUT /v1/tags/{tag-id}` — Update tag
+- `DELETE /v1/tags/{tag-id}` — Delete tag
 
-### Event Types Published
+**Events Published:**
+- `tag_created` — when a new tag is created
+- `tag_updated` — when tag information is updated
+- `tag_deleted` — when a tag is deleted
 
-- `tag_created` - When a new tag is created
-- `tag_updated` - When tag information is updated
-- `tag_deleted` - When a tag is deleted
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: `customer_deleted` → cascading deletion of tags owned by the deleted customer.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
+- `monorepo/bin-customer-manager`: Customer event models for cascading deletes
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
 
 ### Cache Strategy
+Tags are cached in Redis for fast lookups; cache is invalidated on updates and deletions. Uses `pkg/cachehandler` for all Redis operations.
 
-- Tags are cached in Redis for fast lookups
-- Cache is invalidated on updates and deletions
-- Uses `pkg/cachehandler` for all Redis operations
+### Soft Deletes
+Records use `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records).
+
+## Configuration
+
+Environment variables / flags:
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | `testid:testpassword@tcp(127.0.0.1:3306)/test` |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | `amqp://guest:guest@localhost:5672` |
+| `redis_address` / `REDIS_ADDRESS` | Redis server | `127.0.0.1:6379` |
+| `redis_password` / `REDIS_PASSWORD` | Redis password | empty |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | `1` |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `tag_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `tag_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-talk-manager/CLAUDE.md
+++ b/bin-talk-manager/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-talk-manager is a microservice within a larger VoIP monorepo that manages chat functionality with threading and reactions. It handles:
+`bin-talk-manager` is a microservice within the VoIPbin monorepo that manages chat functionality with threading and reactions. It handles:
 - **Chats**: Chat sessions (direct 1:1, group, and public talk channels)
 - **Messages**: Text messages with threading support (replies to messages)
 - **Participants**: Chat membership management with re-join support
@@ -12,7 +12,9 @@ bin-talk-manager is a microservice within a larger VoIP monorepo that manages ch
 
 The service operates as a RabbitMQ-based RPC server, listening for requests and processing chat-related operations.
 
-## Build and Run Commands
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-talk-manager`.
+
+## Common Commands
 
 ### Build
 ```bash
@@ -105,26 +107,6 @@ This service uses a **RabbitMQ RPC pattern** for all external communication:
 - Uses regex-based URI routing (e.g., `/v1/chats`, `/v1/messages`)
 - Request/response via `sock.Request` and `sock.Response` types from `bin-common-handler`
 
-### API Endpoints
-
-| Method | URI | Description |
-|--------|-----|-------------|
-| POST | `/v1/chats` | Create a new chat |
-| GET | `/v1/chats` | List chats |
-| GET | `/v1/chats/{id}` | Get chat by ID |
-| PUT | `/v1/chats/{id}` | Update chat |
-| DELETE | `/v1/chats/{id}` | Delete chat |
-| POST | `/v1/chats/{id}/participants` | Add participant to chat |
-| GET | `/v1/chats/{id}/participants` | List chat participants |
-| DELETE | `/v1/chats/{id}/participants/{pid}` | Remove participant |
-| GET | `/v1/participants` | List participants (filtered) |
-| POST | `/v1/messages` | Create a message |
-| GET | `/v1/messages` | List messages |
-| GET | `/v1/messages/{id}` | Get message by ID |
-| DELETE | `/v1/messages/{id}` | Delete message |
-| POST | `/v1/messages/{id}/reactions` | Add reaction to message |
-| DELETE | `/v1/messages/{id}/reactions` | Remove reaction from message |
-
 ### Core Data Model
 
 The chat system has a three-table structure:
@@ -200,18 +182,52 @@ All tables use:
 - JSON columns for `metadata` (reactions) and `medias` arrays
 - Timestamp fields: `tm_create`, `tm_update`, `tm_delete`
 
-### Configuration
+## Request Routing
+
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
+
+| Method | URI | Description |
+|--------|-----|-------------|
+| POST | `/v1/chats` | Create a new chat |
+| GET | `/v1/chats` | List chats |
+| GET | `/v1/chats/{id}` | Get chat by ID |
+| PUT | `/v1/chats/{id}` | Update chat |
+| DELETE | `/v1/chats/{id}` | Delete chat |
+| POST | `/v1/chats/{id}/participants` | Add participant to chat |
+| GET | `/v1/chats/{id}/participants` | List chat participants |
+| DELETE | `/v1/chats/{id}/participants/{pid}` | Remove participant |
+| GET | `/v1/participants` | List participants (filtered) |
+| POST | `/v1/messages` | Create a message |
+| GET | `/v1/messages` | List messages |
+| GET | `/v1/messages/{id}` | Get message by ID |
+| DELETE | `/v1/messages/{id}` | Delete message |
+| POST | `/v1/messages/{id}/reactions` | Add reaction to message |
+| DELETE | `/v1/messages/{id}/reactions` | Remove reaction from message |
+
+## Event Subscriptions
+
+This service does not subscribe to external events. There is no SubscribeHandler — chat state is driven entirely by inbound RPC.
+
+## Configuration
 
 Runtime configuration via environment variables (see `k8s/deployment.yml`):
-- `DATABASE_DSN`: MySQL connection string
-- `RABBITMQ_ADDRESS`: RabbitMQ server address
-- `REDIS_ADDRESS`: Redis cache server address (optional)
-- `REDIS_PASSWORD`: Redis authentication (optional)
-- `REDIS_DATABASE`: Redis database number (default: 1)
-- `PROMETHEUS_ENDPOINT`: Metrics endpoint path
-- `PROMETHEUS_LISTEN_ADDRESS`: Metrics server address
 
-## Critical Features
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | optional |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | `1` |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `talk_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+
+## Key Implementation Details
 
 ### Threading Validation Policy
 
@@ -423,7 +439,7 @@ log := logrus.WithFields(logrus.Fields{
 })
 ```
 
-## Testing Approach
+## Testing Patterns
 
 ### Test File Organization
 

--- a/bin-timeline-manager/CLAUDE.md
+++ b/bin-timeline-manager/CLAUDE.md
@@ -6,7 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `bin-timeline-manager` is a Go service within the VoIPbin monorepo that manages timeline events stored in ClickHouse. It provides event querying capabilities for tracking the history of resources across the platform (calls, flows, conversations, etc.).
 
-This service operates as an event-driven microservice using RabbitMQ for RPC-style communication.
+**Key Concepts:**
+- **Event**: A timeline record with publisher (service name), type, resource ID, timestamp, and JSON payload.
+- **ClickHouse storage**: Unlike most services (MySQL), this one uses ClickHouse for high-volume time-series queries.
+- **Query-only API**: This service does not write events itself — it reads from ClickHouse, which is populated by a separate ingestion path.
+- **Pattern matching**: Event-type filters support wildcards like `activeflow_*`.
+
+This service operates as an RPC service using RabbitMQ.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-timeline-manager`.
 
 ## Architecture
 
@@ -33,26 +41,29 @@ cmd/timeline-manager/main.go
 - `pkg/dbhandler/`: ClickHouse database operations
 - `pkg/listenhandler/`: RabbitMQ RPC request routing
 
-### Request Routing
+## Request Routing
 
 ListenHandler routes requests using regex patterns:
-- `POST /v1/events` - List events with filters (publisher, resource ID, event patterns)
+- `POST /v1/events` — List events with filters (publisher, resource ID, event-type patterns with wildcards), cursor-paginated.
 
-### Configuration
+## Event Subscriptions
+
+This service does not subscribe to RabbitMQ events. There is no SubscribeHandler — events arrive in ClickHouse via a separate ingestion path (not part of this service).
+
+## Configuration
 
 Uses **Cobra + Viper** pattern (see `internal/config/`):
-- Command-line flags and environment variables
-- Required: `rabbitmq_address`, `clickhouse_address`
-- Optional: `clickhouse_database` (default: `default`), `prometheus_endpoint`, `prometheus_listen_address`, `migrations_path`
 
-Default values:
-- `clickhouse_database`: `default`
-- `migrations_path`: `./migrations`
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `clickhouse_address` / `CLICKHOUSE_ADDRESS` | ClickHouse server (e.g., `clickhouse.infrastructure:9000`) | required |
+| `clickhouse_database` / `CLICKHOUSE_DATABASE` | ClickHouse database | `default` |
+| `migrations_path` / `MIGRATIONS_PATH` | Path to ClickHouse migration files | `./migrations` |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
-Production values (set in k8s deployment):
-- `clickhouse_address`: `clickhouse.infrastructure:9000`
-
-## Development Commands
+## Common Commands
 
 ### Build
 ```bash
@@ -220,9 +231,9 @@ for _, tt := range tests {
 ## Prometheus Metrics
 
 Service exposes metrics on configured endpoint (default `:2112/metrics`):
-- `receive_request_process_time` - Histogram of RPC request processing time (labels: type, method)
+- `timeline_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
 
-## Common Gotchas
+## Key Implementation Details
 
 ### ClickHouse Type Conversion
 

--- a/bin-transcribe-manager/CLAUDE.md
+++ b/bin-transcribe-manager/CLAUDE.md
@@ -4,39 +4,39 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-transcribe-manager is a speech-to-text service that processes real-time audio transcription for VoIP calls and conferences. It integrates with both Google Cloud Speech-to-Text and AWS Transcribe services, using RabbitMQ for messaging and Redis for caching.
+`bin-transcribe-manager` is a speech-to-text service that processes real-time audio transcription for VoIP calls and conferences. It integrates with both Google Cloud Speech-to-Text and AWS Transcribe, using RabbitMQ for messaging and Redis for caching.
 
-## Key Architecture Concepts
+**Key Concepts:**
+- **Transcribe**: A transcription session with reference to a call/conference/recording, language (BCP47), direction (in/out/both), and status (`progressing`/`done`).
+- **Streaming**: An active audio stream connection with provider-specific client configuration; sessions live in memory keyed by UUID and are anchored to one pod.
+- **Transcript**: An individual transcribed text segment with timestamps and confidence scores.
+- **Per-pod queue routing**: Operations targeting an active streaming session are routed via the per-pod queue convention so they reach the pod owning the in-memory state.
+- **Dual provider support**: GCP (`speech.Client`, LINEAR16 8 kHz) and AWS (`transcribestreaming.Client`, PCM 8 kHz). Per-session selection.
 
-### Monorepo Context
-This service is part of a larger monorepo structure (`monorepo/bin-transcribe-manager`). Dependencies use local replace directives in `go.mod` (e.g., `replace monorepo/bin-common-handler => ../bin-common-handler`). When working with shared code, be aware that changes may affect multiple services.
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-transcribe-manager`.
 
-### Message-Based Architecture
-The service operates on a request/response pattern using RabbitMQ queues:
-- **Listen queues**: `bin-manager.transcribe-manager.request` (shared), `bin-manager.transcribe-manager-<uuid>.request` (instance-specific)
-- **Event queue**: `bin-manager.transcribe-manager.event` (outbound notifications)
-- **Subscribe queues**: Listens to `bin-manager.call-manager.event` and `bin-manager.customer-manager.event` for lifecycle events
+## Architecture
 
-### Three Core Handlers
-1. **ListenHandler** (`pkg/listenhandler`): Processes REST-style API requests via RabbitMQ. Routes requests based on URL patterns (e.g., `/v1/transcribes`, `/v1/transcripts`)
-2. **SubscribeHandler** (`pkg/subscribehandler`): Listens to events from other services (call hangups, customer deletions) to trigger cleanup
-3. **StreamingHandler** (`pkg/streaminghandler`): Manages real-time audio streaming connections via WebSocket transport. Dials out to Asterisk's chan_websocket endpoint per-session. Maintains active streaming sessions in memory with mutex-protected map
+### Service Communication Pattern
 
-### Dual STT Provider Support
-The service supports both Google Cloud Platform and AWS transcription:
-- GCP: Uses `speech.Client` with LINEAR16 encoding at 8kHz
-- AWS: Uses `transcribestreaming.Client` with PCM encoding at 8kHz
-- Configuration is per-streaming session based on customer preferences or language requirements
+This service uses **RabbitMQ for RPC-style communication**:
+- **ListenHandler** (`pkg/listenhandler/`): Consumes from two queues:
+  - `bin-manager.transcribe-manager.request` (shared) — RPC requests that don't need to reach a specific pod (`POST /v1/transcribes`, `GET /v1/transcribes/<id>`).
+  - `bin-manager.transcribe-manager.request.<host_id>` (volatile, per-pod) — operations targeting an in-memory streaming session.
+- **SubscribeHandler** (`pkg/subscribehandler/`): Consumes events from `bin-manager.call-manager.event` and `bin-manager.customer-manager.event` for lifecycle cleanup.
+- **StreamingHandler** (`pkg/streaminghandler/`): Manages real-time audio streaming connections via WebSocket transport. Dials out to Asterisk's `chan_websocket` endpoint per session. Maintains active streaming sessions in memory with a mutex-protected map.
+- **NotifyHandler**: Publishes events to `bin-manager.transcribe-manager.event`.
 
-### Data Models
-- **Transcribe** (`models/transcribe`): Represents a transcription session with reference to call/conference/recording, language (BCP47), direction (in/out/both), and status (progressing/done)
-- **Streaming** (`models/streaming`): Represents an active audio stream connection with provider-specific client configuration
-- **Transcript** (`models/transcript`): Individual transcribed text segments with timestamps and confidence scores
+### Per-pod queue routing
+
+Like `bin-pipecat-manager`, this service uses the per-pod RabbitMQ queue convention. The `HostID` is `POD_IP` from the Kubernetes Downward API and is persisted on the streaming session so consumer services can route follow-up RPCs.
+
+See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical pattern (queue naming, identity source, limitations including Calico POD_IP recycle).
 
 ### Database Layer
 `pkg/dbhandler` abstracts database operations with a consistent interface. Uses both MySQL (via `database/sql`) and Redis cache. Always uses context for cancellation support.
 
-## Common Development Commands
+## Common Commands
 
 ### Building
 ```bash
@@ -118,50 +118,113 @@ go generate ./...
 cd pkg/streaminghandler && go generate
 ```
 
-## Working with the Codebase
+## Request Routing
 
-### Configuration via Environment Variables
-The service uses Cobra and Viper for configuration (see `internal/config/main.go`). Key environment variables:
-- `DATABASE_DSN`: MySQL connection string
-- `REDIS_ADDRESS`, `REDIS_DATABASE`, `REDIS_PASSWORD`: Redis configuration
-- `RABBITMQ_ADDRESS`: RabbitMQ connection string
-- `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`: AWS credentials for Transcribe (optional if GCP configured)
-All configuration can also be provided via CLI flags. Run `transcribe-manager --help` for details.
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
 
-**STT Provider Requirements:**
-- At least one STT provider must be configured (GCP or AWS)
-- GCP: Uses Application Default Credentials (ADC) - can be from service account key, gcloud CLI, GKE metadata server, etc.
-- AWS: Requires both `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` environment variables
-- Default provider order is hard-coded as GCP → AWS (no env var needed)
-- At startup, all providers with valid credentials are initialized; at least one must be available
-- Per-request provider selection: callers can pass `provider` ("gcp" or "aws") to try a specific provider first, with fallback to the default order
+**Transcribes API (`/v1/transcribes/*`):**
+- `POST /v1/transcribes` — Start a transcription session. Served on the **shared** queue.
+- `GET /v1/transcribes?<filters>` — List transcriptions. Served on the **shared** queue.
+- `GET /v1/transcribes/<uuid>` — Get a transcription session. Served on the **shared** queue.
+- `POST /v1/transcribes/<uuid>/stop` — Stop a session. Served on the **per-pod** queue (operates on in-memory streaming state).
+- `DELETE /v1/transcribes/<uuid>` — Delete a session.
 
-**Configuration Pattern:**
-Uses singleton pattern with `config.Get()` for thread-safe access. Configuration is loaded once at startup in the Cobra `PersistentPreRunE` hook.
+**Transcripts API (`/v1/transcripts/*`):**
+- `GET /v1/transcripts?<filters>` — List transcript segments
+- `GET /v1/transcripts/<uuid>` — Get a transcript segment
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.call-manager.event**: `call_hangup` — finalizes any associated transcription session (`EventCMCallHangup`).
+- **bin-manager.customer-manager.event**: `customer_deleted` — cascading cleanup of the customer's transcribes (`EventCUCustomerDeleted`).
+
+## Monorepo Context
+
+This service is part of a larger monorepo. Dependencies use local `replace` directives in `go.mod` (e.g., `replace monorepo/bin-common-handler => ../bin-common-handler`). Key local dependencies:
+- `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
+- `monorepo/bin-call-manager`: External media models for streaming setup
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+- Tests use `go.uber.org/mock` for mocking interfaces
+- Database tests may require test database setup (see `scripts/database_scripts_test/`)
+- Mock files follow `mock_*.go` in the same package as the interface
+- Use table-driven tests for multiple scenarios; always test error paths and edge cases (nil contexts, invalid UUIDs, etc.)
+- **Test struct initialization**: Use explicit field names — `{name: "test", input: "value", expectedRes: result}`, not positional.
+- **Test function comments**: Test names should be self-documenting. Use inline comments only where behavior is non-obvious.
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {name: "success case", input: input1, mockSetup: setupMock1, expectRes: expected1, expectErr: false},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### STT Provider Selection
+At startup, all providers with valid credentials are initialized; at least one must be available. Default order: `gcp` → `aws`. Callers may pass `provider` ("gcp" or "aws") to try a specific provider first, with fallback to the default order.
+
+### Streaming Audio Handling
+The streaming handler maintains active connections in `mapStreaming` (mutex-protected via `muSteaming`):
+- Always lock/unlock when accessing the map
+- Implement proper cleanup in `Stop()` to prevent leaks (WebSocket close + external media stop)
+- Use context cancellation for graceful shutdown
+- WebSocket transport delivers raw 8 kHz, 16-bit mono signed linear PCM (slin) binary frames
+- Service dials out to Asterisk via `MediaURI` returned from `ExternalMediaStart` (connection type `server`, transport `websocket`, encapsulation `none`)
+
+### Language Codes
+Must be valid BCP47 format (e.g., `en-US`, `ko-KR`).
+
+### Status Transitions
+Only allow valid state transitions — see `models/transcribe/transcribe.go:IsUpdatableStatus`.
 
 ### Adding New Transcribe Operations
-When adding new transcribe-related endpoints:
 1. Add URL pattern regex to `pkg/listenhandler/main.go`
 2. Implement handler method in `pkg/listenhandler/v1_transcribes.go`
 3. Add business logic to `pkg/transcribehandler/transcribe.go`
 4. Update database methods in `pkg/dbhandler/transcribe.go` if persistence needed
 5. Send notifications via `notifyhandler` for state changes
 
-### Working with Streaming Audio
-The streaming handler maintains active connections in `mapStreaming` (mutex-protected). When modifying streaming logic:
-- Always lock/unlock `muSteaming` when accessing the map
-- Implement proper cleanup in Stop() to prevent resource leaks (WebSocket close + external media stop)
-- Use context cancellation for graceful shutdown
-- WebSocket transport delivers raw 8kHz, 16-bit mono signed linear PCM (slin) binary frames
-- Service dials out to Asterisk via `MediaURI` returned from ExternalMediaStart (connectionType: "server", transport: "websocket", encapsulation: "none")
+## Configuration
 
-### Event-Driven Cleanup
-Subscribe handler methods (e.g., `EventCMCallHangup`, `EventCUCustomerDeleted`) ensure resources are cleaned up when parent entities are deleted. When adding new reference types, implement corresponding event handlers.
+Service uses Cobra and Viper (see `internal/config/main.go`). Configuration uses singleton pattern with `config.Get()` for thread-safe access; loaded once in the Cobra `PersistentPreRunE` hook.
 
-### Prometheus Metrics
-Metrics are registered in handler init() functions:
-- `transcribe_create_total`: Counter for transcription creation by type
-- `receive_request_process_time`: Histogram for request processing latency
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `aws_access_key` / `AWS_ACCESS_KEY` | AWS Transcribe credentials | optional (if GCP configured) |
+| `aws_secret_key` / `AWS_SECRET_KEY` | AWS Transcribe credentials | optional (if GCP configured) |
+| `POD_IP` | **Required.** Used as `HostID` for per-pod queue routing. Set via K8s Downward API (`status.podIP`). | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+GCP authentication uses Application Default Credentials (service account key, `gcloud` CLI, GKE metadata server). At least one STT provider (GCP or AWS) must be configured.
+
+## Prometheus Metrics
+
+Metrics are registered in handler `init()` functions:
+- `transcribe_create_total` — counter for transcription creation (label: `type`)
+- `receive_request_process_time` — histogram for request processing latency
 
 ## CI/CD Pipeline
 
@@ -170,25 +233,3 @@ The GitLab CI pipeline (`.gitlab-ci.yml`) has stages:
 2. **test**: Run golint, go vet, and tests with coverage
 3. **build**: Build Docker image and push to registry
 4. **release**: Deploy to Kubernetes using kustomize (manual trigger)
-
-## Testing Considerations
-
-- Tests use `go.uber.org/mock` for mocking interfaces
-- Database tests may require test database setup (see `scripts/database_scripts_test/`)
-- Mock files follow pattern `mock_*.go` in same package as interface
-- Use table-driven tests for multiple scenarios
-- Always test error paths and edge cases (nil contexts, invalid UUIDs, etc.)
-- **Test struct initialization**: Always use explicit field names in test case structs
-  - Good: `{name: "test", input: "value", expectedRes: result}`
-  - Bad: `{"test", "value", result}`
-- **Test function comments**: Do not add explanatory comments at the top of test functions
-  - Test names should be self-documenting
-  - Use inline comments only where code behavior is non-obvious
-
-## Important Constraints
-
-- **Language codes**: Must be valid BCP47 format (e.g., "en-US", "ko-KR")
-- **Status transitions**: Only allow valid state transitions (see `models/transcribe/transcribe.go:IsUpdatableStatus`)
-- **UUID validation**: All IDs must be valid UUIDs; use `uuid.FromString()` with error checking
-- **Concurrency**: Streaming map requires mutex protection; database operations use transactions where needed
-- **Graceful shutdown**: Use signal handlers and context cancellation to prevent data loss

--- a/bin-transfer-manager/CLAUDE.md
+++ b/bin-transfer-manager/CLAUDE.md
@@ -4,9 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-transfer-manager is a Go microservice that handles call transfer operations in a VoIP system. It manages both attended transfers (where the transferer can speak to the transferee before completing the transfer) and blind transfers (immediate transfer without consultation).
+`bin-transfer-manager` is a Go microservice that handles call transfer operations in a VoIP system. It manages both attended transfers (where the transferer can speak to the transferee before completing the transfer) and blind transfers (immediate transfer without consultation).
 
-## Build and Test Commands
+**Key Concepts:**
+- **Attended Transfer**: Transferer speaks to the transferee first; existing bridge participants are placed on MOH and muted while the consult call happens.
+- **Blind Transfer**: Immediate handoff — transferer hangs up as soon as the transferee answers.
+- **Block / Execute / Unblock phases**: Each transfer type has a block-state setup, an execute step that creates the groupcall to the transferee, and an unblock/rollback step if the transfer fails.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-transfer-manager`.
+
+## Common Commands
 
 ```bash
 # Build the transfer-manager daemon
@@ -108,16 +115,84 @@ RabbitMQ Request → listenhandler (regex routing) → transferhandler → call-
 Call Events → subscribehandler → transferhandler → state transitions
 ```
 
-### Configuration
+## Request Routing
+
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
+
+**Transfers API (`/v1/transfers/*`):**
+- `POST /v1/transfers` — Start transfer service (`attended` or `blind`)
+- `GET /v1/transfers/<uuid>` — Get transfer
+- `GET /v1/transfers?<filters>` — List transfers
+- `DELETE /v1/transfers/<uuid>` — Cancel transfer / rollback
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.call-manager.event**: `groupcall_progressing` (transferee answered → bridge parties), `groupcall_hangup` and `call_hangup` (rollback or finalize transfer state).
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-call-manager`: Call, groupcall, and confbridge operations (creating groupcalls, managing confbridge flags, call muting/MOH)
+- `monorepo/bin-flow-manager`: Flow information used in outbound call routing
+- `monorepo/bin-common-handler`: Shared models (address, identity, outline) and handlers (requesthandler, notifyhandler, sockhandler)
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+- Tests cover attended/blind transfer state transitions, rollback paths, and error handling
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Attended Transfer Block/Unblock
+`attendedBlock` places existing bridge participants on hold (MOH) and mutes their input; `attendedUnblock` reverses this on rollback. Failing to unblock leaves the original parties stuck on hold.
+
+### Blind Transfer ConfBridge Flag
+`blindBlock` sets `FlagNoAutoLeave` on the confbridge so the bridge survives the transferer hangup. `blindUnblock` clears the flag if the transfer fails.
+
+### Soft Deletes
+Records use `tm_delete` timestamp (`"9999-01-01 00:00:00.000000"` for active records).
+
+## Configuration
 
 Environment variables / flags:
-- `DATABASE_DSN` - MySQL connection string
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (e.g., `amqp://guest:guest@localhost:5672`)
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE` - Redis cache
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint
 
-### Dependencies on Other Services
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | required |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | required |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
-- **bin-call-manager**: For call, groupcall, and confbridge operations (creating groupcalls, managing confbridge flags, call muting/MOH)
-- **bin-flow-manager**: For flow information used in outbound call routing
-- **bin-common-handler**: Shared models (address, identity, outline) and handlers (requesthandler, notifyhandler, sockhandler)
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `transfer_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `transfer_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)

--- a/bin-tts-manager/CLAUDE.md
+++ b/bin-tts-manager/CLAUDE.md
@@ -4,13 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-tts-manager is a Go microservice for text-to-speech (TTS) synthesis in a VoIP system. It provides two modes of operation:
-1. **Batch TTS**: Generate and store pre-recorded audio files from text
-2. **Real-time Streaming TTS**: Stream synthesized audio directly to live VoIP calls via AudioSocket protocol
+`bin-tts-manager` is a Go microservice for text-to-speech (TTS) synthesis in a VoIP system. It provides two modes of operation:
+
+1. **Batch TTS**: Generate and store pre-recorded audio files from text.
+2. **Real-time Streaming TTS**: Stream synthesized audio directly to live VoIP calls via the AudioSocket protocol.
 
 The service integrates with multiple TTS providers (Google Cloud TTS, AWS Polly, ElevenLabs) and manages audio delivery through both file storage and real-time streaming.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Batch TTS file**: Audio file generated from text and stored on a shared volume; served by a Python HTTP sidecar on port 80.
+- **Streaming session**: Real-time WebSocket connection to ElevenLabs that pumps audio frames to Asterisk over AudioSocket on port 8080.
+- **Per-pod queue routing**: Streaming control RPCs are routed to the pod owning the in-memory session via `bin-manager.tts-manager.request.<HOSTNAME>`.
+- **Multi-container pod**: Go service + Python HTTP sidecar share `/shared-data` for file delivery.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-tts-manager`.
+
+## Common Commands
 
 ```bash
 # Build the tts-manager daemon
@@ -86,12 +95,14 @@ Asterisk Call → AudioSocket (TCP:8080) → streaminghandler → ElevenLabs Web
                                     RabbitMQ control messages (Start/Say/Stop)
 ```
 
-### Pod-specific Routing
+### Per-pod queue routing
 
-The service supports Kubernetes pod-specific routing:
-- Listens on both a shared queue (`bin-manager.tts-manager.request`) and a pod-specific queue (`bin-manager.tts-manager.request.{HOSTNAME}`)
-- Uses `POD_IP` environment variable to construct the streaming endpoint address
-- Enables direct routing to specific pods for streaming sessions
+This service uses the per-pod RabbitMQ queue convention. The `HostID` is sourced from `HOSTNAME` (rather than `POD_IP` as in `bin-pipecat-manager`):
+- Shared queue: `bin-manager.tts-manager.request` — batch TTS RPCs (`POST /v1/ttses`)
+- Per-pod queue: `bin-manager.tts-manager.request.<HOSTNAME>` — streaming session control (Start/Say/Stop)
+- `POD_IP` is used to advertise the AudioSocket endpoint that callers (Asterisk) dial into
+
+See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical pattern (queue naming, identity source, limitations).
 
 ### TTS Provider Strategy
 
@@ -128,23 +139,99 @@ The streaminghandler maintains concurrent streaming sessions:
 - Vendor-specific handlers (ElevenLabs) manage WebSocket lifecycle
 - Message queuing for say operations (SayInit, SayAdd, SayStop, SayFinish)
 
-### Configuration
+## Request Routing
+
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
+
+**TTSes API (`/v1/ttses/*`):**
+- `POST /v1/ttses` — Generate batch TTS audio file (returns the audio URL). Served on the **shared** queue.
+- `GET /v1/ttses/<uuid>` — Get TTS metadata. Served on the **shared** queue.
+
+**Streaming control (`/v1/streamings/*`):**
+- `POST /v1/streamings/<uuid>/start` — Initialize streaming session.
+- `POST /v1/streamings/<uuid>/say` — Send a text chunk to the session.
+- `POST /v1/streamings/<uuid>/stop` — Stop the streaming session.
+
+Streaming control endpoints are served on the **per-pod** queue.
+
+In addition, the service listens on TCP port 8080 for the AudioSocket protocol — this is how Asterisk delivers media frames to the active streaming session.
+
+## Event Subscriptions
+
+This service does not subscribe to RabbitMQ events. There is no SubscribeHandler — TTS is invoked synchronously via RPC.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared utilities (sockhandler, requesthandler, notifyhandler)
+- `monorepo/bin-call-manager`: External media models (for streaming setup)
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with handlers (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Streaming Session Management
+The streaminghandler maintains concurrent streaming sessions:
+- Each connection gets its own goroutine with context cancellation
+- Keep-alive pings sent every 30 seconds via the AudioSocket protocol
+- Sessions identified by UUID extracted from the initial AudioSocket handshake
+- Vendor-specific handlers (ElevenLabs) manage WebSocket lifecycle
+- Message queuing for say operations (`SayInit`, `SayAdd`, `SayStop`, `SayFinish`)
+
+### Multi-Container Deployment
+Pod deployment runs two containers:
+1. **tts-manager** (Go): main service, listens on port 8080 (AudioSocket) and 2112 (metrics)
+2. **http-server** (Python): serves generated audio files from `/shared-data` on port 80
+
+The shared volume `/shared-data` is the bridge between containers — the Go service writes audio files; the Python HTTP server serves them.
+
+### GCP Regional Endpoint
+GCP TTS uses the regional endpoint `eu-texttospeech.googleapis.com:443` for lower latency in the EU region.
+
+## Configuration
 
 Environment variables / flags:
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (default: `amqp://guest:guest@localhost:5672`)
-- `PROMETHEUS_ENDPOINT` - Metrics endpoint (default: `/metrics`)
-- `PROMETHEUS_LISTEN_ADDRESS` - Metrics server address (default: `:2112`)
-- `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` - AWS Polly credentials
-- `ELEVENLABS_API_KEY` - ElevenLabs API key for streaming
-- `POD_IP` - Pod IP address for streaming endpoint (injected by k8s)
-- `HOSTNAME` - Pod hostname for queue routing (injected by k8s)
 
-GCP credentials are managed via Application Default Credentials (ADC) - typically through `GOOGLE_APPLICATION_CREDENTIALS` environment variable or workload identity.
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | `amqp://guest:guest@localhost:5672` |
+| `aws_access_key` / `AWS_ACCESS_KEY` | AWS Polly credentials | required if AWS used |
+| `aws_secret_key` / `AWS_SECRET_KEY` | AWS Polly credentials | required if AWS used |
+| `elevenlabs_api_key` / `ELEVENLABS_API_KEY` | ElevenLabs API key for streaming | required for streaming |
+| `POD_IP` | **Required.** Used to advertise the AudioSocket endpoint. Injected by k8s. | required |
+| `HOSTNAME` | **Required.** Used as `HostID` for per-pod queue routing. Injected by k8s. | required |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
 
-### Deployment Architecture
+GCP credentials are managed via Application Default Credentials (ADC) — typically through `GOOGLE_APPLICATION_CREDENTIALS` or workload identity.
 
-Multi-container pod deployment:
-1. **tts-manager** container: Main Go service listening on port 8080 (AudioSocket) and 2112 (metrics)
-2. **http-server** container: Python HTTP server on port 80 serving audio files from shared volume
+## Prometheus Metrics
 
-Shared volume `/shared-data` acts as a bridge for generated audio files between containers.
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `tts_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)

--- a/bin-webhook-manager/CLAUDE.md
+++ b/bin-webhook-manager/CLAUDE.md
@@ -4,9 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-bin-webhook-manager is a Go microservice for managing webhook event notifications in a VoIP system. It receives webhook requests from other services and publishes webhook events for delivery to customer-defined endpoints.
+`bin-webhook-manager` is a Go microservice for managing webhook event notifications in a VoIP system. It receives webhook requests from other services and publishes webhook events for delivery to customer-defined endpoints.
 
-## Build and Test Commands
+**Key Concepts:**
+- **Webhook**: An outbound HTTP notification dispatched to a customer-configured URI when an event of interest occurs.
+- **Customer webhook config**: Each customer has a `webhook_method` and `webhook_uri` set in `bin-customer-manager` — this service reads that config to know where to send.
+- **Two delivery modes**: `SendWebhookToCustomer` uses the customer's saved config; `SendWebhookToURI` lets callers override the destination.
+
+> Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md). This file documents only what is specific to `bin-webhook-manager`.
+
+## Common Commands
 
 ```bash
 # Build the webhook-manager daemon
@@ -109,12 +116,77 @@ The service supports two webhook delivery patterns:
 
 Both methods publish `webhook_published` events to the event queue for asynchronous processing.
 
-### Configuration
+## Request Routing
 
-Environment variables / flags (all have defaults):
-- `DATABASE_DSN` - MySQL connection string (default: `testid:testpassword@tcp(127.0.0.1:3306)/test`)
-- `RABBITMQ_ADDRESS` - RabbitMQ connection (default: `amqp://guest:guest@localhost:5672`)
-- `REDIS_ADDRESS`, `REDIS_PASSWORD`, `REDIS_DATABASE` - Redis cache configuration
-- `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` - Metrics endpoint (default: `/metrics` on `:2112`)
+ListenHandler routes RPC requests using regex patterns matching REST-like URIs:
+
+**Webhooks API (`/v1/webhooks/*`):**
+- `POST /v1/webhooks/send-to-customer` — Look up the customer's saved webhook config and dispatch
+- `POST /v1/webhooks/send-to-uri` — Dispatch to a caller-specified URI/method
+
+## Event Subscriptions
+
+SubscribeHandler subscribes to:
+- **bin-manager.customer-manager.event**: `customer_updated`, `customer_deleted` — invalidates the local accounthandler cache so subsequent webhook dispatches see the new URI/method.
+
+## Monorepo Context
+
+This service depends on local monorepo packages (see `go.mod` replace directives):
+- `monorepo/bin-common-handler`: Shared handlers (sockhandler, requesthandler, notifyhandler, databasehandler)
+- `monorepo/bin-customer-manager`: Customer event/account models for resolving webhook destinations
+
+Always run `go mod vendor` after changing dependencies.
+
+## Testing Patterns
+
+Tests use **gomock** (go.uber.org/mock):
+- Mock interfaces co-located with the handler (`mock_*.go`)
+- Table-driven tests with struct slices
+
+```go
+tests := []struct {
+    name      string
+    input     InputType
+    mockSetup func(*MockHandler)
+    expectRes ResultType
+    expectErr bool
+}{
+    {"success case", input1, setupMock1, expected1, false},
+    {"error case", input2, setupMock2, nil, true},
+}
+for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+        mc := gomock.NewController(t)
+        defer mc.Finish()
+        // test implementation
+    })
+}
+```
+
+## Key Implementation Details
+
+### Account Cache Invalidation
+Customer webhook configs are cached in Redis via `pkg/accounthandler/`. The cache must be invalidated when `bin-customer-manager` publishes `customer_updated` or `customer_deleted` events, otherwise webhook dispatches will continue using the old URI/method.
+
+### Event Publishing
+Both delivery paths emit a `webhook_published` event to `bin-manager.webhook-manager.event` after queuing the dispatch. Downstream consumers can correlate these to the originating customer/event for analytics or retry coordination.
+
+## Configuration
 
 Configuration is handled via `spf13/viper` and `spf13/pflag`, supporting both command-line flags and environment variables with automatic env binding.
+
+| Flag / Env | Description | Default |
+|------------|-------------|---------|
+| `database_dsn` / `DATABASE_DSN` | MySQL connection string | `testid:testpassword@tcp(127.0.0.1:3306)/test` |
+| `rabbitmq_address` / `RABBITMQ_ADDRESS` | RabbitMQ server | `amqp://guest:guest@localhost:5672` |
+| `redis_address` / `REDIS_ADDRESS` | Redis cache | required |
+| `redis_password` / `REDIS_PASSWORD` | Redis auth | optional |
+| `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
+| `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
+| `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics port | `:2112` |
+
+## Prometheus Metrics
+
+Service exposes metrics on the configured endpoint (default `:2112/metrics`):
+- `webhook_manager_receive_request_process_time` — histogram of RPC request processing time (labels: type, method)
+- `webhook_manager_subscribe_event_process_time` — histogram of event processing time (labels: publisher, type)


### PR DESCRIPTION
Audit the remaining 31 service-level CLAUDE.md files (the two pilots
bin-common-handler and bin-pipecat-manager were already audited in
PR #859). Each service file is now structurally compliant with
docs/reference/claude-md-template.md: 10 H2 sections present (or N/A
markers), no content duplicated from root CLAUDE.md, pattern doc
references added only where verifiably applicable.

Per directive (a) — strict-audit-only: no new shared patterns are
promoted to docs/patterns/ in this PR. Four candidate cross-cutting
patterns surfaced and are noted as follow-up candidates: external
webhook receiver, cascading customer-deleted cleanup, multi-provider
fallback, AudioSocket/WebSocket external-media streaming.

Highlights:
- All 31 audited files pass `grep -cE "^## (Overview |Architecture|Request Routing|Event Subscriptions|Common Commands|Monorepo Context|Testing Patterns|Key Implementation Details|Configuration|Prometheus Metrics)" = 10`.
- bin-rag-manager near-rewrite (69 -> 150 lines) — facts grounded in pkg/chunker, env vars, GKE Workload Identity, GCP region, document parsers all verified against source.
- bin-api-manager: stripped 22 lines of worktree-mandate content duplicated from root CLAUDE.md; promoted Testing Patterns to its own H2.
- 8 services (agent, billing, call, conference, conversation, customer, email, message) had Request Routing / Event Subscriptions / Configuration as nested H3 under Architecture — promoted to top-level H2 in the review-fix commit.
- bin-campaign-manager: restored the in-memory SQLite testing note that the original audit dropped.
- Verified zero stale docs/<file>.md paths in any service file.

Pattern references added (verified, not speculative):
- docs/patterns/per-pod-queues.md from bin-tts-manager and bin-transcribe-manager (both confirmed POD_IP/HOSTNAME consumers via cmd/<svc>/main.go inspection)
- docs/patterns/webhook-message.md from bin-api-manager (canonical consumer)
- docs/patterns/circuit-breaker.md from bin-api-manager (Prometheus Metrics context)

Heads-up: in-flight feature branches that touch any service-level
CLAUDE.md will need to rebase after this lands.

- bin-flow-manager, bin-call-manager, bin-ai-manager, bin-conference-manager, bin-conversation-manager: Audit against template, strip duplicated cross-cutting content, refresh paths, add pattern references where applicable
- bin-billing-manager, bin-customer-manager, bin-agent-manager, bin-api-manager, bin-openapi-manager: Same audit checklist; bin-api-manager strips worktree-mandate duplication and adds webhook-message and circuit-breaker pattern references
- bin-campaign-manager, bin-outdial-manager, bin-message-manager, bin-email-manager, bin-webhook-manager, bin-talk-manager: Same audit checklist
- bin-route-manager, bin-registrar-manager, bin-queue-manager, bin-transfer-manager, bin-hook-manager, bin-sentinel-manager: Same audit checklist
- bin-dbscheme-manager, bin-storage-manager, bin-rag-manager, bin-transcribe-manager, bin-tts-manager, bin-number-manager, bin-contact-manager, bin-tag-manager, bin-timeline-manager: Same audit checklist; bin-tts-manager and bin-transcribe-manager add per-pod-queues pattern reference; bin-rag-manager rewritten from 69-line stub to template-compliant doc with facts verified against pkg/chunker and config files
- bin-agent-manager, bin-billing-manager, bin-call-manager, bin-conference-manager, bin-conversation-manager, bin-customer-manager, bin-email-manager, bin-message-manager: Promote nested H3 Request Routing / Event Subscriptions / Configuration headings to top-level H2 so all 10 template sections are present at the right level (review-fix commit)
- bin-api-manager: Promote nested Testing Patterns under Architecture to top-level H2 (review-fix commit)
- bin-campaign-manager: Restore in-memory SQLite testing note dropped by the original audit; verified accurate against pkg/dbhandler/main_test.go (review-fix commit)