### PR TITLE
NOJIRA-circleci-bump-python-tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           name: check-updated-files
           base-revision: main
           config-path: .circleci/config_work.yml
-          tag: "3.9"
+          tag: "3.12"
           mapping: |
             bin-agent-manager/.*        run-bin-agent-manager true
             bin-ai-manager/.*           run-bin-ai-manager true


### PR DESCRIPTION
Fix monorepo-wide CircleCI failure caused by an upstream pypa.io change. The path-filtering orb in .circleci/config.yml runs on a cimg/python:3.9 container and its setup curls https://bootstrap.pypa.io/get-pip.py. Pypa recently dropped Python 3.9 support from the latest get-pip.py, so every CI run now fails at the orb's bootstrap step with "ERROR: This script does not work on Python 3.9". Bumping the orb's tag to 3.12 (any 3.10+ would work) restores CI without changing what the orb does — it only diffs changed files against main, so the Python version is immaterial for that work.

- monorepo: Bump path-filtering orb's python tag from 3.9 to 3.12 in .circleci/config.yml so the orb's get-pip.py bootstrap step works after pypa.io dropped Python 3.9 support from the latest get-pip.py