### PR TITLE
NOJIRA-retrigger-ci-after-domain-removal

### DIFF
--- a/bin-api-manager/README.md
+++ b/bin-api-manager/README.md
@@ -255,4 +255,4 @@ See [CLAUDE.md](./CLAUDE.md).
 
 Copyright © 2024 VoIPBIN. All rights reserved.
 
-<!-- Updated dependencies: 2026-03-30 -->
+<!-- Updated dependencies: 2026-04-28 -->

--- a/bin-common-handler/README.md
+++ b/bin-common-handler/README.md
@@ -6,4 +6,4 @@ common-handler for bin namespace.
 $ ls -d */ | xargs -I {} bash -c "cd '{}' && go get -u ./... && go mod vendor && go generate ./... && go test ./..."
 ```
 
-<!-- Updated dependencies: 2026-02-20 -->
+<!-- Updated dependencies: 2026-04-28 -->

--- a/bin-openapi-manager/README.md
+++ b/bin-openapi-manager/README.md
@@ -1,4 +1,4 @@
 bin-openapi-manager
 
 $ go generate ./...
-<!-- Updated dependencies: 2026-02-20 -->
+<!-- Updated dependencies: 2026-04-28 -->


### PR DESCRIPTION
Re-trigger CI for the three projects (bin-api-manager, bin-common-handler, bin-openapi-manager) that were touched by PR #866 (NOJIRA-remove-domain-from-external-error). The original merge's CI never ran successfully because of the upstream pypa.io get-pip.py change that broke the path-filtering orb on Python 3.9. Once #867 (NOJIRA-circleci-bump-python-tag) lands the CI infrastructure fix, this PR's per-service pipelines will run cleanly and validate the merged domain-removal changes.

Each README change is a one-line bump of the existing "Updated dependencies" timestamp comment to today (2026-04-28), matching the established no-op convention already present at the bottom of each file. The path-filtering orb in .circleci/config_work.yml routes per-service jobs based on changed file paths, so touching one file per project is sufficient to fire each pipeline.

- bin-api-manager: Bump README "Updated dependencies" timestamp to 2026-04-28 to retrigger CI for the domain-field-removal merge after the path-filtering python-tag fix lands
- bin-common-handler: Bump README "Updated dependencies" timestamp to 2026-04-28 to retrigger CI for the VoipbinError docstring update from the domain-field-removal merge
- bin-openapi-manager: Bump README "Updated dependencies" timestamp to 2026-04-28 to retrigger CI for the ErrorBody schema update from the domain-field-removal merge