### PR TITLE
NOJIRA-fix-circleci-python-tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           name: check-updated-files
           base-revision: main
           config-path: .circleci/config_work.yml
-          tag: "3.9"
+          tag: "3.12"
           mapping: |
             bin-agent-manager/.*        run-bin-agent-manager true
             bin-ai-manager/.*           run-bin-ai-manager true

--- a/bin-api-manager/README.md
+++ b/bin-api-manager/README.md
@@ -255,4 +255,4 @@ See [CLAUDE.md](./CLAUDE.md).
 
 Copyright © 2024 VoIPBIN. All rights reserved.
 
-<!-- Updated dependencies: 2026-03-30 -->
+<!-- Updated dependencies: 2026-04-28 -->

--- a/bin-common-handler/README.md
+++ b/bin-common-handler/README.md
@@ -6,4 +6,4 @@ common-handler for bin namespace.
 $ ls -d */ | xargs -I {} bash -c "cd '{}' && go get -u ./... && go mod vendor && go generate ./... && go test ./..."
 ```
 
-<!-- Updated dependencies: 2026-02-20 -->
+<!-- Updated dependencies: 2026-04-28 -->

--- a/bin-openapi-manager/README.md
+++ b/bin-openapi-manager/README.md
@@ -1,4 +1,4 @@
 bin-openapi-manager
 
 $ go generate ./...
-<!-- Updated dependencies: 2026-02-20 -->
+<!-- Updated dependencies: 2026-04-28 -->


### PR DESCRIPTION
Fix monorepo-wide CircleCI failure caused by an upstream pypa.io change, and bundle README timestamp bumps to retrigger per-service CI for the recently merged domain-field-removal PR (#866). The path-filtering orb in .circleci/config.yml runs on a cimg/python:3.9 container and its setup curls https://bootstrap.pypa.io/get-pip.py. Pypa recently dropped Python 3.9 support from the latest get-pip.py, so every CI run was failing at the orb's bootstrap step with "ERROR: This script does not work on Python 3.9". Bumping the orb's tag to 3.12 restores CI without changing what the orb does — it only diffs changed files against main, so the Python version is immaterial for that work. Both fixes ship in one branch so this PR's own setup phase uses the new Python 3.12 tag and the README touches trigger per-service jobs for the three projects that were modified by PR #866 (bin-api-manager, bin-common-handler, bin-openapi-manager).

- monorepo: Bump path-filtering orb's python tag from 3.9 to 3.12 in .circleci/config.yml so the orb's get-pip.py bootstrap step works after pypa.io dropped Python 3.9 support from the latest get-pip.py
- bin-api-manager: Bump README "Updated dependencies" timestamp to 2026-04-28 to retrigger CI for the domain-field-removal merge now that the path-filtering python tag is fixed in the same PR
- bin-common-handler: Bump README "Updated dependencies" timestamp to 2026-04-28 to retrigger CI for the VoipbinError docstring update from the domain-field-removal merge
- bin-openapi-manager: Bump README "Updated dependencies" timestamp to 2026-04-28 to retrigger CI for the ErrorBody schema update from the domain-field-removal merge