### PR TITLE
NOJIRA-aicall-terminate-drop-design

### DIFF
--- a/bin-ai-manager/models/message/main.go
+++ b/bin-ai-manager/models/message/main.go
@@ -47,3 +47,13 @@ const (
 	DirectionOutgoing Direction = "outgoing"
 	DirectionNone     Direction = ""
 )
+
+// DeliveryStatus tracks whether a message has been successfully delivered
+// to the user (e.g. TTS audio actually played out to the call).
+type DeliveryStatus string
+
+// list of delivery statuses
+const (
+	DeliveryStatusPending   DeliveryStatus = "pending"
+	DeliveryStatusDelivered DeliveryStatus = "delivered"
+)

--- a/bin-ai-manager/models/message/main.go
+++ b/bin-ai-manager/models/message/main.go
@@ -22,6 +22,9 @@ type Message struct {
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty" db:"tool_calls,json"`
 	ToolCallID string     `json:"tool_call_id,omitempty" db:"tool_call_id"`
 
+	PipecatcallID  uuid.UUID      `json:"-" db:"pipecatcall_id"`
+	DeliveryStatus DeliveryStatus `json:"-" db:"delivery_status"`
+
 	TMCreate *time.Time `json:"tm_create" db:"tm_create"`
 	TMDelete *time.Time `json:"tm_delete" db:"tm_delete"`
 }

--- a/bin-ai-manager/models/message/main.go
+++ b/bin-ai-manager/models/message/main.go
@@ -22,7 +22,7 @@ type Message struct {
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty" db:"tool_calls,json"`
 	ToolCallID string     `json:"tool_call_id,omitempty" db:"tool_call_id"`
 
-	PipecatcallID  uuid.UUID      `json:"-" db:"pipecatcall_id"`
+	PipecatcallID  uuid.UUID      `json:"-" db:"pipecatcall_id,uuid"`
 	DeliveryStatus DeliveryStatus `json:"-" db:"delivery_status"`
 
 	TMCreate *time.Time `json:"tm_create" db:"tm_create"`

--- a/bin-ai-manager/models/message/main_test.go
+++ b/bin-ai-manager/models/message/main_test.go
@@ -1,11 +1,41 @@
 package message
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gofrs/uuid"
 )
+
+func TestMessage_hasPipecatcallIDAndDeliveryStatus(t *testing.T) {
+	m := Message{
+		PipecatcallID:  uuid.Must(uuid.NewV4()),
+		DeliveryStatus: DeliveryStatusPending,
+	}
+	if m.PipecatcallID == uuid.Nil {
+		t.Fatal("PipecatcallID not set")
+	}
+	if m.DeliveryStatus != DeliveryStatusPending {
+		t.Fatal("DeliveryStatus not set")
+	}
+}
+
+func TestWebhookMessage_omitsInternalFields(t *testing.T) {
+	m := Message{
+		PipecatcallID:  uuid.Must(uuid.NewV4()),
+		DeliveryStatus: DeliveryStatusDelivered,
+	}
+	wm := m.ConvertWebhookMessage()
+	raw, _ := json.Marshal(wm)
+	if strings.Contains(string(raw), "pipecatcall_id") {
+		t.Fatalf("webhook leaks pipecatcall_id: %s", raw)
+	}
+	if strings.Contains(string(raw), "delivery_status") {
+		t.Fatalf("webhook leaks delivery_status: %s", raw)
+	}
+}
 
 func TestMessage(t *testing.T) {
 	tests := []struct {

--- a/bin-ai-manager/models/message/main_test.go
+++ b/bin-ai-manager/models/message/main_test.go
@@ -138,6 +138,33 @@ func TestRoleConstants(t *testing.T) {
 	}
 }
 
+func TestDeliveryStatusConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant DeliveryStatus
+		expected string
+	}{
+		{
+			name:     "delivery_status_pending",
+			constant: DeliveryStatusPending,
+			expected: "pending",
+		},
+		{
+			name:     "delivery_status_delivered",
+			constant: DeliveryStatusDelivered,
+			expected: "delivered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if string(tt.constant) != tt.expected {
+				t.Errorf("Wrong constant value. expect: %s, got: %s", tt.expected, tt.constant)
+			}
+		})
+	}
+}
+
 func TestDirectionConstants(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/bin-ai-manager/pkg/aicallhandler/metrics.go
+++ b/bin-ai-manager/pkg/aicallhandler/metrics.go
@@ -1,18 +1,8 @@
 package aicallhandler
 
-import "github.com/prometheus/client_golang/prometheus"
-
-var (
-	promBackstopReplyTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Name:      "aicall_backstop_reply_total",
-			Help:      "Counter of pipecatcall_terminated backstop attempts in messagehandler.EventPMPipecatcallTerminated.",
-		},
-		[]string{"result"},
-	)
-)
-
-func init() {
-	prometheus.MustRegister(promBackstopReplyTotal)
-}
+// The aicall_backstop_reply_total counter previously declared here was relocated
+// to pkg/messagehandler (see metrics_backstop.go) because the only emit site is
+// messagehandler.EventPMPipecatcallTerminated, and aicallhandler imports
+// messagehandler — referencing the counter here would have created a circular
+// import. The fully-qualified metric name (`ai_manager_aicall_backstop_reply_total`)
+// is preserved by reusing the same `metricsNamespace` from this package's main.go.

--- a/bin-ai-manager/pkg/aicallhandler/metrics.go
+++ b/bin-ai-manager/pkg/aicallhandler/metrics.go
@@ -1,0 +1,18 @@
+package aicallhandler
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	promBackstopReplyTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "aicall_backstop_reply_total",
+			Help:      "Counter of pipecatcall_terminated backstop attempts in messagehandler.EventPMPipecatcallTerminated.",
+		},
+		[]string{"result"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(promBackstopReplyTotal)
+}

--- a/bin-ai-manager/pkg/aicallhandler/metrics_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/metrics_test.go
@@ -1,0 +1,51 @@
+package aicallhandler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metricRegistered reports whether a metric with the given fully-qualified
+// name is registered with the default Prometheus registerer.
+//
+// We attempt to register a throwaway counter that shares the target name. The
+// default registerer rejects the registration with AlreadyRegisteredError when
+// the name is already in use, which is the signal we want. Using Gather() is
+// not sufficient for *Vec collectors with no observed children, since they do
+// not emit a metric family until at least one label combination is touched.
+func metricRegistered(name string) bool {
+	probe := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: name,
+		Help: "probe",
+	})
+	err := prometheus.DefaultRegisterer.Register(probe)
+	if err == nil {
+		// Probe registered cleanly, so the real metric was NOT already there.
+		// Unregister our probe so we leave the registry as we found it.
+		prometheus.DefaultRegisterer.Unregister(probe)
+		return false
+	}
+	var are prometheus.AlreadyRegisteredError
+	if errors.As(err, &are) {
+		return true
+	}
+	// CounterVec/GaugeVec collectors register a Desc whose fully-qualified
+	// name plus variable label set must be unique. Re-registering a plain
+	// Counter under the same name surfaces a descriptor-conflict error rather
+	// than AlreadyRegisteredError. Treat any of these "name already in the
+	// registry" messages as positive signal too.
+	msg := err.Error()
+	return strings.Contains(msg, "already registered") ||
+		strings.Contains(msg, "duplicate metrics collector") ||
+		strings.Contains(msg, "previously registered descriptor with the same fully-qualified name")
+}
+
+func TestPromBackstopReplyTotal_registered(t *testing.T) {
+	const name = "ai_manager_aicall_backstop_reply_total"
+	if !metricRegistered(name) {
+		t.Fatalf("metric %s not registered", name)
+	}
+}

--- a/bin-ai-manager/pkg/dbhandler/main.go
+++ b/bin-ai-manager/pkg/dbhandler/main.go
@@ -38,6 +38,7 @@ type DBHandler interface {
 	MessageGet(ctx context.Context, id uuid.UUID) (*message.Message, error)
 	MessageList(ctx context.Context, size uint64, token string, filters map[message.Field]any) ([]*message.Message, error)
 	MessageDelete(ctx context.Context, id uuid.UUID) error
+	MessageUpdateDeliveryStatus(ctx context.Context, id uuid.UUID, status message.DeliveryStatus) error
 	MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error)
 
 	SummaryCreate(ctx context.Context, c *summary.Summary) error

--- a/bin-ai-manager/pkg/dbhandler/main.go
+++ b/bin-ai-manager/pkg/dbhandler/main.go
@@ -38,6 +38,7 @@ type DBHandler interface {
 	MessageGet(ctx context.Context, id uuid.UUID) (*message.Message, error)
 	MessageList(ctx context.Context, size uint64, token string, filters map[message.Field]any) ([]*message.Message, error)
 	MessageDelete(ctx context.Context, id uuid.UUID) error
+	MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error)
 
 	SummaryCreate(ctx context.Context, c *summary.Summary) error
 	SummaryGet(ctx context.Context, id uuid.UUID) (*summary.Summary, error)

--- a/bin-ai-manager/pkg/dbhandler/message.go
+++ b/bin-ai-manager/pkg/dbhandler/message.go
@@ -148,6 +148,35 @@ func (h *handler) MessageDelete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// MessageAssistantReplyExists reports whether a delivered, incoming, assistant-role
+// reply exists for the given pipecatcall_id. Returns false (and no error) when no
+// such row is present. Used by the aicall terminate-drop guard to decide whether
+// to wait for the in-flight assistant reply to finalize before terminating.
+func (h *handler) MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error) {
+	query, args, err := sq.Select("1").
+		From(messageTable).
+		Where(sq.Eq{
+			"pipecatcall_id":  pipecatcallID.Bytes(),
+			"delivery_status": string(message.DeliveryStatusDelivered),
+			"direction":       string(message.DirectionIncoming),
+			"role":            string(message.RoleAssistant),
+		}).
+		Where(sq.Eq{"tm_delete": nil}).
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return false, fmt.Errorf("MessageAssistantReplyExists: could not build query. err: %v", err)
+	}
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return false, fmt.Errorf("MessageAssistantReplyExists: could not query. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return rows.Next(), nil
+}
+
 // MessageGets returns a list of messages.
 func (h *handler) MessageList(ctx context.Context, size uint64, token string, filters map[message.Field]any) ([]*message.Message, error) {
 	if token == "" {

--- a/bin-ai-manager/pkg/dbhandler/message.go
+++ b/bin-ai-manager/pkg/dbhandler/message.go
@@ -148,6 +148,30 @@ func (h *handler) MessageDelete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// MessageUpdateDeliveryStatus updates the delivery_status of a message. Used by the
+// persist-then-mark-delivered flow: a message is created with status=pending, then
+// flipped to delivered after the conversation send succeeds.
+func (h *handler) MessageUpdateDeliveryStatus(ctx context.Context, id uuid.UUID, status message.DeliveryStatus) error {
+	query, args, err := sq.Update(messageTable).
+		SetMap(map[string]any{
+			"delivery_status": string(status),
+		}).
+		Where(sq.Eq{"id": id.Bytes()}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("MessageUpdateDeliveryStatus: could not build query. err: %v", err)
+	}
+
+	if _, err := h.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("MessageUpdateDeliveryStatus: could not execute. err: %v", err)
+	}
+
+	// update the cache
+	_ = h.messageUpdateToCache(ctx, id)
+
+	return nil
+}
+
 // MessageAssistantReplyExists reports whether a delivered, incoming, assistant-role
 // reply exists for the given pipecatcall_id. Returns false (and no error) when no
 // such row is present. Used by the aicall terminate-drop guard to decide whether

--- a/bin-ai-manager/pkg/dbhandler/message_test.go
+++ b/bin-ai-manager/pkg/dbhandler/message_test.go
@@ -187,3 +187,177 @@ func Test_MessageCreate(t *testing.T) {
 		})
 	}
 }
+
+func Test_MessageAssistantReplyExists(t *testing.T) {
+	curTime := func() *time.Time { t := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC); return &t }()
+	deletedTime := func() *time.Time { t := time.Date(2026, 4, 29, 12, 30, 0, 0, time.UTC); return &t }()
+
+	pcA := uuid.FromStringOrNil("a4a4a4a4-2c11-11f1-aaaa-111111111111")
+	pcB := uuid.FromStringOrNil("b5b5b5b5-2c11-11f1-bbbb-222222222222")
+
+	tests := []struct {
+		name string
+
+		seed []*message.Message
+
+		query     uuid.UUID
+		expectRes bool
+	}{
+		{
+			name: "delivered_match",
+			seed: []*message.Message{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("c0000001-2c11-11f1-9000-000000000001"),
+					},
+					AIcallID:       uuid.FromStringOrNil("d0000001-2c11-11f1-9000-000000000001"),
+					PipecatcallID:  pcA,
+					DeliveryStatus: message.DeliveryStatusDelivered,
+					Direction:      message.DirectionIncoming,
+					Role:           message.RoleAssistant,
+				},
+			},
+			query:     pcA,
+			expectRes: true,
+		},
+		{
+			name: "pending_only",
+			seed: []*message.Message{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("c0000002-2c11-11f1-9000-000000000002"),
+					},
+					AIcallID:       uuid.FromStringOrNil("d0000002-2c11-11f1-9000-000000000002"),
+					PipecatcallID:  pcA,
+					DeliveryStatus: message.DeliveryStatusPending,
+					Direction:      message.DirectionIncoming,
+					Role:           message.RoleAssistant,
+				},
+			},
+			query:     pcA,
+			expectRes: false,
+		},
+		{
+			name: "different_pcc",
+			seed: []*message.Message{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("c0000003-2c11-11f1-9000-000000000003"),
+					},
+					AIcallID:       uuid.FromStringOrNil("d0000003-2c11-11f1-9000-000000000003"),
+					PipecatcallID:  pcB,
+					DeliveryStatus: message.DeliveryStatusDelivered,
+					Direction:      message.DirectionIncoming,
+					Role:           message.RoleAssistant,
+				},
+			},
+			query:     pcA,
+			expectRes: false,
+		},
+		{
+			name: "wrong_role",
+			seed: []*message.Message{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("c0000004-2c11-11f1-9000-000000000004"),
+					},
+					AIcallID:       uuid.FromStringOrNil("d0000004-2c11-11f1-9000-000000000004"),
+					PipecatcallID:  pcA,
+					DeliveryStatus: message.DeliveryStatusDelivered,
+					Direction:      message.DirectionIncoming,
+					Role:           message.RoleUser,
+				},
+			},
+			query:     pcA,
+			expectRes: false,
+		},
+		{
+			name: "wrong_direction",
+			seed: []*message.Message{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("c0000005-2c11-11f1-9000-000000000005"),
+					},
+					AIcallID:       uuid.FromStringOrNil("d0000005-2c11-11f1-9000-000000000005"),
+					PipecatcallID:  pcA,
+					DeliveryStatus: message.DeliveryStatusDelivered,
+					Direction:      message.DirectionOutgoing,
+					Role:           message.RoleAssistant,
+				},
+			},
+			query:     pcA,
+			expectRes: false,
+		},
+		{
+			name: "deleted_row",
+			seed: []*message.Message{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("c0000006-2c11-11f1-9000-000000000006"),
+					},
+					AIcallID:       uuid.FromStringOrNil("d0000006-2c11-11f1-9000-000000000006"),
+					PipecatcallID:  pcA,
+					DeliveryStatus: message.DeliveryStatusDelivered,
+					Direction:      message.DirectionIncoming,
+					Role:           message.RoleAssistant,
+				},
+			},
+			query:     pcA,
+			expectRes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+
+			ctx := context.Background()
+
+			// Seed messages via MessageCreate; cache calls are mocked.
+			for _, m := range tt.seed {
+				mockUtil.EXPECT().TimeNow().Return(curTime)
+				mockCache.EXPECT().MessageSet(ctx, gomock.Any())
+				if err := h.MessageCreate(ctx, m); err != nil {
+					t.Fatalf("seed MessageCreate failed. err: %v", err)
+				}
+			}
+
+			// For deleted_row: soft-delete the row after creating it.
+			if tt.name == "deleted_row" {
+				for _, m := range tt.seed {
+					mockUtil.EXPECT().TimeNow().Return(deletedTime)
+					mockCache.EXPECT().MessageSet(ctx, gomock.Any())
+					if err := h.MessageDelete(ctx, m.ID); err != nil {
+						t.Fatalf("seed MessageDelete failed. err: %v", err)
+					}
+				}
+			}
+
+			got, err := h.MessageAssistantReplyExists(ctx, tt.query)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if got != tt.expectRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, got)
+			}
+
+			// Cleanup so each subtest's seed doesn't bleed into the next via the shared in-memory DB.
+			for _, m := range tt.seed {
+				if _, err := dbTest.Exec("DELETE FROM ai_messages WHERE id = ?", m.ID.Bytes()); err != nil {
+					t.Fatalf("cleanup failed. err: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/bin-ai-manager/pkg/dbhandler/message_test.go
+++ b/bin-ai-manager/pkg/dbhandler/message_test.go
@@ -102,6 +102,40 @@ func Test_MessageCreate(t *testing.T) {
 				TMDelete:  nil,
 			},
 		},
+		{
+			name: "with pipecatcall id and delivery status pending",
+
+			message: &message.Message{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("4810ed7c-249a-11f1-9c4d-1be83fbb24d9"),
+					CustomerID: uuid.FromStringOrNil("48541f10-249a-11f1-8c25-7763b87b41e2"),
+				},
+				AIcallID:       uuid.FromStringOrNil("48a04e08-249a-11f1-8e9f-1f53f0e2c9bf"),
+				PipecatcallID:  uuid.FromStringOrNil("48ec3a36-249a-11f1-bc6c-2bd6e2e0fa7b"),
+				DeliveryStatus: message.DeliveryStatusPending,
+
+				Role:    message.RoleAssistant,
+				Content: "queued reply",
+			},
+
+			responseCurTime: curTime,
+			expectRes: &message.Message{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("4810ed7c-249a-11f1-9c4d-1be83fbb24d9"),
+					CustomerID: uuid.FromStringOrNil("48541f10-249a-11f1-8c25-7763b87b41e2"),
+				},
+				AIcallID:       uuid.FromStringOrNil("48a04e08-249a-11f1-8e9f-1f53f0e2c9bf"),
+				PipecatcallID:  uuid.FromStringOrNil("48ec3a36-249a-11f1-bc6c-2bd6e2e0fa7b"),
+				DeliveryStatus: message.DeliveryStatusPending,
+
+				Role:    message.RoleAssistant,
+				Content: "queued reply",
+
+				ToolCalls: nil,
+				TMCreate:  curTime,
+				TMDelete:  nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-ai-manager/pkg/dbhandler/message_test.go
+++ b/bin-ai-manager/pkg/dbhandler/message_test.go
@@ -361,3 +361,87 @@ func Test_MessageAssistantReplyExists(t *testing.T) {
 		})
 	}
 }
+
+func Test_MessageUpdateDeliveryStatus(t *testing.T) {
+	curTime := func() *time.Time { t := time.Date(2026, 4, 29, 13, 0, 0, 0, time.UTC); return &t }()
+
+	tests := []struct {
+		name string
+
+		seed *message.Message
+
+		updateID     uuid.UUID
+		updateStatus message.DeliveryStatus
+
+		expectStatus message.DeliveryStatus
+	}{
+		{
+			name: "pending_to_delivered",
+
+			seed: &message.Message{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("e1000001-2c11-11f1-9000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("e1000001-2c11-11f1-9000-000000000002"),
+				},
+				AIcallID:       uuid.FromStringOrNil("e1000001-2c11-11f1-9000-000000000003"),
+				PipecatcallID:  uuid.FromStringOrNil("e1000001-2c11-11f1-9000-000000000004"),
+				DeliveryStatus: message.DeliveryStatusPending,
+				Direction:      message.DirectionIncoming,
+				Role:           message.RoleAssistant,
+				Content:        "queued reply",
+			},
+
+			updateID:     uuid.FromStringOrNil("e1000001-2c11-11f1-9000-000000000001"),
+			updateStatus: message.DeliveryStatusDelivered,
+
+			expectStatus: message.DeliveryStatusDelivered,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+
+			ctx := context.Background()
+
+			// Seed the message via MessageCreate.
+			mockUtil.EXPECT().TimeNow().Return(curTime)
+			mockCache.EXPECT().MessageSet(ctx, gomock.Any())
+			if err := h.MessageCreate(ctx, tt.seed); err != nil {
+				t.Fatalf("seed MessageCreate failed. err: %v", err)
+			}
+
+			// Update the delivery status. The implementation also refreshes the cache.
+			mockCache.EXPECT().MessageSet(ctx, gomock.Any())
+			if err := h.MessageUpdateDeliveryStatus(ctx, tt.updateID, tt.updateStatus); err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Read back via MessageGet (cache miss → DB) and assert delivery_status was updated.
+			mockCache.EXPECT().MessageGet(ctx, tt.updateID).Return(nil, fmt.Errorf(""))
+			mockCache.EXPECT().MessageSet(ctx, gomock.Any())
+			res, err := h.MessageGet(ctx, tt.updateID)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.DeliveryStatus != tt.expectStatus {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectStatus, res.DeliveryStatus)
+			}
+
+			// Cleanup so this subtest's seed doesn't bleed into other tests via the shared in-memory DB.
+			if _, err := dbTest.Exec("DELETE FROM ai_messages WHERE id = ?", tt.seed.ID.Bytes()); err != nil {
+				t.Fatalf("cleanup failed. err: %v", err)
+			}
+		})
+	}
+}

--- a/bin-ai-manager/pkg/dbhandler/mock_main.go
+++ b/bin-ai-manager/pkg/dbhandler/mock_main.go
@@ -205,6 +205,21 @@ func (mr *MockDBHandlerMockRecorder) AIcallUpdate(ctx, id, fields any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallUpdate", reflect.TypeOf((*MockDBHandler)(nil).AIcallUpdate), ctx, id, fields)
 }
 
+// MessageAssistantReplyExists mocks base method.
+func (m *MockDBHandler) MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MessageAssistantReplyExists", ctx, pipecatcallID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MessageAssistantReplyExists indicates an expected call of MessageAssistantReplyExists.
+func (mr *MockDBHandlerMockRecorder) MessageAssistantReplyExists(ctx, pipecatcallID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MessageAssistantReplyExists", reflect.TypeOf((*MockDBHandler)(nil).MessageAssistantReplyExists), ctx, pipecatcallID)
+}
+
 // MessageCreate mocks base method.
 func (m *MockDBHandler) MessageCreate(ctx context.Context, c *message.Message) error {
 	m.ctrl.T.Helper()

--- a/bin-ai-manager/pkg/dbhandler/mock_main.go
+++ b/bin-ai-manager/pkg/dbhandler/mock_main.go
@@ -278,6 +278,20 @@ func (mr *MockDBHandlerMockRecorder) MessageList(ctx, size, token, filters any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MessageList", reflect.TypeOf((*MockDBHandler)(nil).MessageList), ctx, size, token, filters)
 }
 
+// MessageUpdateDeliveryStatus mocks base method.
+func (m *MockDBHandler) MessageUpdateDeliveryStatus(ctx context.Context, id uuid.UUID, status message.DeliveryStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MessageUpdateDeliveryStatus", ctx, id, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MessageUpdateDeliveryStatus indicates an expected call of MessageUpdateDeliveryStatus.
+func (mr *MockDBHandlerMockRecorder) MessageUpdateDeliveryStatus(ctx, id, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MessageUpdateDeliveryStatus", reflect.TypeOf((*MockDBHandler)(nil).MessageUpdateDeliveryStatus), ctx, id, status)
+}
+
 // SummaryCreate mocks base method.
 func (m *MockDBHandler) SummaryCreate(ctx context.Context, c *summary.Summary) error {
 	m.ctrl.T.Helper()

--- a/bin-ai-manager/pkg/messagehandler/db.go
+++ b/bin-ai-manager/pkg/messagehandler/db.go
@@ -25,6 +25,7 @@ func (h *messageHandler) Create(
 	content string,
 	toolCalls []message.ToolCall,
 	toolCallID string,
+	opts ...CreateOption,
 ) (*message.Message, error) {
 	if id == uuid.Nil {
 		id = h.utilHandler.UUIDCreate()
@@ -33,6 +34,17 @@ func (h *messageHandler) Create(
 	tmpToolCalls := toolCalls
 	if tmpToolCalls == nil {
 		tmpToolCalls = []message.ToolCall{}
+	}
+
+	// Apply defaults first, then override with caller-supplied options.
+	// DeliveryStatusDelivered matches the legacy semantics + DB column default,
+	// so existing callers that pass no opts continue to work unchanged.
+	p := createParams{
+		pipecatcallID:  uuid.Nil,
+		deliveryStatus: message.DeliveryStatusDelivered,
+	}
+	for _, opt := range opts {
+		opt(&p)
 	}
 
 	m := &message.Message{
@@ -48,6 +60,9 @@ func (h *messageHandler) Create(
 		Content:    content,
 		ToolCalls:  tmpToolCalls,
 		ToolCallID: toolCallID,
+
+		PipecatcallID:  p.pipecatcallID,
+		DeliveryStatus: p.deliveryStatus,
 	}
 	if err := h.db.MessageCreate(ctx, m); err != nil {
 		return nil, err

--- a/bin-ai-manager/pkg/messagehandler/db_test.go
+++ b/bin-ai-manager/pkg/messagehandler/db_test.go
@@ -77,6 +77,8 @@ func Test_Create(t *testing.T) {
 					},
 				},
 				ToolCallID: "62ed2280-943b-11f0-b762-4f0b5a0bd115",
+
+				DeliveryStatus: message.DeliveryStatusDelivered,
 			},
 		},
 		{
@@ -88,7 +90,8 @@ func Test_Create(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("0812955a-f262-11ef-a3a2-1bee273dee65"),
 				},
-				ToolCalls: []message.ToolCall{},
+				ToolCalls:      []message.ToolCall{},
+				DeliveryStatus: message.DeliveryStatusDelivered,
 			},
 		},
 	}

--- a/bin-ai-manager/pkg/messagehandler/event.go
+++ b/bin-ai-manager/pkg/messagehandler/event.go
@@ -3,7 +3,6 @@ package messagehandler
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
 	identity "monorepo/bin-common-handler/models/identity"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,6 +23,20 @@ const deliveryStatusUpdateRetryDelay = 100 * time.Millisecond
 // deliveryStatusUpdateSleep is a package-level indirection for time.Sleep so tests
 // can patch it to avoid real wall-clock waits during the retry-path test case.
 var deliveryStatusUpdateSleep = time.Sleep
+
+// backstopGraceDelay is the grace window between receiving a pipecatcall_terminated
+// event and re-checking whether an assistant reply has already been delivered. It
+// gives any in-flight EventPMMessageBotLLM handler enough time to commit the row so
+// the backstop short-circuits via MessageAssistantReplyExists.
+const backstopGraceDelay = 3 * time.Second
+
+// backstopReplyText is the user-visible fallback text the backstop persists and
+// sends when no assistant reply was delivered before pipecatcall termination.
+const backstopReplyText = "Sorry, I'm having trouble responding right now. Please try again."
+
+// backstopGraceSleep is a package-level indirection for time.Sleep so tests can
+// patch it to a no-op without paying real wall-clock time.
+var backstopGraceSleep = time.Sleep
 
 func (h *messageHandler) EventPMMessageUserTranscription(ctx context.Context, evt *pmmessage.Message) {
 	log := logrus.WithFields(logrus.Fields{
@@ -250,12 +264,86 @@ func (h *messageHandler) EventPMTeamMemberSwitched(ctx context.Context, evt *pmm
 	log.WithField("message", tmp).Debugf("Created member-switched notification message.")
 }
 
-// EventPMPipecatcallTerminated is the periodic backstop entrypoint for the
-// pipecatcall_terminated event. The real implementation lands in a follow-up
-// task; this stub ensures the interface contract is in place so the mock
-// regenerates and downstream wiring (subscribe handler) can compile against
-// it. A non-nil error is returned so any accidental invocation surfaces
-// clearly during the interim.
+// EventPMPipecatcallTerminated is the backstop entrypoint for the
+// pipecatcall_terminated event. It guarantees the AIcall+conversation branch
+// always emits an assistant-side reply so the user does not see silence after
+// the pipecatcall ends.
+//
+// Flow (per design doc §5):
+//  1. Skip non-AICall pipecatcalls (label "skipped_not_aicall").
+//  2. Resolve the AIcall. Skip non-conversation references (label "skipped_voice")
+//     and AIcalls already terminated (label "skipped_terminated"). RPC errors
+//     return nil (logged) so the subscribe handler does not requeue forever.
+//  3. Sleep `backstopGraceDelay` to let any in-flight EventPMMessageBotLLM
+//     handler commit its delivered row.
+//  4. Re-check MessageAssistantReplyExists. If a delivered assistant reply
+//     already exists for this pipecatcall, short-circuit (label "skipped_seen").
+//  5. Persist the backstop message with delivery_status='delivered' BEFORE
+//     calling ConversationV1MessageSend. This is intentional: a duplicate event
+//     after retry will short-circuit at MessageAssistantReplyExists rather than
+//     delivering a second reply downstream.
+//  6. Send the backstop reply via the conversation manager. On send failure the
+//     row is left in place (label "send_failed"); on persistence failure the
+//     row never lands (label "failed").
 func (h *messageHandler) EventPMPipecatcallTerminated(ctx context.Context, evt *pmpipecatcall.Pipecatcall) error {
-	return errors.New("not implemented")
+	log := logrus.WithFields(logrus.Fields{
+		"func":           "EventPMPipecatcallTerminated",
+		"pipecatcall_id": evt.ID,
+	})
+
+	if evt.ReferenceType != pmpipecatcall.ReferenceTypeAICall {
+		promBackstopReplyTotal.WithLabelValues("skipped_not_aicall").Inc()
+		return nil
+	}
+
+	ac, err := h.reqHandler.AIV1AIcallGet(ctx, evt.ReferenceID)
+	if err != nil {
+		log.Errorf("Could not get aicall. err: %v", err)
+		return nil
+	}
+
+	if ac.ReferenceType != aicall.ReferenceTypeConversation {
+		promBackstopReplyTotal.WithLabelValues("skipped_voice").Inc()
+		return nil
+	}
+	if ac.Status == aicall.StatusTerminated {
+		promBackstopReplyTotal.WithLabelValues("skipped_terminated").Inc()
+		return nil
+	}
+
+	// Grace window — let any concurrent BotLLM handler commit its delivered row
+	// so the next check short-circuits without persisting/sending a duplicate.
+	backstopGraceSleep(backstopGraceDelay)
+
+	seen, err := h.db.MessageAssistantReplyExists(ctx, evt.ID)
+	if err != nil {
+		return errors.Wrap(err, "could not check assistant reply existence")
+	}
+	if seen {
+		promBackstopReplyTotal.WithLabelValues("skipped_seen").Inc()
+		return nil
+	}
+
+	// Persist BEFORE sending. The row is created with delivery_status='delivered'
+	// on purpose: a duplicated pipecatcall_terminated event after retry will see
+	// the existing row via MessageAssistantReplyExists and short-circuit at the
+	// "skipped_seen" branch above, preventing dual delivery.
+	msg, err := h.Create(ctx, uuid.Nil, ac.CustomerID, ac.ID, ac.ActiveflowID,
+		message.DirectionIncoming, message.RoleAssistant, backstopReplyText, nil, "",
+		WithPipecatcallID(evt.ID),
+		WithDeliveryStatus(message.DeliveryStatusDelivered))
+	if err != nil {
+		promBackstopReplyTotal.WithLabelValues("failed").Inc()
+		return errors.Wrap(err, "could not persist backstop message")
+	}
+
+	if _, errSend := h.reqHandler.ConversationV1MessageSend(ctx, ac.ReferenceID,
+		backstopReplyText, []cvmedia.Media{}); errSend != nil {
+		promBackstopReplyTotal.WithLabelValues("send_failed").Inc()
+		return errors.Wrap(errSend, "could not send backstop conversation reply")
+	}
+
+	promBackstopReplyTotal.WithLabelValues("sent").Inc()
+	log.WithField("message_id", msg.ID).Infof("Backstop reply sent. aicall_id: %s, pipecatcall_id: %s", ac.ID, evt.ID)
+	return nil
 }

--- a/bin-ai-manager/pkg/messagehandler/event.go
+++ b/bin-ai-manager/pkg/messagehandler/event.go
@@ -3,6 +3,7 @@ package messagehandler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
 	identity "monorepo/bin-common-handler/models/identity"
@@ -247,4 +248,14 @@ func (h *messageHandler) EventPMTeamMemberSwitched(ctx context.Context, evt *pmm
 		return
 	}
 	log.WithField("message", tmp).Debugf("Created member-switched notification message.")
+}
+
+// EventPMPipecatcallTerminated is the periodic backstop entrypoint for the
+// pipecatcall_terminated event. The real implementation lands in a follow-up
+// task; this stub ensures the interface contract is in place so the mock
+// regenerates and downstream wiring (subscribe handler) can compile against
+// it. A non-nil error is returned so any accidental invocation surfaces
+// clearly during the interim.
+func (h *messageHandler) EventPMPipecatcallTerminated(ctx context.Context, evt *pmpipecatcall.Pipecatcall) error {
+	return errors.New("not implemented")
 }

--- a/bin-ai-manager/pkg/messagehandler/event.go
+++ b/bin-ai-manager/pkg/messagehandler/event.go
@@ -9,10 +9,19 @@ import (
 	cvmedia "monorepo/bin-conversation-manager/models/media"
 	pmmessage "monorepo/bin-pipecat-manager/models/message"
 	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 )
+
+// deliveryStatusUpdateRetryDelay is the wait between the first and the (single) retried
+// MessageUpdateDeliveryStatus call after a successful conversation send.
+const deliveryStatusUpdateRetryDelay = 100 * time.Millisecond
+
+// deliveryStatusUpdateSleep is a package-level indirection for time.Sleep so tests
+// can patch it to avoid real wall-clock waits during the retry-path test case.
+var deliveryStatusUpdateSleep = time.Sleep
 
 func (h *messageHandler) EventPMMessageUserTranscription(ctx context.Context, evt *pmmessage.Message) {
 	log := logrus.WithFields(logrus.Fields{
@@ -85,8 +94,12 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 	}
 
 	// Persist the assistant message (only after guard #1 passes).
+	// Mark delivery_status='pending' so a guard-#2 failure or send failure leaves the
+	// row 'pending' and the periodic backstop can later finalize/cleanup the message.
 	tmp, err := h.Create(ctx, evt.ID, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID,
-		message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "")
+		message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "",
+		WithPipecatcallID(evt.PipecatcallID),
+		WithDeliveryStatus(message.DeliveryStatusPending))
 	if err != nil {
 		log.Errorf("Could not create the message. err: %v", err)
 		return
@@ -94,6 +107,7 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 	log.WithField("message", tmp).Debugf("Created message.")
 
 	// Guard #2 (secondary) — re-check after persistence to narrow the dual-delivery race window.
+	// On failure here the row stays 'pending' on purpose — the backstop will fire.
 	acFinal, errFinal := h.reqHandler.AIV1AIcallGet(ctx, evt.PipecatcallReferenceID)
 	if errFinal != nil {
 		log.WithField("aicall_id", evt.PipecatcallReferenceID).Warnf("Re-check AIcall fetch failed; skipping conversation delivery. err: %v", errFinal)
@@ -120,6 +134,7 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 			"event_id":        evt.ID,
 		}).Errorf("Could not send conversation message (silent failure): %v", errSend)
 		promConversationReplySendTotal.WithLabelValues("failure").Inc()
+		// Row stays 'pending'; the backstop will fire.
 		return
 	}
 	promConversationReplySendTotal.WithLabelValues("success").Inc()
@@ -128,6 +143,20 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 		"conversation_id":      acFinal.ReferenceID,
 		"conversation_message": sent,
 	}).Debugf("Sent conversation reply.")
+
+	// Mark the row as delivered post-send. A single retry after a short delay is
+	// allowed because the row is now committed and the send already succeeded;
+	// the only remaining work is local DB bookkeeping. If both attempts fail,
+	// we record the failure metric and rely on the backstop to reconcile.
+	errUpd := h.db.MessageUpdateDeliveryStatus(ctx, tmp.ID, message.DeliveryStatusDelivered)
+	if errUpd != nil {
+		deliveryStatusUpdateSleep(deliveryStatusUpdateRetryDelay)
+		errUpd = h.db.MessageUpdateDeliveryStatus(ctx, tmp.ID, message.DeliveryStatusDelivered)
+	}
+	if errUpd != nil {
+		log.Errorf("Could not mark message delivered after retry. msg_id: %s err: %v", tmp.ID, errUpd)
+		promConversationDeliveryStatusUpdateFailedTotal.Inc()
+	}
 }
 
 func (h *messageHandler) EventPMMessageBotLLMIntermediate(ctx context.Context, evt *pmmessage.Message) {

--- a/bin-ai-manager/pkg/messagehandler/event_test.go
+++ b/bin-ai-manager/pkg/messagehandler/event_test.go
@@ -13,6 +13,7 @@ import (
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
 	"monorepo/bin-ai-manager/pkg/dbhandler"
+	"monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -1017,3 +1018,259 @@ func TestEventPMMessageBotLLM_conversation(t *testing.T) {
 	}
 }
 
+// TestEventPMPipecatcallTerminated drives the backstop handler through every
+// result-label outcome. Each case asserts the corresponding Prometheus counter
+// increments by exactly 1 and that ConversationV1MessageSend is called only on
+// the paths that should actually deliver.
+func TestEventPMPipecatcallTerminated(t *testing.T) {
+	cases := []struct {
+		name            string
+		evRefType       pmpipecatcall.ReferenceType
+		aicallRefType   aicall.ReferenceType
+		aicallStatus    aicall.Status
+		aicallGetErr    bool
+		replyExistsCall bool   // whether MessageAssistantReplyExists is expected
+		replyExistsErr  bool   // whether the reply-exists call returns an error
+		replyExists     bool   // value returned by MessageAssistantReplyExists
+		messageCreateOK bool   // whether MessageCreate returns nil (only when reached)
+		sendOK          bool   // whether ConversationV1MessageSend returns nil (only when reached)
+		wantResultLabel string // label whose counter must increment by 1
+		wantNoLabel     bool   // when true, no counter must change (RPC error short-circuit)
+		wantSendCalls   int
+		wantErr         bool
+	}{
+		{
+			name:            "skipped_not_aicall",
+			evRefType:       pmpipecatcall.ReferenceTypeCall,
+			wantResultLabel: "skipped_not_aicall",
+		},
+		{
+			name:            "aicall_get_error_no_label",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallGetErr:    true,
+			wantNoLabel:     true,
+			wantResultLabel: "skipped_voice", // unused (wantNoLabel=true)
+		},
+		{
+			name:            "skipped_voice",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeCall,
+			aicallStatus:    aicall.StatusProgressing,
+			wantResultLabel: "skipped_voice",
+		},
+		{
+			name:            "skipped_terminated",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeConversation,
+			aicallStatus:    aicall.StatusTerminated,
+			wantResultLabel: "skipped_terminated",
+		},
+		{
+			name:            "skipped_seen",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeConversation,
+			aicallStatus:    aicall.StatusProgressing,
+			replyExistsCall: true,
+			replyExists:     true,
+			wantResultLabel: "skipped_seen",
+		},
+		{
+			name:            "sent",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeConversation,
+			aicallStatus:    aicall.StatusProgressing,
+			replyExistsCall: true,
+			replyExists:     false,
+			messageCreateOK: true,
+			sendOK:          true,
+			wantResultLabel: "sent",
+			wantSendCalls:   1,
+		},
+		{
+			name:            "send_failed",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeConversation,
+			aicallStatus:    aicall.StatusProgressing,
+			replyExistsCall: true,
+			replyExists:     false,
+			messageCreateOK: true,
+			sendOK:          false,
+			wantResultLabel: "send_failed",
+			wantSendCalls:   1,
+			wantErr:         true,
+		},
+		{
+			name:            "failed",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeConversation,
+			aicallStatus:    aicall.StatusProgressing,
+			replyExistsCall: true,
+			replyExists:     false,
+			messageCreateOK: false,
+			wantResultLabel: "failed",
+			wantErr:         true,
+		},
+		{
+			name:            "reply_exists_error_returns",
+			evRefType:       pmpipecatcall.ReferenceTypeAICall,
+			aicallRefType:   aicall.ReferenceTypeConversation,
+			aicallStatus:    aicall.StatusProgressing,
+			replyExistsCall: true,
+			replyExistsErr:  true,
+			wantNoLabel:     true,
+			wantResultLabel: "skipped_seen", // unused (wantNoLabel=true)
+			wantErr:         true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			pccID := uuid.Must(uuid.NewV4())
+			aicallID := uuid.Must(uuid.NewV4())
+			convID := uuid.Must(uuid.NewV4())
+			customerID := uuid.Must(uuid.NewV4())
+			activeflowID := uuid.Must(uuid.NewV4())
+
+			ev := &pmpipecatcall.Pipecatcall{
+				ReferenceType: tc.evRefType,
+				ReferenceID:   aicallID,
+			}
+			ev.ID = pccID
+
+			mockDB := dbhandler.NewMockDBHandler(ctrl)
+			mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+			mockReq := requesthandler.NewMockRequestHandler(ctrl)
+
+			// AIcallGet expectations: only when ReferenceType is AICall.
+			if tc.evRefType == pmpipecatcall.ReferenceTypeAICall {
+				if tc.aicallGetErr {
+					mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).
+						Return(nil, errors.New("rpc transient")).Times(1)
+				} else {
+					ac := &aicall.AIcall{
+						Identity: identity.Identity{
+							ID:         aicallID,
+							CustomerID: customerID,
+						},
+						ActiveflowID:  activeflowID,
+						ReferenceType: tc.aicallRefType,
+						ReferenceID:   convID,
+						Status:        tc.aicallStatus,
+					}
+					mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(1)
+				}
+			}
+
+			// MessageAssistantReplyExists expectations.
+			if tc.replyExistsCall {
+				if tc.replyExistsErr {
+					mockDB.EXPECT().MessageAssistantReplyExists(gomock.Any(), pccID).
+						Return(false, errors.New("db transient")).Times(1)
+				} else {
+					mockDB.EXPECT().MessageAssistantReplyExists(gomock.Any(), pccID).
+						Return(tc.replyExists, nil).Times(1)
+				}
+			}
+
+			// MessageCreate / MessageGet only when persistence runs (sent/send_failed/failed).
+			if tc.replyExistsCall && !tc.replyExistsErr && !tc.replyExists {
+				if tc.messageCreateOK {
+					createdMsg := &message.Message{}
+					createdMsg.ID = uuid.Must(uuid.NewV4())
+					mockDB.EXPECT().
+						MessageCreate(gomock.Any(), messageWithPCC(pccID, message.DeliveryStatusDelivered)).
+						Return(nil).Times(1)
+					mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+					mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				} else {
+					mockDB.EXPECT().
+						MessageCreate(gomock.Any(), messageWithPCC(pccID, message.DeliveryStatusDelivered)).
+						Return(errors.New("db down")).Times(1)
+				}
+			}
+
+			// ConversationV1MessageSend only when persist succeeded.
+			if tc.wantSendCalls > 0 {
+				if tc.sendOK {
+					mockReq.EXPECT().
+						ConversationV1MessageSend(gomock.Any(), convID, backstopReplyText, []cvmedia.Media{}).
+						Return(&cvmessage.Message{}, nil).Times(tc.wantSendCalls)
+				} else {
+					mockReq.EXPECT().
+						ConversationV1MessageSend(gomock.Any(), convID, backstopReplyText, []cvmedia.Media{}).
+						Return(nil, errors.New("conversation send failed")).Times(tc.wantSendCalls)
+				}
+			}
+
+			// Patch the grace sleep so tests do not pay 3s of wall-clock per case.
+			origSleep := backstopGraceSleep
+			sleepCalled := 0
+			backstopGraceSleep = func(time.Duration) { sleepCalled++ }
+			t.Cleanup(func() { backstopGraceSleep = origSleep })
+
+			h := &messageHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+				utilHandler:   utilhandler.NewUtilHandler(),
+			}
+
+			// Snapshot all 7 result-label counters so we can assert deltas precisely.
+			labels := []string{
+				"sent", "failed", "send_failed",
+				"skipped_seen", "skipped_voice",
+				"skipped_terminated", "skipped_not_aicall",
+			}
+			before := make(map[string]float64, len(labels))
+			for _, l := range labels {
+				before[l] = testutil.ToFloat64(promBackstopReplyTotal.WithLabelValues(l))
+			}
+
+			err := h.EventPMPipecatcallTerminated(context.Background(), ev)
+
+			if tc.wantErr && err == nil {
+				t.Errorf("expected non-nil error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected nil error, got %v", err)
+			}
+
+			for _, l := range labels {
+				after := testutil.ToFloat64(promBackstopReplyTotal.WithLabelValues(l))
+				delta := after - before[l]
+
+				switch {
+				case tc.wantNoLabel:
+					if delta != 0 {
+						t.Errorf("label %q: no counter should change (wantNoLabel), got delta=%v", l, delta)
+					}
+				case l == tc.wantResultLabel:
+					if delta != 1 {
+						t.Errorf("label %q: expected delta=1, got %v", l, delta)
+					}
+				default:
+					if delta != 0 {
+						t.Errorf("label %q: expected delta=0, got %v", l, delta)
+					}
+				}
+			}
+
+			// Sleep must run iff the backstop reached the grace window: only
+			// when the AIcall was fetched, was a conversation reference, and
+			// was not already terminated.
+			wantSleep := 0
+			if tc.evRefType == pmpipecatcall.ReferenceTypeAICall &&
+				!tc.aicallGetErr &&
+				tc.aicallRefType == aicall.ReferenceTypeConversation &&
+				tc.aicallStatus != aicall.StatusTerminated {
+				wantSleep = 1
+			}
+			if sleepCalled != wantSleep {
+				t.Errorf("backstopGraceSleep call count: want %d got %d", wantSleep, sleepCalled)
+			}
+		})
+	}
+}

--- a/bin-ai-manager/pkg/messagehandler/event_test.go
+++ b/bin-ai-manager/pkg/messagehandler/event_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -338,6 +339,9 @@ func TestEventPMMessageBotLLM_conversation_send_success(t *testing.T) {
 		Return(&cvmessage.Message{}, nil).
 		Times(1)
 
+	// Post-send: mark delivered (succeeds first try).
+	mockDB.EXPECT().MessageUpdateDeliveryStatus(gomock.Any(), gomock.Any(), message.DeliveryStatusDelivered).Return(nil).Times(1)
+
 	h := &messageHandler{
 		db:            mockDB,
 		notifyHandler: mockNotify,
@@ -474,6 +478,9 @@ func TestEventPMMessageBotLLM_customer_id_mismatch_proceeds(t *testing.T) {
 		ConversationV1MessageSend(gomock.Any(), convID, "hello human", []cvmedia.Media{}).
 		Return(&cvmessage.Message{}, nil).
 		Times(1)
+
+	// Post-send: mark delivered (succeeds first try).
+	mockDB.EXPECT().MessageUpdateDeliveryStatus(gomock.Any(), gomock.Any(), message.DeliveryStatusDelivered).Return(nil).Times(1)
 
 	h := &messageHandler{
 		db:            mockDB,
@@ -840,3 +847,173 @@ func TestEventPMMessageUserLLM(t *testing.T) {
 		})
 	}
 }
+
+// TestEventPMMessageBotLLM_conversation drives the AIcall+conversation branch
+// through the four/five outcomes: happy path, guard #2 fail, send fail,
+// update fails-then-retry-OK, update fails both attempts. In every case the row
+// MUST be persisted with delivery_status='pending'. The number of
+// MessageUpdateDeliveryStatus and ConversationV1MessageSend calls varies.
+func TestEventPMMessageBotLLM_conversation(t *testing.T) {
+	cases := []struct {
+		name              string
+		guard2Pass        bool
+		sendOK            bool
+		updateOK          bool
+		updateRetryOK     bool
+		wantUpdateCalls   int
+		wantConvSendCalls int
+		wantSuccessDelta  float64
+		wantFailureDelta  float64
+		wantUpdateFailed  float64
+	}{
+		{"happy", true, true, true, false, 1, 1, 1, 0, 0},
+		{"guard2_fail", false, false, false, false, 0, 0, 0, 0, 0},
+		{"send_fail", true, false, false, false, 0, 1, 0, 1, 0},
+		{"update_fail_but_retry_ok", true, true, false, true, 2, 1, 1, 0, 0},
+		{"update_fail_both", true, true, false, false, 2, 1, 1, 0, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			pccA := uuid.Must(uuid.NewV4())
+			pccB := uuid.Must(uuid.NewV4())
+			aicallID := uuid.Must(uuid.NewV4())
+			convID := uuid.Must(uuid.NewV4())
+
+			evt := &pmmessage.Message{
+				PipecatcallID:            pccA,
+				PipecatcallReferenceType: pmpipecatcall.ReferenceTypeAICall,
+				PipecatcallReferenceID:   aicallID,
+				ActiveflowID:             uuid.Must(uuid.NewV4()),
+				Text:                     "assistant reply",
+			}
+
+			mockDB := dbhandler.NewMockDBHandler(ctrl)
+			mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+			mockReq := requesthandler.NewMockRequestHandler(ctrl)
+
+			// Guard #1 always passes for these scenarios; guard #2 is varied via
+			// the second AIcallGet response.
+			fresh := &aicall.AIcall{
+				PipecatcallID: pccA,
+				ReferenceType: aicall.ReferenceTypeConversation,
+				ReferenceID:   convID,
+			}
+			second := fresh
+			if !tc.guard2Pass {
+				second = &aicall.AIcall{
+					PipecatcallID: pccB, // mismatch on re-check
+					ReferenceType: aicall.ReferenceTypeConversation,
+					ReferenceID:   convID,
+				}
+			}
+			gomock.InOrder(
+				mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(fresh, nil).Times(1),
+				mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(second, nil).Times(1),
+			)
+
+			// Persistence must always happen (after guard #1) with the pending
+			// status and the event's PipecatcallID stamped on the row.
+			testMsg := &message.Message{}
+			testMsg.ID = uuid.Must(uuid.NewV4())
+			mockDB.EXPECT().
+				MessageCreate(gomock.Any(), messageWithPCC(pccA, message.DeliveryStatusPending)).
+				Return(nil).
+				Times(1)
+			mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(testMsg, nil).Times(1)
+			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+			// ConversationV1MessageSend expectations.
+			if tc.wantConvSendCalls > 0 {
+				if tc.sendOK {
+					mockReq.EXPECT().
+						ConversationV1MessageSend(gomock.Any(), convID, "assistant reply", []cvmedia.Media{}).
+						Return(&cvmessage.Message{}, nil).
+						Times(tc.wantConvSendCalls)
+				} else {
+					mockReq.EXPECT().
+						ConversationV1MessageSend(gomock.Any(), convID, "assistant reply", []cvmedia.Media{}).
+						Return(nil, errors.New("delivery failed")).
+						Times(tc.wantConvSendCalls)
+				}
+			}
+
+			// MessageUpdateDeliveryStatus expectations.
+			switch tc.wantUpdateCalls {
+			case 0:
+				// no expectation
+			case 1:
+				mockDB.EXPECT().
+					MessageUpdateDeliveryStatus(gomock.Any(), testMsg.ID, message.DeliveryStatusDelivered).
+					Return(nil).
+					Times(1)
+			case 2:
+				// First call fails; second call's outcome depends on tc.updateRetryOK.
+				retryErr := error(nil)
+				if !tc.updateRetryOK {
+					retryErr = errors.New("update retry failed")
+				}
+				gomock.InOrder(
+					mockDB.EXPECT().
+						MessageUpdateDeliveryStatus(gomock.Any(), testMsg.ID, message.DeliveryStatusDelivered).
+						Return(errors.New("update failed")).
+						Times(1),
+					mockDB.EXPECT().
+						MessageUpdateDeliveryStatus(gomock.Any(), testMsg.ID, message.DeliveryStatusDelivered).
+						Return(retryErr).
+						Times(1),
+				)
+			default:
+				t.Fatalf("unsupported wantUpdateCalls=%d", tc.wantUpdateCalls)
+			}
+
+			// Patch the retry sleep so the test does not pay 100ms wall-clock
+			// per retry case.
+			origSleep := deliveryStatusUpdateSleep
+			sleepCalled := 0
+			deliveryStatusUpdateSleep = func(time.Duration) { sleepCalled++ }
+			t.Cleanup(func() { deliveryStatusUpdateSleep = origSleep })
+
+			h := &messageHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+				utilHandler:   utilhandler.NewUtilHandler(),
+			}
+
+			beforeSuccess := testutil.ToFloat64(promConversationReplySendTotal.WithLabelValues("success"))
+			beforeFailure := testutil.ToFloat64(promConversationReplySendTotal.WithLabelValues("failure"))
+			beforeUpdFailed := testutil.ToFloat64(promConversationDeliveryStatusUpdateFailedTotal)
+
+			h.EventPMMessageBotLLM(context.Background(), evt)
+
+			afterSuccess := testutil.ToFloat64(promConversationReplySendTotal.WithLabelValues("success"))
+			afterFailure := testutil.ToFloat64(promConversationReplySendTotal.WithLabelValues("failure"))
+			afterUpdFailed := testutil.ToFloat64(promConversationDeliveryStatusUpdateFailedTotal)
+
+			if got := afterSuccess - beforeSuccess; got != tc.wantSuccessDelta {
+				t.Errorf("success counter delta: want %v got %v", tc.wantSuccessDelta, got)
+			}
+			if got := afterFailure - beforeFailure; got != tc.wantFailureDelta {
+				t.Errorf("failure counter delta: want %v got %v", tc.wantFailureDelta, got)
+			}
+			if got := afterUpdFailed - beforeUpdFailed; got != tc.wantUpdateFailed {
+				t.Errorf("delivery-status-update-failed counter delta: want %v got %v", tc.wantUpdateFailed, got)
+			}
+
+			// On the retry case, the sleep must be invoked exactly once between
+			// the first and second update attempts.
+			wantSleep := 0
+			if tc.wantUpdateCalls == 2 {
+				wantSleep = 1
+			}
+			if sleepCalled != wantSleep {
+				t.Errorf("deliveryStatusUpdateSleep call count: want %d got %d", wantSleep, sleepCalled)
+			}
+		})
+	}
+}
+

--- a/bin-ai-manager/pkg/messagehandler/main.go
+++ b/bin-ai-manager/pkg/messagehandler/main.go
@@ -48,6 +48,7 @@ type MessageHandler interface {
 		content string,
 		toolCalls []message.ToolCall,
 		toolCallID string,
+		opts ...CreateOption,
 	) (*message.Message, error)
 	Get(ctx context.Context, id uuid.UUID) (*message.Message, error)
 	List(ctx context.Context, size uint64, token string, filters map[message.Field]any) ([]*message.Message, error)

--- a/bin-ai-manager/pkg/messagehandler/main.go
+++ b/bin-ai-manager/pkg/messagehandler/main.go
@@ -17,6 +17,25 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// CreateOption configures optional parameters for Create.
+type CreateOption func(*createParams)
+
+// createParams holds optional parameters for Create.
+type createParams struct {
+	pipecatcallID  uuid.UUID
+	deliveryStatus message.DeliveryStatus
+}
+
+// WithPipecatcallID sets the pipecatcall ID on createParams.
+func WithPipecatcallID(id uuid.UUID) CreateOption {
+	return func(p *createParams) { p.pipecatcallID = id }
+}
+
+// WithDeliveryStatus sets the delivery status on createParams.
+func WithDeliveryStatus(s message.DeliveryStatus) CreateOption {
+	return func(p *createParams) { p.deliveryStatus = s }
+}
+
 type MessageHandler interface {
 	Create(
 		ctx context.Context,

--- a/bin-ai-manager/pkg/messagehandler/main.go
+++ b/bin-ai-manager/pkg/messagehandler/main.go
@@ -12,6 +12,7 @@ import (
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 	pmmessage "monorepo/bin-pipecat-manager/models/message"
+	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
 
 	"github.com/gofrs/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,6 +59,7 @@ type MessageHandler interface {
 	EventPMMessageBotLLMIntermediate(ctx context.Context, evt *pmmessage.Message)
 	EventPMMessageUserLLM(ctx context.Context, evt *pmmessage.Message)
 	EventPMTeamMemberSwitched(ctx context.Context, evt *pmmessage.MemberSwitchedEvent)
+	EventPMPipecatcallTerminated(ctx context.Context, evt *pmpipecatcall.Pipecatcall) error
 }
 
 type messageHandler struct {

--- a/bin-ai-manager/pkg/messagehandler/main_test.go
+++ b/bin-ai-manager/pkg/messagehandler/main_test.go
@@ -1,0 +1,19 @@
+package messagehandler
+
+import (
+	"testing"
+
+	"monorepo/bin-ai-manager/models/message"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestCreateOptions_apply(t *testing.T) {
+	pcID := uuid.Must(uuid.NewV4())
+	var p createParams
+	WithPipecatcallID(pcID)(&p)
+	WithDeliveryStatus(message.DeliveryStatusPending)(&p)
+	if p.pipecatcallID != pcID || p.deliveryStatus != message.DeliveryStatusPending {
+		t.Fatalf("options not applied: %+v", p)
+	}
+}

--- a/bin-ai-manager/pkg/messagehandler/main_test.go
+++ b/bin-ai-manager/pkg/messagehandler/main_test.go
@@ -1,11 +1,17 @@
 package messagehandler
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
 )
 
 func TestCreateOptions_apply(t *testing.T) {
@@ -15,5 +21,104 @@ func TestCreateOptions_apply(t *testing.T) {
 	WithDeliveryStatus(message.DeliveryStatusPending)(&p)
 	if p.pipecatcallID != pcID || p.deliveryStatus != message.DeliveryStatusPending {
 		t.Fatalf("options not applied: %+v", p)
+	}
+}
+
+// messageWithPCC returns a gomock matcher that asserts the *message.Message
+// argument has the expected PipecatcallID and DeliveryStatus fields.
+func messageWithPCC(pcID uuid.UUID, status message.DeliveryStatus) gomock.Matcher {
+	return messageFieldMatcher{pcID: pcID, status: status, checkPCC: true}
+}
+
+// messageWithDelivery returns a gomock matcher that asserts only the
+// DeliveryStatus field of the *message.Message argument.
+func messageWithDelivery(status message.DeliveryStatus) gomock.Matcher {
+	return messageFieldMatcher{status: status}
+}
+
+type messageFieldMatcher struct {
+	pcID     uuid.UUID
+	status   message.DeliveryStatus
+	checkPCC bool
+}
+
+func (m messageFieldMatcher) Matches(x any) bool {
+	msg, ok := x.(*message.Message)
+	if !ok || msg == nil {
+		return false
+	}
+	if m.checkPCC && msg.PipecatcallID != m.pcID {
+		return false
+	}
+	return msg.DeliveryStatus == m.status
+}
+
+func (m messageFieldMatcher) String() string {
+	if m.checkPCC {
+		return fmt.Sprintf("message with PipecatcallID=%s DeliveryStatus=%s", m.pcID, m.status)
+	}
+	return fmt.Sprintf("message with DeliveryStatus=%s", m.status)
+}
+
+func newTestMessageHandler(t *testing.T) (*messageHandler, *dbhandler.MockDBHandler) {
+	t.Helper()
+	mc := gomock.NewController(t)
+	t.Cleanup(mc.Finish)
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	// Allow generated UUID + follow-up Get + notify calls without requiring
+	// per-test setup; these tests focus on the MessageCreate argument.
+	mockUtil.EXPECT().UUIDCreate().AnyTimes().Return(uuid.Must(uuid.NewV4()))
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+		func(_ context.Context, _ uuid.UUID) (*message.Message, error) {
+			return &message.Message{}, nil
+		},
+	)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	h := &messageHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	return h, mockDB
+}
+
+func TestCreate_withPipecatcallID_andDeliveryStatus(t *testing.T) {
+	h, mockDB := newTestMessageHandler(t)
+	ctx := context.Background()
+	pcID := uuid.Must(uuid.NewV4())
+	customerID := uuid.Must(uuid.NewV4())
+	aicallID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().MessageCreate(gomock.Any(), messageWithPCC(pcID, message.DeliveryStatusPending)).Return(nil)
+
+	msg, err := h.Create(ctx, uuid.Nil, customerID, aicallID, activeflowID,
+		message.DirectionIncoming, message.RoleAssistant, "hi", nil, "",
+		WithPipecatcallID(pcID), WithDeliveryStatus(message.DeliveryStatusPending))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg == nil {
+		t.Fatalf("expected non-nil message")
+	}
+}
+
+func TestCreate_withoutOpts_defaultsDelivered(t *testing.T) {
+	h, mockDB := newTestMessageHandler(t)
+	ctx := context.Background()
+	customerID := uuid.Must(uuid.NewV4())
+	aicallID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().MessageCreate(gomock.Any(), messageWithDelivery(message.DeliveryStatusDelivered)).Return(nil)
+
+	if _, err := h.Create(ctx, uuid.Nil, customerID, aicallID, activeflowID,
+		message.DirectionIncoming, message.RoleAssistant, "hi", nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/bin-ai-manager/pkg/messagehandler/main_test.go
+++ b/bin-ai-manager/pkg/messagehandler/main_test.go
@@ -9,10 +9,21 @@ import (
 	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
+	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
 )
+
+// TestMessageHandler_hasEventPMPipecatcallTerminated asserts the MessageHandler
+// interface declares the EventPMPipecatcallTerminated method with the expected
+// signature. This guards against accidental signature drift between the
+// interface, the mock, and the implementation.
+func TestMessageHandler_hasEventPMPipecatcallTerminated(t *testing.T) {
+	var _ interface {
+		EventPMPipecatcallTerminated(context.Context, *pmpipecatcall.Pipecatcall) error
+	} = (MessageHandler)(nil)
+}
 
 func TestCreateOptions_apply(t *testing.T) {
 	pcID := uuid.Must(uuid.NewV4())

--- a/bin-ai-manager/pkg/messagehandler/metrics_backstop.go
+++ b/bin-ai-manager/pkg/messagehandler/metrics_backstop.go
@@ -1,0 +1,32 @@
+package messagehandler
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// promBackstopReplyTotal counts pipecatcall_terminated backstop attempts in
+// EventPMPipecatcallTerminated by their final result. Labels:
+//   - sent                   — backstop reply persisted and sent
+//   - failed                 — persistence failed before send
+//   - send_failed            — persisted but ConversationV1MessageSend errored
+//   - skipped_seen           — assistant reply already exists (short-circuit)
+//   - skipped_voice          — AIcall reference is not a conversation
+//   - skipped_terminated     — AIcall is already in terminated status
+//   - skipped_not_aicall     — pipecatcall reference is not an AICall
+//
+// The counter lives in this package (not aicallhandler) because aicallhandler
+// imports messagehandler; placing it in aicallhandler would create a circular
+// import. The fully-qualified name (`ai_manager_aicall_backstop_reply_total`)
+// is preserved by sharing `metricsNamespace = "ai_manager"`.
+var (
+	promBackstopReplyTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "aicall_backstop_reply_total",
+			Help:      "Counter of pipecatcall_terminated backstop attempts in messagehandler.EventPMPipecatcallTerminated.",
+		},
+		[]string{"result"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(promBackstopReplyTotal)
+}

--- a/bin-ai-manager/pkg/messagehandler/metrics_conversation.go
+++ b/bin-ai-manager/pkg/messagehandler/metrics_conversation.go
@@ -19,10 +19,21 @@ var (
 		},
 		[]string{"guard"},
 	)
+	promConversationDeliveryStatusUpdateFailedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "message_delivery_status_update_failed_total",
+			Help:      "Counter of post-send delivery_status updates that failed even after one retry.",
+		},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(promConversationReplySendTotal, promConversationStaleResponseDroppedTotal)
+	prometheus.MustRegister(
+		promConversationReplySendTotal,
+		promConversationStaleResponseDroppedTotal,
+		promConversationDeliveryStatusUpdateFailedTotal,
+	)
 }
 
 // Test parallelism note:

--- a/bin-ai-manager/pkg/messagehandler/metrics_conversation_test.go
+++ b/bin-ai-manager/pkg/messagehandler/metrics_conversation_test.go
@@ -1,0 +1,51 @@
+package messagehandler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metricRegistered reports whether a metric with the given fully-qualified
+// name is registered with the default Prometheus registerer.
+//
+// We attempt to register a throwaway counter that shares the target name. The
+// default registerer rejects the registration with AlreadyRegisteredError when
+// the name is already in use, which is the signal we want. Using Gather() is
+// not sufficient for *Vec collectors with no observed children, since they do
+// not emit a metric family until at least one label combination is touched.
+func metricRegistered(name string) bool {
+	probe := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: name,
+		Help: "probe",
+	})
+	err := prometheus.DefaultRegisterer.Register(probe)
+	if err == nil {
+		// Probe registered cleanly, so the real metric was NOT already there.
+		// Unregister our probe so we leave the registry as we found it.
+		prometheus.DefaultRegisterer.Unregister(probe)
+		return false
+	}
+	var are prometheus.AlreadyRegisteredError
+	if errors.As(err, &are) {
+		return true
+	}
+	// CounterVec/GaugeVec collectors register a Desc whose fully-qualified
+	// name plus variable label set must be unique. Re-registering a plain
+	// Counter under the same name surfaces a descriptor-conflict error rather
+	// than AlreadyRegisteredError. Treat any of these "name already in the
+	// registry" messages as positive signal too.
+	msg := err.Error()
+	return strings.Contains(msg, "already registered") ||
+		strings.Contains(msg, "duplicate metrics collector") ||
+		strings.Contains(msg, "previously registered descriptor with the same fully-qualified name")
+}
+
+func TestPromConversationDeliveryStatusUpdateFailedTotal_registered(t *testing.T) {
+	const name = "ai_manager_message_delivery_status_update_failed_total"
+	if !metricRegistered(name) {
+		t.Fatalf("metric %s not registered", name)
+	}
+}

--- a/bin-ai-manager/pkg/messagehandler/mock_main.go
+++ b/bin-ai-manager/pkg/messagehandler/mock_main.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	message "monorepo/bin-ai-manager/models/message"
 	message0 "monorepo/bin-pipecat-manager/models/message"
+	pipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -109,6 +110,20 @@ func (m *MockMessageHandler) EventPMMessageUserTranscription(ctx context.Context
 func (mr *MockMessageHandlerMockRecorder) EventPMMessageUserTranscription(ctx, evt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventPMMessageUserTranscription", reflect.TypeOf((*MockMessageHandler)(nil).EventPMMessageUserTranscription), ctx, evt)
+}
+
+// EventPMPipecatcallTerminated mocks base method.
+func (m *MockMessageHandler) EventPMPipecatcallTerminated(ctx context.Context, evt *pipecatcall.Pipecatcall) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EventPMPipecatcallTerminated", ctx, evt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EventPMPipecatcallTerminated indicates an expected call of EventPMPipecatcallTerminated.
+func (mr *MockMessageHandlerMockRecorder) EventPMPipecatcallTerminated(ctx, evt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventPMPipecatcallTerminated", reflect.TypeOf((*MockMessageHandler)(nil).EventPMPipecatcallTerminated), ctx, evt)
 }
 
 // EventPMTeamMemberSwitched mocks base method.

--- a/bin-ai-manager/pkg/messagehandler/mock_main.go
+++ b/bin-ai-manager/pkg/messagehandler/mock_main.go
@@ -44,18 +44,23 @@ func (m *MockMessageHandler) EXPECT() *MockMessageHandlerMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockMessageHandler) Create(ctx context.Context, id, customerID, aicallID, activeflowID uuid.UUID, direction message.Direction, role message.Role, content string, toolCalls []message.ToolCall, toolCallID string) (*message.Message, error) {
+func (m *MockMessageHandler) Create(ctx context.Context, id, customerID, aicallID, activeflowID uuid.UUID, direction message.Direction, role message.Role, content string, toolCalls []message.ToolCall, toolCallID string, opts ...CreateOption) (*message.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, id, customerID, aicallID, activeflowID, direction, role, content, toolCalls, toolCallID)
+	varargs := []any{ctx, id, customerID, aicallID, activeflowID, direction, role, content, toolCalls, toolCallID}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Create", varargs...)
 	ret0, _ := ret[0].(*message.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockMessageHandlerMockRecorder) Create(ctx, id, customerID, aicallID, activeflowID, direction, role, content, toolCalls, toolCallID any) *gomock.Call {
+func (mr *MockMessageHandlerMockRecorder) Create(ctx, id, customerID, aicallID, activeflowID, direction, role, content, toolCalls, toolCallID any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockMessageHandler)(nil).Create), ctx, id, customerID, aicallID, activeflowID, direction, role, content, toolCalls, toolCallID)
+	varargs := append([]any{ctx, id, customerID, aicallID, activeflowID, direction, role, content, toolCalls, toolCallID}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockMessageHandler)(nil).Create), varargs...)
 }
 
 // EventPMMessageBotLLM mocks base method.

--- a/bin-ai-manager/pkg/subscribehandler/main.go
+++ b/bin-ai-manager/pkg/subscribehandler/main.go
@@ -177,6 +177,9 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 	case m.Publisher == string(commonoutline.ServiceNamePipecatManager) && m.Type == string(pmpipecatcall.EventTypeInitialized):
 		err = h.processEventPMPipecatcallInitialized(ctx, m)
 
+	case m.Publisher == string(commonoutline.ServiceNamePipecatManager) && m.Type == pmpipecatcall.EventTypePipecatcallTerminated:
+		err = h.processEventPMPipecatcallTerminated(ctx, m)
+
 	case m.Publisher == string(commonoutline.ServiceNamePipecatManager) && m.Type == string(pmmessage.EventTypeTeamMemberSwitched):
 		err = h.processEventPMTeamMemberSwitched(ctx, m)
 

--- a/bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall.go
+++ b/bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall.go
@@ -6,6 +6,7 @@ import (
 	"monorepo/bin-common-handler/models/sock"
 	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,4 +26,24 @@ func (h *subscribeHandler) processEventPMPipecatcallInitialized(ctx context.Cont
 	go h.aicallHandler.EventPMPipecatcallInitialized(ctx, &evt)
 
 	return nil
+}
+
+// processEventPMPipecatcallTerminated dispatches pipecat-manager's
+// pipecatcall_terminated event to messagehandler.EventPMPipecatcallTerminated,
+// which is the cross-pod backstop that finalises any AIcall whose pipecatcall
+// has terminated without an explicit terminate path completing first.
+func (h *subscribeHandler) processEventPMPipecatcallTerminated(ctx context.Context, m *sock.Event) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":  "processEventPMPipecatcallTerminated",
+		"event": m,
+	})
+	log.Debugf("Received the pipecat-manager's pipecatcall_terminated event.")
+
+	var evt pmpipecatcall.Pipecatcall
+	if err := json.Unmarshal([]byte(m.Data), &evt); err != nil {
+		log.Errorf("Could not unmarshal the data. err: %v", err)
+		return errors.Wrap(err, "could not unmarshal pipecatcall_terminated payload")
+	}
+
+	return h.messageHandler.EventPMPipecatcallTerminated(ctx, &evt)
 }

--- a/bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall_test.go
+++ b/bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall_test.go
@@ -1,7 +1,9 @@
 package subscribehandler
 
 import (
+	"context"
 	"monorepo/bin-ai-manager/pkg/aicallhandler"
+	"monorepo/bin-ai-manager/pkg/messagehandler"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -57,6 +59,54 @@ func Test_processEventPMPipecatcallInitialized(t *testing.T) {
 			h.processEvent(tt.event)
 
 			time.Sleep(100 * time.Millisecond)
+		})
+	}
+}
+
+func Test_processEventPMPipecatcallTerminated(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		event *sock.Event
+
+		expectedEvent *pmpipecatcall.Pipecatcall
+	}{
+		{
+			name: "normal",
+
+			event: &sock.Event{
+				Publisher: "pipecat-manager",
+				Type:      pmpipecatcall.EventTypePipecatcallTerminated,
+				DataType:  "application/json",
+				Data:      []byte(`{"id":"d1ea9b4c-cb5c-11f0-b1c4-3744a2c2f8a6"}`),
+			},
+
+			expectedEvent: &pmpipecatcall.Pipecatcall{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("d1ea9b4c-cb5c-11f0-b1c4-3744a2c2f8a6"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+			h := subscribeHandler{
+				sockHandler:    mockSock,
+				messageHandler: mockMessage,
+			}
+
+			mockMessage.EXPECT().EventPMPipecatcallTerminated(gomock.Any(), tt.expectedEvent).Return(nil)
+
+			if err := h.processEventPMPipecatcallTerminated(context.Background(), tt.event); err != nil {
+				t.Errorf("Wrong match. expected: ok, got: %v", err)
+			}
 		})
 	}
 }

--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_messages.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_messages.sql
@@ -13,6 +13,10 @@ create table ai_messages(
   tool_calls    json,
   tool_call_id  varchar(255),
 
+  -- delivery tracking
+  pipecatcall_id  binary(16),
+  delivery_status varchar(16) not null default 'delivered',
+
   -- timestamps
   tm_create datetime(6),  --
   tm_delete datetime(6),
@@ -24,3 +28,4 @@ create index idx_ai_messages_create on ai_messages(tm_create);
 create index idx_ai_messages_customer_id on ai_messages(customer_id);
 create index idx_ai_messages_aicall_id on ai_messages(aicall_id);
 create index idx_ai_messages_activeflow_id on ai_messages(activeflow_id);
+create index idx_ai_messages_pcc_delivery on ai_messages(pipecatcall_id, delivery_status);

--- a/bin-dbscheme-manager/bin-manager/main/versions/86dd44956fa5_ai_messages_add_pipecatcall_id_delivery_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/86dd44956fa5_ai_messages_add_pipecatcall_id_delivery_.py
@@ -1,0 +1,33 @@
+"""ai_messages add pipecatcall_id delivery_status
+
+Revision ID: 86dd44956fa5
+Revises: 629a307b92d0
+Create Date: 2026-04-29 12:29:35.225461
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision = '86dd44956fa5'
+down_revision = '629a307b92d0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('ai_messages',
+        sa.Column('pipecatcall_id', mysql.BINARY(16), nullable=True))
+    op.add_column('ai_messages',
+        sa.Column('delivery_status', sa.String(16), nullable=False,
+                  server_default='delivered'))
+    op.create_index('idx_ai_messages_pcc_delivery', 'ai_messages',
+                    ['pipecatcall_id', 'delivery_status'])
+
+
+def downgrade():
+    op.drop_index('idx_ai_messages_pcc_delivery', 'ai_messages')
+    op.drop_column('ai_messages', 'delivery_status')
+    op.drop_column('ai_messages', 'pipecatcall_id')

--- a/bin-pipecat-manager/go.mod
+++ b/bin-pipecat-manager/go.mod
@@ -110,6 +110,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/bin-pipecat-manager/models/pipecatcall/event.go
+++ b/bin-pipecat-manager/models/pipecatcall/event.go
@@ -5,4 +5,6 @@ const (
 	EventTypeDeleted string = "pipecatcall_deleted"
 
 	EventTypeInitialized string = "pipecatcall_initialized"
+
+	EventTypePipecatcallTerminated string = "pipecatcall_terminated"
 )

--- a/bin-pipecat-manager/models/pipecatcall/event_test.go
+++ b/bin-pipecat-manager/models/pipecatcall/event_test.go
@@ -1,0 +1,9 @@
+package pipecatcall
+
+import "testing"
+
+func TestEventTypePipecatcallTerminated_value(t *testing.T) {
+	if EventTypePipecatcallTerminated != "pipecatcall_terminated" {
+		t.Fatalf("expected pipecatcall_terminated, got %q", EventTypePipecatcallTerminated)
+	}
+}

--- a/bin-pipecat-manager/models/pipecatcall/session.go
+++ b/bin-pipecat-manager/models/pipecatcall/session.go
@@ -39,7 +39,7 @@ type Session struct {
 	LLMTokenChan  chan string   `json:"-"` // buffered channel for LLM tokens (cap 64)
 	LLMStopChan   chan struct{} `json:"-"` // signals flush goroutine to stop
 	LLMDoneChan   chan struct{} `json:"-"` // closed when flush goroutine completes
-	LLMFlushing   bool          `json:"-"` // whether flush goroutine is running
+	LLMFlushing   atomic.Bool   `json:"-"` // whether flush goroutine is running
 	LLMMessageID  uuid.UUID     `json:"-"` // pre-generated message UUID for current generation
 	LLMFlushOnce  sync.Once     `json:"-"` // ensures LLMStopChan is closed at most once
 	LLMStopReason atomic.Int32  `json:"-"` // set by closer via CAS; read by flush goroutine for metric attribution

--- a/bin-pipecat-manager/models/pipecatcall/session.go
+++ b/bin-pipecat-manager/models/pipecatcall/session.go
@@ -36,11 +36,13 @@ type Session struct {
 	// LLM intermediate event flush coordination.
 	// These fields are managed by the WebSocket read loop (single goroutine per session).
 	// The flush goroutine communicates via channels only — no shared mutable state.
-	LLMTokenChan chan string   `json:"-"` // buffered channel for LLM tokens (cap 64)
-	LLMStopChan  chan struct{} `json:"-"` // signals flush goroutine to stop
-	LLMDoneChan  chan struct{} `json:"-"` // closed when flush goroutine completes
-	LLMFlushing  bool         `json:"-"` // whether flush goroutine is running
-	LLMMessageID uuid.UUID    `json:"-"` // pre-generated message UUID for current generation
+	LLMTokenChan  chan string   `json:"-"` // buffered channel for LLM tokens (cap 64)
+	LLMStopChan   chan struct{} `json:"-"` // signals flush goroutine to stop
+	LLMDoneChan   chan struct{} `json:"-"` // closed when flush goroutine completes
+	LLMFlushing   bool          `json:"-"` // whether flush goroutine is running
+	LLMMessageID  uuid.UUID     `json:"-"` // pre-generated message UUID for current generation
+	LLMFlushOnce  sync.Once     `json:"-"` // ensures LLMStopChan is closed at most once
+	LLMStopReason atomic.Int32  `json:"-"` // set by closer via CAS; read by flush goroutine for metric attribution
 
 	// audio quality monitoring
 	DroppedFrames atomic.Int64 `json:"-"`

--- a/bin-pipecat-manager/models/pipecatcall/session_test.go
+++ b/bin-pipecat-manager/models/pipecatcall/session_test.go
@@ -1,0 +1,12 @@
+package pipecatcall
+
+import "testing"
+
+func TestSession_FlushPrimitives(t *testing.T) {
+	s := &Session{}
+	// Channels are zero-valued; Once and atomic.Int32 are usable in zero-value.
+	s.LLMFlushOnce.Do(func() {}) // should not panic
+	if got := s.LLMStopReason.Load(); got != 0 {
+		t.Fatalf("expected initial reason 0, got %d", got)
+	}
+}

--- a/bin-pipecat-manager/models/pipecatcall/session_test.go
+++ b/bin-pipecat-manager/models/pipecatcall/session_test.go
@@ -10,3 +10,15 @@ func TestSession_FlushPrimitives(t *testing.T) {
 		t.Fatalf("expected initial reason 0, got %d", got)
 	}
 }
+
+func TestSession_LLMFlushing_isAtomicBool(t *testing.T) {
+	s := &Session{}
+	s.LLMFlushing.Store(true)
+	if !s.LLMFlushing.Load() {
+		t.Fatalf("expected LLMFlushing true after Store(true)")
+	}
+	s.LLMFlushing.Store(false)
+	if s.LLMFlushing.Load() {
+		t.Fatalf("expected LLMFlushing false after Store(false)")
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/main.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/main.go
@@ -82,6 +82,9 @@ type pipecatcallHandler struct {
 
 	mapPipecatcallSession map[uuid.UUID]*pipecatcall.Session
 	muPipecatcallSession  sync.Mutex
+
+	muTerminated        sync.Mutex
+	terminatedPublished map[uuid.UUID]struct{}
 }
 
 func NewPipecatcallHandler(
@@ -108,5 +111,8 @@ func NewPipecatcallHandler(
 
 		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
 		muPipecatcallSession:  sync.Mutex{},
+
+		muTerminated:        sync.Mutex{},
+		terminatedPublished: make(map[uuid.UUID]struct{}),
 	}
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go
@@ -1,0 +1,43 @@
+package pipecatcallhandler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Prometheus metrics for the LLM intermediate-flush / finalize subsystem.
+//
+// Names follow the pipecat_manager_* convention used elsewhere in the service
+// (see pkg/listenhandler/main.go). All metrics are registered with the default
+// Prometheus registerer in init().
+var (
+	metricsLLMFlushExit = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipecat_manager_llm_flush_exit_total",
+			Help: "Counter of runLLMIntermediateFlush goroutine exits, by reason.",
+		},
+		[]string{"reason"},
+	)
+
+	metricsIdleWatchdogFired = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pipecat_manager_llm_idle_watchdog_fired_total",
+			Help: "Counter of idle-watchdog firings (no tokens for idleWatchdogTimeout while flushing).",
+		},
+	)
+
+	metricsFlushFinalizeOutcome = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pipecat_manager_llm_flush_finalize_outcome_total",
+			Help: "Counter of flushAndFinalize outcomes from the terminate caller's perspective.",
+		},
+		[]string{"outcome"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		metricsLLMFlushExit,
+		metricsIdleWatchdogFired,
+		metricsFlushFinalizeOutcome,
+	)
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/metrics_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/metrics_test.go
@@ -1,0 +1,72 @@
+package pipecatcallhandler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metricRegistered reports whether a metric with the given fully-qualified
+// name is registered with the default Prometheus registerer.
+//
+// We attempt to register a throwaway counter that shares the target name. The
+// default registerer rejects the registration with AlreadyRegisteredError when
+// the name is already in use, which is the signal we want. Using Gather() is
+// not sufficient for *Vec collectors with no observed children, since they do
+// not emit a metric family until at least one label combination is touched.
+func metricRegistered(name string) bool {
+	probe := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: name,
+		Help: "probe",
+	})
+	err := prometheus.DefaultRegisterer.Register(probe)
+	if err == nil {
+		// Probe registered cleanly, so the real metric was NOT already there.
+		// Unregister our probe so we leave the registry as we found it.
+		prometheus.DefaultRegisterer.Unregister(probe)
+		return false
+	}
+	var are prometheus.AlreadyRegisteredError
+	if errors.As(err, &are) {
+		return true
+	}
+	// CounterVec/GaugeVec collectors register a Desc whose fully-qualified
+	// name plus variable label set must be unique. Re-registering a plain
+	// Counter under the same name surfaces a descriptor-conflict error rather
+	// than AlreadyRegisteredError. Treat any of these "name already in the
+	// registry" messages as positive signal too.
+	msg := err.Error()
+	return strings.Contains(msg, "already registered") ||
+		strings.Contains(msg, "duplicate metrics collector") ||
+		strings.Contains(msg, "previously registered descriptor with the same fully-qualified name")
+}
+
+func TestNewMetrics_registered(t *testing.T) {
+	tests := []struct {
+		name   string
+		metric string
+	}{
+		{
+			name:   "llm flush exit counter",
+			metric: "pipecat_manager_llm_flush_exit_total",
+		},
+		{
+			name:   "llm idle watchdog fired counter",
+			metric: "pipecat_manager_llm_idle_watchdog_fired_total",
+		},
+		{
+			name:   "llm flush finalize outcome counter",
+			metric: "pipecat_manager_llm_flush_finalize_outcome_total",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !metricRegistered(tt.metric) {
+				t.Errorf("metric %s not registered", tt.metric)
+			}
+		})
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -644,7 +644,10 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 		case <-ticker.C:
 			if deltaBuffer != "" {
 				sequence++
-				h.publishIntermediateEvent(se, messageID, deltaBuffer, sequence)
+				// Use context.Background() so a cancelled session ctx (from
+				// terminate path) does not drop the partial reply event on its
+				// way to ai-manager.
+				h.publishIntermediateEvent(context.Background(), se, messageID, deltaBuffer, sequence)
 				log.Debugf("Published intermediate event. sequence: %d, delta_len: %d", sequence, len(deltaBuffer))
 				deltaBuffer = ""
 			}
@@ -664,12 +667,14 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 			// Flush any remaining delta as the last intermediate event.
 			if deltaBuffer != "" {
 				sequence++
-				h.publishIntermediateEvent(se, messageID, deltaBuffer, sequence)
+				h.publishIntermediateEvent(context.Background(), se, messageID, deltaBuffer, sequence)
 				log.Debugf("Published final intermediate event. sequence: %d, delta_len: %d", sequence, len(deltaBuffer))
 			}
 
-			// Publish the final complete bot LLM event.
-			h.publishFinalBotLLMEvent(se.Ctx, se, messageID, fullText)
+			// Publish the final complete bot LLM event. Use context.Background()
+			// because terminate() may have cancelled se.Ctx and we still want
+			// the partial reply to reach ai-manager.
+			h.publishFinalBotLLMEvent(context.Background(), se, messageID, fullText)
 			log.Debugf("Published final bot LLM event. full_text_len: %d", len(fullText))
 			return
 
@@ -698,7 +703,9 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 }
 
 // publishIntermediateEvent publishes a message_bot_llm_intermediate event with the delta text.
-func (h *pipecatcallHandler) publishIntermediateEvent(se *pipecatcall.Session, messageID uuid.UUID, delta string, sequence int) {
+// Accepts an explicit context so callers can use context.Background() when se.Ctx is cancelled
+// (e.g. during the terminate path) and the partial reply must still reach ai-manager.
+func (h *pipecatcallHandler) publishIntermediateEvent(ctx context.Context, se *pipecatcall.Session, messageID uuid.UUID, delta string, sequence int) {
 	evt := message.Message{
 		Identity: commonidentity.Identity{
 			ID:         messageID,
@@ -714,7 +721,7 @@ func (h *pipecatcallHandler) publishIntermediateEvent(se *pipecatcall.Session, m
 		Sequence: sequence,
 	}
 
-	h.notifyHandler.PublishEvent(se.Ctx, message.EventTypeBotLLMIntermediate, evt)
+	h.notifyHandler.PublishEvent(ctx, message.EventTypeBotLLMIntermediate, evt)
 }
 
 // publishFinalBotLLMEvent publishes the final message_bot_llm event with the complete text.

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -576,12 +576,19 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 			return errors.Wrapf(errUnmarshal, "could not unmarshal bot-llm-stopped message")
 		}
 
-		if se.LLMFlushing.Load() {
-			close(se.LLMStopChan)
-			<-se.LLMDoneChan
-		} else {
+		if !se.LLMFlushing.Load() {
 			log.Debugf("BotLLMStopped received but no tokens were received for this generation.")
+			break
 		}
+
+		// Attribute this stop to a normal completion (CAS so a competing closer
+		// — watchdog, terminate, context cancel — that already wrote a more
+		// specific reason wins). sync.Once guarantees close(LLMStopChan) runs
+		// at most once across all closers; the goroutine's defer in Task 1.7
+		// will reset LLMFlushing to false after it exits.
+		se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonNormal))
+		se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+		<-se.LLMDoneChan
 
 	default:
 		log.WithField("frame", frame).Debugf("Unrecognized RTVI message type: %s", frame.Type)

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -628,7 +628,8 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
-	defer close(se.LLMDoneChan)
+	defer close(se.LLMDoneChan)        // close-broadcasts goroutine exit to readers
+	defer se.LLMFlushing.Store(false)  // LIFO: runs before close(LLMDoneChan), so observers see flushing=false
 
 	var fullText string
 	var deltaBuffer string

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -44,10 +44,17 @@ const (
 // idle time. A finer tick rate reduces detection jitter at the cost of slightly
 // more select-loop wakeups.
 //
+// flushFinalizeTimeout is the upper bound flushAndFinalize will wait for the
+// flush goroutine to exit after closing LLMStopChan. If the goroutine has not
+// published its final event and closed LLMDoneChan within this window,
+// flushAndFinalize gives up and lets terminate() proceed to teardown so a
+// stuck flush cannot indefinitely block hangup.
+//
 // These are var (not const) so tests can patch them to short values.
 var (
 	idleWatchdogTimeout  = 8 * time.Second
 	idleWatchdogTickRate = 1 * time.Second
+	flushFinalizeTimeout = 3 * time.Second
 )
 
 // reasonLabel returns the Prometheus label associated with a StopReason.
@@ -737,6 +744,54 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 			metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReason(se.LLMStopReason.Load()))).Inc()
 			return
 		}
+	}
+}
+
+// flushAndFinalize is the synchronous helper that terminate() calls to force
+// the per-generation flush goroutine to publish its final message_bot_llm
+// event before SessionStop tears down the session. It is safe to call when no
+// flush is in progress (it returns immediately as a no-op) and safe to call
+// concurrently with the flush goroutine's normal completion path because the
+// CompareAndSwap on LLMStopReason and sync.Once around close(LLMStopChan)
+// preserve the first-writer-wins invariant.
+//
+// Outcomes (recorded on metricsFlushFinalizeOutcome):
+//   - "noop_never_started": no flush goroutine ever ran for this pipecatcall
+//     (no BotLLMText was received).
+//   - "noop_already_done": the flush goroutine ran and exited cleanly before
+//     terminate() arrived (e.g. BotLLMStopped was received first).
+//   - "done": the flush goroutine was running; we closed LLMStopChan and it
+//     drained, published its final event, and exited within flushFinalizeTimeout.
+//   - "timeout": the flush goroutine was running but did not exit within
+//     flushFinalizeTimeout, so we abandon the wait and let terminate() proceed.
+//     Partial replies may be lost in this rare path; the metric makes that visible.
+func (h *pipecatcallHandler) flushAndFinalize(se *pipecatcall.Session) {
+	if !se.LLMFlushing.Load() {
+		// Distinguish never-started (no generation ever) from already-done
+		// (a generation completed cleanly) using LLMMessageID — set when the
+		// flush goroutine is armed and not cleared on normal exit.
+		if se.LLMMessageID == uuid.Nil {
+			metricsFlushFinalizeOutcome.WithLabelValues("noop_never_started").Inc()
+		} else {
+			metricsFlushFinalizeOutcome.WithLabelValues("noop_already_done").Inc()
+		}
+		return
+	}
+
+	// Attribute this exit to the terminate path (CAS so a concurrent watchdog
+	// or normal-stop closer that already wrote a more specific reason wins),
+	// then close LLMStopChan exactly once across all closers.
+	se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonTerminateForce))
+	se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+
+	timer := time.NewTimer(flushFinalizeTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-se.LLMDoneChan:
+		metricsFlushFinalizeOutcome.WithLabelValues("done").Inc()
+	case <-timer.C:
+		metricsFlushFinalizeOutcome.WithLabelValues("timeout").Inc()
 	}
 }
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -12,6 +12,7 @@ import (
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
 	"monorepo/bin-pipecat-manager/models/pipecatframe"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -576,6 +577,15 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 			se.LLMTokenChan = make(chan string, 64)
 			se.LLMStopChan = make(chan struct{})
 			se.LLMDoneChan = make(chan struct{})
+			// Reset per-generation primitives BEFORE arming the flush flag so the
+			// new generation's machinery is in place before the goroutine launches.
+			// Without this reset, a second generation's LLMFlushOnce.Do(close) is a
+			// no-op (Once already fired in gen 1) — LLMStopChan never closes, the
+			// flush goroutine blocks forever, and the per-generation final event
+			// is never published. Likewise, LLMStopReason still holds gen 1's
+			// value, so the metric label is wrong for gen 2+.
+			se.LLMFlushOnce = sync.Once{}
+			se.LLMStopReason.Store(int32(StopReasonUnset))
 			se.LLMFlushing.Store(true)
 			go h.runLLMIntermediateFlush(se, se.LLMMessageID)
 		}
@@ -610,7 +620,18 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 		// will reset LLMFlushing to false after it exits.
 		se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonNormal))
 		se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
-		<-se.LLMDoneChan
+
+		// Bound the wait so a slow RabbitMQ publish in the flush goroutine
+		// cannot stall the WebSocket read loop (which also handles audio
+		// frames). Reuses flushFinalizeTimeout so all "wait for flush
+		// goroutine to exit" paths share the same upper bound.
+		timer := time.NewTimer(flushFinalizeTimeout)
+		select {
+		case <-se.LLMDoneChan:
+		case <-timer.C:
+			log.Warnf("BotLLMStopped: timed out waiting for flush goroutine after %s", flushFinalizeTimeout)
+		}
+		timer.Stop()
 
 	default:
 		log.WithField("frame", frame).Debugf("Unrecognized RTVI message type: %s", frame.Type)

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -518,12 +518,12 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 			return errors.Wrapf(errUnmarshal, "could not unmarshal bot-llm-text message")
 		}
 
-		if !se.LLMFlushing {
+		if !se.LLMFlushing.Load() {
 			se.LLMMessageID = h.utilHandler.UUIDCreate()
 			se.LLMTokenChan = make(chan string, 64)
 			se.LLMStopChan = make(chan struct{})
 			se.LLMDoneChan = make(chan struct{})
-			se.LLMFlushing = true
+			se.LLMFlushing.Store(true)
 			go h.runLLMIntermediateFlush(se, se.LLMMessageID)
 		}
 
@@ -545,10 +545,9 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 			return errors.Wrapf(errUnmarshal, "could not unmarshal bot-llm-stopped message")
 		}
 
-		if se.LLMFlushing {
+		if se.LLMFlushing.Load() {
 			close(se.LLMStopChan)
 			<-se.LLMDoneChan
-			se.LLMFlushing = false
 		} else {
 			log.Debugf("BotLLMStopped received but no tokens were received for this generation.")
 		}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -35,6 +35,21 @@ const (
 	StopReasonContextCancel
 )
 
+// idleWatchdogTimeout is the duration of inactivity (no tokens received) after
+// which the flush goroutine self-terminates with StopReasonIdleWatchdog. The
+// watchdog only arms after the first token arrives — it never fires on a
+// generation that produced zero tokens.
+//
+// idleWatchdogTickRate is how often the watchdog ticker fires to check elapsed
+// idle time. A finer tick rate reduces detection jitter at the cost of slightly
+// more select-loop wakeups.
+//
+// These are var (not const) so tests can patch them to short values.
+var (
+	idleWatchdogTimeout  = 8 * time.Second
+	idleWatchdogTickRate = 1 * time.Second
+)
+
 // reasonLabel returns the Prometheus label associated with a StopReason.
 // Any value not explicitly mapped (including StopReasonUnset and future
 // additions) is returned as "unknown" so metrics never panic on new values.
@@ -628,18 +643,22 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
+	watchdog := time.NewTicker(idleWatchdogTickRate)
+	defer watchdog.Stop()
 	defer close(se.LLMDoneChan)        // close-broadcasts goroutine exit to readers
 	defer se.LLMFlushing.Store(false)  // LIFO: runs before close(LLMDoneChan), so observers see flushing=false
 
 	var fullText string
 	var deltaBuffer string
 	var sequence int
+	var lastToken time.Time // zero until first token arrives — watchdog uses IsZero() guard
 
 	for {
 		select {
 		case token := <-se.LLMTokenChan:
 			fullText += token
 			deltaBuffer += token
+			lastToken = time.Now()
 
 		case <-ticker.C:
 			if deltaBuffer != "" {
@@ -650,6 +669,18 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 				h.publishIntermediateEvent(context.Background(), se, messageID, deltaBuffer, sequence)
 				log.Debugf("Published intermediate event. sequence: %d, delta_len: %d", sequence, len(deltaBuffer))
 				deltaBuffer = ""
+			}
+
+		case now := <-watchdog.C:
+			// Watchdog only arms after the first token has arrived. A generation
+			// with zero tokens (Python upstream stalled before producing any
+			// output) is the responsibility of the terminate / context-cancel
+			// paths, not the watchdog.
+			if !lastToken.IsZero() && now.Sub(lastToken) >= idleWatchdogTimeout {
+				if se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonIdleWatchdog)) {
+					metricsIdleWatchdogFired.Inc()
+				}
+				se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
 			}
 
 		case <-se.LLMStopChan:
@@ -676,9 +707,15 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 			// the partial reply to reach ai-manager.
 			h.publishFinalBotLLMEvent(context.Background(), se, messageID, fullText)
 			log.Debugf("Published final bot LLM event. full_text_len: %d", len(fullText))
+			metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReason(se.LLMStopReason.Load()))).Inc()
 			return
 
 		case <-se.Ctx.Done():
+			// CAS in StopReasonContextCancel only if no other closer (watchdog,
+			// terminate, normal stop) already attributed the exit. The reason
+			// label on metricsLLMFlushExit reflects whichever reason won.
+			se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonContextCancel))
+
 			// Drain and publish final event to preserve partial LLM response in
 			// conversation history (used by summary handler). Use context.Background()
 			// because the original context is already cancelled.
@@ -697,6 +734,7 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 			} else {
 				log.Debugf("Context cancelled, no text accumulated.")
 			}
+			metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReason(se.LLMStopReason.Load()))).Inc()
 			return
 		}
 	}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -22,6 +22,37 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// StopReason identifies why an LLM-related goroutine exited.
+// Stored atomically on Session.LLMStopReason (as int32) and
+// read by the flush goroutine to attribute the exit in metrics.
+type StopReason int32
+
+const (
+	StopReasonUnset StopReason = iota
+	StopReasonNormal
+	StopReasonIdleWatchdog
+	StopReasonTerminateForce
+	StopReasonContextCancel
+)
+
+// reasonLabel returns the Prometheus label associated with a StopReason.
+// Any value not explicitly mapped (including StopReasonUnset and future
+// additions) is returned as "unknown" so metrics never panic on new values.
+func reasonLabel(r StopReason) string {
+	switch r {
+	case StopReasonNormal:
+		return "stopped_normal"
+	case StopReasonIdleWatchdog:
+		return "idle_watchdog"
+	case StopReasonTerminateForce:
+		return "terminate_force"
+	case StopReasonContextCancel:
+		return "context_cancelled"
+	default:
+		return "unknown"
+	}
+}
+
 func (h *pipecatcallHandler) RunnerStart(pc *pipecatcall.Pipecatcall, se *pipecatcall.Session) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":           "RunnerStart",

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -578,3 +578,71 @@ func TestBotLLMStopped_doubleStop_noPanic(t *testing.T) {
 		t.Fatalf("expected StopReasonNormal (%d), got %d", StopReasonNormal, got)
 	}
 }
+
+// TestRunLLMIntermediateFlush_resetsLLMFlushing_onAllExits verifies that
+// runLLMIntermediateFlush always clears Session.LLMFlushing before returning,
+// regardless of which exit path triggered the goroutine to return.
+//
+// The reset is owned by a defer at the top of the goroutine (Task 1.7) so it
+// fires on every exit path: normal close (LLMStopChan), context cancel
+// (Ctx.Done), or any future addition.
+func TestRunLLMIntermediateFlush_resetsLLMFlushing_onAllExits(t *testing.T) {
+	cases := []struct {
+		name      string
+		causeExit func(*pipecatcall.Session, context.CancelFunc)
+	}{
+		{
+			name: "stopChan",
+			causeExit: func(s *pipecatcall.Session, _ context.CancelFunc) {
+				close(s.LLMStopChan)
+			},
+		},
+		{
+			name: "ctxDone",
+			causeExit: func(s *pipecatcall.Session, cancel context.CancelFunc) {
+				cancel()
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+			h := &pipecatcallHandler{
+				notifyHandler: mockNotify,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			se := &pipecatcall.Session{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaaaaaa-1111-2222-3333-444444444444"),
+					CustomerID: uuid.FromStringOrNil("bbbbbbbb-1111-2222-3333-444444444444"),
+				},
+				Ctx:          ctx,
+				Cancel:       cancel,
+				LLMTokenChan: make(chan string, 64),
+				LLMStopChan:  make(chan struct{}),
+				LLMDoneChan:  make(chan struct{}),
+			}
+			// Arm the flush state to mimic a live generation, then start the goroutine.
+			se.LLMFlushing.Store(true)
+			go h.runLLMIntermediateFlush(se, uuid.FromStringOrNil("cccccccc-1111-2222-3333-444444444444"))
+
+			c.causeExit(se, cancel)
+
+			// Wait for goroutine to exit.
+			<-se.LLMDoneChan
+
+			if se.LLMFlushing.Load() {
+				t.Fatalf("LLMFlushing not reset on %s exit", c.name)
+			}
+		})
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -291,8 +291,8 @@ func Test_runLLMIntermediateFlush(t *testing.T) {
 			LLMTokenChan: make(chan string, 64),
 			LLMStopChan:  make(chan struct{}),
 			LLMDoneChan:  make(chan struct{}),
-			LLMFlushing:  true,
 		}
+		se.LLMFlushing.Store(true)
 
 		var mu sync.Mutex
 		var gen1FinalText string
@@ -315,14 +315,14 @@ func Test_runLLMIntermediateFlush(t *testing.T) {
 		se.LLMTokenChan <- " gen"
 		close(se.LLMStopChan)
 		<-se.LLMDoneChan
-		se.LLMFlushing = false
+		se.LLMFlushing.Store(false)
 
 		// --- Generation 2: reset channels, new UUID ---
 		messageID2 := uuid.FromStringOrNil("44444444-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 		se.LLMTokenChan = make(chan string, 64)
 		se.LLMStopChan = make(chan struct{})
 		se.LLMDoneChan = make(chan struct{})
-		se.LLMFlushing = true
+		se.LLMFlushing.Store(true)
 
 		mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLM), gomock.Any()).DoAndReturn(
 			func(_ any, _ any, evt message.Message) {
@@ -472,7 +472,7 @@ func Test_runLLMIntermediateFlush(t *testing.T) {
 		se.LLMTokenChan = make(chan string, 64)
 		se.LLMStopChan = make(chan struct{})
 		se.LLMDoneChan = make(chan struct{})
-		se.LLMFlushing = true
+		se.LLMFlushing.Store(true)
 
 		mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -1006,3 +1006,184 @@ func TestFlushAndFinalize_outcomes(t *testing.T) {
 		})
 	}
 }
+
+// TestBotLLMText_armNewGeneration_resetsOncePrimitives verifies the
+// arm-new-generation path in the BotLLMText handler resets LLMFlushOnce and
+// LLMStopReason between generations. Without the reset, generation 2's
+// LLMFlushOnce.Do(close) would be a no-op (Once already fired in gen 1), so
+// LLMStopChan would never close, the flush goroutine would block forever, and
+// the per-generation final event would never be published.
+//
+// This test drives the real handler (receiveMessageFrameTypeMessage with a
+// BotLLMText frame, then a BotLLMStopped frame) for two generations and
+// asserts that gen 2's goroutine exits within a deadline AND that a final
+// event is published for both generations.
+func TestBotLLMText_armNewGeneration_resetsOncePrimitives(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+
+	gen1MessageID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+	gen2MessageID := uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	// Each BotLLMText that arms a new generation calls UUIDCreate() once.
+	gomock.InOrder(
+		mockUtil.EXPECT().UUIDCreate().Return(gen1MessageID),
+		mockUtil.EXPECT().UUIDCreate().Return(gen2MessageID),
+	)
+
+	// Allow any number of intermediate publishes; we focus on final events.
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLMIntermediate), gomock.Any()).AnyTimes()
+
+	finalCount := make(chan uuid.UUID, 2)
+	mockNotify.EXPECT().
+		PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLM), gomock.Any()).
+		DoAndReturn(func(_ any, _ any, evt message.Message) {
+			finalCount <- evt.ID
+		}).
+		Times(2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("ffffffff-1111-2222-3333-444444444444"),
+			CustomerID: uuid.FromStringOrNil("dddddddd-1111-2222-3333-444444444444"),
+		},
+		Ctx: ctx,
+	}
+
+	textFrame := func(text string) []byte {
+		return []byte(`{"label":"rtvi-ai","type":"bot-llm-text","data":{"text":"` + text + `"}}`)
+	}
+	stoppedFrame := []byte(`{"label":"rtvi-ai","type":"bot-llm-stopped"}`)
+
+	// --- Generation 1 ---
+	if err := h.receiveMessageFrameTypeMessage(se, textFrame("First")); err != nil {
+		t.Fatalf("gen1 BotLLMText returned unexpected error: %v", err)
+	}
+	if se.LLMMessageID != gen1MessageID {
+		t.Fatalf("gen1: expected LLMMessageID %s, got %s", gen1MessageID, se.LLMMessageID)
+	}
+	gen1Done := se.LLMDoneChan
+	// BotLLMStopped uses LLMFlushOnce.Do (the production path). With the bug,
+	// gen 2 would see Once already fired and never close LLMStopChan.
+	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
+		t.Fatalf("gen1 BotLLMStopped returned unexpected error: %v", err)
+	}
+	select {
+	case <-gen1Done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("gen1 flush goroutine did not exit within 500ms")
+	}
+
+	// --- Generation 2 ---
+	if err := h.receiveMessageFrameTypeMessage(se, textFrame("Second")); err != nil {
+		t.Fatalf("gen2 BotLLMText returned unexpected error: %v", err)
+	}
+	if se.LLMMessageID != gen2MessageID {
+		t.Fatalf("gen2: expected LLMMessageID %s, got %s", gen2MessageID, se.LLMMessageID)
+	}
+	gen2Done := se.LLMDoneChan
+	if gen1Done == gen2Done {
+		t.Fatal("gen2 LLMDoneChan must be a fresh channel, got the gen1 channel")
+	}
+	// Confirm StopReason was reset back to Unset for gen 2.
+	if got := StopReason(se.LLMStopReason.Load()); got != StopReasonUnset {
+		t.Fatalf("gen2: expected LLMStopReason reset to Unset, got %d", got)
+	}
+
+	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
+		t.Fatalf("gen2 BotLLMStopped returned unexpected error: %v", err)
+	}
+	select {
+	case <-gen2Done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("gen2 flush goroutine did not exit within 500ms — LLMFlushOnce was not reset between generations")
+	}
+
+	// Both generations must have produced a final event.
+	close(finalCount)
+	got := []uuid.UUID{}
+	for id := range finalCount {
+		got = append(got, id)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 final events (one per generation), got %d", len(got))
+	}
+}
+
+// TestBotLLMStopped_boundedWaitOnLLMDoneChan verifies that the BotLLMStopped
+// handler does not wait indefinitely on LLMDoneChan. A stalled flush goroutine
+// (e.g. RabbitMQ publish wedged) must not stall the WebSocket read loop —
+// otherwise audio frames stop being processed and the WebSocket peer eventually
+// times out.
+//
+// The test arms a "fake" flush by setting LLMFlushing=true with channels but
+// does NOT start the runLLMIntermediateFlush goroutine. As a result, no one
+// will ever close LLMDoneChan. The handler must give up after
+// flushFinalizeTimeout and return.
+func TestBotLLMStopped_boundedWaitOnLLMDoneChan(t *testing.T) {
+	// Patch flushFinalizeTimeout to a short value so the test runs quickly.
+	origTimeout := flushFinalizeTimeout
+	flushFinalizeTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		flushFinalizeTimeout = origTimeout
+	})
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("11112222-3333-4444-5555-666666666666"),
+			CustomerID: uuid.FromStringOrNil("99998888-7777-6666-5555-444444444444"),
+		},
+		Ctx:          ctx,
+		LLMTokenChan: make(chan string, 64),
+		LLMStopChan:  make(chan struct{}),
+		LLMDoneChan:  make(chan struct{}),
+	}
+	// Arm the flush state but DO NOT start the goroutine — LLMDoneChan will
+	// never be closed. The handler must time out and return.
+	se.LLMFlushing.Store(true)
+
+	stoppedFrame := []byte(`{"label":"rtvi-ai","type":"bot-llm-stopped"}`)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		done <- h.receiveMessageFrameTypeMessage(se, stoppedFrame)
+	}()
+
+	deadline := flushFinalizeTimeout + 100*time.Millisecond
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("BotLLMStopped returned unexpected error: %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > deadline {
+			t.Fatalf("BotLLMStopped returned but took %v (>%v) — bound not enforced", elapsed, deadline)
+		}
+	case <-time.After(deadline):
+		t.Fatalf("BotLLMStopped did not return within %v — wait on LLMDoneChan was unbounded", deadline)
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -13,6 +13,7 @@ import (
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
 
 	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -751,4 +752,133 @@ func TestRunLLMIntermediateFlush_resetsLLMFlushing_onAllExits(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunLLMIntermediateFlush_idleWatchdog_fires verifies that the idle
+// watchdog fires after idleWatchdogTimeout of inactivity following at least
+// one received token, sets StopReasonIdleWatchdog atomically, increments the
+// idle-watchdog Prometheus counter, and the flush goroutine exits cleanly via
+// the LLMStopChan branch (the watchdog closes LLMStopChan via LLMFlushOnce).
+func TestRunLLMIntermediateFlush_idleWatchdog_fires(t *testing.T) {
+	// Patch the timeout to a short value so the test runs quickly. Restore on
+	// cleanup so other tests see the production default.
+	origTimeout := idleWatchdogTimeout
+	origTickRate := idleWatchdogTickRate
+	idleWatchdogTimeout = 200 * time.Millisecond
+	idleWatchdogTickRate = 50 * time.Millisecond
+	t.Cleanup(func() {
+		idleWatchdogTimeout = origTimeout
+		idleWatchdogTickRate = origTickRate
+	})
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+	}
+
+	messageID := uuid.FromStringOrNil("aaaa1234-1111-2222-3333-444444444444")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("bbbb1234-1111-2222-3333-444444444444"),
+			CustomerID: uuid.FromStringOrNil("cccc1234-1111-2222-3333-444444444444"),
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		LLMTokenChan: make(chan string, 64),
+		LLMStopChan:  make(chan struct{}),
+		LLMDoneChan:  make(chan struct{}),
+	}
+	se.LLMFlushing.Store(true)
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	beforeFired := testutil.ToFloat64(metricsIdleWatchdogFired)
+	beforeExitWatchdog := testutil.ToFloat64(metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReasonIdleWatchdog)))
+
+	go h.runLLMIntermediateFlush(se, messageID)
+
+	// Send one token to arm the watchdog (it only fires after the first token).
+	se.LLMTokenChan <- "first token "
+
+	// Wait long enough for the watchdog to fire and the goroutine to exit.
+	select {
+	case <-se.LLMDoneChan:
+	case <-time.After(idleWatchdogTimeout + 2*time.Second):
+		t.Fatal("flush goroutine did not exit within expected window")
+	}
+
+	if got := StopReason(se.LLMStopReason.Load()); got != StopReasonIdleWatchdog {
+		t.Fatalf("expected StopReasonIdleWatchdog (%d), got %d", StopReasonIdleWatchdog, got)
+	}
+
+	afterFired := testutil.ToFloat64(metricsIdleWatchdogFired)
+	if delta := afterFired - beforeFired; delta < 1 {
+		t.Errorf("expected metricsIdleWatchdogFired to be incremented by at least 1, got delta %v", delta)
+	}
+
+	afterExitWatchdog := testutil.ToFloat64(metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReasonIdleWatchdog)))
+	if delta := afterExitWatchdog - beforeExitWatchdog; delta < 1 {
+		t.Errorf("expected metricsLLMFlushExit{reason=idle_watchdog} to be incremented by at least 1, got delta %v", delta)
+	}
+}
+
+// TestRunLLMIntermediateFlush_idleWatchdog_doesNotFireBeforeFirstToken
+// verifies the watchdog's first-token guard: with no token ever sent,
+// the watchdog must NOT fire even if more than idleWatchdogTimeout elapses.
+func TestRunLLMIntermediateFlush_idleWatchdog_doesNotFireBeforeFirstToken(t *testing.T) {
+	origTimeout := idleWatchdogTimeout
+	origTickRate := idleWatchdogTickRate
+	idleWatchdogTimeout = 200 * time.Millisecond
+	idleWatchdogTickRate = 50 * time.Millisecond
+	t.Cleanup(func() {
+		idleWatchdogTimeout = origTimeout
+		idleWatchdogTickRate = origTickRate
+	})
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+	}
+
+	messageID := uuid.FromStringOrNil("dddd1234-1111-2222-3333-444444444444")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("eeee1234-1111-2222-3333-444444444444"),
+			CustomerID: uuid.FromStringOrNil("ffff1234-1111-2222-3333-444444444444"),
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		LLMTokenChan: make(chan string, 64),
+		LLMStopChan:  make(chan struct{}),
+		LLMDoneChan:  make(chan struct{}),
+	}
+	se.LLMFlushing.Store(true)
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	go h.runLLMIntermediateFlush(se, messageID)
+
+	// Wait > idleWatchdogTimeout. No token was sent, so watchdog must NOT fire.
+	time.Sleep(idleWatchdogTimeout + 500*time.Millisecond)
+
+	if got := StopReason(se.LLMStopReason.Load()); got != StopReasonUnset {
+		t.Fatalf("expected StopReasonUnset (%d) before any token, got %d", StopReasonUnset, got)
+	}
+
+	// Cleanup: cancel context and wait for goroutine to exit.
+	cancel()
+	<-se.LLMDoneChan
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -579,6 +579,112 @@ func TestBotLLMStopped_doubleStop_noPanic(t *testing.T) {
 	}
 }
 
+// TestRunLLMIntermediateFlush_publishesAfterCtxCancel verifies that the final
+// and intermediate message_bot_llm publishes use a context that is independent
+// of se.Ctx. When terminate() cancels the session context (Task 2.x), in-flight
+// publishes that hand se.Ctx to PublishEvent would be dropped by the
+// notifyHandler's RPC layer, losing the partial bot response in conversation
+// history.
+//
+// This test cancels se.Ctx and then closes LLMStopChan. Whichever select branch
+// wins (LLMStopChan or Ctx.Done), the ctx passed to PublishEvent for both the
+// intermediate and final events must NOT be cancelled.
+func TestRunLLMIntermediateFlush_publishesAfterCtxCancel(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+	}
+
+	messageID := uuid.FromStringOrNil("aaaa9999-1111-2222-3333-444444444444")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("bbbb9999-1111-2222-3333-444444444444"),
+			CustomerID: uuid.FromStringOrNil("cccc9999-1111-2222-3333-444444444444"),
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		LLMTokenChan: make(chan string, 64),
+		LLMStopChan:  make(chan struct{}),
+		LLMDoneChan:  make(chan struct{}),
+	}
+	se.LLMFlushing.Store(true)
+
+	var (
+		mu                sync.Mutex
+		finalCtx          context.Context
+		finalText         string
+		finalCalled       bool
+		intermediateCtxs  []context.Context
+		intermediateCount int
+	)
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLMIntermediate), gomock.Any()).DoAndReturn(
+		func(c context.Context, _ any, _ message.Message) {
+			mu.Lock()
+			defer mu.Unlock()
+			intermediateCtxs = append(intermediateCtxs, c)
+			intermediateCount++
+		},
+	).AnyTimes()
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLM), gomock.Any()).DoAndReturn(
+		func(c context.Context, _ any, evt message.Message) {
+			mu.Lock()
+			defer mu.Unlock()
+			finalCalled = true
+			finalText = evt.Text
+			finalCtx = c
+		},
+	).Times(1)
+
+	go h.runLLMIntermediateFlush(se, messageID)
+
+	// Send one token, wait for the ticker to publish at least one intermediate
+	// while se.Ctx is still alive (exercises the ticker branch deterministically).
+	se.LLMTokenChan <- "hello "
+	time.Sleep(300 * time.Millisecond)
+
+	// Now simulate the terminate path: cancel se.Ctx then close LLMStopChan.
+	// The final publish must use context.Background() regardless of which
+	// select branch wins (LLMStopChan vs Ctx.Done) — both must be cancellation-
+	// independent so partial replies still reach ai-manager on terminate.
+	se.Cancel()
+	close(se.LLMStopChan)
+
+	<-se.LLMDoneChan
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !finalCalled {
+		t.Fatal("expected final bot LLM event to be published")
+	}
+	if finalText != "hello " {
+		t.Errorf("expected final text 'hello ', got '%s'", finalText)
+	}
+
+	bg := context.Background()
+	if finalCtx != bg {
+		t.Errorf("final publish must use context.Background(); got ctx with err=%v", finalCtx.Err())
+	}
+
+	if intermediateCount == 0 {
+		t.Fatal("expected at least one intermediate event from the ticker branch")
+	}
+	for i, c := range intermediateCtxs {
+		if c != bg {
+			t.Errorf("intermediate[%d]: must use context.Background(); got ctx with err=%v", i, c.Err())
+		}
+	}
+}
+
 // TestRunLLMIntermediateFlush_resetsLLMFlushing_onAllExits verifies that
 // runLLMIntermediateFlush always clears Session.LLMFlushing before returning,
 // regardless of which exit path triggered the goroutine to return.

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -882,3 +882,127 @@ func TestRunLLMIntermediateFlush_idleWatchdog_doesNotFireBeforeFirstToken(t *tes
 	cancel()
 	<-se.LLMDoneChan
 }
+
+// TestFlushAndFinalize_outcomes covers the four observable outcomes of
+// flushAndFinalize, the synchronous helper terminate() will call to
+// deterministically force the flush goroutine to publish its final event
+// before SessionStop tears down the session.
+//
+// Outcome labels (closed set):
+//   - noop_never_started: no flush goroutine ever ran (no BotLLMText was
+//     received). LLMFlushing is false AND LLMMessageID is uuid.Nil.
+//   - noop_already_done: flush goroutine ran and exited cleanly. LLMFlushing
+//     is false but LLMMessageID is non-nil (set when the goroutine was armed).
+//   - done: flush goroutine was running; we closed StopChan and it exited
+//     within timeout.
+//   - timeout: flush goroutine was running but did not return within
+//     flushFinalizeTimeout.
+func TestFlushAndFinalize_outcomes(t *testing.T) {
+	// Patch the timeout to a short value so the timeout case runs quickly.
+	// Restore on cleanup so other tests see the production default.
+	origTimeout := flushFinalizeTimeout
+	flushFinalizeTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { flushFinalizeTimeout = origTimeout })
+
+	// armFlush starts a real flush goroutine on `se` so that flushAndFinalize
+	// must close LLMStopChan and wait for the goroutine to exit via LLMDoneChan.
+	armFlush := func(t *testing.T, h *pipecatcallHandler, se *pipecatcall.Session) {
+		t.Helper()
+		se.LLMMessageID = uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+		se.LLMTokenChan = make(chan string, 64)
+		se.LLMStopChan = make(chan struct{})
+		se.LLMDoneChan = make(chan struct{})
+		se.LLMFlushing.Store(true)
+		go h.runLLMIntermediateFlush(se, se.LLMMessageID)
+	}
+
+	// armAndExitFlush arms a real flush goroutine, then waits for it to drain
+	// and exit cleanly so that by the time flushAndFinalize is called,
+	// LLMFlushing has been reset to false but LLMMessageID is still set.
+	armAndExitFlush := func(t *testing.T, h *pipecatcallHandler, se *pipecatcall.Session) {
+		t.Helper()
+		armFlush(t, h, se)
+		close(se.LLMStopChan)
+		<-se.LLMDoneChan
+		// LLMFlushing is reset to false by the goroutine's defer; LLMMessageID stays set.
+	}
+
+	// armFlushBlocking simulates a flush goroutine that does NOT drain — we
+	// initialize the channels and set the flushing flag, but never start a
+	// goroutine. flushAndFinalize will close LLMStopChan via LLMFlushOnce, then
+	// the timer must fire because LLMDoneChan is never closed.
+	armFlushBlocking := func(t *testing.T, _ *pipecatcallHandler, se *pipecatcall.Session) {
+		t.Helper()
+		se.LLMMessageID = uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+		se.LLMTokenChan = make(chan string, 64)
+		se.LLMStopChan = make(chan struct{})
+		se.LLMDoneChan = make(chan struct{})
+		se.LLMFlushing.Store(true)
+	}
+
+	cases := []struct {
+		name    string
+		setup   func(*testing.T, *pipecatcallHandler, *pipecatcall.Session)
+		outcome string
+	}{
+		{
+			name:    "never_started",
+			setup:   func(_ *testing.T, _ *pipecatcallHandler, _ *pipecatcall.Session) { /* no flush armed */ },
+			outcome: "noop_never_started",
+		},
+		{
+			name:    "already_done",
+			setup:   armAndExitFlush,
+			outcome: "noop_already_done",
+		},
+		{
+			name:    "done",
+			setup:   armFlush,
+			outcome: "done",
+		},
+		{
+			name:    "timeout",
+			setup:   armFlushBlocking,
+			outcome: "timeout",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			// Any PublishEvent calls (final/intermediate) the flush goroutine
+			// emits during the "done" case are not the focus of this test.
+			mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+			h := &pipecatcallHandler{
+				notifyHandler: mockNotify,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			se := &pipecatcall.Session{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaaaaaa-1111-2222-3333-444444444444"),
+					CustomerID: uuid.FromStringOrNil("bbbbbbbb-1111-2222-3333-444444444444"),
+				},
+				Ctx:    ctx,
+				Cancel: cancel,
+			}
+
+			c.setup(t, h, se)
+
+			before := testutil.ToFloat64(metricsFlushFinalizeOutcome.WithLabelValues(c.outcome))
+
+			h.flushAndFinalize(se)
+
+			after := testutil.ToFloat64(metricsFlushFinalizeOutcome.WithLabelValues(c.outcome))
+			if delta := after - before; delta != 1 {
+				t.Fatalf("expected metricsFlushFinalizeOutcome{outcome=%q} to increment by 1, got delta %v", c.outcome, delta)
+			}
+		})
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -506,3 +506,75 @@ func Test_runLLMIntermediateFlush(t *testing.T) {
 		<-se.LLMDoneChan
 	})
 }
+
+// TestBotLLMStopped_doubleStop_noPanic verifies that the BotLLMStopped handler
+// is idempotent: a second BotLLMStopped frame for the same generation must not
+// panic on a double-close of LLMStopChan, and the StopReason set by the first
+// call (StopReasonNormal) must not be overwritten.
+//
+// The defense relies on Session.LLMFlushOnce wrapping close(LLMStopChan) and
+// CompareAndSwap on LLMStopReason — both are tested together here because
+// a regression in either would cause a real-world race with the watchdog and
+// the flush goroutine that lands in subsequent tasks.
+func TestBotLLMStopped_doubleStop_noPanic(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee"),
+			CustomerID: uuid.FromStringOrNil("bbbb2222-cccc-dddd-eeee-ffffffffffff"),
+		},
+		Ctx:          ctx,
+		LLMTokenChan: make(chan string, 64),
+		LLMStopChan:  make(chan struct{}),
+		LLMDoneChan:  make(chan struct{}),
+	}
+	// Arm the flush goroutine: channels initialized + flushing flag set + goroutine running.
+	se.LLMFlushing.Store(true)
+
+	// Allow any number of intermediate / final events; they are not the focus
+	// of this test — we only assert no panic and StopReason correctness.
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	go h.runLLMIntermediateFlush(se, uuid.FromStringOrNil("cccc3333-dddd-eeee-ffff-000000000000"))
+
+	// Build a valid bot-llm-stopped RTVI frame payload that the handler can unmarshal.
+	stoppedFrame := []byte(`{"label":"rtvi-ai","type":"bot-llm-stopped"}`)
+
+	// First BotLLMStopped: should set StopReasonNormal, close LLMStopChan, and
+	// block on <-LLMDoneChan until the flush goroutine completes.
+	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
+		t.Fatalf("first BotLLMStopped returned unexpected error: %v", err)
+	}
+
+	// At this point the first call has unblocked from <-LLMDoneChan, so the
+	// flush goroutine has exited. LLMFlushing is still true (Task 1.7 owns the
+	// reset via defer); the second call's behavior is what this test pins down.
+	//
+	// Without sync.Once, the second close(LLMStopChan) below would panic.
+	// We capture any panic so the test reports a clean assertion failure.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second BotLLMStopped panicked: %v", r)
+		}
+	}()
+
+	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
+		t.Fatalf("second BotLLMStopped returned unexpected error: %v", err)
+	}
+
+	// First call set StopReasonNormal via CAS; second call's CAS must be a no-op.
+	if got := StopReason(se.LLMStopReason.Load()); got != StopReasonNormal {
+		t.Fatalf("expected StopReasonNormal (%d), got %d", StopReasonNormal, got)
+	}
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go
@@ -333,3 +333,21 @@ func Test_runnerWebsocketHandleAudio(t *testing.T) {
 
 }
 
+func TestReasonLabel(t *testing.T) {
+	cases := []struct {
+		in   StopReason
+		want string
+	}{
+		{StopReasonNormal, "stopped_normal"},
+		{StopReasonIdleWatchdog, "idle_watchdog"},
+		{StopReasonTerminateForce, "terminate_force"},
+		{StopReasonContextCancel, "context_cancelled"},
+		{StopReasonUnset, "unknown"},
+	}
+	for _, c := range cases {
+		if got := reasonLabel(c.in); got != c.want {
+			t.Errorf("reasonLabel(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
@@ -104,6 +104,11 @@ func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
 		}
 	}
 
+	// Cancel the session context so any in-flight goroutines (e.g. the flush
+	// goroutine waiting on pc.Ctx.Done()) unblock before we tear down the
+	// Asterisk connection. Mirrors the deferred cleanup in start.go.
+	pc.Cancel()
+
 	if pc.ConnAst != nil {
 		if errClose := pc.ConnAst.Close(); errClose != nil {
 			log.Errorf("Could not close the asterisk connection. err: %v", errClose)
@@ -116,6 +121,9 @@ func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
 	if errStop := h.pythonRunner.Stop(context.Background(), id); errStop != nil {
 		log.Errorf("Could not stop the pipecatcall in python runner. err: %v", errStop)
 	}
+
+	// Prune the terminate dedupe entry so the map does not grow unbounded.
+	h.terminatedDeleteEntry(pc.ID)
 
 	log.Debugf("Stopped pipecatcall session. pipecatcall_id: %s", id)
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go
@@ -283,9 +283,15 @@ func TestSessionStop(t *testing.T) {
 				pythonRunner:          mockPythonRunner,
 				mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
 				muPipecatcallSession:  sync.Mutex{},
+				muTerminated:          sync.Mutex{},
+				terminatedPublished:   make(map[uuid.UUID]struct{}),
 			}
 
 			if tt.existingSession != nil {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				tt.existingSession.Ctx = ctx
+				tt.existingSession.Cancel = cancel
 				h.mapPipecatcallSession[tt.existingSession.ID] = tt.existingSession
 				mockPythonRunner.EXPECT().Stop(gomock.Any(), tt.id).Return(tt.pythonRunnerErr)
 			}
@@ -299,6 +305,101 @@ func TestSessionStop(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSessionStop_cancelsCtx(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockPythonRunner := NewMockPythonRunner(mc)
+
+	id := uuid.FromStringOrNil("9f2cf5ea-c5e0-11f0-aaf6-bb6c8a5b9d2c")
+
+	h := &pipecatcallHandler{
+		pythonRunner:          mockPythonRunner,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+		muTerminated:          sync.Mutex{},
+		terminatedPublished:   make(map[uuid.UUID]struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	connAstReady := make(chan struct{})
+	close(connAstReady)
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		ConnAstReady: connAstReady,
+	}
+	h.mapPipecatcallSession[id] = se
+
+	mockPythonRunner.EXPECT().Stop(gomock.Any(), id).Return(nil)
+
+	done := make(chan struct{})
+	go func() {
+		<-se.Ctx.Done()
+		close(done)
+	}()
+
+	h.SessionStop(id)
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Ctx.Done() did not fire after SessionStop")
+	}
+}
+
+func TestSessionStop_prunesTerminatedMap(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockPythonRunner := NewMockPythonRunner(mc)
+
+	id := uuid.FromStringOrNil("af6b8d28-c5e0-11f0-9d31-237aff5b1a23")
+
+	h := &pipecatcallHandler{
+		pythonRunner:          mockPythonRunner,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+		muTerminated:          sync.Mutex{},
+		terminatedPublished:   make(map[uuid.UUID]struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	connAstReady := make(chan struct{})
+	close(connAstReady)
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		ConnAstReady: connAstReady,
+	}
+	h.mapPipecatcallSession[id] = se
+
+	// simulate a prior terminate() publish — first claim succeeds
+	if !h.markTerminatedOnce(se.ID) {
+		t.Fatalf("expected first markTerminatedOnce to succeed")
+	}
+
+	mockPythonRunner.EXPECT().Stop(gomock.Any(), id).Return(nil)
+
+	h.SessionStop(se.ID)
+
+	if h.markTerminatedOnce(se.ID) == false {
+		t.Fatalf("expected map entry pruned; second markTerminatedOnce should claim again")
 	}
 }
 
@@ -337,6 +438,8 @@ func TestSessionStop_closesWebSocket(t *testing.T) {
 		pythonRunner:          mockPythonRunner,
 		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
 		muPipecatcallSession:  sync.Mutex{},
+		muTerminated:          sync.Mutex{},
+		terminatedPublished:   make(map[uuid.UUID]struct{}),
 	}
 
 	connAstReady := make(chan struct{})

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
@@ -380,3 +380,24 @@ func (h *pipecatcallHandler) terminateReferenceTypeAICall(ctx context.Context, p
 
 	return nil
 }
+
+// markTerminatedOnce claims responsibility for publishing the
+// pipecatcall_terminated event for the given id. Returns true on the first
+// call (caller should publish), false on subsequent calls (already claimed).
+func (h *pipecatcallHandler) markTerminatedOnce(id uuid.UUID) bool {
+	h.muTerminated.Lock()
+	defer h.muTerminated.Unlock()
+	if _, ok := h.terminatedPublished[id]; ok {
+		return false
+	}
+	h.terminatedPublished[id] = struct{}{}
+	return true
+}
+
+// terminatedDeleteEntry removes the dedupe entry for the given id. Safe to
+// call when the entry is missing — Go's delete is a no-op in that case.
+func (h *pipecatcallHandler) terminatedDeleteEntry(id uuid.UUID) {
+	h.muTerminated.Lock()
+	defer h.muTerminated.Unlock()
+	delete(h.terminatedPublished, id)
+}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
@@ -304,6 +304,34 @@ func (h *pipecatcallHandler) terminate(ctx context.Context, pc *pipecatcall.Pipe
 	})
 	log.Infof("Terminating pipecatcall...")
 
+	// If the in-memory session is already gone, a previous terminate has
+	// already run flushAndFinalize, published pipecatcall_terminated, and
+	// torn the session down. Short-circuit so a back-to-back terminate
+	// cannot republish or re-run reference-type cleanup.
+	se, errGet := h.SessionGet(pc.ID)
+	if errGet != nil || se == nil {
+		log.Debugf("Pipecatcall session already stopped; skipping terminate.")
+		return
+	}
+
+	// Drain any in-flight per-generation LLM flush goroutine BEFORE teardown
+	// so partial replies are published as a final message_bot_llm event. Safe
+	// no-op when no flush is armed; safe when a normal-stop closer raced us
+	// (CAS + sync.Once preserve first-writer-wins).
+	h.flushAndFinalize(se)
+
+	// Publish the pipecatcall_terminated event exactly once per pipecatcall.
+	// Use context.Background() because SessionStop below will cancel se.Ctx
+	// and we want the event to leave even when terminate is invoked from a
+	// goroutine whose ctx is already cancelled.
+	if h.markTerminatedOnce(pc.ID) {
+		h.notifyHandler.PublishEvent(
+			context.Background(),
+			pipecatcall.EventTypePipecatcallTerminated,
+			pc,
+		)
+	}
+
 	switch pc.ReferenceType {
 	case pipecatcall.ReferenceTypeCall:
 		if errTerminate := h.terminateReferenceTypeCall(ctx, pc); errTerminate != nil {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
@@ -117,6 +117,49 @@ func Test_startReferenceTypeCall_externalMediaFailure(t *testing.T) {
 	}
 }
 
+func Test_markTerminatedOnce_idempotent(t *testing.T) {
+	h := &pipecatcallHandler{
+		terminatedPublished: make(map[uuid.UUID]struct{}),
+		muTerminated:        sync.Mutex{},
+	}
+
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("could not generate uuid: %v", err)
+	}
+
+	if !h.markTerminatedOnce(id) {
+		t.Fatalf("first call should claim")
+	}
+	if h.markTerminatedOnce(id) {
+		t.Fatalf("second call should not claim")
+	}
+}
+
+func Test_terminatedDeleteEntry(t *testing.T) {
+	h := &pipecatcallHandler{
+		terminatedPublished: make(map[uuid.UUID]struct{}),
+		muTerminated:        sync.Mutex{},
+	}
+
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("could not generate uuid: %v", err)
+	}
+
+	// Deleting a missing entry is a safe no-op.
+	h.terminatedDeleteEntry(id)
+
+	// Claim, delete, then re-claim — second claim should succeed.
+	if !h.markTerminatedOnce(id) {
+		t.Fatalf("first claim should succeed")
+	}
+	h.terminatedDeleteEntry(id)
+	if !h.markTerminatedOnce(id) {
+		t.Fatalf("re-claim after delete should succeed")
+	}
+}
+
 func Test_startReferenceTypeCall_websocketDialFailure(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	cmcall "monorepo/bin-call-manager/models/call"
 	cmexternalmedia "monorepo/bin-call-manager/models/externalmedia"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
 	"monorepo/bin-pipecat-manager/pkg/toolhandler"
@@ -238,5 +241,143 @@ func Test_startReferenceTypeCall_websocketDialFailure(t *testing.T) {
 	err := h.startReferenceTypeCall(context.Background(), pc)
 	if err == nil {
 		t.Fatal("expected error but got nil")
+	}
+}
+
+// Test_terminate_publishesTerminatedEventOnce asserts that calling terminate()
+// twice for the same pipecatcall publishes the pipecatcall_terminated event
+// exactly once (deduped via markTerminatedOnce).
+func Test_terminate_publishesTerminatedEventOnce(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockPythonRunner := NewMockPythonRunner(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler:         mockNotify,
+		pythonRunner:          mockPythonRunner,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+		muTerminated:          sync.Mutex{},
+		terminatedPublished:   make(map[uuid.UUID]struct{}),
+	}
+
+	pcID := uuid.FromStringOrNil("c1d2e3f4-5555-6666-7777-888899990000")
+	pc := &pipecatcall.Pipecatcall{
+		Identity: commonidentity.Identity{
+			ID:         pcID,
+			CustomerID: uuid.FromStringOrNil("d2e3f4a5-5555-6666-7777-888899990000"),
+		},
+		// Use an unknown reference type so terminate() hits the outer default
+		// branch — no extra reference-type RPCs needed.
+		ReferenceType: pipecatcall.ReferenceType("unknown"),
+	}
+
+	// Seed a session so flushAndFinalize takes the noop_never_started branch
+	// and SessionStop can find + delete it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	connAstReady := make(chan struct{})
+	close(connAstReady)
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID: pcID,
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		ConnAstReady: connAstReady,
+	}
+	h.mapPipecatcallSession[pcID] = se
+
+	// Count terminated-event publishes via a recorder. Other event types
+	// shouldn't be emitted here, but allow them with AnyTimes for resilience.
+	var terminatedCount atomic.Int32
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, eventType string, _ any) {
+			if eventType == pipecatcall.EventTypePipecatcallTerminated {
+				terminatedCount.Add(1)
+			}
+		},
+	).AnyTimes()
+
+	// First terminate(): SessionStop will run pythonRunner.Stop once and remove
+	// the session. The second terminate() finds no session, so SessionGet
+	// inside SessionStop logs and returns without invoking pythonRunner.Stop
+	// again.
+	mockPythonRunner.EXPECT().Stop(gomock.Any(), pcID).Return(nil).Times(1)
+
+	h.terminate(context.Background(), pc)
+	h.terminate(context.Background(), pc) // second call must be a no-op for publish
+
+	if got := terminatedCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 pipecatcall_terminated publish, got %d", got)
+	}
+}
+
+// Test_terminate_callsFlushBeforeStop asserts that terminate() calls
+// flushAndFinalize *before* tearing the session down, and that the flush
+// helper attributes its exit to StopReasonTerminateForce.
+func Test_terminate_callsFlushBeforeStop(t *testing.T) {
+	// Patch the timeout so the timeout branch returns quickly when the
+	// stalled flush goroutine never closes LLMDoneChan.
+	origTimeout := flushFinalizeTimeout
+	flushFinalizeTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { flushFinalizeTimeout = origTimeout })
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockPythonRunner := NewMockPythonRunner(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	h := &pipecatcallHandler{
+		notifyHandler:         mockNotify,
+		pythonRunner:          mockPythonRunner,
+		mapPipecatcallSession: make(map[uuid.UUID]*pipecatcall.Session),
+		muPipecatcallSession:  sync.Mutex{},
+		muTerminated:          sync.Mutex{},
+		terminatedPublished:   make(map[uuid.UUID]struct{}),
+	}
+
+	pcID := uuid.FromStringOrNil("e3f4a5b6-5555-6666-7777-888899990000")
+	pc := &pipecatcall.Pipecatcall{
+		Identity: commonidentity.Identity{
+			ID:         pcID,
+			CustomerID: uuid.FromStringOrNil("f4a5b6c7-5555-6666-7777-888899990000"),
+		},
+		ReferenceType: pipecatcall.ReferenceType("unknown"),
+	}
+
+	// Arm a stalled flush: channels + flag set, but no goroutine drains
+	// LLMDoneChan. flushAndFinalize will CAS LLMStopReason to
+	// StopReasonTerminateForce, close LLMStopChan, then time out — but the
+	// CAS already records the reason we assert on.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	connAstReady := make(chan struct{})
+	close(connAstReady)
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID: pcID,
+		},
+		Ctx:          ctx,
+		Cancel:       cancel,
+		ConnAstReady: connAstReady,
+		LLMMessageID: uuid.FromStringOrNil("11112222-3333-4444-5555-666677778888"),
+		LLMTokenChan: make(chan string, 64),
+		LLMStopChan:  make(chan struct{}),
+		LLMDoneChan:  make(chan struct{}),
+	}
+	se.LLMFlushing.Store(true)
+	h.mapPipecatcallSession[pcID] = se
+
+	mockPythonRunner.EXPECT().Stop(gomock.Any(), pcID).Return(nil).Times(1)
+
+	h.terminate(context.Background(), pc)
+
+	if got := StopReason(se.LLMStopReason.Load()); got != StopReasonTerminateForce {
+		t.Fatalf("expected StopReasonTerminateForce (%d), got %d", StopReasonTerminateForce, got)
 	}
 }

--- a/docs/plans/2026-04-29-aicall-terminate-drop-design.md
+++ b/docs/plans/2026-04-29-aicall-terminate-drop-design.md
@@ -1,0 +1,873 @@
+# AIcall terminate-drop & no-final-event recovery — design
+
+**Date:** 2026-04-29
+**Status:** Draft
+**Owner:** pchero
+**Related incident:** aicall `93d1eeac-ae0c-42ba-93e5-0d977d6f532f` stopped responding to a LINE conversation on 2026-04-29 ~01:52 UTC
+
+## 1. Problem, Goals, Scope
+
+### 1.1 Problem
+
+A conversation-type AIcall can lose a user-bound LLM reply when:
+
+1. Pipecat does not emit `BotLLMStopped` for a generation (observed: `gemini-2.5-flash` stream stalled mid-reply after a tool-result re-injection), AND
+2. ai-manager's 30 s `TerminateWithDelay` (`bin-ai-manager/pkg/aicallhandler/send.go:106`) fires while the flush goroutine is still accumulating tokens.
+
+`SessionStop` (`bin-pipecat-manager/pkg/pipecatcallhandler/session.go:82`) does **not** cancel `pc.Ctx`, so the only fallback that publishes a partial `message_bot_llm` (`runLLMIntermediateFlush` → `case <-se.Ctx.Done()` at `runner.go:638-657`) never runs. The user gets total silence.
+
+A second, related defect surfaced during review: `EventPMMessageBotLLM` (`bin-ai-manager/pkg/messagehandler/event.go:35-131`) persists the assistant row **between** guard #1 (pre-persist) and guard #2 (post-persist re-check). When guard #2 fails (a newer pipecatcall has registered), the row stays in `ai_messages` but no conversation message is sent. A naive `AssistantReplyExists` check that only inspects row existence would falsely conclude "delivered" and suppress the backstop. Fix: track a per-row `delivery_status`.
+
+### 1.2 Reproducer (live evidence from the incident)
+
+| Time (UTC) | Event |
+|------------|-------|
+| `01:52:11.6` | New pipecatcall `9d757f46…` created. ai-manager schedules `TerminateWithDelay(30000ms)`. |
+| `01:52:14.2` | First `bot-llm-started` (pre-tool). |
+| `01:52:15.27` | Gemini emits a function call → `BotLLMStopped` with **0 tokens**. |
+| `01:52:15.95` | RAG (`search_knowledge`) returns 5 sources. |
+| `01:52:16.16` | Second `bot-llm-started` (post-tool). Flush goroutine starts. |
+| `01:52:16.60` | First sentence aggregated for TTS. |
+| `01:52:16.76` | Intermediate flush sequence:1, delta_len:100. |
+| `01:52:16.76 → 01:52:42.19` | **24 s of silence — no further `bot-output`, no `BotLLMStopped`.** |
+| `01:52:42.19` | 30 s `TerminateWithDelay` fires → `terminate()` → `SessionStop()`. |
+| `01:53:04.16` | Python side notices WebSocket close. |
+
+No final `message_bot_llm` event ever published → ai-manager sent nothing to the LINE conversation.
+
+### 1.3 Goals
+
+1. **No silent drops.** Every terminated pipecatcall that had any LLM tokens must publish a final `message_bot_llm` event with the accumulated text.
+2. **No silent stalls.** A stuck stream (no tokens for N s) must be forcibly finalized inside pipecat-manager rather than relying solely on the upstream terminate timer.
+3. **No silent users.** If both 1 and 2 still fail to deliver a reply, ai-manager must send a fallback message to the conversation. The check must distinguish *persisted* from *delivered* so guard-#2 race losers don't suppress the backstop.
+4. **Observability.** Every exit path of `runLLMIntermediateFlush` and every backstop firing must be counted in Prometheus and logged at INFO+.
+
+### 1.4 Non-goals
+
+- Fixing the upstream Gemini stream hang itself (out of our control).
+- Changing the 30 s `TerminateWithDelay` value or making it adaptive — separate concern.
+- Voice (Asterisk-bound) aicalls — pipecat-manager fixes (C0–C4) apply uniformly, but the user-facing fallback (Goal 3, C5–C7) only fires for conversation/text aicalls. Voice path correctness is verified in §3.8.
+
+### 1.5 Affected services
+
+- `bin-pipecat-manager` — Goals 1, 2, 4. Adds a new event type.
+- `bin-ai-manager` — Goal 3, plus Goal 4 metrics. Subscribes to the new event; persists `pipecatcall_id` and `delivery_status` on assistant rows.
+- `bin-dbscheme-manager` — Alembic migration to add `pipecatcall_id` and `delivery_status` columns to `ai_messages`.
+
+## 2. Architecture & changes per service
+
+### 2.1 Change map
+
+```
+bin-dbscheme-manager
+└── alembic/versions/<rev>_add_pipecatcall_id_delivery_status_to_ai_messages.py    [ADD]
+    + ai_messages.pipecatcall_id    BINARY(16)         NULL,        indexed
+    + ai_messages.delivery_status   VARCHAR(16)        NOT NULL DEFAULT 'delivered'
+    + composite index (pipecatcall_id, delivery_status)
+
+bin-pipecat-manager
+├── models/pipecatcall/event.go               [MODIFY]  + EventTypePipecatcallTerminated (string)
+├── models/pipecatcall/session.go             [MODIFY]  + LLMFlushOnce sync.Once;
+│                                                       + LLMStopReason atomic.Int32;
+│                                                       LLMFlushing → atomic.Bool
+├── pkg/pipecatcallhandler/session.go         [MODIFY]  SessionStop calls se.Cancel()
+├── pkg/pipecatcallhandler/start.go           [MODIFY]  terminate() → flushAndFinalize, publish terminated, SessionStop;
+│                                                       per-pipecatcall publish-once dedupe (in-memory map)
+├── pkg/pipecatcallhandler/runner.go          [MODIFY]  C2 helper; C3 watchdog; H-4/L-1 ctx fixes;
+│                                                       defer-reset LLMFlushing on goroutine exit
+├── pkg/pipecatcallhandler/metrics.go         [MODIFY]  + 3 new prom metrics
+└── (tests for each)                          [ADD]
+
+bin-ai-manager
+├── models/message/main.go                    [MODIFY]  + Message.PipecatcallID, Message.DeliveryStatus
+│                                                       (both omitted from WebhookMessage — internal only)
+├── pkg/dbhandler/message.go                  [MODIFY]  + AssistantReplyExists; UpdateDeliveryStatus
+├── pkg/messagehandler/main.go                [MODIFY]  + CreateOptions (functional options) for new fields
+├── pkg/messagehandler/event.go               [MODIFY]  EventPMMessageBotLLM persists 'pending' →
+│                                                       on successful send updates to 'delivered'
+├── pkg/messagehandler/event_pm.go            [MODIFY]  + EventPMPipecatcallTerminated handler
+├── pkg/subscribehandler/pipecat_pipecatcall.go [MODIFY] route new event to handler
+├── pkg/aicallhandler/metrics.go              [MODIFY]  + ai_manager_aicall_backstop_reply_total{result}
+└── (tests for each)                          [ADD]
+```
+
+### 2.2 Component responsibilities
+
+| # | Component | Service | Goal |
+|---|-----------|---------|------|
+| **C0** | Publish `pipecatcall_terminated` event from `terminate()` | pipecat-manager | 3 (prereq) |
+| C1 | `SessionStop` cancels `pc.Ctx` | pipecat-manager | 1 |
+| C2 | `flushAndFinalize` synchronous flush before SessionStop | pipecat-manager | 1 |
+| C3 | Idle watchdog inside `runLLMIntermediateFlush` | pipecat-manager | 2 |
+| C4 | Structured exit-reason logs + Prom counters | pipecat-manager | 4 |
+| **C4a** | `pipecatcall_id` + `delivery_status` columns; persist+update flow | dbscheme + ai-manager | 3 (prereq, scoping, delivery truth) |
+| C5 | `AssistantReplyExists` query (filters `delivery_status='delivered'`) | ai-manager | 3 |
+| C6 | `EventPMPipecatcallTerminated` backstop handler | ai-manager | 3 |
+| C7 | Backstop counter metric | ai-manager | 4 |
+
+### 2.3 Event flow (happy → degraded → worst-case)
+
+```
+Happy path
+──────────
+Pipecat → BotLLMText (N tokens) → BotLLMStopped
+   pipecat-manager: flush goroutine → publishFinalBotLLMEvent (msg_bot_llm)
+   ai-manager:     EventPMMessageBotLLM
+                     guard#1 ✓ → persist row(pipecatcall_id, delivery_status='pending')
+                     guard#2 ✓ → ConversationV1MessageSend ✓
+                                → UPDATE delivery_status='delivered'
+   pipecat-manager: terminate() → C2 noop_already_done → publishTerminated → SessionStop
+   ai-manager:     EventPMPipecatcallTerminated → AssistantReplyExists(delivered)=true → skipped_seen
+
+
+Degraded path (LLM stalls; current bug)
+───────────────────────────────────────
+Pipecat → BotLLMText (some tokens) → ⊘ no BotLLMStopped
+   C3 watchdog: idleWatchdogTimeout reached after first token
+                → CAS StopReason=idle_watchdog → close LLMStopChan
+                → flush goroutine drains, publishFinalBotLLMEvent (background ctx, partial)
+   ai-manager:    EventPMMessageBotLLM → persist 'pending' → guard#2 ✓ → send ✓ → 'delivered'
+   pipecat-manager: TerminateWithDelay → terminate() → C2 noop_already_done → publishTerminated
+   ai-manager:    EventPMPipecatcallTerminated → delivered=true → skipped_seen
+
+
+Worst-case (watchdog also missed; terminate fires)
+──────────────────────────────────────────────────
+ai-manager TerminateWithDelay → pipecat-manager terminate()
+   C2 flushAndFinalize: CAS StopReason=terminate_force → close LLMStopChan once
+                        wait LLMDoneChan up to flushFinalizeTimeout
+                        → flush goroutine drains, publishFinalBotLLMEvent (background ctx, partial)
+   C0 publishTerminated (background ctx)
+   C1 SessionStop → se.Cancel()
+   ai-manager:  EventPMMessageBotLLM → persist 'pending' → guard#2 ✓ → send ✓ → 'delivered'
+   ai-manager:  EventPMPipecatcallTerminated → delivered=true → skipped_seen
+
+
+Guard-#2 race (newer turn arrived during this turn's send)
+──────────────────────────────────────────────────────────
+   ai-manager EventPMMessageBotLLM (this turn):
+                     guard#1 ✓ → persist 'pending'
+                     guard#2 ✗ → return WITHOUT updating delivery_status
+                                 row stays 'pending' (semantic: not delivered)
+   ai-manager EventPMPipecatcallTerminated (this turn):
+                     AssistantReplyExists(delivered)=false → C6 backstop fires
+   (the user gets the backstop for this turn; the newer turn delivers separately)
+
+
+Total-failure path (nothing ever streamed; flush goroutine never started)
+──────────────────────────────────────────────────────────────────────────
+   pipecat-manager: terminate() → C2 noop_never_started → publishTerminated → SessionStop
+   ai-manager:    EventPMPipecatcallTerminated → AssistantReplyExists=false
+                  → C6 backstop: persist 'delivered' row, send fallback reply
+                  → C7 metric: …backstop_reply_total{result="sent"}++
+```
+
+### 2.4 Why both C1 and C2
+
+C1 alone would work via the `Ctx.Done` branch in the flush goroutine, but propagation is asynchronous: `SessionStop` returns and starts tearing down the Python runner before the flush goroutine has actually published. C2 makes it deterministic by closing `LLMStopChan` and waiting on `LLMDoneChan` synchronously, with a bounded timeout. C1 is kept as a safety net for any future code path that skips `flushAndFinalize`.
+
+The `terminate()` ordering is **fixed** so C2 always runs before C1's cancel propagates:
+
+```
+terminate()
+  ├── flushAndFinalize(se)        ← C2 (closes Stop chan, waits Done chan)
+  ├── publishTerminated(pc)       ← C0 (after flush so any final msg_bot_llm precedes the terminated event)
+  └── SessionStop(pc.ID)          ← C1 (cancels pc.Ctx, cleanup)
+```
+
+## 3. Pipecat-manager components (C0–C4)
+
+### 3.1 C0 — Publish `pipecatcall_terminated` event
+
+Code search confirmed only `EventTypeInitialized` exists today (`bin-pipecat-manager/models/pipecatcall/event.go`). Constants are declared as `string` (matching `EventTypeCreated`/`EventTypeDeleted`); we follow the same convention:
+
+```go
+// bin-pipecat-manager/models/pipecatcall/event.go
+const (
+    EventTypeCreated     string = "pipecatcall_created"
+    EventTypeDeleted     string = "pipecatcall_deleted"
+    EventTypeInitialized string = "pipecatcall_initialized"
+    EventTypePipecatcallTerminated string = "pipecatcall_terminated"   // NEW
+)
+```
+
+Publish from `terminate()` after `flushAndFinalize` and before `SessionStop`. Payload = the `pipecatcall.Pipecatcall` struct snapshot (same shape as `EventPMPipecatcallInitialized`). Verified the struct already carries the fields the ai-manager handler needs: `ID`, `ReferenceType`, `ReferenceID`, `ActiveflowID`.
+
+```go
+func (h *pipecatcallHandler) terminate(ctx context.Context, pc *pipecatcall.Pipecatcall) {
+    se, _ := h.SessionGet(pc.ID)
+    if se != nil {
+        h.flushAndFinalize(se)            // C2
+    }
+
+    if h.markTerminatedOnce(pc.ID) {      // dedupe (see 3.1.1)
+        h.notifyHandler.PublishEvent(
+            context.Background(),
+            pipecatcall.EventTypePipecatcallTerminated,
+            pc,
+        )
+    }
+
+    switch pc.ReferenceType { /* existing */ }
+
+    h.SessionStop(pc.ID)                  // C1 cancel happens inside SessionStop
+}
+```
+
+#### 3.1.1 Idempotent terminated-event publish (in-memory dedupe)
+
+`terminate()` may be invoked twice if both the per-pod stop RPC and a subsequent reaper fire. The DB-mapped `Pipecatcall` struct does **not** get a new flag (per review H2-1: adding fields with `db:` tags requires migrations and is risky). Instead, dedupe lives in the handler's in-memory map:
+
+```go
+// pipecatcallHandler holds:
+//   muTerminated         sync.Mutex
+//   terminatedPublished  map[uuid.UUID]struct{}
+
+func (h *pipecatcallHandler) markTerminatedOnce(id uuid.UUID) bool {
+    h.muTerminated.Lock()
+    defer h.muTerminated.Unlock()
+    if _, ok := h.terminatedPublished[id]; ok {
+        return false
+    }
+    h.terminatedPublished[id] = struct{}{}
+    return true
+}
+```
+
+Memory is bounded by pod lifetime + concurrent active calls (~hundreds). On pod restart the map is empty, so a duplicate event after restart is possible — but the ai-manager handler is idempotent (C5 short-circuits via `delivery_status='delivered'` rows), so duplicate publishes are non-harmful.
+
+**Map cleanup (iter-3 M3-4):** to avoid long-tail bloat over multi-week pod lifetimes, `SessionStop` removes the entry **after** `terminate()`'s publish has fired:
+
+```go
+// In SessionStop, after the existing teardown:
+h.muTerminated.Lock()
+delete(h.terminatedPublished, pc.ID)
+h.muTerminated.Unlock()
+```
+
+By the time `SessionStop` runs, the dedupe was already used (or `terminate()` was never called and there's nothing to delete). This caps map size at the count of currently-active pipecatcalls.
+
+#### 3.1.2 WebhookMessage / RST docs
+
+The `pipecatcall_terminated` event is internal — consumed only by ai-manager. It is NOT documented in `bin-api-manager/docsdev/source/` and the payload is NOT exposed via any `WebhookMessage`. This follows the root CLAUDE.md "RST struct docs must match `WebhookMessage`, not internal model structs" rule. RST update not required.
+
+### 3.2 C1 — `SessionStop` cancels `pc.Ctx`
+
+**File:** `bin-pipecat-manager/pkg/pipecatcallhandler/session.go`
+
+`Session.Cancel` is verified to be the same `cancel` func captured at session creation (`session.go:39`). The call site is the one used by `defer se.Cancel()` in `start.go:140,158,167,246,261,283`.
+
+**Change:** in `SessionStop`, call `se.Cancel()` after the existing `wait on ConnAstReady or Ctx.Done` block but **before** `close(ConnAst)`.
+
+Sequencing inside `SessionStop`:
+
+```
+wait on ConnAstReady or Ctx.Done       (already there — lets in-flight Asterisk connect race finish)
+[NEW] cancel pc.Ctx                    ← C1
+close ConnAst (if any)                 (already there)
+delete from session map
+stop python runner
+```
+
+Placing `cancel()` *after* the `ConnAstReady` wait avoids racing with the parallel Asterisk-connect goroutine. If `SessionStop` is invoked while the Asterisk connect is still pending, we wait at most until the connect goroutine signals one channel or the other, then cancel deterministically.
+
+### 3.3 C2 — `flushAndFinalize`
+
+#### 3.3.1 Concurrency contract (revised after iteration-2 review)
+
+The Session struct gains three fields:
+
+- `LLMFlushing  atomic.Bool` (was plain `bool`; reads/writes from both WebSocket and flush goroutines now race-free)
+- `LLMFlushOnce sync.Once` (idempotent close of `LLMStopChan`)
+- `LLMStopReason atomic.Int32` (attribution: which closer won)
+
+```go
+type StopReason int32
+const (
+    StopReasonUnset          StopReason = iota
+    StopReasonNormal                     // BotLLMStopped
+    StopReasonIdleWatchdog
+    StopReasonTerminateForce
+    StopReasonContextCancel
+)
+```
+
+Closers MUST CAS the reason before invoking `LLMFlushOnce.Do(close)`:
+
+```go
+atomic.CompareAndSwapInt32(&se.LLMStopReason,
+    int32(StopReasonUnset), int32(StopReasonTerminateForce))
+se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+```
+
+The flush goroutine reads the reason after `<-LLMStopChan` returns:
+
+```go
+case <-se.LLMStopChan:
+    reason := StopReason(atomic.LoadInt32(&se.LLMStopReason))
+    // drain remaining tokens (existing loop)
+    h.publishFinalBotLLMEvent(context.Background(), se, messageID, fullText) // L-1: was se.Ctx
+    metricsLLMFlushExit.WithLabelValues(reasonLabel(reason)).Inc()
+    return
+```
+
+`LLMFlushing` reset (review H-4): the WebSocket goroutine cannot reset `LLMFlushing` reliably because `BotLLMStopped` may never arrive. Move the reset to a `defer` inside the flush goroutine itself:
+
+```go
+func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, messageID uuid.UUID) {
+    defer close(se.LLMDoneChan)
+    defer se.LLMFlushing.Store(false)   // ← reset on every exit, regardless of which path
+    ...
+}
+```
+
+This guarantees `LLMFlushing` reflects "flush goroutine running" as the single source of truth, regardless of who tripped the close. The `BotLLMStopped` handler on the WebSocket goroutine no longer touches `LLMFlushing`; it just CASes the reason and closes the chan once via `Once`.
+
+#### 3.3.2 Helper
+
+```go
+// flushAndFinalize is invoked from terminate(). It forces the flush goroutine
+// (if any) to publish a final message_bot_llm event with whatever tokens have
+// accumulated, then waits for the goroutine to exit (bounded). Idempotent
+// w.r.t. concurrent BotLLMStopped or watchdog firing.
+func (h *pipecatcallHandler) flushAndFinalize(se *pipecatcall.Session) {
+    if !se.LLMFlushing.Load() {
+        // Distinguish two cases for observability:
+        //   never_started: flush goroutine never armed for this pipecatcall
+        //   already_done : flush goroutine ran and exited cleanly
+        if se.LLMMessageID == uuid.Nil {
+            h.metricsFlushFinalizeOutcome.WithLabelValues("noop_never_started").Inc()
+        } else {
+            h.metricsFlushFinalizeOutcome.WithLabelValues("noop_already_done").Inc()
+        }
+        return
+    }
+
+    atomic.CompareAndSwapInt32(&se.LLMStopReason,
+        int32(StopReasonUnset), int32(StopReasonTerminateForce))
+    se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+
+    timer := time.NewTimer(flushFinalizeTimeout)
+    defer timer.Stop()
+
+    select {
+    case <-se.LLMDoneChan:
+        h.metricsFlushFinalizeOutcome.WithLabelValues("done").Inc()
+    case <-timer.C:
+        // Flush goroutine didn't return in time. We proceed to teardown anyway.
+        // C1 (Ctx.Done in SessionStop) will eventually unblock the goroutine.
+        h.metricsFlushFinalizeOutcome.WithLabelValues("timeout").Inc()
+    }
+}
+```
+
+`flushFinalizeTimeout = 3 s` (raised from 1.5 s after iteration-1 review).
+
+`metricsFlushFinalizeOutcome` is a separate counter (`pipecat_manager_llm_flush_finalize_outcome_total{outcome=noop_never_started|noop_already_done|done|timeout}`); `noop_*` split per iteration-2 M2-2.
+
+#### 3.3.3 Existing `BotLLMStopped` handler — required edits
+
+`runner.go:548-554` becomes:
+
+```go
+case pipecatframe.RTVIFrameTypeBotLLMStopped:
+    msg := pipecatframe.RTVIBotLLMStoppedMessage{}
+    if err := json.Unmarshal(m, &msg); err != nil {
+        return errors.Wrapf(err, "could not unmarshal bot-llm-stopped message")
+    }
+    if !se.LLMFlushing.Load() {
+        log.Debugf("BotLLMStopped received but no tokens were received for this generation.")
+        break
+    }
+    atomic.CompareAndSwapInt32(&se.LLMStopReason,
+        int32(StopReasonUnset), int32(StopReasonNormal))
+    se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+    <-se.LLMDoneChan   // wait for goroutine to publish + reset LLMFlushing
+```
+
+The `LLMFlushing = false` line is **removed** — the goroutine's `defer` now owns this reset.
+
+#### 3.3.4 Sequence: C2 timeout → C1 cancel → goroutine exits
+
+```
+t=0      terminate() called
+t=0      C2 flushAndFinalize: CAS reason=terminate_force, close LLMStopChan via Once
+t=0      flush goroutine wakes on <-LLMStopChan, drains, calls publishFinalBotLLMEvent
+         publishFinalBotLLMEvent uses context.Background() (L-1 fix), so even if Ctx is cancelled later
+         the publish proceeds
+t=3s     C2 flushFinalizeTimeout fires (publishEvent took >3s — degraded broker)
+         metric: flush_finalize_outcome_total{outcome="timeout"}++
+         C2 returns; terminate() proceeds.
+t=3s+ε   C0 publishTerminated()
+t=3s+ε   C1 SessionStop → wait ConnAstReady (no-op for conv aicall) → se.Cancel()
+t=3s+ε   flush goroutine still blocked inside notifyHandler.PublishEvent (RabbitMQ slow path)
+t=3s+ε   PublishEvent eventually returns; goroutine sets metric exit_total{reason="terminate_force"}
+         defer LLMFlushing.Store(false); defer close(LLMDoneChan) fire.
+         Goroutine exits cleanly. No leak.
+```
+
+If `PublishEvent` hangs forever (broker-down), the goroutine leaks until the publisher's own internal timeout (set in `bin-common-handler/notifyhandler`) fires — which is bounded. We do not add a second timeout; double-bounding makes diagnostics confusing.
+
+### 3.4 C3 — Idle watchdog inside `runLLMIntermediateFlush`
+
+A new ticker tracks "time since last token." Watchdog fires only if `lastToken` is non-zero (first token has arrived) AND no token has arrived for `idleWatchdogTimeout` (review H-1, M-2).
+
+```go
+const (
+    idleWatchdogTimeout  = 8 * time.Second
+    idleWatchdogTickRate = 1 * time.Second
+)
+```
+
+Sketch (additions in **bold**):
+
+```go
+ticker := time.NewTicker(200 * time.Millisecond)
+**watchdog := time.NewTicker(idleWatchdogTickRate)**
+**defer watchdog.Stop()**
+**var lastToken time.Time   // zero until first token**
+for {
+    select {
+    case token := <-se.LLMTokenChan:
+        fullText += token
+        deltaBuffer += token
+        **lastToken = time.Now()**
+    case <-ticker.C:
+        if deltaBuffer != "" {
+            sequence++
+            // L-1: use context.Background() for intermediate too,
+            //      mirroring the final publish, so terminate-cancel doesn't drop intermediates.
+            h.publishIntermediateEventBg(se, messageID, deltaBuffer, sequence)
+            deltaBuffer = ""
+        }
+    **case now := <-watchdog.C:
+        if !lastToken.IsZero() && now.Sub(lastToken) >= idleWatchdogTimeout {
+            atomic.CompareAndSwapInt32(&se.LLMStopReason,
+                int32(StopReasonUnset), int32(StopReasonIdleWatchdog))
+            se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+        }**
+    case <-se.LLMStopChan:
+        // existing finalize, exit reason from atomic
+    case <-se.Ctx.Done():
+        // existing fallback; reason = StopReasonContextCancel set by a CAS at the head of this branch
+    }
+}
+```
+
+**Tool-call boundary:** `LLMFlushing` is reset to `false` by the goroutine's `defer` after each generation completes. The post-tool `BotLLMText` re-enters `runner.go:521`'s init branch (now `if !se.LLMFlushing.Load()`), creates new `LLMStopChan`/`LLMDoneChan`/`LLMStopReason` and launches a new flush goroutine. New goroutine starts with `lastToken == 0`, so its watchdog is correctly armed only after its own first token. No false fire across the tool boundary.
+
+### 3.5 Bug fixes lifted from review
+
+- **H-4** (iter 1): `publishFinalBotLLMEvent` in the `LLMStopChan` branch unconditionally uses `context.Background()` (was `se.Ctx`).
+- **L-1** (iter 1, made HIGH in iter 2): `publishIntermediateEvent` in the ticker branch also uses `context.Background()` so the goroutine doesn't lose intermediates if `se.Ctx` is cancelled mid-tick. Implemented via a new `publishIntermediateEventBg` wrapper that calls into the existing helper with a background context.
+- The `<-se.Ctx.Done()` branch CASes `StopReason=StopReasonContextCancel` before publishing the partial final, so the metric label correctly attributes the exit.
+
+### 3.6 C4 — Observability (logs + counters)
+
+```go
+metricsLLMFlushExit = prometheus.NewCounterVec(prometheus.CounterOpts{
+    Name: "pipecat_manager_llm_flush_exit_total",
+    Help: "Counter of runLLMIntermediateFlush goroutine exits, by reason.",
+}, []string{"reason"})
+// labels: stopped_normal | idle_watchdog | terminate_force | context_cancelled
+
+metricsIdleWatchdogFired = prometheus.NewCounter(prometheus.CounterOpts{
+    Name: "pipecat_manager_llm_idle_watchdog_fired_total",
+    Help: "Counter of idle-watchdog firings (no tokens for idleWatchdogTimeout while flushing).",
+})
+
+metricsFlushFinalizeOutcome = prometheus.NewCounterVec(prometheus.CounterOpts{
+    Name: "pipecat_manager_llm_flush_finalize_outcome_total",
+    Help: "Counter of flushAndFinalize outcomes from the terminate caller's perspective.",
+}, []string{"outcome"})
+// labels: noop_never_started | noop_already_done | done | timeout
+```
+
+Each goroutine exit logs at INFO with `pipecatcall_id`, `message_id`, `full_text_len`, `sequence_count`, `reason`.
+
+### 3.7 Touch points (pipecat-manager)
+
+| File | Change |
+|------|--------|
+| `models/pipecatcall/event.go` | + `EventTypePipecatcallTerminated` (string) |
+| `models/pipecatcall/session.go` | `LLMFlushing` → `atomic.Bool`; + `LLMFlushOnce`, `LLMStopReason` |
+| `pkg/pipecatcallhandler/main.go` | + `terminatedPublished` map + mutex |
+| `pkg/pipecatcallhandler/session.go` | C1: `Cancel()` in `SessionStop` after ConnAstReady wait |
+| `pkg/pipecatcallhandler/start.go` | C0 + C2 wiring in `terminate()`; `markTerminatedOnce` helper |
+| `pkg/pipecatcallhandler/runner.go` | C2 helper; C3 watchdog (first-token guard); H-4/L-1 ctx fixes; defer-reset `LLMFlushing`; switch all closers to atomic CAS + Once |
+| `pkg/pipecatcallhandler/metrics.go` | 3 new metrics |
+| Tests | exit-reason matrix, watchdog before/after first token, tool-call boundary, ConnAstReady race, terminated-event publish dedupe, C2 timeout-then-Ctx.Done sequence |
+
+#### 3.7.1 Test migrations (compile-break list)
+
+Switching `LLMFlushing` from plain `bool` to `atomic.Bool` is a compile break for any test that builds a `Session` with a struct literal `LLMFlushing: true` or assigns `se.LLMFlushing = false`. Each site below MUST be migrated to `Load()`/`Store(true|false)`:
+
+- `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go` — sites at lines ~294, ~318, ~325, ~475 (per code search). Replace literal initializers with post-construction `se.LLMFlushing.Store(true)` and assertions with `se.LLMFlushing.Load()`.
+- Any helper / fixture in `pkg/pipecatcallhandler/*_test.go` that constructs a `Session` should be audited via `grep -nR 'LLMFlushing' bin-pipecat-manager/`.
+
+This is a mechanical change but easy to miss; the `go test ./...` step in the verification workflow will catch it, and the audit is listed here as a deliverable.
+
+### 3.8 Voice-path correctness (iter-2 H2-5)
+
+C0–C4 ship to voice (`ReferenceTypeCall`) pipecatcalls too. Correctness review per component:
+
+- **C0** publishes `pipecatcall_terminated` for voice as well. ai-manager's C6 handler returns `skipped_voice` for non-conversation aicalls — no user-visible side effect.
+- **C1** `Cancel()` in `SessionStop` for voice respects the `ConnAstReady` wait, so an in-flight Asterisk connect isn't aborted before completion.
+- **C2** `flushAndFinalize` runs on voice too. `flushFinalizeTimeout = 3 s` is well within voice termination latency budgets (Asterisk hangup finalization is typically <1 s for the WS close, plus DB cleanup). Even a 3 s tail-end delay during terminate is invisible to the voice user, who has already hung up.
+- **C3** watchdog for voice: same logic. If a voice LLM stalls, we get a partial final and the conversation history is preserved (visible in summaries / transcripts), even though the user heard nothing. This is strictly better than today's silent drop.
+- **C4** metrics span both reference types; existing dashboards inherit voice traffic without changes.
+
+No voice-specific test is added in v1, but the existing pipecatcallhandler tests cover both reference types.
+
+## 4. AI-manager components (C4a–C7)
+
+### 4.1 C4a — DB schema and persist+update flow
+
+#### 4.1.1 Migration (in `bin-dbscheme-manager`)
+
+```python
+# alembic/versions/<rev>_add_pipecatcall_id_delivery_status_to_ai_messages.py
+def upgrade():
+    op.add_column('ai_messages',
+        sa.Column('pipecatcall_id', mysql.BINARY(16), nullable=True))
+    op.add_column('ai_messages',
+        sa.Column('delivery_status', sa.String(16), nullable=False,
+                  server_default='delivered'))
+    op.create_index('idx_ai_messages_pcc_delivery', 'ai_messages',
+                    ['pipecatcall_id', 'delivery_status'])
+
+def downgrade():
+    op.drop_index('idx_ai_messages_pcc_delivery', 'ai_messages')
+    op.drop_column('ai_messages', 'delivery_status')
+    op.drop_column('ai_messages', 'pipecatcall_id')
+```
+
+Per `bin-dbscheme-manager/CLAUDE.md`, this migration is **created by AI** (`alembic revision`) but **never run by AI** — a human applies it.
+
+**Default-value rationale:** existing rows are reasonable to call `delivered` because they were created by code paths that always followed persist-then-send (and we have no row-level evidence to the contrary). The default lets pre-existing inserts continue to work with `NULL pipecatcall_id` and `delivered` status — both are correctly ignored by `AssistantReplyExists` (which requires `pipecatcall_id = ?`).
+
+#### 4.1.2 Phase-coordination safety (iter-2 M2-3)
+
+Phase 0 (this migration) deploys before any Go code references the new columns. Until Phase 2 ships:
+
+- Inserts from old code omit both columns. MySQL fills `pipecatcall_id NULL` and `delivery_status='delivered'` (default).
+- Reads from old code do not select the new columns. Schema is forward-compatible.
+- `AssistantReplyExists` (Phase 2 only) requires `pipecatcall_id = ?` — old NULL rows never match, so no false positives.
+
+#### 4.1.3 Model & WebhookMessage (iter-2 H2-2 — explicit decision)
+
+`bin-ai-manager/models/message/main.go`:
+
+- `Message.PipecatcallID  uuid.UUID` — **internal correlation only**. Omit from `WebhookMessage.ConvertWebhookMessage()`.
+- `Message.DeliveryStatus DeliveryStatus` (enum: `pending|delivered`) — **internal**. Omit from `WebhookMessage`.
+
+This follows the root CLAUDE.md "RST struct docs must match `WebhookMessage`, not internal model structs" rule. The RST `*_struct_*.rst` files do **not** require updates.
+
+#### 4.1.4 `messageHandler.Create` — functional options (iter-2 H2-3)
+
+Adding a 10th positional parameter to `Create()` would break 8+ callers (`engine_openai_handler`, `engine_dialogflow_handler`, `pkg/aicallhandler/*`, `tool.go`, etc.). Switch to functional options to keep the existing shape and make new fields additive:
+
+```go
+// Create signature (unchanged for existing callers)
+Create(
+    ctx context.Context,
+    id, customerID, aicallID, activeflowID uuid.UUID,
+    direction message.Direction,
+    role message.Role,
+    content string,
+    toolCalls []message.ToolCall,
+    toolCallID string,
+    opts ...CreateOption,    // NEW
+) (*message.Message, error)
+
+// Options
+type CreateOption func(*createParams)
+type createParams struct {
+    pipecatcallID  uuid.UUID
+    deliveryStatus message.DeliveryStatus
+}
+func WithPipecatcallID(id uuid.UUID) CreateOption  { ... }
+func WithDeliveryStatus(s message.DeliveryStatus) CreateOption { ... }
+```
+
+Existing callers compile unchanged. New callers (`EventPMMessageBotLLM` and `EventPMPipecatcallTerminated`) opt in:
+
+```go
+h.Create(ctx, evt.ID, ..., toolCalls, toolCallID,
+    messagehandler.WithPipecatcallID(evt.PipecatcallID),
+    messagehandler.WithDeliveryStatus(message.DeliveryStatusPending))
+```
+
+This pattern matches `~/.claude/rules/golang/patterns.md`'s recommended functional-options idiom.
+
+#### 4.1.5 `EventPMMessageBotLLM` — persist+update flow (iter-2 C2-1)
+
+The handler now persists with `delivery_status='pending'` and updates to `'delivered'` only after `ConversationV1MessageSend` succeeds. The two-guard pattern is preserved exactly as today, but the **completion semantic** is encoded in `delivery_status` rather than mere row existence.
+
+```go
+// Guard #1 (unchanged) — drop stale BEFORE any DB write
+if ac.PipecatcallID != evt.PipecatcallID { ... return }
+
+// Persist with delivery_status='pending' (NEW)
+tmp, err := h.Create(ctx, evt.ID, ..., evt.Text, nil, "",
+    messagehandler.WithPipecatcallID(evt.PipecatcallID),
+    messagehandler.WithDeliveryStatus(message.DeliveryStatusPending))
+if err != nil { ... return }
+
+// Guard #2 (unchanged) — re-check; if fails, row stays 'pending' → backstop will fire
+if acFinal.PipecatcallID != evt.PipecatcallID { ... return }
+
+// Send to conversation
+sent, errSend := h.reqHandler.ConversationV1MessageSend(...)
+if errSend != nil { ... return }   // row stays 'pending' → backstop will fire
+
+// Mark delivered (NEW)
+// Iter-3 L3-1: retry once with short backoff before logging.
+// The conversation send already succeeded; we want the row to reflect that
+// to prevent the backstop from firing a duplicate user-visible reply.
+errUpd := h.dbHandler.MessageUpdateDeliveryStatus(ctx, tmp.ID, message.DeliveryStatusDelivered)
+if errUpd != nil {
+    time.Sleep(deliveryStatusUpdateRetryDelay) // 100 ms
+    errUpd = h.dbHandler.MessageUpdateDeliveryStatus(ctx, tmp.ID, message.DeliveryStatusDelivered)
+}
+if errUpd != nil {
+    log.Errorf("Could not mark message delivered after retry. msg_id: %s err: %v", tmp.ID, errUpd)
+    promConversationDeliveryStatusUpdateFailedTotal.Inc()
+    // Worst case: backstop additionally fires → user sees the real reply + fallback.
+    // Acceptable rare degradation; the metric pages on alarm.
+}
+```
+
+The two existing metrics (`promConversationStaleResponseDroppedTotal`, `promConversationReplySendTotal`) are preserved unchanged. One new metric `promConversationDeliveryStatusUpdateFailedTotal` is added to flag the rare case where the send succeeded but the status update failed (the user got their reply but the row says 'pending'). This would manifest as a backstop firing in addition to the real reply — a known small risk we monitor rather than complicate the code further to prevent.
+
+### 4.2 C5 — `AssistantReplyExists`
+
+```sql
+SELECT 1 FROM ai_messages
+ WHERE pipecatcall_id  = ?
+   AND delivery_status = 'delivered'
+   AND direction       = 'incoming'
+   AND role            = 'assistant'
+   AND tm_delete IS NULL
+ LIMIT 1
+```
+
+The query uses the composite index `idx_ai_messages_pcc_delivery`. Sub-millisecond expected.
+
+`delivery_status='delivered'` is the canonical signal. A row that is `'pending'` (guard-#2 failure or send failure) does NOT count as delivered, so the backstop correctly fires.
+
+**Note (iter-3 M3-1):** `EventPMMessageBotLLMIntermediate` does NOT persist rows in `ai_messages` — it only publishes a webhook event. So intermediate streaming activity cannot accidentally satisfy `AssistantReplyExists`. If a future refactor moves intermediates to persistent storage, the `delivery_status='delivered'` filter still excludes them as long as intermediates are persisted with `delivery_status='pending'` (or a new `'intermediate'` status).
+
+### 4.3 C6 — `EventPMPipecatcallTerminated` backstop handler
+
+```go
+func (h *messageHandler) EventPMPipecatcallTerminated(ctx context.Context, ev *pmpipecatcall.Pipecatcall) error {
+    log := logrus.WithFields(...)
+
+    if ev.ReferenceType != pmpipecatcall.ReferenceTypeAICall {
+        promBackstopReplyTotal.WithLabelValues("skipped_not_aicall").Inc()
+        return nil
+    }
+
+    aicall, err := h.reqHandler.AIV1AIcallGet(ctx, ev.ReferenceID)
+    if err != nil {
+        // unknown aicall — log+swallow; not a backstop case
+        log.Errorf("Could not get aicall for terminated pipecatcall. err: %v", err)
+        return nil
+    }
+    if aicall.ReferenceType != amaicall.ReferenceTypeConversation {
+        promBackstopReplyTotal.WithLabelValues("skipped_voice").Inc()
+        return nil
+    }
+    if aicall.Status == amaicall.StatusTerminated {
+        promBackstopReplyTotal.WithLabelValues("skipped_terminated").Inc()
+        return nil
+    }
+
+    // Race grace: let any in-flight EventPMMessageBotLLM land on the other pod.
+    timer := time.NewTimer(backstopGraceDelay)
+    select {
+    case <-timer.C:
+    case <-ctx.Done():
+        timer.Stop()
+        return ctx.Err()
+    }
+
+    seen, err := h.dbHandler.MessageAssistantReplyExists(ctx, ev.ID)
+    if err != nil {
+        return err
+    }
+    if seen {
+        promBackstopReplyTotal.WithLabelValues("skipped_seen").Inc()
+        return nil
+    }
+
+    // Backstop send: persist 'delivered' immediately (we ARE the delivery), then send.
+    msg, err := h.Create(ctx, uuid.Nil, aicall.CustomerID, aicall.ID, aicall.ActiveflowID,
+        message.DirectionIncoming, message.RoleAssistant, backstopReplyText, nil, "",
+        messagehandler.WithPipecatcallID(ev.ID),
+        messagehandler.WithDeliveryStatus(message.DeliveryStatusDelivered))
+    if err != nil {
+        promBackstopReplyTotal.WithLabelValues("failed").Inc()
+        return errors.Wrap(err, "could not persist backstop message")
+    }
+
+    if _, errSend := h.reqHandler.ConversationV1MessageSend(ctx, aicall.ReferenceID,
+        backstopReplyText, []cvmedia.Media{}); errSend != nil {
+        // Row exists with 'delivered' (a slight lie under failure, but it makes replays idempotent —
+        // we never want a duplicate fallback message). Log+metric.
+        promBackstopReplyTotal.WithLabelValues("send_failed").Inc()
+        return errors.Wrap(errSend, "could not send backstop conversation reply")
+    }
+
+    promBackstopReplyTotal.WithLabelValues("sent").Inc()
+    log.WithField("message_id", msg.ID).Infof(
+        "Backstop reply sent. aicall_id: %s, pipecatcall_id: %s",
+        aicall.ID, ev.ID)
+    return nil
+}
+```
+
+**Constants:**
+
+```go
+backstopGraceDelay = 3 * time.Second
+backstopReplyText  = "Sorry, I'm having trouble responding right now. Please try again."
+```
+
+**Idempotency under at-least-once delivery:** the backstop's `Create` call uses `delivery_status='delivered'`. A duplicate event 30 s later finds the row → `skipped_seen`. Even if the send failed, the row is marked delivered to prevent duplicate user-visible fallbacks (review tradeoff — better to silently swallow than to spam).
+
+### 4.4 C7 — Backstop counter metric
+
+```go
+promBackstopReplyTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+    Name: "ai_manager_aicall_backstop_reply_total",
+    Help: "Counter of pipecatcall_terminated backstop attempts in messagehandler.EventPMPipecatcallTerminated.",
+}, []string{"result"})
+```
+
+**Label values (closed set):**
+
+- `sent` — backstop reply persisted and dispatched
+- `failed` — DB insert error
+- `send_failed` — DB OK, conversation send error (row marked 'delivered' to suppress retries)
+- `skipped_seen` — final reply already 'delivered' in DB
+- `skipped_voice` — non-conversation aicall
+- `skipped_terminated` — aicall already terminated
+- `skipped_not_aicall` — pipecatcall reference_type != ai_call
+
+### 4.5 Dashboard / alert hooks
+
+- **Headline ratio:** `rate(ai_manager_aicall_backstop_reply_total{result="sent"}[5m]) / rate(ai_manager_aicall_backstop_reply_total[5m])`. Sustained >5% means upstream isn't recovering reliably.
+- **Pair with C4 metric:** `pipecat_manager_llm_idle_watchdog_fired_total` should rise *before* `…backstop_reply_total{result="sent"}` does in any incident.
+- **New companion:** `ai_manager_message_delivery_status_update_failed_total` — flags the rare "sent but row stayed pending" case.
+
+### 4.6 Touch points (ai-manager + dbscheme)
+
+| File | Change |
+|------|--------|
+| `bin-dbscheme-manager/alembic/versions/<rev>_*.py` | + `pipecatcall_id` and `delivery_status` columns, composite index |
+| `bin-ai-manager/models/message/main.go` | + `PipecatcallID`, `DeliveryStatus`; both omitted from `WebhookMessage` |
+| `bin-ai-manager/pkg/dbhandler/message.go` | populate + read new columns; `MessageAssistantReplyExists`, `MessageUpdateDeliveryStatus` |
+| `bin-ai-manager/pkg/messagehandler/main.go` | + `CreateOption` functional options; **add `EventPMPipecatcallTerminated(ctx, *pmpipecatcall.Pipecatcall) error` to `MessageHandler` interface** so mockgen regenerates (iter-3 M3-3); doc the persist-then-update invariant |
+| `bin-ai-manager/pkg/messagehandler/event.go` | persist 'pending' → conditional update to 'delivered'; new failure metric |
+| `bin-ai-manager/pkg/messagehandler/event_pm.go` | + `EventPMPipecatcallTerminated` |
+| `bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall.go` | + `processEventPMPipecatcallTerminated(ctx, m *sock.Event) error` adapter that unmarshals the event payload and calls `MessageHandler.EventPMPipecatcallTerminated` |
+| `bin-ai-manager/pkg/subscribehandler/main.go` | one-line dispatch case in the `switch (publisher, type)` block at the existing site (~lines 167-186) |
+| `bin-ai-manager/pkg/aicallhandler/metrics.go` | + `promBackstopReplyTotal` |
+| Tests | per-result-label, grace-delay, persist+update interplay, guard-#2-failure path |
+
+## 5. Testing, rollout, risks
+
+### 5.1 Unit tests
+
+| # | What to verify | Test technique |
+|---|---|---|
+| C0 | `terminate()` publishes once; duplicate `terminate()` does NOT republish | Mock notify; assert publish count |
+| C1 | `SessionStop` causes `<-pc.Ctx.Done()` to fire within 50 ms; does not race with pending Asterisk-connect | Two tests: post-connect cancel; connect-pending cancel asserting no leak |
+| C2 | Outcomes: `noop_never_started`, `noop_already_done`, `done`, `timeout` | Table-driven with controlled flush goroutine timing |
+| C2 | Idempotent under concurrent `flushAndFinalize` | Run two concurrent calls; assert single attribution wins |
+| C3 | Watchdog fires only after first token; fires once; correct atomic reason | Inject clock; assert no fire pre-token |
+| C3 | Tool-call boundary: gen 1 ends, gen 2 re-arms watchdog correctly | Sequence test |
+| C4 | Each goroutine exit emits exactly one counter increment with the correct label | Counter assertions |
+| C4 | Multiple closers race → loser's reason CAS is dropped; metric reflects winner | Two goroutines + atomic check |
+| C4a | `pipecatcall_id` populated; `delivery_status` defaults to `pending` via opt; `delivered` via opt | dbhandler test |
+| C4a | Migration upgrade/downgrade is idempotent on re-run | Alembic test |
+| C5 | `AssistantReplyExists` matches only `delivery_status='delivered'`, scoped by `pipecatcall_id` | Synthetic rows: pending+delivered+other-pcc; assert correct |
+| EventBotLLM | Persist-then-update: happy path → `delivered`; guard-#2 fail → stays `pending`; send fail → stays `pending`; status-update fail → metric ticks but conv send still succeeded | Mock branches |
+| C6 | All 7 result branches | gomock per branch |
+| C6 | Grace delay honored; `NewTimer.Stop()` called on ctx cancel (no leak) | Inject clock; race ctx cancel |
+| C6 | Idempotency: replay → `skipped_seen` | Two sequential calls; second sees the persisted row |
+| C7 | Counter exists; increments per branch | Asserted in C6 |
+
+**Race detector:** all touched packages must pass `go test -race ./...`.
+
+### 5.2 Negative cases (explicit)
+
+- `BotLLMStopped` arrives between `flushAndFinalize`'s close and the wait → flush goroutine drains and exits via `LLMDoneChan` close; no double-close panic.
+- Watchdog and `BotLLMStopped` race on `LLMFlushOnce` → only one close; atomic CAS attributes to whoever won.
+- `EventPMPipecatcallTerminated` arrives before `EventPMMessageBotLLM` (cross-pod race) → grace covers it; `skipped_seen` after grace.
+- `terminate()` called twice → second call's `flushAndFinalize` returns `noop_already_done`; second `pipecatcall_terminated` event suppressed by `markTerminatedOnce`.
+- Status-update RPC fails after a successful send → metric `delivery_status_update_failed_total` ticks; row stays `pending` → backstop will additionally fire (rare; user receives reply + fallback). Prefer this over a duplicate-suppress complication.
+
+### 5.3 Manual / integration
+
+- Reproduce the watchdog: feed tokens then drop the WebSocket without `BotLLMStopped`. Confirm watchdog fires within ~8 s and conversation gets the partial reply with `delivery_status='delivered'`.
+- Reproduce the guard-#2 race: in pre-prod, force two rapid user messages so the second registers a new pipecatcall before the first's `EventPMMessageBotLLM` fires guard #2. Confirm the first turn's row stays `pending` and the backstop fires for the first turn.
+- Reproduce the backstop **end-to-end**: kill the Python runner during a real-traffic pipecatcall before any token. Confirm phase-2's wiring receives `pipecatcall_terminated` and fires the backstop exactly once.
+
+### 5.4 Rollout
+
+**Order matters.**
+
+1. **Phase 0 — Migration.** Apply the C4a Alembic migration in `bin-dbscheme-manager`. Reversible. Bake **2 h**.
+2. **Phase 1 — pipecat-manager (C0–C4).** Backwards-compatible. Publishes new event with no consumers yet. Bake **24 h**.
+3. **Phase 1 success gates:**
+   - `pipecat_manager_llm_flush_exit_total{reason="stopped_normal"}` >95% of total.
+   - `pipecat_manager_llm_idle_watchdog_fired_total` non-zero and stable.
+   - `pipecat_manager_llm_flush_finalize_outcome_total{outcome="timeout"}` ≈ 0.
+   - The new event visible at the broker.
+4. **Phase 2 — ai-manager (C4a model + persist+update + C5/C6/C7).** Pre-deploy: synthetic terminated-event test. Bake **24 h**.
+5. **Phase 2 success gates:**
+   - `ai_manager_aicall_backstop_reply_total{result="sent"}` is single-digit per day.
+   - `{result="skipped_seen"}` dominates total.
+   - `{result="failed"}`, `{result="send_failed"}` ≈ 0.
+   - `ai_manager_message_delivery_status_update_failed_total` ≈ 0.
+
+**Tunable defaults (all package-level `const`):**
+
+- `idleWatchdogTimeout = 8 s`, `idleWatchdogTickRate = 1 s`
+- `flushFinalizeTimeout = 3 s`
+- `backstopGraceDelay = 3 s`
+- `deliveryStatusUpdateRetryDelay = 100 ms` (one retry on the post-send DB update; see §4.1.5)
+
+**Rollback:** each phase reverts independently. Phase 0's column remains harmless after a code revert (nullable + default).
+
+### 5.5 Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| C1 cancels `pc.Ctx` too early | Fixed terminate ordering: flush → publish → SessionStop. Publishes use `context.Background()`. |
+| C3 cuts off slow stream | First-token guard. Watchdog tracks inter-token gap, not total duration. |
+| Backstop spam under event redelivery | First backstop persists `delivered` row; replays take `skipped_seen`. |
+| Cross-pod race grace insufficient | Persist-then-update narrows the window. Observable via `{result="sent"}`; bump to 5 s if needed. |
+| `terminate()` twice | `flushAndFinalize` returns `noop_already_done`; `markTerminatedOnce` dedupes the publish. |
+| Backstop text non-localized | English in v1; locale-keyed text table is a follow-up. |
+| DB query latency | Single composite-indexed SELECT; sub-millisecond expected. Monitor `subscribe_event_process_time{type="pipecatcall_terminated"}`. |
+| Migration deployed without code | Phased rollout enforces order; default `'delivered'` keeps old rows correct. |
+| Goroutine leak on `flushAndFinalize` timeout | C1 cancel + publisher's own timeout bound the goroutine. Counted as `outcome="timeout"`. |
+| Status-update succeeds-but-fails-mid-write | One-retry mitigates transient failures; logged; `delivery_status_update_failed_total` metric. Worst case: extra backstop reply. |
+| Voice path collateral damage | C0–C4 verified safe for voice in §3.8. C5–C7 hit `skipped_voice`. |
+
+### 5.6 Verification before merge
+
+Per monorepo `CLAUDE.md`:
+
+```
+go mod tidy && go mod vendor && go generate ./... && \
+  go test ./... && golangci-lint run -v --timeout 5m
+```
+
+in **both** `bin-pipecat-manager/` and `bin-ai-manager/`. Plus `go test -race ./pkg/pipecatcallhandler/...` and `go test -race ./pkg/messagehandler/... ./pkg/subscribehandler/...`.
+
+Migration verification: `cd bin-dbscheme-manager && alembic check`. Application is a manual step.

--- a/docs/plans/2026-04-29-aicall-terminate-drop-plan.md
+++ b/docs/plans/2026-04-29-aicall-terminate-drop-plan.md
@@ -1,0 +1,1917 @@
+# AIcall terminate-drop & no-final-event recovery — implementation plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop silently dropping LLM replies in conversation-type AIcalls when Pipecat hangs mid-stream or the pipecatcall is terminated; if everything else fails, send a user-visible fallback.
+
+**Architecture:** Three coordinated changes across two services. (1) `bin-pipecat-manager` adds a deterministic flush-and-finalize on terminate, an idle watchdog inside the streaming flush goroutine, and a new `pipecatcall_terminated` event. (2) `bin-ai-manager` records `pipecatcall_id` + `delivery_status` on each assistant row, persists `pending` then updates to `delivered` after a successful send, and adds a `EventPMPipecatcallTerminated` backstop handler that fires a fallback reply only when no `delivered` row exists for the pipecatcall. (3) `bin-dbscheme-manager` ships an Alembic migration with the two new columns + composite index.
+
+**Tech Stack:** Go 1.22+, MySQL via sqlx, RabbitMQ pub/sub, Alembic (Python), gomock for tests, Prometheus client.
+
+**Design doc:** `docs/plans/2026-04-29-aicall-terminate-drop-design.md` (this directory)
+
+**Branch:** `NOJIRA-aicall-terminate-drop-design` (the worktree this plan lives in)
+
+**Worktree:** `~/gitvoipbin/monorepo/.worktrees/NOJIRA-aicall-terminate-drop-design`
+
+---
+
+## Phasing
+
+The plan is split into three phases that ship independently:
+
+- **Phase 0** — Alembic migration (1 task block, ~15 min). Lands and bakes 2 h before Phase 1.
+- **Phase 1** — `bin-pipecat-manager` (Tasks 1.1–1.18). Independent of Phase 2; bakes 24 h.
+- **Phase 2** — `bin-ai-manager` (Tasks 2.1–2.20). Depends on Phase 0 and Phase 1.
+
+Each phase ends with the standard verification workflow (`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`).
+
+---
+
+## Conventions used in this plan
+
+- File paths are relative to the worktree root unless prefixed with `~`.
+- Each task has 5 steps: (1) write failing test, (2) run to confirm fail, (3) implement, (4) run to confirm pass, (5) commit.
+- For changes where TDD doesn't fit (constants, schema migrations, generated mocks), the test step is replaced with a "smoke check" — a build/compile/lint command that fails before and passes after.
+- Commit messages follow the monorepo convention: title `NOJIRA-aicall-terminate-drop-design`, body with `bin-<service>:` prefixes per change. **Do not include AI attribution.**
+- Run all commands from the worktree root unless noted otherwise.
+- `go generate` regenerates mocks via `mockgen`; run it after any interface change.
+
+---
+
+## PHASE 0 — Alembic migration
+
+### Task 0.1: Generate the migration file
+
+**Files:**
+- Create: `bin-dbscheme-manager/bin-manager/main/versions/<auto-rev>_add_pipecatcall_id_delivery_status_to_ai_messages.py`
+
+**Step 1: Generate empty revision via Alembic** (the only correct way — never hand-pick revision IDs)
+
+```bash
+cd bin-dbscheme-manager
+alembic -c bin-manager/main/alembic.ini revision -m "ai_messages add pipecatcall_id delivery_status"
+```
+
+Expected output: a new file under `bin-manager/main/versions/` with auto-generated revision ID. Note the path — you'll edit it next.
+
+**Step 2: Verify the generated file exists and has correct skeleton**
+
+```bash
+ls -la bin-manager/main/versions/*pipecatcall_id*.py
+```
+
+**Step 3: Edit the file** — fill in `upgrade()` and `downgrade()`:
+
+```python
+def upgrade():
+    op.add_column('ai_messages',
+        sa.Column('pipecatcall_id', mysql.BINARY(16), nullable=True))
+    op.add_column('ai_messages',
+        sa.Column('delivery_status', sa.String(16), nullable=False,
+                  server_default='delivered'))
+    op.create_index('idx_ai_messages_pcc_delivery', 'ai_messages',
+                    ['pipecatcall_id', 'delivery_status'])
+
+def downgrade():
+    op.drop_index('idx_ai_messages_pcc_delivery', 'ai_messages')
+    op.drop_column('ai_messages', 'delivery_status')
+    op.drop_column('ai_messages', 'pipecatcall_id')
+```
+
+Make sure imports include `from sqlalchemy.dialects import mysql`.
+
+**Step 4: Smoke-check with `alembic check`**
+
+```bash
+cd bin-dbscheme-manager && alembic -c bin-manager/main/alembic.ini check
+```
+
+Expected: no errors. Do **not** run `alembic upgrade` — that's a human's job per `bin-dbscheme-manager/CLAUDE.md`.
+
+**Step 5: Commit**
+
+```bash
+git add bin-dbscheme-manager/bin-manager/main/versions/*pipecatcall_id*.py
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-dbscheme-manager: Add migration for ai_messages.pipecatcall_id (BINARY(16)) and ai_messages.delivery_status (VARCHAR(16) NOT NULL DEFAULT 'delivered'), with composite index idx_ai_messages_pcc_delivery
+EOF
+)"
+```
+
+---
+
+## PHASE 1 — bin-pipecat-manager
+
+> **Pre-flight:** `cd bin-pipecat-manager && go test ./... 2>&1 | tail -20` should be green before starting. If it isn't, stop and ask.
+
+### Task 1.1: Add `EventTypePipecatcallTerminated` constant
+
+**Files:**
+- Modify: `bin-pipecat-manager/models/pipecatcall/event.go`
+- Test: `bin-pipecat-manager/models/pipecatcall/event_test.go` (create)
+
+**Step 1: Write the failing test**
+
+```go
+// bin-pipecat-manager/models/pipecatcall/event_test.go
+package pipecatcall
+
+import "testing"
+
+func TestEventTypePipecatcallTerminated_value(t *testing.T) {
+    if EventTypePipecatcallTerminated != "pipecatcall_terminated" {
+        t.Fatalf("expected pipecatcall_terminated, got %q", EventTypePipecatcallTerminated)
+    }
+}
+```
+
+**Step 2: Run** — `cd bin-pipecat-manager && go test ./models/pipecatcall/ -run TestEventTypePipecatcallTerminated_value -v` — expected: undefined symbol error.
+
+**Step 3: Implement** — append to `bin-pipecat-manager/models/pipecatcall/event.go`:
+
+```go
+EventTypePipecatcallTerminated string = "pipecatcall_terminated"
+```
+
+**Step 4: Run** — same command, expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/models/pipecatcall/event.go bin-pipecat-manager/models/pipecatcall/event_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add EventTypePipecatcallTerminated event constant for the new terminate-publish flow
+EOF
+)"
+```
+
+### Task 1.2: Add `LLMFlushOnce` and `LLMStopReason` fields to Session
+
+**Files:**
+- Modify: `bin-pipecat-manager/models/pipecatcall/session.go`
+
+**Step 1: Write the failing test**
+
+```go
+// bin-pipecat-manager/models/pipecatcall/session_test.go (extend existing or create)
+func TestSession_FlushPrimitives(t *testing.T) {
+    s := &Session{}
+    // Channels are zero-valued; Once and atomic.Int32 are usable in zero-value.
+    s.LLMFlushOnce.Do(func() {})  // should not panic
+    if got := s.LLMStopReason.Load(); got != 0 {
+        t.Fatalf("expected initial reason 0, got %d", got)
+    }
+}
+```
+
+**Step 2: Run** — `go test ./models/pipecatcall/ -run TestSession_FlushPrimitives -v` — expected: undefined fields.
+
+**Step 3: Implement** — in `models/pipecatcall/session.go`, in the LLM section (lines 36-43), add:
+
+```go
+LLMFlushOnce  sync.Once    `json:"-"` // ensures LLMStopChan is closed at most once
+LLMStopReason atomic.Int32 `json:"-"` // set by closer via CAS; read by flush goroutine for metric attribution
+```
+
+Add `"sync/atomic"` import if not present. `sync` is already imported.
+
+**Step 4: Run** — same command, expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/models/pipecatcall/session.go bin-pipecat-manager/models/pipecatcall/session_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add Session.LLMFlushOnce (sync.Once) and Session.LLMStopReason (atomic.Int32) for safe close-attribution between flush goroutine, BotLLMStopped handler, watchdog, and terminate
+EOF
+)"
+```
+
+### Task 1.3: Migrate `LLMFlushing` from `bool` to `atomic.Bool`
+
+> Per design §3.7.1, this is a compile-break that touches existing test files.
+
+**Files:**
+- Modify: `bin-pipecat-manager/models/pipecatcall/session.go`
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go` (lines 521, 526, 548)
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go` (lines 294, 318, 325, 475)
+
+**Step 1: Audit all sites first**
+
+```bash
+cd bin-pipecat-manager && grep -nR 'LLMFlushing' .
+```
+
+Expected sites: `models/pipecatcall/session.go:42`, `pkg/pipecatcallhandler/runner.go:521,526,548,551`, `pkg/pipecatcallhandler/runner_flush_test.go:294,318,325,475`. Confirm no others before proceeding.
+
+**Step 2: Write the new failing test**
+
+```go
+// bin-pipecat-manager/models/pipecatcall/session_test.go (append)
+func TestSession_LLMFlushing_isAtomicBool(t *testing.T) {
+    s := &Session{}
+    s.LLMFlushing.Store(true)
+    if !s.LLMFlushing.Load() {
+        t.Fatalf("expected LLMFlushing true after Store(true)")
+    }
+    s.LLMFlushing.Store(false)
+    if s.LLMFlushing.Load() {
+        t.Fatalf("expected LLMFlushing false after Store(false)")
+    }
+}
+```
+
+**Step 3: Run** — `go test ./models/pipecatcall/ -run TestSession_LLMFlushing_isAtomicBool -v` — expected: cannot call `.Store` on `bool`.
+
+**Step 4: Migrate the field and all call sites**
+
+In `session.go` line 42: `LLMFlushing atomic.Bool` (was `bool`). The `atomic.Bool` zero value is false; no init needed.
+
+In `runner.go`:
+- Line 521: `if !se.LLMFlushing { ...` → `if !se.LLMFlushing.Load() { ...`
+- Line 526: `se.LLMFlushing = true` → `se.LLMFlushing.Store(true)`
+- Line 548: `if se.LLMFlushing {` → `if se.LLMFlushing.Load() {`
+- Line 551: **delete the `se.LLMFlushing = false` line entirely** — Task 1.7 will replace it with a deferred reset inside the goroutine.
+
+In `runner_flush_test.go`:
+- Line 294 — composite literal `LLMFlushing: true,` → remove from literal; insert `s.LLMFlushing.Store(true)` after the struct construction.
+- Line 318: `se.LLMFlushing = false` → `se.LLMFlushing.Store(false)`.
+- Line 325: `se.LLMFlushing = true` → `se.LLMFlushing.Store(true)`.
+- Line 475: `se.LLMFlushing = true` → `se.LLMFlushing.Store(true)`.
+
+**Step 5: Run the full pipecatcallhandler suite**
+
+```bash
+go test ./models/pipecatcall/... ./pkg/pipecatcallhandler/... -race -v 2>&1 | tail -30
+```
+
+Expected: PASS. (The intermediate state at this point may have a slightly stale handler at runner.go:551 — that's fine because the deletion is a no-op against the new test expectations; the goroutine-level reset comes in Task 1.7.)
+
+**Step 6: Commit**
+
+```bash
+git add bin-pipecat-manager/models/pipecatcall/session.go bin-pipecat-manager/models/pipecatcall/session_test.go bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Migrate Session.LLMFlushing to atomic.Bool to remove the data race between the WebSocket read loop and the flush goroutine; update all call sites in runner.go and runner_flush_test.go
+EOF
+)"
+```
+
+### Task 1.4: Add `StopReason` enum and `reasonLabel` helper
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go`
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go` (extend or create)
+
+**Step 1: Write the failing test**
+
+```go
+func TestReasonLabel(t *testing.T) {
+    cases := []struct {
+        in   StopReason
+        want string
+    }{
+        {StopReasonNormal, "stopped_normal"},
+        {StopReasonIdleWatchdog, "idle_watchdog"},
+        {StopReasonTerminateForce, "terminate_force"},
+        {StopReasonContextCancel, "context_cancelled"},
+        {StopReasonUnset, "unknown"},
+    }
+    for _, c := range cases {
+        if got := reasonLabel(c.in); got != c.want {
+            t.Errorf("reasonLabel(%d) = %q, want %q", c.in, got, c.want)
+        }
+    }
+}
+```
+
+**Step 2: Run** — undefined symbols.
+
+**Step 3: Implement** — in `runner.go` (top-level, near other constants):
+
+```go
+type StopReason int32
+
+const (
+    StopReasonUnset StopReason = iota
+    StopReasonNormal
+    StopReasonIdleWatchdog
+    StopReasonTerminateForce
+    StopReasonContextCancel
+)
+
+func reasonLabel(r StopReason) string {
+    switch r {
+    case StopReasonNormal:
+        return "stopped_normal"
+    case StopReasonIdleWatchdog:
+        return "idle_watchdog"
+    case StopReasonTerminateForce:
+        return "terminate_force"
+    case StopReasonContextCancel:
+        return "context_cancelled"
+    default:
+        return "unknown"
+    }
+}
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add StopReason enum and reasonLabel helper for goroutine exit attribution metrics
+EOF
+)"
+```
+
+### Task 1.5: Add the three new Prometheus metrics
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go`
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/metrics_test.go` (extend or create)
+
+**Step 1: Write the failing test**
+
+```go
+func TestNewMetrics_registered(t *testing.T) {
+    // metrics package is registered at init; just assert the names exist.
+    for _, name := range []string{
+        "pipecat_manager_llm_flush_exit_total",
+        "pipecat_manager_llm_idle_watchdog_fired_total",
+        "pipecat_manager_llm_flush_finalize_outcome_total",
+    } {
+        if !metricRegistered(name) { // helper using prometheus.DefaultGatherer
+            t.Errorf("metric %s not registered", name)
+        }
+    }
+}
+```
+
+(If a `metricRegistered` helper doesn't exist, write a small one using `prometheus.DefaultGatherer.Gather()`.)
+
+**Step 2: Run** — FAIL (metrics not registered).
+
+**Step 3: Implement** — in `metrics.go`:
+
+```go
+var (
+    metricsLLMFlushExit = promauto.NewCounterVec(prometheus.CounterOpts{
+        Name: "pipecat_manager_llm_flush_exit_total",
+        Help: "Counter of runLLMIntermediateFlush goroutine exits, by reason.",
+    }, []string{"reason"})
+
+    metricsIdleWatchdogFired = promauto.NewCounter(prometheus.CounterOpts{
+        Name: "pipecat_manager_llm_idle_watchdog_fired_total",
+        Help: "Counter of idle-watchdog firings (no tokens for idleWatchdogTimeout while flushing).",
+    })
+
+    metricsFlushFinalizeOutcome = promauto.NewCounterVec(prometheus.CounterOpts{
+        Name: "pipecat_manager_llm_flush_finalize_outcome_total",
+        Help: "Counter of flushAndFinalize outcomes from the terminate caller's perspective.",
+    }, []string{"outcome"})
+)
+```
+
+(Use `promauto` if the file already does; otherwise `prometheus.MustRegister` in an `init()`.)
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go bin-pipecat-manager/pkg/pipecatcallhandler/metrics_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add Prometheus metrics for flush goroutine exits, idle-watchdog firings, and flushAndFinalize outcomes
+EOF
+)"
+```
+
+### Task 1.6: Switch `BotLLMStopped` handler to atomic CAS + Once
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go` (lines 542-554)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go` (extend)
+
+**Step 1: Write the failing test** — verifies that calling `BotLLMStopped` twice in a row does not panic and only attributes the close once.
+
+```go
+func TestBotLLMStopped_doubleStop_noPanic(t *testing.T) {
+    se := newTestSessionWithFlushArmed(t) // helper creates Session with channels + flush goroutine
+    // Simulate first BotLLMStopped
+    sendBotLLMStopped(t, se)
+    // Simulate second BotLLMStopped (should be no-op due to Once + LLMFlushing=false)
+    sendBotLLMStopped(t, se)
+    // Reason should remain StopReasonNormal (set by first call), not double-toggled.
+    if got := StopReason(se.LLMStopReason.Load()); got != StopReasonNormal {
+        t.Fatalf("expected StopReasonNormal, got %d", got)
+    }
+}
+```
+
+**Step 2: Run** — FAIL (test won't compile until handler is updated).
+
+**Step 3: Implement** — replace `runner.go:542-554`:
+
+```go
+case pipecatframe.RTVIFrameTypeBotLLMStopped:
+    msg := pipecatframe.RTVIBotLLMStoppedMessage{}
+    if err := json.Unmarshal(m, &msg); err != nil {
+        return errors.Wrapf(err, "could not unmarshal bot-llm-stopped message")
+    }
+    if !se.LLMFlushing.Load() {
+        log.Debugf("BotLLMStopped received but no tokens were received for this generation.")
+        break
+    }
+    atomic.CompareAndSwapInt32((*int32)(unsafe.Pointer(&se.LLMStopReason)),
+        int32(StopReasonUnset), int32(StopReasonNormal))
+    // Cleaner alternative if Session.LLMStopReason is atomic.Int32:
+    se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonNormal))
+    se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+    <-se.LLMDoneChan
+```
+
+(Use the `atomic.Int32.CompareAndSwap` form, not `unsafe.Pointer`.)
+
+Note: the line `se.LLMFlushing = false` was already deleted in Task 1.3; the goroutine's `defer` (added in Task 1.7) owns the reset.
+
+**Step 4: Run** — `go test ./pkg/pipecatcallhandler/... -race -v 2>&1 | tail -10` — expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: BotLLMStopped handler uses atomic CAS for StopReason and sync.Once for closing LLMStopChan, removing the unguarded close racing with watchdog and flushAndFinalize
+EOF
+)"
+```
+
+### Task 1.7: Add `defer LLMFlushing.Store(false)` inside `runLLMIntermediateFlush`
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go` (top of `runLLMIntermediateFlush`)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go` (extend)
+
+**Step 1: Write the failing test** — verifies `LLMFlushing.Load()` returns false after the goroutine returns, regardless of which exit path was taken.
+
+```go
+func TestRunLLMIntermediateFlush_resetsLLMFlushing_onAllExits(t *testing.T) {
+    cases := []struct {
+        name   string
+        causeExit func(*pipecatcall.Session)
+    }{
+        {"stopChan", func(s *pipecatcall.Session) { close(s.LLMStopChan) }},
+        {"ctxDone",  func(s *pipecatcall.Session) { s.Cancel() }},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            se := newTestSessionWithFlushArmed(t)
+            c.causeExit(se)
+            <-se.LLMDoneChan // wait for goroutine to exit
+            if se.LLMFlushing.Load() {
+                t.Fatalf("LLMFlushing not reset on %s exit", c.name)
+            }
+        })
+    }
+}
+```
+
+**Step 2: Run** — FAIL (LLMFlushing remains true after Ctx.Done path).
+
+**Step 3: Implement** — at the top of `runLLMIntermediateFlush`, add:
+
+```go
+defer close(se.LLMDoneChan)        // already present
+defer se.LLMFlushing.Store(false)  // NEW — runs before close so observers see flushing=false
+```
+
+The order of `defer` is LIFO: `LLMFlushing.Store(false)` runs first, then `close(LLMDoneChan)`. That's correct — readers waking on the close should see `LLMFlushing=false`.
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Reset Session.LLMFlushing inside runLLMIntermediateFlush via defer so it always clears regardless of which exit path triggered the goroutine to return
+EOF
+)"
+```
+
+### Task 1.8: Switch `publishFinalBotLLMEvent` and `publishIntermediateEvent` to `context.Background()`
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go` (around lines 609 and 634; verify exact line numbers post-Task-1.7)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go`
+
+**Step 1: Write the failing test** — verifies that publishing succeeds even after `se.Ctx` is cancelled.
+
+```go
+func TestRunLLMIntermediateFlush_publishesAfterCtxCancel(t *testing.T) {
+    se := newTestSessionWithFlushArmed(t)
+    // Send one token, then cancel context, then close StopChan.
+    se.LLMTokenChan <- "hello "
+    se.Cancel()                  // cancels se.Ctx
+    close(se.LLMStopChan)        // triggers final publish via the LLMStopChan branch
+    // Wait for goroutine to exit, then verify a final event was published.
+    <-se.LLMDoneChan
+    assertFinalEventPublished(t, se, "hello ")
+}
+```
+
+**Step 2: Run** — depending on which branch runs first, may fail because publish currently uses `se.Ctx`.
+
+**Step 3: Implement** — in the `case <-se.LLMStopChan:` branch (around runner.go:634), replace:
+
+```go
+h.publishFinalBotLLMEvent(se.Ctx, se, messageID, fullText)
+```
+
+with:
+
+```go
+h.publishFinalBotLLMEvent(context.Background(), se, messageID, fullText)
+```
+
+In the `case <-ticker.C:` branch (around line 609), replace `h.publishIntermediateEvent(se, messageID, deltaBuffer, sequence)` (which internally uses `se.Ctx`) with a new helper or pass context explicitly:
+
+```go
+h.publishIntermediateEventBg(se, messageID, deltaBuffer, sequence)
+```
+
+Add the helper:
+
+```go
+func (h *pipecatcallHandler) publishIntermediateEventBg(se *pipecatcall.Session, messageID uuid.UUID, delta string, sequence int) {
+    evt := message.Message{ /* same fields as publishIntermediateEvent */ }
+    h.notifyHandler.PublishEvent(context.Background(), message.EventTypeBotLLMIntermediate, evt)
+}
+```
+
+(Or simply change the existing `publishIntermediateEvent` to accept `ctx context.Context` and pass `context.Background()` from this call site.)
+
+**Step 4: Run** — `go test ./pkg/pipecatcallhandler/... -race -v 2>&1 | tail -10` — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Use context.Background() for both intermediate and final message_bot_llm publishes so a cancelled session context (from terminate path) doesn't drop the event
+EOF
+)"
+```
+
+### Task 1.9: Add idle watchdog to `runLLMIntermediateFlush`
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go` (the select loop)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go`
+
+**Step 1: Write the failing test** — fires watchdog after silence, verifies metric and exit reason.
+
+```go
+func TestRunLLMIntermediateFlush_idleWatchdog_fires(t *testing.T) {
+    // Use a test-injectable clock OR shorter idleWatchdogTimeout via build tags.
+    se := newTestSessionWithFlushArmed(t)
+    se.LLMTokenChan <- "first token "
+    // Wait > idleWatchdogTimeout (use real time in test only if timeout is short enough)
+    time.Sleep(idleWatchdogTimeout + 500*time.Millisecond)
+    <-se.LLMDoneChan
+    if got := StopReason(se.LLMStopReason.Load()); got != StopReasonIdleWatchdog {
+        t.Fatalf("expected StopReasonIdleWatchdog, got %d", got)
+    }
+    assertMetricIncremented(t, "pipecat_manager_llm_idle_watchdog_fired_total", 1)
+}
+
+func TestRunLLMIntermediateFlush_idleWatchdog_doesNotFireBeforeFirstToken(t *testing.T) {
+    se := newTestSessionWithFlushArmed(t)
+    // No tokens. Wait > idleWatchdogTimeout. Watchdog should NOT fire.
+    time.Sleep(idleWatchdogTimeout + 500*time.Millisecond)
+    if se.LLMStopReason.Load() != int32(StopReasonUnset) {
+        t.Fatalf("watchdog fired before any token arrived")
+    }
+    // Cleanup
+    se.Cancel()
+    <-se.LLMDoneChan
+}
+```
+
+For local dev set `idleWatchdogTimeout = 200*time.Millisecond` via a test-only build tag or override variable. (Or use a global `var` instead of `const` so tests can patch.)
+
+**Step 2: Run** — FAIL (watchdog logic not present).
+
+**Step 3: Implement** — in `runner.go`, near other constants:
+
+```go
+var (
+    idleWatchdogTimeout  = 8 * time.Second   // var (not const) so tests can patch
+    idleWatchdogTickRate = 1 * time.Second
+)
+```
+
+In `runLLMIntermediateFlush`, before the for-loop:
+
+```go
+watchdog := time.NewTicker(idleWatchdogTickRate)
+defer watchdog.Stop()
+var lastToken time.Time   // zero until first token
+```
+
+In the `case token := <-se.LLMTokenChan:` branch, add `lastToken = time.Now()`.
+
+Add the new case in the select:
+
+```go
+case now := <-watchdog.C:
+    if !lastToken.IsZero() && now.Sub(lastToken) >= idleWatchdogTimeout {
+        if se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonIdleWatchdog)) {
+            metricsIdleWatchdogFired.Inc()
+        }
+        se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+    }
+```
+
+In the `case <-se.LLMStopChan:` branch, after publishing the final event, increment the exit metric:
+
+```go
+metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReason(se.LLMStopReason.Load()))).Inc()
+```
+
+In the `case <-se.Ctx.Done():` branch, do the CAS first then increment:
+
+```go
+se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonContextCancel))
+// existing publish-partial logic (already uses context.Background() per Task 1.8 if you extended that to here)
+metricsLLMFlushExit.WithLabelValues(reasonLabel(StopReason(se.LLMStopReason.Load()))).Inc()
+```
+
+**Step 4: Run** — `go test ./pkg/pipecatcallhandler/... -race -v 2>&1 | tail -20` — PASS (note: tests use a patched short `idleWatchdogTimeout`).
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add idle watchdog to runLLMIntermediateFlush — fires after idleWatchdogTimeout (8s) of no tokens, but only after the first token has arrived; exit reason and metric label reflect the watchdog-triggered exit
+EOF
+)"
+```
+
+### Task 1.10: Implement `flushAndFinalize` helper
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go` (or wherever helpers live)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go`
+
+**Step 1: Write the failing test** — table-driven for the four outcomes:
+
+```go
+func TestFlushAndFinalize_outcomes(t *testing.T) {
+    tt := []struct {
+        name    string
+        setup   func(*pipecatcall.Session)
+        outcome string
+    }{
+        {"never_started", func(s *pipecatcall.Session) { /* no flush armed */ }, "noop_never_started"},
+        {"already_done",  func(s *pipecatcall.Session) { armAndExitFlush(s) },   "noop_already_done"},
+        {"done",          func(s *pipecatcall.Session) { armFlush(s) },          "done"},
+        {"timeout",       func(s *pipecatcall.Session) { armFlushBlocking(s) },  "timeout"},
+    }
+    for _, c := range tt {
+        t.Run(c.name, func(t *testing.T) {
+            h := newTestHandler(t)
+            se := newSession()
+            c.setup(se)
+            h.flushAndFinalize(se)
+            assertOutcomeMetric(t, c.outcome, 1)
+        })
+    }
+}
+```
+
+For the `timeout` case use a patched short `flushFinalizeTimeout` (e.g., 50 ms) and a flush goroutine that blocks longer.
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `runner.go`:
+
+```go
+var flushFinalizeTimeout = 3 * time.Second // var so tests can patch
+
+func (h *pipecatcallHandler) flushAndFinalize(se *pipecatcall.Session) {
+    if !se.LLMFlushing.Load() {
+        if se.LLMMessageID == uuid.Nil {
+            metricsFlushFinalizeOutcome.WithLabelValues("noop_never_started").Inc()
+        } else {
+            metricsFlushFinalizeOutcome.WithLabelValues("noop_already_done").Inc()
+        }
+        return
+    }
+
+    se.LLMStopReason.CompareAndSwap(int32(StopReasonUnset), int32(StopReasonTerminateForce))
+    se.LLMFlushOnce.Do(func() { close(se.LLMStopChan) })
+
+    timer := time.NewTimer(flushFinalizeTimeout)
+    defer timer.Stop()
+
+    select {
+    case <-se.LLMDoneChan:
+        metricsFlushFinalizeOutcome.WithLabelValues("done").Inc()
+    case <-timer.C:
+        metricsFlushFinalizeOutcome.WithLabelValues("timeout").Inc()
+    }
+}
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/runner.go bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add flushAndFinalize — synchronously closes LLMStopChan and waits for the flush goroutine to publish its final event, with bounded timeout. Records four outcome labels for observability.
+EOF
+)"
+```
+
+### Task 1.11: Add `markTerminatedOnce` dedupe map
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/main.go` (handler struct + constructor)
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/start.go` (helper)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go` (extend)
+
+**Step 1: Write the failing test**
+
+```go
+func TestMarkTerminatedOnce_idempotent(t *testing.T) {
+    h := newTestHandler(t)
+    id := uuid.Must(uuid.NewV4())
+    if !h.markTerminatedOnce(id) {
+        t.Fatalf("first call should claim")
+    }
+    if h.markTerminatedOnce(id) {
+        t.Fatalf("second call should not claim")
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `main.go` handler struct, add:
+
+```go
+muTerminated        sync.Mutex
+terminatedPublished map[uuid.UUID]struct{}
+```
+
+In the constructor, initialize: `terminatedPublished: make(map[uuid.UUID]struct{})`.
+
+In `start.go` (or `terminate.go` if a new file fits better):
+
+```go
+func (h *pipecatcallHandler) markTerminatedOnce(id uuid.UUID) bool {
+    h.muTerminated.Lock()
+    defer h.muTerminated.Unlock()
+    if _, ok := h.terminatedPublished[id]; ok {
+        return false
+    }
+    h.terminatedPublished[id] = struct{}{}
+    return true
+}
+
+func (h *pipecatcallHandler) terminatedDeleteEntry(id uuid.UUID) {
+    h.muTerminated.Lock()
+    defer h.muTerminated.Unlock()
+    delete(h.terminatedPublished, id)
+}
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/main.go bin-pipecat-manager/pkg/pipecatcallhandler/start.go bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Add in-memory terminatedPublished map + mutex with markTerminatedOnce/terminatedDeleteEntry helpers to dedupe pipecatcall_terminated event publication on repeated terminate() calls
+EOF
+)"
+```
+
+### Task 1.12: Update `SessionStop` to call `Cancel()` and prune dedupe entry
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/session.go` (around line 82)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestSessionStop_cancelsCtx(t *testing.T) {
+    h, se := newTestHandlerWithSession(t)
+    done := make(chan struct{})
+    go func() {
+        <-se.Ctx.Done()
+        close(done)
+    }()
+    h.SessionStop(se.ID)
+    select {
+    case <-done:
+    case <-time.After(100 * time.Millisecond):
+        t.Fatalf("Ctx.Done() did not fire after SessionStop")
+    }
+}
+
+func TestSessionStop_prunesTerminatedMap(t *testing.T) {
+    h, se := newTestHandlerWithSession(t)
+    h.markTerminatedOnce(se.ID) // simulate a prior terminate() publish
+    h.SessionStop(se.ID)
+    if h.markTerminatedOnce(se.ID) == false {
+        t.Fatalf("expected map entry pruned; second markTerminatedOnce should claim again")
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `session.go`, in `SessionStop`, after the existing `wait on ConnAstReady or Ctx.Done` block (around line 105) and **before** `close(ConnAst)`:
+
+```go
+pc.Cancel()  // Session.Cancel — same func used by deferred cleanup in start.go
+```
+
+At the very end of `SessionStop` (after all teardown):
+
+```go
+h.terminatedDeleteEntry(pc.ID)
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/session.go bin-pipecat-manager/pkg/pipecatcallhandler/session_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: SessionStop now cancels pc.Ctx (so the flush goroutine's Ctx.Done branch fires) and prunes the terminatedPublished map entry to bound memory growth
+EOF
+)"
+```
+
+### Task 1.13: Update `terminate()` to call `flushAndFinalize` + publish + dedupe
+
+**Files:**
+- Modify: `bin-pipecat-manager/pkg/pipecatcallhandler/start.go` (around line 300)
+- Test: `bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestTerminate_publishesTerminatedEventOnce(t *testing.T) {
+    h, se := newTestHandlerWithSession(t)
+    pc := pcFromSession(se)
+    h.terminate(context.Background(), pc)
+    h.terminate(context.Background(), pc) // second call
+    publishCalls := h.notifyHandler.PublishEventCalls()
+    terminatedCalls := 0
+    for _, c := range publishCalls {
+        if c.Type == pipecatcall.EventTypePipecatcallTerminated {
+            terminatedCalls++
+        }
+    }
+    if terminatedCalls != 1 {
+        t.Fatalf("expected 1 terminated publish, got %d", terminatedCalls)
+    }
+}
+
+func TestTerminate_callsFlushBeforeStop(t *testing.T) {
+    h, se := newTestHandlerWithSession(t)
+    pc := pcFromSession(se)
+    armAndStallFlush(se) // flush goroutine is running
+    h.terminate(context.Background(), pc)
+    // After terminate, flush goroutine must have exited via terminate_force.
+    if got := StopReason(se.LLMStopReason.Load()); got != StopReasonTerminateForce {
+        t.Fatalf("expected StopReasonTerminateForce, got %d", got)
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — modify `terminate()`:
+
+```go
+func (h *pipecatcallHandler) terminate(ctx context.Context, pc *pipecatcall.Pipecatcall) {
+    log := logrus.WithFields(...)
+    log.Infof("Terminating pipecatcall...")
+
+    if se, _ := h.SessionGet(pc.ID); se != nil {
+        h.flushAndFinalize(se)  // C2
+    }
+
+    if h.markTerminatedOnce(pc.ID) {
+        h.notifyHandler.PublishEvent(
+            context.Background(),
+            pipecatcall.EventTypePipecatcallTerminated,
+            pc,
+        )
+    }
+
+    // existing reference-type-specific cleanup
+    switch pc.ReferenceType {
+    case pipecatcall.ReferenceTypeCall:
+        if errTerminate := h.terminateReferenceTypeCall(ctx, pc); errTerminate != nil { ... }
+    case pipecatcall.ReferenceTypeAICall:
+        if errTerminate := h.terminateReferenceTypeAICall(ctx, pc); errTerminate != nil { ... }
+    default:
+        log.Debugf("No action needed to stop for reference type: %v", pc.ReferenceType)
+    }
+
+    h.SessionStop(pc.ID)
+    log.Infof("Pipecatcall terminated. pipecatcall_id: %s", pc.ID)
+}
+```
+
+**Step 4: Run** — `go test ./pkg/pipecatcallhandler/... -race -v 2>&1 | tail -20` — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-pipecat-manager/pkg/pipecatcallhandler/start.go bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: terminate() now (1) calls flushAndFinalize before any teardown so partial LLM responses are published, (2) emits pipecatcall_terminated event exactly once per pipecatcall via markTerminatedOnce, (3) preserves existing reference-type cleanup before SessionStop
+EOF
+)"
+```
+
+### Task 1.14: Verify Phase 1 fully
+
+**Step 1: Run the full verification workflow**
+
+```bash
+cd bin-pipecat-manager && \
+  go mod tidy && \
+  go mod vendor && \
+  go generate ./... && \
+  go test ./... && \
+  golangci-lint run -v --timeout 5m
+```
+
+Expected: all green. Fix any issues before proceeding.
+
+**Step 2: Run with race detector**
+
+```bash
+cd bin-pipecat-manager && go test -race ./pkg/pipecatcallhandler/...
+```
+
+Expected: PASS, no data races reported.
+
+**Step 3: Commit any housekeeping changes**
+
+```bash
+git add -u
+git status  # confirm only go.mod/go.sum/vendor adjustments
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-pipecat-manager: Run go mod tidy + go mod vendor + go generate after Phase 1 changes
+EOF
+)" 2>/dev/null || echo "no changes to commit"
+```
+
+---
+
+## PHASE 2 — bin-ai-manager
+
+> **Pre-flight:** Phase 0 migration must be applied to staging/prod. Phase 1 must have baked 24 h with green metrics.
+
+### Task 2.1: Add `DeliveryStatus` type to message model
+
+**Files:**
+- Modify: `bin-ai-manager/models/message/main.go`
+- Test: `bin-ai-manager/models/message/main_test.go` (extend or create)
+
+**Step 1: Write the failing test**
+
+```go
+func TestDeliveryStatus_values(t *testing.T) {
+    if string(DeliveryStatusPending) != "pending" {
+        t.Fatalf("expected pending")
+    }
+    if string(DeliveryStatusDelivered) != "delivered" {
+        t.Fatalf("expected delivered")
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `bin-ai-manager/models/message/main.go`:
+
+```go
+type DeliveryStatus string
+
+const (
+    DeliveryStatusPending   DeliveryStatus = "pending"
+    DeliveryStatusDelivered DeliveryStatus = "delivered"
+)
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/models/message/main.go bin-ai-manager/models/message/main_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add DeliveryStatus enum (pending|delivered) for the new message-delivery-truth tracking
+EOF
+)"
+```
+
+### Task 2.2: Add `Message.PipecatcallID` and `Message.DeliveryStatus` fields
+
+**Files:**
+- Modify: `bin-ai-manager/models/message/main.go` (Message struct)
+- Test: `bin-ai-manager/models/message/main_test.go`
+
+**Step 1: Write the failing test** — verifies the new fields exist on Message and are NOT in WebhookMessage.
+
+```go
+func TestMessage_hasPipecatcallIDAndDeliveryStatus(t *testing.T) {
+    m := Message{
+        PipecatcallID:  uuid.Must(uuid.NewV4()),
+        DeliveryStatus: DeliveryStatusPending,
+    }
+    if m.PipecatcallID == uuid.Nil { t.Fatal("PipecatcallID not set") }
+    if m.DeliveryStatus != DeliveryStatusPending { t.Fatal("DeliveryStatus not set") }
+}
+
+func TestWebhookMessage_omitsInternalFields(t *testing.T) {
+    m := Message{
+        PipecatcallID:  uuid.Must(uuid.NewV4()),
+        DeliveryStatus: DeliveryStatusDelivered,
+    }
+    wm := m.ConvertWebhookMessage()
+    raw, _ := json.Marshal(wm)
+    if strings.Contains(string(raw), "pipecatcall_id") {
+        t.Fatalf("webhook leaks pipecatcall_id: %s", raw)
+    }
+    if strings.Contains(string(raw), "delivery_status") {
+        t.Fatalf("webhook leaks delivery_status: %s", raw)
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `Message` struct, append:
+
+```go
+PipecatcallID  uuid.UUID      `json:"-" db:"pipecatcall_id"`
+DeliveryStatus DeliveryStatus `json:"-" db:"delivery_status"`
+```
+
+(`json:"-"` ensures these never appear in JSON serialization, including the WebhookMessage path.)
+
+Confirm `ConvertWebhookMessage()` doesn't explicitly copy these — it shouldn't, since it constructs `WebhookMessage` from named fields.
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/models/message/main.go bin-ai-manager/models/message/main_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add Message.PipecatcallID and Message.DeliveryStatus fields. Both are internal-only (json:"-"); ConvertWebhookMessage does not expose them per the WebhookMessage-vs-internal-model rule.
+EOF
+)"
+```
+
+### Task 2.3: Add the new columns to dbhandler INSERT/SELECT
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/dbhandler/message.go`
+- Test: `bin-ai-manager/pkg/dbhandler/message_test.go`
+
+**Step 1: Write the failing test** — round-trips a Message with the new fields through the DB layer.
+
+```go
+func TestMessageCreate_persistsPipecatcallIDAndDeliveryStatus(t *testing.T) {
+    h, mockDB := newTestDBHandler(t)
+    pcID := uuid.Must(uuid.NewV4())
+    msg := &message.Message{
+        Identity:       commonidentity.Identity{ID: uuid.Must(uuid.NewV4())},
+        AicallID:       uuid.Must(uuid.NewV4()),
+        PipecatcallID:  pcID,
+        DeliveryStatus: message.DeliveryStatusPending,
+        // ... other required fields
+    }
+    mockDB.ExpectExec("INSERT INTO ai_messages.*pipecatcall_id.*delivery_status.*")...
+    err := h.MessageCreate(ctx, msg)
+    require.NoError(t, err)
+}
+```
+
+(Use the existing test infra; if mocks are sqlmock, patterns above apply. If gomock against an interface, mirror that.)
+
+**Step 2: Run** — FAIL (column not in INSERT).
+
+**Step 3: Implement** — add `pipecatcall_id` and `delivery_status` to the INSERT column list and `:pipecatcall_id`, `:delivery_status` to the values clause. Add the same columns to the SELECT used by `MessageGet`.
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/dbhandler/message.go bin-ai-manager/pkg/dbhandler/message_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: dbhandler/message persists and reads the new pipecatcall_id and delivery_status columns
+EOF
+)"
+```
+
+### Task 2.4: Add `MessageAssistantReplyExists`
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/dbhandler/main.go` (interface)
+- Modify: `bin-ai-manager/pkg/dbhandler/message.go` (impl)
+- Test: `bin-ai-manager/pkg/dbhandler/message_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestMessageAssistantReplyExists(t *testing.T) {
+    cases := []struct{
+        name     string
+        rows     []*message.Message  // pre-seeded
+        query    uuid.UUID            // pipecatcall_id
+        expected bool
+    }{
+        {"delivered_match", []*message.Message{{PipecatcallID: pcA, DeliveryStatus: DeliveryStatusDelivered, Direction: DirectionIncoming, Role: RoleAssistant}}, pcA, true},
+        {"pending_only",    []*message.Message{{PipecatcallID: pcA, DeliveryStatus: DeliveryStatusPending,   Direction: DirectionIncoming, Role: RoleAssistant}}, pcA, false},
+        {"different_pcc",   []*message.Message{{PipecatcallID: pcB, DeliveryStatus: DeliveryStatusDelivered, Direction: DirectionIncoming, Role: RoleAssistant}}, pcA, false},
+        {"wrong_role",      []*message.Message{{PipecatcallID: pcA, DeliveryStatus: DeliveryStatusDelivered, Direction: DirectionIncoming, Role: RoleUser}}, pcA, false},
+        {"deleted_row",     []*message.Message{{PipecatcallID: pcA, DeliveryStatus: DeliveryStatusDelivered, Direction: DirectionIncoming, Role: RoleAssistant, TMDelete: someTimestamp}}, pcA, false},
+    }
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) { /* seed + assert */ })
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `dbhandler/main.go` interface, add: `MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error)`. In `dbhandler/message.go`:
+
+```go
+func (h *handler) MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error) {
+    const q = `SELECT 1 FROM ai_messages
+               WHERE pipecatcall_id = ?
+                 AND delivery_status = 'delivered'
+                 AND direction = 'incoming'
+                 AND role = 'assistant'
+                 AND tm_delete IS NULL
+               LIMIT 1`
+    var x int
+    err := h.db.QueryRowContext(ctx, q, pipecatcallID).Scan(&x)
+    if err == sql.ErrNoRows {
+        return false, nil
+    }
+    if err != nil {
+        return false, fmt.Errorf("MessageAssistantReplyExists: %w", err)
+    }
+    return true, nil
+}
+```
+
+(Adjust to `sqlx` style if the codebase uses it.)
+
+Run `go generate ./pkg/dbhandler/...` to regenerate the mock.
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/dbhandler/main.go bin-ai-manager/pkg/dbhandler/message.go bin-ai-manager/pkg/dbhandler/mock_main.go bin-ai-manager/pkg/dbhandler/message_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add dbhandler.MessageAssistantReplyExists query — single-row indexed SELECT scoped by pipecatcall_id with delivery_status='delivered' filter; regenerate mock
+EOF
+)"
+```
+
+### Task 2.5: Add `MessageUpdateDeliveryStatus`
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/dbhandler/main.go` (interface)
+- Modify: `bin-ai-manager/pkg/dbhandler/message.go` (impl)
+- Test: `bin-ai-manager/pkg/dbhandler/message_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestMessageUpdateDeliveryStatus(t *testing.T) {
+    h, mockDB := newTestDBHandler(t)
+    id := uuid.Must(uuid.NewV4())
+    mockDB.ExpectExec("UPDATE ai_messages SET delivery_status = ?.*WHERE id = ?").
+        WithArgs("delivered", id[:]).
+        WillReturnResult(sqlmock.NewResult(0, 1))
+    err := h.MessageUpdateDeliveryStatus(ctx, id, message.DeliveryStatusDelivered)
+    require.NoError(t, err)
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement**
+
+```go
+func (h *handler) MessageUpdateDeliveryStatus(ctx context.Context, id uuid.UUID, status message.DeliveryStatus) error {
+    const q = `UPDATE ai_messages SET delivery_status = ?, tm_update = ? WHERE id = ?`
+    _, err := h.db.ExecContext(ctx, q, string(status), h.utilHandler.TimeGetCurTime(), id)
+    if err != nil {
+        return fmt.Errorf("MessageUpdateDeliveryStatus: %w", err)
+    }
+    return nil
+}
+```
+
+Add to interface, regenerate mock.
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/dbhandler/main.go bin-ai-manager/pkg/dbhandler/message.go bin-ai-manager/pkg/dbhandler/mock_main.go bin-ai-manager/pkg/dbhandler/message_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add dbhandler.MessageUpdateDeliveryStatus for the persist-then-mark-delivered flow
+EOF
+)"
+```
+
+### Task 2.6: Add `CreateOption` functional options
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/main.go`
+- Test: `bin-ai-manager/pkg/messagehandler/main_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestCreateOptions_apply(t *testing.T) {
+    pcID := uuid.Must(uuid.NewV4())
+    var p createParams
+    WithPipecatcallID(pcID)(&p)
+    WithDeliveryStatus(message.DeliveryStatusPending)(&p)
+    if p.pipecatcallID != pcID || p.deliveryStatus != message.DeliveryStatusPending {
+        t.Fatalf("options not applied: %+v", p)
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `messagehandler/main.go`:
+
+```go
+type CreateOption func(*createParams)
+type createParams struct {
+    pipecatcallID  uuid.UUID
+    deliveryStatus message.DeliveryStatus
+}
+func WithPipecatcallID(id uuid.UUID) CreateOption {
+    return func(p *createParams) { p.pipecatcallID = id }
+}
+func WithDeliveryStatus(s message.DeliveryStatus) CreateOption {
+    return func(p *createParams) { p.deliveryStatus = s }
+}
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/messagehandler/main.go bin-ai-manager/pkg/messagehandler/main_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add functional CreateOption / WithPipecatcallID / WithDeliveryStatus so messagehandler.Create can accept new fields without breaking the 8+ existing callers
+EOF
+)"
+```
+
+### Task 2.7: Extend `MessageHandler.Create` signature with `opts ...CreateOption`
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/main.go` (interface + impl)
+- Modify: `bin-ai-manager/pkg/messagehandler/main_test.go`
+- Regenerate mocks
+
+**Step 1: Write the failing test**
+
+```go
+func TestCreate_withPipecatcallID_andDeliveryStatus(t *testing.T) {
+    h, mockDB := newTestMessageHandler(t)
+    pcID := uuid.Must(uuid.NewV4())
+    mockDB.EXPECT().MessageCreate(gomock.Any(), messageWithPCC(pcID, message.DeliveryStatusPending)).Return(nil)
+    msg, err := h.Create(ctx, uuid.Nil, customerID, aicallID, activeflowID,
+        message.DirectionIncoming, message.RoleAssistant, "hi", nil, "",
+        WithPipecatcallID(pcID), WithDeliveryStatus(message.DeliveryStatusPending))
+    require.NoError(t, err)
+    require.Equal(t, pcID, msg.PipecatcallID)
+    require.Equal(t, message.DeliveryStatusPending, msg.DeliveryStatus)
+}
+
+func TestCreate_withoutOpts_defaultsDelivered(t *testing.T) {
+    // Existing callers don't supply opts → DeliveryStatus defaults to "delivered"
+    // (matching the DB column default + existing call-site semantics).
+    h, mockDB := newTestMessageHandler(t)
+    mockDB.EXPECT().MessageCreate(gomock.Any(), messageWithDelivery(message.DeliveryStatusDelivered)).Return(nil)
+    _, err := h.Create(ctx, uuid.Nil, customerID, aicallID, activeflowID,
+        message.DirectionIncoming, message.RoleAssistant, "hi", nil, "")
+    require.NoError(t, err)
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — change interface and impl:
+
+```go
+Create(
+    ctx context.Context,
+    id, customerID, aicallID, activeflowID uuid.UUID,
+    direction message.Direction,
+    role message.Role,
+    content string,
+    toolCalls []message.ToolCall,
+    toolCallID string,
+    opts ...CreateOption,
+) (*message.Message, error)
+```
+
+Inside the impl, build `createParams` with sensible defaults:
+
+```go
+p := createParams{
+    pipecatcallID:  uuid.Nil,
+    deliveryStatus: message.DeliveryStatusDelivered, // safe default for legacy callers
+}
+for _, opt := range opts { opt(&p) }
+```
+
+Then populate `Message.PipecatcallID` and `Message.DeliveryStatus` from `p` before calling `dbHandler.MessageCreate`.
+
+Regenerate mocks: `cd bin-ai-manager && go generate ./pkg/messagehandler/...`.
+
+**Step 4: Run** — `go test ./pkg/messagehandler/... -v` — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/messagehandler/main.go bin-ai-manager/pkg/messagehandler/mock_main.go bin-ai-manager/pkg/messagehandler/main_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Extend MessageHandler.Create with variadic opts ...CreateOption; default delivery_status='delivered' for legacy callers; regenerate mocks. No callers broken.
+EOF
+)"
+```
+
+### Task 2.8: Update `EventPMMessageBotLLM` — persist 'pending', update to 'delivered' after send
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/event.go` (EventPMMessageBotLLM, AICall conversation branch)
+- Test: `bin-ai-manager/pkg/messagehandler/event_test.go`
+
+**Step 1: Write the failing tests** — table-driven for the four outcomes:
+
+```go
+func TestEventPMMessageBotLLM_conversation(t *testing.T) {
+    cases := []struct{
+        name              string
+        guard1Pass        bool
+        guard2Pass        bool
+        sendOK            bool
+        updateOK          bool
+        updateRetryOK     bool
+        wantPersistStatus message.DeliveryStatus
+        wantUpdateCalls   int
+        wantConvSendCalls int
+    }{
+        {"happy",                true, true,  true,  true,  true, "pending", 1, 1},
+        {"guard2_fail",          true, false, false, false, false, "pending", 0, 0},
+        {"send_fail",            true, true,  false, false, false, "pending", 0, 1},
+        {"update_fail_but_retry_ok", true, true, true, false, true, "pending", 2, 1},
+        {"update_fail_both",     true, true,  true,  false, false, "pending", 2, 1},
+    }
+    // For each case: setup mocks, call handler, assert MessageCreate gets persistStatus=pending,
+    // assert MessageUpdateDeliveryStatus is called wantUpdateCalls times,
+    // assert ConversationV1MessageSend is called wantConvSendCalls times.
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — modify `event.go` AICall conversation branch (lines ~78-130). Key changes:
+
+```go
+// Guard #1 (unchanged)
+if ac.PipecatcallID != evt.PipecatcallID { ... return }
+
+// Persist with delivery_status='pending' (NEW)
+tmp, err := h.Create(ctx, evt.ID, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID,
+    message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "",
+    WithPipecatcallID(evt.PipecatcallID),
+    WithDeliveryStatus(message.DeliveryStatusPending))
+if err != nil { ... return }
+
+// Guard #2 (unchanged) — if fail, row stays 'pending' → backstop will fire later.
+acFinal, errFinal := h.reqHandler.AIV1AIcallGet(ctx, evt.PipecatcallReferenceID)
+if errFinal != nil { ... return }
+if acFinal.PipecatcallID != evt.PipecatcallID { ... return }
+
+// Send (unchanged)
+sent, errSend := h.reqHandler.ConversationV1MessageSend(ctx, acFinal.ReferenceID, evt.Text, []cvmedia.Media{})
+if errSend != nil { ... return } // row stays 'pending'
+
+// Mark delivered with one retry (NEW)
+errUpd := h.dbHandler.MessageUpdateDeliveryStatus(ctx, tmp.ID, message.DeliveryStatusDelivered)
+if errUpd != nil {
+    time.Sleep(deliveryStatusUpdateRetryDelay)
+    errUpd = h.dbHandler.MessageUpdateDeliveryStatus(ctx, tmp.ID, message.DeliveryStatusDelivered)
+}
+if errUpd != nil {
+    log.Errorf("Could not mark message delivered after retry. msg_id: %s err: %v", tmp.ID, errUpd)
+    promConversationDeliveryStatusUpdateFailedTotal.Inc()
+}
+
+promConversationReplySendTotal.WithLabelValues("success").Inc()
+log.Debugf("Sent conversation reply.")
+```
+
+Add the constant `deliveryStatusUpdateRetryDelay = 100 * time.Millisecond` near other timeouts.
+
+**Step 4: Run** — `go test ./pkg/messagehandler/... -v` — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/messagehandler/event.go bin-ai-manager/pkg/messagehandler/event_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: EventPMMessageBotLLM AICall-conversation branch persists with delivery_status='pending' and only updates to 'delivered' after a successful conversation send (with one 100ms retry on the update). A guard-#2 failure or send failure leaves the row 'pending' so the backstop will fire.
+EOF
+)"
+```
+
+### Task 2.9: Add `promConversationDeliveryStatusUpdateFailedTotal` metric
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/metrics.go` (or wherever `promConversationReplySendTotal` lives)
+
+**Step 1: Write the failing test**
+
+```go
+func TestPromConversationDeliveryStatusUpdateFailedTotal_registered(t *testing.T) {
+    if !metricRegistered("ai_manager_message_delivery_status_update_failed_total") {
+        t.Fatal("metric not registered")
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement**
+
+```go
+promConversationDeliveryStatusUpdateFailedTotal = promauto.NewCounter(prometheus.CounterOpts{
+    Name: "ai_manager_message_delivery_status_update_failed_total",
+    Help: "Counter of post-send delivery_status updates that failed even after one retry.",
+})
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/messagehandler/metrics.go bin-ai-manager/pkg/messagehandler/metrics_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add Prometheus counter ai_manager_message_delivery_status_update_failed_total
+EOF
+)"
+```
+
+### Task 2.10: Add `EventPMPipecatcallTerminated` to MessageHandler interface
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/main.go` (interface)
+- Regenerate mocks (no impl yet)
+
+**Step 1: Write the failing test**
+
+```go
+func TestMessageHandler_hasEventPMPipecatcallTerminated(t *testing.T) {
+    var _ interface {
+        EventPMPipecatcallTerminated(context.Context, *pmpipecatcall.Pipecatcall) error
+    } = (MessageHandler)(nil)
+}
+```
+
+**Step 2: Run** — FAIL (interface doesn't have the method).
+
+**Step 3: Implement** — add to the interface:
+
+```go
+EventPMPipecatcallTerminated(ctx context.Context, evt *pmpipecatcall.Pipecatcall) error
+```
+
+Add a stub to the impl:
+
+```go
+func (h *messageHandler) EventPMPipecatcallTerminated(ctx context.Context, evt *pmpipecatcall.Pipecatcall) error {
+    return errors.New("not implemented") // implementation in Task 2.11
+}
+```
+
+Regenerate mocks: `go generate ./pkg/messagehandler/...`.
+
+**Step 4: Run** — PASS (interface check), other tests still green (the stub returns an error but no caller invokes it yet).
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/messagehandler/main.go bin-ai-manager/pkg/messagehandler/mock_main.go bin-ai-manager/pkg/messagehandler/main_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Declare MessageHandler.EventPMPipecatcallTerminated interface method (stub impl) so mockgen regenerates; real impl lands in the next commit
+EOF
+)"
+```
+
+### Task 2.11: Add `promBackstopReplyTotal` metric
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/aicallhandler/metrics.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestPromBackstopReplyTotal_registered(t *testing.T) {
+    if !metricRegistered("ai_manager_aicall_backstop_reply_total") {
+        t.Fatal("metric not registered")
+    }
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement**
+
+```go
+promBackstopReplyTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+    Name: "ai_manager_aicall_backstop_reply_total",
+    Help: "Counter of pipecatcall_terminated backstop attempts in messagehandler.EventPMPipecatcallTerminated.",
+}, []string{"result"})
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/aicallhandler/metrics.go bin-ai-manager/pkg/aicallhandler/metrics_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add Prometheus counter ai_manager_aicall_backstop_reply_total{result}
+EOF
+)"
+```
+
+### Task 2.12: Implement `EventPMPipecatcallTerminated` handler
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/event_pm.go` (or `event.go`, wherever `EventPMMessageBotLLM` lives)
+- Test: `bin-ai-manager/pkg/messagehandler/event_pm_test.go`
+
+**Step 1: Write the failing tests** — one per result label:
+
+```go
+func TestEventPMPipecatcallTerminated(t *testing.T) {
+    cases := []struct{
+        name           string
+        evRefType      pmpipecatcall.ReferenceType
+        aicallRefType  amaicall.ReferenceType
+        aicallStatus   amaicall.Status
+        replyExists    bool
+        sendOK         bool
+        wantResultLabel string
+        wantSendCalls  int
+    }{
+        {"skipped_not_aicall",  pmpipecatcall.ReferenceTypeCall, "", "", false, false, "skipped_not_aicall", 0},
+        {"skipped_voice",       pmpipecatcall.ReferenceTypeAICall, amaicall.ReferenceTypeCall, amaicall.StatusProgressing, false, false, "skipped_voice", 0},
+        {"skipped_terminated",  pmpipecatcall.ReferenceTypeAICall, amaicall.ReferenceTypeConversation, amaicall.StatusTerminated, false, false, "skipped_terminated", 0},
+        {"skipped_seen",        pmpipecatcall.ReferenceTypeAICall, amaicall.ReferenceTypeConversation, amaicall.StatusProgressing, true,  false, "skipped_seen", 0},
+        {"sent",                pmpipecatcall.ReferenceTypeAICall, amaicall.ReferenceTypeConversation, amaicall.StatusProgressing, false, true,  "sent", 1},
+        {"send_failed",         pmpipecatcall.ReferenceTypeAICall, amaicall.ReferenceTypeConversation, amaicall.StatusProgressing, false, false, "send_failed", 1},
+        {"failed",              /* DB Create returns error */ ...},
+    }
+    // Setup gomock per branch; assert metric label + ConversationV1MessageSend call count.
+}
+```
+
+For grace delay testing, inject a fake sleep — e.g., a package-level `var backstopGraceSleep = time.Sleep` that tests override.
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `event_pm.go` (replacing the stub):
+
+```go
+const (
+    backstopGraceDelay = 3 * time.Second
+    backstopReplyText  = "Sorry, I'm having trouble responding right now. Please try again."
+)
+
+var backstopGraceSleep = time.Sleep // var so tests can patch
+
+func (h *messageHandler) EventPMPipecatcallTerminated(ctx context.Context, ev *pmpipecatcall.Pipecatcall) error {
+    log := logrus.WithFields(logrus.Fields{
+        "func":           "EventPMPipecatcallTerminated",
+        "pipecatcall_id": ev.ID,
+    })
+
+    if ev.ReferenceType != pmpipecatcall.ReferenceTypeAICall {
+        promBackstopReplyTotal.WithLabelValues("skipped_not_aicall").Inc()
+        return nil
+    }
+
+    aicall, err := h.reqHandler.AIV1AIcallGet(ctx, ev.ReferenceID)
+    if err != nil {
+        log.Errorf("Could not get aicall. err: %v", err)
+        return nil
+    }
+    if aicall.ReferenceType != amaicall.ReferenceTypeConversation {
+        promBackstopReplyTotal.WithLabelValues("skipped_voice").Inc()
+        return nil
+    }
+    if aicall.Status == amaicall.StatusTerminated {
+        promBackstopReplyTotal.WithLabelValues("skipped_terminated").Inc()
+        return nil
+    }
+
+    backstopGraceSleep(backstopGraceDelay)
+
+    seen, err := h.dbHandler.MessageAssistantReplyExists(ctx, ev.ID)
+    if err != nil {
+        return err
+    }
+    if seen {
+        promBackstopReplyTotal.WithLabelValues("skipped_seen").Inc()
+        return nil
+    }
+
+    msg, err := h.Create(ctx, uuid.Nil, aicall.CustomerID, aicall.ID, aicall.ActiveflowID,
+        message.DirectionIncoming, message.RoleAssistant, backstopReplyText, nil, "",
+        WithPipecatcallID(ev.ID),
+        WithDeliveryStatus(message.DeliveryStatusDelivered))
+    if err != nil {
+        promBackstopReplyTotal.WithLabelValues("failed").Inc()
+        return errors.Wrap(err, "could not persist backstop message")
+    }
+
+    if _, errSend := h.reqHandler.ConversationV1MessageSend(ctx, aicall.ReferenceID,
+        backstopReplyText, []cvmedia.Media{}); errSend != nil {
+        promBackstopReplyTotal.WithLabelValues("send_failed").Inc()
+        return errors.Wrap(errSend, "could not send backstop conversation reply")
+    }
+
+    promBackstopReplyTotal.WithLabelValues("sent").Inc()
+    log.WithField("message_id", msg.ID).Infof("Backstop reply sent. aicall_id: %s, pipecatcall_id: %s", aicall.ID, ev.ID)
+    return nil
+}
+```
+
+**Step 4: Run** — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/messagehandler/event_pm.go bin-ai-manager/pkg/messagehandler/event_pm_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Implement EventPMPipecatcallTerminated backstop handler with 7 result labels (sent | failed | send_failed | skipped_seen | skipped_voice | skipped_terminated | skipped_not_aicall). Persists the backstop reply with delivery_status='delivered' before sending so replays of the same event short-circuit on AssistantReplyExists.
+EOF
+)"
+```
+
+### Task 2.13: Wire the new event into `subscribehandler`
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall.go` (add adapter)
+- Modify: `bin-ai-manager/pkg/subscribehandler/main.go` (dispatch case)
+- Test: `bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+func TestProcessEventPMPipecatcallTerminated_dispatches(t *testing.T) {
+    h, mockMH := newTestSubscribeHandler(t)
+    pc := &pmpipecatcall.Pipecatcall{ID: uuid.Must(uuid.NewV4())}
+    raw, _ := json.Marshal(pc)
+    ev := &sock.Event{Type: pmpipecatcall.EventTypePipecatcallTerminated, Data: raw}
+    mockMH.EXPECT().EventPMPipecatcallTerminated(gomock.Any(), pc).Return(nil)
+    err := h.processEventPMPipecatcallTerminated(ctx, ev)
+    require.NoError(t, err)
+}
+```
+
+**Step 2: Run** — FAIL.
+
+**Step 3: Implement** — in `subscribehandler/pipecat_pipecatcall.go`:
+
+```go
+func (h *subscribeHandler) processEventPMPipecatcallTerminated(ctx context.Context, m *sock.Event) error {
+    var pc pmpipecatcall.Pipecatcall
+    if err := json.Unmarshal(m.Data, &pc); err != nil {
+        return errors.Wrap(err, "could not unmarshal pipecatcall_terminated payload")
+    }
+    return h.messageHandler.EventPMPipecatcallTerminated(ctx, &pc)
+}
+```
+
+In `subscribehandler/main.go`, find the `switch (publisher, type)` block (~line 167-186) and add the case for `pmpipecatcall.EventTypePipecatcallTerminated`:
+
+```go
+case pmpipecatcall.EventTypePipecatcallTerminated:
+    return h.processEventPMPipecatcallTerminated(ctx, m)
+```
+
+**Step 4: Run** — `go test ./pkg/subscribehandler/... -v` — PASS.
+
+**Step 5: Commit**
+
+```bash
+git add bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall.go bin-ai-manager/pkg/subscribehandler/main.go bin-ai-manager/pkg/subscribehandler/pipecat_pipecatcall_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Add subscribehandler.processEventPMPipecatcallTerminated adapter and dispatch case so pipecat-manager's pipecatcall_terminated event reaches the new MessageHandler.EventPMPipecatcallTerminated backstop
+EOF
+)"
+```
+
+### Task 2.14: Verify Phase 2 fully
+
+**Step 1: Run the full verification workflow**
+
+```bash
+cd bin-ai-manager && \
+  go mod tidy && \
+  go mod vendor && \
+  go generate ./... && \
+  go test ./... && \
+  golangci-lint run -v --timeout 5m
+```
+
+Expected: all green.
+
+**Step 2: Race detector**
+
+```bash
+cd bin-ai-manager && go test -race ./pkg/messagehandler/... ./pkg/subscribehandler/... ./pkg/aicallhandler/... ./pkg/dbhandler/...
+```
+
+Expected: PASS.
+
+**Step 3: Commit any housekeeping**
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+NOJIRA-aicall-terminate-drop-design
+
+- bin-ai-manager: Run go mod tidy + go mod vendor + go generate after Phase 2 changes
+EOF
+)" 2>/dev/null || echo "no changes to commit"
+```
+
+---
+
+## Final integration check
+
+### Task 3.1: Cross-service verification
+
+**Step 1: Build both services from a clean checkout**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-aicall-terminate-drop-design
+for svc in bin-pipecat-manager bin-ai-manager; do
+  echo "=== $svc ==="
+  cd "$svc" && go build ./... && cd -
+done
+```
+
+Expected: clean compile for both.
+
+**Step 2: Confirm no untracked files**
+
+```bash
+git status --short
+```
+
+Expected: empty (or only the design+plan docs).
+
+**Step 3: Pull latest main and check for conflicts** (per root CLAUDE.md mandatory rule):
+
+```bash
+git fetch origin main
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)" || echo "no conflicts"
+git log --oneline HEAD..origin/main
+```
+
+If conflicts exist, rebase and re-run the verification workflow before opening a PR.
+
+**Step 4: Push and open PR**
+
+```bash
+git push -u origin NOJIRA-aicall-terminate-drop-design
+gh pr create --title "NOJIRA-aicall-terminate-drop-design" --body "$(cat <<'EOF'
+Recover AIcall replies that today are silently dropped when the LLM stream stalls or the pipecatcall terminates mid-stream. Add a user-visible fallback for the worst-case path where no LLM event ever lands.
+
+- bin-pipecat-manager: New EventTypePipecatcallTerminated; flushAndFinalize on terminate; idle watchdog with first-token guard; SessionStop cancels pc.Ctx; atomic StopReason + sync.Once for safe close attribution; three new Prometheus counters
+- bin-ai-manager: New ai_messages.pipecatcall_id and ai_messages.delivery_status columns; persist-then-update flow in EventPMMessageBotLLM; CreateOption functional options; EventPMPipecatcallTerminated backstop handler with 7 result labels; new ai_manager_aicall_backstop_reply_total metric
+- bin-dbscheme-manager: Alembic migration adding the two columns and composite index idx_ai_messages_pcc_delivery
+EOF
+)"
+```
+
+(Do **not** merge without explicit user authorization. Per root CLAUDE.md, all PRs MUST use squash merge.)
+
+---
+
+## Notes for the executor
+
+- **Tests first, every time.** No "I'll write the test after." If you skip a test, you skip a row in the validation matrix.
+- **One commit per task.** Each commit corresponds to a row in the design's touch-points table.
+- **Run `go test -race` after every change** that touches concurrent code paths (Tasks 1.3, 1.6, 1.7, 1.9, 1.10, 1.13). Atomics and channels are easy to get subtly wrong.
+- **Don't run Alembic upgrade.** Phase 0's migration file is created but not applied — a human deploys it.
+- **Check the design doc** (`2026-04-29-aicall-terminate-drop-design.md`) when you're unsure about edge cases. The risk table in §5.5 is especially useful.
+- If a task's test setup references a helper that doesn't exist (`newTestSessionWithFlushArmed`, `metricRegistered`, etc.), introduce it as a first-class testing helper in a `_test_helpers.go` file (build-tag `//go:build test_helpers`) or simply `*_test.go`. Don't pollute production code.


### PR DESCRIPTION
Recover AIcall replies that today are silently dropped when the LLM stream stalls or the pipecatcall terminates mid-stream. Add a user-visible fallback for the worst-case path where no LLM event ever lands.

- bin-pipecat-manager: New EventTypePipecatcallTerminated; flushAndFinalize on terminate; idle watchdog with first-token guard; SessionStop cancels pc.Ctx; atomic StopReason + sync.Once for safe close attribution; three new Prometheus counters
- bin-ai-manager: New ai_messages.pipecatcall_id and ai_messages.delivery_status columns; persist-then-update flow in EventPMMessageBotLLM; CreateOption functional options; EventPMPipecatcallTerminated backstop handler with 7 result labels; new ai_manager_aicall_backstop_reply_total metric
- bin-dbscheme-manager: Alembic migration adding the two columns and composite index idx_ai_messages_pcc_delivery