### PR TITLE
NOJIRA-pipecat-team-resume-current-member

### DIFF
--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
@@ -217,7 +217,10 @@ func (h *pipecatcallHandler) resolveTeamForPython(
 
 // resolveAIFromAIcall resolves the AI entity from the AIcall's assistance type and ID.
 // For AssistanceTypeAI, AssistanceID is the AI ID directly.
-// For AssistanceTypeTeam, it fetches the team, finds the start member, and returns that member's AI.
+// For AssistanceTypeTeam, it returns the AI of the AIcall's CurrentMemberID when set
+// and present in the team's members; otherwise falls back to the team's StartMemberID.
+// This mirrors the resume-at-current-member logic in resolveTeamForPython so callers
+// (e.g., LLM key derivation in start.go) get the correct member's AI on resume.
 func (h *pipecatcallHandler) resolveAIFromAIcall(ctx context.Context, c *amaicall.AIcall) (*amai.AI, error) {
 	switch c.AssistanceType {
 	case amaicall.AssistanceTypeTeam:
@@ -226,13 +229,23 @@ func (h *pipecatcallHandler) resolveAIFromAIcall(ctx context.Context, c *amaical
 			return nil, err
 		}
 
-		// find the start member's AI ID
+		// Pick the member to resolve: CurrentMemberID if valid, else StartMemberID.
+		targetMemberID := team.StartMemberID
+		if c.CurrentMemberID != uuid.Nil {
+			for _, m := range team.Members {
+				if m.ID == c.CurrentMemberID {
+					targetMemberID = c.CurrentMemberID
+					break
+				}
+			}
+		}
+
 		for _, m := range team.Members {
-			if m.ID == team.StartMemberID {
+			if m.ID == targetMemberID {
 				return h.requestHandler.AIV1AIGet(ctx, m.AIID)
 			}
 		}
-		return nil, fmt.Errorf("could not find start member in team. team_id: %s, start_member_id: %s", c.AssistanceID, team.StartMemberID)
+		return nil, fmt.Errorf("could not find target member in team. team_id: %s, target_member_id: %s", c.AssistanceID, targetMemberID)
 
 	default:
 		// AssistanceTypeAI or any other: AssistanceID is the AI ID

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
@@ -147,9 +147,24 @@ func (h *pipecatcallHandler) resolveTeamForPython(
 	}
 	logrus.WithField("team", team).Debugf("Retrieved team info. team_id: %s", team.ID)
 
+	// Resume the team flow at the AIcall's CurrentMemberID if it's set and valid.
+	// Otherwise fall back to the team's StartMemberID. Without this, every new
+	// pipecatcall (one per user turn) starts at StartMemberID and the LLM has to
+	// re-invoke the transition tool, producing a brief reply from the wrong member
+	// before each turn's intended member responds.
+	startMemberID := team.StartMemberID
+	if c.CurrentMemberID != uuid.Nil {
+		for _, m := range team.Members {
+			if m.ID == c.CurrentMemberID {
+				startMemberID = c.CurrentMemberID
+				break
+			}
+		}
+	}
+
 	resolved := &resolvedTeamData{
 		ID:            team.ID,
-		StartMemberID: team.StartMemberID,
+		StartMemberID: startMemberID,
 		Members:       []resolvedMemberData{},
 	}
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
@@ -311,6 +311,59 @@ func Test_resolveAIFromAIcall(t *testing.T) {
 
 			expectedAIID: aiID,
 		},
+		{
+			name: "assistance type team resolves via current member when set",
+
+			aicall: &amaicall.AIcall{
+				AssistanceType:  amaicall.AssistanceTypeTeam,
+				AssistanceID:    teamID,
+				CurrentMemberID: memberID, // not the team's StartMemberID
+			},
+
+			prepareMockFn: func(mockReq *requesthandler.MockRequestHandler) {
+				otherStartID := uuid.FromStringOrNil("c5c5c5c5-5555-5555-5555-555555555555")
+				otherAIID := uuid.FromStringOrNil("d5d5d5d5-5555-5555-5555-555555555555")
+				mockReq.EXPECT().AIV1TeamGet(gomock.Any(), teamID).Return(&amateam.Team{
+					Identity:      commonidentity.Identity{ID: teamID},
+					StartMemberID: otherStartID,
+					Members: []amateam.Member{
+						{ID: otherStartID, AIID: otherAIID},
+						{ID: memberID, AIID: memberAIID},
+					},
+				}, nil)
+				mockReq.EXPECT().AIV1AIGet(gomock.Any(), memberAIID).Return(&amai.AI{
+					Identity:  commonidentity.Identity{ID: memberAIID},
+					EngineKey: "current-member-key",
+				}, nil)
+			},
+
+			expectedAIID: memberAIID,
+		},
+		{
+			name: "assistance type team with stale current_member_id falls back to start member",
+
+			aicall: &amaicall.AIcall{
+				AssistanceType:  amaicall.AssistanceTypeTeam,
+				AssistanceID:    teamID,
+				CurrentMemberID: uuid.FromStringOrNil("ffffffff-ffff-ffff-ffff-ffffffffffff"), // not in team
+			},
+
+			prepareMockFn: func(mockReq *requesthandler.MockRequestHandler) {
+				mockReq.EXPECT().AIV1TeamGet(gomock.Any(), teamID).Return(&amateam.Team{
+					Identity:      commonidentity.Identity{ID: teamID},
+					StartMemberID: memberID,
+					Members: []amateam.Member{
+						{ID: memberID, AIID: memberAIID},
+					},
+				}, nil)
+				mockReq.EXPECT().AIV1AIGet(gomock.Any(), memberAIID).Return(&amai.AI{
+					Identity:  commonidentity.Identity{ID: memberAIID},
+					EngineKey: "fallback-key",
+				}, nil)
+			},
+
+			expectedAIID: memberAIID,
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
@@ -637,6 +637,109 @@ func Test_resolveTeamForPython(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "current_member_id overrides team start_member_id when valid",
+
+			aicall: &amaicall.AIcall{
+				AssistanceType:  amaicall.AssistanceTypeTeam,
+				AssistanceID:    teamID,
+				CurrentMemberID: member2ID, // not the team's StartMemberID
+			},
+
+			prepareMockFn: func(mockReq *requesthandler.MockRequestHandler, mockTool *toolhandler.MockToolHandler) {
+				mockReq.EXPECT().AIV1TeamGet(gomock.Any(), teamID).Return(&amateam.Team{
+					Identity:      commonidentity.Identity{ID: teamID},
+					StartMemberID: member1ID, // team's start
+					Members: []amateam.Member{
+						{ID: member1ID, Name: "greeter", AIID: ai1ID},
+						{ID: member2ID, Name: "support", AIID: ai2ID},
+					},
+				}, nil)
+				mockReq.EXPECT().AIV1AIGet(gomock.Any(), ai1ID).Return(&amai.AI{
+					Identity:    commonidentity.Identity{ID: ai1ID},
+					EngineModel: amai.EngineModelOpenaiGPT5,
+					EngineKey:   "key-1",
+					InitPrompt:  "You are a greeter",
+				}, nil)
+				mockReq.EXPECT().AIV1AIGet(gomock.Any(), ai2ID).Return(&amai.AI{
+					Identity:    commonidentity.Identity{ID: ai2ID},
+					EngineModel: amai.EngineModelOpenaiGPT5,
+					EngineKey:   "key-2",
+					InitPrompt:  "You are support",
+				}, nil)
+				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{}).Times(2)
+			},
+
+			validate: func(t *testing.T, result *resolvedTeamData) {
+				if result.StartMemberID != member2ID {
+					t.Errorf("Expected StartMemberID to override to current_member_id %s, got %s", member2ID, result.StartMemberID)
+				}
+			},
+		},
+		{
+			name: "current_member_id falls back to team start_member_id when not in team",
+
+			aicall: &amaicall.AIcall{
+				AssistanceType:  amaicall.AssistanceTypeTeam,
+				AssistanceID:    teamID,
+				CurrentMemberID: uuid.FromStringOrNil("ffffffff-ffff-ffff-ffff-ffffffffffff"), // stale id
+			},
+
+			prepareMockFn: func(mockReq *requesthandler.MockRequestHandler, mockTool *toolhandler.MockToolHandler) {
+				mockReq.EXPECT().AIV1TeamGet(gomock.Any(), teamID).Return(&amateam.Team{
+					Identity:      commonidentity.Identity{ID: teamID},
+					StartMemberID: member1ID,
+					Members: []amateam.Member{
+						{ID: member1ID, Name: "greeter", AIID: ai1ID},
+					},
+				}, nil)
+				mockReq.EXPECT().AIV1AIGet(gomock.Any(), ai1ID).Return(&amai.AI{
+					Identity:    commonidentity.Identity{ID: ai1ID},
+					EngineModel: amai.EngineModelOpenaiGPT5,
+					EngineKey:   "key-1",
+					InitPrompt:  "You are a greeter",
+				}, nil)
+				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{})
+			},
+
+			validate: func(t *testing.T, result *resolvedTeamData) {
+				if result.StartMemberID != member1ID {
+					t.Errorf("Expected StartMemberID to fall back to team's start %s, got %s", member1ID, result.StartMemberID)
+				}
+			},
+		},
+		{
+			name: "current_member_id zero falls back to team start_member_id",
+
+			aicall: &amaicall.AIcall{
+				AssistanceType: amaicall.AssistanceTypeTeam,
+				AssistanceID:   teamID,
+				// CurrentMemberID intentionally zero
+			},
+
+			prepareMockFn: func(mockReq *requesthandler.MockRequestHandler, mockTool *toolhandler.MockToolHandler) {
+				mockReq.EXPECT().AIV1TeamGet(gomock.Any(), teamID).Return(&amateam.Team{
+					Identity:      commonidentity.Identity{ID: teamID},
+					StartMemberID: member1ID,
+					Members: []amateam.Member{
+						{ID: member1ID, Name: "greeter", AIID: ai1ID},
+					},
+				}, nil)
+				mockReq.EXPECT().AIV1AIGet(gomock.Any(), ai1ID).Return(&amai.AI{
+					Identity:    commonidentity.Identity{ID: ai1ID},
+					EngineModel: amai.EngineModelOpenaiGPT5,
+					EngineKey:   "key-1",
+					InitPrompt:  "You are a greeter",
+				}, nil)
+				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{})
+			},
+
+			validate: func(t *testing.T, result *resolvedTeamData) {
+				if result.StartMemberID != member1ID {
+					t.Errorf("Expected StartMemberID to default to team's start %s, got %s", member1ID, result.StartMemberID)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix a team-mode bug surfaced after the previous deploy: every new pipecatcall (one per user turn) was restarting at the team's StartMemberID, so the LLM kept producing a brief reply from the General Assistant before transitioning to whichever member the conversation had previously moved to.

- bin-pipecat-manager: resolveTeamForPython now resumes the team flow at the AIcall's CurrentMemberID when set and present in the team's members; falls back to team.StartMemberID when CurrentMemberID is zero or stale. Three new unit tests cover override, fallback-on-stale-id, and fallback-on-zero.