### PR TITLE
NOJIRA-Update-doc-routing-and-error-naming-convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,32 +233,45 @@ The RST documentation at `bin-api-manager/docsdev/source/` is what customers, de
 
 ## Where to Document New Information
 
-Use this decision tree when adding new documentation:
+The `docs/` directory is the **live, authoritative shared documentation** for the monorepo. Subdirectories evolve over time — new categories may be added at any time.
 
-**Does this apply to ALL services in the monorepo?**
-- **YES** → Add to Root CLAUDE.md
-  - Examples:
-    - New verification step required for all services
-    - New git workflow rule
-    - New shared pattern from bin-common-handler
-    - Changes to RabbitMQ communication pattern
+**Before adding new documentation, ALWAYS run `ls docs/` and `ls docs/<subdir>/` to inspect the current state of categories.** Do not rely on a memorized list — the categories listed below are a snapshot, not an exhaustive contract. If a topic clearly fits an existing category, place it there. If no category fits, propose a new `docs/<category>/` subdirectory with a brief `README.md`, and update this decision tree in the same change.
 
-**NO → Does it affect 2+ services?**
-  - **YES → Is it a workflow spanning services?**
-    - **YES** → Add to `docs/workflows/` (or root CLAUDE.md if it's a CRITICAL safety rail)
-      - Example: "Adding a New API Endpoint" (touches openapi-manager + api-manager + target service)
-    - **NO → Is it a shared pattern/gotcha?**
-      - **YES** → Add to `docs/patterns/` (with reference implementation) or `docs/workflows/common-gotchas.md`
-        - Example: "Parsing Filters from Request Body"
-      - **NO** → Add to each affected service's CLAUDE.md
-        - Example: How conference-manager and call-manager handle recordings
+Use this decision tree when adding new documentation, in order:
 
-  - **NO** → Add to Service-Specific CLAUDE.md
-    - Examples:
-      - Service-specific API endpoints
-      - Handler patterns unique to this service
-      - Service-specific testing approaches
-      - Domain-specific implementation details
+**1. Is it a coding/style/language convention or pattern that applies broadly to Go code in this monorepo?**
+- **YES** → Add to `docs/conventions/<topic>.md`
+  - Examples: error handling rules (e.g. variable naming in if-init blocks), import grouping, naming conventions, package structure, testing patterns, RPC conventions, database patterns
+  - Current files (run `ls docs/conventions/` to confirm): package-structure, naming, imports, error-handling, logging, models, database, handlers, rpc, api-design, events, configuration, testing, metrics, security, direct-resource-types
+
+**2. Is it an architectural detail (service boundaries, inter-service communication, deployment topology, dependency graph)?**
+- **YES** → Add to `docs/architecture/<topic>.md`
+
+**3. Is it a workflow spanning services (git, verification, deployment, multi-service feature work)?**
+- **YES** → Add to `docs/workflows/<topic>.md`
+  - Promote to root CLAUDE.md if it is a CRITICAL safety rail (e.g. mandatory verification step, branch protection rule)
+  - Example: "Adding a New API Endpoint" (touches openapi-manager + api-manager + target service)
+
+**4. Is it a shared infrastructure pattern with a reference implementation (circuit breaker, liveness preflight, WebhookMessage, per-pod queues)?**
+- **YES** → Add to `docs/patterns/<topic>.md`
+  - For one-off cross-cutting gotchas without a reference implementation, use `docs/workflows/common-gotchas.md` instead
+  - Example: "Parsing Filters from Request Body"
+
+**5. Is it reference material (queue catalog, glossary, service CLAUDE.md template, code-quality standards)?**
+- **YES** → Add to `docs/reference/<topic>.md`
+
+**6. Is it a dated design document or implementation plan for a non-trivial change?**
+- **YES** → Add to `docs/plans/YYYY-MM-DD-<topic>-design.md` (or `-plan.md` for execution plans)
+
+**7. Is it specific to one service?**
+- **YES** → Add to that service's `<service>/CLAUDE.md`
+  - Examples: service-specific API endpoints, handler patterns unique to this service, domain-specific implementation details
+
+**8. Otherwise — does it apply universally to ALL services AND is it a CRITICAL safety rail?**
+- **YES** → Add to root CLAUDE.md
+  - Examples: mandatory verification step required for all services, repo-wide git workflow rule, change to RabbitMQ communication pattern
+
+**Maintenance rule:** Whenever a new `docs/<subdir>/` is introduced (or removed), update this decision tree **and** the "Where to find things (index)" section above in the same change. Stale routing here is the most common failure mode — it sends new content to private memory or service CLAUDE.md files instead of the right shared category.
 
 ## Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,12 +216,12 @@ The RST documentation at `bin-api-manager/docsdev/source/` is what customers, de
 
 ## Where to find things (index)
 
-- **Architecture** → [docs/architecture/](docs/architecture/) — service categories, inter-service communication, deployment, dependencies
-- **Coding conventions** → [docs/conventions/](docs/conventions/) — package structure, naming, imports, errors, logging, models, database, handlers, RPC, API design, events, configuration, testing, metrics, security
-- **Workflows (git, verification, gotchas, dev)** → [docs/workflows/](docs/workflows/) — git workflow, verification, common workflows, special cases, development guide, common gotchas
-- **Shared patterns (CB, liveness preflight, WebhookMessage, ...)** → [docs/patterns/](docs/patterns/) — applied infrastructure patterns with reference implementations
-- **Reference (queues, glossary, service CLAUDE.md template)** → [docs/reference/](docs/reference/) — RabbitMQ queues, code-quality checklist, service CLAUDE.md template
-- **Plans (designs/plans)** → [docs/plans/](docs/plans/) — dated design documents and implementation plans
+- **Architecture** → [docs/architecture/](docs/architecture/) — service boundaries, inter-service communication, deployment topology, dependency graph
+- **Coding conventions** → [docs/conventions/](docs/conventions/) — Go coding rules (package structure, naming, errors, logging, database, handlers, testing, ...). Run `ls docs/conventions/` for the current set.
+- **Workflows** → [docs/workflows/](docs/workflows/) — git, verification, multi-service feature workflows, common gotchas
+- **Shared patterns** → [docs/patterns/](docs/patterns/) — applied infrastructure patterns with reference implementations (e.g. circuit breaker, WebhookMessage)
+- **Reference** → [docs/reference/](docs/reference/) — queue catalog, service CLAUDE.md template, code-quality standards
+- **Plans** → [docs/plans/](docs/plans/) — dated design documents and implementation plans
 
 ## Grafana Dashboards
 
@@ -241,8 +241,8 @@ Use this decision tree when adding new documentation, in order:
 
 **1. Is it a coding/style/language convention or pattern that applies broadly to Go code in this monorepo?**
 - **YES** → Add to `docs/conventions/<topic>.md`
-  - Examples: error handling rules (e.g. variable naming in if-init blocks), import grouping, naming conventions, package structure, testing patterns, RPC conventions, database patterns
-  - Current files (run `ls docs/conventions/` to confirm): package-structure, naming, imports, error-handling, logging, models, database, handlers, rpc, api-design, events, configuration, testing, metrics, security, direct-resource-types
+  - Examples: error-handling rules (e.g. variable naming in if-init blocks), import grouping, naming conventions, package structure, testing patterns, RPC conventions, database patterns
+  - **Run `ls docs/conventions/` to see current files** — the set evolves; do not rely on a memorized list
 
 **2. Is it an architectural detail (service boundaries, inter-service communication, deployment topology, dependency graph)?**
 - **YES** → Add to `docs/architecture/<topic>.md`
@@ -252,12 +252,12 @@ Use this decision tree when adding new documentation, in order:
   - Promote to root CLAUDE.md if it is a CRITICAL safety rail (e.g. mandatory verification step, branch protection rule)
   - Example: "Adding a New API Endpoint" (touches openapi-manager + api-manager + target service)
 
-**4. Is it a shared infrastructure pattern with a reference implementation (circuit breaker, liveness preflight, WebhookMessage, per-pod queues)?**
+**4. Is it a shared infrastructure pattern with a reference implementation (e.g. circuit breaker, WebhookMessage)?**
 - **YES** → Add to `docs/patterns/<topic>.md`
   - For one-off cross-cutting gotchas without a reference implementation, use `docs/workflows/common-gotchas.md` instead
   - Example: "Parsing Filters from Request Body"
 
-**5. Is it reference material (queue catalog, glossary, service CLAUDE.md template, code-quality standards)?**
+**5. Is it reference material (queue catalog, service CLAUDE.md template, code-quality standards)?**
 - **YES** → Add to `docs/reference/<topic>.md`
 
 **6. Is it a dated design document or implementation plan for a non-trivial change?**
@@ -271,7 +271,7 @@ Use this decision tree when adding new documentation, in order:
 - **YES** → Add to root CLAUDE.md
   - Examples: mandatory verification step required for all services, repo-wide git workflow rule, change to RabbitMQ communication pattern
 
-**Maintenance rule:** Whenever a new `docs/<subdir>/` is introduced (or removed), update this decision tree **and** the "Where to find things (index)" section above in the same change. Stale routing here is the most common failure mode — it sends new content to private memory or service CLAUDE.md files instead of the right shared category.
+**Maintenance rule:** Whenever a new `docs/<subdir>/` is introduced or removed, update this decision tree **and** the "Where to find things (index)" section above in the same change. The category descriptions in both sections are intentionally brief — they describe *kinds* of content, not exhaustive file lists, so adding individual files within an existing subdirectory does **not** require updating either section. Stale routing here is the most common failure mode — it sends new content to private memory or service CLAUDE.md files instead of the right shared category.
 
 ## Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,8 @@
 This directory holds VoIPbin engineering documentation. The index of categories and the "where to put new docs" decision tree live in [the root CLAUDE.md](../CLAUDE.md).
 
 - `architecture/` — system shape, service interactions
-- `conventions/` — coding standards (16 topic files, source of truth)
+- `conventions/` — coding standards, source of truth (run `ls conventions/` for the current set)
 - `workflows/` — git, verification, deployment, common tasks, gotchas
-- `patterns/` — applied infrastructure patterns (circuit breaker, per-pod liveness, etc.)
-- `reference/` — quick-lookup tables (queues, glossary, templates)
-- `plans/` — feature design docs and implementation plans (existing convention, unchanged)
+- `patterns/` — applied infrastructure patterns with reference implementations (e.g. circuit breaker, WebhookMessage)
+- `reference/` — quick-lookup tables (queue catalog, service CLAUDE.md template, code-quality standards)
+- `plans/` — feature design docs and implementation plans

--- a/docs/conventions/error-handling.md
+++ b/docs/conventions/error-handling.md
@@ -104,6 +104,51 @@ if err != nil {
 log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 ```
 
+## 4.5 Error Variable Naming in If-Init Blocks
+
+When using Go's if-init form for a single-error-returning call, name the error variable after the action being performed (e.g. `errCreate`, `errUpdate`, `errFetch`) — never the generic `err`.
+
+**Correct:**
+
+```go
+if errCreate := h.db.ConversationCreate(ctx, tmp); errCreate != nil {
+    return errors.Wrapf(errCreate, "could not create conversation")
+}
+
+if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, activeflowID, variables); errSet != nil {
+    return errors.Wrapf(errSet, "could not set variables")
+}
+
+if errExecute := h.reqHandler.FlowV1ActiveflowExecute(ctx, af.ID); errExecute != nil {
+    return errors.Wrapf(errExecute, "could not execute activeflow")
+}
+```
+
+**Wrong:**
+
+```go
+// generic err in if-init form — disallowed
+if err := h.db.ConversationCreate(ctx, tmp); err != nil {
+    return errors.Wrapf(err, "could not create conversation")
+}
+```
+
+The rule applies specifically to the **if-init form** where the call and the nil check are on the same line. For multi-return calls split across two lines, the regular `err` is acceptable — the call itself is visible immediately above the check:
+
+```go
+// CORRECT — multi-return splits the variable from the check; generic err is fine
+res, err := h.handler.Create(ctx, ...)
+if err != nil {
+    return errors.Wrapf(err, "could not create resource")
+}
+```
+
+**Why:** Specific names make the error source obvious at a glance, especially when several if-init blocks appear close together. With `errSet` vs `errExecute`, a single glance at a stack trace, log line, or diff tells you which call failed; with two `err`s in a row, you must read the surrounding context.
+
+**How to apply:**
+- Pick the verb of the call, prefixed with `err`. Common forms: `errGet`, `errCreate`, `errUpdate`, `errDelete`, `errSet`, `errSend`, `errPublish`, `errMarshal`, `errUnmarshal`, `errExecute`, `errValidate`, `errFetch`, `errParse`, `errStart`, `errStop`.
+- Apply repo-wide to **all Go services** in this monorepo. No per-service exceptions.
+
 ---
 
 ## Common Error Scenarios

--- a/docs/conventions/error-handling.md
+++ b/docs/conventions/error-handling.md
@@ -133,13 +133,18 @@ if err := h.db.ConversationCreate(ctx, tmp); err != nil {
 }
 ```
 
-The rule applies specifically to the **if-init form** where the call and the nil check are on the same line. For multi-return calls split across two lines, the regular `err` is acceptable — the call itself is visible immediately above the check:
+The rule targets the **single-return if-init form** specifically — `if errVerb := call(); errVerb != nil`. The following forms keep the regular `err`:
 
 ```go
-// CORRECT — multi-return splits the variable from the check; generic err is fine
+// CORRECT — multi-return split across two lines; the call is visible immediately above the check
 res, err := h.handler.Create(ctx, ...)
 if err != nil {
     return errors.Wrapf(err, "could not create resource")
+}
+
+// CORRECT — multi-return if-init (the value is bound and used inside the block); generic err is fine
+if t, err := time.Parse(layout, raw); err == nil {
+    return t
 }
 ```
 
@@ -237,8 +242,8 @@ func (h *subscribeHandler) processEvent(e *sock.Event) error {
         "type": e.Type,
     })
 
-    if err := h.handleEvent(ctx, e); err != nil {
-        log.Errorf("Could not process event: %v", err)
+    if errHandle := h.handleEvent(ctx, e); errHandle != nil {
+        log.Errorf("Could not process event: %v", errHandle)
         // Return nil to acknowledge message (don't requeue)
         return nil
     }

--- a/docs/conventions/error-handling.md
+++ b/docs/conventions/error-handling.md
@@ -104,7 +104,7 @@ if err != nil {
 log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 ```
 
-## 4.5 Error Variable Naming in If-Init Blocks
+## 4.5 Error Variable Naming in Single-Return If-Init Blocks
 
 When using Go's if-init form for a single-error-returning call, name the error variable after the action being performed (e.g. `errCreate`, `errUpdate`, `errFetch`) — never the generic `err`.
 


### PR DESCRIPTION
Tighten the doc-routing decision tree in the root CLAUDE.md so every docs/ subdirectory is an explicit destination, and add the err<SpecificName> naming convention for Go if-init blocks to docs/conventions/error-handling.md.

- monorepo: Replace "Where to Document New Information" decision tree to cover all current docs/ subdirectories (conventions, architecture, workflows, patterns, reference, plans), service-specific CLAUDE.md, and root CLAUDE.md
- monorepo: Add header note instructing engineers to run "ls docs/" before adding new docs because categories evolve
- monorepo: Add maintenance rule requiring the decision tree and the index to be updated in sync whenever docs/ subdirectories change
- monorepo: Add docs/conventions/error-handling.md §4.5 covering the err<SpecificName> rule for Go if-init blocks, with examples, the multi-return exception, the rationale, and a list of common verb prefixes