### PR TITLE
NOJIRA-ServiceAgent-conversation-permission

### DIFF
--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversation.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversation.go
@@ -26,7 +26,8 @@ func (h *serviceHandler) ServiceAgentConversationGet(ctx context.Context, a *aut
 		return nil, errors.Wrapf(err, "Could not get conversation.")
 	}
 
-	if tmp.OwnerID != a.AgentID() {
+	isAdminOrManager := h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager)
+	if !isAdminOrManager && tmp.OwnerID != a.AgentID() {
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
@@ -46,10 +47,15 @@ func (h *serviceHandler) ServiceAgentConversationList(ctx context.Context, a *au
 		token = h.utilHandler.TimeGetCurTime()
 	}
 
-	// filters
+	// Admin and manager callers see all conversations for their customer.
+	// Regular agents see only conversations they own.
 	filters := map[cvconversation.Field]any{
 		cvconversation.FieldDeleted: false,
-		cvconversation.FieldOwnerID: a.AgentID(),
+	}
+	if h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		filters[cvconversation.FieldCustomerID] = a.CustomerID
+	} else {
+		filters[cvconversation.FieldOwnerID] = a.AgentID()
 	}
 
 	tmps, err := h.conversationList(ctx, a, size, token, filters)

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go
@@ -27,6 +27,7 @@ func Test_ServiceAgentConversationGet(t *testing.T) {
 		conversationID uuid.UUID
 
 		responseConversation *cvconversation.Conversation
+		expectErr            error
 		expectRes            *cvconversation.WebhookMessage
 	}
 
@@ -122,6 +123,52 @@ func Test_ServiceAgentConversationGet(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "regular agent denied for conversation it does not own",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			conversationID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+
+			responseConversation: &cvconversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerID: uuid.FromStringOrNil("aaaaaaaa-3b9f-11ef-98ac-db226570f09a"),
+				},
+			},
+			expectErr: serviceerrors.ErrPermissionDenied,
+		},
+		{
+			name: "admin denied for conversation in different customer",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaaaaaa-3b9f-11ef-98ac-db226570f09a"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+			conversationID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+
+			responseConversation: &cvconversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("cccccccc-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerID: uuid.FromStringOrNil("dddddddd-3b9f-11ef-98ac-db226570f09a"),
+				},
+			},
+			expectErr: serviceerrors.ErrPermissionDenied,
+		},
 	}
 
 	for _, tt := range tests {
@@ -141,6 +188,12 @@ func Test_ServiceAgentConversationGet(t *testing.T) {
 			mockReq.EXPECT().ConversationV1ConversationGet(ctx, tt.conversationID).Return(tt.responseConversation, nil)
 
 			res, err := h.ServiceAgentConversationGet(ctx, tt.agent, tt.conversationID)
+			if tt.expectErr != nil {
+				if !errors.Is(err, tt.expectErr) {
+					t.Errorf("Wrong error. expect: %v, got: %v", tt.expectErr, err)
+				}
+				return
+			}
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go
@@ -60,6 +60,68 @@ func Test_ServiceAgentConversationGet(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "admin gets conversation owned by another agent",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aaaaaaaa-3b9f-11ef-98ac-db226570f09a"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+			conversationID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+
+			responseConversation: &cvconversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+				},
+			},
+			expectRes: &cvconversation.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+				},
+			},
+		},
+		{
+			name: "manager gets conversation owned by another agent",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("bbbbbbbb-3b9f-11ef-98ac-db226570f09b"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Permission: amagent.PermissionCustomerManager,
+			}),
+			conversationID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+
+			responseConversation: &cvconversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+				},
+			},
+			expectRes: &cvconversation.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Owner: commonidentity.Owner{
+					OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -142,6 +204,72 @@ func Test_ServiceAgentConversationList(t *testing.T) {
 						ID: uuid.FromStringOrNil("620bce9e-3ed2-11ef-b45a-3f6e2898153d"),
 					},
 				},
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("62a1ec8a-3ed2-11ef-bb8c-a788ea1ad2ad"),
+					},
+				},
+			},
+		},
+		{
+			name: "admin sees all conversations (no owner filter)",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+			size:  100,
+			token: "2021-03-01T01:00:00.995000Z",
+
+			responseConversations: []cvconversation.Conversation{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("620bce9e-3ed2-11ef-b45a-3f6e2898153d"),
+					},
+				},
+			},
+
+			expectFilters: map[cvconversation.Field]any{
+				cvconversation.FieldCustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				cvconversation.FieldDeleted:    false,
+			},
+			expectRes: []*cvconversation.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("620bce9e-3ed2-11ef-b45a-3f6e2898153d"),
+					},
+				},
+			},
+		},
+		{
+			name: "manager sees all conversations (no owner filter)",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09b"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				},
+				Permission: amagent.PermissionCustomerManager,
+			}),
+			size:  100,
+			token: "2021-03-01T01:00:00.995000Z",
+
+			responseConversations: []cvconversation.Conversation{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("62a1ec8a-3ed2-11ef-bb8c-a788ea1ad2ad"),
+					},
+				},
+			},
+
+			expectFilters: map[cvconversation.Field]any{
+				cvconversation.FieldCustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+				cvconversation.FieldDeleted:    false,
+			},
+			expectRes: []*cvconversation.WebhookMessage{
 				{
 					Identity: commonidentity.Identity{
 						ID: uuid.FromStringOrNil("62a1ec8a-3ed2-11ef-bb8c-a788ea1ad2ad"),

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go
@@ -46,7 +46,8 @@ func Test_ServiceAgentConversationGet(t *testing.T) {
 
 			responseConversation: &cvconversation.Conversation{
 				Identity: commonidentity.Identity{
-					ID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
 				},
 				Owner: commonidentity.Owner{
 					OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
@@ -54,7 +55,8 @@ func Test_ServiceAgentConversationGet(t *testing.T) {
 			},
 			expectRes: &cvconversation.WebhookMessage{
 				Identity: commonidentity.Identity{
-					ID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+					CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
 				},
 				Owner: commonidentity.Owner{
 					OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
@@ -217,6 +219,7 @@ func Test_ServiceAgentConversationList(t *testing.T) {
 		responseConversations []cvconversation.Conversation
 
 		expectFilters map[cvconversation.Field]any
+		expectErr     error
 		expectRes     []*cvconversation.WebhookMessage
 	}
 
@@ -330,6 +333,13 @@ func Test_ServiceAgentConversationList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "non-agent caller is rejected",
+			agent:     &auth.AuthIdentity{Type: auth.TypeAccesskey},
+			size:      10,
+			token:     "2021-03-01T01:00:00.995000Z",
+			expectErr: serviceerrors.ErrAuthenticationRequired,
+		},
 	}
 
 	for _, tt := range tests {
@@ -346,9 +356,17 @@ func Test_ServiceAgentConversationList(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			mockReq.EXPECT().ConversationV1ConversationList(ctx, tt.token, tt.size, tt.expectFilters).Return(tt.responseConversations, nil)
+			if tt.expectErr == nil {
+				mockReq.EXPECT().ConversationV1ConversationList(ctx, tt.token, tt.size, tt.expectFilters).Return(tt.responseConversations, nil)
+			}
 
 			res, err := h.ServiceAgentConversationList(ctx, tt.agent, tt.size, tt.token)
+			if tt.expectErr != nil {
+				if !errors.Is(err, tt.expectErr) {
+					t.Errorf("Wrong error. expect: %v, got: %v", tt.expectErr, err)
+				}
+				return
+			}
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_conversationmessage.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_conversationmessage.go
@@ -3,6 +3,7 @@ package servicehandler
 import (
 	"context"
 	"fmt"
+	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cvmedia "monorepo/bin-conversation-manager/models/media"
@@ -26,7 +27,8 @@ func (h *serviceHandler) ServiceAgentConversationMessageList(ctx context.Context
 		return nil, errors.Wrapf(err, "Could not get conversation.")
 	}
 
-	if cv.OwnerID != a.AgentID() {
+	isAdminOrManager := h.hasPermission(ctx, a, cv.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager)
+	if !isAdminOrManager && cv.OwnerID != a.AgentID() {
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
@@ -75,7 +77,8 @@ func (h *serviceHandler) ServiceAgentConversationMessageSend(
 		return nil, fmt.Errorf("%w: could not verify the conversation", err)
 	}
 
-	if c.OwnerID != a.AgentID() {
+	isAdminOrManager := h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager)
+	if !isAdminOrManager && c.OwnerID != a.AgentID() {
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 

--- a/docs/plans/2026-05-01-serviceagent-conversation-permission-design.md
+++ b/docs/plans/2026-05-01-serviceagent-conversation-permission-design.md
@@ -1,0 +1,58 @@
+# Design: Permission-Aware GET /service_agents/conversations
+
+**Date:** 2026-05-01
+**Branch:** NOJIRA-ServiceAgent-conversation-permission
+
+## Problem
+
+`GET /v1.0/service_agents/conversations` and `GET /v1.0/service_agents/conversations/{id}` always
+scope results to the calling agent's own owned conversations, regardless of the caller's permission
+level. Admin and manager agents cannot see conversations assigned to other agents or unassigned
+conversations via the service-agent path.
+
+## Goal
+
+Admin and manager callers at the service-agent endpoints should see all conversations belonging to
+their customer, matching the behaviour of the existing `/conversations` endpoint.
+
+## Approach: Direct in-place permission check (Approach A)
+
+### `ServiceAgentConversationList`
+
+**Before:** filter map always contains `{FieldDeleted: false, FieldOwnerID: a.AgentID()}`.
+
+**After:**
+
+| Caller | Filter map |
+|--------|-----------|
+| Regular agent (`PermissionCustomerAgent`) | `{FieldDeleted: false, FieldOwnerID: a.AgentID()}` (unchanged) |
+| Admin / Manager | `{FieldDeleted: false, FieldCustomerID: a.CustomerID}` (no owner restriction) |
+
+The `hasPermission(ctx, a, a.CustomerID, PermissionCustomerAdmin|PermissionCustomerManager)` guard
+is the gate — same call used by `ConversationGetsByCustomerID`.
+
+### `ServiceAgentConversationGet`
+
+**Before:** rejects the request if `conversation.OwnerID != a.AgentID()` unconditionally.
+
+**After:**
+- Admin / Manager: allowed if `conversation.CustomerID == a.CustomerID` (enforced via `hasPermission`).
+- Regular agent: still requires `conversation.OwnerID == a.AgentID()`.
+
+## Files changed
+
+- `bin-api-manager/pkg/servicehandler/serviceagent_conversation.go` — two functions modified
+- `bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go` — new test cases
+
+## Out of scope
+
+- No OpenAPI spec changes (no new params or response shape).
+- No RST doc changes (privilege expansion for existing callers, not a new API contract).
+- `ServiceAgentConversationUpdate` and `ServiceAgentConversationUnassign` already use
+  `hasPermission` correctly — no change needed.
+
+## Security notes
+
+- Cross-customer access remains impossible: `hasPermission` binds to `a.CustomerID`.
+- `PermissionProjectSuperAdmin` callers are handled transparently by `hasPermission` (they pass the
+  check for any customer).

--- a/docs/plans/2026-05-01-serviceagent-conversation-permission-plan.md
+++ b/docs/plans/2026-05-01-serviceagent-conversation-permission-plan.md
@@ -1,0 +1,327 @@
+# ServiceAgent Conversation Permission Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Admin and manager callers at `GET /service_agents/conversations` and `GET /service_agents/conversations/{id}` should see all conversations belonging to their customer, not just those they personally own.
+
+**Architecture:** Add a `hasPermission` guard in `ServiceAgentConversationList` and `ServiceAgentConversationGet` inside `bin-api-manager/pkg/servicehandler/serviceagent_conversation.go`. Admin/manager callers get a customer-scoped filter (or customer-level ownership check); regular agents keep the current owner-scoped behaviour. No OpenAPI or RST changes required.
+
+**Tech Stack:** Go, gomock (`go.uber.org/mock/gomock`), `bin-agent-manager/models/agent` permission constants.
+
+---
+
+### Task 1: Add failing tests for admin/manager in `ServiceAgentConversationList`
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go`
+
+**Step 1: Add two new test cases to `Test_ServiceAgentConversationList`**
+
+Insert after the existing `"normal"` case (after line 151, before the closing `}`):
+
+```go
+{
+    name: "admin sees all conversations (no owner filter)",
+
+    agent: auth.NewAgentIdentity(&amagent.Agent{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Permission: amagent.PermissionCustomerAdmin,
+    }),
+    size:  100,
+    token: "2021-03-01T01:00:00.995000Z",
+
+    responseConversations: []cvconversation.Conversation{
+        {
+            Identity: commonidentity.Identity{
+                ID: uuid.FromStringOrNil("620bce9e-3ed2-11ef-b45a-3f6e2898153d"),
+            },
+        },
+    },
+
+    expectFilters: map[cvconversation.Field]any{
+        cvconversation.FieldCustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        cvconversation.FieldDeleted:    false,
+    },
+    expectRes: []*cvconversation.WebhookMessage{
+        {
+            Identity: commonidentity.Identity{
+                ID: uuid.FromStringOrNil("620bce9e-3ed2-11ef-b45a-3f6e2898153d"),
+            },
+        },
+    },
+},
+{
+    name: "manager sees all conversations (no owner filter)",
+
+    agent: auth.NewAgentIdentity(&amagent.Agent{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09b"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Permission: amagent.PermissionCustomerManager,
+    }),
+    size:  100,
+    token: "2021-03-01T01:00:00.995000Z",
+
+    responseConversations: []cvconversation.Conversation{
+        {
+            Identity: commonidentity.Identity{
+                ID: uuid.FromStringOrNil("62a1ec8a-3ed2-11ef-bb8c-a788ea1ad2ad"),
+            },
+        },
+    },
+
+    expectFilters: map[cvconversation.Field]any{
+        cvconversation.FieldCustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        cvconversation.FieldDeleted:    false,
+    },
+    expectRes: []*cvconversation.WebhookMessage{
+        {
+            Identity: commonidentity.Identity{
+                ID: uuid.FromStringOrNil("62a1ec8a-3ed2-11ef-bb8c-a788ea1ad2ad"),
+            },
+        },
+    },
+},
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-ServiceAgent-conversation-permission/bin-api-manager
+go test ./pkg/servicehandler/... -run Test_ServiceAgentConversationList -v 2>&1 | tail -20
+```
+
+Expected: FAIL — the admin/manager cases will call `ConversationV1ConversationList` with the wrong filter (OwnerID instead of CustomerID).
+
+---
+
+### Task 2: Add failing tests for admin/manager in `ServiceAgentConversationGet`
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go`
+
+**Step 1: Add new test cases to `Test_ServiceAgentConversationGet`**
+
+Insert after the existing `"normal"` case (after line 63, before the closing `}`):
+
+```go
+{
+    name: "admin gets conversation owned by another agent",
+
+    agent: auth.NewAgentIdentity(&amagent.Agent{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("aaaaaaaa-3b9f-11ef-98ac-db226570f09a"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Permission: amagent.PermissionCustomerAdmin,
+    }),
+    conversationID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+
+    responseConversation: &cvconversation.Conversation{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Owner: commonidentity.Owner{
+            OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"), // different agent
+        },
+    },
+    expectRes: &cvconversation.WebhookMessage{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Owner: commonidentity.Owner{
+            OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+        },
+    },
+},
+{
+    name: "manager gets conversation owned by another agent",
+
+    agent: auth.NewAgentIdentity(&amagent.Agent{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("bbbbbbbb-3b9f-11ef-98ac-db226570f09b"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Permission: amagent.PermissionCustomerManager,
+    }),
+    conversationID: uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+
+    responseConversation: &cvconversation.Conversation{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Owner: commonidentity.Owner{
+            OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"), // different agent
+        },
+    },
+    expectRes: &cvconversation.WebhookMessage{
+        Identity: commonidentity.Identity{
+            ID:         uuid.FromStringOrNil("14189ed4-3ed1-11ef-8056-bffadb501e2f"),
+            CustomerID: uuid.FromStringOrNil("5d16712c-3b9f-11ef-8a51-f30f1e2ce1e9"),
+        },
+        Owner: commonidentity.Owner{
+            OwnerID: uuid.FromStringOrNil("5cd8c836-3b9f-11ef-98ac-db226570f09a"),
+        },
+    },
+},
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-ServiceAgent-conversation-permission/bin-api-manager
+go test ./pkg/servicehandler/... -run Test_ServiceAgentConversationGet -v 2>&1 | tail -20
+```
+
+Expected: FAIL — admin/manager cases will be blocked by the `OwnerID != AgentID` check.
+
+---
+
+### Task 3: Implement the fix in `ServiceAgentConversationList`
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/serviceagent_conversation.go`
+
+**Step 1: Replace the `ServiceAgentConversationList` body**
+
+Current code (lines 40-68):
+```go
+func (h *serviceHandler) ServiceAgentConversationList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*cvconversation.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	if token == "" {
+		token = h.utilHandler.TimeGetCurTime()
+	}
+
+	// filters
+	filters := map[cvconversation.Field]any{
+		cvconversation.FieldDeleted: false,
+		cvconversation.FieldOwnerID: a.AgentID(),
+	}
+
+	tmps, err := h.conversationList(ctx, a, size, token, filters)
+	...
+```
+
+Replace the filter block with:
+```go
+	// Admin and manager callers see all conversations for their customer.
+	// Regular agents see only conversations they own.
+	filters := map[cvconversation.Field]any{
+		cvconversation.FieldDeleted: false,
+	}
+	if h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		filters[cvconversation.FieldCustomerID] = a.CustomerID
+	} else {
+		filters[cvconversation.FieldOwnerID] = a.AgentID()
+	}
+```
+
+Also add the missing import at the top if not already present:
+```go
+amagent "monorepo/bin-agent-manager/models/agent"
+```
+
+**Step 2: Run the list tests**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-ServiceAgent-conversation-permission/bin-api-manager
+go test ./pkg/servicehandler/... -run Test_ServiceAgentConversationList -v 2>&1 | tail -20
+```
+
+Expected: all cases PASS.
+
+---
+
+### Task 4: Implement the fix in `ServiceAgentConversationGet`
+
+**Files:**
+- Modify: `bin-api-manager/pkg/servicehandler/serviceagent_conversation.go`
+
+**Step 1: Replace the ownership check in `ServiceAgentConversationGet`**
+
+Current code:
+```go
+	if tmp.OwnerID != a.AgentID() {
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+```
+
+Replace with:
+```go
+	isAdminOrManager := h.hasPermission(ctx, a, tmp.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager)
+	if !isAdminOrManager && tmp.OwnerID != a.AgentID() {
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+```
+
+**Step 2: Run the get tests**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-ServiceAgent-conversation-permission/bin-api-manager
+go test ./pkg/servicehandler/... -run Test_ServiceAgentConversationGet -v 2>&1 | tail -20
+```
+
+Expected: all cases PASS.
+
+---
+
+### Task 5: Run full verification workflow
+
+**Step 1: Run all verification steps**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-ServiceAgent-conversation-permission/bin-api-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all steps succeed with no errors.
+
+---
+
+### Task 6: Commit, push, and create PR
+
+**Step 1: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-ServiceAgent-conversation-permission
+git add bin-api-manager/pkg/servicehandler/serviceagent_conversation.go \
+        bin-api-manager/pkg/servicehandler/serviceagent_conversation_test.go \
+        docs/plans/
+git commit -m "NOJIRA-ServiceAgent-conversation-permission
+
+- bin-api-manager: admin/manager callers at GET /service_agents/conversations now see all customer conversations (filter by CustomerID)
+- bin-api-manager: admin/manager callers at GET /service_agents/conversations/{id} can fetch any conversation belonging to their customer
+- bin-api-manager: add test cases for admin and manager permission in ServiceAgentConversationList and ServiceAgentConversationGet"
+```
+
+**Step 2: Push**
+
+```bash
+git push -u origin NOJIRA-ServiceAgent-conversation-permission
+```
+
+**Step 3: Create PR**
+
+```bash
+gh pr create \
+  --title "NOJIRA-ServiceAgent-conversation-permission" \
+  --body "Admin and manager agents at GET /service_agents/conversations now see all conversations for their customer instead of only their own.
+
+- bin-api-manager: ServiceAgentConversationList uses CustomerID filter for admin/manager, OwnerID filter for regular agents
+- bin-api-manager: ServiceAgentConversationGet allows admin/manager to fetch any conversation in their customer scope
+- bin-api-manager: new test cases cover admin and manager paths in both functions"
+```


### PR DESCRIPTION
Admin and manager agents at GET /service_agents/conversations now see all conversations for their customer instead of only their own.

- bin-api-manager: ServiceAgentConversationList uses CustomerID filter for admin/manager, OwnerID filter for regular agents
- bin-api-manager: ServiceAgentConversationGet allows admin/manager to fetch any conversation in their customer scope
- bin-api-manager: new test cases cover admin and manager paths in both functions