### PR TITLE
NOJIRA-Fix-500-regressions

### DIFF
--- a/bin-agent-manager/pkg/agenthandler/db.go
+++ b/bin-agent-manager/pkg/agenthandler/db.go
@@ -7,6 +7,8 @@ import (
 
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
 	"monorepo/bin-agent-manager/pkg/metricshandler"
@@ -63,7 +65,11 @@ func (h *agentHandler) dbCreate(ctx context.Context, customerID uuid.UUID, usern
 
 	if ringMethod != agent.RingMethodRingAll {
 		log.Errorf("Unsupported ring method. Currently, support ringall only. ringMethod: %s", ringMethod)
-		return nil, fmt.Errorf("wrong ring_method")
+		return nil, cerrors.InvalidArgument(
+			commonoutline.ServiceNameAgentManager,
+			"INVALID_RING_METHOD",
+			fmt.Sprintf("unsupported ring_method %q: only %q is supported", ringMethod, agent.RingMethodRingAll),
+		)
 	}
 
 	// generate hash password

--- a/bin-agent-manager/pkg/listenhandler/v1_agents.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_agents.go
@@ -140,7 +140,7 @@ func (h *listenHandler) processV1AgentsPost(ctx context.Context, m *sock.Request
 	)
 	if err != nil {
 		log.Errorf("Could not create an agent info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-agent-manager/pkg/listenhandler/v1_agents_additional_test.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_agents_additional_test.go
@@ -3,10 +3,13 @@ package listenhandler
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 
 	"github.com/gofrs/uuid"
@@ -376,6 +379,51 @@ func Test_processV1AgentsIDAddressesPut(t *testing.T) {
 	}
 }
 
+
+func Test_processV1AgentsPost_invalid_ring_method(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockAgent := agenthandler.NewMockAgentHandler(mc)
+	h := &listenHandler{
+		agentHandler: mockAgent,
+	}
+	ctx := context.Background()
+
+	mockAgent.EXPECT().Create(
+		gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		agent.RingMethod("invalid"),
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, cerrors.InvalidArgument(
+		commonoutline.ServiceNameAgentManager,
+		"INVALID_RING_METHOD",
+		`unsupported ring_method "invalid": only "ringall" is supported`,
+	))
+
+	req := &sock.Request{
+		URI: "/v1/agents",
+		Data: []byte(`{
+			"customer_id": "442f5d62-7f55-11ec-a2c0-0bcd3814d515",
+			"username": "test@example.com",
+			"password": "password",
+			"ring_method": "invalid"
+		}`),
+	}
+
+	res, err := h.processV1AgentsPost(ctx, req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("Wrong status code. expect: %d, got: %d", http.StatusBadRequest, res.StatusCode)
+	}
+
+	if res.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("Wrong data type. expect: %s, got: %s", cerrors.DataTypeVoipbinError, res.DataType)
+	}
+}
 
 func Test_processV1AgentsPost_unmarshal_error(t *testing.T) {
 	mc := gomock.NewController(t)

--- a/bin-api-manager/server/me.go
+++ b/bin-api-manager/server/me.go
@@ -24,7 +24,7 @@ func (h *server) GetMe(c *gin.Context) {
 
 	if !a.IsAgent() {
 		log.Infof("Non-agent auth type attempted GET /me. type: %s", a.Type)
-		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AGENT_AUTH_REQUIRED", "Agent authentication required for this endpoint."))
+		abortWithError(c, cerrors.PermissionDenied(commonoutline.ServiceNameAPIManager, "AGENT_AUTH_REQUIRED", "This endpoint requires agent authentication."))
 		return
 	}
 

--- a/bin-api-manager/server/me.go
+++ b/bin-api-manager/server/me.go
@@ -22,6 +22,12 @@ func (h *server) GetMe(c *gin.Context) {
 	}
 	log = log.WithField("agent", a)
 
+	if !a.IsAgent() {
+		log.Infof("Non-agent auth type attempted GET /me. type: %s", a.Type)
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AGENT_AUTH_REQUIRED", "Agent authentication required for this endpoint."))
+		return
+	}
+
 	res, err := h.serviceHandler.AgentGet(c.Request.Context(), a, a.AgentID())
 	if err != nil {
 		log.Infof("Could not get the agent info. err: %v", err)

--- a/bin-queue-manager/pkg/listenhandler/v1_queues.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues.go
@@ -46,7 +46,7 @@ func (h *listenHandler) processV1QueuesPost(ctx context.Context, m *sock.Request
 	)
 	if err != nil {
 		log.Errorf("Could not create the queue. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-queue-manager/pkg/listenhandler/v1_queues_test.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues_test.go
@@ -1,13 +1,16 @@
 package listenhandler
 
 import (
+	"context"
+	"net/http"
 	reflect "reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
-
-	commonidentity "monorepo/bin-common-handler/models/identity"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 
@@ -106,6 +109,49 @@ func Test_processV1QueuesPost(t *testing.T) {
 				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectedRes, res)
 			}
 		})
+	}
+}
+
+func Test_processV1QueuesPost_invalid_routing_method(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockQueue := queuehandler.NewMockQueueHandler(mc)
+	h := &listenHandler{
+		queueHandler: mockQueue,
+	}
+	ctx := context.Background()
+
+	mockQueue.EXPECT().Create(
+		gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(),
+		queue.RoutingMethod("invalid"),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, cerrors.InvalidArgument(
+		commonoutline.ServiceNameQueueManager,
+		"INVALID_ROUTING_METHOD",
+		`unsupported routing_method "invalid": only "random" is supported`,
+	))
+
+	req := &sock.Request{
+		URI: "/v1/queues",
+		Data: []byte(`{
+			"customer_id": "442f5d62-7f55-11ec-a2c0-0bcd3814d515",
+			"routing_method": "invalid"
+		}`),
+	}
+
+	res, err := h.processV1QueuesPost(ctx, req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("Wrong status code. expect: %d, got: %d", http.StatusBadRequest, res.StatusCode)
+	}
+
+	if res.DataType != cerrors.DataTypeVoipbinError {
+		t.Errorf("Wrong data type. expect: %s, got: %s", cerrors.DataTypeVoipbinError, res.DataType)
 	}
 }
 

--- a/bin-queue-manager/pkg/queuehandler/create.go
+++ b/bin-queue-manager/pkg/queuehandler/create.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	bmaccount "monorepo/bin-billing-manager/models/account"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
 	"github.com/gofrs/uuid"
@@ -69,7 +71,11 @@ func (h *queueHandler) Create(
 		if _, errDelete := h.reqHandler.DirectV1DirectDelete(ctx, d.ID); errDelete != nil {
 			log.Errorf("Could not cleanup orphaned direct. direct_id: %s, err: %v", d.ID, errDelete)
 		}
-		return nil, fmt.Errorf("wrong routing_method. routing_method: %s", routingMethod)
+		return nil, cerrors.InvalidArgument(
+			commonoutline.ServiceNameQueueManager,
+			"INVALID_ROUTING_METHOD",
+			fmt.Sprintf("unsupported routing_method %q: only %q is supported", routingMethod, queue.RoutingMethodRandom),
+		)
 	}
 
 	// create a new queue


### PR DESCRIPTION
Fix two distinct HTTP 500 regressions affecting production API endpoints.

**Problem 1 — GET /me → 500 for accesskey tokens (regression from f301e96b9)**

After commit f301e96b9 changed `c.AbortWithStatus(400)` to `abortWithServiceError(c, err)` in me.go, `GetMe` unconditionally calls `AgentGet` for all auth types. Customer accesskeys have `AgentID() = uuid.Nil`, so agent-manager returns an error, which propagates back as HTTP 500. Fix: add `IsAgent()` guard that returns 401 for non-agent auth types before calling AgentGet.

**Problem 2 — POST /agents and POST /queues → 500 for invalid and valid data**

Backend handlers `processV1AgentsPost` and `processV1QueuesPost` returned `simpleResponse(500)` for all errors. Validation errors for invalid enum values (`ring_method`, `routing_method`) were plain `fmt.Errorf` strings that mapped to 500 instead of 400.

Fix: wrap ring_method and routing_method validation errors with `cerrors.InvalidArgument`, and change `processV1AgentsPost`/`processV1QueuesPost` to use `errorResponse(err)` so typed errors propagate the correct HTTP status code (400 for invalid arguments, 404 for not found, 500 only for true internal errors).

- bin-api-manager: Guard GET /me against non-agent auth; return 401 for accesskeys and direct tokens
- bin-agent-manager: Wrap invalid ring_method error with cerrors.InvalidArgument
- bin-agent-manager: Use errorResponse(err) in processV1AgentsPost
- bin-queue-manager: Wrap invalid routing_method error with cerrors.InvalidArgument
- bin-queue-manager: Use errorResponse(err) in processV1QueuesPost