### PR TITLE
NOJIRA-Fix-aimessages-500

### DIFF
--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
@@ -126,7 +126,7 @@ func (h *listenHandler) processV1AIcallsIDGet(ctx context.Context, m *sock.Reque
 	tmp, err := h.aicallHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls_test.go
@@ -4,7 +4,9 @@ import (
 	reflect "reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -224,9 +226,11 @@ func Test_processV1AIcallsIDGet(t *testing.T) {
 		request *sock.Request
 
 		responseAIcall *aicall.AIcall
+		responseErr    error
 
-		expectedID  uuid.UUID
-		expectedRes *sock.Response
+		expectedID          uuid.UUID
+		expectedResStatus   int
+		expectedResDataType string
 	}{
 		{
 			name: "normal",
@@ -241,12 +245,22 @@ func Test_processV1AIcallsIDGet(t *testing.T) {
 				},
 			},
 
-			expectedID: uuid.FromStringOrNil("3e349bb8-7b31-4533-8e2b-6654ebc84e3e"),
-			expectedRes: &sock.Response{
-				StatusCode: 200,
-				DataType:   "application/json",
-				Data:       []byte(`{"id":"3e349bb8-7b31-4533-8e2b-6654ebc84e3e","customer_id":"00000000-0000-0000-0000-000000000000","assistance_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","reference_id":"00000000-0000-0000-0000-000000000000","confbridge_id":"00000000-0000-0000-0000-000000000000","pipecatcall_id":"00000000-0000-0000-0000-000000000000","current_member_id":"00000000-0000-0000-0000-000000000000","tm_end":null,"tm_create":null,"tm_update":null,"tm_delete":null}`),
+			expectedID:          uuid.FromStringOrNil("3e349bb8-7b31-4533-8e2b-6654ebc84e3e"),
+			expectedResStatus:   200,
+			expectedResDataType: "application/json",
+		},
+		{
+			name: "not found",
+			request: &sock.Request{
+				URI:    "/v1/aicalls/00000000-0000-0000-0000-000000000000",
+				Method: sock.RequestMethodGet,
 			},
+
+			responseErr: cerrors.NotFound(outline.ServiceNameAIManager, "AICALL_NOT_FOUND", "The AI call was not found."),
+
+			expectedID:          uuid.Nil,
+			expectedResStatus:   404,
+			expectedResDataType: cerrors.DataTypeVoipbinError,
 		},
 	}
 
@@ -263,14 +277,17 @@ func Test_processV1AIcallsIDGet(t *testing.T) {
 				aicallHandler: mockAIcall,
 			}
 
-			mockAIcall.EXPECT().Get(gomock.Any(), tt.expectedID).Return(tt.responseAIcall, nil)
+			mockAIcall.EXPECT().Get(gomock.Any(), tt.expectedID).Return(tt.responseAIcall, tt.responseErr)
 			res, err := h.processRequest(tt.request)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 
-			if reflect.DeepEqual(res, tt.expectedRes) != true {
-				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectedRes, res)
+			if res.StatusCode != tt.expectedResStatus {
+				t.Errorf("Wrong status code.\nexpect: %d\ngot: %d", tt.expectedResStatus, res.StatusCode)
+			}
+			if tt.expectedResDataType != "" && res.DataType != tt.expectedResDataType {
+				t.Errorf("Wrong data type.\nexpect: %s\ngot: %s", tt.expectedResDataType, res.DataType)
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_messages.go
@@ -91,7 +91,7 @@ func (h *listenHandler) processV1MessagesPost(ctx context.Context, m *sock.Reque
 	tmp, err := h.aicallHandler.Send(ctx, req.AIcallID, req.Role, req.Content, req.RunImmediately, req.AudioResponse)
 	if err != nil {
 		log.Errorf("Could not create ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)


### PR DESCRIPTION
POST /aimessages was returning HTTP 500 when given a non-existent aicall_id (including the zero UUID), because the ai-manager listenhandler mapped all handler errors to simpleResponse(500).

The aicallHandler.Get already returns a typed cerrors.NotFound when the aicall is not found, and the errorResponse helper in the same package correctly translates it to a 404 with a VoipbinError envelope — but processV1AIcallsIDGet and processV1MessagesPost were not using it.

- bin-ai-manager: Use errorResponse(err) instead of simpleResponse(500) in processV1AIcallsIDGet so not-found aicalls return 404 instead of 500
- bin-ai-manager: Use errorResponse(err) instead of simpleResponse(500) in processV1MessagesPost for consistent error propagation
- bin-ai-manager: Add not-found test case to Test_processV1AIcallsIDGet verifying 404 response when aicall does not exist