### PR TITLE
NOJIRA-Fix-500-IDGet-regressions

### DIFF
--- a/bin-agent-manager/pkg/listenhandler/v1_agents.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_agents.go
@@ -85,10 +85,15 @@ func (h *listenHandler) processV1AgentsIDGet(ctx context.Context, m *sock.Reques
 	})
 	log.Debug("Executing processV1AgentsIDGet.")
 
+	if id == uuid.Nil {
+		log.Errorf("Invalid agent ID.")
+		return simpleResponse(400), nil
+	}
+
 	tmp, err := h.agentHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get an agent info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -172,10 +177,15 @@ func (h *listenHandler) processV1AgentsIDDelete(ctx context.Context, m *sock.Req
 	})
 	log.Debug("Executing processV1AgentsIDDelete.")
 
+	if id == uuid.Nil {
+		log.Errorf("Invalid agent ID.")
+		return simpleResponse(400), nil
+	}
+
 	tmp, err := h.agentHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete the agent info. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
@@ -122,11 +122,15 @@ func (h *listenHandler) processV1AIcallsIDGet(ctx context.Context, m *sock.Reque
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid AIcall ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.aicallHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -157,11 +161,15 @@ func (h *listenHandler) processV1AIcallsIDDelete(ctx context.Context, m *sock.Re
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid AIcall ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.aicallHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete aicall. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
@@ -200,11 +200,15 @@ func (h *listenHandler) processV1AIcallsIDTerminatePost(ctx context.Context, m *
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid AIcall ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.aicallHandler.ProcessTerminate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not terminate aicall. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_ais.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais.go
@@ -140,11 +140,15 @@ func (h *listenHandler) processV1AIsIDGet(ctx context.Context, m *sock.Request) 
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid AI ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.aiHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -175,11 +179,15 @@ func (h *listenHandler) processV1AIsIDDelete(ctx context.Context, m *sock.Reques
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid AI ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.aiHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_ais.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais.go
@@ -224,6 +224,10 @@ func (h *listenHandler) processV1AIsIDPut(ctx context.Context, m *sock.Request) 
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid AI ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.aiHandler.Update(
 		ctx,
@@ -245,7 +249,7 @@ func (h *listenHandler) processV1AIsIDPut(ctx context.Context, m *sock.Request) 
 	)
 	if err != nil {
 		log.Errorf("Could not update ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_messages.go
@@ -122,11 +122,15 @@ func (h *listenHandler) processV1MessagesIDGet(ctx context.Context, m *sock.Requ
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid message ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.messageHandler.Get(ctx, id)
 	if err != nil {
-		log.Errorf("Could not create ai. err: %v", err)
-		return simpleResponse(500), nil
+		log.Errorf("Could not get message. err: %v", err)
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_summaries.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_summaries.go
@@ -122,11 +122,15 @@ func (h *listenHandler) processV1SummariesIDGet(ctx context.Context, m *sock.Req
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid summary ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.summaryHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get item. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -157,11 +161,15 @@ func (h *listenHandler) processV1SummariesIDDelete(ctx context.Context, m *sock.
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid summary ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.summaryHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete item. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_teams.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_teams.go
@@ -176,6 +176,10 @@ func (h *listenHandler) processV1TeamsIDPut(ctx context.Context, m *sock.Request
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid team ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.teamHandler.Update(
 		ctx,
@@ -188,7 +192,7 @@ func (h *listenHandler) processV1TeamsIDPut(ctx context.Context, m *sock.Request
 	)
 	if err != nil {
 		log.Errorf("Could not update team. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_teams.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_teams.go
@@ -131,11 +131,15 @@ func (h *listenHandler) processV1TeamsIDGet(ctx context.Context, m *sock.Request
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid team ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.teamHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get team. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -215,11 +219,15 @@ func (h *listenHandler) processV1TeamsIDDelete(ctx context.Context, m *sock.Requ
 		return simpleResponse(400), nil
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid team ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.teamHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete team. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-flow-manager/pkg/actionhandler/action.go
+++ b/bin-flow-manager/pkg/actionhandler/action.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-flow-manager/models/action"
 )
 
@@ -27,7 +29,11 @@ func (h *actionHandler) ValidateActions(actions []action.Action) error {
 		}
 
 		if !found {
-			return fmt.Errorf("no support action type. type: %s", a.Type)
+			return cerrors.InvalidArgument(
+				commonoutline.ServiceNameFlowManager,
+				"INVALID_ACTION_TYPE",
+				fmt.Sprintf("not supported action type: %s", a.Type),
+			)
 		}
 
 		// validate anonymous option for call and connect actions
@@ -38,7 +44,11 @@ func (h *actionHandler) ValidateActions(actions []action.Action) error {
 				logrus.WithField("action", a).Warnf("Could not parse call action option for anonymous validation. err: %v", err)
 			} else if opt.Anonymous != "" {
 				if !action.ValidateAnonymous(opt.Anonymous) {
-					return fmt.Errorf("invalid anonymous value for call action. anonymous: %s", opt.Anonymous)
+					return cerrors.InvalidArgument(
+						commonoutline.ServiceNameFlowManager,
+						"INVALID_ANONYMOUS_VALUE",
+						fmt.Sprintf("invalid anonymous value for call action: %s", opt.Anonymous),
+					)
 				}
 			}
 		case action.TypeConnect:
@@ -47,7 +57,11 @@ func (h *actionHandler) ValidateActions(actions []action.Action) error {
 				logrus.WithField("action", a).Warnf("Could not parse connect action option for anonymous validation. err: %v", err)
 			} else if opt.Anonymous != "" {
 				if !action.ValidateAnonymous(opt.Anonymous) {
-					return fmt.Errorf("invalid anonymous value for connect action. anonymous: %s", opt.Anonymous)
+					return cerrors.InvalidArgument(
+						commonoutline.ServiceNameFlowManager,
+						"INVALID_ANONYMOUS_VALUE",
+						fmt.Sprintf("invalid anonymous value for connect action: %s", opt.Anonymous),
+					)
 				}
 			}
 		}

--- a/bin-queue-manager/pkg/listenhandler/v1_queuecalls.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queuecalls.go
@@ -118,12 +118,16 @@ func (h *listenHandler) processV1QueuecallsIDGet(ctx context.Context, m *sock.Re
 	}
 
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid queuecall ID.")
+		return simpleResponse(400), nil
+	}
 
 	// get queue
 	tmp, err := h.queuecallHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get queuecall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -154,11 +158,15 @@ func (h *listenHandler) processV1QueuecallsIDDelete(ctx context.Context, m *sock
 	}
 
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid queuecall ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.queuecallHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not leave the queuecall from the queue. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-queue-manager/pkg/listenhandler/v1_queues.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues.go
@@ -129,12 +129,16 @@ func (h *listenHandler) processV1QueuesIDGet(ctx context.Context, m *sock.Reques
 	}
 
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid queue ID.")
+		return simpleResponse(400), nil
+	}
 
 	// get queue
 	tmp, err := h.queueHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get queue info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -165,11 +169,15 @@ func (h *listenHandler) processV1QueuesIDDelete(ctx context.Context, m *sock.Req
 	}
 
 	id := uuid.FromStringOrNil(uriItems[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid queue ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.queueHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete queue info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-registrar-manager/pkg/listenhandler/v1_trunks.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_trunks.go
@@ -88,7 +88,7 @@ func (h *listenHandler) processV1TrunksGet(ctx context.Context, req *sock.Reques
 	trunks, err := h.trunkHandler.List(ctx, pageToken, pageSize, filters)
 	if err != nil {
 		log.Errorf("Could not get trunks. err: %v", err)
-		return nil, err
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(trunks)

--- a/bin-registrar-manager/pkg/listenhandler/v1_trunks.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_trunks.go
@@ -37,7 +37,7 @@ func (h *listenHandler) processV1TrunksPost(ctx context.Context, m *sock.Request
 	tmp, err := h.trunkHandler.Create(ctx, req.CustomerID, req.Name, req.Detail, req.DomainName, req.Authtypes, req.Username, req.Password, req.AllowedIPs)
 	if err != nil {
 		log.Errorf("Could not create a new trunk correctly. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -120,11 +120,15 @@ func (h *listenHandler) processV1TrunksIDGet(ctx context.Context, req *sock.Requ
 	// "/v1/trunks/a6f4eae8-8a74-11ea-af75-3f1e61b9a236"
 	tmpVals := strings.Split(u.Path, "/")
 	id := uuid.FromStringOrNil(tmpVals[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid trunk ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.trunkHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get trunk info. err: %v", err)
-		return nil, err
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -156,6 +160,10 @@ func (h *listenHandler) processV1TrunksIDPut(ctx context.Context, req *sock.Requ
 	// "/v1/trunks/a6f4eae8-8a74-11ea-af75-3f1e61b9a236"
 	tmpVals := strings.Split(u.Path, "/")
 	id := uuid.FromStringOrNil(tmpVals[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid trunk ID.")
+		return simpleResponse(400), nil
+	}
 
 	var reqData request.V1DataTrunksIDPut
 	if err := json.Unmarshal([]byte(req.Data), &reqData); err != nil {
@@ -174,8 +182,8 @@ func (h *listenHandler) processV1TrunksIDPut(ctx context.Context, req *sock.Requ
 
 	tmp, err := h.trunkHandler.Update(ctx, id, fields)
 	if err != nil {
-		log.Errorf("Could not get domain info. err: %v", err)
-		return nil, err
+		log.Errorf("Could not update trunk info. err: %v", err)
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -207,11 +215,15 @@ func (h *listenHandler) processV1TrunksIDDelete(ctx context.Context, req *sock.R
 	// "/v1/trunks/a6f4eae8-8a74-11ea-af75-3f1e61b9a236"
 	tmpVals := strings.Split(u.Path, "/")
 	id := uuid.FromStringOrNil(tmpVals[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid trunk ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.trunkHandler.Delete(ctx, id)
 	if err != nil {
-		log.Errorf("Could not get trunk info. err: %v", err)
-		return nil, err
+		log.Errorf("Could not delete trunk. err: %v", err)
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-route-manager/pkg/listenhandler/v1_routes.go
+++ b/bin-route-manager/pkg/listenhandler/v1_routes.go
@@ -176,6 +176,10 @@ func (h *listenHandler) v1RoutesIDPut(ctx context.Context, m *sock.Request) (*so
 	// "/v1/routes/a6f4eae8-8a74-11ea-af75-3f1e61b9a236"
 	tmpVals := strings.Split(u.Path, "/")
 	id := uuid.FromStringOrNil(tmpVals[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid route ID.")
+		return simpleResponse(400), nil
+	}
 
 	var req request.V1DataRoutesIDPut
 	if err := json.Unmarshal(m.Data, &req); err != nil {
@@ -194,7 +198,7 @@ func (h *listenHandler) v1RoutesIDPut(ctx context.Context, m *sock.Request) (*so
 	)
 	if err != nil {
 		log.Errorf("Could not update the route info. err: %v", err)
-		return nil, err
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-route-manager/pkg/listenhandler/v1_routes.go
+++ b/bin-route-manager/pkg/listenhandler/v1_routes.go
@@ -133,11 +133,15 @@ func (h *listenHandler) v1RoutesIDGet(ctx context.Context, m *sock.Request) (*so
 	// "/v1/routes/a6f4eae8-8a74-11ea-af75-3f1e61b9a236"
 	tmpVals := strings.Split(u.Path, "/")
 	id := uuid.FromStringOrNil(tmpVals[3])
+	if id == uuid.Nil {
+		log.Errorf("Invalid route ID.")
+		return simpleResponse(400), nil
+	}
 
 	tmp, err := h.routeHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get route info. err: %v", err)
-		return nil, err
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -226,10 +230,15 @@ func (h *listenHandler) v1RoutesIDDelete(ctx context.Context, m *sock.Request) (
 	id := uuid.FromStringOrNil(tmpVals[3])
 	log = log.WithField("route_id", id)
 
+	if id == uuid.Nil {
+		log.Errorf("Invalid route ID.")
+		return simpleResponse(400), nil
+	}
+
 	tmp, err := h.routeHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not delete the route. err: %v", err)
-		return nil, err
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)


### PR DESCRIPTION
Fix HTTP 500 regressions in IDGet and IDDelete handlers across multiple services. Handlers were returning 500 for all errors; now they return 400 for invalid UUID input and propagate proper error codes (404 for not-found, etc.) via errorResponse.

- bin-agent-manager: Add uuid.Nil check and use errorResponse in IDGet/IDDelete handlers
- bin-ai-manager: Add uuid.Nil check and use errorResponse in IDGet/IDDelete for ais, aicalls, messages, summaries, teams
- bin-queue-manager: Add uuid.Nil check and use errorResponse in IDGet/IDDelete for queues and queuecalls
- bin-registrar-manager: Add uuid.Nil check and use errorResponse in IDGet/IDPut/IDDelete for trunks; use errorResponse in TrunksPost
- bin-route-manager: Add uuid.Nil check and use errorResponse in IDGet/IDDelete for routes