### PR TITLE
NOJIRA-Add-password-reset-openapi

### DIFF
--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -6042,6 +6042,21 @@ type RequestBodyAuthEmailVerifyPOST struct {
 	Token string `json:"token"`
 }
 
+// RequestBodyAuthPasswordForgotPOST Request body for POST /auth/password-forgot (initiate password reset).
+type RequestBodyAuthPasswordForgotPOST struct {
+	// Username The agent's username (email address). A reset link will be sent to this address if an account exists.
+	Username string `json:"username"`
+}
+
+// RequestBodyAuthPasswordResetPOST Request body for POST /auth/password-reset (complete password reset).
+type RequestBodyAuthPasswordResetPOST struct {
+	// Password The new password to set for the account.
+	Password string `json:"password"`
+
+	// Token 64-character lowercase hexadecimal password reset token. Received via the link in the reset email sent by `POST /auth/password-forgot`.
+	Token string `json:"token"`
+}
+
 // RequestBodyAuthSignupPOST Request body for POST /auth/signup (self-service customer registration).
 type RequestBodyAuthSignupPOST struct {
 	// AcceptedTos Must be `true` to confirm acceptance of the Terms of Service. Requests with `false` or missing value are rejected with HTTP 400.
@@ -8766,6 +8781,12 @@ type PostAuthBootJSONRequestBody = RequestBodyAuthBootPOST
 
 // PostAuthEmailVerifyJSONRequestBody defines body for PostAuthEmailVerify for application/json ContentType.
 type PostAuthEmailVerifyJSONRequestBody = RequestBodyAuthEmailVerifyPOST
+
+// PostAuthPasswordForgotJSONRequestBody defines body for PostAuthPasswordForgot for application/json ContentType.
+type PostAuthPasswordForgotJSONRequestBody = RequestBodyAuthPasswordForgotPOST
+
+// PostAuthPasswordResetJSONRequestBody defines body for PostAuthPasswordReset for application/json ContentType.
+type PostAuthPasswordResetJSONRequestBody = RequestBodyAuthPasswordResetPOST
 
 // PostAuthSignupJSONRequestBody defines body for PostAuthSignup for application/json ContentType.
 type PostAuthSignupJSONRequestBody = RequestBodyAuthSignupPOST

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -6050,7 +6050,7 @@ type RequestBodyAuthPasswordForgotPOST struct {
 
 // RequestBodyAuthPasswordResetPOST Request body for POST /auth/password-reset (complete password reset).
 type RequestBodyAuthPasswordResetPOST struct {
-	// Password The new password to set for the account.
+	// Password The new password to set for the account. Must be at least 8 characters.
 	Password string `json:"password"`
 
 	// Token 64-character lowercase hexadecimal password reset token. Received via the link in the reset email sent by `POST /auth/password-forgot`.
@@ -6995,6 +6995,12 @@ type PostAisummariesJSONBody struct {
 
 	// ReferenceType Type of reference for the AI summary.
 	ReferenceType AIManagerSummaryReferenceType `json:"reference_type"`
+}
+
+// GetAuthPasswordResetParams defines parameters for GetAuthPasswordReset.
+type GetAuthPasswordResetParams struct {
+	// Token 64-character lowercase hexadecimal password reset token from the reset email.
+	Token string `form:"token" json:"token"`
 }
 
 // DeleteAuthUnregisterParams defines parameters for DeleteAuthUnregister.

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -6907,6 +6907,35 @@ components:
           description: "The direct hash link (e.g., \"direct.a1b2c3d4e5f6\"). Obtained from resource direct hash endpoints such as `POST /ais/{id}/direct_hash_regenerate`."
           example: "direct.a1b2c3d4e5f6"
 
+    RequestBodyAuthPasswordForgotPOST:
+      type: object
+      required:
+        - username
+      description: Request body for POST /auth/password-forgot (initiate password reset).
+      properties:
+        username:
+          type: string
+          format: email
+          x-go-type: string
+          description: "The agent's username (email address). A reset link will be sent to this address if an account exists."
+          example: "agent@example.com"
+
+    RequestBodyAuthPasswordResetPOST:
+      type: object
+      required:
+        - token
+        - password
+      description: Request body for POST /auth/password-reset (complete password reset).
+      properties:
+        token:
+          type: string
+          description: "64-character lowercase hexadecimal password reset token. Received via the link in the reset email sent by `POST /auth/password-forgot`."
+          example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd"
+        password:
+          type: string
+          description: "The new password to set for the account."
+          example: "myNewSecurePassword123"
+
     AuthBootResponse:
       type: object
       description: "Result of a successful boot request. Contains a resource-scoped JWT and metadata about the scoped resource."
@@ -7115,6 +7144,10 @@ paths:
     $ref: './paths/auth/email-verify.yaml'
   /auth/unregister:
     $ref: './paths/auth/unregister.yaml'
+  /auth/password-forgot:
+    $ref: './paths/auth/password-forgot.yaml'
+  /auth/password-reset:
+    $ref: './paths/auth/password-reset.yaml'
 
   /available_numbers:
     $ref: './paths/available_numbers/main.yaml'

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -6929,11 +6929,15 @@ components:
       properties:
         token:
           type: string
+          pattern: "^[0-9a-f]{64}$"
+          minLength: 64
+          maxLength: 64
           description: "64-character lowercase hexadecimal password reset token. Received via the link in the reset email sent by `POST /auth/password-forgot`."
           example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd"
         password:
           type: string
-          description: "The new password to set for the account."
+          minLength: 8
+          description: "The new password to set for the account. Must be at least 8 characters."
           example: "myNewSecurePassword123"
 
     AuthBootResponse:

--- a/bin-openapi-manager/openapi/paths/auth/password-forgot.yaml
+++ b/bin-openapi-manager/openapi/paths/auth/password-forgot.yaml
@@ -1,0 +1,34 @@
+post:
+  summary: Request a password reset email.
+  description: |
+    Generates a password reset token and sends an email to the agent with a reset link.
+    The link expires in 1 hour.
+
+    Always returns HTTP 200 regardless of whether the username exists, to prevent
+    username enumeration attacks.
+
+    This endpoint is unauthenticated. Use `POST /auth/password-reset` with the token
+    from the email to complete the reset.
+  tags:
+    - Auth
+  operationId: postAuthPasswordForgot
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/RequestBodyAuthPasswordForgotPOST'
+  responses:
+    '200':
+      description: |
+        Request accepted. A reset email will be sent if the username exists.
+        Always returns 200 to prevent username enumeration.
+      content:
+        application/json:
+          schema:
+            type: object
+    '400':
+      description: |
+        Bad request. Possible causes:
+        - `username` is missing.
+        - Request body is malformed JSON.

--- a/bin-openapi-manager/openapi/paths/auth/password-reset.yaml
+++ b/bin-openapi-manager/openapi/paths/auth/password-reset.yaml
@@ -1,3 +1,36 @@
+get:
+  summary: Serve the password reset form (browser redirect target).
+  description: |
+    Returns an HTML page containing the password reset form. This endpoint is
+    the link target embedded in the reset email sent by `POST /auth/password-forgot`.
+
+    The `token` query parameter must be a 64-character lowercase hex string.
+    An invalid or missing token returns HTTP 400.
+
+    This endpoint is unauthenticated and intended for browser use only.
+    To perform the actual password update, the form submits to `POST /auth/password-reset`.
+  tags:
+    - Auth
+  operationId: getAuthPasswordReset
+  parameters:
+    - name: token
+      in: query
+      required: true
+      schema:
+        type: string
+        pattern: "^[0-9a-f]{64}$"
+        example: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd"
+      description: "64-character lowercase hexadecimal password reset token from the reset email."
+  responses:
+    '200':
+      description: HTML password reset form rendered successfully.
+      content:
+        text/html:
+          schema:
+            type: string
+    '400':
+      description: Token is missing, not 64 lowercase hex characters, or otherwise invalid.
+
 post:
   summary: Reset agent password using a reset token.
   description: |
@@ -26,7 +59,6 @@ post:
     '400':
       description: |
         Bad request. Possible causes:
-        - `token` is missing or invalid.
-        - `token` has expired (tokens expire after 1 hour).
-        - `password` is missing.
+        - `token` is missing, invalid, or expired (tokens expire after 1 hour).
+        - `password` is missing or fewer than 8 characters.
         - Request body is malformed JSON.

--- a/bin-openapi-manager/openapi/paths/auth/password-reset.yaml
+++ b/bin-openapi-manager/openapi/paths/auth/password-reset.yaml
@@ -1,0 +1,32 @@
+post:
+  summary: Reset agent password using a reset token.
+  description: |
+    Validates the password reset token (received via email from `POST /auth/password-forgot`)
+    and updates the agent's password.
+
+    The token is single-use and expires in 1 hour. Guest agents cannot reset their password.
+
+    This endpoint is unauthenticated. The reset token acts as proof of identity.
+  tags:
+    - Auth
+  operationId: postAuthPasswordReset
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/RequestBodyAuthPasswordResetPOST'
+  responses:
+    '200':
+      description: Password updated successfully.
+      content:
+        application/json:
+          schema:
+            type: object
+    '400':
+      description: |
+        Bad request. Possible causes:
+        - `token` is missing or invalid.
+        - `token` has expired (tokens expire after 1 hour).
+        - `password` is missing.
+        - Request body is malformed JSON.


### PR DESCRIPTION
Add POST /auth/password-forgot, GET /auth/password-reset, and POST /auth/password-reset to the OpenAPI spec. These endpoints have been live in the API but were missing from the spec.

- bin-openapi-manager: Add POST /auth/password-forgot path spec (initiates reset email)
- bin-openapi-manager: Add GET /auth/password-reset path spec (serves HTML reset form)
- bin-openapi-manager: Add POST /auth/password-reset path spec (validates token and updates password)
- bin-openapi-manager: Add RequestBodyAuthPasswordForgotPOST and RequestBodyAuthPasswordResetPOST schemas with AI-native constraints (pattern, minLength, examples)
- bin-openapi-manager: Regenerate models with new request body and parameter types