### PR TITLE
NOJIRA-Fix-table-name-convention

### DIFF
--- a/bin-call-manager/pkg/dbhandler/outbound_config.go
+++ b/bin-call-manager/pkg/dbhandler/outbound_config.go
@@ -14,9 +14,9 @@ import (
 	outboundconfig "monorepo/bin-call-manager/models/outboundconfig"
 )
 
-const outboundConfigTable = "outbound_configs"
+const outboundConfigTable = "call_outbound_configs"
 
-// outboundConfigGetFromRow scans a single outbound_configs row into an OutboundConfig.
+// outboundConfigGetFromRow scans a single call_outbound_configs row into an OutboundConfig.
 func (h *handler) outboundConfigGetFromRow(row *sql.Rows) (*outboundconfig.OutboundConfig, error) {
 	res := &outboundconfig.OutboundConfig{}
 
@@ -71,7 +71,7 @@ func (h *handler) OutboundConfigCreate(ctx context.Context, c *outboundconfig.Ou
 	}
 
 	now := time.Now()
-	q := `INSERT INTO outbound_configs (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	q := `INSERT INTO call_outbound_configs (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 	if _, err := h.db.ExecContext(ctx, q, c.ID, c.CustomerID, c.Name, c.Detail, whitelistJSON, c.Codecs, now, now); err != nil {
 		log.Errorf("Could not create outbound_config. err: %v", err)
 		return err
@@ -84,7 +84,7 @@ func (h *handler) OutboundConfigCreate(ctx context.Context, c *outboundconfig.Ou
 func (h *handler) OutboundConfigDelete(ctx context.Context, id uuid.UUID) error {
 	log := logrus.WithField("func", "OutboundConfigDelete")
 
-	q := `UPDATE outbound_configs SET tm_delete = ? WHERE id = ? AND tm_delete IS NULL`
+	q := `UPDATE call_outbound_configs SET tm_delete = ? WHERE id = ? AND tm_delete IS NULL`
 	if _, err := h.db.ExecContext(ctx, q, time.Now(), id); err != nil {
 		log.Errorf("Could not delete outbound_config. err: %v", err)
 		return err
@@ -98,7 +98,7 @@ func (h *handler) OutboundConfigDelete(ctx context.Context, id uuid.UUID) error 
 func (h *handler) OutboundConfigGetByID(ctx context.Context, id uuid.UUID) (*outboundconfig.OutboundConfig, error) {
 	log := logrus.WithField("func", "OutboundConfigGetByID")
 
-	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM outbound_configs WHERE id = ? AND tm_delete IS NULL LIMIT 1`
+	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM call_outbound_configs WHERE id = ? AND tm_delete IS NULL LIMIT 1`
 	rows, err := h.db.QueryContext(ctx, q, id)
 	if err != nil {
 		log.Errorf("Could not get outbound_config. err: %v", err)
@@ -123,7 +123,7 @@ func (h *handler) OutboundConfigGetByID(ctx context.Context, id uuid.UUID) (*out
 func (h *handler) OutboundConfigGetByCustomerID(ctx context.Context, customerID uuid.UUID) (*outboundconfig.OutboundConfig, error) {
 	log := logrus.WithField("func", "OutboundConfigGetByCustomerID")
 
-	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM outbound_configs WHERE customer_id = ? AND tm_delete IS NULL LIMIT 1`
+	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM call_outbound_configs WHERE customer_id = ? AND tm_delete IS NULL LIMIT 1`
 	rows, err := h.db.QueryContext(ctx, q, customerID)
 	if err != nil {
 		log.Errorf("Could not get outbound_config by customer. err: %v", err)
@@ -173,7 +173,7 @@ func (h *handler) OutboundConfigUpdate(ctx context.Context, id uuid.UUID, req *o
 	}
 
 	args = append(args, id)
-	q := fmt.Sprintf("UPDATE outbound_configs SET %s WHERE id = ? AND tm_delete IS NULL", strings.Join(sets, ", "))
+	q := fmt.Sprintf("UPDATE call_outbound_configs SET %s WHERE id = ? AND tm_delete IS NULL", strings.Join(sets, ", "))
 
 	if _, err := h.db.ExecContext(ctx, q, args...); err != nil {
 		log.Errorf("Could not update outbound_config. err: %v", err)
@@ -183,12 +183,12 @@ func (h *handler) OutboundConfigUpdate(ctx context.Context, id uuid.UUID, req *o
 	return h.OutboundConfigGetByID(ctx, id)
 }
 
-// OutboundConfigList returns a page of outbound_configs for the given customer,
+// OutboundConfigList returns a page of call_outbound_configs for the given customer,
 // ordered by tm_create DESC. pageToken is an ISO-8601 timestamp used as a cursor.
 func (h *handler) OutboundConfigList(ctx context.Context, customerID uuid.UUID, pageSize uint64, pageToken string) ([]*outboundconfig.OutboundConfig, error) {
 	log := logrus.WithField("func", "OutboundConfigList")
 
-	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM outbound_configs WHERE customer_id = ? AND tm_delete IS NULL`
+	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM call_outbound_configs WHERE customer_id = ? AND tm_delete IS NULL`
 	args := []interface{}{customerID}
 
 	if pageToken != "" {
@@ -200,7 +200,7 @@ func (h *handler) OutboundConfigList(ctx context.Context, customerID uuid.UUID, 
 
 	rows, err := h.db.QueryContext(ctx, q, args...)
 	if err != nil {
-		log.Errorf("Could not list outbound_configs. err: %v", err)
+		log.Errorf("Could not list call_outbound_configs. err: %v", err)
 		return nil, err
 	}
 	defer func() {

--- a/bin-dbscheme-manager/bin-manager/main/versions/60e68bfd6442_outbound_configs_create_table.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/60e68bfd6442_outbound_configs_create_table.py
@@ -1,4 +1,4 @@
-"""outbound_configs_create_table
+"""call_outbound_configs_create_table
 
 Revision ID: 60e68bfd6442
 Revises: 86dd44956fa5
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     op.execute("""
-        CREATE TABLE outbound_configs (
+        CREATE TABLE call_outbound_configs (
             id                    VARCHAR(36)  NOT NULL,
             customer_id           VARCHAR(36)  NOT NULL,
             name                  VARCHAR(255) NOT NULL DEFAULT '',
@@ -35,4 +35,4 @@ def upgrade():
 
 
 def downgrade():
-    op.execute("DROP TABLE IF EXISTS outbound_configs")
+    op.execute("DROP TABLE IF EXISTS call_outbound_configs")

--- a/bin-dbscheme-manager/bin-manager/main/versions/b43193683818_outbound_configs_bootstrap_existing_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/b43193683818_outbound_configs_bootstrap_existing_.py
@@ -1,4 +1,4 @@
-"""outbound_configs_bootstrap_existing_customers
+"""call_outbound_configs_bootstrap_existing_customers
 
 Revision ID: b43193683818
 Revises: 60e68bfd6442
@@ -19,15 +19,15 @@ depends_on = None
 def upgrade():
     # Insert an empty OutboundConfig for every active customer that doesn't have one.
     # customer_customers uses '9999-01-01 00:00:00.000000' for active records (sentinel pattern).
-    # outbound_configs uses NULL for active records.
+    # call_outbound_configs uses NULL for active records.
     # INSERT IGNORE skips customers that already have an outbound_config row (idempotent).
     op.execute("""
-        INSERT IGNORE INTO outbound_configs (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update)
+        INSERT IGNORE INTO call_outbound_configs (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update)
         SELECT UUID(), c.id, '', '', '[]', '', NOW(), NOW()
         FROM customer_customers c
         WHERE c.tm_delete = '9999-01-01 00:00:00.000000'
           AND NOT EXISTS (
-              SELECT 1 FROM outbound_configs oc
+              SELECT 1 FROM call_outbound_configs oc
               WHERE oc.customer_id = c.id AND oc.tm_delete IS NULL
           )
     """)
@@ -37,7 +37,7 @@ def downgrade():
     # Remove auto-bootstrapped configs (those with empty name/detail/whitelist/codecs).
     # Note: this does NOT remove configs that were manually configured by customers.
     op.execute("""
-        DELETE FROM outbound_configs
+        DELETE FROM call_outbound_configs
         WHERE name = '' AND detail = '' AND codecs = ''
           AND JSON_LENGTH(destination_whitelist) = 0
           AND tm_delete IS NULL

--- a/docs/conventions/database.md
+++ b/docs/conventions/database.md
@@ -36,6 +36,10 @@ const outboundConfigTable = "call_outbound_configs"  // CORRECT
 const outboundConfigTable = "outbound_configs"        // WRONG — missing prefix
 ```
 
+When adding a new service, derive the prefix from the service name (e.g. `bin-rag-manager` → `rag_`) and add it to the table above.
+
+**Exception — `bin-call-manager`:** This service uses direct SQL (not Squirrel) per its own `CLAUDE.md`. The §7.0 prefix rule still applies; the §7.1 Squirrel rule does not.
+
 ---
 
 ## 7.1 Squirrel Query Builder (Mandatory)
@@ -192,6 +196,7 @@ Use this checklist when adding or modifying database models and operations:
 
 ### Database Operations
 
+- [ ] Table name uses the owning service's domain prefix (`call_`, `flow_`, `agent_`, …) (§7.0)
 - [ ] Queries use the squirrel query builder, not raw SQL (§7.1)
 - [ ] INSERT/UPDATE go through `commondatabasehandler.PrepareFields` (§7.2)
 - [ ] SELECT uses `commondatabasehandler.GetDBFields` + `ScanRow` — never manual `rows.Scan` (§7.2)

--- a/docs/conventions/database.md
+++ b/docs/conventions/database.md
@@ -1,5 +1,43 @@
 # Database Patterns
 
+## 7.0 Table Naming Convention
+
+**MANDATORY:** Every MySQL table name must be prefixed with its owning service's domain abbreviation:
+
+| Service | Prefix | Example |
+|---------|--------|---------|
+| `bin-call-manager` | `call_` | `call_calls`, `call_groupcalls`, `call_outbound_configs` |
+| `bin-flow-manager` | `flow_` | `flow_flows`, `flow_activeflows` |
+| `bin-customer-manager` | `customer_` | `customer_customers` |
+| `bin-agent-manager` | `agent_` | `agent_agents` |
+| `bin-billing-manager` | `billing_` | `billing_accounts`, `billing_billings` |
+| `bin-conference-manager` | `conference_` | `conference_conferences` |
+| `bin-campaign-manager` | `campaign_` | `campaign_campaigns` |
+| `bin-number-manager` | `number_` | `number_numbers` |
+| `bin-registrar-manager` | `registrar_` | `registrar_trunks` |
+
+Format: `<domain>_<plural-entity>` — always lowercase, words separated by underscores.
+
+```python
+# CORRECT
+CREATE TABLE call_outbound_configs (...)         # call-manager owns this table
+
+# WRONG — missing service prefix
+CREATE TABLE outbound_configs (...)
+
+# WRONG — use short prefix, not full service name
+CREATE TABLE call_manager_outbound_configs (...)
+```
+
+The Go constant in the matching `pkg/dbhandler/` file must use the full prefixed name:
+
+```go
+const outboundConfigTable = "call_outbound_configs"  // CORRECT
+const outboundConfigTable = "outbound_configs"        // WRONG — missing prefix
+```
+
+---
+
 ## 7.1 Squirrel Query Builder (Mandatory)
 
 All SQL queries MUST use the squirrel query builder. Raw SQL strings are forbidden.

--- a/docs/plans/2026-05-07-outbound-config-design.md
+++ b/docs/plans/2026-05-07-outbound-config-design.md
@@ -1,5 +1,7 @@
 # OutboundConfig Design
 
+> **Note:** This document was written before the table naming convention (§7.0 in [docs/conventions/database.md](../conventions/database.md)) was enforced. All references to `outbound_configs` in this document should be read as `call_outbound_configs` — that is the actual table name in production.
+
 **Date:** 2026-05-07
 **Branch:** NOJIRA-outbound-config
 

--- a/docs/plans/2026-05-07-outbound-config-plan.md
+++ b/docs/plans/2026-05-07-outbound-config-plan.md
@@ -1,5 +1,7 @@
 # OutboundConfig Implementation Plan
 
+> **Note:** This document was written before the table naming convention (§7.0 in [docs/conventions/database.md](../conventions/database.md)) was enforced. All references to `outbound_configs` in this document should be read as `call_outbound_configs` — that is the actual table name in production.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add a per-customer `OutboundConfig` resource (destination country whitelist + codec preference) that gates every outbound PSTN call in `bin-call-manager`, and removes `Customer.Metadata.OutboundCodecs`.


### PR DESCRIPTION
Fix table naming convention violations in the OutboundConfig feature and document the rule.

All MySQL tables must be prefixed with the owning service's domain abbreviation (e.g. call_ for bin-call-manager, flow_ for bin-flow-manager). The outbound_configs table was missing the call_ prefix.

- bin-dbscheme-manager: Rename table outbound_configs → call_outbound_configs in CREATE TABLE migration (60e68bfd6442) and bootstrap migration (b43193683818)
- bin-call-manager: Update outboundConfigTable constant and all SQL queries to use call_outbound_configs
- docs: Add §7.0 Table Naming Convention to docs/conventions/database.md with prefix table, correct/wrong examples, and Go constant guidance