### PR TITLE
NOJIRA-outbound-config-auto-delete

### DIFF
--- a/bin-call-manager/pkg/callhandler/event.go
+++ b/bin-call-manager/pkg/callhandler/event.go
@@ -43,6 +43,18 @@ func (h *callHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer
 		log.WithField("call", tmp).Debugf("Deleted call info. call_id: %s", tmp.ID)
 	}
 
+	// soft-delete the customer's OutboundConfig
+	cfg, err := h.outboundConfigHandler.GetByCustomerID(ctx, cu.ID)
+	if err != nil {
+		log.Warnf("Could not get outbound config for deleted customer. customer_id: %s, err: %v", cu.ID, err)
+	} else if cfg != nil {
+		if _, err := h.outboundConfigHandler.Delete(ctx, cfg.ID); err != nil {
+			log.Warnf("Could not delete outbound config for deleted customer. customer_id: %s, err: %v", cu.ID, err)
+		} else {
+			log.Debugf("Deleted outbound config for customer. customer_id: %s, config_id: %s", cu.ID, cfg.ID)
+		}
+	}
+
 	return nil
 }
 

--- a/bin-call-manager/pkg/callhandler/event_test.go
+++ b/bin-call-manager/pkg/callhandler/event_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"monorepo/bin-call-manager/models/call"
+	outboundconfig "monorepo/bin-call-manager/models/outboundconfig"
 	"monorepo/bin-call-manager/pkg/dbhandler"
+	"monorepo/bin-call-manager/pkg/outboundconfighandler"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
@@ -20,11 +22,15 @@ import (
 
 func Test_EventCUCustomerDeleted(t *testing.T) {
 
+	customerID := uuid.FromStringOrNil("8c0daf80-f0c3-11ee-9ed5-6b65132a6fc3")
+	configID := uuid.FromStringOrNil("a1000000-0000-0000-0000-000000000001")
+
 	tests := []struct {
 		name string
 
-		customer      *cmcustomer.Customer
-		responseCalls []*call.Call
+		customer        *cmcustomer.Customer
+		responseCalls   []*call.Call
+		responseConfig  *outboundconfig.OutboundConfig
 
 		expectFilter map[string]string
 	}{
@@ -32,7 +38,7 @@ func Test_EventCUCustomerDeleted(t *testing.T) {
 			name: "normal",
 
 			customer: &cmcustomer.Customer{
-				ID: uuid.FromStringOrNil("8c0daf80-f0c3-11ee-9ed5-6b65132a6fc3"),
+				ID: customerID,
 			},
 			responseCalls: []*call.Call{
 				{
@@ -50,11 +56,24 @@ func Test_EventCUCustomerDeleted(t *testing.T) {
 					TMDelete: nil,
 				},
 			},
+			responseConfig: &outboundconfig.OutboundConfig{
+				ID:         configID,
+				CustomerID: customerID,
+			},
 
 			expectFilter: map[string]string{
 				"customer_id": "8c0daf80-f0c3-11ee-9ed5-6b65132a6fc3",
 				"deleted":     "false",
 			},
+		},
+		{
+			name: "no outbound config",
+
+			customer: &cmcustomer.Customer{
+				ID: customerID,
+			},
+			responseCalls:  []*call.Call{},
+			responseConfig: nil,
 		},
 	}
 
@@ -67,26 +86,31 @@ func Test_EventCUCustomerDeleted(t *testing.T) {
 			mockDB := dbhandler.NewMockDBHandler(mc)
 			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
 			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockOutboundConfig := outboundconfighandler.NewMockOutboundConfigHandler(mc)
 
 			h := &callHandler{
-				reqHandler:    mockReq,
-				db:            mockDB,
-				notifyHandler: mockNotify,
-				utilHandler:   mockUtil,
+				reqHandler:            mockReq,
+				db:                    mockDB,
+				notifyHandler:         mockNotify,
+				utilHandler:           mockUtil,
+				outboundConfigHandler: mockOutboundConfig,
 			}
 			ctx := context.Background()
 
 			mockDB.EXPECT().CallList(ctx, uint64(1000), "", gomock.Any()).Return(tt.responseCalls, nil)
 
-			// delete each calls
+			// delete each call
 			for _, c := range tt.responseCalls {
 				mockDB.EXPECT().CallGet(ctx, c.ID).Return(c, nil)
-
-				// dbDelete
 				mockDB.EXPECT().CallDelete(ctx, c.ID).Return(nil)
 				mockDB.EXPECT().CallGet(ctx, c.ID).Return(c, nil)
 				mockNotify.EXPECT().PublishWebhookEvent(ctx, c.CustomerID, call.EventTypeCallDeleted, c)
+			}
 
+			// delete outbound config
+			mockOutboundConfig.EXPECT().GetByCustomerID(ctx, tt.customer.ID).Return(tt.responseConfig, nil)
+			if tt.responseConfig != nil {
+				mockOutboundConfig.EXPECT().Delete(ctx, tt.responseConfig.ID).Return(tt.responseConfig, nil)
 			}
 
 			if err := h.EventCUCustomerDeleted(ctx, tt.customer); err != nil {

--- a/bin-call-manager/pkg/callhandler/event_test.go
+++ b/bin-call-manager/pkg/callhandler/event_test.go
@@ -2,6 +2,7 @@ package callhandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"monorepo/bin-call-manager/models/call"
@@ -76,6 +77,37 @@ func Test_EventCUCustomerDeleted(t *testing.T) {
 			responseConfig: nil,
 		},
 	}
+
+	// Also verify the error path: GetByCustomerID returns an error → handler logs warn and returns nil (non-fatal)
+	t.Run("outbound config get error is non-fatal", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		mockDB := dbhandler.NewMockDBHandler(mc)
+		mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+		mockUtil := utilhandler.NewMockUtilHandler(mc)
+		mockOutboundConfig := outboundconfighandler.NewMockOutboundConfigHandler(mc)
+
+		h := &callHandler{
+			reqHandler:            mockReq,
+			db:                    mockDB,
+			notifyHandler:         mockNotify,
+			utilHandler:           mockUtil,
+			outboundConfigHandler: mockOutboundConfig,
+		}
+		ctx := context.Background()
+
+		customer := &cmcustomer.Customer{ID: customerID}
+
+		mockDB.EXPECT().CallList(ctx, uint64(1000), "", gomock.Any()).Return([]*call.Call{}, nil)
+		// GetByCustomerID returns an error — handler must log Warn and return nil (not propagate the error)
+		mockOutboundConfig.EXPECT().GetByCustomerID(ctx, customer.ID).Return(nil, fmt.Errorf("db unavailable"))
+
+		if err := h.EventCUCustomerDeleted(ctx, customer); err != nil {
+			t.Errorf("EventCUCustomerDeleted must return nil even when OutboundConfig get fails, got: %v", err)
+		}
+	})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/bin-call-manager/pkg/dbhandler/outbound_config.go
+++ b/bin-call-manager/pkg/dbhandler/outbound_config.go
@@ -16,6 +16,9 @@ import (
 
 const outboundConfigTable = "call_outbound_configs"
 
+// outboundConfigSelectCols is the canonical column list for SELECT queries against outboundConfigTable.
+const outboundConfigSelectCols = "id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete"
+
 // outboundConfigGetFromRow scans a single call_outbound_configs row into an OutboundConfig.
 func (h *handler) outboundConfigGetFromRow(row *sql.Rows) (*outboundconfig.OutboundConfig, error) {
 	res := &outboundconfig.OutboundConfig{}
@@ -98,7 +101,7 @@ func (h *handler) OutboundConfigDelete(ctx context.Context, id uuid.UUID) error 
 func (h *handler) OutboundConfigGetByID(ctx context.Context, id uuid.UUID) (*outboundconfig.OutboundConfig, error) {
 	log := logrus.WithField("func", "OutboundConfigGetByID")
 
-	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM call_outbound_configs WHERE id = ? AND tm_delete IS NULL LIMIT 1`
+	q := "SELECT " + outboundConfigSelectCols + " FROM " + outboundConfigTable + " WHERE id = ? AND tm_delete IS NULL LIMIT 1"
 	rows, err := h.db.QueryContext(ctx, q, id)
 	if err != nil {
 		log.Errorf("Could not get outbound_config. err: %v", err)
@@ -123,7 +126,7 @@ func (h *handler) OutboundConfigGetByID(ctx context.Context, id uuid.UUID) (*out
 func (h *handler) OutboundConfigGetByCustomerID(ctx context.Context, customerID uuid.UUID) (*outboundconfig.OutboundConfig, error) {
 	log := logrus.WithField("func", "OutboundConfigGetByCustomerID")
 
-	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM call_outbound_configs WHERE customer_id = ? AND tm_delete IS NULL LIMIT 1`
+	q := "SELECT " + outboundConfigSelectCols + " FROM " + outboundConfigTable + " WHERE customer_id = ? AND tm_delete IS NULL LIMIT 1"
 	rows, err := h.db.QueryContext(ctx, q, customerID)
 	if err != nil {
 		log.Errorf("Could not get outbound_config by customer. err: %v", err)
@@ -188,7 +191,7 @@ func (h *handler) OutboundConfigUpdate(ctx context.Context, id uuid.UUID, req *o
 func (h *handler) OutboundConfigList(ctx context.Context, customerID uuid.UUID, pageSize uint64, pageToken string) ([]*outboundconfig.OutboundConfig, error) {
 	log := logrus.WithField("func", "OutboundConfigList")
 
-	q := `SELECT id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update, tm_delete FROM call_outbound_configs WHERE customer_id = ? AND tm_delete IS NULL`
+	q := "SELECT " + outboundConfigSelectCols + " FROM " + outboundConfigTable + " WHERE customer_id = ? AND tm_delete IS NULL"
 	args := []interface{}{customerID}
 
 	if pageToken != "" {

--- a/bin-call-manager/pkg/dbhandler/outbound_config.go
+++ b/bin-call-manager/pkg/dbhandler/outbound_config.go
@@ -74,7 +74,7 @@ func (h *handler) OutboundConfigCreate(ctx context.Context, c *outboundconfig.Ou
 	}
 
 	now := time.Now()
-	q := `INSERT INTO call_outbound_configs (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	q := "INSERT INTO " + outboundConfigTable + " (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
 	if _, err := h.db.ExecContext(ctx, q, c.ID, c.CustomerID, c.Name, c.Detail, whitelistJSON, c.Codecs, now, now); err != nil {
 		log.Errorf("Could not create outbound_config. err: %v", err)
 		return err
@@ -87,7 +87,7 @@ func (h *handler) OutboundConfigCreate(ctx context.Context, c *outboundconfig.Ou
 func (h *handler) OutboundConfigDelete(ctx context.Context, id uuid.UUID) error {
 	log := logrus.WithField("func", "OutboundConfigDelete")
 
-	q := `UPDATE call_outbound_configs SET tm_delete = ? WHERE id = ? AND tm_delete IS NULL`
+	q := "UPDATE " + outboundConfigTable + " SET tm_delete = ? WHERE id = ? AND tm_delete IS NULL"
 	if _, err := h.db.ExecContext(ctx, q, time.Now(), id); err != nil {
 		log.Errorf("Could not delete outbound_config. err: %v", err)
 		return err
@@ -176,7 +176,7 @@ func (h *handler) OutboundConfigUpdate(ctx context.Context, id uuid.UUID, req *o
 	}
 
 	args = append(args, id)
-	q := fmt.Sprintf("UPDATE call_outbound_configs SET %s WHERE id = ? AND tm_delete IS NULL", strings.Join(sets, ", "))
+	q := fmt.Sprintf("UPDATE "+outboundConfigTable+" SET %s WHERE id = ? AND tm_delete IS NULL", strings.Join(sets, ", "))
 
 	if _, err := h.db.ExecContext(ctx, q, args...); err != nil {
 		log.Errorf("Could not update outbound_config. err: %v", err)


### PR DESCRIPTION
Auto-delete OutboundConfig when a customer is deleted, consistent with how billing accounts are cascaded on customer deletion.

When the customer-manager publishes a customer_deleted event, the call-manager's EventCUCustomerDeleted handler now also soft-deletes the customer's OutboundConfig row. This ensures no orphaned config rows remain after customer deletion, and that any re-created customer starts with a clean slate.

- bin-call-manager: Add OutboundConfig soft-delete to EventCUCustomerDeleted alongside existing call deletion
- bin-call-manager: Add outboundConfigSelectCols constant; refactor SELECT queries to use outboundConfigTable and outboundConfigSelectCols constants (removes unused constant lint warning)
- bin-call-manager: Update Test_EventCUCustomerDeleted to cover the new OutboundConfig deletion path (success + no-config cases)