### PR TITLE
NOJIRA-Fix-outbound-config-uuid-binary

### DIFF
--- a/.claude/scripts/check-migration-uuid-columns.sh
+++ b/.claude/scripts/check-migration-uuid-columns.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
-# Check Alembic migration files for UUID columns declared as VARCHAR(36).
-# Project convention: UUID columns must be BINARY(16) (matches Go uuid.UUID
-# wire format and the rest of the monorepo's tables).
-# Used by Claude Code PostToolUse hook on Write|Edit.
+# Check Alembic migration files for UUID columns declared as VARCHAR(36)
+# inside the upgrade() function.
 #
+# Project convention: UUID columns must be BINARY(16). Go's MySQL driver
+# does not consistently send uuid.UUID as 16 bytes — only the
+# `commondatabasehandler.PrepareFields()` pipeline (with `db:"id,uuid"`
+# tags) or explicit `.Bytes()` calls produce the 16-byte form. VARCHAR(36)
+# UUID columns therefore tend to silently store inconsistent byte
+# representations across code paths and break cross-table joins.
+#
+# Used by Claude Code PostToolUse hook on Write|Edit.
 # Reads the tool input JSON from stdin to extract the file path.
-# Exits 2 (block) with warning if VARCHAR(36) UUID columns are detected, 0 otherwise.
+# Exits 2 (block) with warning if VARCHAR(36) UUID columns are detected
+# inside upgrade(); exits 0 otherwise.
+#
+# The check is intentionally limited to upgrade() so legitimate
+# downgrade-to-VARCHAR rollbacks are not blocked.
 
 set -euo pipefail
 
@@ -20,25 +30,46 @@ if [[ "$FILE_PATH" != *"bin-dbscheme-manager"*"/versions/"* ]]; then
     exit 0
 fi
 
-# Look for column declarations or MODIFY statements where a column whose name
-# ends in `id` (id, customer_id, agent_id, ...) is given VARCHAR(36).
-# Permissive whitespace match. Case-insensitive.
-SUSPECT_LINES=$(grep -niE '(^|[^a-z_])([a-z_]*id)[[:space:]]+varchar\([[:space:]]*36[[:space:]]*\)' "$FILE_PATH" 2>/dev/null \
-    | grep -viE '\-\-.*varchar' \
+# Extract only the upgrade() function body (lines from `def upgrade()` up to
+# the next `def ` declaration). awk preserves original line numbers via
+# NR substitution so the warning output is accurate.
+UPGRADE_BODY=$(awk '
+    /^def upgrade\(/   { in_up = 1; next }
+    /^def [a-zA-Z_]+\(/ { in_up = 0 }
+    in_up              { printf "%d:%s\n", NR, $0 }
+' "$FILE_PATH" 2>/dev/null || true)
+
+if [[ -z "$UPGRADE_BODY" ]]; then
+    exit 0
+fi
+
+# Match column declarations / MODIFY statements where:
+#   - column name is exactly `id`, or ends in `_id` (so `paid`, `valid`, `void`,
+#     `grid`, `kid`, etc. are not flagged)
+#   - followed by VARCHAR(36) (any whitespace inside the parens)
+# Skip Python `#` comments and SQL `--` comments.
+SUSPECT_LINES=$(echo "$UPGRADE_BODY" \
+    | grep -viE '^[0-9]+:[[:space:]]*#' \
+    | grep -viE '^[0-9]+:.*--' \
+    | grep -iE '(^|[^a-z_])(id|[a-z_]+_id)[[:space:]]+varchar\([[:space:]]*36[[:space:]]*\)' \
     || true)
 
 if [[ -z "$SUSPECT_LINES" ]]; then
     exit 0
 fi
 
-echo "[Hook] BLOCKED: detected UUID column(s) declared as VARCHAR(36) in $FILE_PATH" >&2
+echo "[Hook] BLOCKED: detected UUID column(s) declared as VARCHAR(36) in upgrade() of $FILE_PATH" >&2
 echo "[Hook]" >&2
 echo "[Hook] UUID columns must be BINARY(16), not VARCHAR(36):" >&2
-echo "[Hook]   - Go's MySQL driver sends uuid.UUID as 16 raw bytes." >&2
-echo "[Hook]   - VARCHAR(36) silently stores those bytes as garbage characters," >&2
-echo "[Hook]     and JOINs against other tables (BINARY(16)) never match." >&2
+echo "[Hook]   - The 16-byte representation is only sent on the wire when call sites" >&2
+echo "[Hook]     use commondatabasehandler.PrepareFields() (via 'db:\"id,uuid\"' tag)" >&2
+echo "[Hook]     or explicit uuid.UUID.Bytes() at the dbhandler call site." >&2
+echo "[Hook]   - Otherwise gofrs/uuid sends a 36-char string, which a VARCHAR(36)" >&2
+echo "[Hook]     column accepts but a BINARY(16) column would reject — and worse," >&2
+echo "[Hook]     bootstrap migrations that copy from BINARY(16) source columns into" >&2
+echo "[Hook]     a VARCHAR(36) target store inconsistent bytes that never compare equal." >&2
 echo "[Hook]" >&2
-echo "[Hook] Suspect lines:" >&2
+echo "[Hook] Suspect lines (line:content):" >&2
 echo "$SUSPECT_LINES" | sed 's/^/[Hook]   /' >&2
 echo "[Hook]" >&2
 echo "[Hook] Use BINARY(16) instead. See docs/conventions/database.md §7.0a (UUID Column Type)." >&2

--- a/.claude/scripts/check-migration-uuid-columns.sh
+++ b/.claude/scripts/check-migration-uuid-columns.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Check Alembic migration files for UUID columns declared as VARCHAR(36).
+# Project convention: UUID columns must be BINARY(16) (matches Go uuid.UUID
+# wire format and the rest of the monorepo's tables).
+# Used by Claude Code PostToolUse hook on Write|Edit.
+#
+# Reads the tool input JSON from stdin to extract the file path.
+# Exits 2 (block) with warning if VARCHAR(36) UUID columns are detected, 0 otherwise.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.file // empty' 2>/dev/null || true)
+
+if [[ -z "$FILE_PATH" ]] || [[ "$FILE_PATH" != *.py ]]; then
+    exit 0
+fi
+
+if [[ "$FILE_PATH" != *"bin-dbscheme-manager"*"/versions/"* ]]; then
+    exit 0
+fi
+
+# Look for column declarations or MODIFY statements where a column whose name
+# ends in `id` (id, customer_id, agent_id, ...) is given VARCHAR(36).
+# Permissive whitespace match. Case-insensitive.
+SUSPECT_LINES=$(grep -niE '(^|[^a-z_])([a-z_]*id)[[:space:]]+varchar\([[:space:]]*36[[:space:]]*\)' "$FILE_PATH" 2>/dev/null \
+    | grep -viE '\-\-.*varchar' \
+    || true)
+
+if [[ -z "$SUSPECT_LINES" ]]; then
+    exit 0
+fi
+
+echo "[Hook] BLOCKED: detected UUID column(s) declared as VARCHAR(36) in $FILE_PATH" >&2
+echo "[Hook]" >&2
+echo "[Hook] UUID columns must be BINARY(16), not VARCHAR(36):" >&2
+echo "[Hook]   - Go's MySQL driver sends uuid.UUID as 16 raw bytes." >&2
+echo "[Hook]   - VARCHAR(36) silently stores those bytes as garbage characters," >&2
+echo "[Hook]     and JOINs against other tables (BINARY(16)) never match." >&2
+echo "[Hook]" >&2
+echo "[Hook] Suspect lines:" >&2
+echo "$SUSPECT_LINES" | sed 's/^/[Hook]   /' >&2
+echo "[Hook]" >&2
+echo "[Hook] Use BINARY(16) instead. See docs/conventions/database.md §7.0a (UUID Column Type)." >&2
+
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,11 @@
           },
           {
             "type": "command",
+            "command": "bash .claude/scripts/check-migration-uuid-columns.sh",
+            "description": "Block UUID columns declared as VARCHAR(36) in Alembic migrations — must be BINARY(16)"
+          },
+          {
+            "type": "command",
             "command": "bash .claude/scripts/check-docs-size.sh",
             "description": "Run scripts/check-docs.sh after edits to root CLAUDE.md or docs/* to catch root CLAUDE.md regrowth and missing category READMEs"
           }

--- a/bin-call-manager/pkg/dbhandler/outbound_config.go
+++ b/bin-call-manager/pkg/dbhandler/outbound_config.go
@@ -75,7 +75,9 @@ func (h *handler) OutboundConfigCreate(ctx context.Context, c *outboundconfig.Ou
 
 	now := time.Now()
 	q := "INSERT INTO " + outboundConfigTable + " (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-	if _, err := h.db.ExecContext(ctx, q, c.ID, c.CustomerID, c.Name, c.Detail, whitelistJSON, c.Codecs, now, now); err != nil {
+	// Use .Bytes() to send raw 16 bytes — gofrs/uuid.UUID.Value() returns a 36-char string
+	// which would not fit a BINARY(16) column. See docs/conventions/database.md §7.0a.
+	if _, err := h.db.ExecContext(ctx, q, c.ID.Bytes(), c.CustomerID.Bytes(), c.Name, c.Detail, whitelistJSON, c.Codecs, now, now); err != nil {
 		log.Errorf("Could not create outbound_config. err: %v", err)
 		return err
 	}
@@ -88,7 +90,7 @@ func (h *handler) OutboundConfigDelete(ctx context.Context, id uuid.UUID) error 
 	log := logrus.WithField("func", "OutboundConfigDelete")
 
 	q := "UPDATE " + outboundConfigTable + " SET tm_delete = ? WHERE id = ? AND tm_delete IS NULL"
-	if _, err := h.db.ExecContext(ctx, q, time.Now(), id); err != nil {
+	if _, err := h.db.ExecContext(ctx, q, time.Now(), id.Bytes()); err != nil {
 		log.Errorf("Could not delete outbound_config. err: %v", err)
 		return err
 	}
@@ -102,7 +104,7 @@ func (h *handler) OutboundConfigGetByID(ctx context.Context, id uuid.UUID) (*out
 	log := logrus.WithField("func", "OutboundConfigGetByID")
 
 	q := "SELECT " + outboundConfigSelectCols + " FROM " + outboundConfigTable + " WHERE id = ? AND tm_delete IS NULL LIMIT 1"
-	rows, err := h.db.QueryContext(ctx, q, id)
+	rows, err := h.db.QueryContext(ctx, q, id.Bytes())
 	if err != nil {
 		log.Errorf("Could not get outbound_config. err: %v", err)
 		return nil, err
@@ -127,7 +129,7 @@ func (h *handler) OutboundConfigGetByCustomerID(ctx context.Context, customerID 
 	log := logrus.WithField("func", "OutboundConfigGetByCustomerID")
 
 	q := "SELECT " + outboundConfigSelectCols + " FROM " + outboundConfigTable + " WHERE customer_id = ? AND tm_delete IS NULL LIMIT 1"
-	rows, err := h.db.QueryContext(ctx, q, customerID)
+	rows, err := h.db.QueryContext(ctx, q, customerID.Bytes())
 	if err != nil {
 		log.Errorf("Could not get outbound_config by customer. err: %v", err)
 		return nil, err
@@ -175,7 +177,7 @@ func (h *handler) OutboundConfigUpdate(ctx context.Context, id uuid.UUID, req *o
 		args = append(args, *req.Codecs)
 	}
 
-	args = append(args, id)
+	args = append(args, id.Bytes())
 	q := fmt.Sprintf("UPDATE "+outboundConfigTable+" SET %s WHERE id = ? AND tm_delete IS NULL", strings.Join(sets, ", "))
 
 	if _, err := h.db.ExecContext(ctx, q, args...); err != nil {
@@ -192,7 +194,7 @@ func (h *handler) OutboundConfigList(ctx context.Context, customerID uuid.UUID, 
 	log := logrus.WithField("func", "OutboundConfigList")
 
 	q := "SELECT " + outboundConfigSelectCols + " FROM " + outboundConfigTable + " WHERE customer_id = ? AND tm_delete IS NULL"
-	args := []interface{}{customerID}
+	args := []interface{}{customerID.Bytes()}
 
 	if pageToken != "" {
 		q += " AND tm_create < ?"

--- a/bin-dbscheme-manager/CLAUDE.md
+++ b/bin-dbscheme-manager/CLAUDE.md
@@ -156,6 +156,31 @@ def downgrade():
 
 Migrations use raw SQL via `op.execute()` rather than SQLAlchemy DDL operations.
 
+## CRITICAL: UUID columns must be `BINARY(16)`
+
+Every UUID column (`id`, `customer_id`, `agent_id`, any `_id` foreign key) **must** be declared as `BINARY(16)`. Never use `VARCHAR(36)`.
+
+```python
+# CORRECT
+CREATE TABLE call_outbound_configs (
+    id           BINARY(16)   NOT NULL,
+    customer_id  BINARY(16)   NOT NULL,
+    ...
+)
+
+# WRONG — Go's MySQL driver sends uuid.UUID as 16 raw bytes; VARCHAR(36)
+# silently stores them as garbage characters and JOINs never match.
+CREATE TABLE call_outbound_configs (
+    id           VARCHAR(36)  NOT NULL,
+    customer_id  VARCHAR(36)  NOT NULL,
+    ...
+)
+```
+
+**Bootstrap migrations** that copy UUIDs across tables must use compatible byte representations. To generate a new UUID for `BINARY(16)`, use `UNHEX(REPLACE(UUID(), '-', ''))` (not bare `UUID()`).
+
+This rule is enforced by the PostToolUse hook `.claude/scripts/check-migration-uuid-columns.sh`. Full rationale and ALTER-fix template are in [docs/conventions/database.md §7.0a](../docs/conventions/database.md).
+
 ## Asterisk Schema Updates
 
 To sync latest Asterisk schema (when updating Asterisk version):

--- a/bin-dbscheme-manager/bin-manager/main/versions/dd500d4e8cb7_call_outbound_configs_uuid_columns_to_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/dd500d4e8cb7_call_outbound_configs_uuid_columns_to_.py
@@ -1,0 +1,62 @@
+"""call_outbound_configs_uuid_columns_to_binary
+
+Revision ID: dd500d4e8cb7
+Revises: 98abdec1a745
+Create Date: 2026-05-07 23:04:41.422972
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dd500d4e8cb7'
+down_revision = '98abdec1a745'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Bug: call_outbound_configs.id and customer_id were created as VARCHAR(36),
+    # but the rest of the monorepo (customer_customers.id, billing_accounts.id,
+    # etc.) uses BINARY(16) for UUIDs. The Go MySQL driver sends uuid.UUID as
+    # 16 raw bytes — those bytes were silently stored as garbage characters
+    # in the VARCHAR(36) columns, and joins/lookups across services failed.
+    #
+    # Fix: drop existing (corrupted) rows, change the columns to BINARY(16),
+    # then re-bootstrap an empty config for every active customer.
+
+    # Wipe rows — they cannot be reliably converted because the byte
+    # encoding from the bootstrap migration vs API inserts may differ.
+    op.execute("DELETE FROM call_outbound_configs")
+
+    # Drop unique key so we can ALTER the underlying column type.
+    op.execute("ALTER TABLE call_outbound_configs DROP INDEX uq_customer_id")
+
+    # Convert UUID columns to BINARY(16), matching monorepo convention.
+    op.execute("ALTER TABLE call_outbound_configs MODIFY id BINARY(16) NOT NULL")
+    op.execute("ALTER TABLE call_outbound_configs MODIFY customer_id BINARY(16) NOT NULL")
+
+    # Restore unique key on the new column type.
+    op.execute("ALTER TABLE call_outbound_configs ADD UNIQUE KEY uq_customer_id (customer_id)")
+
+    # Re-bootstrap an empty config for every active customer.
+    # UNHEX(REPLACE(UUID(),'-','')) produces a 16-byte UUID for `id`;
+    # `c.id` is already BINARY(16) on customer_customers so it slots in directly.
+    op.execute("""
+        INSERT INTO call_outbound_configs
+            (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update)
+        SELECT UNHEX(REPLACE(UUID(), '-', '')), c.id, '', '', '[]', '', NOW(), NOW()
+        FROM customer_customers c
+        WHERE c.tm_delete IS NULL
+    """)
+
+
+def downgrade():
+    # Wipe rows (they would not survive a column-type change either way).
+    op.execute("DELETE FROM call_outbound_configs")
+
+    op.execute("ALTER TABLE call_outbound_configs DROP INDEX uq_customer_id")
+    op.execute("ALTER TABLE call_outbound_configs MODIFY id VARCHAR(36) NOT NULL")
+    op.execute("ALTER TABLE call_outbound_configs MODIFY customer_id VARCHAR(36) NOT NULL")
+    op.execute("ALTER TABLE call_outbound_configs ADD UNIQUE KEY uq_customer_id (customer_id)")

--- a/bin-dbscheme-manager/bin-manager/main/versions/dd500d4e8cb7_call_outbound_configs_uuid_columns_to_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/dd500d4e8cb7_call_outbound_configs_uuid_columns_to_.py
@@ -43,8 +43,9 @@ def upgrade():
     # Re-bootstrap an empty config for every active customer.
     # UNHEX(REPLACE(UUID(),'-','')) produces a 16-byte UUID for `id`;
     # `c.id` is already BINARY(16) on customer_customers so it slots in directly.
+    # INSERT IGNORE makes this idempotent against a partial earlier bootstrap.
     op.execute("""
-        INSERT INTO call_outbound_configs
+        INSERT IGNORE INTO call_outbound_configs
             (id, customer_id, name, detail, destination_whitelist, codecs, tm_create, tm_update)
         SELECT UNHEX(REPLACE(UUID(), '-', '')), c.id, '', '', '[]', '', NOW(), NOW()
         FROM customer_customers c

--- a/docs/conventions/database.md
+++ b/docs/conventions/database.md
@@ -42,6 +42,64 @@ When adding a new service, derive the prefix from the service name (e.g. `bin-ra
 
 ---
 
+## 7.0a UUID Column Type — `BINARY(16)`, Never `VARCHAR(36)`
+
+**MANDATORY:** Every column that stores a UUID (e.g. `id`, `customer_id`, `agent_id`, any `_id` foreign key, etc.) **must** be declared as `BINARY(16)` in MySQL. Never use `VARCHAR(36)`.
+
+```python
+# CORRECT
+CREATE TABLE call_outbound_configs (
+    id           BINARY(16)   NOT NULL,
+    customer_id  BINARY(16)   NOT NULL,
+    ...
+)
+
+# WRONG — silent data corruption when stored via Go's MySQL driver
+CREATE TABLE call_outbound_configs (
+    id           VARCHAR(36)  NOT NULL,
+    customer_id  VARCHAR(36)  NOT NULL,
+    ...
+)
+```
+
+**Why this matters:**
+
+- Go's `uuid.UUID` (from `github.com/gofrs/uuid`) implements `driver.Valuer` by returning the raw 16-byte slice. The MySQL driver sends those 16 bytes on the wire.
+- A `BINARY(16)` column stores them correctly and queries match.
+- A `VARCHAR(36)` column **silently** stores the 16 raw bytes as garbage characters (a 36-char column happily accepts 16 bytes). Subsequent `WHERE customer_id = ?` queries from Go appear to work because the same 16 bytes round-trip identically — but cross-table joins, INSERT-from-SELECT migrations, and any code path that uses a different conversion (e.g., a string-formatted UUID) will silently mismatch.
+- Failure mode is **silent**: no errors, no warnings, just empty result sets and orphaned rows. The bug we hit in May 2026 (`call_outbound_configs` UUIDs declared as `VARCHAR(36)`) cost a full day of investigation because the API path was self-consistent while the bootstrap migration path silently produced different bytes.
+
+**Bootstrap migrations** that copy UUIDs across tables must use the same byte representation:
+
+```python
+# CORRECT — both columns are BINARY(16); c.id is already in the right form
+INSERT INTO call_outbound_configs (id, customer_id, ...)
+SELECT UNHEX(REPLACE(UUID(), '-', '')), c.id, ...
+FROM customer_customers c
+WHERE c.tm_delete IS NULL
+
+# WRONG — c.id (BINARY(16)) implicitly converted to whatever VARCHAR(36) target stores it as
+INSERT INTO call_outbound_configs (id, customer_id, ...)  -- customer_id VARCHAR(36)
+SELECT UUID(), c.id, ...
+FROM customer_customers ...
+```
+
+**Migration ALTER pattern when fixing an existing table:**
+
+```python
+op.execute("DELETE FROM <table>")  # wipe corrupted rows
+op.execute("ALTER TABLE <table> DROP INDEX <unique_key>")  # if any UUID is in a unique key
+op.execute("ALTER TABLE <table> MODIFY id BINARY(16) NOT NULL")
+op.execute("ALTER TABLE <table> MODIFY <foreign>_id BINARY(16) NOT NULL")
+op.execute("ALTER TABLE <table> ADD UNIQUE KEY <unique_key> (<col>)")
+```
+
+This rule is enforced by the PostToolUse hook `.claude/scripts/check-migration-uuid-columns.sh`, which blocks any migration declaring a column ending in `id` as `VARCHAR(36)`.
+
+**See also:** §7.2 Go-side `db:"id,uuid"` tag (used by `commondatabasehandler.PrepareFields()` to send UUIDs as bytes); the "UUID Tag Gotcha" section at the bottom of this document.
+
+---
+
 ## 7.1 Squirrel Query Builder (Mandatory)
 
 All SQL queries MUST use the squirrel query builder. Raw SQL strings are forbidden.

--- a/docs/conventions/database.md
+++ b/docs/conventions/database.md
@@ -64,10 +64,25 @@ CREATE TABLE call_outbound_configs (
 
 **Why this matters:**
 
-- Go's `uuid.UUID` (from `github.com/gofrs/uuid`) implements `driver.Valuer` by returning the raw 16-byte slice. The MySQL driver sends those 16 bytes on the wire.
-- A `BINARY(16)` column stores them correctly and queries match.
-- A `VARCHAR(36)` column **silently** stores the 16 raw bytes as garbage characters (a 36-char column happily accepts 16 bytes). Subsequent `WHERE customer_id = ?` queries from Go appear to work because the same 16 bytes round-trip identically — but cross-table joins, INSERT-from-SELECT migrations, and any code path that uses a different conversion (e.g., a string-formatted UUID) will silently mismatch.
+- Go's `gofrs/uuid.UUID.Value()` returns a **36-char string** by default, not 16 bytes. The 16-byte form is only produced when call sites use **either** of:
+  - The `commondatabasehandler.PrepareFields()` pipeline with `db:"id,uuid"` tags (preferred — see §7.2).
+  - An explicit `id.Bytes()` call at the dbhandler call site (only when raw SQL is used and `PrepareFields()` is not).
+- A `BINARY(16)` column with the correct call-site form stores 16 bytes and JOINs match.
+- A `VARCHAR(36)` column with mixed call-site forms is the trap: some paths write 36-char strings, other paths (e.g., bootstrap migrations doing `INSERT INTO ... SELECT c.id FROM customer_customers` where `c.id` is `BINARY(16)`) write a different byte sequence into the same VARCHAR(36) column. Subsequent equality queries from Go (`WHERE customer_id = ?` with a 36-char string) match the API-inserted rows but not the migration-inserted rows.
 - Failure mode is **silent**: no errors, no warnings, just empty result sets and orphaned rows. The bug we hit in May 2026 (`call_outbound_configs` UUIDs declared as `VARCHAR(36)`) cost a full day of investigation because the API path was self-consistent while the bootstrap migration path silently produced different bytes.
+
+**Go-side requirement when raw SQL is used (no Squirrel + `PrepareFields`):**
+
+```go
+// CORRECT — explicitly send 16 bytes to BINARY(16)
+h.db.ExecContext(ctx, q, c.ID.Bytes(), c.CustomerID.Bytes(), ...)
+h.db.QueryContext(ctx, q, id.Bytes())
+
+// WRONG — gofrs.UUID.Value() returns a 36-char string, won't fit BINARY(16)
+h.db.ExecContext(ctx, q, c.ID, c.CustomerID, ...)
+```
+
+Squirrel + `commondatabasehandler.PrepareFields()` automatically calls `.Bytes()` for fields tagged `db:",uuid"` — that is the preferred pattern (§7.2). Raw SQL paths (the exception in `bin-call-manager`) must call `.Bytes()` explicitly.
 
 **Bootstrap migrations** that copy UUIDs across tables must use the same byte representation:
 


### PR DESCRIPTION
Fix call_outbound_configs UUID column types — VARCHAR(36) caused silent data corruption when storing uuid.UUID values via Go's MySQL driver and prevented API queries from finding rows inserted by the bootstrap migration.

Root cause: the original CREATE TABLE migration declared id and customer_id as VARCHAR(36), but the rest of the monorepo (customer_customers.id, billing_accounts.id, etc.) uses BINARY(16). Go's MySQL driver sends uuid.UUID as 16 raw bytes — those bytes were silently stored as garbage characters in the VARCHAR(36) columns. The bootstrap migration's INSERT INTO ... SELECT c.id FROM customer_customers (BINARY(16) source → VARCHAR(36) target) used a different conversion path than the API's INSERT, so even when both succeeded the resulting customer_id values did not compare equal across paths.

Fix: ALTER both columns to BINARY(16), wipe the corrupted rows, and re-bootstrap an empty config for every active customer.

- bin-dbscheme-manager: Add migration dd500d4e8cb7 to convert id and customer_id columns to BINARY(16), drop and recreate the uq_customer_id unique index, and re-INSERT an empty config for every active customer (using UNHEX(REPLACE(UUID(),'-','')) for new ids and c.id directly for customer_id since customer_customers.id is already BINARY(16))