### PR TITLE
NOJIRA-Fix-outbound-config-wire-format

### DIFF
--- a/bin-call-manager/models/outboundconfig/iso.go
+++ b/bin-call-manager/models/outboundconfig/iso.go
@@ -43,11 +43,15 @@ var ISOCountryCodes = map[string]struct{}{
 	"za": {}, "zm": {}, "zw": {},
 }
 
-// codecsRegexp validates the codecs field format: alphanumeric tokens separated by commas.
-var codecsRegexp = regexp.MustCompile(`^[A-Za-z0-9]+(,[A-Za-z0-9]+)*$`)
+// codecsRegexp validates the codecs field format: alphanumeric tokens (optionally
+// containing hyphens) separated by commas. Hyphens are permitted because real-world
+// SDP/RTP codec names use them — for example AMR-WB, GSM-EFR, telephone-event.
+// A leading or trailing hyphen on a token is rejected by the surrounding `+`
+// quantifiers, so each token must start and end with an alphanumeric character.
+var codecsRegexp = regexp.MustCompile(`^[A-Za-z0-9]+(-[A-Za-z0-9]+)*(,[A-Za-z0-9]+(-[A-Za-z0-9]+)*)*$`)
 
 // ValidateCodecs returns true if the codecs string is empty (server default) or
-// matches the expected comma-separated alphanumeric token format.
+// matches the expected comma-separated codec token format.
 func ValidateCodecs(codecs string) bool {
 	if codecs == "" {
 		return true

--- a/bin-call-manager/pkg/listenhandler/models/request/outbound_configs.go
+++ b/bin-call-manager/pkg/listenhandler/models/request/outbound_configs.go
@@ -1,17 +1,26 @@
 package request
 
 import (
-	outboundconfig "monorepo/bin-call-manager/models/outboundconfig"
 	"github.com/gofrs/uuid"
 )
 
 // V1DataOutboundConfigsPost is the request body for POST /v1/outbound_configs.
+//
+// Pointer fields preserve the "absent" (nil) vs. "explicit empty" (non-nil pointer
+// to zero value) distinction used by outboundconfig.UpdateRequest in the partial-update
+// SQL builder.
 type V1DataOutboundConfigsPost struct {
-	CustomerID uuid.UUID                     `json:"customer_id"`
-	Request    outboundconfig.UpdateRequest  `json:"request"`
+	CustomerID           uuid.UUID `json:"customer_id"`
+	Name                 *string   `json:"name,omitempty"`
+	Detail               *string   `json:"detail,omitempty"`
+	DestinationWhitelist *[]string `json:"destination_whitelist,omitempty"`
+	Codecs               *string   `json:"codecs,omitempty"`
 }
 
 // V1DataOutboundConfigsIDPut is the request body for PUT /v1/outbound_configs/<id>.
 type V1DataOutboundConfigsIDPut struct {
-	Request outboundconfig.UpdateRequest `json:"request"`
+	Name                 *string   `json:"name,omitempty"`
+	Detail               *string   `json:"detail,omitempty"`
+	DestinationWhitelist *[]string `json:"destination_whitelist,omitempty"`
+	Codecs               *string   `json:"codecs,omitempty"`
 }

--- a/bin-call-manager/pkg/listenhandler/v1_outbound_configs.go
+++ b/bin-call-manager/pkg/listenhandler/v1_outbound_configs.go
@@ -29,7 +29,14 @@ func (h *listenHandler) processV1OutboundConfigsPost(ctx context.Context, m *soc
 		return simpleResponse(400), nil
 	}
 
-	c, err := h.outboundConfigHandler.Create(ctx, req.CustomerID, &req.Request)
+	updateReq := &outboundconfig.UpdateRequest{
+		Name:                 req.Name,
+		Detail:               req.Detail,
+		DestinationWhitelist: req.DestinationWhitelist,
+		Codecs:               req.Codecs,
+	}
+
+	c, err := h.outboundConfigHandler.Create(ctx, req.CustomerID, updateReq)
 	if err != nil {
 		log.Errorf("Could not create outbound config. err: %v", err)
 		if strings.Contains(err.Error(), "Duplicate entry") {
@@ -182,7 +189,14 @@ func (h *listenHandler) processV1OutboundConfigsIDPut(ctx context.Context, m *so
 		return simpleResponse(400), nil
 	}
 
-	c, err := h.outboundConfigHandler.Update(ctx, id, &req.Request)
+	updateReq := &outboundconfig.UpdateRequest{
+		Name:                 req.Name,
+		Detail:               req.Detail,
+		DestinationWhitelist: req.DestinationWhitelist,
+		Codecs:               req.Codecs,
+	}
+
+	c, err := h.outboundConfigHandler.Update(ctx, id, updateReq)
 	if err != nil {
 		log.Errorf("Could not update outbound config. err: %v", err)
 		return errorResponse(err), nil

--- a/bin-call-manager/pkg/listenhandler/v1_outbound_configs_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_outbound_configs_test.go
@@ -31,7 +31,7 @@ func Test_processV1OutboundConfigsPost(t *testing.T) {
 				URI:      "/v1/outbound_configs",
 				Method:   sock.RequestMethodPost,
 				DataType: "application/json",
-				Data:     []byte(`{"customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","request":{"name":"test","codecs":"PCMU"}}`),
+				Data:     []byte(`{"customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","name":"test","codecs":"PCMU"}`),
 			},
 			expectCustomerID: uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
 			expectReq: func() *outboundconfig.UpdateRequest {
@@ -67,7 +67,7 @@ func Test_processV1OutboundConfigsPost(t *testing.T) {
 			}
 
 			mockOutboundConfig.EXPECT().
-				Create(gomock.Any(), tt.expectCustomerID, gomock.Any()).
+				Create(gomock.Any(), tt.expectCustomerID, tt.expectReq).
 				Return(tt.responseConfig, nil)
 
 			res, err := h.processRequest(tt.request)
@@ -269,6 +269,7 @@ func Test_processV1OutboundConfigsIDPut(t *testing.T) {
 		request *sock.Request
 
 		expectID       uuid.UUID
+		expectReq      *outboundconfig.UpdateRequest
 		responseConfig *outboundconfig.OutboundConfig
 		expectRes      *sock.Response
 	}{
@@ -278,9 +279,13 @@ func Test_processV1OutboundConfigsIDPut(t *testing.T) {
 				URI:      "/v1/outbound_configs/c1234567-f7f5-11ef-92b3-0be9c3b04574",
 				Method:   sock.RequestMethodPut,
 				DataType: "application/json",
-				Data:     []byte(`{"request":{"name":"updated"}}`),
+				Data:     []byte(`{"name":"updated"}`),
 			},
 			expectID: uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+			expectReq: func() *outboundconfig.UpdateRequest {
+				n := "updated"
+				return &outboundconfig.UpdateRequest{Name: &n}
+			}(),
 			responseConfig: &outboundconfig.OutboundConfig{
 				ID:         uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
 				CustomerID: uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
@@ -290,6 +295,36 @@ func Test_processV1OutboundConfigsIDPut(t *testing.T) {
 				StatusCode: 200,
 				DataType:   "application/json",
 				Data:       []byte(`{"id":"c1234567-f7f5-11ef-92b3-0be9c3b04574","customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","name":"updated","detail":"","destination_whitelist":null,"codecs":"","tm_create":null,"tm_update":null,"tm_delete":null}`),
+			},
+		},
+		{
+			name: "all fields populated",
+			request: &sock.Request{
+				URI:      "/v1/outbound_configs/c1234567-f7f5-11ef-92b3-0be9c3b04574",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`{"name":"my-config","detail":"detail-text","destination_whitelist":["us","kr"],"codecs":"PCMU,PCMA"}`),
+			},
+			expectID: uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+			expectReq: func() *outboundconfig.UpdateRequest {
+				n := "my-config"
+				d := "detail-text"
+				w := []string{"us", "kr"}
+				c := "PCMU,PCMA"
+				return &outboundconfig.UpdateRequest{Name: &n, Detail: &d, DestinationWhitelist: &w, Codecs: &c}
+			}(),
+			responseConfig: &outboundconfig.OutboundConfig{
+				ID:                   uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+				CustomerID:           uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
+				Name:                 "my-config",
+				Detail:               "detail-text",
+				DestinationWhitelist: []string{"us", "kr"},
+				Codecs:               "PCMU,PCMA",
+			},
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"c1234567-f7f5-11ef-92b3-0be9c3b04574","customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","name":"my-config","detail":"detail-text","destination_whitelist":["us","kr"],"codecs":"PCMU,PCMA","tm_create":null,"tm_update":null,"tm_delete":null}`),
 			},
 		},
 	}
@@ -308,7 +343,7 @@ func Test_processV1OutboundConfigsIDPut(t *testing.T) {
 			}
 
 			mockOutboundConfig.EXPECT().
-				Update(gomock.Any(), tt.expectID, gomock.Any()).
+				Update(gomock.Any(), tt.expectID, tt.expectReq).
 				Return(tt.responseConfig, nil)
 
 			res, err := h.processRequest(tt.request)

--- a/bin-call-manager/pkg/outboundconfighandler/validate.go
+++ b/bin-call-manager/pkg/outboundconfighandler/validate.go
@@ -20,7 +20,7 @@ func (h *outboundConfigHandler) validateUpdateRequest(req *outboundconfig.Update
 	}
 	if req.Codecs != nil {
 		if !outboundconfig.ValidateCodecs(*req.Codecs) {
-			return fmt.Errorf("codecs must be empty or comma-separated alphanumeric tokens (max 255 chars, no special chars)")
+			return fmt.Errorf("codecs must be empty or a comma-separated list of codec names. Each name must be alphanumeric and may contain internal hyphens (e.g. AMR-WB). Max 255 chars")
 		}
 	}
 	return nil

--- a/bin-call-manager/pkg/outboundconfighandler/validate_test.go
+++ b/bin-call-manager/pkg/outboundconfighandler/validate_test.go
@@ -73,7 +73,11 @@ func Test_outboundConfigHandler_validateUpdateRequest(t *testing.T) {
 	validWL := []string{"us", "gb"}
 	invalidWL := []string{"xx"}
 	validCodecs := "PCMU,G729"
-	invalidCodecs := "PCMU;G729" // semicolon not allowed
+	validHyphenCodecs := "PCMU,PCMA,G729,AMR,AMR-WB,GSM,GSM-EFR,opus,telephone-event"
+	invalidCodecs := "PCMU;G729"            // semicolon not allowed
+	invalidLeadingHyphenCodecs := "-PCMU"   // token must start with alnum
+	invalidTrailingHyphenCodecs := "PCMU-"  // token must end with alnum
+	invalidDoubleHyphenCodecs := "AMR--WB"  // hyphens may not be adjacent
 	emptyCodecs := ""
 
 	tests := []struct {
@@ -104,6 +108,26 @@ func Test_outboundConfigHandler_validateUpdateRequest(t *testing.T) {
 		{
 			name:    "invalid codecs - semicolon separator",
 			req:     &outboundconfig.UpdateRequest{Codecs: &invalidCodecs},
+			wantErr: true,
+		},
+		{
+			name:    "valid codecs with hyphens (AMR-WB, GSM-EFR, telephone-event)",
+			req:     &outboundconfig.UpdateRequest{Codecs: &validHyphenCodecs},
+			wantErr: false,
+		},
+		{
+			name:    "invalid codecs - leading hyphen",
+			req:     &outboundconfig.UpdateRequest{Codecs: &invalidLeadingHyphenCodecs},
+			wantErr: true,
+		},
+		{
+			name:    "invalid codecs - trailing hyphen",
+			req:     &outboundconfig.UpdateRequest{Codecs: &invalidTrailingHyphenCodecs},
+			wantErr: true,
+		},
+		{
+			name:    "invalid codecs - double hyphen",
+			req:     &outboundconfig.UpdateRequest{Codecs: &invalidDoubleHyphenCodecs},
 			wantErr: true,
 		},
 		{

--- a/bin-call-manager/pkg/outboundconfighandler/validate_test.go
+++ b/bin-call-manager/pkg/outboundconfighandler/validate_test.go
@@ -1,6 +1,7 @@
 package outboundconfighandler
 
 import (
+	"strings"
 	"testing"
 
 	outboundconfig "monorepo/bin-call-manager/models/outboundconfig"
@@ -73,12 +74,23 @@ func Test_outboundConfigHandler_validateUpdateRequest(t *testing.T) {
 	validWL := []string{"us", "gb"}
 	invalidWL := []string{"xx"}
 	validCodecs := "PCMU,G729"
-	validHyphenCodecs := "PCMU,PCMA,G729,AMR,AMR-WB,GSM,GSM-EFR,opus,telephone-event"
-	invalidCodecs := "PCMU;G729"            // semicolon not allowed
-	invalidLeadingHyphenCodecs := "-PCMU"   // token must start with alnum
-	invalidTrailingHyphenCodecs := "PCMU-"  // token must end with alnum
-	invalidDoubleHyphenCodecs := "AMR--WB"  // hyphens may not be adjacent
+	validHyphenCodecs := "PCMU,PCMA,G729,AMR,AMR-WB,GSM,GSM-EFR,GSM-HR-08,opus,telephone-event"
+	invalidCodecs := "PCMU;G729"                       // semicolon not allowed
+	invalidLeadingHyphenCodecs := "-PCMU"              // token must start with alnum
+	invalidTrailingHyphenCodecs := "PCMU-"             // token must end with alnum
+	invalidDoubleHyphenCodecs := "AMR--WB"             // hyphens may not be adjacent
+	invalidSecondTokenLeadingHyphen := "PCMU,-AMR"     // second token may not start with hyphen
 	emptyCodecs := ""
+
+	// 255-char boundary: build a comma-separated string of exactly 255 chars and one of 256.
+	// Each "PCMU," is 5 bytes; 51 copies = 255, 51+"P" = 256, 52 copies (with trailing trim) etc.
+	// Use exact lengths so the boundary check is deterministic.
+	codecsAt255 := strings.Repeat("PCMU,", 50) + "PCMU"        // 5*50 + 4 = 254 — adjust to 255
+	codecsAt255 = codecsAt255 + "U"                            // 255
+	codecsAt256 := codecsAt255 + "U"                           // 256
+	if len(codecsAt255) != 255 || len(codecsAt256) != 256 {
+		t.Fatalf("test setup error: codecsAt255=%d, codecsAt256=%d", len(codecsAt255), len(codecsAt256))
+	}
 
 	tests := []struct {
 		name    string
@@ -128,6 +140,21 @@ func Test_outboundConfigHandler_validateUpdateRequest(t *testing.T) {
 		{
 			name:    "invalid codecs - double hyphen",
 			req:     &outboundconfig.UpdateRequest{Codecs: &invalidDoubleHyphenCodecs},
+			wantErr: true,
+		},
+		{
+			name:    "invalid codecs - second token leading hyphen",
+			req:     &outboundconfig.UpdateRequest{Codecs: &invalidSecondTokenLeadingHyphen},
+			wantErr: true,
+		},
+		{
+			name:    "valid codecs at 255-char boundary",
+			req:     &outboundconfig.UpdateRequest{Codecs: &codecsAt255},
+			wantErr: false,
+		},
+		{
+			name:    "invalid codecs at 256-char boundary",
+			req:     &outboundconfig.UpdateRequest{Codecs: &codecsAt256},
 			wantErr: true,
 		},
 		{

--- a/bin-common-handler/pkg/requesthandler/call_outbound_configs.go
+++ b/bin-common-handler/pkg/requesthandler/call_outbound_configs.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	cmoutboundconfig "monorepo/bin-call-manager/models/outboundconfig"
+	cmrequest "monorepo/bin-call-manager/pkg/listenhandler/models/request"
 	"monorepo/bin-common-handler/models/sock"
 
 	"github.com/gofrs/uuid"
@@ -16,14 +17,13 @@ import (
 func (r *requestHandler) CallV1OutboundConfigCreate(ctx context.Context, customerID uuid.UUID, req *cmoutboundconfig.UpdateRequest) (*cmoutboundconfig.OutboundConfig, error) {
 	uri := "/v1/outbound_configs"
 
-	body := struct {
-		CustomerID uuid.UUID                    `json:"customer_id"`
-		Request    *cmoutboundconfig.UpdateRequest `json:"request"`
-	}{
-		CustomerID: customerID,
-		Request:    req,
-	}
-	m, err := json.Marshal(body)
+	m, err := json.Marshal(cmrequest.V1DataOutboundConfigsPost{
+		CustomerID:           customerID,
+		Name:                 req.Name,
+		Detail:               req.Detail,
+		DestinationWhitelist: req.DestinationWhitelist,
+		Codecs:               req.Codecs,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,12 @@ func (r *requestHandler) CallV1OutboundConfigDelete(ctx context.Context, id uuid
 func (r *requestHandler) CallV1OutboundConfigUpdate(ctx context.Context, id uuid.UUID, req *cmoutboundconfig.UpdateRequest) (*cmoutboundconfig.OutboundConfig, error) {
 	uri := fmt.Sprintf("/v1/outbound_configs/%s", id)
 
-	m, err := json.Marshal(req)
+	m, err := json.Marshal(cmrequest.V1DataOutboundConfigsIDPut{
+		Name:                 req.Name,
+		Detail:               req.Detail,
+		DestinationWhitelist: req.DestinationWhitelist,
+		Codecs:               req.Codecs,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/bin-common-handler/pkg/requesthandler/call_outbound_configs_test.go
+++ b/bin-common-handler/pkg/requesthandler/call_outbound_configs_test.go
@@ -1,0 +1,230 @@
+package requesthandler
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	cmoutboundconfig "monorepo/bin-call-manager/models/outboundconfig"
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_CallV1OutboundConfigCreate(t *testing.T) {
+	tests := []struct {
+		name string
+
+		customerID uuid.UUID
+		req        *cmoutboundconfig.UpdateRequest
+
+		response *sock.Response
+
+		expectTarget  string
+		expectRequest *sock.Request
+		expectRes     *cmoutboundconfig.OutboundConfig
+	}{
+		{
+			name: "all fields populated",
+
+			customerID: uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
+			req: func() *cmoutboundconfig.UpdateRequest {
+				n := "my-config"
+				d := "detail-text"
+				w := []string{"us", "kr"}
+				c := "PCMU,PCMA"
+				return &cmoutboundconfig.UpdateRequest{Name: &n, Detail: &d, DestinationWhitelist: &w, Codecs: &c}
+			}(),
+
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"c1234567-f7f5-11ef-92b3-0be9c3b04574","customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"}`),
+			},
+
+			expectTarget: "bin-manager.call-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/outbound_configs",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","name":"my-config","detail":"detail-text","destination_whitelist":["us","kr"],"codecs":"PCMU,PCMA"}`),
+			},
+			expectRes: &cmoutboundconfig.OutboundConfig{
+				ID:         uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+				CustomerID: uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
+			},
+		},
+		{
+			name: "only name set",
+
+			customerID: uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
+			req: func() *cmoutboundconfig.UpdateRequest {
+				n := "minimal"
+				return &cmoutboundconfig.UpdateRequest{Name: &n}
+			}(),
+
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"c1234567-f7f5-11ef-92b3-0be9c3b04574","customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"}`),
+			},
+
+			expectTarget: "bin-manager.call-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/outbound_configs",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","name":"minimal"}`),
+			},
+			expectRes: &cmoutboundconfig.OutboundConfig{
+				ID:         uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+				CustomerID: uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			reqHandler := requestHandler{
+				sock: mockSock,
+			}
+
+			ctx := context.Background()
+			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
+
+			// Wire-format guard: marshaled body must NOT contain a "request" wrapper key.
+			if strings.Contains(string(tt.expectRequest.Data), `"request":`) {
+				t.Fatalf("expected flat wire format, but expectRequest.Data contains a `request` wrapper: %s", tt.expectRequest.Data)
+			}
+			// Round-trip guard: marshaling the input UpdateRequest must yield top-level fields, no wrapper.
+			marshaled, err := json.Marshal(tt.req)
+			if err != nil {
+				t.Fatalf("could not marshal req: %v", err)
+			}
+			if strings.Contains(string(marshaled), `"request":`) {
+				t.Fatalf("UpdateRequest unexpectedly serialized with a `request` wrapper: %s", marshaled)
+			}
+
+			res, err := reqHandler.CallV1OutboundConfigCreate(ctx, tt.customerID, tt.req)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if !reflect.DeepEqual(*tt.expectRes, *res) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", *tt.expectRes, *res)
+			}
+		})
+	}
+}
+
+func Test_CallV1OutboundConfigUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+
+		id  uuid.UUID
+		req *cmoutboundconfig.UpdateRequest
+
+		response *sock.Response
+
+		expectTarget  string
+		expectRequest *sock.Request
+		expectRes     *cmoutboundconfig.OutboundConfig
+	}{
+		{
+			name: "all fields populated",
+
+			id: uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+			req: func() *cmoutboundconfig.UpdateRequest {
+				n := "my-config"
+				d := "detail-text"
+				w := []string{"us", "kr"}
+				c := "PCMU,PCMA"
+				return &cmoutboundconfig.UpdateRequest{Name: &n, Detail: &d, DestinationWhitelist: &w, Codecs: &c}
+			}(),
+
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"c1234567-f7f5-11ef-92b3-0be9c3b04574","customer_id":"b3fe6c84-f7f5-11ef-92b3-0be9c3b04574","name":"my-config","detail":"detail-text","destination_whitelist":["us","kr"],"codecs":"PCMU,PCMA"}`),
+			},
+
+			expectTarget: "bin-manager.call-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/outbound_configs/c1234567-f7f5-11ef-92b3-0be9c3b04574",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`{"name":"my-config","detail":"detail-text","destination_whitelist":["us","kr"],"codecs":"PCMU,PCMA"}`),
+			},
+			expectRes: &cmoutboundconfig.OutboundConfig{
+				ID:                   uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+				CustomerID:           uuid.FromStringOrNil("b3fe6c84-f7f5-11ef-92b3-0be9c3b04574"),
+				Name:                 "my-config",
+				Detail:               "detail-text",
+				DestinationWhitelist: []string{"us", "kr"},
+				Codecs:               "PCMU,PCMA",
+			},
+		},
+		{
+			name: "only name set",
+
+			id: uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+			req: func() *cmoutboundconfig.UpdateRequest {
+				n := "renamed"
+				return &cmoutboundconfig.UpdateRequest{Name: &n}
+			}(),
+
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"c1234567-f7f5-11ef-92b3-0be9c3b04574","name":"renamed"}`),
+			},
+
+			expectTarget: "bin-manager.call-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/outbound_configs/c1234567-f7f5-11ef-92b3-0be9c3b04574",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`{"name":"renamed"}`),
+			},
+			expectRes: &cmoutboundconfig.OutboundConfig{
+				ID:   uuid.FromStringOrNil("c1234567-f7f5-11ef-92b3-0be9c3b04574"),
+				Name: "renamed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			reqHandler := requestHandler{
+				sock: mockSock,
+			}
+
+			ctx := context.Background()
+			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
+
+			// Wire-format guard: marshaled body must NOT contain a "request" wrapper key.
+			if strings.Contains(string(tt.expectRequest.Data), `"request":`) {
+				t.Fatalf("expected flat wire format, but expectRequest.Data contains a `request` wrapper: %s", tt.expectRequest.Data)
+			}
+
+			res, err := reqHandler.CallV1OutboundConfigUpdate(ctx, tt.id, tt.req)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if !reflect.DeepEqual(*tt.expectRes, *res) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", *tt.expectRes, *res)
+			}
+		})
+	}
+}

--- a/docs/conventions/rpc.md
+++ b/docs/conventions/rpc.md
@@ -66,4 +66,51 @@ return &sock.Response{StatusCode: 404}, nil
 return &sock.Response{StatusCode: 500}, nil
 ```
 
+### 9.5 Listener Request-Body Models Are Flat
+
+Request structs in `pkg/listenhandler/models/request/` MUST be flat — top-level fields directly, no nested `Request` wrapper. This matches `calls.go`, `recordings.go`, `confbridge.go`, etc.
+
+```go
+// CORRECT — flat
+type V1DataOutboundConfigsIDPut struct {
+    Name                 *string   `json:"name,omitempty"`
+    Detail               *string   `json:"detail,omitempty"`
+    DestinationWhitelist *[]string `json:"destination_whitelist,omitempty"`
+    Codecs               *string   `json:"codecs,omitempty"`
+}
+
+// WRONG — wrapper introduces a wire-format mismatch with bin-common-handler clients
+type V1DataOutboundConfigsIDPut struct {
+    Request outboundconfig.UpdateRequest `json:"request"`
+}
+```
+
+**Why this matters.** Wire-format wrappers must agree on both sides — `bin-common-handler/pkg/requesthandler/*.go` marshals the body, `bin-call-manager/pkg/listenhandler/v1_*.go` unmarshals it. `json.Unmarshal` silently ignores unknown top-level keys, so a mismatch produces a zero-valued struct with no error. The downstream handler then operates on nil/zero fields and the bug surfaces as "200 OK but nothing changed." A real production incident — see [`../workflows/common-gotchas.md`](../workflows/common-gotchas.md) (Listener Wire-Format Mismatch).
+
+**Domain models stay where they belong.** A handler-layer "partial update" model with pointer fields (e.g., `outboundconfig.UpdateRequest`) is legitimately reused by the DB layer to build dynamic `UPDATE … SET` SQL. Keep it in `models/<entity>/`. The listener translates the flat RPC struct into the domain model:
+
+```go
+var req request.V1DataOutboundConfigsIDPut
+if err := json.Unmarshal(m.Data, &req); err != nil { ... }
+
+updateReq := &outboundconfig.UpdateRequest{
+    Name:                 req.Name,
+    Detail:               req.Detail,
+    DestinationWhitelist: req.DestinationWhitelist,
+    Codecs:               req.Codecs,
+}
+c, err := h.outboundConfigHandler.Update(ctx, id, updateReq)
+```
+
+### 9.6 Checklist for New RPC Methods
+
+Every new `requesthandler` typed method + listener handler pair must:
+
+1. **Listener model is flat.** No `Request` wrapper field; no import of the domain model from `pkg/listenhandler/models/request/`. (§9.5)
+2. **Client marshals via the listener model.** `json.Marshal(cmrequest.V1DataXxx{...})` — never `json.Marshal(domainRequest)` or an inline anonymous struct.
+3. **Listener test asserts the parsed payload.** Replace `gomock.Any()` with a field-by-field matcher on the request body. (See [`testing.md`](testing.md) §13.8.)
+4. **Client test asserts the marshaled wire shape.** Mock `sockHandler.RequestPublish` and verify `sock.Request.Data` byte-for-byte. (See [`testing.md`](testing.md) §13.9.)
+
+If any one of these is missing, a wire-format mismatch can silently round-trip as a no-op. All four must be in place.
+
 ---

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -150,6 +150,75 @@ mockDB.EXPECT().AgentGet(ctx, gomock.Any()).Return(tt.responseAgent, nil)
 mockDB.EXPECT().AgentGet(ctx, id).Return(gomock.Any(), nil)  // PANIC
 ```
 
+## 13.8 Never Use gomock.Any() For Parsed Request Payloads
+
+`gomock.Any()` is the right matcher for opaque values you don't care about (a context, a randomly generated ID a previous call returned). It is the wrong matcher for **anything the test parsed out of an inbound RPC body**.
+
+A listener handler typically does:
+
+```go
+var req request.V1DataXxxPut
+if err := json.Unmarshal(m.Data, &req); err != nil { ... }
+domainReq := &xxx.UpdateRequest{Name: req.Name, ...}
+result, err := h.xxxHandler.Update(ctx, id, domainReq)
+```
+
+If the test asserts only `Update(gomock.Any(), tt.expectID, gomock.Any())`, it never validates that `m.Data` actually deserialized into the expected struct. A wire-format mismatch between the client and listener (e.g., a missing `request` wrapper, a renamed JSON tag) produces a zero-valued struct, and the test passes anyway. This is exactly the failure mode that produced the Listener Wire-Format Mismatch incident — see [`../workflows/common-gotchas.md`](../workflows/common-gotchas.md).
+
+```go
+// WRONG — third arg is the parsed body; gomock.Any() bypasses the assertion
+mockOutboundConfig.EXPECT().
+    Update(gomock.Any(), tt.expectID, gomock.Any()).
+    Return(tt.responseConfig, nil)
+
+// CORRECT — pass the expected struct; gomock falls back to reflect.DeepEqual
+mockOutboundConfig.EXPECT().
+    Update(gomock.Any(), tt.expectID, tt.expectReq).
+    Return(tt.responseConfig, nil)
+```
+
+The `tt.expectReq` should be the **exact** `*UpdateRequest` (or equivalent) that the listener should construct from `m.Data`. Setting up `expectReq` per row in the table-driven test is the smallest unit that catches a wire-format regression.
+
+When the value crosses pointer or slice boundaries, build it once with a helper closure so the test stays readable:
+
+```go
+expectReq: func() *outboundconfig.UpdateRequest {
+    n := "updated"
+    w := []string{"us", "kr"}
+    return &outboundconfig.UpdateRequest{Name: &n, DestinationWhitelist: &w}
+}(),
+```
+
+`gomock.Any()` is still appropriate for `ctx` and for genuinely opaque return values from the same mock.
+
+## 13.9 RequestHandler Tests Must Assert The Marshaled Wire Shape
+
+Every `bin-common-handler/pkg/requesthandler/<service>_<resource>.go` typed method that constructs a request body MUST have a paired test that:
+
+1. Mocks `sockHandler.RequestPublish` with the **exact** `sock.Request` (URI, Method, DataType, **and `Data`** byte string).
+2. Asserts the marshaled JSON shape — including which top-level keys must and must not be present.
+
+```go
+expectRequest: &sock.Request{
+    URI:      "/v1/outbound_configs/c1234567-f7f5-11ef-92b3-0be9c3b04574",
+    Method:   sock.RequestMethodPut,
+    DataType: "application/json",
+    Data:     []byte(`{"name":"my-config","detail":"detail-text","destination_whitelist":["us","kr"],"codecs":"PCMU,PCMA"}`),
+},
+// ...
+mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
+```
+
+When the convention requires the body to be flat (no `request` wrapper), add an explicit guard so a future refactor that re-introduces the wrapper fails the test, not production:
+
+```go
+if strings.Contains(string(tt.expectRequest.Data), `"request":`) {
+    t.Fatalf("expected flat wire format, but expectRequest.Data contains a `request` wrapper: %s", tt.expectRequest.Data)
+}
+```
+
+Reference implementations: `bin-common-handler/pkg/requesthandler/call_calls_test.go`, `call_recordings_test.go`, `call_outbound_configs_test.go`.
+
 ---
 
 ## Test Utilities

--- a/docs/plans/2026-05-08-outbound-config-wire-format-design.md
+++ b/docs/plans/2026-05-08-outbound-config-wire-format-design.md
@@ -1,0 +1,187 @@
+# Outbound Config RPC Wire-Format Fix — Design
+
+**Date:** 2026-05-08
+**Status:** Approved
+**Branch:** `NOJIRA-Fix-outbound-config-wire-format`
+
+## Problem
+
+`PUT /v1.0/outbound_config` returns HTTP 200 but the row is never updated. Reproduced in production (api-manager pod `f7t5k` at 16:13:34 UTC: `PUT 200`, `GET 200` returns unchanged data).
+
+### Root cause — JSON wire-format mismatch on the internal RPC
+
+| Side | Code | Wire shape produced/expected |
+|---|---|---|
+| Client | `bin-common-handler/pkg/requesthandler/call_outbound_configs.go:99` — `json.Marshal(req)` | `{"name":"...","detail":"...","destination_whitelist":[...],"codecs":"..."}` |
+| Listener | `bin-call-manager/pkg/listenhandler/v1_outbound_configs.go:179-180` — `json.Unmarshal(m.Data, &V1DataOutboundConfigsIDPut)` | `{"request":{...}}` |
+
+`json.Unmarshal` silently ignores unknown top-level keys, so `req.Request` is the zero value. Every pointer field on `*UpdateRequest` is nil. The DB layer (`bin-call-manager/pkg/dbhandler/outbound_config.go::OutboundConfigUpdate`) treats nil pointers as "no change," updates only `tm_update`, and returns the unchanged row → 200 OK with stale data.
+
+### Why this slipped through
+
+- `Test_processV1OutboundConfigsIDPut` (`v1_outbound_configs_test.go:281`) hard-codes the wrapped shape `{"request":{"name":"updated"}}`, then asserts via `Update(gomock.Any(), tt.expectID, gomock.Any())` — the third arg matcher is `gomock.Any()`, so the parsed `*UpdateRequest` is never validated. The test would pass even with all fields zeroed.
+- No client-side test exists for `CallV1OutboundConfigUpdate` in `bin-common-handler` (`ls bin-common-handler/pkg/requesthandler/call_outbound_configs*` shows only the source file).
+- The handler logs only on the error path; a silent no-op produces no logs.
+
+### Why the wire format diverged
+
+`outbound_configs.go` is the only request file in `bin-call-manager/pkg/listenhandler/models/request/` that uses a `Request` wrapper field. Every other resource (`calls.go`, `recordings.go`, `confbridge.go`, `channels.go`, `externalmedias.go`, `groupcalls.go`, `recovery.go`) is flat. The wrapper was introduced to import `outboundconfig.UpdateRequest` directly into the listener request package, which conflated the **wire format** (RPC contract) with the **domain model** (handler/DB partial-update shape).
+
+## Goals
+
+1. Fix `PUT /v1.0/outbound_config` so it actually persists changes.
+2. Align outbound_config's RPC wire format with the rest of the service (flat structs in `pkg/listenhandler/models/request/`).
+3. Tighten tests so this class of bug fails CI next time.
+
+## Non-goals
+
+- Changing the public REST API (`PUT /v1.0/outbound_config` body shape stays the same).
+- Schema or migration changes.
+- RST documentation changes (user-facing contract is unchanged).
+- Refactoring other resources' wire formats.
+
+## Design
+
+### Wire format (call-manager listener)
+
+`bin-call-manager/pkg/listenhandler/models/request/outbound_configs.go` becomes:
+
+```go
+package request
+
+import "github.com/gofrs/uuid"
+
+// V1DataOutboundConfigsPost is the request body for POST /v1/outbound_configs.
+type V1DataOutboundConfigsPost struct {
+    CustomerID           uuid.UUID `json:"customer_id"`
+    Name                 *string   `json:"name,omitempty"`
+    Detail               *string   `json:"detail,omitempty"`
+    DestinationWhitelist *[]string `json:"destination_whitelist,omitempty"`
+    Codecs               *string   `json:"codecs,omitempty"`
+}
+
+// V1DataOutboundConfigsIDPut is the request body for PUT /v1/outbound_configs/<id>.
+type V1DataOutboundConfigsIDPut struct {
+    Name                 *string   `json:"name,omitempty"`
+    Detail               *string   `json:"detail,omitempty"`
+    DestinationWhitelist *[]string `json:"destination_whitelist,omitempty"`
+    Codecs               *string   `json:"codecs,omitempty"`
+}
+```
+
+- No `Request` wrapper — flat, matches `V1DataCallsPost`, `V1DataRecordingsPost`, etc.
+- Drops the import of `outboundconfig.UpdateRequest` from this package (separates wire shape from domain model).
+- Pointer fields preserve the "absent" vs. "explicit empty" distinction.
+
+### Listener handlers
+
+`bin-call-manager/pkg/listenhandler/v1_outbound_configs.go`:
+
+```go
+// PUT
+var req request.V1DataOutboundConfigsIDPut
+if err := json.Unmarshal(m.Data, &req); err != nil { ... }
+
+updateReq := &outboundconfig.UpdateRequest{
+    Name:                 req.Name,
+    Detail:               req.Detail,
+    DestinationWhitelist: req.DestinationWhitelist,
+    Codecs:               req.Codecs,
+}
+c, err := h.outboundConfigHandler.Update(ctx, id, updateReq)
+```
+
+POST gets the same translation. The `outboundconfig.UpdateRequest` model in `models/outboundconfig/outboundconfig.go` is **kept where it is** — it's a legitimate handler/DB-layer model used by `OutboundConfigUpdate` to build dynamic `UPDATE … SET` SQL. Only the listener boundary changes.
+
+### Client (bin-common-handler)
+
+`bin-common-handler/pkg/requesthandler/call_outbound_configs.go`:
+
+```go
+// CallV1OutboundConfigCreate
+m, err := json.Marshal(cmrequest.V1DataOutboundConfigsPost{
+    CustomerID:           customerID,
+    Name:                 req.Name,
+    Detail:               req.Detail,
+    DestinationWhitelist: req.DestinationWhitelist,
+    Codecs:               req.Codecs,
+})
+
+// CallV1OutboundConfigUpdate
+m, err := json.Marshal(cmrequest.V1DataOutboundConfigsIDPut{
+    Name:                 req.Name,
+    Detail:               req.Detail,
+    DestinationWhitelist: req.DestinationWhitelist,
+    Codecs:               req.Codecs,
+})
+```
+
+- Drops the inline anonymous struct in `CallV1OutboundConfigCreate`.
+- Drops the bare `json.Marshal(req)` in `CallV1OutboundConfigUpdate` (the bug).
+- Public function signatures are unchanged — `bin-api-manager` callers are not touched.
+
+### Test hardening
+
+1. **`bin-call-manager/pkg/listenhandler/v1_outbound_configs_test.go`:**
+   - Update `Data` payloads to flat shape: `{"name":"updated"}` (PUT), `{"customer_id":"...","name":"new"}` (POST).
+   - Replace `Update(gomock.Any(), tt.expectID, gomock.Any())` with a struct-literal matcher (gomock falls back to `reflect.DeepEqual` for non-`Matcher` args), so the parsed `*UpdateRequest` is verified field-by-field.
+   - Same for the POST test (`Test_processV1OutboundConfigsPost`).
+
+2. **`bin-common-handler/pkg/requesthandler/call_outbound_configs_test.go` (new):**
+   - For `CallV1OutboundConfigUpdate`: use mock `sockHandler.EXPECT().RequestPublish(...)` capturing the published message; assert `m.Data` unmarshals into `V1DataOutboundConfigsIDPut` with the expected pointer values.
+   - Same shape for `CallV1OutboundConfigCreate`.
+
+## Trade-offs and risks
+
+### Mixed-version deploy window
+
+Both POST and PUT change wire format. During a rolling deploy:
+- Old api-manager pod (sends wrapped) → new call-manager pod (expects flat): unknown keys silently dropped → POST creates a config with all fields nil; PUT no-ops.
+- New api-manager pod (sends flat) → old call-manager pod (expects wrapped): same silent failure.
+
+**Impact:** outbound_config is admin-frequency, not high-volume; the window is the duration of a rolling deploy (typically 1–3 minutes per service). Customer-visible failure mode is "POST/PUT returned 200 but data wasn't saved" — same as the existing PUT bug, just briefly extended to POST.
+
+**Mitigation:**
+1. Deploy `bin-call-manager` first (the listener accepting the new shape). At this point old api-manager is still sending wrapped → broken, but PUT was already broken so this is no regression for PUT; POST briefly degrades.
+2. Deploy `bin-api-manager` second, immediately after.
+3. Pause heavy outbound_config CRUD during the deploy window if practical (admin operation, easy to schedule).
+
+Alternative considered and rejected: have the listener accept both shapes during transition, then drop wrapped support in a follow-up. Adds complexity and a temporary code path that must be cleaned up; not worth it given the small impact window.
+
+### Cross-service verification
+
+`bin-common-handler` is changed → must run the verification workflow in `bin-common-handler`, `bin-api-manager`, and `bin-call-manager`. Public signatures (`CallV1OutboundConfigCreate`, `CallV1OutboundConfigUpdate`) are unchanged, so callers don't recompile differently — but `go mod vendor` must be refreshed in api-manager and call-manager, and tests must pass in all three.
+
+### Scope of refactor
+
+We are touching the working POST path to keep both methods consistent. If consistency is not worth the deploy-window risk, the alternative (PR 1 from earlier discussion) is a one-line wrap in `CallV1OutboundConfigUpdate` only. **User approved the full refactor** (option C) on 2026-05-08, accepting the trade-off.
+
+## Acceptance criteria
+
+- `PUT /v1.0/outbound_config` with `{"name": "x"}` results in `name = 'x'` in the DB and the GET response reflects it.
+- `POST /v1/outbound_configs` (admin) continues to work after redeploy.
+- `golangci-lint run -v --timeout 5m` passes in `bin-common-handler`, `bin-call-manager`, `bin-api-manager`.
+- `go test ./...` passes in all three services.
+- `Test_processV1OutboundConfigsIDPut` and `Test_processV1OutboundConfigsPost` both fail (with a clear assertion message) if the listener's `*UpdateRequest` would be all-nil — i.e., the test would have caught the original bug.
+- New test `Test_CallV1OutboundConfigUpdate` in `bin-common-handler` asserts the marshaled JSON contains the expected top-level fields and does NOT contain a `request` wrapper key.
+
+## Files changed
+
+```
+bin-call-manager/pkg/listenhandler/models/request/outbound_configs.go    # flatten structs
+bin-call-manager/pkg/listenhandler/v1_outbound_configs.go                # translate flat → UpdateRequest
+bin-call-manager/pkg/listenhandler/v1_outbound_configs_test.go           # flat data + tightened matchers
+bin-common-handler/pkg/requesthandler/call_outbound_configs.go           # marshal flat structs
+bin-common-handler/pkg/requesthandler/call_outbound_configs_test.go      # NEW: assert wire shape
+docs/plans/2026-05-08-outbound-config-wire-format-design.md              # this doc
+```
+
+No files in `bin-api-manager/`, `models/outboundconfig/`, RST docs, OpenAPI spec, migrations, or other services.
+
+## Verification workflow
+
+For each of `bin-common-handler`, `bin-call-manager`, `bin-api-manager` (in that order):
+
+```
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```

--- a/docs/workflows/common-gotchas.md
+++ b/docs/workflows/common-gotchas.md
@@ -170,6 +170,39 @@ TalkManagerMedia:
 
 **For complete gotcha explanations and troubleshooting, see [code-quality-standards.md#common-gotchas](../reference/code-quality-standards.md#common-gotchas)**
 
+## Listener Wire-Format Mismatch (Silent No-Op)
+
+**Symptom:** A POST or PUT to a public endpoint returns HTTP 200, but a follow-up GET shows nothing changed. No error logs anywhere.
+
+**Root cause:** The `bin-common-handler` requesthandler client and the target service's listenhandler disagree on the JSON shape of the RPC body. `json.Unmarshal` silently ignores unknown top-level keys, so the listener parses a zero-valued struct, the handler operates on nil/zero fields, and the dynamic-update SQL writes nothing (or the create writes empty fields).
+
+**Real incident (2026-05-08):** `PUT /v1.0/outbound_config` returned 200 for weeks but never persisted any change.
+
+- Client (`bin-common-handler/pkg/requesthandler/call_outbound_configs.go`) marshaled the bare `outboundconfig.UpdateRequest`: `{"name":"...","codecs":"..."}`
+- Listener (`bin-call-manager/pkg/listenhandler/v1_outbound_configs.go`) expected the body wrapped in `{"request":{...}}` because `V1DataOutboundConfigsIDPut` had `Request outboundconfig.UpdateRequest` as its only field.
+- Result: `req.Request` was the zero `UpdateRequest{}` — every `*string` / `*[]string` pointer was nil. The DB layer treated nil as "no change," updated only `tm_update`, and returned the unchanged row with HTTP 200.
+
+**Why nobody caught it sooner:**
+- The listener test (`Test_processV1OutboundConfigsIDPut`) used `Update(gomock.Any(), tt.expectID, gomock.Any())` — `gomock.Any()` for the third argument meant the parsed payload was never validated. The test passed even when every field was zero.
+- No client-side test existed for `CallV1OutboundConfigUpdate`, so the marshaled wire shape was never asserted.
+
+### Prevention rules (already encoded in conventions)
+
+1. **Listener request models must be flat.** No `Request` wrapper field in `pkg/listenhandler/models/request/*.go`. See [`../conventions/rpc.md`](../conventions/rpc.md) §9.5.
+2. **Client must marshal via the listener model**, not via the domain model and not via an inline anonymous struct. See [`../conventions/rpc.md`](../conventions/rpc.md) §9.6.
+3. **Listener tests must use a struct-literal matcher for parsed bodies** — never `gomock.Any()` for an argument the test parsed from `m.Data`. See [`../conventions/testing.md`](../conventions/testing.md) §13.8.
+4. **Every requesthandler typed method needs a wire-shape test** — assert the exact `sock.Request.Data` bytes, plus a `strings.Contains` guard against accidental wrapper re-introduction. See [`../conventions/testing.md`](../conventions/testing.md) §13.9.
+
+If you find yourself violating any of these "just for this one resource," go back and read the incident — every one of these rules exists because skipping it caused a silent production failure.
+
+### Diagnostic procedure when symptom appears
+
+1. **Confirm the HTTP layer is fine.** `kubectl logs -n bin-manager api-manager-* | grep -i "PUT.*<endpoint>"` should show 200. If non-200, the bug is upstream of the RPC.
+2. **Check the listener request model.** Open `bin-<target>-manager/pkg/listenhandler/models/request/<resource>.go`. If a struct has a single `Request <DomainModel>` field, that's the smoking gun.
+3. **Check the client marshaling.** Open `bin-common-handler/pkg/requesthandler/<service>_<resource>.go`. If it does `json.Marshal(req)` directly (instead of marshaling a `cmrequest.V1DataXxx` wrapper-or-flat struct), it's almost certainly mismatched.
+4. **Inspect the listener test.** If the mock matcher is `Update(gomock.Any(), id, gomock.Any())` (or `Create(...)`), the test is too loose to have caught this.
+5. **Reproduce locally** by writing a minimal test that unmarshals what the client actually sends into the listener's struct and prints the result — every nil pointer/zero field confirms the diagnosis.
+
 ## Feature Changes Require RST Documentation Updates
 
 **CRITICAL: The RST docs in `bin-api-manager/docsdev/source/` are the primary user-facing documentation and the single source of truth for how the platform works. When adding or changing any user-visible feature, you MUST update the relevant RST docs.**


### PR DESCRIPTION
PUT /v1.0/outbound_config returned 200 but never persisted changes. The bin-common-handler client marshaled the bare UpdateRequest while the call-manager listener expected a {request: {...}} wrapper, so json.Unmarshal silently zeroed every pointer field and the dynamic-update SQL touched only tm_update.

Aligned the wire format with the rest of bin-call-manager's listenhandler models by flattening V1DataOutboundConfigsPost / V1DataOutboundConfigsIDPut, mirroring calls.go, recordings.go, etc. The handler/DB-layer outboundconfig.UpdateRequest is unchanged — only the wire boundary moves.

- bin-call-manager: Flatten listener wire-format structs (drop {request:...} wrapper)
- bin-call-manager: Translate flat request into outboundconfig.UpdateRequest in POST/PUT handlers
- bin-call-manager: Tighten listener tests with field-by-field UpdateRequest matchers and add all-fields PUT case
- bin-common-handler: Marshal cmrequest.V1DataOutboundConfigs{Post,IDPut} from CallV1OutboundConfigCreate/Update
- bin-common-handler: Add CallV1OutboundConfigCreate/Update tests asserting the flat wire shape and guarding against the request wrapper regression

Deploy order: roll bin-call-manager first (listener accepts new shape), then bin-api-manager. Mixed-version window briefly degrades POST/PUT to silent no-ops; PUT was already broken so no regression there, POST has a short window where old api-manager → new call-manager would silently no-op. outbound_config writes are admin-frequency, so the impact window is acceptable.