### PR TITLE
NOJIRA-Update-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ We recommend reading the platform architecture guide (coming soon) before setup.
 ### Clone the Repo
 
 ```
-   $ git clone https://github.com/your-org/voipbin.git
-   $ cd voipbin
+   $ git clone https://github.com/voipbin/monorepo.git
+   $ cd monorepo
 ```
 
 ### Configure Your Secrets

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # VoIPbin Monorepo
 
-VoIPbin is a cloud-native, open-source CPaaS platform for programmable voice communication. This repository is the primary backend services monorepo — it contains the 34 Go microservices that handle call routing, AI pipelines, conferencing, billing, messaging, and more.
+VoIPbin is a cloud-native, open-source CPaaS platform for programmable voice communication. This repository is the main backend services monorepo — it contains backend services that handle call routing, AI pipelines, conferencing, billing, messaging, and more.
 
 This is one of VoIPbin's main repositories. It covers the backend service layer; other infrastructure (Kamailio, Kubernetes configs) lives in separate repos.
 
 ## 🧱 Why a Monorepo?
 
-VoIPBin uses a **monorepo** to manage all backend services in a single codebase. This approach is intentional and comes with many advantages:
+VoIPbin uses a **monorepo** to manage all backend services in a single codebase. This approach is intentional and comes with many advantages:
 
 ### ✅ Benefits
 
@@ -111,7 +111,7 @@ The monorepo includes many backend services under separate directories:
 
 This monorepo handles only part of voipbin services.
 
-![VoIPBin Architecture](architecture_overview_all.png)
+![VoIPbin Architecture](architecture_overview_all.png)
 
 
 That said, here's how to begin:
@@ -150,5 +150,5 @@ You'll need a Kubernetes manifest or Helm chart per service. For now, these are 
 We’re here to help. Visit voipbin.net or reach out to the team via the contact link on the site.
 
 ## 📞 Need Help?
-If you're exploring VoIPBin for your own product, team, or integration — feel free to reach out. We're building it to empower engineers like you.
+If you're exploring VoIPbin for your own product, team, or integration — feel free to reach out. We're building it to empower engineers like you.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # VoIPbin Monorepo
 
-Welcome to the VoIPBin monorepo — the unified backend codebase that powers all VoIPBin services.
+VoIPbin is a cloud-native, open-source CPaaS platform for programmable voice communication. This repository is the primary backend services monorepo — it contains the 34 Go microservices that handle call routing, AI pipelines, conferencing, billing, messaging, and more.
 
-VoIPBin is a cloud-native, scalable CPaaS platform designed for modern voice communication. This repository provides all the backend components for managing users, routing calls, handling media, running chatbots, and more — all in a single place.
-
-This repository is a **monorepo** for all VoIPbin backend services. It provides a unified development environment for managing the services that power the VoIPbin platform.
+This is one of VoIPbin's main repositories. It covers the backend service layer; other infrastructure (Kamailio, Kubernetes configs) lives in separate repos.
 
 ## 🧱 Why a Monorepo?
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ VoIPbin is composed of multiple services that run independently and communicate 
 * A media path (RTPEngine or equivalent)
 * Optionally, Asterisk instances for call bridging, conferencing, and SIP registration
 
-We recommend reading the platform architecture guide (coming soon) before setup.
-
 ### Clone the Repo
 
 ```

--- a/docs/plans/2026-05-09-readme-update-design.md
+++ b/docs/plans/2026-05-09-readme-update-design.md
@@ -1,0 +1,56 @@
+# README Update Design
+
+**Date:** 2026-05-09  
+**Branch:** NOJIRA-Update-readme  
+**Audience:** External developers / open-source users who want to self-host or integrate VoIPbin
+
+---
+
+## Problem
+
+The root `README.md` has three concrete issues that mislead external developers:
+
+1. **Placeholder clone URL** — `github.com/your-org/voipbin.git` is never valid
+2. **Overstated scope** — the intro says "the unified backend codebase that powers all VoIPBin services", but this is one of multiple VoIPbin repositories
+3. **Stale "coming soon"** — "platform architecture guide (coming soon)" still in the Getting Started section; there is no public link to provide
+
+---
+
+## Decisions
+
+### 1. Intro reframe
+
+Replace the opening paragraph to scope the repo correctly:
+
+> **VoIPbin Monorepo** — the primary backend services repository for the VoIPbin CPaaS platform.
+>
+> VoIPbin is a cloud-native, open-source CPaaS platform for programmable voice communication. This repository contains the 34 Go microservices that handle call routing, AI pipelines, conferencing, billing, messaging, and more.
+>
+> This is one of VoIPbin's main repositories. It covers the backend service layer; other infrastructure (SIP proxy, Kamailio, Kubernetes configs) lives in separate repos.
+
+### 2. Directory table — no changes
+
+The 37-row table (34 `bin-*` + 3 `voip-*` proxies) is accurate. `docs/`, `monitoring/`, and `scripts/` are **not** added — they are internal or not ready for external use.
+
+### 3. Clone URL
+
+Replace placeholder with real URL:
+
+```bash
+$ git clone https://github.com/voipbin/monorepo.git
+$ cd monorepo
+```
+
+### 4. Remove stale "coming soon"
+
+Delete the sentence: _"We recommend reading the platform architecture guide (coming soon) before setup."_  
+No replacement link — no public architecture guide exists yet.
+
+---
+
+## Out of scope
+
+- Service description rewrites
+- New sections (contributing, prerequisites, CI/CD)
+- `monitoring/`, `docs/`, `scripts/` directory entries
+- Any other structural changes

--- a/docs/plans/2026-05-09-readme-update-plan.md
+++ b/docs/plans/2026-05-09-readme-update-plan.md
@@ -1,0 +1,185 @@
+# README Update Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix three misleading sections in `README.md` for external developers — wrong scope framing, placeholder clone URL, and stale "coming soon" text.
+
+**Architecture:** Pure markdown edit — no build pipeline, no tests, no Go toolchain. Four surgical string replacements in one file. Commit and push when done.
+
+**Tech Stack:** Markdown, git
+
+---
+
+### Task 1: Reframe the intro paragraph
+
+**Files:**
+- Modify: `README.md` (lines 1–7)
+
+**Step 1: Open README.md and locate the intro**
+
+The current opening reads:
+
+```
+# VoIPbin Monorepo
+
+Welcome to the VoIPBin monorepo — the unified backend codebase that powers all VoIPBin services.
+
+VoIPBin is a cloud-native, scalable CPaaS platform designed for modern voice communication. This repository provides all the backend components for managing users, routing calls, handling media, running chatbots, and more — all in a single place.
+
+This repository is a **monorepo** for all VoIPbin backend services. It provides a unified development environment for managing the services that power the VoIPbin platform.
+```
+
+**Step 2: Replace the intro with scoped text**
+
+Replace lines 1–7 with:
+
+```markdown
+# VoIPbin Monorepo
+
+VoIPbin is a cloud-native, open-source CPaaS platform for programmable voice communication. This repository is the primary backend services monorepo — it contains the 34 Go microservices that handle call routing, AI pipelines, conferencing, billing, messaging, and more.
+
+This is one of VoIPbin's main repositories. It covers the backend service layer; other infrastructure (SIP proxy, Kamailio, Kubernetes configs) lives in separate repos.
+```
+
+**Step 3: Verify visually**
+
+Open `README.md` and confirm:
+- No mention of "unified backend codebase that powers all VoIPBin services"
+- No mention of "all VoIPbin backend services"
+- New text correctly scopes to "34 Go microservices" and "backend service layer"
+
+**Step 4: Commit**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-Update-readme
+git add README.md
+git commit -m "NOJIRA-Update-readme
+
+- monorepo: Reframe intro to scope this as one of VoIPbin's main repos"
+```
+
+---
+
+### Task 2: Fix the clone URL
+
+**Files:**
+- Modify: `README.md` (the "Clone the Repo" section, around line 133–137)
+
+**Step 1: Locate the clone block**
+
+Find:
+```
+   $ git clone https://github.com/your-org/voipbin.git
+   $ cd voipbin
+```
+
+**Step 2: Replace with the real URL**
+
+Replace with:
+```
+   $ git clone https://github.com/voipbin/monorepo.git
+   $ cd monorepo
+```
+
+**Step 3: Verify**
+
+Confirm no `your-org` or `voipbin.git` (old name) remains in the file:
+```bash
+grep -n "your-org\|cd voipbin" README.md
+# Expected: no output
+```
+
+**Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "NOJIRA-Update-readme
+
+- monorepo: Fix placeholder clone URL to https://github.com/voipbin/monorepo.git"
+```
+
+---
+
+### Task 3: Remove the stale "coming soon" sentence
+
+**Files:**
+- Modify: `README.md` (the "Understand the Architecture" subsection)
+
+**Step 1: Locate the stale sentence**
+
+Find:
+```
+We recommend reading the platform architecture guide (coming soon) before setup.
+```
+
+**Step 2: Delete that sentence entirely**
+
+Remove the line. Do not replace it with anything.
+
+**Step 3: Verify**
+
+```bash
+grep -n "coming soon" README.md
+# Expected: no output
+```
+
+**Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "NOJIRA-Update-readme
+
+- monorepo: Remove stale 'platform architecture guide (coming soon)' sentence"
+```
+
+---
+
+### Task 4: Check conflicts with main and push
+
+**Step 1: Fetch latest main**
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-Update-readme
+git fetch origin main
+```
+
+**Step 2: Check for conflicts**
+
+```bash
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"
+# Expected: no output (no conflicts)
+```
+
+**Step 3: Review what changed on main since branch was created**
+
+```bash
+git log --oneline HEAD..origin/main
+```
+
+If anything touches `README.md`, resolve manually before proceeding.
+
+**Step 4: Push branch**
+
+```bash
+git push -u origin NOJIRA-Update-readme
+```
+
+---
+
+### Task 5: Create PR
+
+**Step 1: Create PR via gh**
+
+```bash
+gh pr create \
+  --title "NOJIRA-Update-readme" \
+  --body "Fix three misleading sections in README.md for external developers.
+
+- monorepo: Reframe intro to scope this as one of VoIPbin's main repos containing 34 Go microservices
+- monorepo: Fix placeholder clone URL from github.com/your-org/voipbin.git to https://github.com/voipbin/monorepo.git
+- monorepo: Remove stale 'platform architecture guide (coming soon)' sentence"
+```
+
+**Step 2: Confirm PR URL is returned**
+
+Copy the URL and share with the user for review.


### PR DESCRIPTION
Fix three misleading sections in README.md for external developers.

- monorepo: Reframe intro to scope this as one of VoIPbin's main repos containing 34 Go microservices
- monorepo: Fix placeholder clone URL from github.com/your-org/voipbin.git to https://github.com/voipbin/monorepo.git
- monorepo: Remove stale 'platform architecture guide (coming soon)' sentence