### PR TITLE
NOJIRA-No-auto-merge-hook

### DIFF
--- a/.claude/scripts/block-merge-without-permission.sh
+++ b/.claude/scripts/block-merge-without-permission.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Block `gh pr merge` unless the user explicitly authorized it in this turn.
+# PreToolUse hook on Bash tool — exits 2 to block the command.
+#
+# The ONLY safe time to call gh pr merge is when the user has just said
+# "merge" (or equivalent) in their message for that specific PR.
+# Review loops, automation workflows, and CI helpers MUST stop at approval
+# and report back — they must NOT merge on the AI's own initiative.
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+if [[ -z "$COMMAND" ]]; then
+    exit 0
+fi
+
+if echo "$COMMAND" | grep -q "gh pr merge"; then
+    echo ""
+    echo "========================================================================"
+    echo "  BLOCKED: gh pr merge requires explicit user permission"
+    echo "========================================================================"
+    echo ""
+    echo "NEVER merge a PR without the user explicitly saying 'merge' for this PR"
+    echo "in this turn. This applies even after a review loop approves the PR."
+    echo ""
+    echo "A review loop ends at approval — report the approval and STOP."
+    echo "Do not merge. Wait for the user to authorize the merge."
+    echo ""
+    echo "========================================================================"
+    echo ""
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/block-merge-without-permission.sh",
+            "description": "Block gh pr merge — requires explicit user permission in this turn; review loops end at approval, not merge"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ NOJIRA-brief-description-of-change
 
 **NEVER commit directly to `main` without explicit user permission.**
 **NEVER merge any branch to `main` without explicit user permission.**
-**NEVER merge as part of a review loop, automation workflow, or any process not explicitly authorized for merging.** A review loop ends at approval — report the verdict and STOP. Wait for the user to say "merge" before calling `gh pr merge`. The pre-commit hook in `.claude/settings.json` enforces this by blocking `gh pr merge` calls.
+**NEVER merge as part of a review loop, automation workflow, or any process not explicitly authorized for merging.** A review loop ends at approval — report the verdict and STOP. Wait for the user to say "merge" before calling `gh pr merge`. The PreToolUse hook in `.claude/settings.json` enforces this by blocking `gh pr merge` calls.
 
 **CRITICAL: ALL PR merges MUST use squash merge — no exceptions.**
 
@@ -220,7 +220,7 @@ The RST documentation at `bin-api-manager/docsdev/source/` is what customers, de
 bash docs/reference/extractor.sh <service-dir>
 ```
 
-**The pre-commit hook (`scripts/check-service-docs.sh`) will warn (not block) when these source files change without a matching docs update.** Stage the relevant `docs/*.md` alongside the source change to suppress the warning.
+**The PostToolUse hook (`scripts/check-service-docs.sh`) will warn (not block) when these source files change without a matching docs update.** Stage the relevant `docs/*.md` alongside the source change to suppress the warning.
 
 → Script: [scripts/check-service-docs.sh](scripts/check-service-docs.sh)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ NOJIRA-brief-description-of-change
 
 **NEVER commit directly to `main` without explicit user permission.**
 **NEVER merge any branch to `main` without explicit user permission.**
+**NEVER merge as part of a review loop, automation workflow, or any process not explicitly authorized for merging.** A review loop ends at approval — report the verdict and STOP. Wait for the user to say "merge" before calling `gh pr merge`. The pre-commit hook in `.claude/settings.json` enforces this by blocking `gh pr merge` calls.
 
 **CRITICAL: ALL PR merges MUST use squash merge — no exceptions.**
 


### PR DESCRIPTION
Enforce no-auto-merge rule via PreToolUse hook and strengthened CLAUDE.md rule.

- .claude/scripts/block-merge-without-permission.sh: New PreToolUse hook; intercepts every Bash tool call and blocks any command containing `gh pr merge` with exit code 2; always allows all other commands; enforces that merging requires explicit user permission in the current turn
- .claude/settings.json: Add PreToolUse Bash hook entry calling the new script
- CLAUDE.md: Strengthen existing merge rule to explicitly cover review loops and automation workflows — a review loop ends at approval, not merge; references the PreToolUse hook as the enforcement mechanism