### PR TITLE
NOJIRA-Fix-merge-hook

### DIFF
--- a/.claude/scripts/block-merge-without-permission.sh
+++ b/.claude/scripts/block-merge-without-permission.sh
@@ -16,7 +16,15 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
-if echo "$COMMAND" | grep -q "gh pr merge"; then
+if echo "$COMMAND" | grep -qP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
+    # Allow when the command is prefixed with MERGE_AUTHORIZED=1.
+    # Claude must include this prefix only when the user has said
+    # "merge" (or equivalent) in the current turn.  Automated loops must
+    # never add this prefix on their own initiative.
+    if echo "$COMMAND" | grep -q "^MERGE_AUTHORIZED=1"; then
+        exit 0
+    fi
+
     echo ""
     echo "========================================================================"
     echo "  BLOCKED: gh pr merge requires explicit user permission"
@@ -27,6 +35,10 @@ if echo "$COMMAND" | grep -q "gh pr merge"; then
     echo ""
     echo "A review loop ends at approval — report the approval and STOP."
     echo "Do not merge. Wait for the user to authorize the merge."
+    echo ""
+    echo "When the user does authorize a merge, prefix the command with"
+    echo "MERGE_AUTHORIZED=1, e.g.:"
+    echo "  MERGE_AUTHORIZED=1 gh pr merge <pr> --squash --delete-branch"
     echo ""
     echo "========================================================================"
     echo ""

--- a/.claude/scripts/block-merge-without-permission.sh
+++ b/.claude/scripts/block-merge-without-permission.sh
@@ -16,15 +16,14 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
-if echo "$COMMAND" | grep -qP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
-    # Allow when the command is prefixed with MERGE_AUTHORIZED=1.
-    # Claude must include this prefix only when the user has said
-    # "merge" (or equivalent) in the current turn.  Automated loops must
-    # never add this prefix on their own initiative.
-    if echo "$COMMAND" | grep -q "^MERGE_AUTHORIZED=1"; then
-        exit 0
-    fi
+# Allow when MERGE_AUTHORIZED=1 immediately precedes gh pr merge in command-position.
+# The combined PCRE matches the authorized form in one pass, preventing the newline
+# bypass that two separate greps would allow.
+if echo "$COMMAND" | grep -qP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*MERGE_AUTHORIZED=1\s+(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
+    exit 0
+fi
 
+if echo "$COMMAND" | grep -qP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
     echo ""
     echo "========================================================================"
     echo "  BLOCKED: gh pr merge requires explicit user permission"

--- a/.claude/scripts/block-merge-without-permission.sh
+++ b/.claude/scripts/block-merge-without-permission.sh
@@ -16,14 +16,18 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
+# Use printf+grep -z so the whole command string is treated as one record.
+# This makes ^ anchor to the start of the full string — not to each line —
+# which prevents heredoc body content from triggering a false positive.
+
 # Allow when MERGE_AUTHORIZED=1 immediately precedes gh pr merge in command-position.
 # The combined PCRE matches the authorized form in one pass, preventing the newline
 # bypass that two separate greps would allow.
-if echo "$COMMAND" | grep -qP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*MERGE_AUTHORIZED=1\s+(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
+if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*MERGE_AUTHORIZED=1\s+(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
     exit 0
 fi
 
-if echo "$COMMAND" | grep -qP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
+if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
     echo ""
     echo "========================================================================"
     echo "  BLOCKED: gh pr merge requires explicit user permission"

--- a/.claude/scripts/block-merge-without-permission.sh
+++ b/.claude/scripts/block-merge-without-permission.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
 if [[ -z "$COMMAND" ]]; then
     exit 0
@@ -29,7 +29,7 @@ if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(])[ \t]*(?:\w+=\S+[ \t]+)*MER
     exit 0
 fi
 
-if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
+if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(`)]\s*(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
     echo ""
     echo "========================================================================"
     echo "  BLOCKED: gh pr merge requires explicit user permission"

--- a/.claude/scripts/block-merge-without-permission.sh
+++ b/.claude/scripts/block-merge-without-permission.sh
@@ -16,14 +16,16 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
-# Use printf+grep -z so the whole command string is treated as one record.
-# This makes ^ anchor to the start of the full string — not to each line —
-# which prevents heredoc body content from triggering a false positive.
+# Use printf+grep -z so the whole command string is treated as one record,
+# making ^ anchor to the very start of the string rather than to each line.
+# This prevents a heredoc body line that starts with the gh command text from
+# triggering a false positive.
 
-# Allow when MERGE_AUTHORIZED=1 immediately precedes gh pr merge in command-position.
-# The combined PCRE matches the authorized form in one pass, preventing the newline
-# bypass that two separate greps would allow.
-if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(])\s*(?:\w+=\S+\s+)*MERGE_AUTHORIZED=1\s+(?:\w+=\S+\s+)*gh\s+pr\s+merge\b'; then
+# ALLOW when MERGE_AUTHORIZED=1 immediately precedes gh pr merge in command-position
+# on the SAME LINE ([ \t]+ — no newlines).  Using \s+ instead would let an AI bypass
+# the guard by injecting a newline between the prefix and the command (PCRE \s matches \n).
+# Note: $(gh pr merge ...) is intentionally blocked — the subshell executes the command.
+if printf '%s\0' "$COMMAND" | grep -zqP '(?:^|[;&|(])[ \t]*(?:\w+=\S+[ \t]+)*MERGE_AUTHORIZED=1[ \t]+(?:\w+=\S+[ \t]+)*gh[ \t]+pr[ \t]+merge\b'; then
     exit 0
 fi
 


### PR DESCRIPTION
Fix the merge guard hook so Claude can act on explicit user merge instructions.

- .claude/scripts: Add MERGE_AUTHORIZED=1 prefix check — when the user says "merge", Claude prefixes the command with this env var and the hook allows it through
- .claude/scripts: Tighten the detection regex from a simple substring match to a PCRE that only fires when the gh command appears in command position (after a shell operator or at start of line), preventing false positives when commit messages or strings mention the command text