### PR TITLE
NOJIRA-Fix-ai-prompt-history-migration

### DIFF
--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_ai_prompt_histories.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_ai_prompt_histories.sql
@@ -1,10 +1,11 @@
-CREATE TABLE ai_ai_prompt_histories (
-  id          BINARY(16)  NOT NULL,
-  customer_id BINARY(16)  NOT NULL,
-  ai_id       BINARY(16)  NOT NULL,
-  prompt      LONGTEXT    NOT NULL DEFAULT '',
-  tm_create   DATETIME(6) NOT NULL,
-  PRIMARY KEY (id),
-  INDEX idx_ai_ai_prompt_histories_ai_id_tm_create (ai_id, tm_create),
-  INDEX idx_ai_ai_prompt_histories_customer_id (customer_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+create table ai_ai_prompt_histories (
+  id          binary(16)  not null,
+  customer_id binary(16)  not null,
+  ai_id       binary(16)  not null,
+  prompt      longtext    not null,
+  tm_create   datetime(6) not null,
+  primary key (id)
+);
+
+create index idx_ai_ai_prompt_histories_ai_id_tm_create on ai_ai_prompt_histories(ai_id, tm_create);
+create index idx_ai_ai_prompt_histories_customer_id on ai_ai_prompt_histories(customer_id);

--- a/bin-dbscheme-manager/bin-manager/main/versions/ece6ccf25201_add_ai_ai_prompt_histories.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/ece6ccf25201_add_ai_ai_prompt_histories.py
@@ -23,7 +23,7 @@ def upgrade():
             id          BINARY(16)   NOT NULL,
             customer_id BINARY(16)   NOT NULL,
             ai_id       BINARY(16)   NOT NULL,
-            prompt      LONGTEXT     NOT NULL DEFAULT '',
+            prompt      LONGTEXT     NOT NULL,
             tm_create   DATETIME(6)  NOT NULL,
             PRIMARY KEY (id),
             INDEX idx_ai_ai_prompt_histories_ai_id_tm_create (ai_id, tm_create),


### PR DESCRIPTION
Fix MySQL error 1101 that prevented the ai_ai_prompt_histories table from being created.

- bin-dbscheme-manager: Remove DEFAULT '' from prompt LONGTEXT column — MySQL strict mode (error 1101) does not allow DEFAULT values on BLOB/TEXT/GEOMETRY/JSON columns
- bin-ai-manager: Rewrite test SQL to use SQLite-compatible separate CREATE INDEX statements instead of MySQL inline INDEX syntax inside CREATE TABLE