### PR TITLE
NOJIRA-Fix-aicall-terminate-pipecatcall-not-found

### DIFF
--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -310,7 +310,7 @@ func (h *aicallHandler) UpdateCurrentMemberID(ctx context.Context, id uuid.UUID,
 	return res, nil
 }
 
-// UpdateStatusTerminating updates the status to terminating
+// UpdateStatus updates the aicall status and emits the corresponding webhook event.
 func (h *aicallHandler) UpdateStatus(ctx context.Context, id uuid.UUID, status aicall.Status) (*aicall.AIcall, error) {
 	fields := map[aicall.Field]any{
 		aicall.FieldStatus: status,
@@ -320,7 +320,7 @@ func (h *aicallHandler) UpdateStatus(ctx context.Context, id uuid.UUID, status a
 		fields[aicall.FieldTMEnd] = now
 	}
 	if errUpdate := h.db.AIcallUpdate(ctx, id, fields); errUpdate != nil {
-		return nil, errors.Wrapf(errUpdate, "could not update the status to terminating. aicall_id: %s", id)
+		return nil, errors.Wrapf(errUpdate, "could not update the aicall status. aicall_id: %s", id)
 	}
 
 	res, err := h.Get(ctx, id)

--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -315,6 +315,10 @@ func (h *aicallHandler) UpdateStatus(ctx context.Context, id uuid.UUID, status a
 	fields := map[aicall.Field]any{
 		aicall.FieldStatus: status,
 	}
+	if status == aicall.StatusTerminated {
+		now := h.utilHandler.TimeNow()
+		fields[aicall.FieldTMEnd] = now
+	}
 	if errUpdate := h.db.AIcallUpdate(ctx, id, fields); errUpdate != nil {
 		return nil, errors.Wrapf(errUpdate, "could not update the status to terminating. aicall_id: %s", id)
 	}

--- a/bin-ai-manager/pkg/aicallhandler/process.go
+++ b/bin-ai-manager/pkg/aicallhandler/process.go
@@ -79,7 +79,13 @@ func (h *aicallHandler) ProcessTerminate(ctx context.Context, id uuid.UUID) (*ai
 			log.Debugf("Got pipecatcall. Sending terminate RPC. pipecatcall_id: %s, host_id: %s", pc.ID, pc.HostID)
 			tmpPC, err := h.reqHandler.PipecatV1PipecatcallTerminate(ctx, pc.HostID, pc.ID)
 			if err != nil {
-				log.Errorf("Could not terminate the pipecatcall. err: %v", err)
+				var ve *cerrors.VoipbinError
+				if stderrors.As(err, &ve) && ve.Status == cerrors.StatusNotFound {
+					// pipecatcall already gone by the time the terminate RPC arrived; benign
+					log.Debugf("Pipecatcall already gone during terminate RPC. pipecatcall_id: %s", pc.ID)
+				} else {
+					log.Errorf("Could not terminate the pipecatcall. err: %v", err)
+				}
 			} else {
 				log.Debugf("Pipecatcall terminate RPC completed. pipecatcall_id: %s", tmpPC.ID)
 			}

--- a/bin-ai-manager/pkg/aicallhandler/process.go
+++ b/bin-ai-manager/pkg/aicallhandler/process.go
@@ -65,6 +65,7 @@ func (h *aicallHandler) ProcessTerminate(ctx context.Context, id uuid.UUID) (*ai
 
 	if tmp.PipecatcallID != uuid.Nil {
 		// terminate the pipecatcall
+		log.Debugf("Getting pipecatcall. pipecatcall_id: %s", tmp.PipecatcallID)
 		pc, err := h.reqHandler.PipecatV1PipecatcallGet(ctx, tmp.PipecatcallID)
 		if err != nil {
 			var ve *cerrors.VoipbinError
@@ -75,12 +76,12 @@ func (h *aicallHandler) ProcessTerminate(ctx context.Context, id uuid.UUID) (*ai
 				return nil, errors.Wrap(err, "could not get the pipecatcall correctly")
 			}
 		} else {
-			log.WithField("pipecatcall", pc).Debugf("Terminating the pipecatcall. pipecatcall_id: %s", pc.ID)
+			log.Debugf("Got pipecatcall. Sending terminate RPC. pipecatcall_id: %s, host_id: %s", pc.ID, pc.HostID)
 			tmpPC, err := h.reqHandler.PipecatV1PipecatcallTerminate(ctx, pc.HostID, pc.ID)
 			if err != nil {
 				log.Errorf("Could not terminate the pipecatcall. err: %v", err)
 			} else {
-				log.WithField("pipecatcall", tmpPC).Debugf("Terminated the pipecatcall. pipecatcall_id: %s", tmpPC.ID)
+				log.Debugf("Pipecatcall terminate RPC completed. pipecatcall_id: %s", tmpPC.ID)
 			}
 		}
 	}

--- a/bin-ai-manager/pkg/aicallhandler/process.go
+++ b/bin-ai-manager/pkg/aicallhandler/process.go
@@ -2,12 +2,14 @@ package aicallhandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-ai-manager/models/aicall"
+	cerrors "monorepo/bin-common-handler/models/errors"
 )
 
 // ProcessStart starts a aicall process
@@ -65,15 +67,21 @@ func (h *aicallHandler) ProcessTerminate(ctx context.Context, id uuid.UUID) (*ai
 		// terminate the pipecatcall
 		pc, err := h.reqHandler.PipecatV1PipecatcallGet(ctx, tmp.PipecatcallID)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get the pipecatcall correctly")
-		}
-
-		log.WithField("pipecatcall", pc).Debugf("Terminating the pipecatcall. pipecatcall_id: %s", pc.ID)
-		tmpPC, err := h.reqHandler.PipecatV1PipecatcallTerminate(ctx, pc.HostID, pc.ID)
-		if err != nil {
-			log.Errorf("Could not terminate the pipecatcall. err: %v", err)
+			var ve *cerrors.VoipbinError
+			if stderrors.As(err, &ve) && ve.Status == cerrors.StatusNotFound {
+				// pipecat call already gone (e.g. stale aicall); treat as already terminated
+				log.Debugf("Pipecatcall not found, treating as already terminated. pipecatcall_id: %s", tmp.PipecatcallID)
+			} else {
+				return nil, errors.Wrap(err, "could not get the pipecatcall correctly")
+			}
 		} else {
-			log.WithField("pipecatcall", tmpPC).Debugf("Terminated the pipecatcall. pipecatcall_id: %s", tmpPC.ID)
+			log.WithField("pipecatcall", pc).Debugf("Terminating the pipecatcall. pipecatcall_id: %s", pc.ID)
+			tmpPC, err := h.reqHandler.PipecatV1PipecatcallTerminate(ctx, pc.HostID, pc.ID)
+			if err != nil {
+				log.Errorf("Could not terminate the pipecatcall. err: %v", err)
+			} else {
+				log.WithField("pipecatcall", tmpPC).Debugf("Terminated the pipecatcall. pipecatcall_id: %s", tmpPC.ID)
+			}
 		}
 	}
 

--- a/bin-ai-manager/pkg/aicallhandler/process_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/process_test.go
@@ -8,6 +8,7 @@ import (
 
 	cmconfbridge "monorepo/bin-call-manager/models/confbridge"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -98,8 +99,9 @@ func Test_ProcessTerminate(t *testing.T) {
 
 		id uuid.UUID
 
-		responseAicall      *aicall.AIcall
-		responsePipecatcall *pmpipecatcall.Pipecatcall
+		responseAicall         *aicall.AIcall
+		responsePipecatcall    *pmpipecatcall.Pipecatcall
+		pipecatcallGetErr      error // non-nil to simulate stale/missing pipecatcall
 	}{
 		{
 			name: "normal - reference type is task",
@@ -141,6 +143,26 @@ func Test_ProcessTerminate(t *testing.T) {
 				HostID: "host-12345",
 			},
 		},
+		{
+			// Stale aicall: pipecatcall_id is set but the pipecatcall no longer exists.
+			// ProcessTerminate should skip the terminate RPC and continue to StatusTerminated.
+			name: "stale aicall - pipecatcall not found",
+
+			id: uuid.FromStringOrNil("e1a2b3c4-d9d8-11f0-bf0e-13aea4f95ca9"),
+
+			responseAicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("e1a2b3c4-d9d8-11f0-bf0e-13aea4f95ca9"),
+				},
+				PipecatcallID: uuid.FromStringOrNil("f1a2b3c4-d9d8-11f0-9dfe-4b563d93e22c"),
+				ReferenceType: aicall.ReferenceTypeTask,
+			},
+			pipecatcallGetErr: &cerrors.VoipbinError{
+				Status:  cerrors.StatusNotFound,
+				Reason:  "PIPECATCALL_NOT_FOUND",
+				Message: "The pipecat call was not found.",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -170,8 +192,12 @@ func Test_ProcessTerminate(t *testing.T) {
 			}
 
 			if tt.responseAicall.PipecatcallID != uuid.Nil {
-				mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(tt.responsePipecatcall, nil)
-				mockReq.EXPECT().PipecatV1PipecatcallTerminate(ctx, tt.responsePipecatcall.HostID, tt.responsePipecatcall.ID).Return(tt.responsePipecatcall, nil)
+				if tt.pipecatcallGetErr != nil {
+					mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(nil, tt.pipecatcallGetErr)
+				} else {
+					mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(tt.responsePipecatcall, nil)
+					mockReq.EXPECT().PipecatV1PipecatcallTerminate(ctx, tt.responsePipecatcall.HostID, tt.responsePipecatcall.ID).Return(tt.responsePipecatcall, nil)
+				}
 			}
 
 			if tt.responseAicall.ConfbridgeID != uuid.Nil {

--- a/bin-ai-manager/pkg/aicallhandler/process_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/process_test.go
@@ -104,6 +104,19 @@ func Test_ProcessTerminate(t *testing.T) {
 		pipecatcallGetErr      error // non-nil to simulate stale/missing pipecatcall
 	}{
 		{
+			// Already-terminated: idempotency guard returns early without any further RPCs.
+			name: "already terminated - no-op",
+
+			id: uuid.FromStringOrNil("f0f0f0f0-d9d8-11f0-bf0e-13aea4f95ca9"),
+
+			responseAicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("f0f0f0f0-d9d8-11f0-bf0e-13aea4f95ca9"),
+				},
+				Status: aicall.StatusTerminated,
+			},
+		},
+		{
 			name: "normal - reference type is task",
 
 			id: uuid.FromStringOrNil("dd188916-d791-11f0-b284-4359b8729dde"),
@@ -207,29 +220,32 @@ func Test_ProcessTerminate(t *testing.T) {
 			ctx := context.Background()
 
 			mockDB.EXPECT().AIcallGet(ctx, tt.id).Return(tt.responseAicall, nil)
-			mockReq.EXPECT().FlowV1ActiveflowServiceStop(ctx, tt.responseAicall.ActiveflowID, tt.responseAicall.ID, 0).Return(nil)
-			if tt.responseAicall.ReferenceType != aicall.ReferenceTypeCall {
-				mockReq.EXPECT().FlowV1ActiveflowContinue(ctx, tt.responseAicall.ActiveflowID, tt.responseAicall.ID).Return(nil)
-			}
 
-			if tt.responseAicall.PipecatcallID != uuid.Nil {
-				if tt.pipecatcallGetErr != nil {
-					mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(nil, tt.pipecatcallGetErr)
-				} else {
-					mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(tt.responsePipecatcall, nil)
-					mockReq.EXPECT().PipecatV1PipecatcallTerminate(ctx, tt.responsePipecatcall.HostID, tt.responsePipecatcall.ID).Return(tt.responsePipecatcall, nil)
+			if tt.responseAicall.Status != aicall.StatusTerminated {
+				mockReq.EXPECT().FlowV1ActiveflowServiceStop(ctx, tt.responseAicall.ActiveflowID, tt.responseAicall.ID, 0).Return(nil)
+				if tt.responseAicall.ReferenceType != aicall.ReferenceTypeCall {
+					mockReq.EXPECT().FlowV1ActiveflowContinue(ctx, tt.responseAicall.ActiveflowID, tt.responseAicall.ID).Return(nil)
 				}
-			}
 
-			if tt.responseAicall.ConfbridgeID != uuid.Nil {
-				mockReq.EXPECT().CallV1ConfbridgeTerminate(ctx, tt.responseAicall.ConfbridgeID).Return(&cmconfbridge.Confbridge{}, nil)
-			}
+				if tt.responseAicall.PipecatcallID != uuid.Nil {
+					if tt.pipecatcallGetErr != nil {
+						mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(nil, tt.pipecatcallGetErr)
+					} else {
+						mockReq.EXPECT().PipecatV1PipecatcallGet(ctx, tt.responseAicall.PipecatcallID).Return(tt.responsePipecatcall, nil)
+						mockReq.EXPECT().PipecatV1PipecatcallTerminate(ctx, tt.responsePipecatcall.HostID, tt.responsePipecatcall.ID).Return(tt.responsePipecatcall, nil)
+					}
+				}
 
-			now := time.Now()
-			mockUtil.EXPECT().TimeNow().Return(&now)
-			mockDB.EXPECT().AIcallUpdate(ctx, tt.responseAicall.ID, gomock.Any()).Return(nil)
-			mockDB.EXPECT().AIcallGet(ctx, tt.responseAicall.ID).Return(tt.responseAicall, nil)
-			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseAicall.CustomerID, aicall.EventTypeStatusTerminated, tt.responseAicall)
+				if tt.responseAicall.ConfbridgeID != uuid.Nil {
+					mockReq.EXPECT().CallV1ConfbridgeTerminate(ctx, tt.responseAicall.ConfbridgeID).Return(&cmconfbridge.Confbridge{}, nil)
+				}
+
+				now := time.Now()
+				mockUtil.EXPECT().TimeNow().Return(&now)
+				mockDB.EXPECT().AIcallUpdate(ctx, tt.responseAicall.ID, gomock.Any()).Return(nil)
+				mockDB.EXPECT().AIcallGet(ctx, tt.responseAicall.ID).Return(tt.responseAicall, nil)
+				mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseAicall.CustomerID, aicall.EventTypeStatusTerminated, tt.responseAicall)
+			}
 
 			res, err := h.ProcessTerminate(ctx, tt.id)
 			if err != nil {

--- a/bin-ai-manager/pkg/aicallhandler/process_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/process_test.go
@@ -163,6 +163,27 @@ func Test_ProcessTerminate(t *testing.T) {
 				Message: "The pipecat call was not found.",
 			},
 		},
+		{
+			// Stale aicall with a live confbridge: pipecatcall not found, but confbridge
+			// still exists and must still be terminated.
+			name: "stale aicall - pipecatcall not found, confbridge present",
+
+			id: uuid.FromStringOrNil("a1b2c3d4-d9d8-11f0-bf0e-13aea4f95ca9"),
+
+			responseAicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a1b2c3d4-d9d8-11f0-bf0e-13aea4f95ca9"),
+				},
+				ConfbridgeID:  uuid.FromStringOrNil("b1b2c3d4-d9d8-11f0-b6e2-73784ba2c3f2"),
+				PipecatcallID: uuid.FromStringOrNil("c1b2c3d4-d9d8-11f0-9dfe-4b563d93e22c"),
+				ReferenceType: aicall.ReferenceTypeTask,
+			},
+			pipecatcallGetErr: &cerrors.VoipbinError{
+				Status:  cerrors.StatusNotFound,
+				Reason:  "PIPECATCALL_NOT_FOUND",
+				Message: "The pipecat call was not found.",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-ai-manager/pkg/aicallhandler/process_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/process_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	cmconfbridge "monorepo/bin-call-manager/models/confbridge"
 	commonidentity "monorepo/bin-common-handler/models/identity"
@@ -177,6 +178,8 @@ func Test_ProcessTerminate(t *testing.T) {
 				mockReq.EXPECT().CallV1ConfbridgeTerminate(ctx, tt.responseAicall.ConfbridgeID).Return(&cmconfbridge.Confbridge{}, nil)
 			}
 
+			now := time.Now()
+			mockUtil.EXPECT().TimeNow().Return(&now)
 			mockDB.EXPECT().AIcallUpdate(ctx, tt.responseAicall.ID, gomock.Any()).Return(nil)
 			mockDB.EXPECT().AIcallGet(ctx, tt.responseAicall.ID).Return(tt.responseAicall, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseAicall.CustomerID, aicall.EventTypeStatusTerminated, tt.responseAicall)

--- a/bin-ai-manager/pkg/aicallhandler/start_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/start_test.go
@@ -1034,6 +1034,7 @@ func Test_startReferenceTypeConversation(t *testing.T) {
 				m.db.EXPECT().AIcallGetByReferenceID(ctx, gomock.Any()).Return(existingIdle, nil)
 
 				// idle-expiry branch: UpdateStatus(StatusTerminated) on the OLD AIcall
+				m.util.EXPECT().TimeNow().DoAndReturn(func() *time.Time { now := time.Now(); return &now })
 				m.db.EXPECT().AIcallUpdate(ctx, oldAIcallID, gomock.Any()).Return(nil)
 				m.db.EXPECT().AIcallGet(ctx, oldAIcallID).Return(terminatedOld, nil)
 				m.notify.EXPECT().PublishWebhookEvent(ctx, terminatedOld.CustomerID, aicall.EventTypeStatusTerminated, terminatedOld)

--- a/bin-ai-manager/pkg/aicallhandler/tool_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_test.go
@@ -513,6 +513,7 @@ func Test_toolHandleServiceStop(t *testing.T) {
 				mockReq.EXPECT().CallV1ConfbridgeTerminate(ctx, tt.aicall.ConfbridgeID).Return(&cmconfbridge.Confbridge{}, nil)
 			}
 
+			mockUtil.EXPECT().TimeNow().DoAndReturn(func() *time.Time { now := time.Now(); return &now })
 			mockDB.EXPECT().AIcallUpdate(ctx, tt.aicall.ID, gomock.Any()).Return(nil)
 			mockDB.EXPECT().AIcallGet(ctx, tt.aicall.ID).Return(tt.aicall, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.aicall.CustomerID, aicall.EventTypeStatusTerminated, tt.aicall)

--- a/bin-pipecat-manager/go.sum
+++ b/bin-pipecat-manager/go.sum
@@ -443,6 +443,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
@@ -114,7 +114,8 @@ func (h *listenHandler) processV1PipecatcallsIDStopPost(ctx context.Context, m *
 	log.Debugf("Received stop request. pipecatcall_id: %s", id)
 	tmp, err := h.pipecatcallHandler.Terminate(ctx, id)
 	if err != nil {
-		return simpleResponse(500), nil
+		log.Debugf("Could not terminate pipecatcall. err: %v", err)
+		return nil, err
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
@@ -111,6 +111,7 @@ func (h *listenHandler) processV1PipecatcallsIDStopPost(ctx context.Context, m *
 	}
 	id := uuid.FromStringOrNil(uriItems[3])
 
+	log.Debugf("Received stop request. pipecatcall_id: %s", id)
 	tmp, err := h.pipecatcallHandler.Terminate(ctx, id)
 	if err != nil {
 		return simpleResponse(500), nil

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
@@ -121,6 +121,14 @@ func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
 			case <-pc.ConnAstReady:
 				return pc.ConnAst
 			case <-pc.Ctx.Done():
+				// Re-drain ConnAstReady: if both fired simultaneously and the
+				// scheduler chose Ctx.Done(), a concurrent SetConnAst may have
+				// written ConnAst — closing it here prevents a socket leak.
+				select {
+				case <-pc.ConnAstReady:
+					return pc.ConnAst
+				default:
+				}
 				return nil
 			}
 		}()

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
@@ -102,20 +102,34 @@ func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
 	// runner eventually exits on its own (~3 s timeout).
 	pc.Cancel()
 
-	// Wait until the Asterisk connection is fully established (or context cancelled)
-	// before closing it, so we don't race with SetConnAst on the call path.
+	// Resolve the Asterisk connection safely.
+	// ConnAst must only be read after receiving from ConnAstReady (which is closed
+	// by SetConnAst after writing ConnAst). Reading via Ctx.Done() would race with
+	// a concurrent SetConnAst write, so we avoid it.
+	//
+	// Double-select pattern: prefer ConnAstReady when both channels are ready
+	// simultaneously (established session + context just cancelled). Fall through
+	// to the blocking select only when ConnAstReady is not yet closed.
 	if pc.ConnAstReady != nil {
-		select {
-		case <-pc.ConnAstReady:
-		case <-pc.Ctx.Done():
-		}
-	}
-
-	if pc.ConnAst != nil {
-		if errClose := pc.ConnAst.Close(); errClose != nil {
-			log.Errorf("Could not close the asterisk connection. err: %v", errClose)
-		} else {
-			log.Infof("Closed the asterisk connection.")
+		connAst := func() *websocket.Conn {
+			select {
+			case <-pc.ConnAstReady:
+				return pc.ConnAst
+			default:
+			}
+			select {
+			case <-pc.ConnAstReady:
+				return pc.ConnAst
+			case <-pc.Ctx.Done():
+				return nil
+			}
+		}()
+		if connAst != nil {
+			if errClose := connAst.Close(); errClose != nil {
+				log.Errorf("Could not close the asterisk connection. err: %v", errClose)
+			} else {
+				log.Infof("Closed the asterisk connection.")
+			}
 		}
 	}
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/session.go
@@ -96,18 +96,20 @@ func (h *pipecatcallHandler) SessionStop(id uuid.UUID) {
 		log.Warnf("Session had %d dropped audio frames. pipecatcall_id: %s", dropped, id)
 	}
 
-	// Wait for Asterisk connection to be ready (or context cancelled) before closing
+	// Cancel the session context first. For non-Asterisk paths (task/conversation),
+	// ConnAstReady is never closed, so the wait below must escape via Ctx.Done().
+	// Calling Cancel here makes that immediate instead of blocking until the Python
+	// runner eventually exits on its own (~3 s timeout).
+	pc.Cancel()
+
+	// Wait until the Asterisk connection is fully established (or context cancelled)
+	// before closing it, so we don't race with SetConnAst on the call path.
 	if pc.ConnAstReady != nil {
 		select {
 		case <-pc.ConnAstReady:
 		case <-pc.Ctx.Done():
 		}
 	}
-
-	// Cancel the session context so any in-flight goroutines (e.g. the flush
-	// goroutine waiting on pc.Ctx.Done()) unblock before we tear down the
-	// Asterisk connection. Mirrors the deferred cleanup in start.go.
-	pc.Cancel()
 
 	if pc.ConnAst != nil {
 		if errClose := pc.ConnAst.Close(); errClose != nil {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start.go
@@ -318,7 +318,9 @@ func (h *pipecatcallHandler) terminate(ctx context.Context, pc *pipecatcall.Pipe
 	// so partial replies are published as a final message_bot_llm event. Safe
 	// no-op when no flush is armed; safe when a normal-stop closer raced us
 	// (CAS + sync.Once preserve first-writer-wins).
+	log.Debugf("Flushing and finalizing. pipecatcall_id: %s", pc.ID)
 	h.flushAndFinalize(se)
+	log.Debugf("Flush done. Publishing terminated event. pipecatcall_id: %s", pc.ID)
 
 	// Publish the pipecatcall_terminated event exactly once per pipecatcall.
 	// Use context.Background() because SessionStop below will cancel se.Ctx
@@ -332,6 +334,7 @@ func (h *pipecatcallHandler) terminate(ctx context.Context, pc *pipecatcall.Pipe
 		)
 	}
 
+	log.Debugf("Handling reference type cleanup. reference_type: %s, pipecatcall_id: %s", pc.ReferenceType, pc.ID)
 	switch pc.ReferenceType {
 	case pipecatcall.ReferenceTypeCall:
 		if errTerminate := h.terminateReferenceTypeCall(ctx, pc); errTerminate != nil {
@@ -350,6 +353,7 @@ func (h *pipecatcallHandler) terminate(ctx context.Context, pc *pipecatcall.Pipe
 		log.Debugf("No action needed to stop for reference type: %v", pc.ReferenceType)
 	}
 
+	log.Debugf("Reference type cleanup done. Stopping session. pipecatcall_id: %s", pc.ID)
 	h.SessionStop(pc.ID)
 	log.Infof("Pipecatcall terminated. pipecatcall_id: %s", pc.ID)
 }


### PR DESCRIPTION
Fix PIPECATCALL_NOT_FOUND 404 error when terminating a stale aicall whose pipecat call no longer exists.

- bin-ai-manager: In ProcessTerminate, when PipecatV1PipecatcallGet returns a NOT_FOUND VoipbinError, treat the pipecat call as already terminated and continue with aicall termination instead of hard-failing with a 404