### PR TITLE
NOJIRA-Fix-aiaudit-soft-delete-pattern

### DIFF
--- a/bin-ai-manager/pkg/aiaudithandler/main.go
+++ b/bin-ai-manager/pkg/aiaudithandler/main.go
@@ -207,9 +207,11 @@ func (h *aiauditHandler) runAuditJob(ctx context.Context, recordID uuid.UUID, ac
 		}
 		writeCtx, writeCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer writeCancel()
-		_, dbErr := h.db.AIAuditUpdateFinal(writeCtx, recordID, finalStatus, finalScore, finalEvalJSON, finalErr)
+		n, dbErr := h.db.AIAuditUpdateFinal(writeCtx, recordID, finalStatus, finalScore, finalEvalJSON, finalErr)
 		if dbErr != nil {
 			log.WithError(dbErr).Error("could not write final audit result")
+		} else if n == 0 {
+			log.Warnf("final audit result not written: record %s was deleted or swept before goroutine finished (intended status=%s)", recordID, finalStatus)
 		}
 	}()
 
@@ -326,10 +328,10 @@ func (h *aiauditHandler) Delete(ctx context.Context, id uuid.UUID) (*aiaudit.AIA
 	return record, nil
 }
 
-// SweepStaleAudits marks any 'progressing' audits older than staleAuditAgeMinutes as 'failed'.
-// This is called at service startup to recover from crashed goroutines.
+// SweepStaleAudits is called at service startup to recover from crashed goroutines.
+// TODO: implement — mark 'progressing' audits older than staleAuditAgeMinutes as 'failed'.
 func (h *aiauditHandler) SweepStaleAudits(ctx context.Context) {
-	logrus.Infof("startup stale audit sweep: any 'progressing' audits older than %d min will be marked 'failed'", staleAuditAgeMinutes)
+	logrus.Infof("startup stale audit sweep: not yet implemented (stale threshold: %d min)", staleAuditAgeMinutes)
 }
 
 // extractPromptSnapshots parses the prompt_snapshots metadata from an AIcall.

--- a/bin-ai-manager/pkg/aiaudithandler/main.go
+++ b/bin-ai-manager/pkg/aiaudithandler/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -201,7 +202,7 @@ func (h *aiauditHandler) runAuditJob(ctx context.Context, recordID uuid.UUID, ac
 	defer func() {
 		defer func() { <-h.semaphore }() // released after all cleanup
 		if r := recover(); r != nil {
-			log.Errorf("panic in runAuditJob: %v", r)
+			log.Errorf("panic in runAuditJob: %v\n%s", r, debug.Stack())
 			finalErr = string(aiaudit.ErrorEvaluatorUnavailable)
 			finalStatus = aiaudit.StatusFailed
 		}

--- a/bin-ai-manager/pkg/aiaudithandler/main_test.go
+++ b/bin-ai-manager/pkg/aiaudithandler/main_test.go
@@ -7,12 +7,81 @@ import (
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
+	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/aiaudit"
 	"monorepo/bin-ai-manager/pkg/aiaudithandler"
 	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-ai-manager/pkg/geminiaudithandler"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 )
+
+func TestCreate_HappyPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockGemini := geminiaudithandler.NewMockGeminiAuditHandler(ctrl)
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	aicallID := uuid.FromStringOrNil("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	aiID := uuid.FromStringOrNil("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	auditID := uuid.FromStringOrNil("dddddddd-dddd-dddd-dddd-dddddddddddd")
+	promptHistoryID := uuid.FromStringOrNil("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+
+	ac := &aicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         aicallID,
+			CustomerID: customerID,
+		},
+		AssistanceType: aicall.AssistanceTypeAI,
+		AssistanceID:   aiID,
+		Status:         aicall.StatusTerminated,
+		Metadata: map[string]any{
+			aicall.MetaKeyPromptSnapshots: []aicall.PromptSnapshot{
+				{
+					AIID:            aiID,
+					PromptHistoryID: promptHistoryID,
+					Prompt:          "You are a helpful assistant.",
+				},
+			},
+		},
+	}
+
+	expectedAudit := &aiaudit.AIAudit{
+		Identity: commonidentity.Identity{
+			ID:         auditID,
+			CustomerID: customerID,
+		},
+		AIcallID: aicallID,
+		AIID:     aiID,
+		Status:   aiaudit.StatusProgressing,
+	}
+
+	mockDB.EXPECT().AIcallGet(gomock.Any(), aicallID).Return(ac, nil)
+	mockDB.EXPECT().AIAuditCountProgressing(gomock.Any(), customerID).Return(int64(0), nil)
+	mockDB.EXPECT().AIAuditUpsert(gomock.Any(), gomock.Any()).Return(int64(1), nil)
+	mockDB.EXPECT().AIAuditList(gomock.Any(), uint64(1), "", gomock.Any()).Return([]*aiaudit.AIAudit{expectedAudit}, nil)
+
+	// Background goroutine may call these; AnyTimes to prevent test flakiness.
+	mockDB.EXPECT().MessageList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockGemini.EXPECT().Evaluate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil, nil).AnyTimes()
+	mockDB.EXPECT().AIAuditUpdateFinal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(1), nil).AnyTimes()
+
+	h := aiaudithandler.NewAIAuditHandler(mockDB, mockGemini)
+	got, err := h.Create(context.Background(), customerID, aicallID, "en-US")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 audit record, got %d", len(got))
+	}
+	if got[0].ID != auditID {
+		t.Errorf("expected audit ID %s, got %s", auditID, got[0].ID)
+	}
+	if got[0].Status != aiaudit.StatusProgressing {
+		t.Errorf("expected status %s, got %s", aiaudit.StatusProgressing, got[0].Status)
+	}
+}
 
 func TestAIAuditHandlerInterfaceExists(t *testing.T) {
 	var _ aiaudithandler.AIAuditHandler = nil

--- a/bin-ai-manager/pkg/dbhandler/aiaudit.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	aiauditTable           = "ai_ai_audits"
-	aiauditSoftDeleteEpoch = "9999-01-01 00:00:00.000000"
+	aiauditTable = "ai_ai_audits"
 )
 
 // AIAuditUpsert inserts a new audit row or resets an existing non-progressing one.
@@ -32,17 +31,17 @@ func (h *handler) AIAuditUpsert(ctx context.Context, a *aiaudit.AIAudit) (int64,
 		INSERT INTO %s
 			(id, customer_id, aicall_id, ai_id, prompt_history_id, status, overall_score, evaluation, language, error, tm_create, tm_update, tm_delete)
 		VALUES
-			(?, ?, ?, ?, ?, 'progressing', NULL, NULL, ?, NULL, ?, NULL, '%s')
+			(?, ?, ?, ?, ?, 'progressing', NULL, NULL, ?, NULL, ?, NULL, NULL)
 		ON DUPLICATE KEY UPDATE
 			status            = IF(status = 'progressing', status, 'progressing'),
-			tm_delete         = '%s',
+			tm_delete         = NULL,
 			overall_score     = NULL,
 			evaluation        = NULL,
 			error             = NULL,
 			language          = VALUES(language),
 			prompt_history_id = VALUES(prompt_history_id),
 			tm_update         = NULL
-	`, aiauditTable, aiauditSoftDeleteEpoch, aiauditSoftDeleteEpoch)
+	`, aiauditTable)
 
 	result, err := h.db.ExecContext(ctx, query,
 		a.ID.Bytes(),
@@ -166,7 +165,7 @@ func (h *handler) AIAuditDelete(ctx context.Context, id uuid.UUID) error {
 }
 
 // AIAuditUpdateFinal writes the goroutine's final result atomically.
-// Only updates rows where status='progressing' AND tm_delete='9999-01-01' to
+// Only updates rows where status='progressing' AND tm_delete IS NULL to
 // prevent overwriting a 'failed' status set by the stale recovery sweep.
 // Returns rowsAffected: 0 means the record was already soft-deleted or swept.
 func (h *handler) AIAuditUpdateFinal(ctx context.Context, id uuid.UUID, status aiaudit.Status, overallScore *int, evaluation json.RawMessage, errStr string) (int64, error) {
@@ -180,8 +179,8 @@ func (h *handler) AIAuditUpdateFinal(ctx context.Context, id uuid.UUID, status a
 	query := fmt.Sprintf(`
 		UPDATE %s
 		SET status = ?, overall_score = ?, evaluation = ?, error = ?, tm_update = ?
-		WHERE id = ? AND tm_delete = '%s' AND status = 'progressing'
-	`, aiauditTable, aiauditSoftDeleteEpoch)
+		WHERE id = ? AND tm_delete IS NULL AND status = 'progressing'
+	`, aiauditTable)
 
 	result, err := h.db.ExecContext(ctx, query,
 		string(status),
@@ -207,8 +206,8 @@ func (h *handler) AIAuditUpdateFinal(ctx context.Context, id uuid.UUID, status a
 func (h *handler) AIAuditCountProgressing(ctx context.Context, customerID uuid.UUID) (int64, error) {
 	query := fmt.Sprintf(`
 		SELECT COUNT(*) FROM %s
-		WHERE customer_id = ? AND status = 'progressing' AND tm_delete = '%s'
-	`, aiauditTable, aiauditSoftDeleteEpoch)
+		WHERE customer_id = ? AND status = 'progressing' AND tm_delete IS NULL
+	`, aiauditTable)
 
 	row := h.db.QueryRowContext(ctx, query, customerID.Bytes())
 

--- a/bin-ai-manager/pkg/dbhandler/aiaudit.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit.go
@@ -150,7 +150,10 @@ func (h *handler) AIAuditDelete(ctx context.Context, id uuid.UUID) error {
 			"tm_update": ts,
 			"tm_delete": ts,
 		}).
-		Where(sq.Eq{"id": id.Bytes()}).
+		Where(sq.And{
+			sq.Eq{"id": id.Bytes()},
+			sq.Eq{"tm_delete": nil},
+		}).
 		ToSql()
 	if err != nil {
 		return fmt.Errorf("AIAuditDelete: could not build query. err: %v", err)

--- a/bin-ai-manager/pkg/dbhandler/aiaudit.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit.go
@@ -156,9 +156,17 @@ func (h *handler) AIAuditDelete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("AIAuditDelete: could not build query. err: %v", err)
 	}
 
-	_, err = h.db.ExecContext(ctx, query, args...)
+	result, err := h.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("AIAuditDelete: could not execute. err: %v", err)
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("AIAuditDelete: could not get rows affected. err: %v", err)
+	}
+	if n == 0 {
+		return ErrNotFound
 	}
 
 	return nil

--- a/bin-ai-manager/pkg/dbhandler/aiaudit.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit.go
@@ -70,7 +70,10 @@ func (h *handler) aiauditGetFromDB(id uuid.UUID) (*aiaudit.AIAudit, error) {
 
 	query, args, err := sq.Select(cols...).
 		From(aiauditTable).
-		Where(sq.Eq{"id": id.Bytes()}).
+		Where(sq.And{
+			sq.Eq{"id": id.Bytes()},
+			sq.Eq{"tm_delete": nil},
+		}).
 		ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("aiauditGetFromDB: could not build query. err: %v", err)

--- a/bin-ai-manager/pkg/dbhandler/aiaudit_test.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit_test.go
@@ -128,7 +128,7 @@ func Test_AIAuditUpdateFinal_OnlyUpdatesWhenNotDeleted(t *testing.T) {
 
 	score := 85
 
-	// Live record: should update (1 row affected).
+	// Live record: should update (1 row affected) and final state verified.
 	mockUtil.EXPECT().TimeNow().Return(curTime)
 	n, err := h.AIAuditUpdateFinal(ctx, liveID, aiaudit.StatusCompleted, &score, nil, "")
 	if err != nil {
@@ -138,7 +138,19 @@ func Test_AIAuditUpdateFinal_OnlyUpdatesWhenNotDeleted(t *testing.T) {
 		t.Errorf("expected 1 row updated for live record, got %d", n)
 	}
 
-	// Soft-deleted record: must return 0 rows.
+	// Verify the live record was actually mutated in DB.
+	got, getErr := h.AIAuditGet(ctx, liveID)
+	if getErr != nil {
+		t.Fatalf("AIAuditGet after update error = %v", getErr)
+	}
+	if got.Status != aiaudit.StatusCompleted {
+		t.Errorf("expected status completed after UpdateFinal, got %s", got.Status)
+	}
+	if got.OverallScore == nil || *got.OverallScore != score {
+		t.Errorf("expected overall_score=%d after UpdateFinal, got %v", score, got.OverallScore)
+	}
+
+	// Soft-deleted record: must return 0 rows and remain unchanged.
 	mockUtil.EXPECT().TimeNow().Return(curTime)
 	n, err = h.AIAuditUpdateFinal(ctx, deletedID, aiaudit.StatusCompleted, &score, nil, "")
 	if err != nil {
@@ -146,6 +158,65 @@ func Test_AIAuditUpdateFinal_OnlyUpdatesWhenNotDeleted(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("expected 0 rows updated for soft-deleted record, got %d", n)
+	}
+}
+
+func Test_AIAuditList_ExcludesSoftDeleted(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	ctx := context.Background()
+	tm := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	// Token after the seeded records so they appear in the result window.
+	token := "2024-06-01 13:00:00.000000"
+
+	customerID := uuid.FromStringOrNil("bbbb0004-0004-0004-0004-000000000001")
+	aicallID := uuid.FromStringOrNil("cccc0004-0004-0004-0004-000000000001")
+
+	liveAudit := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: uuid.FromStringOrNil("aaaa0004-0004-0004-0004-000000000001"), CustomerID: customerID},
+		AIcallID:        aicallID,
+		AIID:            uuid.FromStringOrNil("dddd0004-0004-0004-0004-000000000001"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0004-0004-0004-0004-000000000001"),
+		Language:        "en-US",
+	}
+	deletedAudit := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: uuid.FromStringOrNil("aaaa0004-0004-0004-0004-000000000002"), CustomerID: customerID},
+		AIcallID:        aicallID,
+		AIID:            uuid.FromStringOrNil("dddd0004-0004-0004-0004-000000000002"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0004-0004-0004-0004-000000000002"),
+		Language:        "en-US",
+	}
+
+	insertTestAudit(t, liveAudit, aiaudit.StatusProgressing, nil, &tm)
+	insertTestAudit(t, deletedAudit, aiaudit.StatusProgressing, &tm, &tm)
+
+	filters := map[aiaudit.Field]any{
+		aiaudit.FieldAIcallID: aicallID,
+		aiaudit.FieldDeleted:  false,
+	}
+
+	list, err := h.AIAuditList(ctx, 100, token, filters)
+	if err != nil {
+		t.Fatalf("AIAuditList error = %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 record (live only), got %d", len(list))
+	}
+	if list[0].ID != liveAudit.ID {
+		t.Errorf("expected live audit ID %s, got %s", liveAudit.ID, list[0].ID)
+	}
+	if list[0].TMDelete != nil {
+		t.Errorf("returned record has non-nil tm_delete: %v", list[0].TMDelete)
 	}
 }
 

--- a/bin-ai-manager/pkg/dbhandler/aiaudit_test.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit_test.go
@@ -1,0 +1,194 @@
+package dbhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-ai-manager/models/aiaudit"
+	"monorepo/bin-ai-manager/pkg/cachehandler"
+	"monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+)
+
+// insertTestAudit seeds a row directly via SQL to avoid MySQL-specific ON DUPLICATE KEY syntax.
+func insertTestAudit(t *testing.T, a *aiaudit.AIAudit, status aiaudit.Status, tmDelete *time.Time, tmCreate *time.Time) {
+	t.Helper()
+
+	var tmDeleteVal any
+	if tmDelete != nil {
+		tmDeleteVal = tmDelete.Format("2006-01-02 15:04:05.000000")
+	}
+	var tmCreateVal any
+	if tmCreate != nil {
+		tmCreateVal = tmCreate.Format("2006-01-02 15:04:05.000000")
+	}
+
+	_, err := dbTest.Exec(
+		`INSERT INTO ai_ai_audits
+		 (id, customer_id, aicall_id, ai_id, prompt_history_id, status, language, error, tm_create, tm_update, tm_delete)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, NULL, ?)`,
+		a.ID.Bytes(),
+		a.CustomerID.Bytes(),
+		a.AIcallID.Bytes(),
+		a.AIID.Bytes(),
+		a.PromptHistoryID.Bytes(),
+		string(status),
+		a.Language,
+		tmCreateVal,
+		tmDeleteVal,
+	)
+	if err != nil {
+		t.Fatalf("insertTestAudit: %v", err)
+	}
+}
+
+func Test_AIAuditGet_ReturnsTMDeleteNull(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	ctx := context.Background()
+	tm := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	a := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: uuid.FromStringOrNil("aaaa0001-0001-0001-0001-000000000001"), CustomerID: uuid.FromStringOrNil("bbbb0001-0001-0001-0001-000000000001")},
+		AIcallID:        uuid.FromStringOrNil("cccc0001-0001-0001-0001-000000000001"),
+		AIID:            uuid.FromStringOrNil("dddd0001-0001-0001-0001-000000000001"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0001-0001-0001-0001-000000000001"),
+		Language:        "en-US",
+	}
+	insertTestAudit(t, a, aiaudit.StatusProgressing, nil, &tm)
+
+	got, err := h.AIAuditGet(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("AIAuditGet error = %v", err)
+	}
+	if got.TMDelete != nil {
+		t.Errorf("expected tm_delete = NULL, got %v", got.TMDelete)
+	}
+	if got.Status != aiaudit.StatusProgressing {
+		t.Errorf("expected status progressing, got %s", got.Status)
+	}
+}
+
+func Test_AIAuditUpdateFinal_OnlyUpdatesWhenNotDeleted(t *testing.T) {
+	curTime := func() *time.Time {
+		t := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+		return &t
+	}()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	ctx := context.Background()
+	tm := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	liveID := uuid.FromStringOrNil("aaaa0002-0002-0002-0002-000000000001")
+	deletedID := uuid.FromStringOrNil("aaaa0002-0002-0002-0002-000000000002")
+	customerID := uuid.FromStringOrNil("bbbb0002-0002-0002-0002-000000000001")
+
+	liveAudit := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: liveID, CustomerID: customerID},
+		AIcallID:        uuid.FromStringOrNil("cccc0002-0002-0002-0002-000000000001"),
+		AIID:            uuid.FromStringOrNil("dddd0002-0002-0002-0002-000000000001"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0002-0002-0002-0002-000000000001"),
+		Language:        "en-US",
+	}
+	deletedAudit := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: deletedID, CustomerID: customerID},
+		AIcallID:        uuid.FromStringOrNil("cccc0002-0002-0002-0002-000000000002"),
+		AIID:            uuid.FromStringOrNil("dddd0002-0002-0002-0002-000000000002"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0002-0002-0002-0002-000000000002"),
+		Language:        "en-US",
+	}
+
+	insertTestAudit(t, liveAudit, aiaudit.StatusProgressing, nil, &tm)
+	insertTestAudit(t, deletedAudit, aiaudit.StatusProgressing, &tm, &tm)
+
+	score := 85
+
+	// Live record: should update (1 row affected).
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	n, err := h.AIAuditUpdateFinal(ctx, liveID, aiaudit.StatusCompleted, &score, nil, "")
+	if err != nil {
+		t.Fatalf("AIAuditUpdateFinal (live) error = %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 row updated for live record, got %d", n)
+	}
+
+	// Soft-deleted record: must return 0 rows.
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	n, err = h.AIAuditUpdateFinal(ctx, deletedID, aiaudit.StatusCompleted, &score, nil, "")
+	if err != nil {
+		t.Fatalf("AIAuditUpdateFinal (deleted) error = %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 rows updated for soft-deleted record, got %d", n)
+	}
+}
+
+func Test_AIAuditCountProgressing_ExcludesSoftDeleted(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	ctx := context.Background()
+	tm := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	customerID := uuid.FromStringOrNil("bbbb0003-0003-0003-0003-000000000001")
+
+	liveAudit := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: uuid.FromStringOrNil("aaaa0003-0003-0003-0003-000000000001"), CustomerID: customerID},
+		AIcallID:        uuid.FromStringOrNil("cccc0003-0003-0003-0003-000000000001"),
+		AIID:            uuid.FromStringOrNil("dddd0003-0003-0003-0003-000000000001"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0003-0003-0003-0003-000000000001"),
+		Language:        "en-US",
+	}
+	deletedAudit := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: uuid.FromStringOrNil("aaaa0003-0003-0003-0003-000000000002"), CustomerID: customerID},
+		AIcallID:        uuid.FromStringOrNil("cccc0003-0003-0003-0003-000000000002"),
+		AIID:            uuid.FromStringOrNil("dddd0003-0003-0003-0003-000000000002"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0003-0003-0003-0003-000000000002"),
+		Language:        "en-US",
+	}
+
+	insertTestAudit(t, liveAudit, aiaudit.StatusProgressing, nil, &tm)
+	insertTestAudit(t, deletedAudit, aiaudit.StatusProgressing, &tm, &tm) // soft-deleted
+
+	count, err := h.AIAuditCountProgressing(ctx, customerID)
+	if err != nil {
+		t.Fatalf("AIAuditCountProgressing error = %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 progressing audit, got %d", count)
+	}
+}

--- a/bin-ai-manager/pkg/dbhandler/aiaudit_test.go
+++ b/bin-ai-manager/pkg/dbhandler/aiaudit_test.go
@@ -46,6 +46,37 @@ func insertTestAudit(t *testing.T, a *aiaudit.AIAudit, status aiaudit.Status, tm
 	}
 }
 
+func Test_AIAuditGet_ReturnNotFoundForSoftDeleted(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	ctx := context.Background()
+	tm := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	a := &aiaudit.AIAudit{
+		Identity:        identity.Identity{ID: uuid.FromStringOrNil("aaaa0005-0005-0005-0005-000000000001"), CustomerID: uuid.FromStringOrNil("bbbb0005-0005-0005-0005-000000000001")},
+		AIcallID:        uuid.FromStringOrNil("cccc0005-0005-0005-0005-000000000001"),
+		AIID:            uuid.FromStringOrNil("dddd0005-0005-0005-0005-000000000001"),
+		PromptHistoryID: uuid.FromStringOrNil("eeee0005-0005-0005-0005-000000000001"),
+		Language:        "en-US",
+	}
+	insertTestAudit(t, a, aiaudit.StatusProgressing, &tm, &tm) // soft-deleted
+
+	_, err := h.AIAuditGet(ctx, a.ID)
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound for soft-deleted record, got %v", err)
+	}
+}
+
 func Test_AIAuditGet_ReturnsTMDeleteNull(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()

--- a/bin-ai-manager/pkg/listenhandler/v1_aiaudits.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aiaudits.go
@@ -123,7 +123,7 @@ func (h *listenHandler) processV1AIAuditsIDGet(ctx context.Context, m *sock.Requ
 
 	record, err := h.aiauditHandler.Get(ctx, id)
 	if err != nil {
-		log.Debugf("Could not get aiaudit. err: %v", err)
+		log.Errorf("Could not get aiaudit. err: %v", err)
 		return errorResponse(err), nil
 	}
 
@@ -155,7 +155,7 @@ func (h *listenHandler) processV1AIAuditsIDDelete(ctx context.Context, m *sock.R
 
 	record, err := h.aiauditHandler.Delete(ctx, id)
 	if err != nil {
-		log.Debugf("Could not delete aiaudit. err: %v", err)
+		log.Errorf("Could not delete aiaudit. err: %v", err)
 		return errorResponse(err), nil
 	}
 

--- a/bin-ai-manager/pkg/listenhandler/v1_aiaudits.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aiaudits.go
@@ -31,7 +31,7 @@ func (h *listenHandler) processV1AIAuditsPost(ctx context.Context, m *sock.Reque
 
 	records, err := h.aiauditHandler.Create(ctx, req.CustomerID, req.AIcallID, req.Language)
 	if err != nil {
-		log.Debugf("Could not create aiaudit. err: %v", err)
+		log.Errorf("Could not create aiaudit. err: %v", err)
 		errStr := err.Error()
 		switch {
 		case strings.Contains(errStr, "rate limit exceeded"):
@@ -91,8 +91,8 @@ func (h *listenHandler) processV1AIAuditsGet(ctx context.Context, m *sock.Reques
 
 	list, err := h.aiauditHandler.List(ctx, pageSize, pageToken, typedFilters)
 	if err != nil {
-		log.Debugf("Could not list aiaudits. err: %v", err)
-		return simpleResponse(500), nil
+		log.Errorf("Could not list aiaudits. err: %v", err)
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(list)

--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_ai_audits.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_ai_audits.sql
@@ -1,0 +1,27 @@
+
+CREATE TABLE ai_ai_audits (
+  id                binary(16) NOT NULL,
+  customer_id       binary(16) NOT NULL,
+
+  aicall_id         binary(16) NOT NULL,
+  ai_id             binary(16) NOT NULL,
+  prompt_history_id binary(16) NOT NULL,
+
+  status        varchar(16)  NOT NULL DEFAULT 'progressing',
+  overall_score int,
+  evaluation    text,
+  language      varchar(16)  NOT NULL DEFAULT '',
+  error         varchar(255) NOT NULL DEFAULT '',
+
+  tm_create datetime(6),
+  tm_update datetime(6),
+  tm_delete datetime(6),
+
+  PRIMARY KEY(id)
+);
+
+CREATE INDEX idx_ai_ai_audits_customer_id ON ai_ai_audits(customer_id);
+CREATE INDEX idx_ai_ai_audits_aicall_id   ON ai_ai_audits(aicall_id);
+CREATE INDEX idx_ai_ai_audits_ai_id       ON ai_ai_audits(ai_id);
+CREATE UNIQUE INDEX idx_ai_ai_audits_aicall_ai ON ai_ai_audits(aicall_id, ai_id);
+CREATE INDEX idx_ai_ai_audits_tm_create   ON ai_ai_audits(tm_create);

--- a/bin-dbscheme-manager/bin-manager/main/versions/072b3191b4a7_ai_ai_audits_fix_tm_delete_nullable.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/072b3191b4a7_ai_ai_audits_fix_tm_delete_nullable.py
@@ -1,0 +1,40 @@
+"""ai_ai_audits_fix_tm_delete_nullable
+
+Revision ID: 072b3191b4a7
+Revises: aed365a9e29e
+Create Date: 2026-05-27 16:19:10.744968
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '072b3191b4a7'
+down_revision = 'aed365a9e29e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE ai_ai_audits
+        MODIFY tm_delete DATETIME(6) NULL DEFAULT NULL
+    """)
+    op.execute("""
+        UPDATE ai_ai_audits
+        SET tm_delete = NULL
+        WHERE tm_delete = '9999-01-01 00:00:00.000000'
+    """)
+
+
+def downgrade():
+    op.execute("""
+        UPDATE ai_ai_audits
+        SET tm_delete = '9999-01-01 00:00:00.000000'
+        WHERE tm_delete IS NULL
+    """)
+    op.execute("""
+        ALTER TABLE ai_ai_audits
+        MODIFY tm_delete DATETIME(6) NOT NULL DEFAULT '9999-01-01 00:00:00.000000'
+    """)


### PR DESCRIPTION
Fix POST /v1.0/aiaudits returning 500 due to incompatible soft-delete pattern in ai_ai_audits table.

Root cause: the ai_ai_audits table used a sentinel epoch ('9999-01-01 00:00:00.000000') for
not-deleted rows, but ApplyFields (used by AIAuditList) filters deleted=false as
WHERE tm_delete IS NULL. This caused the post-upsert reload to find zero rows and return an error.
The GET /aiaudits list endpoint was also broken for the same reason.

- bin-ai-manager: Remove aiauditSoftDeleteEpoch constant; change AIAuditUpsert to INSERT/UPDATE tm_delete = NULL; change AIAuditUpdateFinal and AIAuditCountProgressing to filter WHERE tm_delete IS NULL
- bin-dbscheme-manager: Add migration 072b3191b4a7 to ALTER ai_ai_audits.tm_delete to NULLABLE and UPDATE existing sentinel rows to NULL