### PR TITLE
NOJIRA-Fix-member-switched-active-ai-attribution

### DIFF
--- a/bin-ai-manager/pkg/messagehandler/event.go
+++ b/bin-ai-manager/pkg/messagehandler/event.go
@@ -340,9 +340,10 @@ func (h *messageHandler) EventPMTeamMemberSwitched(ctx context.Context, evt *pmm
 		return
 	}
 
-	activeAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.ToMember.ID)
+	fromAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.FromMember.ID)
+	toAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.ToMember.ID)
 	tmp, err := h.Create(ctx, uuid.Nil, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID, message.DirectionOutgoing, message.RoleNotification, string(contentBytes), nil, "",
-		WithActiveAIID(activeAIID))
+		WithActiveAIID(fromAIID))
 	if err != nil {
 		log.Errorf("Could not create the notification message. err: %v", err)
 		return
@@ -350,12 +351,12 @@ func (h *messageHandler) EventPMTeamMemberSwitched(ctx context.Context, evt *pmm
 	log.WithField("message", tmp).Debugf("Created member-switched notification message.")
 
 	if h.participantHandler != nil {
-		if activeAIID == uuid.Nil {
+		if toAIID == uuid.Nil {
 			log.Warnf("Could not resolve AI ID for new member — skipping participant write. aicall_id: %s, member_id: %s",
 				evt.PipecatcallReferenceID, evt.ToMember.ID)
-		} else if err := h.participantHandler.Create(ctx, evt.PipecatcallReferenceID, activeAIID); err != nil {
+		} else if err := h.participantHandler.Create(ctx, evt.PipecatcallReferenceID, toAIID); err != nil {
 			log.Warnf("Could not record aicall participant. aicall_id: %s, ai_id: %s, err: %v",
-				evt.PipecatcallReferenceID, activeAIID, err)
+				evt.PipecatcallReferenceID, toAIID, err)
 		}
 	}
 }

--- a/bin-ai-manager/pkg/messagehandler/event_test.go
+++ b/bin-ai-manager/pkg/messagehandler/event_test.go
@@ -1548,7 +1548,8 @@ func TestEventPMTeamMemberSwitched(t *testing.T) {
 	teamID := uuid.Must(uuid.NewV4())
 	toMemberID := uuid.Must(uuid.NewV4())
 	fromMemberID := uuid.Must(uuid.NewV4())
-	aiID := uuid.Must(uuid.NewV4())
+	fromAIID := uuid.Must(uuid.NewV4())
+	toAIID := uuid.Must(uuid.NewV4())
 	activeflowID := uuid.Must(uuid.NewV4())
 	createdMsgID := uuid.Must(uuid.NewV4())
 
@@ -1569,24 +1570,27 @@ func TestEventPMTeamMemberSwitched(t *testing.T) {
 		},
 	}
 
-	// resolveTeamMemberAIID will call AIV1AIcallGet then TeamGet.
+	// resolveTeamMemberAIID is called twice: once for fromMember, once for toMember.
 	ac := &aicall.AIcall{
 		AssistanceType: aicall.AssistanceTypeTeam,
 		AssistanceID:   teamID,
 	}
 	mockReq := requesthandler.NewMockRequestHandler(ctrl)
-	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
 
 	mockDB := dbhandler.NewMockDBHandler(ctrl)
 	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
-		Members: []team.Member{{ID: toMemberID, AIID: aiID}},
-	}, nil)
+		Members: []team.Member{
+			{ID: fromMemberID, AIID: fromAIID},
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
 
-	// Capture the created message to verify ActiveAIID is set correctly.
+	// Notification must be attributed to the FROM AI (fromAIID).
 	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, m *message.Message) error {
-			if m.ActiveAIID != aiID {
-				t.Errorf("expected ActiveAIID %v, got %v", aiID, m.ActiveAIID)
+			if m.ActiveAIID != fromAIID {
+				t.Errorf("expected ActiveAIID %v (fromAIID), got %v", fromAIID, m.ActiveAIID)
 			}
 			if m.AIcallID != aicallID {
 				t.Errorf("expected AIcallID %v, got %v", aicallID, m.AIcallID)
@@ -1626,7 +1630,8 @@ func TestEventPMTeamMemberSwitched_participant_written(t *testing.T) {
 	teamID := uuid.Must(uuid.NewV4())
 	toMemberID := uuid.Must(uuid.NewV4())
 	fromMemberID := uuid.Must(uuid.NewV4())
-	aiID := uuid.Must(uuid.NewV4())
+	fromAIID := uuid.Must(uuid.NewV4())
+	toAIID := uuid.Must(uuid.NewV4())
 	activeflowID := uuid.Must(uuid.NewV4())
 	createdMsgID := uuid.Must(uuid.NewV4())
 
@@ -1645,12 +1650,15 @@ func TestEventPMTeamMemberSwitched_participant_written(t *testing.T) {
 	}
 
 	mockReq := requesthandler.NewMockRequestHandler(ctrl)
-	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
 
 	mockDB := dbhandler.NewMockDBHandler(ctrl)
 	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
-		Members: []team.Member{{ID: toMemberID, AIID: aiID}},
-	}, nil)
+		Members: []team.Member{
+			{ID: fromMemberID, AIID: fromAIID},
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
 	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, m *message.Message) error {
 			m.ID = createdMsgID
@@ -1666,7 +1674,8 @@ func TestEventPMTeamMemberSwitched_participant_written(t *testing.T) {
 	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
-	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, aiID).Return(nil).Times(1)
+	// Participant record must use the TO AI's ID.
+	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, toAIID).Return(nil).Times(1)
 
 	h := &messageHandler{
 		db:                 mockDB,
@@ -1699,9 +1708,9 @@ func TestEventPMTeamMemberSwitched_participant_skipped_when_nil_ai(t *testing.T)
 		ToMember:               pmmessage.MemberInfo{ID: toMemberID, Name: "Bob"},
 	}
 
-	// resolveTeamMemberAIID returns uuid.Nil because AIcall get fails
+	// Both resolveTeamMemberAIID calls (from and to) fail because AIcall get fails.
 	mockReq := requesthandler.NewMockRequestHandler(ctrl)
-	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(nil, errors.New("not found"))
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(nil, errors.New("not found")).Times(2)
 
 	mockDB := dbhandler.NewMockDBHandler(ctrl)
 	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -1719,7 +1728,7 @@ func TestEventPMTeamMemberSwitched_participant_skipped_when_nil_ai(t *testing.T)
 	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
-	// Create must NOT be called when activeAIID == uuid.Nil
+	// Create must NOT be called when toAIID == uuid.Nil
 	mockParticipant.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	h := &messageHandler{
@@ -1742,7 +1751,8 @@ func TestEventPMTeamMemberSwitched_participant_create_error(t *testing.T) {
 	teamID := uuid.Must(uuid.NewV4())
 	toMemberID := uuid.Must(uuid.NewV4())
 	fromMemberID := uuid.Must(uuid.NewV4())
-	aiID := uuid.Must(uuid.NewV4())
+	fromAIID := uuid.Must(uuid.NewV4())
+	toAIID := uuid.Must(uuid.NewV4())
 	activeflowID := uuid.Must(uuid.NewV4())
 	createdMsgID := uuid.Must(uuid.NewV4())
 
@@ -1761,12 +1771,15 @@ func TestEventPMTeamMemberSwitched_participant_create_error(t *testing.T) {
 	}
 
 	mockReq := requesthandler.NewMockRequestHandler(ctrl)
-	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
 
 	mockDB := dbhandler.NewMockDBHandler(ctrl)
 	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
-		Members: []team.Member{{ID: toMemberID, AIID: aiID}},
-	}, nil)
+		Members: []team.Member{
+			{ID: fromMemberID, AIID: fromAIID},
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
 	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, m *message.Message) error {
 			m.ID = createdMsgID
@@ -1782,8 +1795,82 @@ func TestEventPMTeamMemberSwitched_participant_create_error(t *testing.T) {
 	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
-	// Create returns an error; the handler must log a warning and continue, not panic or return early.
-	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, aiID).Return(errors.New("db error")).Times(1)
+	// Create is called with toAIID; returns an error — handler must log a warning and continue.
+	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, toAIID).Return(errors.New("db error")).Times(1)
+
+	h := &messageHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		reqHandler:         mockReq,
+		utilHandler:        utilhandler.NewUtilHandler(),
+		participantHandler: mockParticipant,
+	}
+
+	h.EventPMTeamMemberSwitched(context.Background(), evt)
+}
+
+func TestEventPMTeamMemberSwitched_from_ai_nil_participant_still_written(t *testing.T) {
+	// fromMember is absent from the team → fromAIID resolves to uuid.Nil.
+	// toMember is present → toAIID resolves to a real ID.
+	// Expected: notification has ActiveAIID = uuid.Nil; participant Create is still called with toAIID.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID := uuid.Must(uuid.NewV4())
+	aicallID := uuid.Must(uuid.NewV4())
+	teamID := uuid.Must(uuid.NewV4())
+	toMemberID := uuid.Must(uuid.NewV4())
+	fromMemberID := uuid.Must(uuid.NewV4()) // will NOT appear in team members
+	toAIID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	createdMsgID := uuid.Must(uuid.NewV4())
+
+	evt := &pmmessage.MemberSwitchedEvent{
+		CustomerID:             customerID,
+		PipecatcallReferenceID: aicallID,
+		ActiveflowID:           activeflowID,
+		TransitionFunctionName: "escalate",
+		FromMember:             pmmessage.MemberInfo{ID: fromMemberID, Name: "Alice", EngineModel: "openai.gpt-4o"},
+		ToMember:               pmmessage.MemberInfo{ID: toMemberID, Name: "Bob", EngineModel: "openai.gpt-4o-mini"},
+	}
+
+	ac := &aicall.AIcall{
+		AssistanceType: aicall.AssistanceTypeTeam,
+		AssistanceID:   teamID,
+	}
+
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
+
+	// Team only contains toMember; fromMember lookup will log a warning and return uuid.Nil.
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
+		Members: []team.Member{
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
+
+	// Notification is created with ActiveAIID = uuid.Nil (fromAIID not found).
+	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, m *message.Message) error {
+			if m.ActiveAIID != uuid.Nil {
+				t.Errorf("expected ActiveAIID uuid.Nil (fromMember absent), got %v", m.ActiveAIID)
+			}
+			m.ID = createdMsgID
+			return nil
+		},
+	).Times(1)
+	createdMsg := &message.Message{}
+	createdMsg.ID = createdMsgID
+	createdMsg.CustomerID = customerID
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
+	// Participant Create must still be called with toAIID despite fromAIID being uuid.Nil.
+	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, toAIID).Return(nil).Times(1)
 
 	h := &messageHandler{
 		db:                 mockDB,

--- a/docs/superpowers/plans/2026-05-28-fix-member-switched-active-ai-attribution.md
+++ b/docs/superpowers/plans/2026-05-28-fix-member-switched-active-ai-attribution.md
@@ -1,0 +1,510 @@
+# Fix member_switched active_ai_id Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `EventPMTeamMemberSwitched` so the `member_switched` notification message is attributed to the FROM AI (not the TO AI), giving each AI a complete and accurate audit transcript.
+
+**Architecture:** Split the single `resolveTeamMemberAIID` call in `EventPMTeamMemberSwitched` into two — `fromAIID` for the notification message's `active_ai_id`, and `toAIID` for participant recording. No schema changes; no other services touched.
+
+**Tech Stack:** Go 1.21+, gomock, `bin-ai-manager` service only.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `bin-ai-manager/pkg/messagehandler/event.go` | Split `activeAIID` into `fromAIID` + `toAIID`; route each to its correct use |
+| `bin-ai-manager/pkg/messagehandler/event_test.go` | Update all 4 `TestEventPMTeamMemberSwitched*` tests to reflect two-lookup behavior and corrected attribution |
+
+No other files change.
+
+---
+
+## Task 1: Update Tests (TDD — write failing tests first)
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/event_test.go`
+
+The four existing `TestEventPMTeamMemberSwitched*` tests all assume a single `resolveTeamMemberAIID` call (one `AIV1AIcallGet` + one `TeamGet`) and that `ActiveAIID` on the notification equals the TO member's AI ID. After the fix these tests must pass against the new behavior. Rewrite all four now so they fail red against the current code.
+
+### 1a — `TestEventPMTeamMemberSwitched`: verify notification has `fromAIID`
+
+- [ ] Replace the entire `TestEventPMTeamMemberSwitched` function with the version below.
+
+```go
+func TestEventPMTeamMemberSwitched(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID   := uuid.Must(uuid.NewV4())
+	aicallID     := uuid.Must(uuid.NewV4())
+	teamID       := uuid.Must(uuid.NewV4())
+	fromMemberID := uuid.Must(uuid.NewV4())
+	toMemberID   := uuid.Must(uuid.NewV4())
+	fromAIID     := uuid.Must(uuid.NewV4())
+	toAIID       := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	createdMsgID := uuid.Must(uuid.NewV4())
+
+	evt := &pmmessage.MemberSwitchedEvent{
+		CustomerID:             customerID,
+		PipecatcallReferenceID: aicallID,
+		ActiveflowID:           activeflowID,
+		TransitionFunctionName: "escalate",
+		FromMember: pmmessage.MemberInfo{
+			ID:          fromMemberID,
+			Name:        "Alice",
+			EngineModel: "openai.gpt-4o",
+		},
+		ToMember: pmmessage.MemberInfo{
+			ID:          toMemberID,
+			Name:        "Bob",
+			EngineModel: "openai.gpt-4o-mini",
+		},
+	}
+
+	ac := &aicall.AIcall{
+		AssistanceType: aicall.AssistanceTypeTeam,
+		AssistanceID:   teamID,
+	}
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	// resolveTeamMemberAIID is called twice: once for fromMember, once for toMember.
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	// TeamGet is called twice for the same team.
+	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
+		Members: []team.Member{
+			{ID: fromMemberID, AIID: fromAIID},
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
+
+	// Notification message must be attributed to the FROM AI.
+	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, m *message.Message) error {
+			if m.ActiveAIID != fromAIID {
+				t.Errorf("expected ActiveAIID (fromAIID) %v, got %v", fromAIID, m.ActiveAIID)
+			}
+			if m.AIcallID != aicallID {
+				t.Errorf("expected AIcallID %v, got %v", aicallID, m.AIcallID)
+			}
+			if m.Role != message.RoleNotification {
+				t.Errorf("expected Role notification, got %s", m.Role)
+			}
+			m.ID = createdMsgID
+			return nil
+		},
+	).Times(1)
+
+	createdMsg := &message.Message{}
+	createdMsg.ID = createdMsgID
+	createdMsg.CustomerID = customerID
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	h := &messageHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+		reqHandler:    mockReq,
+		utilHandler:   utilhandler.NewUtilHandler(),
+	}
+
+	h.EventPMTeamMemberSwitched(context.Background(), evt)
+}
+```
+
+### 1b — `TestEventPMTeamMemberSwitched_participant_written`: participant created with `toAIID`
+
+- [ ] Replace the entire `TestEventPMTeamMemberSwitched_participant_written` function with the version below.
+
+```go
+func TestEventPMTeamMemberSwitched_participant_written(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID   := uuid.Must(uuid.NewV4())
+	aicallID     := uuid.Must(uuid.NewV4())
+	teamID       := uuid.Must(uuid.NewV4())
+	fromMemberID := uuid.Must(uuid.NewV4())
+	toMemberID   := uuid.Must(uuid.NewV4())
+	fromAIID     := uuid.Must(uuid.NewV4())
+	toAIID       := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	createdMsgID := uuid.Must(uuid.NewV4())
+
+	evt := &pmmessage.MemberSwitchedEvent{
+		CustomerID:             customerID,
+		PipecatcallReferenceID: aicallID,
+		ActiveflowID:           activeflowID,
+		TransitionFunctionName: "escalate",
+		FromMember: pmmessage.MemberInfo{ID: fromMemberID, Name: "Alice", EngineModel: "openai.gpt-4o"},
+		ToMember:   pmmessage.MemberInfo{ID: toMemberID, Name: "Bob", EngineModel: "openai.gpt-4o-mini"},
+	}
+
+	ac := &aicall.AIcall{
+		AssistanceType: aicall.AssistanceTypeTeam,
+		AssistanceID:   teamID,
+	}
+
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
+		Members: []team.Member{
+			{ID: fromMemberID, AIID: fromAIID},
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
+	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, m *message.Message) error {
+			m.ID = createdMsgID
+			return nil
+		},
+	).Times(1)
+	createdMsg := &message.Message{}
+	createdMsg.ID = createdMsgID
+	createdMsg.CustomerID = customerID
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
+	// Participant must be recorded for the TO AI, not the FROM AI.
+	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, toAIID).Return(nil).Times(1)
+
+	h := &messageHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		reqHandler:         mockReq,
+		utilHandler:        utilhandler.NewUtilHandler(),
+		participantHandler: mockParticipant,
+	}
+
+	h.EventPMTeamMemberSwitched(context.Background(), evt)
+}
+```
+
+### 1c — `TestEventPMTeamMemberSwitched_participant_skipped_when_nil_ai`: AIcall fails twice
+
+- [ ] Replace the entire `TestEventPMTeamMemberSwitched_participant_skipped_when_nil_ai` function with the version below.
+
+```go
+func TestEventPMTeamMemberSwitched_participant_skipped_when_nil_ai(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID   := uuid.Must(uuid.NewV4())
+	aicallID     := uuid.Must(uuid.NewV4())
+	fromMemberID := uuid.Must(uuid.NewV4())
+	toMemberID   := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	createdMsgID := uuid.Must(uuid.NewV4())
+
+	evt := &pmmessage.MemberSwitchedEvent{
+		CustomerID:             customerID,
+		PipecatcallReferenceID: aicallID,
+		ActiveflowID:           activeflowID,
+		TransitionFunctionName: "escalate",
+		FromMember: pmmessage.MemberInfo{ID: fromMemberID, Name: "Alice"},
+		ToMember:   pmmessage.MemberInfo{ID: toMemberID, Name: "Bob"},
+	}
+
+	// AIcall get fails for both resolveTeamMemberAIID calls → fromAIID=uuid.Nil, toAIID=uuid.Nil.
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(nil, errors.New("not found")).Times(2)
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, m *message.Message) error {
+			m.ID = createdMsgID
+			return nil
+		},
+	).Times(1)
+	createdMsg := &message.Message{}
+	createdMsg.ID = createdMsgID
+	createdMsg.CustomerID = customerID
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
+	// toAIID is uuid.Nil → participant write must be skipped.
+	mockParticipant.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	h := &messageHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		reqHandler:         mockReq,
+		utilHandler:        utilhandler.NewUtilHandler(),
+		participantHandler: mockParticipant,
+	}
+
+	h.EventPMTeamMemberSwitched(context.Background(), evt)
+}
+```
+
+### 1d — `TestEventPMTeamMemberSwitched_participant_create_error`: participant error still uses `toAIID`
+
+- [ ] Replace the entire `TestEventPMTeamMemberSwitched_participant_create_error` function with the version below.
+
+```go
+func TestEventPMTeamMemberSwitched_participant_create_error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID   := uuid.Must(uuid.NewV4())
+	aicallID     := uuid.Must(uuid.NewV4())
+	teamID       := uuid.Must(uuid.NewV4())
+	fromMemberID := uuid.Must(uuid.NewV4())
+	toMemberID   := uuid.Must(uuid.NewV4())
+	fromAIID     := uuid.Must(uuid.NewV4())
+	toAIID       := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	createdMsgID := uuid.Must(uuid.NewV4())
+
+	evt := &pmmessage.MemberSwitchedEvent{
+		CustomerID:             customerID,
+		PipecatcallReferenceID: aicallID,
+		ActiveflowID:           activeflowID,
+		TransitionFunctionName: "escalate",
+		FromMember: pmmessage.MemberInfo{ID: fromMemberID, Name: "Alice", EngineModel: "openai.gpt-4o"},
+		ToMember:   pmmessage.MemberInfo{ID: toMemberID, Name: "Bob", EngineModel: "openai.gpt-4o-mini"},
+	}
+
+	ac := &aicall.AIcall{
+		AssistanceType: aicall.AssistanceTypeTeam,
+		AssistanceID:   teamID,
+	}
+
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
+		Members: []team.Member{
+			{ID: fromMemberID, AIID: fromAIID},
+			{ID: toMemberID, AIID: toAIID},
+		},
+	}, nil).Times(2)
+	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, m *message.Message) error {
+			m.ID = createdMsgID
+			return nil
+		},
+	).Times(1)
+	createdMsg := &message.Message{}
+	createdMsg.ID = createdMsgID
+	createdMsg.CustomerID = customerID
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
+	// Participant create fails; handler must warn and continue (not panic or return early).
+	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, toAIID).Return(errors.New("db error")).Times(1)
+
+	h := &messageHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		reqHandler:         mockReq,
+		utilHandler:        utilhandler.NewUtilHandler(),
+		participantHandler: mockParticipant,
+	}
+
+	h.EventPMTeamMemberSwitched(context.Background(), evt)
+}
+```
+
+### 1e — `TestEventPMTeamMemberSwitched_from_ai_nil_participant_still_written`: only `fromAIID` nil, participant proceeds with `toAIID`
+
+- [ ] Add the new test below after the four existing ones.
+
+```go
+func TestEventPMTeamMemberSwitched_from_ai_nil_participant_still_written(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID   := uuid.Must(uuid.NewV4())
+	aicallID     := uuid.Must(uuid.NewV4())
+	teamID       := uuid.Must(uuid.NewV4())
+	fromMemberID := uuid.Must(uuid.NewV4())
+	toMemberID   := uuid.Must(uuid.NewV4())
+	toAIID       := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	createdMsgID := uuid.Must(uuid.NewV4())
+
+	evt := &pmmessage.MemberSwitchedEvent{
+		CustomerID:             customerID,
+		PipecatcallReferenceID: aicallID,
+		ActiveflowID:           activeflowID,
+		TransitionFunctionName: "escalate",
+		FromMember: pmmessage.MemberInfo{ID: fromMemberID, Name: "Alice"},
+		ToMember:   pmmessage.MemberInfo{ID: toMemberID, Name: "Bob"},
+	}
+
+	ac := &aicall.AIcall{
+		AssistanceType: aicall.AssistanceTypeTeam,
+		AssistanceID:   teamID,
+	}
+
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	// Both calls to resolveTeamMemberAIID go through AIV1AIcallGet.
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil).Times(2)
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	// Team only contains the toMember; fromMember is not found → fromAIID = uuid.Nil.
+	// TeamGet is still called twice (once per resolveTeamMemberAIID).
+	mockDB.EXPECT().TeamGet(gomock.Any(), teamID).Return(&team.Team{
+		Members: []team.Member{
+			{ID: toMemberID, AIID: toAIID},
+			// fromMemberID deliberately absent → resolveTeamMemberAIID returns uuid.Nil for it
+		},
+	}, nil).Times(2)
+
+	// Notification is created with uuid.Nil for active_ai_id (from lookup failed).
+	mockDB.EXPECT().MessageCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, m *message.Message) error {
+			if m.ActiveAIID != uuid.Nil {
+				t.Errorf("expected ActiveAIID uuid.Nil when from-member not found, got %v", m.ActiveAIID)
+			}
+			m.ID = createdMsgID
+			return nil
+		},
+	).Times(1)
+	createdMsg := &message.Message{}
+	createdMsg.ID = createdMsgID
+	createdMsg.CustomerID = customerID
+	mockDB.EXPECT().MessageGet(gomock.Any(), gomock.Any()).Return(createdMsg, nil).Times(1)
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockParticipant := participanthandler.NewMockParticipantHandler(ctrl)
+	// toAIID is valid → participant write must still proceed even though fromAIID is nil.
+	mockParticipant.EXPECT().Create(gomock.Any(), aicallID, toAIID).Return(nil).Times(1)
+
+	h := &messageHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		reqHandler:         mockReq,
+		utilHandler:        utilhandler.NewUtilHandler(),
+		participantHandler: mockParticipant,
+	}
+
+	h.EventPMTeamMemberSwitched(context.Background(), evt)
+}
+```
+
+- [ ] Run the target tests to confirm they are RED:
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-member-switched-active-ai-attribution/bin-ai-manager
+go test ./pkg/messagehandler/... -run TestEventPMTeamMemberSwitched -v 2>&1 | tail -30
+```
+
+Expected: tests fail (mock call count mismatch — `AIV1AIcallGet` and `TeamGet` called once but expected twice, and `ActiveAIID` mismatch).
+
+---
+
+## Task 2: Implement the Fix
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/messagehandler/event.go`
+
+- [ ] In `EventPMTeamMemberSwitched`, replace the single `activeAIID` resolution with two separate lookups. Find this block (near the end of the function, after `contentBytes` is marshalled):
+
+```go
+	activeAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.ToMember.ID)
+	tmp, err := h.Create(ctx, uuid.Nil, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID, message.DirectionOutgoing, message.RoleNotification, string(contentBytes), nil, "",
+		WithActiveAIID(activeAIID))
+	if err != nil {
+		log.Errorf("Could not create the notification message. err: %v", err)
+		return
+	}
+	log.WithField("message", tmp).Debugf("Created member-switched notification message.")
+
+	if h.participantHandler != nil {
+		if activeAIID == uuid.Nil {
+			log.Warnf("Could not resolve AI ID for new member — skipping participant write. aicall_id: %s, member_id: %s",
+				evt.PipecatcallReferenceID, evt.ToMember.ID)
+		} else if err := h.participantHandler.Create(ctx, evt.PipecatcallReferenceID, activeAIID); err != nil {
+			log.Warnf("Could not record aicall participant. aicall_id: %s, ai_id: %s, err: %v",
+				evt.PipecatcallReferenceID, activeAIID, err)
+		}
+	}
+```
+
+Replace with:
+
+```go
+	fromAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.FromMember.ID)
+	toAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.ToMember.ID)
+	tmp, err := h.Create(ctx, uuid.Nil, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID, message.DirectionOutgoing, message.RoleNotification, string(contentBytes), nil, "",
+		WithActiveAIID(fromAIID))
+	if err != nil {
+		log.Errorf("Could not create the notification message. err: %v", err)
+		return
+	}
+	log.WithField("message", tmp).Debugf("Created member-switched notification message.")
+
+	if h.participantHandler != nil {
+		if toAIID == uuid.Nil {
+			log.Warnf("Could not resolve AI ID for new member — skipping participant write. aicall_id: %s, member_id: %s",
+				evt.PipecatcallReferenceID, evt.ToMember.ID)
+		} else if err := h.participantHandler.Create(ctx, evt.PipecatcallReferenceID, toAIID); err != nil {
+			log.Warnf("Could not record aicall participant. aicall_id: %s, ai_id: %s, err: %v",
+				evt.PipecatcallReferenceID, toAIID, err)
+		}
+	}
+```
+
+- [ ] Run the target tests to confirm they are GREEN:
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-member-switched-active-ai-attribution/bin-ai-manager
+go test ./pkg/messagehandler/... -run TestEventPMTeamMemberSwitched -v 2>&1 | tail -30
+```
+
+Expected: all four `TestEventPMTeamMemberSwitched*` tests pass.
+
+---
+
+## Task 3: Full Verification and Commit
+
+**Files:** No new changes — verification only.
+
+- [ ] Run the full verification workflow:
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-member-switched-active-ai-attribution/bin-ai-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all steps exit 0.
+
+- [ ] Commit:
+
+```bash
+cd /home/pchero/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-member-switched-active-ai-attribution
+git add bin-ai-manager/pkg/messagehandler/event.go \
+        bin-ai-manager/pkg/messagehandler/event_test.go
+git commit -m "$(cat <<'EOF'
+NOJIRA-Fix-member-switched-active-ai-attribution
+
+- bin-ai-manager: Attribute member_switched notification to FROM AI for correct audit transcripts
+- bin-ai-manager: Update EventPMTeamMemberSwitched tests to reflect two-lookup behavior
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-28-fix-member-switched-active-ai-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-28-fix-member-switched-active-ai-attribution-design.md
@@ -1,0 +1,124 @@
+# Design: Fix member_switched Notification active_ai_id Attribution
+
+**Date:** 2026-05-28
+**Branch:** NOJIRA-Fix-member-switched-active-ai-attribution
+**Status:** Draft
+
+---
+
+## 1. Problem Statement
+
+When a team AI call transitions from one member to another, `EventPMTeamMemberSwitched` creates a `member_switched` notification message. This message's `active_ai_id` is currently set to the **TO** (incoming) member's AI ID.
+
+The AI audit system filters messages by `active_ai_id = aiID` when building each AI's transcript for performance evaluation. This causes two defects:
+
+1. **FROM AI's transcript is incomplete.** The transition notification does not appear in the outgoing AI's transcript. Its transcript ends abruptly, making it look as though the AI stopped without completing a proper handoff.
+2. **TO AI's transcript is misleading.** The transition notification appears as the first message in the incoming AI's transcript, as if the new AI had initiated the switch itself.
+
+---
+
+## 2. Root Cause
+
+In `bin-ai-manager/pkg/messagehandler/event.go`, `EventPMTeamMemberSwitched` resolves a **single** `activeAIID` from `evt.ToMember.ID` and uses it for **two distinct purposes**:
+
+```go
+// current code (simplified)
+activeAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.ToMember.ID)
+
+h.Create(..., WithActiveAIID(activeAIID))        // notification message — wrong AI
+h.participantHandler.Create(ctx, ..., activeAIID) // participant record — correct AI
+```
+
+The two uses have opposite requirements:
+- **Notification message `active_ai_id`** should be the FROM AI — the transition is the outgoing AI's final action (it called the transition function that triggered the switch).
+- **Participant recording** should be the TO AI — the incoming AI is the new participant joining.
+
+---
+
+## 3. Proposed Solution
+
+Resolve two separate AI IDs and use each for its correct purpose:
+
+```go
+fromAIID := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.FromMember.ID)
+toAIID   := h.resolveTeamMemberAIID(ctx, evt.PipecatcallReferenceID, evt.ToMember.ID)
+
+h.Create(..., WithActiveAIID(fromAIID))   // notification attributed to FROM AI
+
+if h.participantHandler != nil {
+    if toAIID == uuid.Nil {               // guard uses toAIID, not fromAIID
+        log.Warnf(...)
+    } else if err := h.participantHandler.Create(ctx, ..., toAIID); err != nil {
+        log.Warnf(...)
+    }
+}
+```
+
+The nil-guard on participant recording uses `toAIID` — not `fromAIID`. If `toAIID` is `uuid.Nil` the participant write is skipped (same semantics as today); if `fromAIID` is `uuid.Nil` the notification is still created with `uuid.Nil` and the participant block continues unaffected.
+
+### Why `fromAIID` is correct for the notification
+
+The `member_switched` event fires because the FROM member's LLM invoked a transition function. The notification is a direct record of that action. Attributing it to the FROM AI makes the outgoing AI's transcript complete and causal: its conversation turns end with the notification that it handed off.
+
+### Timing safety
+
+`resolveTeamMemberAIID` looks up the team and walks `Members` to find the AI ID for a given member ID. It does **not** rely on `CurrentMemberID` (which has not been updated yet when this handler runs). Passing `evt.FromMember.ID` is safe for the same reason passing `evt.ToMember.ID` was safe — the member ID comes directly from the event.
+
+### Nil-safety
+
+If `fromAIID` resolves to `uuid.Nil` (team data unavailable or race condition), the existing `uuid.Nil` guard and warning log in the current code already handles this case gracefully — the notification message is created with `active_ai_id = uuid.Nil` and execution continues. The participant recording for `toAIID` proceeds independently and is unaffected.
+
+---
+
+## 4. Impact on Audit Transcripts
+
+After the fix, each AI's audit transcript will contain:
+
+| Message type | `active_ai_id` | Appears in |
+|---|---|---|
+| FROM AI conversation turns (user + assistant) | `fromAIID` | FROM AI audit |
+| `member_switched` notification | `fromAIID` | FROM AI audit |
+| TO AI conversation turns | `toAIID` | TO AI audit |
+
+The TO AI's transcript starts with its own first user turn — no misleading notification at the top. The FROM AI's transcript ends with the transition notification — a complete and correct record of its participation.
+
+---
+
+## 5. Scope
+
+### In scope
+- `bin-ai-manager/pkg/messagehandler/event.go` — `EventPMTeamMemberSwitched`: split one `resolveTeamMemberAIID` call into two and route each result correctly.
+- `bin-ai-manager/pkg/messagehandler/event_test.go` — update/add tests to assert `active_ai_id = fromAIID` on the notification and `toAIID` on the participant record.
+
+### Out of scope
+- No DB migration. The `active_ai_id` column exists; only the value stored changes.
+- No audit query changes. The existing `active_ai_id = aiID` filter already produces the correct result once attribution is fixed at creation time.
+- No pipecat-manager changes. The `MemberSwitchedEvent` struct already carries both `FromMember` and `ToMember`.
+- No other service changes.
+
+---
+
+## 6. Performance
+
+The fix adds one extra `resolveTeamMemberAIID` call per member switch. Each call issues two RPCs internally: one to fetch the AIcall and one to fetch the team. Since both calls resolve from the same AIcall and the same team, the additional cost is two RPCs per switch event — negligible given member switches are rare within a call. A future optimization could fetch the team once and pass it to both lookups, but this is not required for correctness.
+
+---
+
+## 7. Testing Plan
+
+| Test case | Expected |
+|---|---|
+| `EventPMTeamMemberSwitched` — notification created with `fromAIID` | `active_ai_id` = FROM member's AI ID |
+| `EventPMTeamMemberSwitched` — participant recorded with `toAIID` | participant AI ID = TO member's AI ID |
+| `EventPMTeamMemberSwitched` — `resolveTeamMemberAIID` returns `uuid.Nil` for from-member (team data unavailable or race condition) | notification created with `active_ai_id = uuid.Nil`, participant record still attempted with `toAIID`; existing `uuid.Nil` warning log fires |
+| Existing tests for single-AI calls | No regression |
+
+---
+
+## 8. Acceptance Criteria
+
+- [ ] `member_switched` notification message has `active_ai_id` equal to the FROM member's AI ID.
+- [ ] Participant record is created with the TO member's AI ID (unchanged from current behavior).
+- [ ] All existing tests pass.
+- [ ] New tests cover the corrected attribution.
+- [ ] Full verification workflow passes (`go mod tidy`, `go mod vendor`, `go generate`, `go test`, `golangci-lint`).


### PR DESCRIPTION
Fix member_switched notification active_ai_id attribution in team AI calls.

Previously, EventPMTeamMemberSwitched resolved a single activeAIID from the TO member and used it for both the notification message and the participant record. This caused the AI audit system to mis-attribute the transition event: the FROM AI's transcript was missing the handoff notification, and the TO AI's transcript started with a notification it did not initiate.

- bin-ai-manager: Split single resolveTeamMemberAIID call in EventPMTeamMemberSwitched into fromAIID (for notification attribution) and toAIID (for participant recording); notification is now attributed to the FROM AI whose LLM triggered the transition
- bin-ai-manager: Update 4 existing TestEventPMTeamMemberSwitched* tests to assert fromAIID on the notification message and toAIID on the participant record; add new test covering the fromAIID-nil edge case where participant write still proceeds with toAIID