### PR TITLE
NOJIRA-Fix-migration-instant-lock

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/43a66dafdec9_add_proposal_id_to_ai_ai_prompt_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/43a66dafdec9_add_proposal_id_to_ai_ai_prompt_.py
@@ -17,11 +17,14 @@ depends_on = None
 
 
 def upgrade():
+    # ALGORITHM=INSTANT performs the change without locking, so a LOCK clause
+    # is invalid. Combining ALGORITHM=INSTANT with LOCK=NONE/SHARED/EXCLUSIVE
+    # is rejected by MySQL with error 1221.
     op.execute(
         "ALTER TABLE ai_ai_prompt_histories "
         "ADD COLUMN proposal_id BINARY(16) NOT NULL "
         "DEFAULT 0x00000000000000000000000000000000, "
-        "ALGORITHM=INSTANT, LOCK=NONE"
+        "ALGORITHM=INSTANT"
     )
 
 


### PR DESCRIPTION
Fix the failing add_proposal_id_to_ai_ai_prompt_histories migration that was
rejected by MySQL with error 1221 "Incorrect usage of ALGORITHM=INSTANT and
LOCK=NONE/SHARED/EXCLUSIVE".

ALGORITHM=INSTANT performs the change without locking, so a LOCK clause is
invalid in combination. The migration never applied successfully anywhere,
so editing the file in place is safe — no environments have the broken
revision recorded.

- bin-dbscheme-manager: Remove invalid LOCK=NONE clause from ALGORITHM=INSTANT add-column migration