### PR TITLE
NOJIRA-Fix-api-manager-bare-status-error-translation

### DIFF
--- a/bin-api-manager/server/aipromptproposals_test.go
+++ b/bin-api-manager/server/aipromptproposals_test.go
@@ -12,9 +12,11 @@ import (
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/servicehandler"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gofrs/uuid"
+	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
 )
 
@@ -297,6 +299,45 @@ func Test_GetAipromptproposalsId(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectedRes, w.Body)
 			}
 		})
+	}
+}
+
+// Test_GetAipromptproposalsId_NotFound_Returns404 is the handler-level
+// regression guard for issue #953: when the servicehandler returns a bare
+// requesthandler.ErrNotFound (emitted when ai-manager replies with a bare
+// simpleResponse(404)), wrapped via pkg/errors.Wrapf as aipromptproposalGet
+// does, the endpoint must respond with HTTP 404 — not 500.
+func Test_GetAipromptproposalsId_NotFound_Returns404(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+	h := &server{
+		serviceHandler: mockSvc,
+	}
+
+	agent := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("33333333-0000-0000-0000-000000000001"),
+		},
+	})
+	targetID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000099")
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+
+	r.Use(func(c *gin.Context) {
+		c.Set("auth_identity", agent)
+	})
+	openapi_server.RegisterHandlers(r, h)
+
+	req, _ := http.NewRequest("GET", "/aipromptproposals/33333333-0000-0000-0000-000000000099", nil)
+	mockSvc.EXPECT().AIPromptProposalGet(req.Context(), agent, targetID).
+		Return(nil, pkgerrors.Wrapf(requesthandler.ErrNotFound, "could not get ai prompt proposal info"))
+
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Wrong match. expect: %d, got: %d, body: %s", http.StatusNotFound, w.Code, w.Body.String())
 	}
 }
 

--- a/bin-api-manager/server/error_test.go
+++ b/bin-api-manager/server/error_test.go
@@ -11,8 +11,10 @@ import (
 	"monorepo/bin-api-manager/lib/middleware"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	"github.com/gin-gonic/gin"
+	pkgerrors "github.com/pkg/errors"
 )
 
 func TestAbortWithErrorSetsStatusAndBody(t *testing.T) {
@@ -181,6 +183,25 @@ func TestAbortWithErrorOmitsEmptyDetails(t *testing.T) {
 	if strings.Contains(w.Body.String(), `"details"`) {
 		t.Errorf("details should be omitted when empty; body=%s", w.Body.String())
 	}
+}
+
+// TestAbortWithServiceErrorBareNotFoundRoundTrips404 guards the full
+// client-observed path for issue #953: a bare requesthandler.ErrNotFound
+// (emitted when a backend returns simpleResponse(404)), wrapped by
+// servicehandler with pkg/errors.Wrapf, must surface as HTTP 404 with the
+// RESOURCE_NOT_FOUND envelope — not 500.
+func TestAbortWithServiceErrorBareNotFoundRoundTrips404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.RequestID())
+	r.GET("/", func(c *gin.Context) {
+		abortWithServiceError(c, pkgerrors.Wrapf(requesthandler.ErrNotFound, "could not get ai prompt proposal info"))
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assertErrorResponse(t, w, cerrors.StatusNotFound, "RESOURCE_NOT_FOUND")
 }
 
 // assertErrorResponse is a test helper shared across handler tests. It

--- a/bin-api-manager/server/error_translate.go
+++ b/bin-api-manager/server/error_translate.go
@@ -13,7 +13,8 @@ import (
 // translateToVoipbinError maps any error returned from a servicehandler
 // into a *VoipbinError. Priority order:
 //  1. Typed passthrough (errors.As).
-//  2. Sentinel match (errors.Is against serviceerrors.Err*).
+//  2. Sentinel match (errors.Is against serviceerrors.Err* and the bare
+//     requesthandler.Err* HTTP-status sentinels).
 //  3. Transport-failure detection (context.Canceled / DeadlineExceeded).
 //  4. Default: Internal with the original error wrapped as Cause.
 //
@@ -29,10 +30,14 @@ import (
 // substring-fallback step has been removed; any unmatched error
 // correctly degrades to INTERNAL via the default branch.
 //
-// Exception: backend services that return a bare status code (e.g.
-// simpleResponse(400)) without a typed VoipbinError body produce a
-// requesthandler.ErrBadRequest sentinel instead of a VoipbinError.
-// That case is handled explicitly below.
+// Bare status codes: backend services that return a bare status code
+// (e.g. simpleResponse(404)) without a typed VoipbinError body produce a
+// requesthandler.Err* sentinel (via HttpStatusErrorMap) instead of a
+// VoipbinError. Step 2 maps the closed set of these sentinels
+// (400/401/402/403/404/409/429/503/500) back to the canonical cerrors
+// status, mirroring cerrors.HTTPStatusFor in reverse so the client sees
+// the same HTTP code the backend emitted. Statuses outside that set fall
+// through to the Default branch (INTERNAL).
 func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -64,6 +69,26 @@ func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 		return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request is invalid.")
 	case stderrors.Is(err, requesthandler.ErrBadRequest):
 		return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request contains invalid data.")
+	case stderrors.Is(err, requesthandler.ErrUnauthorized):
+		return cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required.")
+	case stderrors.Is(err, requesthandler.ErrPaymentRequired):
+		return cerrors.PaymentRequired(commonoutline.ServiceNameAPIManager, "INSUFFICIENT_BALANCE",
+			"Customer balance is below the minimum required for this operation.").Wrap(err)
+	case stderrors.Is(err, requesthandler.ErrForbidden):
+		return cerrors.PermissionDenied(commonoutline.ServiceNameAPIManager, "PERMISSION_DENIED", "You do not have permission to access this resource.")
+	case stderrors.Is(err, requesthandler.ErrNotFound):
+		return cerrors.NotFound(commonoutline.ServiceNameAPIManager, "RESOURCE_NOT_FOUND", "The requested resource was not found.")
+	case stderrors.Is(err, requesthandler.ErrConflict):
+		return cerrors.FailedPrecondition(commonoutline.ServiceNameAPIManager, "STATE_INVALID",
+			"The operation is invalid for the current resource state.").Wrap(err)
+	case stderrors.Is(err, requesthandler.ErrTooManyRequests):
+		return cerrors.ResourceExhausted(commonoutline.ServiceNameAPIManager, "RATE_LIMIT_EXCEEDED",
+			"Too many requests. Please retry later.").Wrap(err)
+	case stderrors.Is(err, requesthandler.ErrServiceUnavailable):
+		return cerrors.Unavailable(commonoutline.ServiceNameAPIManager, "SERVICE_UNAVAILABLE",
+			"An upstream service is temporarily unavailable.").Wrap(err)
+	case stderrors.Is(err, requesthandler.ErrInternal):
+		return cerrors.Internal(commonoutline.ServiceNameAPIManager, "INTERNAL", "An internal error occurred.").Wrap(err)
 	case stderrors.Is(err, serviceerrors.ErrInternal):
 		return cerrors.Internal(commonoutline.ServiceNameAPIManager, "INTERNAL", "An internal error occurred.").Wrap(err)
 	case stderrors.Is(err, serviceerrors.ErrIdentityVerificationRequired):

--- a/bin-api-manager/server/error_translate.go
+++ b/bin-api-manager/server/error_translate.go
@@ -67,6 +67,10 @@ func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 		return cerrors.NotFound(commonoutline.ServiceNameAPIManager, "RESOURCE_NOT_FOUND", "The requested resource was not found.")
 	case stderrors.Is(err, serviceerrors.ErrInvalidArgument):
 		return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request is invalid.")
+	// Bare requesthandler HTTP-status sentinels (backend returned a bare
+	// status with no typed body). Wrap behavior mirrors the serviceerrors
+	// analogues above: 401/403/404 return unwrapped; the rest .Wrap(err) to
+	// keep the originating sentinel in the server-side Cause chain.
 	case stderrors.Is(err, requesthandler.ErrBadRequest):
 		return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request contains invalid data.")
 	case stderrors.Is(err, requesthandler.ErrUnauthorized):

--- a/bin-api-manager/server/error_translate_test.go
+++ b/bin-api-manager/server/error_translate_test.go
@@ -177,16 +177,17 @@ func TestTranslateBareStatusSentinels(t *testing.T) {
 		err        error
 		wantStatus cerrors.Status
 		wantReason string
+		wantHTTP   int
 	}{
-		{"bad_request", requesthandler.ErrBadRequest, cerrors.StatusInvalidArgument, "INVALID_ARGUMENT"},
-		{"unauthorized", requesthandler.ErrUnauthorized, cerrors.StatusUnauthenticated, "AUTHENTICATION_REQUIRED"},
-		{"payment_required", requesthandler.ErrPaymentRequired, cerrors.StatusPaymentRequired, "INSUFFICIENT_BALANCE"},
-		{"forbidden", requesthandler.ErrForbidden, cerrors.StatusPermissionDenied, "PERMISSION_DENIED"},
-		{"not_found", requesthandler.ErrNotFound, cerrors.StatusNotFound, "RESOURCE_NOT_FOUND"},
-		{"conflict", requesthandler.ErrConflict, cerrors.StatusFailedPrecondition, "STATE_INVALID"},
-		{"too_many_requests", requesthandler.ErrTooManyRequests, cerrors.StatusResourceExhausted, "RATE_LIMIT_EXCEEDED"},
-		{"service_unavailable", requesthandler.ErrServiceUnavailable, cerrors.StatusUnavailable, "SERVICE_UNAVAILABLE"},
-		{"internal", requesthandler.ErrInternal, cerrors.StatusInternal, "INTERNAL"},
+		{"bad_request", requesthandler.ErrBadRequest, cerrors.StatusInvalidArgument, "INVALID_ARGUMENT", 400},
+		{"unauthorized", requesthandler.ErrUnauthorized, cerrors.StatusUnauthenticated, "AUTHENTICATION_REQUIRED", 401},
+		{"payment_required", requesthandler.ErrPaymentRequired, cerrors.StatusPaymentRequired, "INSUFFICIENT_BALANCE", 402},
+		{"forbidden", requesthandler.ErrForbidden, cerrors.StatusPermissionDenied, "PERMISSION_DENIED", 403},
+		{"not_found", requesthandler.ErrNotFound, cerrors.StatusNotFound, "RESOURCE_NOT_FOUND", 404},
+		{"conflict", requesthandler.ErrConflict, cerrors.StatusFailedPrecondition, "STATE_INVALID", 409},
+		{"too_many_requests", requesthandler.ErrTooManyRequests, cerrors.StatusResourceExhausted, "RATE_LIMIT_EXCEEDED", 429},
+		{"service_unavailable", requesthandler.ErrServiceUnavailable, cerrors.StatusUnavailable, "SERVICE_UNAVAILABLE", 503},
+		{"internal", requesthandler.ErrInternal, cerrors.StatusInternal, "INTERNAL", 500},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -195,9 +196,9 @@ func TestTranslateBareStatusSentinels(t *testing.T) {
 				t.Errorf("got status=%q reason=%q want %q/%q", got.Status, got.Reason, tt.wantStatus, tt.wantReason)
 			}
 			// HTTPStatusFor must round-trip the resulting status back to the
-			// HTTP code the backend originally emitted.
-			if cerrors.HTTPStatusFor(got.Status) == 500 && tt.wantStatus != cerrors.StatusInternal {
-				t.Errorf("status %q unexpectedly maps to HTTP 500", got.Status)
+			// exact HTTP code the backend originally emitted.
+			if gotHTTP := cerrors.HTTPStatusFor(got.Status); gotHTTP != tt.wantHTTP {
+				t.Errorf("HTTPStatusFor(%q) = %d want %d", got.Status, gotHTTP, tt.wantHTTP)
 			}
 		})
 	}

--- a/bin-api-manager/server/error_translate_test.go
+++ b/bin-api-manager/server/error_translate_test.go
@@ -8,6 +8,7 @@ import (
 
 	"monorepo/bin-api-manager/pkg/serviceerrors"
 	cerrors "monorepo/bin-common-handler/models/errors"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	pkgerrors "github.com/pkg/errors"
 )
@@ -164,3 +165,56 @@ func TestTranslatePanicRecovery(t *testing.T) {
 type panickingError struct{}
 
 func (panickingError) Error() string { panic("boom") }
+
+// TestTranslateBareStatusSentinels verifies that a bare requesthandler
+// HTTP-status sentinel (produced when a backend returns a bare
+// simpleResponse(<code>) with no typed VoipbinError body) is translated to
+// the matching cerrors status/reason, mirroring cerrors.HTTPStatusFor.
+// This is the regression guard for issue #953.
+func TestTranslateBareStatusSentinels(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus cerrors.Status
+		wantReason string
+	}{
+		{"bad_request", requesthandler.ErrBadRequest, cerrors.StatusInvalidArgument, "INVALID_ARGUMENT"},
+		{"unauthorized", requesthandler.ErrUnauthorized, cerrors.StatusUnauthenticated, "AUTHENTICATION_REQUIRED"},
+		{"payment_required", requesthandler.ErrPaymentRequired, cerrors.StatusPaymentRequired, "INSUFFICIENT_BALANCE"},
+		{"forbidden", requesthandler.ErrForbidden, cerrors.StatusPermissionDenied, "PERMISSION_DENIED"},
+		{"not_found", requesthandler.ErrNotFound, cerrors.StatusNotFound, "RESOURCE_NOT_FOUND"},
+		{"conflict", requesthandler.ErrConflict, cerrors.StatusFailedPrecondition, "STATE_INVALID"},
+		{"too_many_requests", requesthandler.ErrTooManyRequests, cerrors.StatusResourceExhausted, "RATE_LIMIT_EXCEEDED"},
+		{"service_unavailable", requesthandler.ErrServiceUnavailable, cerrors.StatusUnavailable, "SERVICE_UNAVAILABLE"},
+		{"internal", requesthandler.ErrInternal, cerrors.StatusInternal, "INTERNAL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := translateToVoipbinError(tt.err)
+			if got.Status != tt.wantStatus || got.Reason != tt.wantReason {
+				t.Errorf("got status=%q reason=%q want %q/%q", got.Status, got.Reason, tt.wantStatus, tt.wantReason)
+			}
+			// HTTPStatusFor must round-trip the resulting status back to the
+			// HTTP code the backend originally emitted.
+			if cerrors.HTTPStatusFor(got.Status) == 500 && tt.wantStatus != cerrors.StatusInternal {
+				t.Errorf("status %q unexpectedly maps to HTTP 500", got.Status)
+			}
+		})
+	}
+}
+
+// TestTranslateBareNotFoundWrapped verifies the production wrapping path:
+// servicehandler wraps the bare-404 sentinel with pkg/errors.Wrapf (e.g.
+// serviceHandler.aipromptproposalGet does errors.Wrapf(err, "could not get
+// ai prompt proposal info")). The sentinel must still be recovered through
+// the wrap.
+func TestTranslateBareNotFoundWrapped(t *testing.T) {
+	wrapped := pkgerrors.Wrapf(requesthandler.ErrNotFound, "could not get ai prompt proposal info")
+	got := translateToVoipbinError(wrapped)
+	if got.Status != cerrors.StatusNotFound {
+		t.Errorf("wrapped bare 404 should map to NOT_FOUND, got %q", got.Status)
+	}
+	if got.Reason != "RESOURCE_NOT_FOUND" {
+		t.Errorf("reason = %q want RESOURCE_NOT_FOUND", got.Reason)
+	}
+}

--- a/docs/superpowers/plans/2026-06-01-api-manager-bare-status-error-translation.md
+++ b/docs/superpowers/plans/2026-06-01-api-manager-bare-status-error-translation.md
@@ -1,0 +1,399 @@
+# api-manager bare-status error translation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `bin-api-manager` translate bare RPC status sentinels (404/409/429/etc.) to the correct client HTTP status instead of collapsing them to 500, fixing [#953](https://github.com/voipbin/monorepo/issues/953).
+
+**Architecture:** Single-file change to the central error translator `translateToVoipbinError` in `bin-api-manager/server/error_translate.go`. Add a closed set of `requesthandler.Err*` → `cerrors` constructor cases (step 2, the sentinel-match section), mirroring `cerrors.HTTPStatusFor` in reverse and reusing the exact reason/message strings already used by the existing typed-sentinel cases. No backend changes; typed `VoipbinError` envelopes still take precedence via step 1.
+
+**Tech Stack:** Go, `go test` (table-driven), gin + httptest (edge tests), `golangci-lint`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md`
+
+---
+
+## Background (read before starting)
+
+When a backend manager (e.g. `bin-ai-manager`) returns a **bare** status code via `simpleResponse(404)` — i.e. no typed `VoipbinError` body — the `requesthandler.parseResponse` layer converts it to a sentinel error from `HttpStatusErrorMap` (e.g. `requesthandler.ErrNotFound`). That sentinel propagates up to `bin-api-manager`'s `translateToVoipbinError`, which currently handles only `requesthandler.ErrBadRequest` (bare 400). Every other bare status falls through to the Default branch → `Internal` → HTTP 500.
+
+This plan adds the missing cases. The mapping mirrors `cerrors.HTTPStatusFor` (`bin-common-handler/models/errors/rpc.go:54`) so a bare backend status round-trips back to the same client HTTP code:
+
+| `requesthandler` sentinel | HTTP | `cerrors` constructor | Status | reason | message | wraps cause? |
+|---|---|---|---|---|---|---|
+| `ErrBadRequest` | 400 | `InvalidArgument` | `INVALID_ARGUMENT` | `INVALID_ARGUMENT` | "The request contains invalid data." | *(already present)* |
+| `ErrUnauthorized` | 401 | `Unauthenticated` | `UNAUTHENTICATED` | `AUTHENTICATION_REQUIRED` | "Authentication is required." | no |
+| `ErrPaymentRequired` | 402 | `PaymentRequired` | `PAYMENT_REQUIRED` | `INSUFFICIENT_BALANCE` | "Customer balance is below the minimum required for this operation." | yes |
+| `ErrForbidden` | 403 | `PermissionDenied` | `PERMISSION_DENIED` | `PERMISSION_DENIED` | "You do not have permission to access this resource." | no |
+| `ErrNotFound` | 404 | `NotFound` | `NOT_FOUND` | `RESOURCE_NOT_FOUND` | "The requested resource was not found." | no |
+| `ErrConflict` | 409 | `FailedPrecondition` | `FAILED_PRECONDITION` | `STATE_INVALID` | "The operation is invalid for the current resource state." | yes |
+| `ErrTooManyRequests` | 429 | `ResourceExhausted` | `RESOURCE_EXHAUSTED` | `RATE_LIMIT_EXCEEDED` | "Too many requests. Please retry later." | yes |
+| `ErrServiceUnavailable` | 503 | `Unavailable` | `UNAVAILABLE` | `SERVICE_UNAVAILABLE` | "An upstream service is temporarily unavailable." | yes |
+| `ErrInternal` | 500 | `Internal` | `INTERNAL` | `INTERNAL` | "An internal error occurred." | yes |
+
+The "wraps cause?" column matches the wrap behavior of each existing typed-sentinel analogue in `error_translate.go` (e.g. the existing `INSUFFICIENT_BALANCE`/`STATE_INVALID`/`UNAVAILABLE`/`INTERNAL` cases call `.Wrap(err)`; the existing `PERMISSION_DENIED`/`RESOURCE_NOT_FOUND` cases do not). `.Wrap(err)` only sets the internal `Cause` chain (used by `errors.Is`); it is **stripped from the external client envelope** by `lib/apierror`, so it never changes the response body — it is purely about preserving the internal error chain.
+
+**Already-imported, no new imports in the implementation file:** `error_translate.go` already imports `requesthandler` (the existing `ErrBadRequest` case uses it), `cerrors`, `commonoutline`, and `stderrors`. The two **test** files need import additions (called out per task).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `bin-api-manager/server/error_translate.go` | Central servicehandler-error → `*VoipbinError` translator | Add 8 bare-status sentinel cases in step 2; update the stale doc comment. |
+| `bin-api-manager/server/error_translate_test.go` | Unit tests for `translateToVoipbinError` | Add table test for all 9 bare-status sentinels + a `pkg/errors`-wrapped 404 variant. |
+| `bin-api-manager/server/error_test.go` | Edge tests driving real gin recorder through `abortWithServiceError` | Add one HTTP round-trip test: wrapped bare-404 → `w.Code == 404`. |
+
+---
+
+## Task 1: Add bare-status sentinel cases to the translator (unit-tested)
+
+**Files:**
+- Modify: `bin-api-manager/server/error_translate.go` (function `translateToVoipbinError`, the step-2 switch; and the doc comment above it)
+- Test: `bin-api-manager/server/error_translate_test.go`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Add the `requesthandler` import to the test file's import block. The current import block (`error_translate_test.go:3-13`) is:
+
+```go
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	cerrors "monorepo/bin-common-handler/models/errors"
+
+	pkgerrors "github.com/pkg/errors"
+)
+```
+
+Replace it with (adds one line — the `requesthandler` import):
+
+```go
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"testing"
+
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	pkgerrors "github.com/pkg/errors"
+)
+```
+
+Then append these two test functions to the end of `error_translate_test.go`:
+
+```go
+// TestTranslateBareStatusSentinels verifies that a bare requesthandler
+// HTTP-status sentinel (produced when a backend returns a bare
+// simpleResponse(<code>) with no typed VoipbinError body) is translated to
+// the matching cerrors status/reason, mirroring cerrors.HTTPStatusFor.
+// This is the regression guard for issue #953.
+func TestTranslateBareStatusSentinels(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus cerrors.Status
+		wantReason string
+	}{
+		{"bad_request", requesthandler.ErrBadRequest, cerrors.StatusInvalidArgument, "INVALID_ARGUMENT"},
+		{"unauthorized", requesthandler.ErrUnauthorized, cerrors.StatusUnauthenticated, "AUTHENTICATION_REQUIRED"},
+		{"payment_required", requesthandler.ErrPaymentRequired, cerrors.StatusPaymentRequired, "INSUFFICIENT_BALANCE"},
+		{"forbidden", requesthandler.ErrForbidden, cerrors.StatusPermissionDenied, "PERMISSION_DENIED"},
+		{"not_found", requesthandler.ErrNotFound, cerrors.StatusNotFound, "RESOURCE_NOT_FOUND"},
+		{"conflict", requesthandler.ErrConflict, cerrors.StatusFailedPrecondition, "STATE_INVALID"},
+		{"too_many_requests", requesthandler.ErrTooManyRequests, cerrors.StatusResourceExhausted, "RATE_LIMIT_EXCEEDED"},
+		{"service_unavailable", requesthandler.ErrServiceUnavailable, cerrors.StatusUnavailable, "SERVICE_UNAVAILABLE"},
+		{"internal", requesthandler.ErrInternal, cerrors.StatusInternal, "INTERNAL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := translateToVoipbinError(tt.err)
+			if got.Status != tt.wantStatus || got.Reason != tt.wantReason {
+				t.Errorf("got status=%q reason=%q want %q/%q", got.Status, got.Reason, tt.wantStatus, tt.wantReason)
+			}
+			// HTTPStatusFor must round-trip the resulting status back to the
+			// HTTP code the backend originally emitted.
+			if cerrors.HTTPStatusFor(got.Status) == 500 && tt.wantStatus != cerrors.StatusInternal {
+				t.Errorf("status %q unexpectedly maps to HTTP 500", got.Status)
+			}
+		})
+	}
+}
+
+// TestTranslateBareNotFoundWrapped verifies the production wrapping path:
+// servicehandler wraps the bare-404 sentinel with pkg/errors.Wrapf (e.g.
+// serviceHandler.aipromptproposalGet does errors.Wrapf(err, "could not get
+// ai prompt proposal info")). The sentinel must still be recovered through
+// the wrap.
+func TestTranslateBareNotFoundWrapped(t *testing.T) {
+	wrapped := pkgerrors.Wrapf(requesthandler.ErrNotFound, "could not get ai prompt proposal info")
+	got := translateToVoipbinError(wrapped)
+	if got.Status != cerrors.StatusNotFound {
+		t.Errorf("wrapped bare 404 should map to NOT_FOUND, got %q", got.Status)
+	}
+	if got.Reason != "RESOURCE_NOT_FOUND" {
+		t.Errorf("reason = %q want RESOURCE_NOT_FOUND", got.Reason)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd bin-api-manager && go test ./server/ -run 'TestTranslateBareStatus|TestTranslateBareNotFoundWrapped' -v`
+
+Expected: FAIL. Cases like `unauthorized`, `not_found`, `conflict`, `too_many_requests`, `service_unavailable` currently fall through to the Default branch, so `got.Status` is `INTERNAL` / `got.Reason` is `INTERNAL` instead of the expected values. (`bad_request` already passes; `internal` already passes via Default — the others fail.)
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `error_translate.go`, find the existing `ErrBadRequest` case in the step-2 switch:
+
+```go
+		case stderrors.Is(err, requesthandler.ErrBadRequest):
+			return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request contains invalid data.")
+```
+
+Replace that single case with the full closed set (the `ErrBadRequest` case is unchanged; the 8 new cases are inserted immediately after it):
+
+```go
+		case stderrors.Is(err, requesthandler.ErrBadRequest):
+			return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "The request contains invalid data.")
+		case stderrors.Is(err, requesthandler.ErrUnauthorized):
+			return cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required.")
+		case stderrors.Is(err, requesthandler.ErrPaymentRequired):
+			return cerrors.PaymentRequired(commonoutline.ServiceNameAPIManager, "INSUFFICIENT_BALANCE",
+				"Customer balance is below the minimum required for this operation.").Wrap(err)
+		case stderrors.Is(err, requesthandler.ErrForbidden):
+			return cerrors.PermissionDenied(commonoutline.ServiceNameAPIManager, "PERMISSION_DENIED", "You do not have permission to access this resource.")
+		case stderrors.Is(err, requesthandler.ErrNotFound):
+			return cerrors.NotFound(commonoutline.ServiceNameAPIManager, "RESOURCE_NOT_FOUND", "The requested resource was not found.")
+		case stderrors.Is(err, requesthandler.ErrConflict):
+			return cerrors.FailedPrecondition(commonoutline.ServiceNameAPIManager, "STATE_INVALID",
+				"The operation is invalid for the current resource state.").Wrap(err)
+		case stderrors.Is(err, requesthandler.ErrTooManyRequests):
+			return cerrors.ResourceExhausted(commonoutline.ServiceNameAPIManager, "RATE_LIMIT_EXCEEDED",
+				"Too many requests. Please retry later.").Wrap(err)
+		case stderrors.Is(err, requesthandler.ErrServiceUnavailable):
+			return cerrors.Unavailable(commonoutline.ServiceNameAPIManager, "SERVICE_UNAVAILABLE",
+				"An upstream service is temporarily unavailable.").Wrap(err)
+		case stderrors.Is(err, requesthandler.ErrInternal):
+			return cerrors.Internal(commonoutline.ServiceNameAPIManager, "INTERNAL", "An internal error occurred.").Wrap(err)
+```
+
+Then update the doc comment above `translateToVoipbinError` so it documents the full bare-status set instead of only the bare-400 exception. Find the existing comment lines (the priority-order block and the "Exception" paragraph):
+
+```go
+// translateToVoipbinError maps any error returned from a servicehandler
+// into a *VoipbinError. Priority order:
+//  1. Typed passthrough (errors.As).
+//  2. Sentinel match (errors.Is against serviceerrors.Err*).
+//  3. Transport-failure detection (context.Canceled / DeadlineExceeded).
+//  4. Default: Internal with the original error wrapped as Cause.
+```
+
+Replace the priority-order line `//  2.` so it reads:
+
+```go
+//  2. Sentinel match (errors.Is against serviceerrors.Err* and the bare
+//     requesthandler.Err* HTTP-status sentinels).
+```
+
+And find the "Exception" paragraph:
+
+```go
+// Exception: backend services that return a bare status code (e.g.
+// simpleResponse(400)) without a typed VoipbinError body produce a
+// requesthandler.ErrBadRequest sentinel instead of a VoipbinError.
+// That case is handled explicitly below.
+```
+
+Replace it with:
+
+```go
+// Bare status codes: backend services that return a bare status code
+// (e.g. simpleResponse(404)) without a typed VoipbinError body produce a
+// requesthandler.Err* sentinel (via HttpStatusErrorMap) instead of a
+// VoipbinError. Step 2 maps the closed set of these sentinels
+// (400/401/402/403/404/409/429/503/500) back to the canonical cerrors
+// status, mirroring cerrors.HTTPStatusFor in reverse so the client sees
+// the same HTTP code the backend emitted. Statuses outside that set fall
+// through to the Default branch (INTERNAL).
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd bin-api-manager && go test ./server/ -run 'TestTranslateBareStatus|TestTranslateBareNotFoundWrapped' -v`
+
+Expected: PASS (all sub-tests).
+
+- [ ] **Step 5: Run the full server-package test to confirm no regression**
+
+Run: `cd bin-api-manager && go test ./server/ -run TestTranslate -v`
+
+Expected: PASS — including the pre-existing `TestTranslateSentinels`, `TestTranslateTypedPassthrough`, `TestTranslatePkgErrorsWrappedTypedError`, `TestTranslateLegacyStringFallsThroughToInternal`, `TestTranslateDefault`. (The "legacy string falls through to INTERNAL" test must still pass — bare *string* errors are not `requesthandler.Err*` sentinels, so they are unaffected.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd bin-api-manager
+git add server/error_translate.go server/error_translate_test.go
+git commit -m "NOJIRA-Fix-api-manager-bare-status-error-translation
+
+- bin-api-manager: Translate bare requesthandler HTTP-status sentinels (401/402/403/404/409/429/503/500) to matching VoipbinError statuses in translateToVoipbinError; fixes 500-instead-of-404 for nonexistent aipromptproposals IDs (#953)"
+```
+
+---
+
+## Task 2: Add edge-level HTTP round-trip test (boundary regression guard)
+
+This test drives the real gin → `abortWithServiceError` → `abortWithError` → `HTTPStatusFor` path the client actually observes, asserting the wrapped bare-404 produces HTTP `404` with the correct body. The implementation already landed in Task 1, so this test passes immediately; it exists as a permanent boundary guard (the Task 1 unit test only checks the translator's `Status`/`Reason`, not the HTTP status code written to the response).
+
+**Files:**
+- Test: `bin-api-manager/server/error_test.go`
+
+- [ ] **Step 1: Add the edge test**
+
+Add two imports to `error_test.go`. The current import block (`error_test.go:3-16`) is:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"monorepo/bin-api-manager/lib/middleware"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	"github.com/gin-gonic/gin"
+)
+```
+
+Replace it with (adds `requesthandler` and `pkgerrors`):
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"monorepo/bin-api-manager/lib/middleware"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	"github.com/gin-gonic/gin"
+	pkgerrors "github.com/pkg/errors"
+)
+```
+
+Then append this test function to the end of `error_test.go` (it reuses the existing `assertErrorResponse` helper, which asserts both `w.Code` via `HTTPStatusFor` and the response body's status/reason):
+
+```go
+// TestAbortWithServiceErrorBareNotFoundRoundTrips404 guards the full
+// client-observed path for issue #953: a bare requesthandler.ErrNotFound
+// (emitted when a backend returns simpleResponse(404)), wrapped by
+// servicehandler with pkg/errors.Wrapf, must surface as HTTP 404 with the
+// RESOURCE_NOT_FOUND envelope — not 500.
+func TestAbortWithServiceErrorBareNotFoundRoundTrips404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.RequestID())
+	r.GET("/", func(c *gin.Context) {
+		abortWithServiceError(c, pkgerrors.Wrapf(requesthandler.ErrNotFound, "could not get ai prompt proposal info"))
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assertErrorResponse(t, w, cerrors.StatusNotFound, "RESOURCE_NOT_FOUND")
+}
+```
+
+- [ ] **Step 2: Run the edge test**
+
+Run: `cd bin-api-manager && go test ./server/ -run TestAbortWithServiceErrorBareNotFoundRoundTrips404 -v`
+
+Expected: PASS — `w.Code == 404`, body `status == "NOT_FOUND"`, `reason == "RESOURCE_NOT_FOUND"`, `request_id` present, no `domain` key.
+
+- [ ] **Step 3: Run the full error_test.go suite to confirm no regression**
+
+Run: `cd bin-api-manager && go test ./server/ -run 'TestAbortWith|TestAssertErrorResponseHelper' -v`
+
+Expected: PASS (all pre-existing edge tests plus the new one).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd bin-api-manager
+git add server/error_test.go
+git commit -m "NOJIRA-Fix-api-manager-bare-status-error-translation
+
+- bin-api-manager: Add edge-level HTTP round-trip test asserting wrapped bare-404 surfaces as 404 NOT_FOUND (#953)"
+```
+
+---
+
+## Task 3: Full verification workflow
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the mandatory verification workflow**
+
+Run:
+
+```bash
+cd bin-api-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all five steps succeed. `go test ./...` runs the whole `bin-api-manager` suite (including `server/`). `golangci-lint` reports no new issues in `server/error_translate.go` / test files.
+
+Notes:
+- No new third-party dependency is added (`requesthandler`, `cerrors`, `pkg/errors` are all already in `go.mod`), so `go mod tidy` should produce no changes. If it does modify `go.mod`/`go.sum`, that is expected housekeeping — stage and commit those files too.
+- `vendor/` is **not** committed (root `.gitignore` excludes it). Do **not** `git add -f vendor/`.
+
+- [ ] **Step 2: Commit any go.mod/go.sum changes (only if the workflow modified them)**
+
+```bash
+cd bin-api-manager
+git status --short go.mod go.sum
+# If either file changed:
+git add go.mod go.sum
+git commit -m "NOJIRA-Fix-api-manager-bare-status-error-translation
+
+- bin-api-manager: go mod tidy housekeeping"
+```
+
+If `git status` shows no changes to `go.mod`/`go.sum`, skip this commit.
+
+---
+
+## Out of scope (do NOT do in this plan)
+
+- **No `bin-ai-manager` or `bin-common-handler` changes.** The fix is entirely within `bin-api-manager/server/`.
+- **Do not touch** the "proposal not found" → 404 branches in ai-manager's accept/reject listenhandlers. They are redundant for the common api-manager path but still fire on a TOCTOU race or a direct/non-api-manager RPC caller — not dead code, not removable.
+- **api-validator follow-up (separate repo, separate PR):** after this fix is deployed, un-`xfail` the 4 affected tests in `monorepo-monitoring/api-validator`. Track separately; not part of this monorepo PR.
+
+## Done criteria
+
+- `GET`, `DELETE`, `POST .../accept`, `POST .../reject` on a nonexistent `aipromptproposals` ID return `404 NOT_FOUND` (verified at the translator + edge-test level).
+- Bare backend statuses 401/402/403/404/409/429/503/500 translate to the matching client HTTP status.
+- Typed `VoipbinError` precedence unchanged; legacy bare-string errors still degrade to INTERNAL.
+- Full verification workflow passes in `bin-api-manager`.

--- a/docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md
+++ b/docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md
@@ -1,0 +1,111 @@
+# Design: Central translation of bare RPC status sentinels in bin-api-manager
+
+**Issue:** [#953](https://github.com/voipbin/monorepo/issues/953) — GET/DELETE/accept/reject `/aipromptproposals/{id}` returns `500 INTERNAL` instead of `404 NOT_FOUND` for a nonexistent ID.
+
+**Date:** 2026-06-01
+**Branch:** `NOJIRA-Fix-api-manager-bare-status-error-translation`
+
+---
+
+## Problem
+
+All four `aipromptproposals` ID-scoped endpoints (`GET`, `DELETE`, `POST .../accept`, `POST .../reject`) return `500 INTERNAL` instead of `404 NOT_FOUND` when the proposal ID does not exist.
+
+The issue's symptom and expected behavior (404) are correct, but its stated root cause ("the backend does not handle the not-found case gracefully") is **wrong**. The backend handles not-found correctly. The defect is a single gap in the api-manager error translator.
+
+## Root-cause analysis
+
+For a nonexistent ID, every one of these endpoints flows through `serviceHandler.aipromptproposalGet` → RPC `GET /v1/aipromptproposals/<id>`. (accept/reject/delete each perform a permission-check `GET` **first**, so they fail at the GET step before their own RPC is sent.)
+
+The not-found error then propagates:
+
+1. **bin-ai-manager DB** (`aipromptproposalGetFromDB`, `pkg/dbhandler/aipromptproposal.go`) returns `dbhandler.ErrNotFound`. ✅ correct
+2. **bin-ai-manager listenhandler** (`errorResponse`, `pkg/listenhandler/main.go:158`) maps `dbhandler.ErrNotFound` → `simpleResponse(404)` — a **bare 404 status code with no typed-error body**. ✅ returns 404
+3. **requesthandler `parseResponse`** (`bin-common-handler/pkg/requesthandler/common.go:121`): no typed `VoipbinError` envelope is present (`DataType` is empty), so `getResponseStatusCodeError(404)` returns the sentinel `requesthandler.ErrNotFound` (from `HttpStatusErrorMap`). ✅ still "not found"
+4. **bin-api-manager `translateToVoipbinError`** (`server/error_translate.go:36`): **the bug.** Step 2 has an explicit case for `requesthandler.ErrBadRequest` (bare 400) but **no case for `requesthandler.ErrNotFound` (bare 404)**, so the error falls through to the Default branch → `cerrors.Internal(...)` → **500**.
+
+The smoking gun (`error_translate.go:65`): bare-400 was wired up, bare-404 was forgotten.
+
+```go
+case stderrors.Is(err, requesthandler.ErrBadRequest):   // 400 handled
+    return cerrors.InvalidArgument(...)
+// ← no requesthandler.ErrNotFound case → falls to Internal(500)
+```
+
+### This is a class of bugs, not a single endpoint
+
+`translateToVoipbinError` is the **single central translator** for every api-manager service error. Any endpoint whose backend returns a bare status via `simpleResponse(...)` (no typed `VoipbinError` envelope) for a status the translator does not explicitly handle will incorrectly degrade to 500.
+
+The same `aipromptproposals` endpoints already exhibit two more latent instances of this bug:
+
+- **accept/reject** return bare **409** (`simpleResponse(409)`, "proposal not completed") → `requesthandler.ErrConflict` → Default → **500** instead of 409.
+- **create** returns bare **429** (`simpleResponse(429)`, "rate limit exceeded") → `requesthandler.ErrTooManyRequests` → Default → **500** instead of 429.
+
+## Goal / acceptance criteria
+
+- `GET`, `DELETE`, `POST .../accept`, `POST .../reject` on a nonexistent `aipromptproposals` ID return `404 NOT_FOUND` with the standard api-manager not-found envelope.
+- Bare backend statuses `401/402/403/404/409/429/503/500` are translated to the matching client HTTP status instead of collapsing to 500.
+- Typed `VoipbinError` envelopes continue to take precedence (no behavior change for already-migrated backends).
+- Regression tests cover each sentinel, including the `pkg/errors`-wrapped form used by servicehandler.
+- Full verification workflow passes in `bin-api-manager`.
+
+## Approach (chosen: central translator fix, full bare-status set)
+
+Add cases to step 2 of `translateToVoipbinError`, immediately adjacent to the existing `requesthandler.ErrBadRequest` case, mapping each `requesthandler` HTTP-status sentinel to the canonical `cerrors` constructor. The mapping mirrors `cerrors.HTTPStatusFor` (`bin-common-handler/models/errors/rpc.go:54`, the single source of truth for Status→HTTP) in reverse, so a bare backend status round-trips back to the same client HTTP code.
+
+| `requesthandler` sentinel | HTTP | → `cerrors` constructor | resulting `Status` | reason constant |
+|---|---|---|---|---|
+| `ErrBadRequest` | 400 | `InvalidArgument` | `INVALID_ARGUMENT` | *(already present — unchanged)* |
+| `ErrUnauthorized` | 401 | `Unauthenticated` | `UNAUTHENTICATED` | `AUTHENTICATION_REQUIRED` |
+| `ErrPaymentRequired` | 402 | `PaymentRequired` | `PAYMENT_REQUIRED` | `PAYMENT_REQUIRED` |
+| `ErrForbidden` | 403 | `PermissionDenied` | `PERMISSION_DENIED` | `PERMISSION_DENIED` |
+| **`ErrNotFound`** | **404** | **`NotFound`** | **`NOT_FOUND`** | **`RESOURCE_NOT_FOUND`** |
+| `ErrConflict` | 409 | `FailedPrecondition` | `FAILED_PRECONDITION` | `STATE_INVALID` |
+| `ErrTooManyRequests` | 429 | `ResourceExhausted` | `RESOURCE_EXHAUSTED` | `RATE_LIMIT_EXCEEDED` |
+| `ErrServiceUnavailable` | 503 | `Unavailable` | `UNAVAILABLE` | `SERVICE_UNAVAILABLE` |
+| `ErrInternal` | 500 | `Internal` | `INTERNAL` | `INTERNAL` |
+
+Notes:
+- **Reason/message wording** matches the existing typed-sentinel cases where one exists (e.g. `RESOURCE_NOT_FOUND` / "The requested resource was not found." reuses the exact strings from the `serviceerrors.ErrNotFound` case) so the external envelope is identical whether the not-found originated as a typed sentinel or a bare backend status.
+- **409 → `FailedPrecondition`** rather than `AlreadyExists`. Both map to HTTP 409 via `HTTPStatusFor`, but the bare-409 emitters in practice (accept/reject "not completed") are state-precondition failures, and `FailedPrecondition` already has an established api-manager mapping (`STATE_INVALID`). `AlreadyExists` semantics are not represented by a bare status code today.
+- **Ordering:** these sentinel cases must run **after** step 1 (typed passthrough) — which they do, since they live in step 2 — so a migrated backend's typed `VoipbinError` is never overridden by a coincidental status-code match.
+- `ErrInternal` (500) → `Internal` is explicit and harmless (same outcome as the Default branch) but documents the full closed set and guards against a future Default-branch change.
+
+### Why the full set, not just 404
+
+The bare statuses above are exactly the ones backends emit via `simpleResponse(...)`. Cherry-picking 404 would leave the identical 409/429 bugs on the very same endpoints. A closed set mirroring `HTTPStatusFor` is more principled, self-documenting, and maintainable, and it remains fully consistent with the typed-error migration design (typed envelopes still win via step 1; the Default branch still degrades genuinely-unmatched errors to INTERNAL).
+
+## Components touched
+
+| File | Change |
+|---|---|
+| `bin-api-manager/server/error_translate.go` | Add 8 sentinel cases (7 new + the existing 400) in step 2 of `translateToVoipbinError`. |
+| `bin-api-manager/server/error_translate_test.go` | Add a table-driven test over every `requesthandler.Err*` sentinel → expected `Status`, plus a `pkg/errors`-wrapped variant for the 404 case (mirrors servicehandler's `errors.Wrapf`). |
+
+No backend (`bin-ai-manager`) changes. No `bin-common-handler` changes.
+
+## Error handling / edge cases
+
+- **Wrapped errors:** servicehandler wraps RPC errors with `pkg/errors.Wrapf`. `stderrors.Is` walks the chain (pkg/errors v0.9+ implements `Unwrap`), so the sentinel match works through the wrap. The test suite asserts this explicitly.
+- **Typed precedence preserved:** step 1 (`errors.As(&ve)`) runs first; only bare-status sentinels (no typed body) reach step 2's new cases.
+- **Unmatched statuses:** any status not in the table (e.g. 405, 410, 422) still falls through to Default → INTERNAL, unchanged. This is acceptable — those are not emitted by current backends; they can be added if/when a backend starts emitting them.
+- **Panic safety:** unchanged — the existing `defer recover()` still degrades to INTERNAL.
+
+## Testing strategy
+
+1. **Unit (translator):** extend `error_translate_test.go`:
+   - Table: each `requesthandler.Err{BadRequest,Unauthorized,PaymentRequired,Forbidden,NotFound,Conflict,TooManyRequests,ServiceUnavailable,Internal}` → expected `cerrors.Status` and reason.
+   - `pkg/errors.Wrapf(requesthandler.ErrNotFound, "...")` → `StatusNotFound` (production wrapping path).
+   - Confirm an unmatched status string still yields `StatusInternal`.
+2. **Verification workflow** in `bin-api-manager`: `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
+3. **api-validator follow-up (separate, per repo convention):** un-`xfail` the 4 affected tests in `monorepo-monitoring/api-validator` once the fix is deployed. Tracked as a follow-up, not part of this monorepo PR.
+
+## Out of scope
+
+- The dead-code "proposal not found" → 404 branches in ai-manager's accept/reject listenhandlers (unreachable for the not-found case because the api-manager GET fails first). Harmless; left as-is.
+- Migrating ai-manager's `errorResponse` to emit typed `NotFound` envelopes. The central fix makes this unnecessary for correctness; it can be a future cleanup.
+- Statuses not currently emitted by backends (405/410/422/etc.).
+
+## Rollback
+
+Single-file behavioral change with no schema/state impact. Revert the PR commit to restore prior behavior. Low risk: strictly turns previously-500 responses into their correct 4xx/503 codes.

--- a/docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md
+++ b/docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md
@@ -36,10 +36,10 @@ case stderrors.Is(err, requesthandler.ErrBadRequest):   // 400 handled
 
 `translateToVoipbinError` is the **single central translator** for every api-manager service error. Any endpoint whose backend returns a bare status via `simpleResponse(...)` (no typed `VoipbinError` envelope) for a status the translator does not explicitly handle will incorrectly degrade to 500.
 
-The same `aipromptproposals` endpoints already exhibit two more latent instances of this bug:
+The `aipromptproposals` resource already exhibits two more latent instances of this bug, on **different** endpoints from the 404 (so they are the same *class*, not the same endpoints):
 
-- **accept/reject** return bare **409** (`simpleResponse(409)`, "proposal not completed") → `requesthandler.ErrConflict` → Default → **500** instead of 409.
-- **create** returns bare **429** (`simpleResponse(429)`, "rate limit exceeded") → `requesthandler.ErrTooManyRequests` → Default → **500** instead of 429.
+- **accept / reject** (the ID-scoped endpoints from this issue) return bare **409** (`simpleResponse(409)`, "proposal not completed") → `requesthandler.ErrConflict` → Default → **500** instead of 409. This is reachable for a *valid* proposal acted on in the wrong state (independent of the not-found defect).
+- **create** (`POST /aipromptproposals`, a separate endpoint) returns bare **429** (`simpleResponse(429)`, "rate limit exceeded") → `requesthandler.ErrTooManyRequests` → Default → **500** instead of 429. Reached via the rate-limit path, not the not-found path.
 
 ## Goal / acceptance criteria
 
@@ -57,7 +57,7 @@ Add cases to step 2 of `translateToVoipbinError`, immediately adjacent to the ex
 |---|---|---|---|---|
 | `ErrBadRequest` | 400 | `InvalidArgument` | `INVALID_ARGUMENT` | *(already present — unchanged)* |
 | `ErrUnauthorized` | 401 | `Unauthenticated` | `UNAUTHENTICATED` | `AUTHENTICATION_REQUIRED` |
-| `ErrPaymentRequired` | 402 | `PaymentRequired` | `PAYMENT_REQUIRED` | `PAYMENT_REQUIRED` |
+| `ErrPaymentRequired` | 402 | `PaymentRequired` | `PAYMENT_REQUIRED` | `INSUFFICIENT_BALANCE` |
 | `ErrForbidden` | 403 | `PermissionDenied` | `PERMISSION_DENIED` | `PERMISSION_DENIED` |
 | **`ErrNotFound`** | **404** | **`NotFound`** | **`NOT_FOUND`** | **`RESOURCE_NOT_FOUND`** |
 | `ErrConflict` | 409 | `FailedPrecondition` | `FAILED_PRECONDITION` | `STATE_INVALID` |
@@ -66,21 +66,23 @@ Add cases to step 2 of `translateToVoipbinError`, immediately adjacent to the ex
 | `ErrInternal` | 500 | `Internal` | `INTERNAL` | `INTERNAL` |
 
 Notes:
-- **Reason/message wording** matches the existing typed-sentinel cases where one exists (e.g. `RESOURCE_NOT_FOUND` / "The requested resource was not found." reuses the exact strings from the `serviceerrors.ErrNotFound` case) so the external envelope is identical whether the not-found originated as a typed sentinel or a bare backend status.
-- **409 → `FailedPrecondition`** rather than `AlreadyExists`. Both map to HTTP 409 via `HTTPStatusFor`, but the bare-409 emitters in practice (accept/reject "not completed") are state-precondition failures, and `FailedPrecondition` already has an established api-manager mapping (`STATE_INVALID`). `AlreadyExists` semantics are not represented by a bare status code today.
+- **Reason/message wording reuses the existing typed-sentinel cases verbatim where one exists**, so the external envelope is identical whether the error originated as a typed sentinel or a bare backend status. Concretely, each bare-status case reuses the exact reason/message strings already present in `translateToVoipbinError` (`error_translate.go`): 404 → `RESOURCE_NOT_FOUND` ("The requested resource was not found."), 401 → `AUTHENTICATION_REQUIRED`, 403 → `PERMISSION_DENIED`, 402 → `INSUFFICIENT_BALANCE`, 409 → `STATE_INVALID`, 503 → `SERVICE_UNAVAILABLE`, 500 → `INTERNAL`. Only 429 introduces a new reason (`RATE_LIMIT_EXCEEDED`) because no existing case maps to `ResourceExhausted`.
+- **402 reuses `INSUFFICIENT_BALANCE`** (not a new `PAYMENT_REQUIRED` reason) to stay consistent with the established 402 mapping at `error_translate.go:78-80` and its test (`error_translate_test.go:76`), so there is a single 402 envelope. No backend emits a bare 402 today, so this is a consistency choice with no live path.
+- **409 → `FailedPrecondition`** rather than `AlreadyExists`. Both map to HTTP 409 via `HTTPStatusFor`, but the bare-409 emitters in practice (accept/reject "not completed") are state-precondition failures. This is already the documented contract: the `AlreadyExists` constructor doc (`constructors.go:40-45`) explicitly states "the api-manager translator never emits ALREADY_EXISTS as a fallback mapping — 409 responses default to FAILED_PRECONDITION." Reusing `STATE_INVALID` matches the existing `serviceerrors.ErrStateInvalid` case.
 - **Ordering:** these sentinel cases must run **after** step 1 (typed passthrough) — which they do, since they live in step 2 — so a migrated backend's typed `VoipbinError` is never overridden by a coincidental status-code match.
-- `ErrInternal` (500) → `Internal` is explicit and harmless (same outcome as the Default branch) but documents the full closed set and guards against a future Default-branch change.
+- **`ErrInternal` (500) → `Internal`** yields the same outcome as the Default branch, so to avoid any behavioral divergence the explicit case **must `.Wrap(err)` exactly as the Default branch does** (`error_translate.go:92`). It is included only to document the full closed set and guard against a future Default-branch change; the implementer may instead omit it and rely on Default — either is acceptable as long as the wrap behavior is identical.
 
 ### Why the full set, not just 404
 
-The bare statuses above are exactly the ones backends emit via `simpleResponse(...)`. Cherry-picking 404 would leave the identical 409/429 bugs on the very same endpoints. A closed set mirroring `HTTPStatusFor` is more principled, self-documenting, and maintainable, and it remains fully consistent with the typed-error migration design (typed envelopes still win via step 1; the Default branch still degrades genuinely-unmatched errors to INTERNAL).
+The bare statuses above are exactly the ones backends emit via `simpleResponse(...)`. Cherry-picking 404 would leave the identical-class 409 bug (accept/reject) and 429 bug (create) unfixed. A closed set mirroring `HTTPStatusFor` is more principled, self-documenting, and maintainable, and it remains fully consistent with the typed-error migration design (typed envelopes still win via step 1; the Default branch still degrades genuinely-unmatched errors to INTERNAL).
 
 ## Components touched
 
 | File | Change |
 |---|---|
 | `bin-api-manager/server/error_translate.go` | Add 8 sentinel cases (7 new + the existing 400) in step 2 of `translateToVoipbinError`. |
-| `bin-api-manager/server/error_translate_test.go` | Add a table-driven test over every `requesthandler.Err*` sentinel → expected `Status`, plus a `pkg/errors`-wrapped variant for the 404 case (mirrors servicehandler's `errors.Wrapf`). |
+| `bin-api-manager/server/error_translate_test.go` | Add a table-driven test over every `requesthandler.Err*` sentinel → expected `Status`/reason, plus a `pkg/errors`-wrapped variant for the 404 case (mirrors servicehandler's `errors.Wrapf`). |
+| `bin-api-manager/server/error_test.go` | Add one edge-level test driving `abortWithServiceError` through a real `gin` recorder for a wrapped `requesthandler.ErrNotFound`, asserting `w.Code == 404` — covers the full status round-trip via `HTTPStatusFor`, not just the translator's `Status` field. |
 
 No backend (`bin-ai-manager`) changes. No `bin-common-handler` changes.
 
@@ -89,20 +91,23 @@ No backend (`bin-ai-manager`) changes. No `bin-common-handler` changes.
 - **Wrapped errors:** servicehandler wraps RPC errors with `pkg/errors.Wrapf`. `stderrors.Is` walks the chain (pkg/errors v0.9+ implements `Unwrap`), so the sentinel match works through the wrap. The test suite asserts this explicitly.
 - **Typed precedence preserved:** step 1 (`errors.As(&ve)`) runs first; only bare-status sentinels (no typed body) reach step 2's new cases.
 - **Unmatched statuses:** any status not in the table (e.g. 405, 410, 422) still falls through to Default → INTERNAL, unchanged. This is acceptable — those are not emitted by current backends; they can be added if/when a backend starts emitting them.
+- **Bare 404 is also emitted by the no-handler-found default route**, not only by resource-not-found. ai-manager's `processRequest` returns a bare `simpleResponse(404)` for an unmatched RPC route (`pkg/listenhandler/main.go:507`). After this change, a missing RPC route surfaces to the client as `404 NOT_FOUND` instead of `500 INTERNAL`. This is an accepted trade-off: a missing route is a deploy/wiring bug that should be caught before production, and 404-vs-500 for it is a minor cosmetic difference. Reviewers should be aware the blast radius of the 404 mapping is not strictly limited to resource-not-found.
+- **No existing edge test asserts bare-status→500.** Verified: the only 500-asserting edge tests (`error_test.go:84`, `:116`) use a `nil` error and a generic `fmt.Errorf` — neither is a `requesthandler.Err*` sentinel, so neither changes behavior. All `serviceerrors.ErrNotFound` test sites use the typed-sentinel path (step-2 `serviceerrors.ErrNotFound`, unchanged).
 - **Panic safety:** unchanged — the existing `defer recover()` still degrades to INTERNAL.
 
 ## Testing strategy
 
 1. **Unit (translator):** extend `error_translate_test.go`:
-   - Table: each `requesthandler.Err{BadRequest,Unauthorized,PaymentRequired,Forbidden,NotFound,Conflict,TooManyRequests,ServiceUnavailable,Internal}` → expected `cerrors.Status` and reason.
+   - Table: each `requesthandler.Err{BadRequest,Unauthorized,PaymentRequired,Forbidden,NotFound,Conflict,TooManyRequests,ServiceUnavailable,Internal}` → expected `cerrors.Status` and reason (reasons per the mapping table above).
    - `pkg/errors.Wrapf(requesthandler.ErrNotFound, "...")` → `StatusNotFound` (production wrapping path).
    - Confirm an unmatched status string still yields `StatusInternal`.
-2. **Verification workflow** in `bin-api-manager`: `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
-3. **api-validator follow-up (separate, per repo convention):** un-`xfail` the 4 affected tests in `monorepo-monitoring/api-validator` once the fix is deployed. Tracked as a follow-up, not part of this monorepo PR.
+2. **Edge (HTTP status round-trip):** extend `error_test.go` — drive `abortWithServiceError(c, pkgerrors.Wrapf(requesthandler.ErrNotFound, "..."))` through a `httptest`/`gin` recorder and assert `w.Code == 404`. This guards the boundary the client actually observes (`translateToVoipbinError` → `abortWithError` → `HTTPStatusFor`), which the translator-unit test alone does not cover.
+3. **Verification workflow** in `bin-api-manager`: `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
+4. **api-validator follow-up (separate, per repo convention):** un-`xfail` the 4 affected tests in `monorepo-monitoring/api-validator` once the fix is deployed. Tracked as a follow-up, not part of this monorepo PR.
 
 ## Out of scope
 
-- The dead-code "proposal not found" → 404 branches in ai-manager's accept/reject listenhandlers (unreachable for the not-found case because the api-manager GET fails first). Harmless; left as-is.
+- The "proposal not found" → 404 branches in ai-manager's accept/reject listenhandlers. These are **redundant for the common api-manager path** (the api-manager permission-check GET fails first), but they are **not dead code**: they still fire for a TOCTOU race (proposal deleted between the GET and the accept/reject RPC) or any direct/non-api-manager RPC caller. Left as-is — do **not** treat them as removable.
 - Migrating ai-manager's `errorResponse` to emit typed `NotFound` envelopes. The central fix makes this unnecessary for correctness; it can be a future cleanup.
 - Statuses not currently emitted by backends (405/410/422/etc.).
 

--- a/docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md
+++ b/docs/superpowers/specs/2026-06-01-api-manager-bare-status-error-translation-design.md
@@ -66,7 +66,16 @@ Add cases to step 2 of `translateToVoipbinError`, immediately adjacent to the ex
 | `ErrInternal` | 500 | `Internal` | `INTERNAL` | `INTERNAL` |
 
 Notes:
-- **Reason/message wording reuses the existing typed-sentinel cases verbatim where one exists**, so the external envelope is identical whether the error originated as a typed sentinel or a bare backend status. Concretely, each bare-status case reuses the exact reason/message strings already present in `translateToVoipbinError` (`error_translate.go`): 404 → `RESOURCE_NOT_FOUND` ("The requested resource was not found."), 401 → `AUTHENTICATION_REQUIRED`, 403 → `PERMISSION_DENIED`, 402 → `INSUFFICIENT_BALANCE`, 409 → `STATE_INVALID`, 503 → `SERVICE_UNAVAILABLE`, 500 → `INTERNAL`. Only 429 introduces a new reason (`RATE_LIMIT_EXCEEDED`) because no existing case maps to `ResourceExhausted`.
+- **Reason/message wording reuses the existing typed-sentinel cases verbatim where one exists**, so the external envelope is identical whether the error originated as a typed sentinel or a bare backend status. Concretely, each bare-status case reuses the exact reason **and message** strings already present in `translateToVoipbinError` (`error_translate.go`):
+  - 401 → `AUTHENTICATION_REQUIRED` / "Authentication is required." (`:56`)
+  - 402 → `INSUFFICIENT_BALANCE` / "Customer balance is below the minimum required for this operation." (`:79-80`)
+  - 403 → `PERMISSION_DENIED` / "You do not have permission to access this resource." (`:58`)
+  - 404 → `RESOURCE_NOT_FOUND` / "The requested resource was not found." (`:62`)
+  - 409 → `STATE_INVALID` / "The operation is invalid for the current resource state." (`:73-74`)
+  - 503 → `SERVICE_UNAVAILABLE` / "An upstream service is temporarily unavailable." (`:76-77`)
+  - 500 → `INTERNAL` / "An internal error occurred." (`:68`)
+  - 429 → `RATE_LIMIT_EXCEEDED` / "Too many requests. Please retry later." — the **only new** reason, because no existing case maps to `ResourceExhausted`.
+- **403 maps to the generic `PERMISSION_DENIED`**, not the `DIRECT_ACCESS_NOT_SUPPORTED` PermissionDenied variant (`:60`). A bare backend 403 carries no direct-access semantics, so the generic permission-denied envelope is correct.
 - **402 reuses `INSUFFICIENT_BALANCE`** (not a new `PAYMENT_REQUIRED` reason) to stay consistent with the established 402 mapping at `error_translate.go:78-80` and its test (`error_translate_test.go:76`), so there is a single 402 envelope. No backend emits a bare 402 today, so this is a consistency choice with no live path.
 - **409 → `FailedPrecondition`** rather than `AlreadyExists`. Both map to HTTP 409 via `HTTPStatusFor`, but the bare-409 emitters in practice (accept/reject "not completed") are state-precondition failures. This is already the documented contract: the `AlreadyExists` constructor doc (`constructors.go:40-45`) explicitly states "the api-manager translator never emits ALREADY_EXISTS as a fallback mapping — 409 responses default to FAILED_PRECONDITION." Reusing `STATE_INVALID` matches the existing `serviceerrors.ErrStateInvalid` case.
 - **Ordering:** these sentinel cases must run **after** step 1 (typed passthrough) — which they do, since they live in step 2 — so a migrated backend's typed `VoipbinError` is never overridden by a coincidental status-code match.
@@ -80,7 +89,7 @@ The bare statuses above are exactly the ones backends emit via `simpleResponse(.
 
 | File | Change |
 |---|---|
-| `bin-api-manager/server/error_translate.go` | Add 8 sentinel cases (7 new + the existing 400) in step 2 of `translateToVoipbinError`. |
+| `bin-api-manager/server/error_translate.go` | Add 8 sentinel cases (7 new + the existing 400) in step 2 of `translateToVoipbinError`. **Also update the stale doc comment** (`:32-35`, which currently says only the bare-400 case is handled) and the "Migration status" note (`:23-30`) to describe the full closed bare-status set. |
 | `bin-api-manager/server/error_translate_test.go` | Add a table-driven test over every `requesthandler.Err*` sentinel → expected `Status`/reason, plus a `pkg/errors`-wrapped variant for the 404 case (mirrors servicehandler's `errors.Wrapf`). |
 | `bin-api-manager/server/error_test.go` | Add one edge-level test driving `abortWithServiceError` through a real `gin` recorder for a wrapped `requesthandler.ErrNotFound`, asserting `w.Code == 404` — covers the full status round-trip via `HTTPStatusFor`, not just the translator's `Status` field. |
 


### PR DESCRIPTION
Fix bin-api-manager returning HTTP 500 instead of the correct client status code when a backend manager responds with a bare status code (no typed VoipbinError body). Closes #953, where GET/DELETE/accept/reject on a nonexistent aipromptproposals ID returned 500 INTERNAL instead of 404 NOT_FOUND.

The root cause is in the central error translator translateToVoipbinError (server/error_translate.go): it mapped only the bare-400 requesthandler.ErrBadRequest sentinel, so every other bare backend status (notably bare-404 from simpleResponse(404) -> requesthandler.ErrNotFound) fell through to the Default branch and degraded to 500. This is a class of bugs, not specific to aipromptproposals; the same resource also had latent 409 (accept/reject "not completed") and 429 (create "rate limit") cases collapsing to 500.

The fix adds the closed set of bare-status requesthandler.Err* -> cerrors mappings (401/402/403/404/409/429/503/500), mirroring cerrors.HTTPStatusFor in reverse so a bare backend status round-trips back to the same client HTTP code. Typed VoipbinError envelopes still take precedence (step-1 errors.As passthrough is unchanged), and genuinely-unmatched errors still degrade to INTERNAL. Reason/message strings reuse the existing typed-sentinel cases verbatim. No backend or bin-common-handler changes.

Note: bare 404 is also emitted by ai-manager's no-handler-found default route, so an unmatched RPC route now surfaces to the client as 404 instead of 500 — an accepted, more-honest trade-off.

- bin-api-manager: Add bare-status requesthandler.Err* (401/402/403/404/409/429/503/500) -> cerrors mappings to translateToVoipbinError, fixing 500-instead-of-404 for nonexistent aipromptproposals IDs (#953)
- bin-api-manager: Document the intentional .Wrap(err) asymmetry (401/403/404 unwrapped; rest wrapped) mirroring the serviceerrors analogues
- bin-api-manager: Add translator unit table test (all 9 sentinels + HTTPStatusFor round-trip) and a wrapped-404 variant covering the production pkg/errors.Wrapf path
- bin-api-manager: Add edge-level gin HTTP round-trip test asserting a wrapped bare-404 surfaces as 404 NOT_FOUND