### PR TITLE
NOJIRA-Fix-email-list-customer-filter

### DIFF
--- a/bin-email-manager/go.sum
+++ b/bin-email-manager/go.sum
@@ -435,6 +435,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-email-manager/models/email/filters.go
+++ b/bin-email-manager/models/email/filters.go
@@ -10,6 +10,9 @@ import "github.com/gofrs/uuid"
 // JSON columns (source, destinations, attachments) and large free-text columns
 // (subject, content) are intentionally excluded — they are not equality-filter
 // targets.
+//
+// The `filter:` tags must stay in sync with the corresponding Field constants in
+// field.go (e.g. FieldCustomerID = "customer_id").
 type FieldStruct struct {
 	ID                  uuid.UUID    `filter:"id"`
 	CustomerID          uuid.UUID    `filter:"customer_id"`

--- a/bin-email-manager/models/email/filters.go
+++ b/bin-email-manager/models/email/filters.go
@@ -1,0 +1,21 @@
+package email
+
+import "github.com/gofrs/uuid"
+
+// FieldStruct defines the allowed filters for Email list queries.
+// Each field corresponds to a filterable database column. The `filter:` tag is
+// both the wire key sent by callers (api-manager) and the DB column name applied
+// by databasehandler.ApplyFields.
+//
+// JSON columns (source, destinations, attachments) and large free-text columns
+// (subject, content) are intentionally excluded — they are not equality-filter
+// targets.
+type FieldStruct struct {
+	ID                  uuid.UUID    `filter:"id"`
+	CustomerID          uuid.UUID    `filter:"customer_id"`
+	ActiveflowID        uuid.UUID    `filter:"activeflow_id"`
+	ProviderType        ProviderType `filter:"provider_type"`
+	ProviderReferenceID string       `filter:"provider_reference_id"`
+	Status              Status       `filter:"status"`
+	Deleted             bool         `filter:"deleted"`
+}

--- a/bin-email-manager/pkg/listenhandler/v1_emails.go
+++ b/bin-email-manager/pkg/listenhandler/v1_emails.go
@@ -3,19 +3,27 @@ package listenhandler
 import (
 	"context"
 	"encoding/json"
-	"monorepo/bin-common-handler/models/sock"
-	"monorepo/bin-email-manager/models/email"
-	"monorepo/bin-email-manager/pkg/listenhandler/models/request"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+	"monorepo/bin-email-manager/models/email"
+	"monorepo/bin-email-manager/pkg/listenhandler/models/request"
+
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // v1EmailsGet handles /v1/emails GET request
 func (h *listenHandler) v1EmailsGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "v1EmailsGet",
+		"request": m,
+	})
+
 	u, err := url.Parse(m.URI)
 	if err != nil {
 		return nil, err
@@ -26,11 +34,17 @@ func (h *listenHandler) v1EmailsGet(ctx context.Context, m *sock.Request) (*sock
 	pageSize := uint64(tmpSize)
 	pageToken := u.Query().Get(PageToken)
 
-	// parse the filters
-	urlFilters := h.utilHandler.URLParseFilters(u)
-	filters := make(map[email.Field]any)
-	for k, v := range urlFilters {
-		filters[email.Field(k)] = v
+	// parse the filters from the request body
+	tmpFilters, err := utilhandler.ParseFiltersFromRequestBody(m.Data)
+	if err != nil {
+		log.Errorf("Could not parse filters. err: %v", err)
+		return simpleResponse(400), nil
+	}
+
+	filters, err := utilhandler.ConvertFilters[email.FieldStruct, email.Field](email.FieldStruct{}, tmpFilters)
+	if err != nil {
+		log.Errorf("Could not convert filters. err: %v", err)
+		return simpleResponse(400), nil
 	}
 
 	tmp, err := h.emailHandler.List(ctx, pageToken, pageSize, filters)

--- a/bin-email-manager/pkg/listenhandler/v1_emails_test.go
+++ b/bin-email-manager/pkg/listenhandler/v1_emails_test.go
@@ -25,30 +25,22 @@ func Test_v1EmailsGet(t *testing.T) {
 		pageToken string
 		pageSize  uint64
 
-		responseFilters map[string]string
-		expectFilters   map[email.Field]any
-		responseEmails  []*email.Email
+		responseEmails []*email.Email
 
 		expectRes *sock.Response
 	}{
 		{
 			name: "1 item",
 			request: &sock.Request{
-				URI:    "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10&filter_customer_id=16d3fcf0-7f4c-11ec-a4c3-7bf43125108d&filter_deleted=false",
-				Method: sock.RequestMethodGet,
+				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"16d3fcf0-7f4c-11ec-a4c3-7bf43125108d","deleted":false}`),
 			},
 
 			pageToken: "2020-10-10T03:30:17.000000Z",
 			pageSize:  10,
 
-			responseFilters: map[string]string{
-				"customer_id": "16d3fcf0-7f4c-11ec-a4c3-7bf43125108d",
-				"deleted":     "false",
-			},
-			expectFilters: map[email.Field]any{
-				email.FieldCustomerID: "16d3fcf0-7f4c-11ec-a4c3-7bf43125108d",
-				email.FieldDeleted:    "false",
-			},
 			responseEmails: []*email.Email{
 				{
 					Identity: identity.Identity{
@@ -66,21 +58,15 @@ func Test_v1EmailsGet(t *testing.T) {
 		{
 			name: "2 items",
 			request: &sock.Request{
-				URI:    "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10&filter_customer_id=2457d824-7f4c-11ec-9489-b3552a7c9d63&filter_deleted=false",
-				Method: sock.RequestMethodGet,
+				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"2457d824-7f4c-11ec-9489-b3552a7c9d63","deleted":false}`),
 			},
 
 			pageToken: "2020-10-10T03:30:17.000000Z",
 			pageSize:  10,
 
-			responseFilters: map[string]string{
-				"customer_id": "2457d824-7f4c-11ec-9489-b3552a7c9d63",
-				"deleted":     "false",
-			},
-			expectFilters: map[email.Field]any{
-				email.FieldCustomerID: "2457d824-7f4c-11ec-9489-b3552a7c9d63",
-				email.FieldDeleted:    "false",
-			},
 			responseEmails: []*email.Email{
 				{
 					Identity: identity.Identity{
@@ -102,22 +88,15 @@ func Test_v1EmailsGet(t *testing.T) {
 		{
 			name: "empty",
 			request: &sock.Request{
-				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10&filter_customer_id=3ee14bee-7f4c-11ec-a1d8-a3a488ed5885&filter_deleted=false",
+				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
 				Method:   sock.RequestMethodGet,
 				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"3ee14bee-7f4c-11ec-a1d8-a3a488ed5885","deleted":false}`),
 			},
 
 			pageToken: "2020-10-10T03:30:17.000000Z",
 			pageSize:  10,
 
-			responseFilters: map[string]string{
-				"customer_id": "3ee14bee-7f4c-11ec-a1d8-a3a488ed5885",
-				"deleted":     "false",
-			},
-			expectFilters: map[email.Field]any{
-				email.FieldCustomerID: "3ee14bee-7f4c-11ec-a1d8-a3a488ed5885",
-				email.FieldDeleted:    "false",
-			},
 			responseEmails: []*email.Email{},
 			expectRes: &sock.Response{
 				StatusCode: 200,
@@ -143,7 +122,6 @@ func Test_v1EmailsGet(t *testing.T) {
 				emailHandler: mockEmail,
 			}
 
-			mockUtil.EXPECT().URLParseFilters(gomock.Any()).Return(tt.responseFilters)
 			mockEmail.EXPECT().List(gomock.Any(), tt.pageToken, tt.pageSize, gomock.Any()).Return(tt.responseEmails, nil)
 
 			res, err := h.processRequest(tt.request)
@@ -155,6 +133,38 @@ func Test_v1EmailsGet(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_v1EmailsGet_malformedBody(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockEmail := emailhandler.NewMockEmailHandler(mc)
+
+	h := &listenHandler{
+		utilHandler:  mockUtil,
+		sockHandler:  mockSock,
+		emailHandler: mockEmail,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+		Method:   sock.RequestMethodGet,
+		DataType: "application/json",
+		Data:     []byte(`{not-json`),
+	}
+
+	// emailHandler.List must NOT be called when the body cannot be parsed.
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != 400 {
+		t.Errorf("Wrong match. expect: 400, got: %d", res.StatusCode)
 	}
 }
 

--- a/bin-email-manager/pkg/listenhandler/v1_emails_test.go
+++ b/bin-email-manager/pkg/listenhandler/v1_emails_test.go
@@ -188,6 +188,40 @@ func Test_v1EmailsGet_malformedBody(t *testing.T) {
 	}
 }
 
+func Test_v1EmailsGet_invalidCustomerID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockEmail := emailhandler.NewMockEmailHandler(mc)
+
+	h := &listenHandler{
+		utilHandler:  mockUtil,
+		sockHandler:  mockSock,
+		emailHandler: mockEmail,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+		Method:   sock.RequestMethodGet,
+		DataType: "application/json",
+		Data:     []byte(`{"customer_id":"not-a-uuid"}`),
+	}
+
+	// A syntactically-valid body with an invalid customer_id must fail closed
+	// (400), never fall through to an unfiltered query. emailHandler.List must
+	// NOT be called (no EXPECT set, so gomock fails the test if it is).
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != 400 {
+		t.Errorf("Wrong match. expect: 400, got: %d", res.StatusCode)
+	}
+}
+
 func Test_v1EmailsPost(t *testing.T) {
 
 	tests := []struct {

--- a/bin-email-manager/pkg/listenhandler/v1_emails_test.go
+++ b/bin-email-manager/pkg/listenhandler/v1_emails_test.go
@@ -3,6 +3,7 @@ package listenhandler
 import (
 	commonaddress "monorepo/bin-common-handler/models/address"
 
+	"context"
 	"monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
@@ -25,6 +26,7 @@ func Test_v1EmailsGet(t *testing.T) {
 		pageToken string
 		pageSize  uint64
 
+		expectFilters  map[email.Field]any
 		responseEmails []*email.Email
 
 		expectRes *sock.Response
@@ -41,6 +43,10 @@ func Test_v1EmailsGet(t *testing.T) {
 			pageToken: "2020-10-10T03:30:17.000000Z",
 			pageSize:  10,
 
+			expectFilters: map[email.Field]any{
+				email.FieldCustomerID: uuid.FromStringOrNil("16d3fcf0-7f4c-11ec-a4c3-7bf43125108d"),
+				email.FieldDeleted:    false,
+			},
 			responseEmails: []*email.Email{
 				{
 					Identity: identity.Identity{
@@ -67,6 +73,10 @@ func Test_v1EmailsGet(t *testing.T) {
 			pageToken: "2020-10-10T03:30:17.000000Z",
 			pageSize:  10,
 
+			expectFilters: map[email.Field]any{
+				email.FieldCustomerID: uuid.FromStringOrNil("2457d824-7f4c-11ec-9489-b3552a7c9d63"),
+				email.FieldDeleted:    false,
+			},
 			responseEmails: []*email.Email{
 				{
 					Identity: identity.Identity{
@@ -97,6 +107,10 @@ func Test_v1EmailsGet(t *testing.T) {
 			pageToken: "2020-10-10T03:30:17.000000Z",
 			pageSize:  10,
 
+			expectFilters: map[email.Field]any{
+				email.FieldCustomerID: uuid.FromStringOrNil("3ee14bee-7f4c-11ec-a1d8-a3a488ed5885"),
+				email.FieldDeleted:    false,
+			},
 			responseEmails: []*email.Email{},
 			expectRes: &sock.Response{
 				StatusCode: 200,
@@ -122,7 +136,13 @@ func Test_v1EmailsGet(t *testing.T) {
 				emailHandler: mockEmail,
 			}
 
-			mockEmail.EXPECT().List(gomock.Any(), tt.pageToken, tt.pageSize, gomock.Any()).Return(tt.responseEmails, nil)
+			mockEmail.EXPECT().List(gomock.Any(), tt.pageToken, tt.pageSize, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ string, _ uint64, filters map[email.Field]any) ([]*email.Email, error) {
+					if !reflect.DeepEqual(filters, tt.expectFilters) {
+						t.Errorf("Wrong filters.\nexpect: %v\ngot: %v", tt.expectFilters, filters)
+					}
+					return tt.responseEmails, nil
+				})
 
 			res, err := h.processRequest(tt.request)
 			if err != nil {

--- a/docs/superpowers/plans/2026-06-02-email-list-customer-filter.md
+++ b/docs/superpowers/plans/2026-06-02-email-list-customer-filter.md
@@ -1,0 +1,400 @@
+# Fix cross-customer email leak in `GET /emails` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `GET /v1.0/emails` (list) return only the authenticated customer's emails by having `bin-email-manager` parse the `customer_id` filter from the RPC request body instead of (non-existent) URL query params.
+
+**Architecture:** Adopt the established repo filter pattern (ai-manager / call-manager). Add a typed `email.FieldStruct` whose `filter:` tags drive `utilhandler.ConvertFilters`, then rewrite `v1EmailsGet` to read filters from `m.Data` (request body) via `ParseFiltersFromRequestBody` + `ConvertFilters`. `ConvertFilters` re-types the JSON `customer_id` string into `uuid.UUID`, so `ApplyFields` emits the correct **binary** `WHERE customer_id = ?` clause. No api-manager or DB-schema changes.
+
+**Tech Stack:** Go, `go.uber.org/mock/gomock`, `github.com/gofrs/uuid`, `github.com/sirupsen/logrus`, squirrel (via `bin-common-handler/pkg/databasehandler.ApplyFields`), RabbitMQ RPC (`sock.Request`).
+
+**Spec:** `docs/superpowers/specs/2026-06-02-email-list-customer-filter-design.md`
+**Branch:** `NOJIRA-Fix-email-list-customer-filter` (worktree already created)
+**Working dir for all commands:** `~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter/bin-email-manager`
+
+---
+
+## File Structure
+
+- **Create:** `bin-email-manager/models/email/filters.go` — typed `FieldStruct` declaring the filterable email columns with `filter:` tags. Single responsibility: define the allowed list-filter surface. Mirrors `bin-ai-manager/models/ai/filters.go`.
+- **Modify:** `bin-email-manager/pkg/listenhandler/v1_emails.go` (`v1EmailsGet`, lines ~17-52) — read filters from the request body instead of URL query params; add a logrus logger and the `utilhandler` package import.
+- **Modify:** `bin-email-manager/pkg/listenhandler/v1_emails_test.go` (`Test_v1EmailsGet`, lines ~19-160) — drive filters through `m.Data`, drop the `URLParseFilters` mock expectation, add a malformed-body 400 case.
+
+No other endpoints are affected: `URLParseFilters` has exactly one production call site in email-manager (`v1_emails.go:30`).
+
+---
+
+## Task 1: Add `email.FieldStruct`
+
+**Files:**
+- Create: `bin-email-manager/models/email/filters.go`
+
+This is a declarative struct with no behavior of its own (exactly like `ai/filters.go`, which has no dedicated test). It is exercised end-to-end by the handler test in Task 2. We still verify it compiles and that the package builds.
+
+- [ ] **Step 1: Create the FieldStruct file**
+
+Create `bin-email-manager/models/email/filters.go` with this exact content:
+
+```go
+package email
+
+import "github.com/gofrs/uuid"
+
+// FieldStruct defines the allowed filters for Email list queries.
+// Each field corresponds to a filterable database column. The `filter:` tag is
+// both the wire key sent by callers (api-manager) and the DB column name applied
+// by databasehandler.ApplyFields.
+//
+// JSON columns (source, destinations, attachments) and large free-text columns
+// (subject, content) are intentionally excluded — they are not equality-filter
+// targets.
+type FieldStruct struct {
+	ID                  uuid.UUID    `filter:"id"`
+	CustomerID          uuid.UUID    `filter:"customer_id"`
+	ActiveflowID        uuid.UUID    `filter:"activeflow_id"`
+	ProviderType        ProviderType `filter:"provider_type"`
+	ProviderReferenceID string       `filter:"provider_reference_id"`
+	Status              Status       `filter:"status"`
+	Deleted             bool         `filter:"deleted"`
+}
+```
+
+Notes for the implementer:
+- `ProviderType` and `Status` are named string types already declared in `models/email/main.go`. They are used here for intent/documentation; `ConvertFilters` down-converts them to a plain `string` at runtime, which is correct because `provider_type`/`status` are plain (non-binary) columns.
+- `uuid` is referenced by three fields, so the import is used — no unused-import lint error.
+
+- [ ] **Step 2: Verify the package compiles**
+
+Run: `cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter/bin-email-manager && go build ./models/email/`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter
+git add bin-email-manager/models/email/filters.go
+git commit -m "NOJIRA-Fix-email-list-customer-filter
+
+- bin-email-manager: Add email.FieldStruct for typed list filters"
+```
+
+---
+
+## Task 2: Rewrite `v1EmailsGet` to read filters from the request body (TDD)
+
+**Files:**
+- Modify: `bin-email-manager/pkg/listenhandler/v1_emails.go`
+- Test: `bin-email-manager/pkg/listenhandler/v1_emails_test.go`
+
+The current handler calls `h.utilHandler.URLParseFilters(u)` and builds filters from URL `filter_*` query params. We change it to parse the request body. We update the test FIRST (red), then change the handler (green).
+
+- [ ] **Step 1: Rewrite the test to drive filters from the request body**
+
+Replace the entire `Test_v1EmailsGet` function in `bin-email-manager/pkg/listenhandler/v1_emails_test.go` with the following. Key changes vs. the original: filters now live in `request.Data` (JSON body); the URI keeps its `?...page_token=...&page_size=...` query string (required for routing to match `regV1EmailsGet = /v1/emails\?`); the `responseFilters`/`expectFilters`/`URLParseFilters` machinery is removed; a malformed-body case asserts a `400`.
+
+```go
+func Test_v1EmailsGet(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		request *sock.Request
+
+		pageToken string
+		pageSize  uint64
+
+		responseEmails []*email.Email
+
+		expectRes *sock.Response
+	}{
+		{
+			name: "1 item",
+			request: &sock.Request{
+				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"16d3fcf0-7f4c-11ec-a4c3-7bf43125108d","deleted":false}`),
+			},
+
+			pageToken: "2020-10-10T03:30:17.000000Z",
+			pageSize:  10,
+
+			responseEmails: []*email.Email{
+				{
+					Identity: identity.Identity{
+						ID:         uuid.FromStringOrNil("2a046c74-00c7-11f0-b07e-a385bcd60724"),
+						CustomerID: uuid.FromStringOrNil("16d3fcf0-7f4c-11ec-a4c3-7bf43125108d"),
+					},
+				},
+			},
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`[{"id":"2a046c74-00c7-11f0-b07e-a385bcd60724","customer_id":"16d3fcf0-7f4c-11ec-a4c3-7bf43125108d","activeflow_id":"00000000-0000-0000-0000-000000000000","provider_type":"","provider_reference_id":"","source":null,"destinations":null,"status":"","subject":"","content":"","attachments":null,"tm_create":null,"tm_update":null,"tm_delete":null}]`),
+			},
+		},
+		{
+			name: "2 items",
+			request: &sock.Request{
+				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"2457d824-7f4c-11ec-9489-b3552a7c9d63","deleted":false}`),
+			},
+
+			pageToken: "2020-10-10T03:30:17.000000Z",
+			pageSize:  10,
+
+			responseEmails: []*email.Email{
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("2a242316-00c7-11f0-96db-93d500b33431"),
+					},
+				},
+				{
+					Identity: identity.Identity{
+						ID: uuid.FromStringOrNil("2c2a494c-00c7-11f0-be49-8f6777e928d8"),
+					},
+				},
+			},
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`[{"id":"2a242316-00c7-11f0-96db-93d500b33431","customer_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","provider_type":"","provider_reference_id":"","source":null,"destinations":null,"status":"","subject":"","content":"","attachments":null,"tm_create":null,"tm_update":null,"tm_delete":null},{"id":"2c2a494c-00c7-11f0-be49-8f6777e928d8","customer_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","provider_type":"","provider_reference_id":"","source":null,"destinations":null,"status":"","subject":"","content":"","attachments":null,"tm_create":null,"tm_update":null,"tm_delete":null}]`),
+			},
+		},
+		{
+			name: "empty",
+			request: &sock.Request{
+				URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"3ee14bee-7f4c-11ec-a1d8-a3a488ed5885","deleted":false}`),
+			},
+
+			pageToken: "2020-10-10T03:30:17.000000Z",
+			pageSize:  10,
+
+			responseEmails: []*email.Email{},
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`[]`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockEmail := emailhandler.NewMockEmailHandler(mc)
+
+			h := &listenHandler{
+				utilHandler: mockUtil,
+				sockHandler: mockSock,
+
+				emailHandler: mockEmail,
+			}
+
+			mockEmail.EXPECT().List(gomock.Any(), tt.pageToken, tt.pageSize, gomock.Any()).Return(tt.responseEmails, nil)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_v1EmailsGet_malformedBody(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockEmail := emailhandler.NewMockEmailHandler(mc)
+
+	h := &listenHandler{
+		utilHandler:  mockUtil,
+		sockHandler:  mockSock,
+		emailHandler: mockEmail,
+	}
+
+	request := &sock.Request{
+		URI:      "/v1/emails?page_token=2020-10-10T03:30:17.000000Z&page_size=10",
+		Method:   sock.RequestMethodGet,
+		DataType: "application/json",
+		Data:     []byte(`{not-json`),
+	}
+
+	// emailHandler.List must NOT be called when the body cannot be parsed.
+	res, err := h.processRequest(request)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != 400 {
+		t.Errorf("Wrong match. expect: 400, got: %d", res.StatusCode)
+	}
+}
+```
+
+Note: `commonaddress` may become an unused import after this rewrite. If `goimports`/the compiler flags it, remove the `commonaddress "monorepo/bin-common-handler/models/address"` line from the test's import block. (Leave all other imports — `identity`, `sock`, `sockhandler`, `utilhandler`, `email`, `emailhandler`, `reflect`, `testing`, `uuid`, `gomock` — in place; they are all still used.)
+
+- [ ] **Step 2: Run the test to verify it fails (RED)**
+
+Run: `cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter/bin-email-manager && go test ./pkg/listenhandler/ -run Test_v1EmailsGet -v`
+Expected: FAIL. The current handler still calls `h.utilHandler.URLParseFilters(...)`, which is no longer mocked → gomock reports an unexpected call to `URLParseFilters` (and/or the malformed-body test fails because the current handler returns 200, not 400).
+
+- [ ] **Step 3: Rewrite the handler to parse filters from the body (GREEN)**
+
+In `bin-email-manager/pkg/listenhandler/v1_emails.go`, replace the import block and the `v1EmailsGet` function body.
+
+First, update the import block (top of file) to this:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+	"monorepo/bin-email-manager/models/email"
+	"monorepo/bin-email-manager/pkg/listenhandler/models/request"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+```
+
+(Removed `strings` — only used by the deleted URL-filter loop. Added `utilhandler` and `logrus`. Keep `uuid`, `errors`, `json`, `request` — they are used by other handlers in this file such as `v1EmailsPost`. If after the full edit the compiler reports `strings` or any other import as unused, remove that line; if it reports `uuid`/`errors`/`request` as unused, that means another handler in the file was changed unexpectedly — do not remove them.)
+
+Then replace the `v1EmailsGet` function (currently lines ~16-52) with:
+
+```go
+// v1EmailsGet handles /v1/emails GET request
+func (h *listenHandler) v1EmailsGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "v1EmailsGet",
+		"request": m,
+	})
+
+	u, err := url.Parse(m.URI)
+	if err != nil {
+		return nil, err
+	}
+
+	// parse the pagination params
+	tmpSize, _ := strconv.Atoi(u.Query().Get(PageSize))
+	pageSize := uint64(tmpSize)
+	pageToken := u.Query().Get(PageToken)
+
+	// parse the filters from the request body
+	tmpFilters, err := utilhandler.ParseFiltersFromRequestBody(m.Data)
+	if err != nil {
+		log.Errorf("Could not parse filters. err: %v", err)
+		return simpleResponse(400), nil
+	}
+
+	filters, err := utilhandler.ConvertFilters[email.FieldStruct, email.Field](email.FieldStruct{}, tmpFilters)
+	if err != nil {
+		log.Errorf("Could not convert filters. err: %v", err)
+		return simpleResponse(400), nil
+	}
+
+	tmp, err := h.emailHandler.List(ctx, pageToken, pageSize, filters)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get emails")
+	}
+
+	data, err := json.Marshal(tmp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not marshal the res")
+	}
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes (GREEN)**
+
+Run: `cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter/bin-email-manager && go test ./pkg/listenhandler/ -run Test_v1EmailsGet -v`
+Expected: PASS for `Test_v1EmailsGet` (all three subtests) and `Test_v1EmailsGet_malformedBody`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter
+git add bin-email-manager/pkg/listenhandler/v1_emails.go bin-email-manager/pkg/listenhandler/v1_emails_test.go
+git commit -m "NOJIRA-Fix-email-list-customer-filter
+
+- bin-email-manager: Parse GET /emails list filters from request body so customer_id is enforced (fixes cross-customer leak, issue #956)"
+```
+
+---
+
+## Task 3: Full verification workflow
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the mandatory verification workflow**
+
+Run, from the service directory:
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter/bin-email-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+Expected: all five steps succeed; `go test ./...` passes; `golangci-lint` reports no issues. `go generate ./...` regenerates mocks — `URLParseFilters` stays on the `UtilHandler` interface (other handlers/services still use it), so no mock churn is expected for this change.
+
+- [ ] **Step 2: Commit any go.mod/go.sum/generated changes (if produced)**
+
+If `go mod tidy` or `go generate` changed tracked files (e.g. `go.mod`, `go.sum`, regenerated mocks — NOT `vendor/`, which is gitignored):
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-email-list-customer-filter
+git add -A -- ':!bin-email-manager/vendor'
+git status --short
+git commit -m "NOJIRA-Fix-email-list-customer-filter
+
+- bin-email-manager: Sync go.mod/go.sum and generated files after filter change"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Post-implementation (handled outside this plan)
+
+- **api-validator regression:** `test_get_email_if_exists` should pass once deployed — every listed ID is now owned by the caller, so the follow-up single GET returns 200. Add/confirm api-validator coverage per repo workflow.
+- **PR:** Per repo rules, fetch latest `main`, check for conflicts, then open a PR titled `NOJIRA-Fix-email-list-customer-filter`. Do NOT merge without explicit user authorization.
+
+---
+
+## Acceptance Criteria (from spec)
+
+1. `GET /v1.0/emails` returns only records whose `customer_id` matches the authenticated customer.
+2. Every ID returned by the list endpoint returns `200` (not `403`) on `GET /v1.0/emails/{id}` for the same credential.
+3. `test_get_email_if_exists` passes in api-validator.
+4. Full `bin-email-manager` verification workflow passes (tidy, vendor, generate, test, lint).

--- a/docs/superpowers/specs/2026-06-02-email-list-customer-filter-design.md
+++ b/docs/superpowers/specs/2026-06-02-email-list-customer-filter-design.md
@@ -1,0 +1,213 @@
+# Fix cross-customer email leak in `GET /emails`
+
+- **Date:** 2026-06-02
+- **Issue:** [#956](https://github.com/voipbin/monorepo/issues/956)
+- **Branch:** `NOJIRA-Fix-email-list-customer-filter`
+- **Status:** Approved design
+
+## Problem
+
+`GET /v1.0/emails` (list) returns email records belonging to customers other than
+the authenticated account. When one of those leaked IDs is then used in
+`GET /v1.0/emails/{id}`, the single-item endpoint correctly returns
+`403 PERMISSION_DENIED`. This is a data-isolation violation and causes the
+api-validator CI test `test_get_email_if_exists` to fail on every run.
+
+## Root cause
+
+The bug is isolated to a single handler:
+`bin-email-manager/pkg/listenhandler/v1_emails.go` → `v1EmailsGet` (line 30).
+
+End-to-end flow today:
+
+1. **api-manager** (`bin-api-manager/pkg/servicehandler/email.go:77`) correctly builds
+   filters `{customer_id: <auth customer>, deleted: false}`, type-converts them via
+   `convertEmailFilters` → `ConvertMapToTypedMap`, and passes them to the request handler.
+2. **request handler** (`bin-common-handler/pkg/requesthandler/email_emails.go:20`)
+   marshals the filters to JSON and sends them in the **request body** of the RPC.
+   The URI carries only `page_token` and `page_size`.
+3. **email-manager** (`v1EmailsGet`) ignores the request body and instead reads filters
+   from **URL query params** via `utilHandler.URLParseFilters(u)`. Because the filters
+   were never in the URL, the resulting filter map is empty.
+4. **dbhandler** (`bin-email-manager/pkg/dbhandler/emails.go:154` `EmailList`) calls
+   `ApplyFields` with the empty map → no `WHERE customer_id` clause → the query returns
+   **every customer's emails**.
+
+The single-item `GET /emails/{id}` is unaffected because api-manager performs an explicit
+ownership check (`hasPermission`) on the returned record, which is the source of the 403.
+
+### Secondary subtlety: binary `customer_id`
+
+`customer_id` (and `id`) are stored as **binary** in the database (see
+`emails.go` using `id.Bytes()` in WHERE clauses). A naive "parse the body as
+`map[string]any`" fix would deliver `customer_id` as a plain string, and
+`ApplyFields`' string branch would emit `WHERE customer_id = '<uuid-string>'`,
+which matches **no** binary rows — turning a data leak into a silently-empty list.
+
+The established repo pattern (ai-manager, call-manager, etc.) solves both parsing
+and typing at once with a typed `FieldStruct` whose fields carry `filter:` tags,
+fed through `utilhandler.ConvertFilters`. `ConvertFilters` re-types the raw JSON
+value (string → `uuid.UUID`), so `ApplyFields` emits the correct **binary** WHERE.
+The `email` model never adopted this pattern because it has only
+`type Field string` and **no `FieldStruct`**.
+
+## Convention check
+
+Inspected the api-manager list handlers for `call`, `message`, `conference`, and
+`agent`. **None** of them re-filter the RPC result by `customer_id`; they all rely
+solely on the manager-level `customer_id` filter as the single enforcement boundary.
+`email.go`'s `EmailList` already follows this exact pattern correctly — the only
+break is the email-manager side discarding the filter. Therefore the fix stays
+entirely within email-manager, and **no api-manager defense-in-depth re-filter** is
+added (it would be inconsistent with every other resource).
+
+## Design
+
+All changes are in `bin-email-manager`.
+
+### 1. New file: `models/email/filters.go`
+
+Add a typed `FieldStruct` covering the sensibly-filterable columns, mirroring
+`bin-ai-manager/models/ai/filters.go`. JSON columns (`source`, `destinations`,
+`attachments`) and large text columns (`subject`, `content`) are intentionally
+excluded — they are not equality-filter targets. The model's named types
+(`ProviderType`, `Status`) are used directly, exactly as `ai/filters.go` uses its
+own named enum types.
+
+```go
+package email
+
+import "github.com/gofrs/uuid"
+
+// FieldStruct defines the filterable fields for Email list queries.
+// The `filter:` tag is the wire key sent by callers (api-manager) and the
+// DB column name applied by ApplyFields.
+type FieldStruct struct {
+	ID                  uuid.UUID    `filter:"id"`
+	CustomerID          uuid.UUID    `filter:"customer_id"`
+	ActiveflowID        uuid.UUID    `filter:"activeflow_id"`
+	ProviderType        ProviderType `filter:"provider_type"`
+	ProviderReferenceID string       `filter:"provider_reference_id"`
+	Status              Status       `filter:"status"`
+	Deleted             bool         `filter:"deleted"`
+}
+```
+
+### 2. `pkg/listenhandler/v1_emails.go` → `v1EmailsGet`
+
+Replace the URL-filter block with the body-parse + type-convert pattern used by
+call-manager (`bin-call-manager/pkg/listenhandler/v1_calls.go:44`):
+
+```go
+// parse the filters from the request body
+tmpFilters, err := utilhandler.ParseFiltersFromRequestBody(m.Data)
+if err != nil {
+	log.Errorf("Could not parse filters. err: %v", err)
+	return simpleResponse(400), nil
+}
+
+filters, err := utilhandler.ConvertFilters[email.FieldStruct, email.Field](email.FieldStruct{}, tmpFilters)
+if err != nil {
+	log.Errorf("Could not convert filters. err: %v", err)
+	return simpleResponse(400), nil
+}
+```
+
+Remove the now-dead `URLParseFilters(u)` block and the manual
+`map[email.Field]any` construction loop.
+
+**Implementation notes (verified against current code):**
+
+- **Logger must be declared — it is NOT currently in scope.** Unlike call-manager's
+  `processV1CallsGet`, the current `v1EmailsGet` has no `log` variable. The snippet
+  above assumes one. Add a logger at the top of the handler, matching call-manager:
+  ```go
+  log := logrus.WithFields(logrus.Fields{"func": "v1EmailsGet", "request": m})
+  ```
+  (Add the `github.com/sirupsen/logrus` import.) If a different error/logging
+  convention is already established elsewhere in email-manager's listenhandler, match
+  that instead — but the handler currently logs nothing, so introducing the
+  call-manager-style logger is the expected outcome.
+- **`ParseFiltersFromRequestBody` and `ConvertFilters` are package-level functions**
+  on `bin-common-handler/pkg/utilhandler`, not methods on the `h.utilHandler` interface
+  field. Add `import "monorepo/bin-common-handler/pkg/utilhandler"` to `v1_emails.go`
+  (it is currently imported only in the package's `main.go`). Do not look for an
+  interface method.
+- **`simpleResponse` already exists** in the package (`listenhandler/main.go:77`) — no
+  new helper needed.
+- **`url` import stays** (pagination still parses the URI); drop `strings` only if it
+  becomes unreferenced after removing the URL-filter loop.
+- **Named-type precision:** `ProviderType` and `Status` are declared in `FieldStruct`
+  for intent/documentation, but `ConvertFilters` down-converts named string types to a
+  plain Go `string` at runtime. That is harmless — `ApplyFields` handles the string via
+  its `case string:` branch and `status`/`provider_type` are plain (non-binary) columns.
+  Do not expect a typed `email.Status` value to reach `ApplyFields`.
+
+### Data flow after the fix
+
+```
+api-manager sets {customer_id, deleted}
+  → marshalled into RPC request body
+  → email-manager ParseFiltersFromRequestBody  (map[string]any)
+  → ConvertFilters[FieldStruct, Field]          (customer_id string → uuid.UUID, deleted → bool)
+  → emailHandler.List(filters)
+  → dbhandler.EmailList → ApplyFields
+  → WHERE customer_id = <binary> AND tm_delete IS NULL
+```
+
+## Error handling
+
+- Malformed JSON body → `400` (matches call-manager).
+- Empty body → `ParseFiltersFromRequestBody` returns an empty map → no filters
+  applied. In practice api-manager always sends `customer_id`, so an unfiltered list
+  is only reachable by direct/internal RPC callers — identical to the behavior of
+  every other manager and therefore acceptable.
+- Unknown filter keys in the body are ignored by `ConvertFilters` (it iterates the
+  `FieldStruct` fields, not the incoming map), so unexpected keys cannot inject
+  arbitrary WHERE clauses.
+
+## Testing
+
+### Unit — `pkg/listenhandler/v1_emails_test.go`
+- Remove the `mockUtil.EXPECT().URLParseFilters(...)` expectation (no longer called).
+- **Keep the `?`-query URI form on each test request.** Routing matches
+  `regV1EmailsGet = /v1/emails\?...` (`main.go:46`), so the request URI must still
+  carry `?page_token=...&page_size=...` for `processRequest` to reach `v1EmailsGet`.
+  Only the *filters* move to `m.Data`; pagination stays in the URI.
+- Drive filters through `m.Data` (request body) instead. Add/adjust cases:
+  - body `{"customer_id":"<uuid>"}` → `emailHandler.List` receives a map whose
+    `customer_id` value is a `uuid.UUID` (not a string).
+  - body `{"customer_id":"<uuid>","deleted":false}` → both filters present and typed.
+  - malformed body (e.g. `[`) → handler returns `400`, `List` not called.
+  - empty body → `List` called with an empty filter map.
+
+### Unit — `pkg/dbhandler/emails_test.go`
+- Confirm (or add) a case asserting `EmailList` with a `customer_id` filter emits a
+  binary-bound `WHERE customer_id = ?` (the `.Bytes()` form). Likely already covered
+  by `ApplyFields`; verify rather than duplicate.
+
+### Regression — api-validator
+- `test_get_email_if_exists` (the failing test in the issue) goes green: every listed
+  ID is now owned by the caller, so the follow-up single GET returns `200`.
+
+### Verification workflow (before commit, in `bin-email-manager`)
+```
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+## Out of scope
+
+- No api-manager changes (its filter logic is already correct).
+- No DB migration (all referenced columns already exist).
+- No other endpoints — only `v1EmailsGet` exhibited the bug (`URLParseFilters` has a
+  single production call site in email-manager).
+
+## Acceptance criteria
+
+1. `GET /v1.0/emails` returns only records whose `customer_id` matches the
+   authenticated customer.
+2. Every ID returned by the list endpoint returns `200` (not `403`) on
+   `GET /v1.0/emails/{id}` for the same credential.
+3. `test_get_email_if_exists` passes in api-validator.
+4. Full `bin-email-manager` verification workflow passes (tidy, vendor, generate,
+   test, lint).


### PR DESCRIPTION
Fix a cross-customer data-isolation leak in GET /emails. The list endpoint returned email records belonging to other customers because bin-email-manager's list handler read filters from URL query params, while bin-api-manager sends the customer_id filter in the RPC request body. The filter was silently dropped, so the query ran unfiltered. This closes issue #956 and the api-validator test_get_email_if_exists failure.

- bin-email-manager: Add email.FieldStruct typed filter allow-list for list queries (models/email/filters.go)
- bin-email-manager: Rewrite v1EmailsGet to parse list filters from the request body via ParseFiltersFromRequestBody + ConvertFilters, so customer_id is re-typed to uuid.UUID and applied as a binary WHERE clause (matches the call-manager/ai-manager pattern)
- bin-email-manager: Update v1_emails_test.go to drive filters through the request body, assert the typed customer_id/deleted filters reach emailHandler.List, and cover the malformed-body 400 path
- bin-email-manager: Refresh go.sum after go mod tidy