### PR TITLE
NOJIRA-Fix-listenhandler-error-mapping

### DIFF
--- a/bin-call-manager/pkg/listenhandler/v1_groupcalls.go
+++ b/bin-call-manager/pkg/listenhandler/v1_groupcalls.go
@@ -52,7 +52,7 @@ func (h *listenHandler) processV1GroupcallsGet(ctx context.Context, m *sock.Requ
 	tmp, err := h.groupcallHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get recordings. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -105,7 +105,7 @@ func (h *listenHandler) processV1GroupcallsPost(ctx context.Context, m *sock.Req
 	)
 	if err != nil {
 		log.Debugf("Could not create a outgoing call. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -141,7 +141,7 @@ func (h *listenHandler) processV1GroupcallsIDGet(ctx context.Context, m *sock.Re
 	tmp, err := h.groupcallHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get groupcall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -177,7 +177,7 @@ func (h *listenHandler) processV1GroupcallsIDDelete(ctx context.Context, m *sock
 	tmp, err := h.groupcallHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get groupcall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -213,7 +213,7 @@ func (h *listenHandler) processV1GroupcallsIDHangupPost(ctx context.Context, m *
 	tmp, err := h.groupcallHandler.Hangingup(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get groupcall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -255,7 +255,7 @@ func (h *listenHandler) processV1GroupcallsIDAnswerGroupcallIDPost(ctx context.C
 	tmp, err := h.groupcallHandler.AnswerGroupcall(ctx, id, req.AnswerGroupcallID)
 	if err != nil {
 		log.Errorf("Could not get groupcall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -291,7 +291,7 @@ func (h *listenHandler) processV1GroupcallsIDHangupGroupcallPost(ctx context.Con
 	tmp, err := h.groupcallHandler.HangupGroupcall(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get groupcall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -327,7 +327,7 @@ func (h *listenHandler) processV1GroupcallsIDHangupCallPost(ctx context.Context,
 	tmp, err := h.groupcallHandler.HangupCall(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get groupcall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go
@@ -14,6 +14,7 @@ import (
 
 	"monorepo/bin-call-manager/models/groupcall"
 	"monorepo/bin-call-manager/pkg/callhandler"
+	"monorepo/bin-call-manager/pkg/dbhandler"
 	"monorepo/bin-call-manager/pkg/externalmediahandler"
 	"monorepo/bin-call-manager/pkg/groupcallhandler"
 )
@@ -560,6 +561,74 @@ func Test_processV1GroupcallsIDHangupCallPost(t *testing.T) {
 
 			if reflect.DeepEqual(res, tt.expectRes) != true {
 				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_processV1GroupcallsID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+		setup   func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID)
+	}{
+		{
+			name: "GET non-existent groupcall returns 404",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID) {
+				m.EXPECT().Get(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "DELETE non-existent groupcall returns 404",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID) {
+				m.EXPECT().Delete(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "POST hangup non-existent groupcall returns 404",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099/hangup",
+				Method: sock.RequestMethodPost,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID) {
+				m.EXPECT().Hangingup(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockGroupcall := groupcallhandler.NewMockGroupcallHandler(mc)
+			h := &listenHandler{
+				sockHandler:      mockSock,
+				callHandler:      mockCall,
+				groupcallHandler: mockGroupcall,
+			}
+			tt.setup(mockGroupcall, tt.id)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
 		})
 	}

--- a/bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go
@@ -615,6 +615,9 @@ func Test_processV1GroupcallsID_notFoundTyped(t *testing.T) {
 			if res.StatusCode != 404 {
 				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
+			if res.DataType != cerrors.DataTypeVoipbinError {
+				t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, res.DataType)
+			}
 		})
 	}
 }

--- a/bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go
@@ -4,8 +4,10 @@ import (
 	reflect "reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -561,6 +563,57 @@ func Test_processV1GroupcallsIDHangupCallPost(t *testing.T) {
 
 			if reflect.DeepEqual(res, tt.expectRes) != true {
 				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+// Test_processV1GroupcallsID_notFoundTyped verifies that the typed
+// *cerrors.VoipbinError (NotFound) returned by the real groupcallHandler.Get
+// is correctly translated to HTTP 404 via the errors.As → cerrors.ToResponse branch
+// in errorResponse.
+func Test_processV1GroupcallsID_notFoundTyped(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent groupcall returns 404 via typed cerrors.NotFound",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockGroupcall := groupcallhandler.NewMockGroupcallHandler(mc)
+			h := &listenHandler{
+				sockHandler:      mockSock,
+				callHandler:      mockCall,
+				groupcallHandler: mockGroupcall,
+			}
+
+			mockGroupcall.EXPECT().Get(gomock.Any(), tt.id).Return(nil, cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"GROUPCALL_NOT_FOUND",
+				"The group call was not found.",
+			))
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
 		})
 	}

--- a/bin-conversation-manager/pkg/listenhandler/v1_conversations.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_conversations.go
@@ -67,7 +67,7 @@ func (h *listenHandler) processV1ConversationsGet(ctx context.Context, m *sock.R
 	tmps, err := h.conversationHandler.List(ctx, pageToken, pageSize, fields)
 	if err != nil {
 		log.Debugf("Could not get conversations. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmps)
@@ -111,7 +111,7 @@ func (h *listenHandler) processV1ConversationsPost(ctx context.Context, m *sock.
 	)
 	if err != nil {
 		log.Errorf("Could not create the account. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -147,7 +147,7 @@ func (h *listenHandler) processV1ConversationsIDGet(ctx context.Context, req *so
 	tmp, err := h.conversationHandler.Get(ctx, id)
 	if err != nil {
 		log.Debugf("Could not get a conversation. conversation_id: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go
@@ -18,6 +18,7 @@ import (
 	"monorepo/bin-conversation-manager/models/conversation"
 	"monorepo/bin-conversation-manager/pkg/accounthandler"
 	"monorepo/bin-conversation-manager/pkg/conversationhandler"
+	"monorepo/bin-conversation-manager/pkg/dbhandler"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -415,6 +416,47 @@ func Test_processV1ConversationsIDPut(t *testing.T) {
 
 			if reflect.DeepEqual(tt.expectRes, res) != true {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_processV1ConversationsID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent conversation returns 404",
+			request: &sock.Request{
+				URI:    "/v1/conversations/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockConversation := conversationhandler.NewMockConversationHandler(mc)
+			h := &listenHandler{
+				sockHandler:         mockSock,
+				conversationHandler: mockConversation,
+			}
+
+			mockConversation.EXPECT().Get(gomock.Any(), tt.id).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
 		})
 	}

--- a/bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go
@@ -507,6 +507,9 @@ func Test_processV1ConversationsID_notFoundTyped(t *testing.T) {
 			if res.StatusCode != 404 {
 				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
+			if res.DataType != cerrors.DataTypeVoipbinError {
+				t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, res.DataType)
+			}
 		})
 	}
 }

--- a/bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go
@@ -462,6 +462,55 @@ func Test_processV1ConversationsID_notFound(t *testing.T) {
 	}
 }
 
+// Test_processV1ConversationsID_notFoundTyped verifies that the typed
+// *cerrors.VoipbinError (NotFound) returned by the real conversationHandler.Get
+// is correctly translated to HTTP 404 via the errors.As → cerrors.ToResponse branch
+// in errorResponse.
+func Test_processV1ConversationsID_notFoundTyped(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent conversation returns 404 via typed cerrors.NotFound",
+			request: &sock.Request{
+				URI:    "/v1/conversations/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockConversation := conversationhandler.NewMockConversationHandler(mc)
+			h := &listenHandler{
+				sockHandler:         mockSock,
+				conversationHandler: mockConversation,
+			}
+
+			mockConversation.EXPECT().Get(gomock.Any(), tt.id).Return(nil, cerrors.NotFound(
+				commonoutline.ServiceNameConversationManager,
+				"CONVERSATION_NOT_FOUND",
+				"The conversation was not found.",
+			))
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
 // Test_processV1ConversationsIDPut_ErrorPassthrough verifies that errors
 // returned from conversationHandler.Update flow through errorResponse so the
 // api-manager edge sees the right HTTP status (design §5.4):

--- a/bin-message-manager/go.sum
+++ b/bin-message-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-message-manager/pkg/listenhandler/messages.go
+++ b/bin-message-manager/pkg/listenhandler/messages.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1MessagesGet(ctx context.Context, m *sock.Reques
 	messages, err := h.messageHandler.List(ctx, pageToken, pageSize, filters)
 	if err != nil {
 		log.Debugf("Could not get messages. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(messages)
@@ -86,7 +86,7 @@ func (h *listenHandler) processV1MessagesPost(ctx context.Context, m *sock.Reque
 	ms, err := h.messageHandler.Send(ctx, req.ID, req.CustomerID, req.Source, req.Destinations, req.Text)
 	if err != nil {
 		log.Errorf("Could not send a message. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(ms)
@@ -121,7 +121,7 @@ func (h *listenHandler) processV1MessagesIDGet(ctx context.Context, m *sock.Requ
 	tmp, err := h.messageHandler.Get(ctx, id)
 	if err != nil {
 		log.Debugf("Could not get a message. message_id: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -156,7 +156,7 @@ func (h *listenHandler) processV1MessagesIDDelete(ctx context.Context, m *sock.R
 	tmp, err := h.messageHandler.Delete(ctx, id)
 	if err != nil {
 		log.Debugf("Could not get a message. message_id: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-message-manager/pkg/listenhandler/messages_test.go
+++ b/bin-message-manager/pkg/listenhandler/messages_test.go
@@ -360,6 +360,9 @@ func Test_processV1MessagesID_notFoundTyped(t *testing.T) {
 			if res.StatusCode != 404 {
 				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
+			if res.DataType != cerrors.DataTypeVoipbinError {
+				t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, res.DataType)
+			}
 		})
 	}
 }

--- a/bin-message-manager/pkg/listenhandler/messages_test.go
+++ b/bin-message-manager/pkg/listenhandler/messages_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-message-manager/models/message"
+	"monorepo/bin-message-manager/pkg/dbhandler"
 	"monorepo/bin-message-manager/pkg/messagehandler"
 )
 
@@ -308,6 +309,61 @@ func Test_processV1MessagesIDDelete(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.response, res)
 			}
 
+		})
+	}
+}
+
+func Test_processV1MessagesID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+		setup   func(m *messagehandler.MockMessageHandler, id uuid.UUID)
+	}{
+		{
+			name: "GET non-existent message returns 404",
+			request: &sock.Request{
+				URI:    "/v1/messages/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *messagehandler.MockMessageHandler, id uuid.UUID) {
+				m.EXPECT().Get(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "DELETE non-existent message returns 404",
+			request: &sock.Request{
+				URI:    "/v1/messages/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *messagehandler.MockMessageHandler, id uuid.UUID) {
+				m.EXPECT().Delete(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+			h := &listenHandler{
+				sockHandler:    mockSock,
+				messageHandler: mockMessage,
+			}
+			tt.setup(mockMessage, tt.id)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
 		})
 	}
 }

--- a/bin-message-manager/pkg/listenhandler/messages_test.go
+++ b/bin-message-manager/pkg/listenhandler/messages_test.go
@@ -4,8 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -309,6 +311,55 @@ func Test_processV1MessagesIDDelete(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.response, res)
 			}
 
+		})
+	}
+}
+
+// Test_processV1MessagesID_notFoundTyped verifies that the typed
+// *cerrors.VoipbinError (NotFound) returned by the real messageHandler.Get
+// is correctly translated to HTTP 404 via the errors.As → cerrors.ToResponse branch
+// in errorResponse.
+func Test_processV1MessagesID_notFoundTyped(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent message returns 404 via typed cerrors.NotFound",
+			request: &sock.Request{
+				URI:    "/v1/messages/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+			h := &listenHandler{
+				sockHandler:    mockSock,
+				messageHandler: mockMessage,
+			}
+
+			mockMessage.EXPECT().Get(gomock.Any(), tt.id).Return(nil, cerrors.NotFound(
+				commonoutline.ServiceNameMessageManager,
+				"MESSAGE_NOT_FOUND",
+				"The message was not found.",
+			))
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
 		})
 	}
 }

--- a/bin-number-manager/go.sum
+++ b/bin-number-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-number-manager/pkg/listenhandler/v1_numbers.go
+++ b/bin-number-manager/pkg/listenhandler/v1_numbers.go
@@ -41,7 +41,7 @@ func (h *listenHandler) processV1NumbersPost(ctx context.Context, m *sock.Reques
 	}
 	if err != nil {
 		log.Errorf("Could not handle the order number. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(numb)
@@ -77,7 +77,7 @@ func (h *listenHandler) processV1NumbersIDDelete(ctx context.Context, m *sock.Re
 	number, err := h.numberHandler.Delete(ctx, id)
 	if err != nil {
 		log.Debugf("Could not delete the number. number: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(number)
@@ -113,7 +113,7 @@ func (h *listenHandler) processV1NumbersIDGet(ctx context.Context, m *sock.Reque
 	number, err := h.numberHandler.Get(ctx, id)
 	if err != nil {
 		log.Debugf("Could not get a number. number: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(number)
@@ -162,7 +162,7 @@ func (h *listenHandler) processV1NumbersIDPut(ctx context.Context, m *sock.Reque
 	num, err := h.numberHandler.Update(ctx, id, fields)
 	if err != nil {
 		log.Debugf("Could not update the number. number: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(num)
@@ -214,7 +214,7 @@ func (h *listenHandler) processV1NumbersGet(ctx context.Context, m *sock.Request
 	numbers, err := h.numberHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Debugf("Could not get numbers. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(numbers)
@@ -261,7 +261,7 @@ func (h *listenHandler) processV1NumbersIDFlowIDsPut(ctx context.Context, m *soc
 	num, err := h.numberHandler.Update(ctx, id, fields)
 	if err != nil {
 		log.Debugf("Could not update the number's flow_id. number_id: %s, err: %v", id, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(num)
@@ -295,7 +295,7 @@ func (h *listenHandler) processV1NumbersRenewPost(ctx context.Context, m *sock.R
 	numb, err := h.numberHandler.RenewNumbers(ctx, req.Days, req.Hours, req.TMRenew)
 	if err != nil {
 		log.Errorf("Could not handle the order number. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(numb)

--- a/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
+++ b/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
@@ -986,6 +986,9 @@ func Test_processV1NumbersID_notFoundTyped(t *testing.T) {
 			if res.StatusCode != 404 {
 				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
 			}
+			if res.DataType != cerrors.DataTypeVoipbinError {
+				t.Errorf("DataType mismatch. expected: %s, got: %s", cerrors.DataTypeVoipbinError, res.DataType)
+			}
 		})
 	}
 }

--- a/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
+++ b/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-number-manager/models/number"
+	"monorepo/bin-number-manager/pkg/dbhandler"
 	"monorepo/bin-number-manager/pkg/numberhandler"
 )
 
@@ -935,5 +936,60 @@ func Test_processV1NumbersIDMetadataPut_handlerError(t *testing.T) {
 	}
 	if res.StatusCode != 400 {
 		t.Errorf("Expected status 400, got %d", res.StatusCode)
+	}
+}
+
+func Test_processV1NumbersID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+		setup   func(m *numberhandler.MockNumberHandler, id uuid.UUID)
+	}{
+		{
+			name: "GET non-existent number returns 404",
+			request: &sock.Request{
+				URI:    "/v1/numbers/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *numberhandler.MockNumberHandler, id uuid.UUID) {
+				m.EXPECT().Get(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "DELETE non-existent number returns 404",
+			request: &sock.Request{
+				URI:    "/v1/numbers/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *numberhandler.MockNumberHandler, id uuid.UUID) {
+				m.EXPECT().Delete(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockNumber := numberhandler.NewMockNumberHandler(mc)
+			h := &listenHandler{
+				sockHandler:   mockSock,
+				numberHandler: mockNumber,
+			}
+			tt.setup(mockNumber, tt.id)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
 	}
 }

--- a/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
+++ b/bin-number-manager/pkg/listenhandler/v1_numbers_test.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -936,6 +938,55 @@ func Test_processV1NumbersIDMetadataPut_handlerError(t *testing.T) {
 	}
 	if res.StatusCode != 400 {
 		t.Errorf("Expected status 400, got %d", res.StatusCode)
+	}
+}
+
+// Test_processV1NumbersID_notFoundTyped verifies that the typed
+// *cerrors.VoipbinError (NotFound) returned by the real numberHandler.Get
+// is correctly translated to HTTP 404 via the errors.As → cerrors.ToResponse branch
+// in errorResponse.
+func Test_processV1NumbersID_notFoundTyped(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent number returns 404 via typed cerrors.NotFound",
+			request: &sock.Request{
+				URI:    "/v1/numbers/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockNumber := numberhandler.NewMockNumberHandler(mc)
+			h := &listenHandler{
+				sockHandler:   mockSock,
+				numberHandler: mockNumber,
+			}
+
+			mockNumber.EXPECT().Get(gomock.Any(), tt.id).Return(nil, cerrors.NotFound(
+				commonoutline.ServiceNameNumberManager,
+				"NUMBER_NOT_FOUND",
+				"The phone number was not found.",
+			))
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
 	}
 }
 

--- a/docs/conventions/listenhandler-error-mapping.md
+++ b/docs/conventions/listenhandler-error-mapping.md
@@ -1,0 +1,44 @@
+# Listenhandler Error Mapping
+
+> Backend `bin-*-manager` services map errors to RPC `sock.Response` status codes
+> in their `pkg/listenhandler`. This is the canonical convention. Reference
+> implementation: `bin-flow-manager/pkg/listenhandler`.
+
+## Rule
+
+Every endpoint function maps a **handler-call error** at the call site with the
+shared `errorResponse` helper:
+
+```go
+tmp, err := h.xHandler.Method(ctx, ...)
+if err != nil {
+    return errorResponse(err), nil
+}
+```
+
+`errorResponse(err)` maps:
+- `*cerrors.VoipbinError` → its true HTTP status (via `cerrors.ToResponse`)
+- `dbhandler.ErrNotFound` (matched through `errors.Wrap`/`%w`) → `404`
+- anything else → `500`
+
+Keep these **local** (do not route through `errorResponse`):
+- request URI/`json.Unmarshal` parse failures → `simpleResponse(400)`
+- response `json.Marshal` failures → `simpleResponse(500)`
+
+## Do NOT
+
+- Do **not** swallow handler errors with `return simpleResponse(500), nil` — that
+  discards the typed not-found the handler layer produces and yields 500 for a
+  missing resource (bug class of #955, #953).
+- Do **not** flip the central dispatch tail default from `400` to `500`: several
+  endpoints return bare `(nil, err)` for parse-class failures that rely on the
+  `400` default; flipping regresses them. Map at the site instead.
+- Do **not** wire an unwired central tail as part of a de-swallow change if it
+  would silently reclassify unrelated bare-`(nil, err)` endpoints (e.g.
+  call-manager). Track tail-wiring as its own enumerated + tested change.
+
+## Helper location
+
+`errorResponse` and `simpleResponse` live in each service's
+`pkg/listenhandler/main.go`. Helper-level behavior is covered by
+`pkg/listenhandler/error_response_test.go`.

--- a/docs/superpowers/plans/2026-06-02-listenhandler-error-mapping.md
+++ b/docs/superpowers/plans/2026-06-02-listenhandler-error-mapping.md
@@ -1,0 +1,649 @@
+# Listenhandler Error Mapping (Phase 0 + Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the four `bin-*-manager` services named in [#955](https://github.com/voipbin/monorepo/issues/955) return the correct HTTP status (notably `404` for a non-existent UUID) instead of `500`, by mapping handler-call errors at the listenhandler call site with the existing `errorResponse` helper.
+
+**Architecture:** Each listenhandler endpoint currently swallows every handler error with `return simpleResponse(500), nil`, discarding the typed `cerrors.NotFound` / raw `dbhandler.ErrNotFound` the handler layer already produces. The fix replaces the *handler-call-error* swallow with `return errorResponse(err), nil`. `errorResponse` (already present in all four services) maps typed `*cerrors.VoipbinError`→true status, `dbhandler.ErrNotFound` (through `errors.Wrap`)→404, everything else→500. Response-`json.Marshal` failures keep `simpleResponse(500)`; request-parse failures keep their local `simpleResponse(400)`. No central-dispatch-tail changes; no handler-layer changes.
+
+**Tech Stack:** Go, gomock, RabbitMQ RPC (`sock.Request`/`sock.Response`), `monorepo/bin-common-handler/models/errors` (`cerrors`).
+
+**Scope:** This plan is **Phase 0** (convention doc) + **Phase 1** (the four issue managers). Phase 2 (monorepo audit) and Phase 3+ (remaining services) are separate plans, written when reached. Within Phase 1, edits cover the four **issue resources'** listenhandler files (`v1_conversations.go`, `messages.go`, `v1_numbers.go`, `v1_groupcalls.go`); other resources hosted in the same managers (e.g. call-manager `calls`/`confbridges`, conversation-manager `accounts`) are deferred to the audit. **call-manager's central tail is intentionally NOT wired** here (see spec) — only the at-site `errorResponse` change is applied.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-02-listenhandler-error-mapping-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `docs/conventions/listenhandler-error-mapping.md` | Canonical listenhandler error-mapping convention | Create (Task 0) |
+| `bin-conversation-manager/pkg/listenhandler/v1_conversations.go` | conversation by-id/collection endpoints | Modify (Task 1) |
+| `bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go` | conversation endpoint tests | Modify (Task 1) |
+| `bin-message-manager/pkg/listenhandler/messages.go` | message endpoints | Modify (Task 2) |
+| `bin-message-manager/pkg/listenhandler/messages_test.go` | message endpoint tests | Modify (Task 2) |
+| `bin-number-manager/pkg/listenhandler/v1_numbers.go` | number endpoints | Modify (Task 3) |
+| `bin-number-manager/pkg/listenhandler/v1_numbers_test.go` | number endpoint tests | Modify (Task 3) |
+| `bin-call-manager/pkg/listenhandler/v1_groupcalls.go` | groupcall endpoints | Modify (Task 4) |
+| `bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go` | groupcall endpoint tests | Modify (Task 4) |
+
+**The canonical edit (apply at every handler-call-error site):**
+
+```go
+// BEFORE — handler-call error swallowed as 500
+tmp, err := h.<xHandler>.<Method>(ctx, ...)
+if err != nil {
+    log.<...>("... err: %v", err)
+    return simpleResponse(500), nil
+}
+
+// AFTER — map at the site
+tmp, err := h.<xHandler>.<Method>(ctx, ...)
+if err != nil {
+    log.<...>("... err: %v", err)
+    return errorResponse(err), nil
+}
+```
+
+Leave the `if err != nil { return simpleResponse(500), nil }` block that follows `data, err := json.Marshal(...)` **unchanged** (a marshal failure is genuinely internal). `errorResponse` lives in each service's `main.go` (same package) — no new imports needed in the endpoint files.
+
+---
+
+### Task 0: Phase 0 — Convention document
+
+**Files:**
+- Create: `docs/conventions/listenhandler-error-mapping.md`
+
+- [ ] **Step 1: Create the convention doc**
+
+Create `docs/conventions/listenhandler-error-mapping.md` with this content:
+
+````markdown
+# Listenhandler Error Mapping
+
+> Backend `bin-*-manager` services map errors to RPC `sock.Response` status codes
+> in their `pkg/listenhandler`. This is the canonical convention. Reference
+> implementation: `bin-flow-manager/pkg/listenhandler`.
+
+## Rule
+
+Every endpoint function maps a **handler-call error** at the call site with the
+shared `errorResponse` helper:
+
+```go
+tmp, err := h.xHandler.Method(ctx, ...)
+if err != nil {
+    return errorResponse(err), nil
+}
+```
+
+`errorResponse(err)` maps:
+- `*cerrors.VoipbinError` → its true HTTP status (via `cerrors.ToResponse`)
+- `dbhandler.ErrNotFound` (matched through `errors.Wrap`/`%w`) → `404`
+- anything else → `500`
+
+Keep these **local** (do not route through `errorResponse`):
+- request URI/`json.Unmarshal` parse failures → `simpleResponse(400)`
+- response `json.Marshal` failures → `simpleResponse(500)`
+
+## Do NOT
+
+- Do **not** swallow handler errors with `return simpleResponse(500), nil` — that
+  discards the typed not-found the handler layer produces and yields 500 for a
+  missing resource (bug class of #955, #953).
+- Do **not** flip the central dispatch tail default from `400` to `500`: several
+  endpoints return bare `(nil, err)` for parse-class failures that rely on the
+  `400` default; flipping regresses them. Map at the site instead.
+- Do **not** wire an unwired central tail as part of a de-swallow change if it
+  would silently reclassify unrelated bare-`(nil, err)` endpoints (e.g.
+  call-manager). Track tail-wiring as its own enumerated + tested change.
+
+## Helper location
+
+`errorResponse` and `simpleResponse` live in each service's
+`pkg/listenhandler/main.go`. Helper-level behavior is covered by
+`pkg/listenhandler/error_response_test.go`.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping
+git add docs/conventions/listenhandler-error-mapping.md
+git commit -m "NOJIRA-Fix-listenhandler-error-mapping
+
+- docs: Add listenhandler error-mapping convention (Phase 0)"
+```
+
+---
+
+### Task 1: conversation-manager
+
+**Files:**
+- Modify: `bin-conversation-manager/pkg/listenhandler/v1_conversations.go` (handler-call swallows at lines ~70, ~114, ~150)
+- Test: `bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go`
+
+Note: `processV1ConversationsIDPut` (line ~211) already uses `errorResponse(err)` and already returns 404 for a missing id — leave it unchanged (no edit, no test required).
+
+- [ ] **Step 1: Add not-found tests**
+
+Append to `bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go`. The package already imports `reflect`, `testing`, `gomock`, `sockhandler`, `conversationhandler`, `sock`, `uuid`; add the dbhandler import if not present:
+`"monorepo/bin-conversation-manager/pkg/dbhandler"`.
+
+```go
+func Test_processV1ConversationsID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent conversation returns 404",
+			request: &sock.Request{
+				URI:    "/v1/conversations/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockConversation := conversationhandler.NewMockConversationHandler(mc)
+			h := &listenHandler{
+				sockHandler:         mockSock,
+				conversationHandler: mockConversation,
+			}
+
+			mockConversation.EXPECT().Get(gomock.Any(), tt.id).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-conversation-manager
+go test ./pkg/listenhandler/ -run Test_processV1ConversationsID_notFound -v
+```
+Expected: FAIL — `StatusCode mismatch. expected: 404, got: 500` (the GET site still swallows to 500).
+
+- [ ] **Step 3: Apply the canonical edit at the handler-call swallows**
+
+In `bin-conversation-manager/pkg/listenhandler/v1_conversations.go`, change the **handler-call-error** `return simpleResponse(500), nil` to `return errorResponse(err), nil` in these functions (the one immediately after the `h.conversationHandler.<Method>` call — NOT the one after `json.Marshal`):
+
+- `processV1ConversationsGet` — after `h.conversationHandler.List(...)` (~line 70)
+- `processV1ConversationsPost` — after `h.conversationHandler.Create(...)` (~line 114)
+- `processV1ConversationsIDGet` — after `h.conversationHandler.Get(...)` (~line 150)
+
+Example (IDGet):
+
+```go
+	tmp, err := h.conversationHandler.Get(ctx, id)
+	if err != nil {
+		log.Debugf("Could not get a conversation. conversation_id: %s, err: %v", id, err)
+		return errorResponse(err), nil
+	}
+```
+
+- [ ] **Step 4: Run the not-found test — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -run Test_processV1ConversationsID_notFound -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full listenhandler package tests — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -v
+```
+Expected: PASS (existing tests assert success-path responses, which are unchanged).
+
+- [ ] **Step 6: Run the mandatory verification workflow**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-conversation-manager
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping
+git add bin-conversation-manager/pkg/listenhandler/v1_conversations.go bin-conversation-manager/pkg/listenhandler/v1_conversations_test.go bin-conversation-manager/go.mod bin-conversation-manager/go.sum
+git commit -m "NOJIRA-Fix-listenhandler-error-mapping
+
+- bin-conversation-manager: Map handler errors at the listenhandler call site (errorResponse) so non-existent conversation IDs return 404 instead of 500 (#955)"
+```
+
+---
+
+### Task 2: message-manager
+
+**Files:**
+- Modify: `bin-message-manager/pkg/listenhandler/messages.go` (handler-call swallows at lines ~54, ~89, ~124, ~159)
+- Test: `bin-message-manager/pkg/listenhandler/messages_test.go`
+
+- [ ] **Step 1: Add not-found tests**
+
+Append to `bin-message-manager/pkg/listenhandler/messages_test.go`. Add the dbhandler import if not present:
+`"monorepo/bin-message-manager/pkg/dbhandler"`.
+
+```go
+func Test_processV1MessagesID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+		setup   func(m *messagehandler.MockMessageHandler, id uuid.UUID)
+	}{
+		{
+			name: "GET non-existent message returns 404",
+			request: &sock.Request{
+				URI:    "/v1/messages/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *messagehandler.MockMessageHandler, id uuid.UUID) {
+				m.EXPECT().Get(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "DELETE non-existent message returns 404",
+			request: &sock.Request{
+				URI:    "/v1/messages/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *messagehandler.MockMessageHandler, id uuid.UUID) {
+				m.EXPECT().Delete(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+			h := &listenHandler{
+				sockHandler:    mockSock,
+				messageHandler: mockMessage,
+			}
+			tt.setup(mockMessage, tt.id)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-message-manager
+go test ./pkg/listenhandler/ -run Test_processV1MessagesID_notFound -v
+```
+Expected: FAIL — both subtests `expected: 404, got: 500`.
+
+- [ ] **Step 3: Apply the canonical edit at the handler-call swallows**
+
+In `bin-message-manager/pkg/listenhandler/messages.go`, change the handler-call-error `return simpleResponse(500), nil` to `return errorResponse(err), nil` in:
+
+- `processV1MessagesGet` — after `h.messageHandler.List(...)` (~line 54)
+- `processV1MessagesPost` — after `h.messageHandler.Send(...)` (~line 89)
+- `processV1MessagesIDGet` — after `h.messageHandler.Get(...)` (~line 124)
+- `processV1MessagesIDDelete` — after `h.messageHandler.Delete(...)` (~line 159)
+
+Leave each post-`json.Marshal` `simpleResponse(500)` unchanged.
+
+- [ ] **Step 4: Run the not-found test — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -run Test_processV1MessagesID_notFound -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full listenhandler package tests — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -v
+```
+
+- [ ] **Step 6: Run the mandatory verification workflow**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-message-manager
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping
+git add bin-message-manager/pkg/listenhandler/messages.go bin-message-manager/pkg/listenhandler/messages_test.go bin-message-manager/go.mod bin-message-manager/go.sum
+git commit -m "NOJIRA-Fix-listenhandler-error-mapping
+
+- bin-message-manager: Map handler errors at the listenhandler call site (errorResponse) so non-existent message IDs return 404 instead of 500 (#955)"
+```
+
+---
+
+### Task 3: number-manager
+
+**Files:**
+- Modify: `bin-number-manager/pkg/listenhandler/v1_numbers.go` (handler-call swallows at lines ~44, ~80, ~116, ~165, ~217, ~264, ~298)
+- Test: `bin-number-manager/pkg/listenhandler/v1_numbers_test.go`
+
+- [ ] **Step 1: Add not-found tests**
+
+Append to `bin-number-manager/pkg/listenhandler/v1_numbers_test.go`. Add the dbhandler import if not present:
+`"monorepo/bin-number-manager/pkg/dbhandler"`.
+
+```go
+func Test_processV1NumbersID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+		setup   func(m *numberhandler.MockNumberHandler, id uuid.UUID)
+	}{
+		{
+			name: "GET non-existent number returns 404",
+			request: &sock.Request{
+				URI:    "/v1/numbers/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *numberhandler.MockNumberHandler, id uuid.UUID) {
+				m.EXPECT().Get(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "DELETE non-existent number returns 404",
+			request: &sock.Request{
+				URI:    "/v1/numbers/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *numberhandler.MockNumberHandler, id uuid.UUID) {
+				m.EXPECT().Delete(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockNumber := numberhandler.NewMockNumberHandler(mc)
+			h := &listenHandler{
+				sockHandler:   mockSock,
+				numberHandler: mockNumber,
+			}
+			tt.setup(mockNumber, tt.id)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-number-manager
+go test ./pkg/listenhandler/ -run Test_processV1NumbersID_notFound -v
+```
+Expected: FAIL — both subtests `expected: 404, got: 500`.
+
+- [ ] **Step 3: Apply the canonical edit at the handler-call swallows**
+
+In `bin-number-manager/pkg/listenhandler/v1_numbers.go`, change the handler-call-error `return simpleResponse(500), nil` to `return errorResponse(err), nil` in:
+
+- `processV1NumbersPost` — after the `h.numberHandler.Create/CreateVirtual(...)` block (~line 44)
+- `processV1NumbersIDDelete` — after `h.numberHandler.Delete(...)` (~line 80)
+- `processV1NumbersIDGet` — after `h.numberHandler.Get(...)` (~line 116)
+- `processV1NumbersIDPut` — after `h.numberHandler.Update(...)` (~line 165)
+- `processV1NumbersGet` — after `h.numberHandler.List(...)` (~line 217)
+- `processV1NumbersIDFlowIDsPut` — after `h.numberHandler.Update(...)` (~line 264)
+- `processV1NumbersRenewPost` — after `h.numberHandler.RenewNumbers(...)` (~line 298)
+
+Leave each post-`json.Marshal` `simpleResponse(500)` unchanged.
+
+- [ ] **Step 4: Run the not-found test — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -run Test_processV1NumbersID_notFound -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run the full listenhandler package tests — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -v
+```
+
+- [ ] **Step 6: Run the mandatory verification workflow**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-number-manager
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping
+git add bin-number-manager/pkg/listenhandler/v1_numbers.go bin-number-manager/pkg/listenhandler/v1_numbers_test.go bin-number-manager/go.mod bin-number-manager/go.sum
+git commit -m "NOJIRA-Fix-listenhandler-error-mapping
+
+- bin-number-manager: Map handler errors at the listenhandler call site (errorResponse) so non-existent number IDs return 404 instead of 500 (#955)"
+```
+
+---
+
+### Task 4: call-manager (groupcalls)
+
+**Files:**
+- Modify: `bin-call-manager/pkg/listenhandler/v1_groupcalls.go` (handler-call swallows at lines ~55, ~108, ~144, ~180, ~216, ~258, ~294, ~330)
+- Test: `bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go`
+
+Note: do **not** touch `bin-call-manager/pkg/listenhandler/main.go` (the central tail stays unwired — see spec).
+
+- [ ] **Step 1: Add not-found tests**
+
+Append to `bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go`. The package already imports `sockhandler`, `callhandler`, `groupcallhandler`, `sock`, `uuid`, `gomock`; add the dbhandler import if not present:
+`"monorepo/bin-call-manager/pkg/dbhandler"`.
+
+```go
+func Test_processV1GroupcallsID_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+		setup   func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID)
+	}{
+		{
+			name: "GET non-existent groupcall returns 404",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID) {
+				m.EXPECT().Get(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "DELETE non-existent groupcall returns 404",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID) {
+				m.EXPECT().Delete(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+		{
+			name: "POST hangup non-existent groupcall returns 404",
+			request: &sock.Request{
+				URI:    "/v1/groupcalls/00000000-0000-0000-0000-000000000099/hangup",
+				Method: sock.RequestMethodPost,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+			setup: func(m *groupcallhandler.MockGroupcallHandler, id uuid.UUID) {
+				m.EXPECT().Hangingup(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockGroupcall := groupcallhandler.NewMockGroupcallHandler(mc)
+			h := &listenHandler{
+				sockHandler:      mockSock,
+				callHandler:      mockCall,
+				groupcallHandler: mockGroupcall,
+			}
+			tt.setup(mockGroupcall, tt.id)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-call-manager
+go test ./pkg/listenhandler/ -run Test_processV1GroupcallsID_notFound -v
+```
+Expected: FAIL — all three subtests `expected: 404, got: 500`.
+
+- [ ] **Step 3: Apply the canonical edit at the handler-call swallows**
+
+In `bin-call-manager/pkg/listenhandler/v1_groupcalls.go`, change the handler-call-error `return simpleResponse(500), nil` to `return errorResponse(err), nil` in:
+
+- `processV1GroupcallsGet` — after `h.groupcallHandler.List(...)` (~line 55)
+- `processV1GroupcallsPost` — after `h.groupcallHandler.Start(...)` (~line 108)
+- `processV1GroupcallsIDGet` — after `h.groupcallHandler.Get(...)` (~line 144)
+- `processV1GroupcallsIDDelete` — after `h.groupcallHandler.Delete(...)` (~line 180)
+- `processV1GroupcallsIDHangupPost` — after `h.groupcallHandler.Hangingup(...)` (~line 216)
+- `processV1GroupcallsIDAnswerGroupcallIDPost` — after `h.groupcallHandler.AnswerGroupcall(...)` (~line 258)
+- `processV1GroupcallsIDHangupGroupcallPost` — after `h.groupcallHandler.HangupGroupcall(...)` (~line 294)
+- `processV1GroupcallsIDHangupCallPost` — after `h.groupcallHandler.HangupCall(...)` (~line 330)
+
+Leave each post-`json.Marshal` `simpleResponse(500)` unchanged.
+
+- [ ] **Step 4: Run the not-found test — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -run Test_processV1GroupcallsID_notFound -v
+```
+Expected: PASS (all three subtests).
+
+- [ ] **Step 5: Run the full listenhandler package tests — expect PASS**
+
+```bash
+go test ./pkg/listenhandler/ -v
+```
+
+- [ ] **Step 6: Run the mandatory verification workflow**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping/bin-call-manager
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping
+git add bin-call-manager/pkg/listenhandler/v1_groupcalls.go bin-call-manager/pkg/listenhandler/v1_groupcalls_test.go bin-call-manager/go.mod bin-call-manager/go.sum
+git commit -m "NOJIRA-Fix-listenhandler-error-mapping
+
+- bin-call-manager: Map groupcall handler errors at the listenhandler call site (errorResponse) so non-existent groupcall IDs return 404 instead of 500 (#955)"
+```
+
+---
+
+## Final verification (whole-program)
+
+- [ ] **Confirm the four packages build and pass together**
+
+```bash
+cd ~/gitvoipbin/monorepo/.worktrees/NOJIRA-Fix-listenhandler-error-mapping
+for d in bin-conversation-manager bin-message-manager bin-number-manager bin-call-manager; do
+  echo "=== $d ===" && (cd $d && go test ./pkg/listenhandler/...) || exit 1
+done
+```
+Expected: each prints `ok`.
+
+- [ ] **Confirm no central-tail / main.go changes leaked in**
+
+```bash
+git diff --name-only main...HEAD | grep 'listenhandler/main.go' && echo "UNEXPECTED main.go change" || echo "OK: no main.go changes"
+```
+Expected: `OK: no main.go changes`.
+
+## Notes for PR / handoff
+
+- The spec recommends **one PR per manager** for reviewable, revertible diffs. The
+  four commits above are independent; they can be split onto per-manager branches
+  or shipped as a single issue PR titled `NOJIRA-Fix-listenhandler-error-mapping`.
+  Decide with the user before pushing. Do **not** merge without explicit
+  authorization (squash merge only).
+- **api-validator:** the 9 endpoints are already covered by the existing
+  api-validator suite (the failing tests cited in #955). No new api-validator
+  tests are required; the suite turns green after deploy. Verify post-deploy, not
+  as part of this plan.
+- **Out of scope (deferred to Phase 2/3):** other resources in these managers
+  (call-manager `calls`/`confbridges`/`recordings`, conversation-manager
+  `accounts`/conversation-messages, number-manager `metadata`/`available_numbers`),
+  and call-manager central-tail wiring.

--- a/docs/superpowers/specs/2026-06-02-listenhandler-error-mapping-design.md
+++ b/docs/superpowers/specs/2026-06-02-listenhandler-error-mapping-design.md
@@ -1,0 +1,225 @@
+# Listenhandler Error Mapping — Not-Found→500 Fix and Full Typed-Error Fidelity
+
+**Date:** 2026-06-02
+**Issue:** [#955](https://github.com/voipbin/monorepo/issues/955)
+**Branch:** `NOJIRA-Fix-listenhandler-error-mapping`
+
+## Problem
+
+Several resource endpoints return `500 INTERNAL` when a valid-format but
+non-existent UUID is passed in the path (e.g.
+`GET /v1.0/conversations/00000000-0000-0000-0000-000000000099`). The correct
+response is `404 NOT_FOUND`. UUID *format* validation already works (malformed
+strings return `400`).
+
+Endpoints named in #955 (9 total):
+
+| Endpoint | Method | Expected | Actual |
+|---|---|---|---|
+| `/conversations/{id}` | GET | 404 | 500 |
+| `/conversations/{id}` | PUT | 404 | 500 |
+| `/groupcalls/{id}` | GET | 404 | 500 |
+| `/groupcalls/{id}` | DELETE | 404 | 500 |
+| `/groupcalls/{id}/hangup` | POST | 404 | 500 |
+| `/messages/{id}` | GET | 404 | 500 |
+| `/messages/{id}` | DELETE | 404 | 500 |
+| `/numbers/{id}` | GET | 404 | 500 |
+| `/numbers/{id}` | DELETE | 404 | 500 |
+
+These 9 are a **subset** of a widespread pattern; the same swallow exists across
+many more endpoints in these and other managers.
+
+## Root Cause
+
+The bug is in the **backend manager listenhandler dispatch layer**, not the edge.
+
+1. The **handler layers already emit typed errors.** For all four issue
+   services, `xHandler.Get(...)` converts `dbhandler.ErrNotFound` into a typed
+   `cerrors.NotFound(...)` VoipbinError. Example
+   (`bin-conversation-manager/pkg/conversationhandler`):
+
+   ```go
+   func (h *conversationHandler) Get(ctx, id) (*conversation.Conversation, error) {
+       res, err := h.db.ConversationGet(ctx, id)
+       if err != nil {
+           if stderrors.Is(err, dbhandler.ErrNotFound) {
+               return nil, cerrors.NotFound(
+                   commonoutline.ServiceNameConversationManager,
+                   "CONVERSATION_NOT_FOUND", "The conversation was not found.").Wrap(err)
+           }
+           return nil, err
+       }
+       return res, nil
+   }
+   ```
+
+2. The **listenhandler endpoint functions swallow every error** before it can
+   reach the dispatcher
+   (`bin-conversation-manager/pkg/listenhandler/v1_conversations.go`):
+
+   ```go
+   tmp, err := h.conversationHandler.Get(ctx, id)
+   if err != nil {
+       log.Debugf("...err: %v", err)
+       return simpleResponse(500), nil   // ← discards the typed not-found
+   }
+   ```
+
+3. The **central dispatch tail already routes errors correctly** in 3 of the 4
+   issue services. Only `call-manager` still uses the legacy
+   `simpleResponse(400)` tail with no `errorResponse` helper.
+
+| Service | Central tail maps `VoipbinError`/`ErrNotFound`→404? | `errorResponse` helper |
+|---|---|---|
+| conversation-manager | yes | present |
+| message-manager | yes | present |
+| number-manager | yes | present |
+| **call-manager** (groupcalls) | no (legacy `simpleResponse(400)`) | none |
+| flow-manager (reference) | yes | present |
+
+The api-manager edge translator (`server/error_translate.go`, fixed in #954)
+already converts typed VoipbinError and bare `requesthandler.Err*` statuses to
+the correct client HTTP code. **No edge change is required** — the information
+is destroyed at the backend before it ever reaches the edge.
+
+## Scope
+
+- **Breadth:** All four issue managers **plus a monorepo-wide audit** of all 37
+  services for the same swallow pattern.
+- **Error classes:** **Full typed-error fidelity** — wherever a handler returns
+  a typed `cerrors.VoipbinError` (404/403/409/429/etc.), stop swallowing it so
+  the client receives the true status. Genuine internal errors (response
+  marshal failures, untyped DB errors) correctly remain `500`. Request-parse /
+  body-unmarshal failures correctly remain `400`.
+
+## Design — Canonical Listenhandler Error Convention
+
+Every `bin-*-manager` listenhandler converges on:
+
+1. **Endpoint functions propagate handler errors.** Replace
+   `return simpleResponse(500), nil` (where the swallowed value is a
+   *handler-layer call* error) with `return nil, err`.
+2. **Request-parse failures stay local & client-class.** Bad URI split and
+   request-body `json.Unmarshal` failures keep `return simpleResponse(400), nil`.
+   Response `json.Marshal` failures keep `simpleResponse(500)`. These are *not*
+   propagated.
+3. **Central dispatch tail** (in `main.go`) maps the propagated error:
+   - `*cerrors.VoipbinError` → `errorResponse(err)` (→ `cerrors.ToResponse`, true status)
+   - `dbhandler.ErrNotFound` → 404 (defensive net for handlers still returning the raw sentinel)
+   - **default → 500** (handler-call errors are server-side; a deliberate flip
+     from the legacy `400` default present in several services)
+4. **`errorResponse` helper** present in every service (port flow-manager's
+   verbatim where missing).
+
+Reference `errorResponse` (flow-manager):
+
+```go
+func errorResponse(err error) *sock.Response {
+    if err == nil { return simpleResponse(http.StatusInternalServerError) }
+    var ve *cerrors.VoipbinError
+    if stderrors.As(err, &ve) {
+        resp, e := cerrors.ToResponse(ve)
+        if e == nil { return resp }
+        return simpleResponse(http.StatusInternalServerError)
+    }
+    if stderrors.Is(err, dbhandler.ErrNotFound) {
+        return simpleResponse(http.StatusNotFound)
+    }
+    return simpleResponse(http.StatusInternalServerError)
+}
+```
+
+### Key correctness note — central-default flip (400→500)
+
+In conversation/message/number the central default is currently `400`. Handler-
+call errors are server-side and must default to `500`, so the default is flipped
+to `simpleResponse(500)`. Before flipping, each service is audited to confirm no
+endpoint relies on the legacy `400` default by propagating a *client-class*
+error as bare `(nil, err)` (parse failures should already be local `400`). Any
+such case is made local before the flip.
+
+### Rejected approaches
+
+- **Local `errorResponse(err)` at each swallow site** (no central-tail change):
+  works and keeps internal at 500, but scatters mapping calls across every call
+  site and diverges from the central-tail convention used by 4 of 5 reference
+  services.
+- **Edge-only (api-manager):** not viable — the backend emits a bare HTTP 500
+  with no surviving "not found" signal; the edge cannot reconstruct it.
+
+## Phasing
+
+Each phase is its own spec → plan → implement → PR cycle. Dependency is linear:
+**Phase 0 → Phase 1 → Phase 2 → Phase 3+**.
+
+### Phase 0 — Establish the convention (docs, no behavior change)
+- Write the canonical convention to `docs/conventions/listenhandler-error-mapping.md`,
+  referencing flow-manager as the template. Single source of truth for later phases.
+
+### Phase 1 — The 4 issue managers (closes #955)
+Full typed-error fidelity for all by-ID and state-changing endpoints (not only
+the 9 named):
+- **conversation / message / number:** central infra present → de-swallow,
+  propagate `(nil, err)`, flip central default 400→500 after per-service audit,
+  add/extend `error_response_test.go`.
+- **call-manager:** additionally port the `errorResponse` helper and upgrade the
+  central dispatch tail before propagating.
+- Re-run api-validator against the 9 endpoints → green.
+- **One PR per manager** (4 PRs) for reviewable, revertible diffs.
+
+### Phase 2 — Monorepo audit (discovery, no code change)
+- Sweep all 37 services. For each listenhandler, classify every
+  `simpleResponse(500)` / swallow as (a) swallowed handler error → **fix**, or
+  (b) legitimate local internal/parse error → **leave**.
+- Output: tracking checklist in `docs/plans/` (per service: infra present?,
+  endpoints to fix, handler emits typed errors?).
+
+### Phase 3..N — Remaining services (batched)
+- Group by effort: **infra-present** (propagate + tests) vs **infra-missing**
+  (port `errorResponse` + upgrade dispatch first).
+- One PR per service (or small batch). Each independently verifiable.
+- Services whose handler layer still returns *raw* `dbhandler.ErrNotFound` are
+  caught by the central `ErrNotFound`→404 branch, so they are fixed without a
+  forced handler-layer rewrite; upgrading them to typed errors is optional
+  follow-up.
+
+## Per-Service Procedure (repeatable unit)
+
+1. **Infra check** — does `errorResponse` exist and does the `main.go` tail
+   route `*cerrors.VoipbinError` and `dbhandler.ErrNotFound`? If missing, port
+   flow-manager's helper and upgrade the tail.
+2. **Default-flip audit** — grep endpoints returning bare `(nil, err)`; confirm
+   none rely on the legacy `400` default for a client-class error. Make any such
+   case local before flipping the default to 500.
+3. **De-swallow** — replace handler-call `return simpleResponse(500), nil` with
+   `return nil, err`. Leave parse→`400` and marshal→`500` untouched.
+4. **Handler-layer spot check** — confirm `xHandler.Get/Delete/Update` emit
+   typed `cerrors.NotFound` (or at least raw `dbhandler.ErrNotFound`).
+5. **Tests** — extend `pkg/listenhandler/*_test.go` / `error_response_test.go`:
+   not-found→404; (full fidelity) invalid-state→409, permission→403, etc.;
+   malformed/parse→400; marshal failure→500.
+6. **Verify** — in the service dir:
+   `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
+
+## Testing & Verification Story
+
+- **Unit (per service):** listenhandler tests with a mocked handler returning
+  typed errors, asserting `sock.Response.StatusCode`. This is the regression
+  guard that would have caught #955.
+- **Edge integration:** translator path covered by #954; add one Phase-1 sanity
+  test asserting a backend 404 round-trips to client 404.
+- **End-to-end:** api-validator
+  (`monorepo-monitoring/api-validator/`) already exercises the 9 endpoints every
+  6h; Phase 1 turns them green. Add matching read-only api-validator tests for
+  any newly touched endpoints (no cost-sensitive operations).
+- **Per-PR DoD:** 5-step verification workflow passes; listenhandler tests
+  assert the new status codes; PR body lists each manager with `bin-<service>:`
+  prefixes.
+
+## Definition of Done (program)
+
+- All four issue managers return 404 for non-existent UUIDs and true status for
+  other typed errors; api-validator's 9 tests pass.
+- Convention documented in `docs/conventions/`.
+- Monorepo audit checklist produced; remaining services fixed in batched PRs.
+- Every PR passes the mandatory 5-step verification workflow.

--- a/docs/superpowers/specs/2026-06-02-listenhandler-error-mapping-design.md
+++ b/docs/superpowers/specs/2026-06-02-listenhandler-error-mapping-design.md
@@ -31,11 +31,15 @@ many more endpoints in these and other managers.
 
 ## Root Cause
 
-The bug is in the **backend manager listenhandler dispatch layer**, not the edge.
+The bug is in the **backend manager listenhandler endpoint layer**, not the edge.
+The codebase is **partially migrated in conversation-manager only** (its PUT maps
+errors correctly while its GET still swallows); message-manager, number-manager,
+and call-manager have no migrated by-id endpoints. See the per-service baseline
+table below.
 
-1. The **handler layers already emit typed errors.** For all four issue
-   services, `xHandler.Get(...)` converts `dbhandler.ErrNotFound` into a typed
-   `cerrors.NotFound(...)` VoipbinError. Example
+1. The **handler `Get` methods already emit typed not-found errors.** For all
+   four issue services, `xHandler.Get(...)` converts `dbhandler.ErrNotFound`
+   into a typed `cerrors.NotFound(...)` VoipbinError. Example
    (`bin-conversation-manager/pkg/conversationhandler`):
 
    ```go
@@ -53,29 +57,65 @@ The bug is in the **backend manager listenhandler dispatch layer**, not the edge
    }
    ```
 
-2. The **listenhandler endpoint functions swallow every error** before it can
-   reach the dispatcher
-   (`bin-conversation-manager/pkg/listenhandler/v1_conversations.go`):
+   **State-changing handler methods (`Delete`/`Update`/`Hangingup`) do NOT emit
+   typed not-found.** Verified: `conversationHandler.Update`,
+   `messageHandler.Delete`, `numberHandler.Delete/Update/UpdateMetadata`,
+   `groupcallHandler.Delete/Hangup/Hangingup` either return the raw db error or
+   `errors.Wrap(err, ...)` (pkg/errors, which preserves `Unwrap`). For these,
+   not-found correctness depends on the raw `dbhandler.ErrNotFound` **sentinel
+   surviving the wrap chain** and being matched by `errorResponse`'s sentinel
+   branch (`stderrors.Is`).
+
+2. Some **listenhandler endpoint functions still swallow every error** with
+   `return simpleResponse(500), nil`, discarding both the typed not-found and
+   the raw sentinel. Confirmed still-swallowing for the issue endpoints, e.g.
+   `bin-conversation-manager/pkg/listenhandler/v1_conversations.go`
+   (`processV1ConversationsIDGet`):
 
    ```go
    tmp, err := h.conversationHandler.Get(ctx, id)
    if err != nil {
-       log.Debugf("...err: %v", err)
-       return simpleResponse(500), nil   // ← discards the typed not-found
+       return simpleResponse(500), nil   // ← discards typed not-found
    }
    ```
 
-3. The **central dispatch tail already routes errors correctly** in 3 of the 4
-   issue services. Only `call-manager` still uses the legacy
-   `simpleResponse(400)` tail with no `errorResponse` helper.
+   Meanwhile the PUT sibling (`processV1ConversationsIDPut`,
+   `v1_conversations.go:211`) already uses `return errorResponse(err), nil` — the
+   exact convention this spec recommends for new sites (map at the call site),
+   **not** bare `(nil, err)` + central tail. So the one truly-migrated endpoint
+   already validates the recommended mechanism. Phase 1 must **enumerate the
+   specific still-swallowing sites per service**, not assume a uniform starting
+   point.
 
-| Service | Central tail maps `VoipbinError`/`ErrNotFound`→404? | `errorResponse` helper |
-|---|---|---|
-| conversation-manager | yes | present |
-| message-manager | yes | present |
-| number-manager | yes | present |
-| **call-manager** (groupcalls) | no (legacy `simpleResponse(400)`) | none |
-| flow-manager (reference) | yes | present |
+   **Per-service baseline (verified):**
+
+   | Service | Migrated by-id sites | Still-swallowing | Central tail |
+   |---|---|---|---|
+   | conversation-manager | PUT (`errorResponse`-at-site) | GET + others (`simpleResponse(500)`) | wired (backstop) |
+   | message-manager | none | all by-id (`simpleResponse(500)`) | wired (backstop) |
+   | number-manager | none | all by-id (`simpleResponse(500)`) | wired (backstop) |
+   | call-manager (groupcalls) | none | all by-id (`simpleResponse(500)`) | **unwired** (bare `simpleResponse(400)`) |
+
+   Do not look for already-correct GET/PUT siblings in message/number — there are
+   none.
+
+3. The **shared `errorResponse` helper exists in all four issue services**
+   (identical to flow-manager's). It maps:
+   `*cerrors.VoipbinError` → `cerrors.ToResponse` (true status);
+   `dbhandler.ErrNotFound` → 404; everything else → **500**.
+
+4. **Central dispatch tails differ:**
+
+   | Service | Central tail routes `VoipbinError`+`ErrNotFound`→`errorResponse`? | `errorResponse` helper exists? | Tail default |
+   |---|---|---|---|
+   | conversation-manager | yes | yes | `simpleResponse(400)` |
+   | message-manager | yes | yes | `simpleResponse(400)` |
+   | number-manager | yes | yes | `simpleResponse(400)` |
+   | **call-manager** (groupcalls) | **no** (bare `simpleResponse(400)`) | **yes (unwired)** | `simpleResponse(400)` |
+   | flow-manager (reference) | yes | yes | `simpleResponse(400)` |
+
+   Note: call-manager's gap is that its tail **does not call the existing
+   `errorResponse` helper** — not that the helper is absent.
 
 The api-manager edge translator (`server/error_translate.go`, fixed in #954)
 already converts typed VoipbinError and bare `requesthandler.Err*` statuses to
@@ -87,31 +127,16 @@ is destroyed at the backend before it ever reaches the edge.
 - **Breadth:** All four issue managers **plus a monorepo-wide audit** of all 37
   services for the same swallow pattern.
 - **Error classes:** **Full typed-error fidelity** — wherever a handler returns
-  a typed `cerrors.VoipbinError` (404/403/409/429/etc.), stop swallowing it so
-  the client receives the true status. Genuine internal errors (response
-  marshal failures, untyped DB errors) correctly remain `500`. Request-parse /
-  body-unmarshal failures correctly remain `400`.
+  a typed `cerrors.VoipbinError` (404/403/409/429/503/etc.), or a raw
+  `dbhandler.ErrNotFound` sentinel, stop swallowing it so the client receives
+  the true status. Genuine internal errors (response marshal failures, untyped
+  DB/connection errors) correctly resolve to `500`. Request-parse / body-
+  unmarshal failures correctly resolve to `400`.
 
 ## Design — Canonical Listenhandler Error Convention
 
-Every `bin-*-manager` listenhandler converges on:
-
-1. **Endpoint functions propagate handler errors.** Replace
-   `return simpleResponse(500), nil` (where the swallowed value is a
-   *handler-layer call* error) with `return nil, err`.
-2. **Request-parse failures stay local & client-class.** Bad URI split and
-   request-body `json.Unmarshal` failures keep `return simpleResponse(400), nil`.
-   Response `json.Marshal` failures keep `simpleResponse(500)`. These are *not*
-   propagated.
-3. **Central dispatch tail** (in `main.go`) maps the propagated error:
-   - `*cerrors.VoipbinError` → `errorResponse(err)` (→ `cerrors.ToResponse`, true status)
-   - `dbhandler.ErrNotFound` → 404 (defensive net for handlers still returning the raw sentinel)
-   - **default → 500** (handler-call errors are server-side; a deliberate flip
-     from the legacy `400` default present in several services)
-4. **`errorResponse` helper** present in every service (port flow-manager's
-   verbatim where missing).
-
-Reference `errorResponse` (flow-manager):
+The shared `errorResponse(err)` helper is the single canonical mapper. Reference
+(flow-manager, present verbatim in all four issue services):
 
 ```go
 func errorResponse(err error) *sock.Response {
@@ -122,30 +147,92 @@ func errorResponse(err error) *sock.Response {
         if e == nil { return resp }
         return simpleResponse(http.StatusInternalServerError)
     }
-    if stderrors.Is(err, dbhandler.ErrNotFound) {
+    if stderrors.Is(err, dbhandler.ErrNotFound) {   // matches through errors.Wrap
         return simpleResponse(http.StatusNotFound)
     }
-    return simpleResponse(http.StatusInternalServerError)
+    return simpleResponse(http.StatusInternalServerError)   // internal → 500
 }
 ```
 
-### Key correctness note — central-default flip (400→500)
+Every `bin-*-manager` listenhandler converges on:
 
-In conversation/message/number the central default is currently `400`. Handler-
-call errors are server-side and must default to `500`, so the default is flipped
-to `simpleResponse(500)`. Before flipping, each service is audited to confirm no
-endpoint relies on the legacy `400` default by propagating a *client-class*
-error as bare `(nil, err)` (parse failures should already be local `400`). Any
-such case is made local before the flip.
+1. **Handler-call errors are mapped at the call site** with the shared helper:
+   replace `return simpleResponse(500), nil` with `return errorResponse(err), nil`.
+   This yields not-found→404 (typed *or* surviving sentinel), other typed
+   codes→true status, and genuine internal errors→500 — with **no change to the
+   central tail and no regression of parse-class errors**.
+2. **Request-parse failures stay local & client-class:** bad URI split and
+   request-body `json.Unmarshal` failures keep `return simpleResponse(400), nil`.
+   Response `json.Marshal` failures keep `simpleResponse(500)`.
+3. **Central dispatch tail is a defensive backstop, left unchanged** (default
+   `simpleResponse(400)` in all four services). Because every handler-call error
+   is mapped at the site, the tail is not relied upon for handler errors — so
+   **call-manager's unwired tail does not need to be wired for the #955 fix**.
+   Wiring it (route `*cerrors.VoipbinError` + `dbhandler.ErrNotFound` through the
+   existing `errorResponse` helper) is deferred to optional separate work; see
+   the call-manager note in Phase 1.
 
-### Rejected approaches
+### Why call the helper at the site (not bare `(nil, err)` + central tail)
 
-- **Local `errorResponse(err)` at each swallow site** (no central-tail change):
-  works and keeps internal at 500, but scatters mapping calls across every call
-  site and diverges from the central-tail convention used by 4 of 5 reference
-  services.
-- **Edge-only (api-manager):** not viable — the backend emits a bare HTTP 500
-  with no surviving "not found" signal; the edge cannot reconstruct it.
+Returning bare `(nil, err)` defers mapping to the central tail, whose **default
+is `400`**. A propagated *genuine internal* handler error (e.g. a DB connection
+failure on a GET) would then become `400` — a server fault mislabeled as a
+client error, and a regression from today's `500`. Calling `errorResponse(err)`
+at the site maps internal→`500` correctly. This also avoids the central-default
+flip considered and rejected below, and matches the de-facto pattern of the one
+already-migrated endpoint (conversation PUT, `v1_conversations.go:211`).
+
+### Rejected: flipping the central default 400→500
+
+Flipping the central tail default to `500` would regress legitimate client-class
+errors. Multiple endpoints return bare `(nil, err)` for request-body parse
+failures (e.g. `requesthandler.GetFilteredItems` JSON unmarshal, field-type
+conversion) that resolve to `400` via the default branch today; a `500` default
+silently turns each into a server error. It also contradicts the flow-manager
+reference, whose default is `400`. Therefore the central default is **kept at
+400**, and correct internal→500 mapping is achieved at the call site via
+`errorResponse`.
+
+### Rejected: edge-only (api-manager)
+
+Not viable — the backend emits a bare HTTP 500 with no surviving "not found"
+signal; the edge cannot reconstruct it.
+
+## Not-Found Path Verification (per state-changing method)
+
+Because `Delete`/`Update`/`Hangingup` do not emit typed not-found, each must be
+verified to surface the raw `dbhandler.ErrNotFound` sentinel (preserved through
+`errors.Wrap`) so `errorResponse` maps it to 404:
+
+- **GET (all four):** `Get` emits typed `cerrors.NotFound` → 404 directly. ✔
+- **conversation PUT (`Update`):** confirm the update path performs a get/lookup
+  that returns `ErrNotFound` for a missing id (not a silent 0-row update).
+- **message DELETE, number DELETE/UPDATE:** `numberHandler.Delete` re-fetches via
+  `Get` first → ErrNotFound naturally; confirm `messageHandler.Delete` surfaces
+  the sentinel rather than returning success on 0 rows.
+- **groupcall DELETE:** returns the already-deleted record with `200` when
+  `TMDelete != nil` (soft-delete); for a never-existed id, confirm it surfaces
+  ErrNotFound.
+- **groupcall `/hangup` (`Hangingup`) — highest risk:** path is
+  `Hangingup → UpdateStatus → GroupcallSetStatus` (SQL UPDATE, which returns nil
+  on 0 rows) then `GroupcallGet` (returns wrapped `ErrNotFound`). Must verify the
+  re-fetch actually runs and the wrapped sentinel propagates; otherwise hangup of
+  a non-existent groupcall returns `200`/`500` instead of `404`. If the path does
+  not re-fetch, add an explicit existence check.
+
+## Delete / Soft-Delete Semantics (canonical rule)
+
+- **Never-existed id → 404.** This is what #955 and api-validator assert, and the
+  only behavior this program guarantees for DELETE.
+- **Already-deleted id → per-service, must not regress.** Behavior varies today:
+  `groupcallHandler.Delete` has an explicit `if gc.TMDelete != nil { return gc }`
+  idempotency short-circuit (→ 200); `messageHandler.Delete` / `numberHandler.Delete`
+  have no such short-circuit and currently return 200 with a re-deleted record as
+  a side effect. This program does **not** unify that behavior — it only requires
+  that the de-swallow not change the already-deleted response. Unifying
+  idempotent-delete semantics is optional follow-up.
+- Each affected DELETE endpoint is checked so a **never-existed** id returns 404,
+  and the corresponding api-validator assertions are confirmed to encode that.
 
 ## Phasing
 
@@ -153,73 +240,108 @@ Each phase is its own spec → plan → implement → PR cycle. Dependency is li
 **Phase 0 → Phase 1 → Phase 2 → Phase 3+**.
 
 ### Phase 0 — Establish the convention (docs, no behavior change)
-- Write the canonical convention to `docs/conventions/listenhandler-error-mapping.md`,
-  referencing flow-manager as the template. Single source of truth for later phases.
+- Write the canonical convention to
+  `docs/conventions/listenhandler-error-mapping.md`, referencing flow-manager as
+  the template and `errorResponse` as the canonical mapper. Single source of
+  truth for later phases.
 
 ### Phase 1 — The 4 issue managers (closes #955)
 Full typed-error fidelity for all by-ID and state-changing endpoints (not only
 the 9 named):
-- **conversation / message / number:** central infra present → de-swallow,
-  propagate `(nil, err)`, flip central default 400→500 after per-service audit,
-  add/extend `error_response_test.go`.
-- **call-manager:** additionally port the `errorResponse` helper and upgrade the
-  central dispatch tail before propagating.
+- **conversation / message / number:** enumerate still-swallowing sites; replace
+  `return simpleResponse(500), nil` with `return errorResponse(err), nil`; verify
+  each state-changing method's not-found path (section above); add/extend
+  `error_response_test.go`.
+- **call-manager:** apply `errorResponse`-at-site to the groupcall by-id
+  endpoints (GET/DELETE/hangup and any by-id siblings) exactly like the other
+  three; verify the `Hangingup` 0-row path. **Do NOT wire the central tail in
+  this PR** — the tail is currently bare `simpleResponse(400)`, and routing
+  `dbhandler.ErrNotFound` through it would silently flip ~30 unrelated by-id call
+  endpoints (Hold/Mute/MOH/Play/Silence/etc., which return bare
+  `(nil, errors.Wrap(...))`) from 400→404 with no enumeration or test coverage.
+  Tail-wiring for call-manager is tracked as optional separate work, with its own
+  enumeration + tests, so the groupcall fix stays a reviewable, revertible diff.
 - Re-run api-validator against the 9 endpoints → green.
 - **One PR per manager** (4 PRs) for reviewable, revertible diffs.
 
 ### Phase 2 — Monorepo audit (discovery, no code change)
-- Sweep all 37 services. For each listenhandler, classify every
+- Sweep all 37 services. For each listenhandler endpoint, classify every
   `simpleResponse(500)` / swallow as (a) swallowed handler error → **fix**, or
   (b) legitimate local internal/parse error → **leave**.
-- Output: tracking checklist in `docs/plans/` (per service: infra present?,
-  endpoints to fix, handler emits typed errors?).
+- **Classify cache-miss error types per service:** services that read from Redis
+  first (e.g. call-manager) may surface not-found as a representation other than
+  the MySQL `dbhandler.ErrNotFound` sentinel; the `ErrNotFound`→404 net assumes
+  the DB sentinel reaches the mapper. Record any cache-path not-found types that
+  need explicit handling.
+- Output: tracking checklist in `docs/plans/` (per service: tail wired?,
+  endpoints to fix, handler emits typed not-found vs raw sentinel?, cache-miss
+  error type).
 
 ### Phase 3..N — Remaining services (batched)
-- Group by effort: **infra-present** (propagate + tests) vs **infra-missing**
-  (port `errorResponse` + upgrade dispatch first).
+- All services get the same at-site treatment (site changes + tests). Group only
+  by incidental effort; for tail-unwired services, wiring the `errorResponse`
+  backstop into the tail is optional and, where it would silently reclassify
+  unrelated bare-`(nil, err)` endpoints, must be its own enumerated+tested change.
 - One PR per service (or small batch). Each independently verifiable.
-- Services whose handler layer still returns *raw* `dbhandler.ErrNotFound` are
-  caught by the central `ErrNotFound`→404 branch, so they are fixed without a
-  forced handler-layer rewrite; upgrading them to typed errors is optional
-  follow-up.
+- Services whose handler layer returns only the *raw* `dbhandler.ErrNotFound`
+  sentinel are still fixed via `errorResponse`'s sentinel branch; upgrading them
+  to typed `cerrors.NotFound` is optional follow-up, not required for the 404 fix.
 
 ## Per-Service Procedure (repeatable unit)
 
-1. **Infra check** — does `errorResponse` exist and does the `main.go` tail
-   route `*cerrors.VoipbinError` and `dbhandler.ErrNotFound`? If missing, port
-   flow-manager's helper and upgrade the tail.
-2. **Default-flip audit** — grep endpoints returning bare `(nil, err)`; confirm
-   none rely on the legacy `400` default for a client-class error. Make any such
-   case local before flipping the default to 500.
+1. **Tail check (informational, not required for the fix)** — note whether
+   `main.go`'s `if err != nil` tail routes `*cerrors.VoipbinError` and
+   `dbhandler.ErrNotFound` through `errorResponse`. Because every handler-call
+   error is mapped at the site (step 3), the fix does not depend on the tail. Do
+   **not** wire an unwired tail as part of a de-swallow PR if doing so would
+   silently reclassify unrelated bare-`(nil, err)` endpoints (e.g. call-manager);
+   track tail-wiring as separate work with its own enumeration + tests.
+   (`errorResponse` already exists in all four issue services.)
+2. **Enumerate swallow sites** — grep `simpleResponse(500)` in the listenhandler
+   endpoint files; for each, decide handler-call error (→ fix) vs response-marshal
+   failure (→ leave as 500).
 3. **De-swallow** — replace handler-call `return simpleResponse(500), nil` with
-   `return nil, err`. Leave parse→`400` and marshal→`500` untouched.
-4. **Handler-layer spot check** — confirm `xHandler.Get/Delete/Update` emit
-   typed `cerrors.NotFound` (or at least raw `dbhandler.ErrNotFound`).
-5. **Tests** — extend `pkg/listenhandler/*_test.go` / `error_response_test.go`:
-   not-found→404; (full fidelity) invalid-state→409, permission→403, etc.;
-   malformed/parse→400; marshal failure→500.
+   `return errorResponse(err), nil`. Leave parse→`400` and marshal→`500` intact.
+4. **Not-found path verification** — for each state-changing method, confirm the
+   raw `dbhandler.ErrNotFound` sentinel (or typed `cerrors.NotFound`) reaches
+   `errorResponse`; add an existence check where a 0-row update would otherwise
+   succeed silently (e.g. groupcall `Hangingup`).
+5. **Tests** — two layers:
+   - *Helper-level* (`error_response_test.go`, already exists): asserts
+     `errorResponse` maps typed VoipbinError (404/403/409/429/503), raw
+     `dbhandler.ErrNotFound` (through `errors.Wrap`), internal→500, and nil. Add
+     any missing codes here once — this is where full-fidelity mapping is proven.
+   - *Per-endpoint* (`*_test.go`): assert only the codes the endpoint's handler
+     **actually emits**. For the #955 endpoints that is not-found→404 (and, e.g.,
+     conversation PUT's `InvalidArgument`→400 for a bad agent id). Do NOT add
+     synthetic 409/403/429/503 per-endpoint tests for paths that never produce
+     those codes.
 6. **Verify** — in the service dir:
    `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
 
 ## Testing & Verification Story
 
-- **Unit (per service):** listenhandler tests with a mocked handler returning
-  typed errors, asserting `sock.Response.StatusCode`. This is the regression
-  guard that would have caught #955.
+- **Unit (per service):** helper-level `error_response_test.go` proves the full
+  code matrix (404/403/409/429/503/500/400/nil) once; per-endpoint listenhandler
+  tests with a mocked handler assert only the codes that endpoint emits
+  (primarily not-found→404, plus the parse→400 / marshal→500 locals). This is the
+  regression guard that would have caught #955. Avoid synthetic per-endpoint
+  tests for codes a path never produces.
 - **Edge integration:** translator path covered by #954; add one Phase-1 sanity
   test asserting a backend 404 round-trips to client 404.
-- **End-to-end:** api-validator
-  (`monorepo-monitoring/api-validator/`) already exercises the 9 endpoints every
-  6h; Phase 1 turns them green. Add matching read-only api-validator tests for
-  any newly touched endpoints (no cost-sensitive operations).
-- **Per-PR DoD:** 5-step verification workflow passes; listenhandler tests
-  assert the new status codes; PR body lists each manager with `bin-<service>:`
-  prefixes.
+- **End-to-end:** api-validator (`monorepo-monitoring/api-validator/`) already
+  exercises the 9 endpoints every 6h; Phase 1 turns them green. Add matching
+  read-only api-validator tests for any newly touched endpoints (no
+  cost-sensitive operations per repo policy).
+- **Per-PR DoD:** 5-step verification workflow passes; listenhandler tests assert
+  the new status codes; PR body lists each manager with `bin-<service>:` prefixes.
 
 ## Definition of Done (program)
 
-- All four issue managers return 404 for non-existent UUIDs and true status for
-  other typed errors; api-validator's 9 tests pass.
+- All four issue managers return 404 for non-existent UUIDs (GET and
+  state-changing verbs) and true status for other typed errors; api-validator's 9
+  tests pass.
 - Convention documented in `docs/conventions/`.
-- Monorepo audit checklist produced; remaining services fixed in batched PRs.
+- Monorepo audit checklist produced (including cache-miss classification);
+  remaining services fixed in batched PRs.
 - Every PR passes the mandatory 5-step verification workflow.


### PR DESCRIPTION
Fix backend manager listenhandlers returning HTTP 500 instead of 404 for a valid-format but non-existent UUID on conversations, groupcalls, messages, and numbers (closes #955). The handler layers already produce a typed not-found; the listenhandler endpoints were swallowing it with bare 500 responses. Each affected endpoint now maps handler-call errors at the call site via the existing shared errorResponse helper (typed VoipbinError to its true status, dbhandler.ErrNotFound to 404, everything else to 500). Response-marshal 500s and request-parse 400s are left untouched, and no central dispatch tail / main.go changes are made.

- docs: Add listenhandler error-mapping convention (docs/conventions/listenhandler-error-mapping.md) and the design spec + implementation plan under docs/superpowers/
- bin-conversation-manager: Map handler errors at the listenhandler call site so non-existent conversation IDs return 404 instead of 500; add not-found test
- bin-message-manager: Map handler errors at the listenhandler call site so non-existent message IDs return 404 instead of 500; add GET/DELETE not-found tests
- bin-number-manager: Map handler errors at the listenhandler call site so non-existent number IDs return 404 instead of 500; add GET/DELETE not-found tests
- bin-call-manager: Map groupcall handler errors at the listenhandler call site so non-existent groupcall IDs return 404 instead of 500 (GET/DELETE/hangup); add not-found tests; central dispatch tail intentionally left unwired