### PR TITLE
NOJIRA-Fix-listenhandler-errmap-p1

### DIFF
--- a/bin-call-manager/pkg/listenhandler/main_test.go
+++ b/bin-call-manager/pkg/listenhandler/main_test.go
@@ -803,16 +803,16 @@ func Test_processRequest_errorPaths(t *testing.T) {
 			expectCode: 500,
 		},
 		{
-			name: "GET /v1/confbridges/<id> returns 400 on error",
+			name: "GET /v1/confbridges/<id> returns 500 on generic error",
 			request: &sock.Request{
 				URI:    "/v1/confbridges/68e9edd8-3609-11ec-ad76-b72fa8f57f23",
 				Method: sock.RequestMethodGet,
 			},
 			setupMocks: func(mc *gomock.Controller, h *listenHandler) {
 				mockConfbridge := h.confbridgeHandler.(*confbridgehandler.MockConfbridgeHandler)
-				mockConfbridge.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("not found"))
+				mockConfbridge.EXPECT().Get(gomock.Any(), uuid.FromStringOrNil("68e9edd8-3609-11ec-ad76-b72fa8f57f23")).Return(nil, fmt.Errorf("connection refused"))
 			},
-			expectCode: 400,
+			expectCode: 500,
 		},
 		{
 			name: "GET /v1/recordings/<id> returns 404 on typed NotFound error",

--- a/bin-call-manager/pkg/listenhandler/v1_calls.go
+++ b/bin-call-manager/pkg/listenhandler/v1_calls.go
@@ -57,7 +57,7 @@ func (h *listenHandler) processV1CallsGet(ctx context.Context, m *sock.Request) 
 	calls, err := h.callHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get calls. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(calls)
@@ -141,7 +141,7 @@ func (h *listenHandler) processV1CallsPost(ctx context.Context, m *sock.Request)
 	calls, groupcalls, err := h.callHandler.CreateCallsOutgoing(ctx, req.CustomerID, req.FlowID, req.MasterCallID, req.Source, req.Destinations, req.EarlyExecution, req.Connect, req.Anonymous, req.Metadata)
 	if err != nil {
 		log.Debugf("Could not create a outgoing call. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	tmp := &response.V1ResponseCallsPost{
@@ -197,7 +197,7 @@ func (h *listenHandler) processV1CallsIDPost(ctx context.Context, m *sock.Reques
 	c, err := h.callHandler.CreateCallOutgoing(ctx, id, req.CustomerID, req.FlowID, req.ActiveflosID, req.MasterCallID, req.GroupcallID, req.Source, req.Destination, req.EarlyExecution, req.Connect, req.Anonymous, req.Metadata)
 	if err != nil {
 		log.Debugf("Could not create a outgoing call. flow: %s, source: %v, destination: %v, err: %v", req.FlowID, req.Source, req.Destination, err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(c)
@@ -234,7 +234,7 @@ func (h *listenHandler) processV1CallsIDDelete(ctx context.Context, m *sock.Requ
 	tmp, err := h.callHandler.Delete(ctx, id)
 	if err != nil {
 		log.Debugf("Could not delete the call. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -271,7 +271,7 @@ func (h *listenHandler) processV1CallsIDHangupPost(ctx context.Context, m *sock.
 	tmp, err := h.callHandler.HangingUp(ctx, id, call.HangupReasonNormal)
 	if err != nil {
 		log.Debugf("Could not hanging up the call. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -427,7 +427,7 @@ func (h *listenHandler) processV1CallsIDChainedCallIDsPost(ctx context.Context, 
 	tmp, err := h.callHandler.ChainedCallIDAdd(ctx, id, req.ChainedCallID)
 	if err != nil {
 		log.Debugf("Could not get updated call info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -463,7 +463,7 @@ func (h *listenHandler) processV1CallsIDChainedCallIDsDelete(ctx context.Context
 	tmp, err := h.callHandler.ChainedCallIDRemove(ctx, id, chainedCallID)
 	if err != nil {
 		log.Debugf("Could not get updated call info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -593,7 +593,7 @@ func (h *listenHandler) processV1CallsIDDigitsGet(ctx context.Context, m *sock.R
 	digit, err := h.callHandler.DigitsGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get call's digits. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	tmp := &response.V1ResponseCallsIDDigitsGet{
@@ -635,7 +635,7 @@ func (h *listenHandler) processV1CallsIDDigitsSet(ctx context.Context, m *sock.R
 
 	if err := h.callHandler.DigitsSet(ctx, id, req.Digits); err != nil {
 		log.Errorf("Could not get call's digits. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	res := &sock.Response{
@@ -667,7 +667,7 @@ func (h *listenHandler) processV1CallsIDRecordingIDPut(ctx context.Context, m *s
 	tmp, err := h.callHandler.UpdateRecordingID(ctx, id, req.RecordingID)
 	if err != nil {
 		log.Errorf("Could not update call's recording id. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -706,7 +706,7 @@ func (h *listenHandler) processV1CallsIDConfbridgeIDPut(ctx context.Context, m *
 	tmp, err := h.callHandler.UpdateConfbridgeID(ctx, id, req.ConfbridgeID)
 	if err != nil {
 		log.Errorf("Could not update call's recording id. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -745,7 +745,7 @@ func (h *listenHandler) processV1CallsIDRecordingStartPost(ctx context.Context, 
 	tmp, err := h.callHandler.RecordingStart(ctx, id, req.Format, req.EndOfSilence, req.EndOfKey, req.Duration, req.OnEndFlowID)
 	if err != nil {
 		log.Errorf("Could not start call recording. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -780,7 +780,7 @@ func (h *listenHandler) processV1CallsIDRecordingStopPost(ctx context.Context, m
 	tmp, err := h.callHandler.RecordingStop(ctx, id)
 	if err != nil {
 		log.Errorf("Could not start call recording. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -819,7 +819,7 @@ func (h *listenHandler) processV1CallsIDTalkPost(ctx context.Context, m *sock.Re
 
 	if errTalk := h.callHandler.Talk(ctx, id, false, req.Text, req.Language, req.Provider, req.VoiceID); errTalk != nil {
 		log.Errorf("Could not talk to the call. err: %v", errTalk)
-		return simpleResponse(500), nil
+		return errorResponse(errTalk), nil
 	}
 
 	res := &sock.Response{
@@ -876,7 +876,7 @@ func (h *listenHandler) processV1CallsIDMediaStopPost(ctx context.Context, m *so
 
 	if errStop := h.callHandler.MediaStop(ctx, id); errStop != nil {
 		log.Errorf("Could not stop the media. err: %v", errStop)
-		return simpleResponse(500), nil
+		return errorResponse(errStop), nil
 	}
 
 	res := &sock.Response{

--- a/bin-call-manager/pkg/listenhandler/v1_confbridges.go
+++ b/bin-call-manager/pkg/listenhandler/v1_confbridges.go
@@ -35,13 +35,13 @@ func (h *listenHandler) processV1ConfbridgesPost(ctx context.Context, m *sock.Re
 	cb, err := h.confbridgeHandler.Create(ctx, req.CustomerID, req.ActiveflowID, req.ReferenceType, req.ReferenceID, req.Type)
 	if err != nil {
 		log.Errorf("Could not create the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	tmp, err := json.Marshal(cb)
 	if err != nil {
 		log.Errorf("Could not marshal the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -70,13 +70,13 @@ func (h *listenHandler) processV1ConfbridgesIDGet(ctx context.Context, m *sock.R
 	cb, err := h.confbridgeHandler.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	tmp, err := json.Marshal(cb)
 	if err != nil {
 		log.Errorf("Could not marshal the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -104,7 +104,7 @@ func (h *listenHandler) processV1ConfbridgesIDDelete(ctx context.Context, m *soc
 	tmp, err := h.confbridgeHandler.Delete(ctx, id)
 	if err != nil {
 		log.Errorf("Could not terminate the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -139,7 +139,7 @@ func (h *listenHandler) processV1ConfbridgesIDTerminatePost(ctx context.Context,
 	tmp, err := h.confbridgeHandler.Terminating(ctx, id)
 	if err != nil {
 		log.Errorf("Could not terminate the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -174,7 +174,7 @@ func (h *listenHandler) processV1ConfbridgesIDCallsIDDelete(ctx context.Context,
 
 	if err := h.confbridgeHandler.Kick(ctx, id, callID); err != nil {
 		log.Errorf("Could not kick out the call from the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	return simpleResponse(200), nil
@@ -197,7 +197,7 @@ func (h *listenHandler) processV1ConfbridgesIDCallsIDPost(ctx context.Context, m
 
 	if err := h.confbridgeHandler.Join(ctx, id, callID); err != nil {
 		log.Errorf("Could not join the call to the confbridge. err: %v", err)
-		return simpleResponse(400), nil
+		return errorResponse(err), nil
 	}
 
 	return simpleResponse(200), nil
@@ -321,7 +321,7 @@ func (h *listenHandler) processV1ConfbridgesIDRecordingStartPost(ctx context.Con
 	tmp, err := h.confbridgeHandler.RecordingStart(ctx, id, req.Format, req.EndOfSilence, req.EndOfKey, req.Duration, req.OnEndFlowID)
 	if err != nil {
 		log.Errorf("Could not start call recording. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -356,7 +356,7 @@ func (h *listenHandler) processV1ConfbridgesIDRecordingStopPost(ctx context.Cont
 	tmp, err := h.confbridgeHandler.RecordingStop(ctx, id)
 	if err != nil {
 		log.Errorf("Could not start call recording. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -396,7 +396,7 @@ func (h *listenHandler) processV1ConfbridgesIDFlagsPost(ctx context.Context, m *
 	tmp, err := h.confbridgeHandler.FlagAdd(ctx, id, req.Flag)
 	if err != nil {
 		log.Errorf("Could not add the flag. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -436,7 +436,7 @@ func (h *listenHandler) processV1ConfbridgesIDFlagsDelete(ctx context.Context, m
 	tmp, err := h.confbridgeHandler.FlagRemove(ctx, id, req.Flag)
 	if err != nil {
 		log.Errorf("Could not remove the flag. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -470,7 +470,7 @@ func (h *listenHandler) processV1ConfbridgesIDRingPost(ctx context.Context, m *s
 
 	if errRing := h.confbridgeHandler.Ring(ctx, id); errRing != nil {
 		log.Errorf("Could not ring the confbridge. err: %v", errRing)
-		return simpleResponse(500), nil
+		return errorResponse(errRing), nil
 	}
 
 	return simpleResponse(200), nil
@@ -492,7 +492,7 @@ func (h *listenHandler) processV1ConfbridgesIDAnswerPost(ctx context.Context, m 
 
 	if errRing := h.confbridgeHandler.Answer(ctx, id); errRing != nil {
 		log.Errorf("Could not answer the confbridge. err: %v", errRing)
-		return simpleResponse(500), nil
+		return errorResponse(errRing), nil
 	}
 
 	return simpleResponse(200), nil

--- a/bin-call-manager/pkg/listenhandler/v1_external_medias.go
+++ b/bin-call-manager/pkg/listenhandler/v1_external_medias.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1ExternalMediasGet(ctx context.Context, m *sock.
 	tmps, err := h.externalMediaHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get external medias. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmps)
@@ -98,7 +98,7 @@ func (h *listenHandler) processV1ExternalMediasPost(ctx context.Context, m *sock
 	)
 	if err != nil {
 		log.Errorf("Could not start the external media. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-call-manager/pkg/listenhandler/v1_notfound_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_notfound_test.go
@@ -1,0 +1,286 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-call-manager/pkg/callhandler"
+	"monorepo/bin-call-manager/pkg/confbridgehandler"
+	"monorepo/bin-call-manager/pkg/dbhandler"
+	"monorepo/bin-call-manager/pkg/externalmediahandler"
+	"monorepo/bin-call-manager/pkg/outboundconfighandler"
+	"monorepo/bin-call-manager/pkg/recordinghandler"
+)
+
+// Test_processV1CallsIDDelete_notFound verifies that a handler returning
+// dbhandler.ErrNotFound is translated to HTTP 404 (not 500).
+func Test_processV1CallsIDDelete_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "DELETE non-existent call returns 404",
+			request: &sock.Request{
+				URI:    "/v1/calls/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				callHandler: mockCall,
+			}
+
+			mockCall.EXPECT().Delete(gomock.Any(), tt.id).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1ConfbridgesIDGet_notFound verifies that confbridgeHandler.Get
+// returning dbhandler.ErrNotFound produces HTTP 404.
+func Test_processV1ConfbridgesIDGet_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent confbridge returns 404",
+			request: &sock.Request{
+				URI:    "/v1/confbridges/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockConfbridge := confbridgehandler.NewMockConfbridgeHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:       mockSock,
+				callHandler:       mockCall,
+				confbridgeHandler: mockConfbridge,
+			}
+
+			mockConfbridge.EXPECT().Get(gomock.Any(), tt.id).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1ConfbridgesIDDelete_notFound verifies that confbridgeHandler.Delete
+// returning dbhandler.ErrNotFound produces HTTP 404.
+func Test_processV1ConfbridgesIDDelete_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "DELETE non-existent confbridge returns 404",
+			request: &sock.Request{
+				URI:    "/v1/confbridges/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockConfbridge := confbridgehandler.NewMockConfbridgeHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:       mockSock,
+				callHandler:       mockCall,
+				confbridgeHandler: mockConfbridge,
+			}
+
+			mockConfbridge.EXPECT().Delete(gomock.Any(), tt.id).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1RecordingsGet_notFound verifies that recordingHandler.List
+// returning dbhandler.ErrNotFound produces HTTP 404 (not 500).
+func Test_processV1RecordingsGet_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+	}{
+		{
+			name: "GET recordings list with ErrNotFound returns 404",
+			request: &sock.Request{
+				URI:    "/v1/recordings?page_size=10",
+				Method: sock.RequestMethodGet,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockRecording := recordinghandler.NewMockRecordingHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:      mockSock,
+				callHandler:      mockCall,
+				recordingHandler: mockRecording,
+			}
+
+			mockRecording.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1ExternalMediasGet_notFound verifies that externalMediaHandler.List
+// returning dbhandler.ErrNotFound produces HTTP 404 (not 500).
+func Test_processV1ExternalMediasGet_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+	}{
+		{
+			name: "GET external-medias list with ErrNotFound returns 404",
+			request: &sock.Request{
+				URI:    "/v1/external-medias?page_size=10",
+				Method: sock.RequestMethodGet,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockExternalMedia := externalmediahandler.NewMockExternalMediaHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:          mockSock,
+				callHandler:          mockCall,
+				externalMediaHandler: mockExternalMedia,
+			}
+
+			mockExternalMedia.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1OutboundConfigsGet_notFound verifies that outboundConfigHandler.List
+// returning dbhandler.ErrNotFound produces HTTP 404 (not 500).
+func Test_processV1OutboundConfigsGet_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+	}{
+		{
+			name: "GET outbound configs list with ErrNotFound returns 404",
+			request: &sock.Request{
+				URI:    "/v1/outbound_configs?customer_id=00000000-0000-0000-0000-000000000001",
+				Method: sock.RequestMethodGet,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockOutboundConfig := outboundconfighandler.NewMockOutboundConfigHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:           mockSock,
+				callHandler:           mockCall,
+				outboundConfigHandler: mockOutboundConfig,
+			}
+
+			mockOutboundConfig.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}

--- a/bin-call-manager/pkg/listenhandler/v1_outbound_configs.go
+++ b/bin-call-manager/pkg/listenhandler/v1_outbound_configs.go
@@ -42,7 +42,7 @@ func (h *listenHandler) processV1OutboundConfigsPost(ctx context.Context, m *soc
 		if strings.Contains(err.Error(), "Duplicate entry") {
 			return simpleResponse(409), nil
 		}
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(outboundconfig.ConvertWebhookMessage(c))
@@ -81,7 +81,7 @@ func (h *listenHandler) processV1OutboundConfigsGet(ctx context.Context, m *sock
 	configs, err := h.outboundConfigHandler.List(ctx, customerID, pageSize, pageToken)
 	if err != nil {
 		log.Errorf("Could not list outbound configs. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// convert to webhook messages

--- a/bin-call-manager/pkg/listenhandler/v1_recordings.go
+++ b/bin-call-manager/pkg/listenhandler/v1_recordings.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1RecordingsGet(ctx context.Context, m *sock.Requ
 	tmps, err := h.recordingHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Debugf("Could not get recordings. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmps)
@@ -85,7 +85,7 @@ func (h *listenHandler) processV1RecordingsPost(ctx context.Context, m *sock.Req
 	tmp, err := h.recordingHandler.Start(ctx, req.ActiveflowID, req.ReferenceType, req.ReferenceID, req.Format, req.EndOfSilence, req.EndOfKey, req.Duration, req.OnEndFlowID)
 	if err != nil {
 		log.Errorf("Could not start the recording. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-queue-manager/go.sum
+++ b/bin-queue-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-queue-manager/pkg/listenhandler/v1_count.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_count.go
@@ -34,7 +34,7 @@ func (h *listenHandler) processV1QueuesCountByCustomerGet(ctx context.Context, m
 	count, err := h.queueHandler.CountByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get queue count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})

--- a/bin-queue-manager/pkg/listenhandler/v1_queuecalls.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queuecalls.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1QueuecallsGet(ctx context.Context, m *sock.Requ
 	tmp, err := h.queuecallHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get queuecalls info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -87,7 +87,7 @@ func (h *listenHandler) processV1QueuecallsReferenceIDIDGet(ctx context.Context,
 	tmp, err := h.queuecallHandler.GetByReferenceID(ctx, referenceID)
 	if err != nil {
 		log.Errorf("Could not get queuecall info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -255,7 +255,7 @@ func (h *listenHandler) processV1QueuecallsIDExecutePost(ctx context.Context, m 
 	tmp, err := h.queuecallHandler.Execute(ctx, id, req.AgentID)
 	if err != nil {
 		log.Errorf("Could not leave the queuecall from the queue. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -290,7 +290,7 @@ func (h *listenHandler) processV1QueuecallsIDKickPost(ctx context.Context, m *so
 	tmp, err := h.queuecallHandler.Kick(ctx, id)
 	if err != nil {
 		log.Errorf("Could not leave the queuecall from the queue. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -325,7 +325,7 @@ func (h *listenHandler) processV1QueuecallsReferenceIDIDKickPost(ctx context.Con
 	tmp, err := h.queuecallHandler.KickByReferenceID(ctx, referenceID)
 	if err != nil {
 		log.Errorf("Could not leave the queuecall from the queue. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-queue-manager/pkg/listenhandler/v1_queuecalls_test.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queuecalls_test.go
@@ -1,6 +1,7 @@
 package listenhandler
 
 import (
+	"net/http"
 	reflect "reflect"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	"monorepo/bin-queue-manager/models/queuecall"
+	"monorepo/bin-queue-manager/pkg/dbhandler"
 	"monorepo/bin-queue-manager/pkg/queuecallhandler"
 )
 
@@ -554,5 +556,36 @@ func Test_processV1QueuecallsIDStatusWaitingPost(t *testing.T) {
 				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectedRes, res)
 			}
 		})
+	}
+}
+
+func Test_processV1QueuecallsReferenceIDIDGet_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockQueuecall := queuecallhandler.NewMockQueuecallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:      mockSock,
+		queuecallHandler: mockQueuecall,
+	}
+
+	referenceID := uuid.FromStringOrNil("bb000000-0000-0000-0000-000000000001")
+
+	mockQueuecall.EXPECT().GetByReferenceID(gomock.Any(), referenceID).Return(nil, dbhandler.ErrNotFound)
+
+	req := &sock.Request{
+		URI:    "/v1/queuecalls/reference_id/bb000000-0000-0000-0000-000000000001",
+		Method: sock.RequestMethodGet,
+	}
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("Wrong status code. expect: %d, got: %d", http.StatusNotFound, res.StatusCode)
 	}
 }

--- a/bin-queue-manager/pkg/listenhandler/v1_queues.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues.go
@@ -98,7 +98,7 @@ func (h *listenHandler) processV1QueuesGet(ctx context.Context, m *sock.Request)
 	tmp, err := h.queueHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get queue info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -229,7 +229,7 @@ func (h *listenHandler) processV1QueuesIDPut(ctx context.Context, m *sock.Reques
 	)
 	if err != nil {
 		log.Errorf("Could not update the queue info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -271,7 +271,7 @@ func (h *listenHandler) processV1QueuesIDTagIDsPut(ctx context.Context, m *sock.
 	tmp, err := h.queueHandler.UpdateTagIDs(ctx, id, req.TagIDs)
 	if err != nil {
 		log.Errorf("Could not get queue info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -313,7 +313,7 @@ func (h *listenHandler) processV1QueuesIDRoutingMethodPut(ctx context.Context, m
 	tmp, err := h.queueHandler.UpdateRoutingMethod(ctx, id, queue.RoutingMethod(req.RoutingMethod))
 	if err != nil {
 		log.Errorf("Could not update the queue info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -405,7 +405,7 @@ func (h *listenHandler) processV1QueuesIDAgentsGet(ctx context.Context, m *sock.
 	tmp, err := h.queueHandler.GetAgents(ctx, id, status)
 	if err != nil {
 		log.Errorf("Could not get agents. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -471,7 +471,7 @@ func (h *listenHandler) processV1QueuesIDExecutePut(ctx context.Context, m *sock
 	tmp, err := h.queueHandler.UpdateExecute(ctx, id, req.Execute)
 	if err != nil {
 		log.Errorf("Could not get agents. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -506,7 +506,7 @@ func (h *listenHandler) processV1QueuecallsIDStatusWaitingPost(ctx context.Conte
 	tmp, err := h.queuecallHandler.UpdateStatusWaiting(ctx, id)
 	if err != nil {
 		log.Errorf("Could not leave the queuecall from the queue. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-queue-manager/pkg/listenhandler/v1_queues_direct_hash.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues_direct_hash.go
@@ -28,7 +28,7 @@ func (h *listenHandler) processV1QueuesIDDirectHashRegeneratePost(ctx context.Co
 	tmp, err := h.queueHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-queue-manager/pkg/listenhandler/v1_queues_direct_hash_test.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues_direct_hash_test.go
@@ -1,0 +1,46 @@
+package listenhandler
+
+import (
+	"net/http"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-queue-manager/pkg/dbhandler"
+	"monorepo/bin-queue-manager/pkg/queuehandler"
+)
+
+func Test_processV1QueuesIDDirectHashRegeneratePost_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockQueue := queuehandler.NewMockQueueHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:  mockSock,
+		queueHandler: mockQueue,
+	}
+
+	queueID := uuid.FromStringOrNil("aa000000-0000-0000-0000-000000000001")
+
+	mockQueue.EXPECT().DirectHashRegenerate(gomock.Any(), queueID).Return(nil, dbhandler.ErrNotFound)
+
+	req := &sock.Request{
+		URI:    "/v1/queues/aa000000-0000-0000-0000-000000000001/direct-hash-regenerate",
+		Method: sock.RequestMethodPost,
+	}
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("Wrong status code. expect: %d, got: %d", http.StatusNotFound, res.StatusCode)
+	}
+}

--- a/bin-queue-manager/pkg/listenhandler/v1_queues_test.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_queues_test.go
@@ -18,6 +18,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	"monorepo/bin-queue-manager/models/queue"
+	"monorepo/bin-queue-manager/pkg/dbhandler"
 	"monorepo/bin-queue-manager/pkg/queuehandler"
 )
 
@@ -885,5 +886,39 @@ func Test_processV1QueuesIDExecutePut(t *testing.T) {
 				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectedRes, res)
 			}
 		})
+	}
+}
+
+func Test_processV1QueuesIDPut_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockQueue := queuehandler.NewMockQueueHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:  mockSock,
+		queueHandler: mockQueue,
+	}
+
+	mockQueue.EXPECT().UpdateBasicInfo(
+		gomock.Any(),
+		uuid.FromStringOrNil("66f7d436-5f6c-11ec-9298-677df04a59c2"),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil, dbhandler.ErrNotFound)
+
+	req := &sock.Request{
+		URI:    "/v1/queues/66f7d436-5f6c-11ec-9298-677df04a59c2",
+		Method: sock.RequestMethodPut,
+		Data:   []byte(`{"name":"x","detail":"","routing_method":"random","tag_ids":[],"wait_flow_id":"00000000-0000-0000-0000-000000000000","wait_timeout":0,"service_timeout":0}`),
+	}
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("Wrong status code. expect: %d, got: %d", http.StatusNotFound, res.StatusCode)
 	}
 }

--- a/bin-queue-manager/pkg/listenhandler/v1_services.go
+++ b/bin-queue-manager/pkg/listenhandler/v1_services.go
@@ -30,7 +30,7 @@ func (h *listenHandler) processV1ServicesTypeQueuecallPost(ctx context.Context, 
 	tmp, err := h.queuecallHandler.ServiceStart(ctx, req.QueueID, req.ActiveflowID, req.ReferenceType, req.ReferenceID)
 	if err != nil {
 		log.Errorf("Could not create aicall. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-rag-manager/go.sum
+++ b/bin-rag-manager/go.sum
@@ -479,6 +479,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-rag-manager/pkg/listenhandler/v1_query.go
+++ b/bin-rag-manager/pkg/listenhandler/v1_query.go
@@ -38,7 +38,7 @@ func (h *listenHandler) processV1QueryPost(ctx context.Context, m *sock.Request)
 	res, err := h.ragHandler.QueryRag(ctx, req.RagID, req.Query, req.TopK)
 	if err != nil {
 		log.Errorf("Could not query rag. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, res), nil

--- a/bin-rag-manager/pkg/listenhandler/v1_rags.go
+++ b/bin-rag-manager/pkg/listenhandler/v1_rags.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1RagsPost(ctx context.Context, m *sock.Request) 
 	r, err := h.ragHandler.RagCreate(ctx, reqData.CustomerID, reqData.Name, reqData.Description, reqData.StorageFileIDs, reqData.SourceURLs)
 	if err != nil {
 		log.Errorf("Could not create rag. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, r), nil
@@ -87,7 +87,7 @@ func (h *listenHandler) processV1RagsGet(ctx context.Context, m *sock.Request) (
 	rags, err := h.ragHandler.RagList(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not list rags. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, rags), nil
@@ -112,7 +112,7 @@ func (h *listenHandler) processV1RagsIDGet(ctx context.Context, m *sock.Request)
 	r, err := h.ragHandler.RagGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get rag. err: %v", err)
-		return simpleResponse(404), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, r), nil
@@ -159,7 +159,7 @@ func (h *listenHandler) processV1RagsIDPut(ctx context.Context, m *sock.Request)
 	r, err := h.ragHandler.RagUpdate(ctx, id, fields)
 	if err != nil {
 		log.Errorf("Could not update rag. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, r), nil
@@ -183,7 +183,7 @@ func (h *listenHandler) processV1RagsIDDelete(ctx context.Context, m *sock.Reque
 
 	if err := h.ragHandler.RagDelete(ctx, id); err != nil {
 		log.Errorf("Could not delete rag. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return simpleResponse(200), nil
@@ -223,7 +223,7 @@ func (h *listenHandler) processV1RagsIDSourcesPost(ctx context.Context, m *sock.
 	r, err := h.ragHandler.RagAddSources(ctx, ragID, reqData.StorageFileIDs, reqData.SourceURLs)
 	if err != nil {
 		log.Errorf("Could not add sources. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, r), nil
@@ -256,7 +256,7 @@ func (h *listenHandler) processV1RagsIDSourcesIDDelete(ctx context.Context, m *s
 	r, err := h.ragHandler.RagRemoveSource(ctx, ragID, sourceID)
 	if err != nil {
 		log.Errorf("Could not remove source. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return jsonResponse(200, r), nil

--- a/bin-rag-manager/pkg/listenhandler/v1_rags_errmap_test.go
+++ b/bin-rag-manager/pkg/listenhandler/v1_rags_errmap_test.go
@@ -1,0 +1,292 @@
+package listenhandler
+
+// Tests for handler-call error mapping in v1_rags.go and v1_query.go.
+// These tests verify that errors from the ragHandler call site are forwarded
+// through errorResponse() so that ErrNotFound yields 404 (not 500) and
+// generic internal errors yield 500 (not the wrong 404).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-rag-manager/pkg/dbhandler"
+	"monorepo/bin-rag-manager/pkg/raghandler"
+)
+
+// newTestHandler builds a listenHandler backed by the supplied raghandler mock.
+func newTestHandler(t *testing.T, rh raghandler.RagHandler) *listenHandler {
+	t.Helper()
+	return &listenHandler{
+		sockHandler: &mockSockHandler{},
+		ragHandler:  rh,
+	}
+}
+
+// uriWithID builds a URI like /v1/rags/<uuid>.
+func uriWithID(prefix string, id uuid.UUID) string {
+	return prefix + id.String()
+}
+
+// ---------------------------------------------------------------------------
+// processV1RagsIDGet — latent-bug fix: previously returned 404 for ALL errors;
+// must now return 404 only for ErrNotFound, 500 for generic errors.
+// ---------------------------------------------------------------------------
+
+func TestProcessV1RagsIDGet_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	id := uuid.Must(uuid.NewV4())
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().RagGet(gomock.Any(), id).Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+	req := &sock.Request{
+		URI:    uriWithID("/v1/rags/", id),
+		Method: sock.RequestMethodGet,
+	}
+	resp, err := h.processV1RagsIDGet(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessV1RagsIDGet_GenericError_Returns500(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	id := uuid.Must(uuid.NewV4())
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().RagGet(gomock.Any(), id).Return(nil, fmt.Errorf("boom"))
+
+	h := newTestHandler(t, mock)
+	req := &sock.Request{
+		URI:    uriWithID("/v1/rags/", id),
+		Method: sock.RequestMethodGet,
+	}
+	resp, err := h.processV1RagsIDGet(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500 for generic error, got %d (latent-bug fix: was returning 404)", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processV1RagsIDPut — was returning 500 for all errors; must return 404 for ErrNotFound.
+// ---------------------------------------------------------------------------
+
+func TestProcessV1RagsIDPut_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	id := uuid.Must(uuid.NewV4())
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().RagUpdate(gomock.Any(), id, gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+
+	name := "updated-name"
+	body, _ := json.Marshal(map[string]string{"name": name})
+	req := &sock.Request{
+		URI:    uriWithID("/v1/rags/", id),
+		Method: sock.RequestMethodPut,
+		Data:   body,
+	}
+	resp, err := h.processV1RagsIDPut(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processV1RagsIDDelete — was returning 500 for all errors; must return 404 for ErrNotFound.
+// ---------------------------------------------------------------------------
+
+func TestProcessV1RagsIDDelete_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	id := uuid.Must(uuid.NewV4())
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().RagDelete(gomock.Any(), id).Return(dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+	req := &sock.Request{
+		URI:    uriWithID("/v1/rags/", id),
+		Method: sock.RequestMethodDelete,
+	}
+	resp, err := h.processV1RagsIDDelete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional coverage: processV1RagsPost, processV1RagsGet,
+// processV1RagsIDSourcesPost, processV1RagsIDSourcesIDDelete, processV1QueryPost.
+// All were returning 500 for all errors; must return 404 for ErrNotFound.
+// ---------------------------------------------------------------------------
+
+func TestProcessV1RagsPost_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	customerID := uuid.Must(uuid.NewV4())
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().
+		RagCreate(gomock.Any(), customerID, "test", "", gomock.Any(), gomock.Any()).
+		Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+
+	body, _ := json.Marshal(map[string]any{
+		"customer_id":      customerID.String(),
+		"name":             "test",
+		"storage_file_ids": []string{uuid.Must(uuid.NewV4()).String()},
+	})
+	req := &sock.Request{
+		URI:    "/v1/rags",
+		Method: sock.RequestMethodPost,
+		Data:   body,
+	}
+	resp, err := h.processV1RagsPost(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessV1RagsGet_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().
+		RagList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+	req := &sock.Request{
+		URI:    "/v1/rags",
+		Method: sock.RequestMethodGet,
+		Data:   []byte("{}"),
+	}
+	resp, err := h.processV1RagsGet(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessV1RagsIDSourcesPost_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ragID := uuid.Must(uuid.NewV4())
+	fileID := uuid.Must(uuid.NewV4())
+
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().
+		RagAddSources(gomock.Any(), ragID, gomock.Any(), gomock.Any()).
+		Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+	body, _ := json.Marshal(map[string]any{
+		"storage_file_ids": []string{fileID.String()},
+	})
+	req := &sock.Request{
+		URI:    "/v1/rags/" + ragID.String() + "/sources",
+		Method: sock.RequestMethodPost,
+		Data:   body,
+	}
+	resp, err := h.processV1RagsIDSourcesPost(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessV1RagsIDSourcesIDDelete_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ragID := uuid.Must(uuid.NewV4())
+	sourceID := uuid.Must(uuid.NewV4())
+
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().
+		RagRemoveSource(gomock.Any(), ragID, sourceID).
+		Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+	req := &sock.Request{
+		URI:    "/v1/rags/" + ragID.String() + "/sources/" + sourceID.String(),
+		Method: sock.RequestMethodDelete,
+	}
+	resp, err := h.processV1RagsIDSourcesIDDelete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+func TestProcessV1QueryPost_NotFound_Returns404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ragID := uuid.Must(uuid.NewV4())
+	mock := raghandler.NewMockRagHandler(ctrl)
+	mock.EXPECT().
+		QueryRag(gomock.Any(), ragID, "test query", 0).
+		Return(nil, dbhandler.ErrNotFound)
+
+	h := newTestHandler(t, mock)
+	body, _ := json.Marshal(map[string]any{
+		"rag_id": ragID.String(),
+		"query":  "test query",
+	})
+	req := &sock.Request{
+		URI:    "/v1/query",
+		Method: sock.RequestMethodPost,
+		Data:   body,
+	}
+	resp, err := h.processV1QueryPost(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for ErrNotFound, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time check: MockRagHandler satisfies raghandler.RagHandler.
+// ---------------------------------------------------------------------------
+
+var _ raghandler.RagHandler = (*raghandler.MockRagHandler)(nil)

--- a/bin-talk-manager/go.sum
+++ b/bin-talk-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-talk-manager/pkg/listenhandler/v1_chats.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats.go
@@ -48,7 +48,7 @@ func (h *listenHandler) v1ChatsPost(ctx context.Context, m commonsock.Request) (
 
 	t, err := h.chatHandler.ChatCreate(ctx, customerID, chat.Type(req.Type), req.Name, req.Detail, req.CreatorType, creatorID, participants)
 	if err != nil {
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(t)
@@ -89,7 +89,7 @@ func (h *listenHandler) v1ChatsGet(ctx context.Context, m commonsock.Request) (*
 
 	chats, err := h.chatHandler.ChatList(ctx, typedFilters, pageToken, pageSize)
 	if err != nil {
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(chats)
@@ -134,7 +134,7 @@ func (h *listenHandler) v1ChatsIDPut(ctx context.Context, m commonsock.Request) 
 	t, err := h.chatHandler.ChatUpdate(ctx, chatID, req.Name, req.Detail)
 	if err != nil {
 		logrus.Errorf("Failed to update chat: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(t)
@@ -151,7 +151,7 @@ func (h *listenHandler) v1ChatsIDDelete(ctx context.Context, m commonsock.Reques
 
 	t, err := h.chatHandler.ChatDelete(ctx, chatID)
 	if err != nil {
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(t)

--- a/bin-talk-manager/pkg/listenhandler/v1_chats_participants.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats_participants.go
@@ -36,7 +36,7 @@ func (h *listenHandler) v1ChatsIDParticipantsPost(ctx context.Context, m commons
 	participant, err := h.participantHandler.ParticipantAdd(ctx, chatID, ownerID, req.OwnerType)
 	if err != nil {
 		logrus.Errorf("Failed to add participant: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(participant)
@@ -67,7 +67,7 @@ func (h *listenHandler) v1ChatsIDParticipantsGet(ctx context.Context, m commonso
 	participants, err := h.participantHandler.ParticipantList(ctx, chat.CustomerID, chatID)
 	if err != nil {
 		logrus.Errorf("Failed to list participants: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(participants)
@@ -99,7 +99,7 @@ func (h *listenHandler) v1ChatsIDParticipantsIDDelete(ctx context.Context, m com
 	err = h.participantHandler.ParticipantRemove(ctx, chat.CustomerID, participantID)
 	if err != nil {
 		logrus.Errorf("Failed to remove participant: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	return &commonsock.Response{

--- a/bin-talk-manager/pkg/listenhandler/v1_chats_test.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_chats_test.go
@@ -16,6 +16,7 @@ import (
 	"monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-talk-manager/models/chat"
 	"monorepo/bin-talk-manager/pkg/chathandler"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
 )
 
 func timePtrChat(t time.Time) *time.Time {
@@ -583,6 +584,71 @@ func Test_processV1TalkChatsIDDelete(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_processV1TalkChatsIDPut_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockChat := chathandler.NewMockChatHandler(mc)
+
+	h := &listenHandler{
+		sockHandler: mockSock,
+		chatHandler: mockChat,
+	}
+
+	ctx := context.Background()
+	chatID := uuid.FromStringOrNil("6ebc6880-31da-11ed-8e95-a3bc92af9795")
+	mockChat.EXPECT().ChatUpdate(ctx, chatID, gomock.Any(), gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+	req := &sock.Request{
+		URI:      "/v1/chats/6ebc6880-31da-11ed-8e95-a3bc92af9795",
+		Method:   sock.RequestMethodPut,
+		DataType: "application/json",
+		Data:     []byte(`{"name":"irrelevant"}`),
+	}
+
+	res, err := h.v1ChatsIDPut(ctx, *req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != 404 {
+		t.Errorf("Wrong match. expect: 404, got: %d", res.StatusCode)
+	}
+}
+
+func Test_processV1TalkChatsIDDelete_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockChat := chathandler.NewMockChatHandler(mc)
+
+	h := &listenHandler{
+		sockHandler: mockSock,
+		chatHandler: mockChat,
+	}
+
+	ctx := context.Background()
+	chatID := uuid.FromStringOrNil("6ebc6880-31da-11ed-8e95-a3bc92af9795")
+	mockChat.EXPECT().ChatDelete(ctx, chatID).Return(nil, dbhandler.ErrNotFound)
+
+	req := &sock.Request{
+		URI:      "/v1/chats/6ebc6880-31da-11ed-8e95-a3bc92af9795",
+		Method:   sock.RequestMethodDelete,
+		DataType: "application/json",
+	}
+
+	res, err := h.v1ChatsIDDelete(ctx, *req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != 404 {
+		t.Errorf("Wrong match. expect: 404, got: %d", res.StatusCode)
 	}
 }
 

--- a/bin-talk-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_messages.go
@@ -51,7 +51,7 @@ func (h *listenHandler) v1MessagesPost(ctx context.Context, m commonsock.Request
 	msg, err := h.messageHandler.MessageCreate(ctx, createReq)
 	if err != nil {
 		logrus.Errorf("Failed to create message: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(msg)
@@ -95,7 +95,7 @@ func (h *listenHandler) v1MessagesGet(ctx context.Context, m commonsock.Request)
 	messages, err := h.messageHandler.MessageList(ctx, typedFilters, pageToken, pageSize)
 	if err != nil {
 		log.Errorf("Could not list the messages. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(messages)
@@ -137,7 +137,7 @@ func (h *listenHandler) v1MessagesIDDelete(ctx context.Context, m commonsock.Req
 	msg, err := h.messageHandler.MessageDelete(ctx, messageID)
 	if err != nil {
 		log.Errorf("Could not delete the message. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(msg)

--- a/bin-talk-manager/pkg/listenhandler/v1_messages_test.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_messages_test.go
@@ -15,6 +15,7 @@ import (
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 	"monorepo/bin-talk-manager/models/message"
+	"monorepo/bin-talk-manager/pkg/dbhandler"
 	"monorepo/bin-talk-manager/pkg/messagehandler"
 )
 
@@ -470,6 +471,38 @@ func Test_processV1MessagesIDDelete(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_processV1MessagesIDDelete_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:    mockSock,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+	messageID := uuid.FromStringOrNil("9ade9b10-64ed-11ed-b1c8-d6ef95af9798")
+	mockMessage.EXPECT().MessageDelete(ctx, messageID).Return(nil, dbhandler.ErrNotFound)
+
+	req := &sock.Request{
+		URI:      "/v1/messages/9ade9b10-64ed-11ed-b1c8-d6ef95af9798",
+		Method:   sock.RequestMethodDelete,
+		DataType: "application/json",
+	}
+
+	res, err := h.v1MessagesIDDelete(ctx, *req)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if res.StatusCode != 404 {
+		t.Errorf("Wrong match. expect: 404, got: %d", res.StatusCode)
 	}
 }
 

--- a/bin-talk-manager/pkg/listenhandler/v1_participants.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_participants.go
@@ -43,7 +43,7 @@ func (h *listenHandler) v1ParticipantsGet(ctx context.Context, m commonsock.Requ
 
 	participants, err := h.participantHandler.ParticipantListWithFilters(ctx, typedFilters, pageToken, pageSize)
 	if err != nil {
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(participants)

--- a/bin-talk-manager/pkg/listenhandler/v1_reactions.go
+++ b/bin-talk-manager/pkg/listenhandler/v1_reactions.go
@@ -31,7 +31,7 @@ func (h *listenHandler) v1MessagesIDReactionsPost(ctx context.Context, m commons
 	msg, err := h.reactionHandler.ReactionAdd(ctx, messageID, req.Emoji, req.OwnerType, ownerID)
 	if err != nil {
 		logrus.Errorf("Failed to add reaction: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(msg)
@@ -62,7 +62,7 @@ func (h *listenHandler) v1MessagesIDReactionsDelete(ctx context.Context, m commo
 	msg, err := h.reactionHandler.ReactionRemove(ctx, messageID, req.Emoji, req.OwnerType, ownerID)
 	if err != nil {
 		logrus.Errorf("Failed to remove reaction: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, _ := json.Marshal(msg)


### PR DESCRIPTION
Phase 3 Batch 1 (P1) of the listenhandler error-mapping work (follow-up to #955 / PR #959, per the audit in #960). Converts handler-call error swallows to the shared errorResponse helper across the four highest-impact services, so non-existent IDs return 404 (and other typed errors their true status) instead of 500/400. Response-marshal 500s and request-parse 400s are left intact; no central-tail/main.go changes.

- bin-call-manager: Map handler errors at the listenhandler call site (errorResponse) for calls/confbridges/recordings/external-medias/outbound-configs so non-existent IDs return 404; confbridge handler errors no longer collapse to 400 and confbridge marshal failures corrected to 500; outbound-config Duplicate-entry 409 preserved
- bin-queue-manager: Map handler errors at the listenhandler call site for queues/queuecalls so non-existent IDs return 404 instead of 500
- bin-talk-manager: Map handler errors at the listenhandler call site for chats/messages/participants/reactions so non-existent IDs return 404 instead of 500
- bin-rag-manager: Map handler errors at the listenhandler call site for rags/query so non-existent IDs return 404 instead of 500; fix RagsIDGet returning 404 for all errors (internal errors now 500)