### PR TITLE
NOJIRA-Fix-listenhandler-errmap-p2

### DIFF
--- a/bin-agent-manager/go.sum
+++ b/bin-agent-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-agent-manager/pkg/listenhandler/v1_agents.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_agents.go
@@ -58,7 +58,7 @@ func (h *listenHandler) processV1AgentsGet(ctx context.Context, req *sock.Reques
 	tmp, err := h.agentHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get agents info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -238,7 +238,7 @@ func (h *listenHandler) processV1AgentsGetByCustomerIDAddressPost(ctx context.Co
 	)
 	if err != nil {
 		log.Errorf("Could not create an agent info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-agent-manager/pkg/listenhandler/v1_agents_direct_hash.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_agents_direct_hash.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1AgentsIDDirectHashRegenerate(ctx context.Contex
 	tmp, err := h.agentHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-agent-manager/pkg/listenhandler/v1_agents_direct_hash_test.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_agents_direct_hash_test.go
@@ -1,0 +1,61 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-agent-manager/pkg/agenthandler"
+	"monorepo/bin-agent-manager/pkg/dbhandler"
+)
+
+func Test_processV1AgentsIDDirectHashRegenerate_notFound(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentID   uuid.UUID
+		request   *sock.Request
+		expectRes *sock.Response
+	}{
+		{
+			name:    "not found returns 404",
+			agentID: uuid.FromStringOrNil("b1c2d3e4-0001-0001-0001-000000000001"),
+			request: &sock.Request{
+				URI:    "/v1/agents/b1c2d3e4-0001-0001-0001-000000000001/direct-hash-regenerate",
+				Method: sock.RequestMethodPost,
+			},
+			expectRes: &sock.Response{
+				StatusCode: 404,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockAgent := agenthandler.NewMockAgentHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:  mockSock,
+				agentHandler: mockAgent,
+			}
+
+			mockAgent.EXPECT().DirectHashRegenerate(gomock.Any(), tt.agentID).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if res.StatusCode != tt.expectRes.StatusCode {
+				t.Errorf("Wrong status code. expect: %d, got: %d", tt.expectRes.StatusCode, res.StatusCode)
+			}
+		})
+	}
+}

--- a/bin-agent-manager/pkg/listenhandler/v1_count.go
+++ b/bin-agent-manager/pkg/listenhandler/v1_count.go
@@ -34,7 +34,7 @@ func (h *listenHandler) processV1AgentsCountByCustomerGet(ctx context.Context, m
 	count, err := h.agentHandler.CountByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get agent count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})

--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls.go
@@ -57,7 +57,7 @@ func (h *listenHandler) processV1AIcallsGet(ctx context.Context, m *sock.Request
 	tmp, err := h.aicallHandler.List(ctx, pageSize, pageToken, typedFilters)
 	if err != nil {
 		log.Debugf("Could not get conferences. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -91,7 +91,7 @@ func (h *listenHandler) processV1AIcallsPost(ctx context.Context, m *sock.Reques
 	tmp, err := h.aicallHandler.Start(ctx, req.AssistanceType, req.AssistanceID, req.ActiveflowID, req.ReferenceType, req.ReferenceID)
 	if err != nil {
 		log.Errorf("Could not create aicall. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -249,7 +249,7 @@ func (h *listenHandler) processV1AIcallsIDToolExecutePost(ctx context.Context, m
 	tmp, err := h.aicallHandler.ToolHandle(ctx, id, req.ID, req.Type, req.Function)
 	if err != nil {
 		log.Errorf("Could not execute tool. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_aicalls_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aicalls_test.go
@@ -16,6 +16,7 @@ import (
 	"monorepo/bin-ai-manager/models/message"
 	"monorepo/bin-ai-manager/models/participant"
 	"monorepo/bin-ai-manager/pkg/aicallhandler"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-ai-manager/pkg/participanthandler"
 )
 
@@ -463,6 +464,51 @@ func Test_processV1AIcallsIDParticipantsGet(t *testing.T) {
 			}
 			if res.StatusCode != tt.expectRes.StatusCode {
 				t.Fatalf("expected status %d, got %d", tt.expectRes.StatusCode, res.StatusCode)
+			}
+		})
+	}
+}
+
+func Test_processV1AIcallsIDToolExecutePost_errorMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		request      *sock.Request
+		handlerErr   error
+		expectStatus int
+	}{
+		{
+			name: "dbhandler.ErrNotFound maps to 404",
+			request: &sock.Request{
+				URI:      "/v1/aicalls/a02f9d60-bbb6-11f0-81e6-7fbbd900fc6b/tool_execute",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"id":"tool-1","type":"function","function":{"name":"connect","arguments":"{}"}}`),
+			},
+			handlerErr:   dbhandler.ErrNotFound,
+			expectStatus: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockAIcall := aicallhandler.NewMockAIcallHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:   mockSock,
+				aicallHandler: mockAIcall,
+			}
+
+			mockAIcall.EXPECT().ToolHandle(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tt.handlerErr)
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if res.StatusCode != tt.expectStatus {
+				t.Fatalf("expected status %d, got %d", tt.expectStatus, res.StatusCode)
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/listenhandler/v1_ais.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais.go
@@ -58,7 +58,7 @@ func (h *listenHandler) processV1AIsGet(ctx context.Context, m *sock.Request) (*
 	tmp, err := h.aiHandler.List(ctx, pageSize, pageToken, typedFilters)
 	if err != nil {
 		log.Debugf("Could not get conferences. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -110,7 +110,7 @@ func (h *listenHandler) processV1AIsPost(ctx context.Context, m *sock.Request) (
 	)
 	if err != nil {
 		log.Errorf("Could not create ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_ais_direct_hash.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais_direct_hash.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1AIsIDDirectHashRegenerate(ctx context.Context, 
 	tmp, err := h.aiHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_ais_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais_test.go
@@ -15,6 +15,7 @@ import (
 	"monorepo/bin-ai-manager/models/ai"
 	"monorepo/bin-ai-manager/models/participant"
 	"monorepo/bin-ai-manager/pkg/aihandler"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-ai-manager/pkg/participanthandler"
 )
 
@@ -466,6 +467,58 @@ func Test_processV1AIsIDParticipantsGet(t *testing.T) {
 			}
 			if res.StatusCode != tt.expectRes.StatusCode {
 				t.Fatalf("expected status %d, got %d", tt.expectRes.StatusCode, res.StatusCode)
+			}
+		})
+	}
+}
+
+func Test_processV1AIsIDDirectHashRegenerate_errorMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		request        *sock.Request
+		handlerErr     error
+		expectStatus   int
+	}{
+		{
+			name: "dbhandler.ErrNotFound maps to 404",
+			request: &sock.Request{
+				URI:    "/v1/ais/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/direct-hash-regenerate",
+				Method: sock.RequestMethodPost,
+			},
+			handlerErr:   dbhandler.ErrNotFound,
+			expectStatus: 404,
+		},
+		{
+			name: "generic error maps to 500",
+			request: &sock.Request{
+				URI:    "/v1/ais/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/direct-hash-regenerate",
+				Method: sock.RequestMethodPost,
+			},
+			handlerErr:   dbhandler.ErrNotFound, // placeholder — tested separately in error_response_test.go
+			expectStatus: 404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockAI := aihandler.NewMockAIHandler(mc)
+
+			h := &listenHandler{
+				sockHandler: mockSock,
+				aiHandler:   mockAI,
+			}
+
+			mockAI.EXPECT().DirectHashRegenerate(gomock.Any(), gomock.Any()).Return(nil, tt.handlerErr)
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if res.StatusCode != tt.expectStatus {
+				t.Fatalf("expected status %d, got %d", tt.expectStatus, res.StatusCode)
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/listenhandler/v1_ais_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais_test.go
@@ -1,6 +1,7 @@
 package listenhandler
 
 import (
+	"fmt"
 	reflect "reflect"
 	"testing"
 	"time"
@@ -105,7 +106,7 @@ func Test_processV1AIsPost(t *testing.T) {
 		expectName        string
 		expectDetail      string
 		expectEngineModel ai.EngineModel
-		expectParameter  map[string]any
+		expectParameter   map[string]any
 		expectEngineKey   string
 		expectInitPrompt  string
 		expectTTSType     ai.TTSType
@@ -324,7 +325,7 @@ func Test_processV1AIsIDPut(t *testing.T) {
 		expectName        string
 		expectDetail      string
 		expectEngineModel ai.EngineModel
-		expectParameter  map[string]any
+		expectParameter   map[string]any
 		expectEngineKey   string
 		expectInitPrompt  string
 		expectTTSType     ai.TTSType
@@ -474,10 +475,10 @@ func Test_processV1AIsIDParticipantsGet(t *testing.T) {
 
 func Test_processV1AIsIDDirectHashRegenerate_errorMapping(t *testing.T) {
 	tests := []struct {
-		name           string
-		request        *sock.Request
-		handlerErr     error
-		expectStatus   int
+		name         string
+		request      *sock.Request
+		handlerErr   error
+		expectStatus int
 	}{
 		{
 			name: "dbhandler.ErrNotFound maps to 404",
@@ -494,8 +495,8 @@ func Test_processV1AIsIDDirectHashRegenerate_errorMapping(t *testing.T) {
 				URI:    "/v1/ais/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/direct-hash-regenerate",
 				Method: sock.RequestMethodPost,
 			},
-			handlerErr:   dbhandler.ErrNotFound, // placeholder — tested separately in error_response_test.go
-			expectStatus: 404,
+			handlerErr:   fmt.Errorf("boom"),
+			expectStatus: 500,
 		},
 	}
 

--- a/bin-ai-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_messages.go
@@ -57,7 +57,7 @@ func (h *listenHandler) processV1MessagesGet(ctx context.Context, m *sock.Reques
 	tmp, err := h.messageHandler.List(ctx, pageSize, pageToken, typedFilters)
 	if err != nil {
 		log.Debugf("Could not get messages. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -91,7 +91,7 @@ func (h *listenHandler) processV1MessagesPost(ctx context.Context, m *sock.Reque
 	tmp, err := h.aicallHandler.Send(ctx, req.AIcallID, req.Role, req.Content, req.RunImmediately, req.AudioResponse)
 	if err != nil {
 		log.Errorf("Could not create ai. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_participants.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_participants.go
@@ -44,7 +44,7 @@ func (h *listenHandler) processV1AIcallsIDParticipantsGet(ctx context.Context, m
 	tmp, err := h.participantHandler.ListByAIcallID(ctx, id, pageSize, pageToken)
 	if err != nil {
 		log.Errorf("Could not get participants. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// convert to WebhookMessage before marshaling
@@ -91,7 +91,7 @@ func (h *listenHandler) processV1AIsIDParticipantsGet(ctx context.Context, m *so
 	tmp, err := h.participantHandler.ListByAIID(ctx, id, pageSize, pageToken)
 	if err != nil {
 		log.Errorf("Could not get participants. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// convert to WebhookMessage before marshaling

--- a/bin-ai-manager/pkg/listenhandler/v1_services.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_services.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1ServicesTypeAIcallPost(ctx context.Context, m *
 	tmp, err := h.aicallHandler.ServiceStart(ctx, req.AssistanceType, req.AssistanceID, req.ActiveflowID, req.ReferenceType, req.ReferenceID)
 	if err != nil {
 		log.Errorf("Could not start ai service. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -69,7 +69,7 @@ func (h *listenHandler) processV1ServicesTypeSummaryPost(ctx context.Context, m 
 	)
 	if err != nil {
 		log.Errorf("Could not start summary service. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -103,7 +103,7 @@ func (h *listenHandler) processV1ServicesTypeTaskPost(ctx context.Context, m *so
 	tmp, err := h.aicallHandler.ServiceStartTypeTask(ctx, req.AssistanceType, req.AssistanceID, req.ActiveflowID)
 	if err != nil {
 		log.Errorf("Could not start task service. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_summaries.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_summaries.go
@@ -57,7 +57,7 @@ func (h *listenHandler) processV1SummariesGet(ctx context.Context, m *sock.Reque
 	tmp, err := h.summaryHandler.List(ctx, pageSize, pageToken, typedFilters)
 	if err != nil {
 		log.Debugf("Could not get items. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -91,7 +91,7 @@ func (h *listenHandler) processV1SummariesPost(ctx context.Context, m *sock.Requ
 	tmp, err := h.summaryHandler.Start(ctx, req.CustomerID, req.ActiveflowID, req.OnEndFlowID, req.ReferenceType, req.ReferenceID, req.Language)
 	if err != nil {
 		log.Errorf("Could not create item. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_teams.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_teams.go
@@ -58,7 +58,7 @@ func (h *listenHandler) processV1TeamsGet(ctx context.Context, m *sock.Request) 
 	tmp, err := h.teamHandler.List(ctx, pageSize, pageToken, typedFilters)
 	if err != nil {
 		log.Debugf("Could not get teams. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -100,7 +100,7 @@ func (h *listenHandler) processV1TeamsPost(ctx context.Context, m *sock.Request)
 	)
 	if err != nil {
 		log.Errorf("Could not create team. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-ai-manager/pkg/listenhandler/v1_teams_direct_hash.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_teams_direct_hash.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1TeamsIDDirectHashRegenerate(ctx context.Context
 	tmp, err := h.teamHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-conference-manager/go.sum
+++ b/bin-conference-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-conference-manager/pkg/listenhandler/v1_conferencecalls.go
+++ b/bin-conference-manager/pkg/listenhandler/v1_conferencecalls.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1ConferencecallsGet(ctx context.Context, m *sock
 	confs, err := h.conferencecallHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Debugf("Could not get conferencecalls. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(confs)

--- a/bin-conference-manager/pkg/listenhandler/v1_conferences.go
+++ b/bin-conference-manager/pkg/listenhandler/v1_conferences.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1ConferencesGet(ctx context.Context, m *sock.Req
 	confs, err := h.conferenceHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Debugf("Could not get conferences. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(confs)
@@ -97,7 +97,7 @@ func (h *listenHandler) processV1ConferencesPost(ctx context.Context, m *sock.Re
 	)
 	if err != nil {
 		log.Errorf("Could not create a conference. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	tmp, err := json.Marshal(cf)

--- a/bin-conference-manager/pkg/listenhandler/v1_conferences_direct_hash.go
+++ b/bin-conference-manager/pkg/listenhandler/v1_conferences_direct_hash.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1ConferencesIDDirectHashRegenerate(ctx context.C
 	tmp, err := h.conferenceHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-conference-manager/pkg/listenhandler/v1_conferences_direct_hash_test.go
+++ b/bin-conference-manager/pkg/listenhandler/v1_conferences_direct_hash_test.go
@@ -1,0 +1,45 @@
+package listenhandler
+
+import (
+	"net/http"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	pkgerrors "github.com/pkg/errors"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-conference-manager/pkg/conferencehandler"
+	"monorepo/bin-conference-manager/pkg/dbhandler"
+)
+
+func Test_processV1ConferencesIDDirectHashRegenerate_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockConf := conferencehandler.NewMockConferenceHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:       mockSock,
+		conferenceHandler: mockConf,
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/conferences/a1b2c3d4-0000-0000-0000-000000000001/direct-hash-regenerate",
+		Method: sock.RequestMethodPost,
+	}
+
+	mockConf.EXPECT().
+		DirectHashRegenerate(gomock.Any(), gomock.Any()).
+		Return(nil, pkgerrors.Wrap(dbhandler.ErrNotFound, "conference not found"))
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+	}
+}

--- a/bin-conference-manager/pkg/listenhandler/v1_count.go
+++ b/bin-conference-manager/pkg/listenhandler/v1_count.go
@@ -34,7 +34,7 @@ func (h *listenHandler) processV1ConferencesCountByCustomerGet(ctx context.Conte
 	count, err := h.conferenceHandler.CountByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get conference count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})

--- a/bin-conference-manager/pkg/listenhandler/v1_services.go
+++ b/bin-conference-manager/pkg/listenhandler/v1_services.go
@@ -28,7 +28,7 @@ func (h *listenHandler) processV1ServicesTypeConferencecallPost(ctx context.Cont
 	tmp, err := h.conferencecallHandler.ServiceStart(ctx, req.ActiveflowID, req.ConferenceID, req.ReferenceType, req.ReferenceID)
 	if err != nil {
 		log.Errorf("Could not create aicall. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-conversation-manager/pkg/listenhandler/v1_accounts.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_accounts.go
@@ -51,7 +51,7 @@ func (h *listenHandler) processV1AccountsGet(ctx context.Context, m *sock.Reques
 	tmps, err := h.accountHandler.List(ctx, pageToken, pageSize, filters)
 	if err != nil {
 		log.Debugf("Could not get conversations. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	webhookMessages := make([]*account.WebhookMessage, len(tmps))

--- a/bin-conversation-manager/pkg/listenhandler/v1_accounts_test.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_accounts_test.go
@@ -30,6 +30,7 @@ func Test_processV1AccountsGet(t *testing.T) {
 		expectFilters   map[account.Field]any
 
 		responseAccounts []*account.Account
+		responseErr      error
 
 		response *sock.Response
 	}{
@@ -100,6 +101,30 @@ func Test_processV1AccountsGet(t *testing.T) {
 				Data:       []byte(`[{"id":"6b5f9da6-fecb-11ed-a0ea-4fdabd236387","customer_id":"00000000-0000-0000-0000-000000000000","message_flow_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null},{"id":"6b906c9c-fecb-11ed-a341-f38426e7e737","customer_id":"00000000-0000-0000-0000-000000000000","message_flow_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null}]`),
 			},
 		},
+		{
+			name: "not found returns 404",
+
+			request: &sock.Request{
+				URI:      "/v1/accounts?page_size=10&page_token=2021-03-01T03:30:17.000000Z",
+				Method:   sock.RequestMethodGet,
+				DataType: requesthandler.ContentTypeJSON,
+				Data:     []byte(`{"customer_id":"7c3f0faf-fecb-11ed-b1fb-afbcde345678","deleted":false}`),
+			},
+
+			expectPageSize:  10,
+			expectPageToken: "2021-03-01T03:30:17.000000Z",
+			expectFilters: map[account.Field]any{
+				account.FieldCustomerID: uuid.FromStringOrNil("7c3f0faf-fecb-11ed-b1fb-afbcde345678"),
+				account.FieldDeleted:    false,
+			},
+
+			responseAccounts: nil,
+			responseErr:      dbhandler.ErrNotFound,
+
+			response: &sock.Response{
+				StatusCode: 404,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -117,7 +142,7 @@ func Test_processV1AccountsGet(t *testing.T) {
 				accountHandler: mockAccount,
 			}
 
-			mockAccount.EXPECT().List(gomock.Any(), tt.expectPageToken, tt.expectPageSize, gomock.Any()).Return(tt.responseAccounts, nil)
+			mockAccount.EXPECT().List(gomock.Any(), tt.expectPageToken, tt.expectPageSize, gomock.Any()).Return(tt.responseAccounts, tt.responseErr)
 			res, err := h.processRequest(tt.request)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)

--- a/bin-conversation-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_messages.go
@@ -30,7 +30,7 @@ func (h *listenHandler) processV1MessagesPost(ctx context.Context, m *sock.Reque
 	tmp, err := h.conversationHandler.MessageSend(ctx, req.ConversationID, req.Text, req.Medias)
 	if err != nil {
 		log.Errorf("Could not send the message. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -129,7 +129,7 @@ func (h *listenHandler) processV1MessagesCreatePost(ctx context.Context, m *sock
 	)
 	if err != nil {
 		log.Errorf("Could not create the message. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-conversation-manager/pkg/listenhandler/v1_messages_test.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_messages_test.go
@@ -14,6 +14,7 @@ import (
 	"monorepo/bin-conversation-manager/models/message"
 	"monorepo/bin-conversation-manager/pkg/accounthandler"
 	"monorepo/bin-conversation-manager/pkg/conversationhandler"
+	"monorepo/bin-conversation-manager/pkg/dbhandler"
 	"monorepo/bin-conversation-manager/pkg/messagehandler"
 
 	"github.com/gofrs/uuid"
@@ -27,6 +28,7 @@ func Test_processV1MessagesPost(t *testing.T) {
 		request *sock.Request
 
 		responseMessage *message.Message
+		responseErr     error
 
 		expectedConversationID uuid.UUID
 		expectedText           string
@@ -46,6 +48,7 @@ func Test_processV1MessagesPost(t *testing.T) {
 					ID: uuid.FromStringOrNil("f702762c-1bd3-11f0-8f2b-9f2159c784a9"),
 				},
 			},
+			responseErr: nil,
 
 			expectedConversationID: uuid.FromStringOrNil("f6d0a7a0-1bd3-11f0-9e4d-6f54fac53b80"),
 			expectedText:           "I'm your father",
@@ -53,6 +56,24 @@ func Test_processV1MessagesPost(t *testing.T) {
 				StatusCode: 200,
 				DataType:   "application/json",
 				Data:       []byte(`{"id":"f702762c-1bd3-11f0-8f2b-9f2159c784a9","customer_id":"00000000-0000-0000-0000-000000000000","conversation_id":"00000000-0000-0000-0000-000000000000","reference_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null}`),
+			},
+		},
+		{
+			name: "not found returns 404",
+			request: &sock.Request{
+				URI:      "/v1/messages",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"conversation_id":"a1b2c3d4-1bd3-11f0-9e4d-6f54fac53b80","text":"hello"}`),
+			},
+
+			responseMessage: nil,
+			responseErr:     dbhandler.ErrNotFound,
+
+			expectedConversationID: uuid.FromStringOrNil("a1b2c3d4-1bd3-11f0-9e4d-6f54fac53b80"),
+			expectedText:           "hello",
+			expectedRes: &sock.Response{
+				StatusCode: 404,
 			},
 		},
 	}
@@ -70,7 +91,7 @@ func Test_processV1MessagesPost(t *testing.T) {
 				conversationHandler: mockConversation,
 			}
 
-			mockConversation.EXPECT().MessageSend(gomock.Any(), tt.expectedConversationID, tt.expectedText, nil).Return(tt.responseMessage, nil)
+			mockConversation.EXPECT().MessageSend(gomock.Any(), tt.expectedConversationID, tt.expectedText, nil).Return(tt.responseMessage, tt.responseErr)
 			res, err := h.processRequest(tt.request)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
@@ -200,6 +221,7 @@ func Test_processV1MessagesCreatePost(t *testing.T) {
 		request *sock.Request
 
 		responseMessage *message.Message
+		responseErr     error
 
 		expectedID             uuid.UUID
 		expectedCustomerID     uuid.UUID
@@ -229,6 +251,7 @@ func Test_processV1MessagesCreatePost(t *testing.T) {
 					ID: uuid.FromStringOrNil("34e82c6e-1bcc-11f0-9c76-0fef42a4c318"),
 				},
 			},
+			responseErr: nil,
 
 			expectedID:             uuid.FromStringOrNil("34e82c6e-1bcc-11f0-9c76-0fef42a4c318"),
 			expectedCustomerID:     uuid.FromStringOrNil("456609ea-fecc-11ed-a717-5f6984c51794"),
@@ -245,6 +268,34 @@ func Test_processV1MessagesCreatePost(t *testing.T) {
 				StatusCode: 200,
 				DataType:   "application/json",
 				Data:       []byte(`{"id":"34e82c6e-1bcc-11f0-9c76-0fef42a4c318","customer_id":"00000000-0000-0000-0000-000000000000","conversation_id":"00000000-0000-0000-0000-000000000000","reference_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null}`),
+			},
+		},
+		{
+			name: "not found returns 404",
+
+			request: &sock.Request{
+				URI:      "/v1/messages/create",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"id":"45f93d7f-1bcc-11f0-9c76-0fef42a4c318","customer_id":"556609ea-fecc-11ed-a717-5f6984c51794","conversation_id":"696f3930-1adb-11f0-b87e-67f6dad44afa","direction":"incoming","status":"done","reference_type":"line","reference_id":"69a1726a-1adb-11f0-b618-979f6c3070ea","transaction_id":"69caa388-1adb-11f0-a5f0-7f93f53de671","text":"not found","medias":[]}`),
+			},
+
+			responseMessage: nil,
+			responseErr:     dbhandler.ErrNotFound,
+
+			expectedID:             uuid.FromStringOrNil("45f93d7f-1bcc-11f0-9c76-0fef42a4c318"),
+			expectedCustomerID:     uuid.FromStringOrNil("556609ea-fecc-11ed-a717-5f6984c51794"),
+			expectedConversationID: uuid.FromStringOrNil("696f3930-1adb-11f0-b87e-67f6dad44afa"),
+			expectedDirection:      message.DirectionIncoming,
+			expectedStatus:         message.StatusDone,
+			expectedReferenceType:  message.ReferenceTypeLine,
+			expectedReferenceID:    uuid.FromStringOrNil("69a1726a-1adb-11f0-b618-979f6c3070ea"),
+			expectedTransactionID:  "69caa388-1adb-11f0-a5f0-7f93f53de671",
+			expectedText:           "not found",
+			expectedMedias:         []media.Media{},
+
+			expectedRes: &sock.Response{
+				StatusCode: 404,
 			},
 		},
 	}
@@ -278,7 +329,7 @@ func Test_processV1MessagesCreatePost(t *testing.T) {
 				tt.expectedTransactionID,
 				tt.expectedText,
 				tt.expectedMedias,
-			).Return(tt.responseMessage, nil)
+			).Return(tt.responseMessage, tt.responseErr)
 			res, err := h.processRequest(tt.request)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)

--- a/bin-customer-manager/pkg/listenhandler/v1_accesskeys.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_accesskeys.go
@@ -53,7 +53,7 @@ func (h *listenHandler) processV1AccesskeysGet(ctx context.Context, m *sock.Requ
 	tmp, err := h.accesskeyHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get accesskyes info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -96,7 +96,7 @@ func (h *listenHandler) processV1AccesskeysPost(ctx context.Context, m *sock.Req
 	)
 	if err != nil {
 		log.Errorf("Could not create the accesskye info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-customer-manager/pkg/listenhandler/v1_accesskeys_errmap_test.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_accesskeys_errmap_test.go
@@ -1,0 +1,85 @@
+package listenhandler
+
+import (
+	"net/http"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	pkgerrors "github.com/pkg/errors"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-customer-manager/pkg/accesskeyhandler"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
+)
+
+// Test that processV1AccesskeysGet maps dbhandler.ErrNotFound → 404 via errorResponse.
+func Test_processV1AccesskeysGet_errmap_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockAccesskey := accesskeyhandler.NewMockAccesskeyHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:      mockSock,
+		reqHandler:       mockReq,
+		accesskeyHandler: mockAccesskey,
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/accesskeys?page_size=10&page_token=2021-11-23T17:55:39.712000Z",
+		Method: sock.RequestMethodGet,
+		Data:   []byte(`{}`),
+	}
+
+	mockAccesskey.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, pkgerrors.Wrap(dbhandler.ErrNotFound, "db lookup"))
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+	}
+}
+
+// Test that processV1AccesskeysPost maps dbhandler.ErrNotFound → 404 via errorResponse.
+func Test_processV1AccesskeysPost_errmap_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockAccesskey := accesskeyhandler.NewMockAccesskeyHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:      mockSock,
+		reqHandler:       mockReq,
+		accesskeyHandler: mockAccesskey,
+	}
+
+	req := &sock.Request{
+		URI:      "/v1/accesskeys",
+		Method:   sock.RequestMethodPost,
+		DataType: "application/json",
+		Data:     []byte(`{"customer_id":"0324e804-ab36-11ef-8a73-971d5f0ad5ee","name":"n","detail":"d","expire":3600}`),
+	}
+
+	mockAccesskey.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, pkgerrors.Wrap(dbhandler.ErrNotFound, "db lookup"))
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+	}
+}

--- a/bin-customer-manager/pkg/listenhandler/v1_customers.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers.go
@@ -52,7 +52,7 @@ func (h *listenHandler) processV1CustomersGet(ctx context.Context, m *sock.Reque
 	tmp, err := h.customerHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get customers info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)
@@ -98,7 +98,7 @@ func (h *listenHandler) processV1CustomersPost(ctx context.Context, m *sock.Requ
 	)
 	if err != nil {
 		log.Errorf("Could not create the customer info. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-customer-manager/pkg/listenhandler/v1_customers_errmap_test.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers_errmap_test.go
@@ -1,0 +1,99 @@
+package listenhandler
+
+import (
+	"net/http"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	pkgerrors "github.com/pkg/errors"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-customer-manager/pkg/customerhandler"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
+)
+
+// Test that processV1CustomersPost maps dbhandler.ErrNotFound → 404.
+// List/Create are collection endpoints that would not naturally 404 from DB, but the
+// handler must still relay whatever error the business layer returns via errorResponse.
+// We use a typed cerrors.NotFound (which business handlers wrap around ErrNotFound)
+// to validate the end-to-end mapping through processRequest.
+func Test_processV1CustomersPost_errmap_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCustomer := customerhandler.NewMockCustomerHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:     mockSock,
+		reqHandler:      mockReq,
+		customerHandler: mockCustomer,
+	}
+
+	req := &sock.Request{
+		URI:      "/v1/customers",
+		Method:   sock.RequestMethodPost,
+		DataType: "application/json",
+		Data:     []byte(`{"name":"test","email":"test@example.com"}`),
+	}
+
+	// Business handler returns a typed cerrors.NotFound (wrapping dbhandler.ErrNotFound),
+	// which should map to 404 via errorResponse rather than the legacy 500.
+	notFoundErr := cerrors.NotFound(
+		commonoutline.ServiceNameCustomerManager,
+		"CUSTOMER_NOT_FOUND",
+		"customer not found",
+	).Wrap(pkgerrors.Wrap(dbhandler.ErrNotFound, "db lookup"))
+
+	mockCustomer.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, notFoundErr)
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+	}
+}
+
+// Test that processV1CustomersGet maps dbhandler.ErrNotFound → 404.
+func Test_processV1CustomersGet_errmap_notFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCustomer := customerhandler.NewMockCustomerHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:     mockSock,
+		reqHandler:      mockReq,
+		customerHandler: mockCustomer,
+	}
+
+	req := &sock.Request{
+		URI:    "/v1/customers?page_size=10&page_token=2021-11-23T17:55:39.712000Z",
+		Method: sock.RequestMethodGet,
+		Data:   []byte(`{}`),
+	}
+
+	mockCustomer.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, pkgerrors.Wrap(dbhandler.ErrNotFound, "db lookup"))
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+	}
+}

--- a/bin-flow-manager/go.sum
+++ b/bin-flow-manager/go.sum
@@ -435,6 +435,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-flow-manager/pkg/listenhandler/v1_count.go
+++ b/bin-flow-manager/pkg/listenhandler/v1_count.go
@@ -34,7 +34,7 @@ func (h *listenHandler) processV1FlowsCountByCustomerGet(ctx context.Context, m 
 	count, err := h.flowHandler.CountByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get flow count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})

--- a/bin-flow-manager/pkg/listenhandler/v1_count_test.go
+++ b/bin-flow-manager/pkg/listenhandler/v1_count_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
+	"monorepo/bin-flow-manager/pkg/dbhandler"
 	"monorepo/bin-flow-manager/pkg/flowhandler"
 )
 
@@ -21,6 +22,7 @@ func Test_processV1FlowsCountByCustomerGet(t *testing.T) {
 
 		customerID    uuid.UUID
 		responseCount int
+		responseErr   error
 		expectRes     *sock.Response
 	}{
 		{
@@ -34,10 +36,27 @@ func Test_processV1FlowsCountByCustomerGet(t *testing.T) {
 
 			customerID:    uuid.FromStringOrNil("a2b3c4d5-0001-0001-0001-000000000001"),
 			responseCount: 5,
+			responseErr:   nil,
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
 				Data:       []byte(`{"count":5}`),
+			},
+		},
+		{
+			name: "not found returns 404",
+			request: &sock.Request{
+				URI:      "/v1/flows/count_by_customer",
+				Method:   sock.RequestMethodGet,
+				DataType: "application/json",
+				Data:     []byte(`{"customer_id":"b3c4d5e6-0002-0002-0002-000000000002"}`),
+			},
+
+			customerID:    uuid.FromStringOrNil("b3c4d5e6-0002-0002-0002-000000000002"),
+			responseCount: 0,
+			responseErr:   dbhandler.ErrNotFound,
+			expectRes: &sock.Response{
+				StatusCode: 404,
 			},
 		},
 	}
@@ -55,7 +74,7 @@ func Test_processV1FlowsCountByCustomerGet(t *testing.T) {
 				flowHandler: mockFlow,
 			}
 
-			mockFlow.EXPECT().CountByCustomerID(gomock.Any(), tt.customerID).Return(tt.responseCount, nil)
+			mockFlow.EXPECT().CountByCustomerID(gomock.Any(), tt.customerID).Return(tt.responseCount, tt.responseErr)
 			res, err := h.processRequest(tt.request)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)

--- a/bin-flow-manager/pkg/listenhandler/v1_flows_direct_hash.go
+++ b/bin-flow-manager/pkg/listenhandler/v1_flows_direct_hash.go
@@ -37,7 +37,7 @@ func (h *listenHandler) processV1FlowsIDDirectHashRegeneratePost(ctx context.Con
 	tmp, err := h.flowHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-flow-manager/pkg/listenhandler/v1_flows_direct_hash_test.go
+++ b/bin-flow-manager/pkg/listenhandler/v1_flows_direct_hash_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-flow-manager/models/flow"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
 	"monorepo/bin-flow-manager/pkg/flowhandler"
 )
 
@@ -67,6 +68,22 @@ func Test_processV1FlowsIDDirectHashRegeneratePost(t *testing.T) {
 			expectedFlowID: uuid.FromStringOrNil("b7f5fbe9-9b85-22fb-bf86-4f2f72c0b347"),
 			expectedRes: &sock.Response{
 				StatusCode: 500,
+			},
+		},
+		{
+			name: "not found returns 404",
+			request: &sock.Request{
+				URI:      "/v1/flows/c8f6fcfa-ab96-33fc-cf97-5f3f83d1c458/direct-hash-regenerate",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+			},
+
+			responseFlow: nil,
+			responseErr:  dbhandler.ErrNotFound,
+
+			expectedFlowID: uuid.FromStringOrNil("c8f6fcfa-ab96-33fc-cf97-5f3f83d1c458"),
+			expectedRes: &sock.Response{
+				StatusCode: 404,
 			},
 		},
 	}

--- a/bin-registrar-manager/go.sum
+++ b/bin-registrar-manager/go.sum
@@ -431,6 +431,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-registrar-manager/pkg/listenhandler/v1_count.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_count.go
@@ -34,7 +34,7 @@ func (h *listenHandler) processV1ExtensionsCountByCustomerGet(ctx context.Contex
 	count, err := h.extensionHandler.CountByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get extension count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})
@@ -66,7 +66,7 @@ func (h *listenHandler) processV1TrunksCountByCustomerGet(ctx context.Context, m
 	count, err := h.trunkHandler.CountByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get trunk count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})

--- a/bin-registrar-manager/pkg/listenhandler/v1_extensions.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_extensions.go
@@ -45,7 +45,7 @@ func (h *listenHandler) processV1ExtensionsPost(ctx context.Context, m *sock.Req
 	)
 	if err != nil {
 		log.Errorf("Could not create a new extension correctly. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-registrar-manager/pkg/listenhandler/v1_extensions_direct_hash.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_extensions_direct_hash.go
@@ -27,7 +27,7 @@ func (h *listenHandler) processV1ExtensionsIDDirectHashRegenerate(ctx context.Co
 	tmp, err := h.extensionHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {
 		log.Errorf("Could not regenerate direct hash. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-registrar-manager/pkg/listenhandler/v1_extensions_direct_hash_test.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_extensions_direct_hash_test.go
@@ -1,0 +1,64 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
+	"monorepo/bin-registrar-manager/pkg/extensionhandler"
+)
+
+func Test_processV1ExtensionsIDDirectHashRegenerate_notFound(t *testing.T) {
+	tests := []struct {
+		name        string
+		extensionID uuid.UUID
+		request     *sock.Request
+		expectRes   *sock.Response
+	}{
+		{
+			name:        "not found returns 404",
+			extensionID: uuid.FromStringOrNil("a1b2c3d4-0001-0001-0001-000000000001"),
+			request: &sock.Request{
+				URI:    "/v1/extensions/a1b2c3d4-0001-0001-0001-000000000001/direct-hash-regenerate",
+				Method: sock.RequestMethodPost,
+			},
+			expectRes: &sock.Response{
+				StatusCode: 404,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockExtension := extensionhandler.NewMockExtensionHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:      mockSock,
+				reqHandler:       mockReq,
+				extensionHandler: mockExtension,
+			}
+
+			mockExtension.EXPECT().DirectHashRegenerate(gomock.Any(), tt.extensionID).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if res.StatusCode != tt.expectRes.StatusCode {
+				t.Errorf("Wrong status code. expect: %d, got: %d", tt.expectRes.StatusCode, res.StatusCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 3 Batch 2 (P2) of the listenhandler error-mapping work (follow-up to #955 / PR #959, per the audit in #960). Converts handler-call error swallows to the shared errorResponse helper across seven services, so typed errors (including not-found) return their true status instead of 500. Response-marshal 500s and request-parse 400s are left intact; no central-tail/main.go changes.

- bin-ai-manager: Map handler errors at the listenhandler call site (errorResponse) for ais/aicalls/teams/summaries/messages/participants/services
- bin-conference-manager: Map handler errors at the listenhandler call site for conferences/conferencecalls
- bin-customer-manager: Map handler errors at the listenhandler call site for customers/accesskeys
- bin-registrar-manager: Map handler errors at the listenhandler call site for extensions/trunks
- bin-agent-manager: Map handler errors at the listenhandler call site for agents
- bin-conversation-manager: Map handler errors at the listenhandler call site for accounts/messages (v1_conversations.go already handled in #959)
- bin-flow-manager: Map handler errors at the listenhandler call site for count/direct-hash so non-existent flow IDs return 404 instead of 500