### PR TITLE
NOJIRA-Fix-listenhandler-errmap-p3

### DIFF
--- a/bin-number-manager/pkg/listenhandler/v1_available_numbers.go
+++ b/bin-number-manager/pkg/listenhandler/v1_available_numbers.go
@@ -72,7 +72,7 @@ func (h *listenHandler) processV1AvailableNumbersGet(ctx context.Context, m *soc
 	}
 	if err != nil {
 		log.Debugf("Could not get available numbers. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(numbers)

--- a/bin-number-manager/pkg/listenhandler/v1_available_numbers_test.go
+++ b/bin-number-manager/pkg/listenhandler/v1_available_numbers_test.go
@@ -1,9 +1,13 @@
 package listenhandler
 
 import (
+	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -95,6 +99,61 @@ func TestProcessV1AvailableNumbersGet(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.response, res)
 			}
 
+		})
+	}
+}
+
+func TestProcessV1AvailableNumbersGet_errorMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		handlerErr     error
+		expectStatus   int
+		expectDataType string
+	}{
+		{
+			name:           "typed NotFound error maps to 404",
+			handlerErr:     cerrors.NotFound(commonoutline.ServiceNameNumberManager, "NUMBER_NOT_FOUND", "no numbers available"),
+			expectStatus:   http.StatusNotFound,
+			expectDataType: cerrors.DataTypeVoipbinError,
+		},
+		{
+			name:         "generic error maps to 500",
+			handlerErr:   fmt.Errorf("provider unavailable"),
+			expectStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:   mockSock,
+				numberHandler: mockNumber,
+			}
+
+			req := &sock.Request{
+				URI:    "/v1/available_numbers?page_size=10",
+				Method: sock.RequestMethodGet,
+				Data:   []byte(`{"country_code":"US"}`),
+			}
+
+			mockNumber.EXPECT().GetAvailableNumbers("US", uint(10)).Return(nil, tt.handlerErr)
+
+			res, err := h.processRequest(req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res.StatusCode != tt.expectStatus {
+				t.Errorf("wrong status: expect %d, got %d", tt.expectStatus, res.StatusCode)
+			}
+			if tt.expectDataType != "" && res.DataType != tt.expectDataType {
+				t.Errorf("wrong data type: expect %s, got %s", tt.expectDataType, res.DataType)
+			}
 		})
 	}
 }

--- a/bin-number-manager/pkg/listenhandler/v1_count.go
+++ b/bin-number-manager/pkg/listenhandler/v1_count.go
@@ -34,7 +34,7 @@ func (h *listenHandler) processV1NumbersCountVirtualByCustomerGet(ctx context.Co
 	count, err := h.numberHandler.CountVirtualByCustomerID(ctx, req.CustomerID)
 	if err != nil {
 		log.Errorf("Could not get virtual number count. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(&countByCustomerResponse{Count: count})

--- a/bin-number-manager/pkg/listenhandler/v1_count_test.go
+++ b/bin-number-manager/pkg/listenhandler/v1_count_test.go
@@ -1,9 +1,13 @@
 package listenhandler
 
 import (
+	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -81,6 +85,63 @@ func TestProcessV1NumbersCountVirtualByCustomerGet(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.response, res)
 			}
 
+		})
+	}
+}
+
+func TestProcessV1NumbersCountVirtualByCustomerGet_errorMapping(t *testing.T) {
+	customerID := uuid.FromStringOrNil("a1b2c3d4-e5f6-11ee-aaaa-000000000099")
+	req := &sock.Request{
+		URI:      "/v1/numbers/count_virtual_by_customer",
+		Method:   sock.RequestMethodGet,
+		DataType: "application/json",
+		Data:     []byte(`{"customer_id":"a1b2c3d4-e5f6-11ee-aaaa-000000000099"}`),
+	}
+
+	tests := []struct {
+		name           string
+		handlerErr     error
+		expectStatus   int
+		expectDataType string
+	}{
+		{
+			name:           "typed NotFound maps to 404",
+			handlerErr:     cerrors.NotFound(commonoutline.ServiceNameNumberManager, "NUMBER_NOT_FOUND", "customer not found"),
+			expectStatus:   http.StatusNotFound,
+			expectDataType: cerrors.DataTypeVoipbinError,
+		},
+		{
+			name:         "generic error maps to 500",
+			handlerErr:   fmt.Errorf("db unavailable"),
+			expectStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockNumber := numberhandler.NewMockNumberHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:   mockSock,
+				numberHandler: mockNumber,
+			}
+
+			mockNumber.EXPECT().CountVirtualByCustomerID(gomock.Any(), customerID).Return(0, tt.handlerErr)
+
+			res, err := h.processRequest(req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res.StatusCode != tt.expectStatus {
+				t.Errorf("wrong status: expect %d, got %d", tt.expectStatus, res.StatusCode)
+			}
+			if tt.expectDataType != "" && res.DataType != tt.expectDataType {
+				t.Errorf("wrong data type: expect %s, got %s", tt.expectDataType, res.DataType)
+			}
 		})
 	}
 }

--- a/bin-pipecat-manager/pkg/listenhandler/main_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/main_test.go
@@ -3,9 +3,12 @@ package listenhandler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
@@ -232,6 +235,246 @@ func TestProcessV1PipecatcallsIDStopPost_InvalidURI(t *testing.T) {
 	}
 	if resp.StatusCode != 400 {
 		t.Errorf("processV1PipecatcallsIDStopPost() StatusCode = %v, want 400", resp.StatusCode)
+	}
+}
+
+// TestProcessV1PipecatcallsPost_HandlerTypedError asserts that a typed
+// cerrors.NotFound returned by pipecatcallHandler.Start surfaces as 404
+// (not 500) after the errorResponse conversion.
+func TestProcessV1PipecatcallsPost_HandlerTypedError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockPipecatcall := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:        mockSock,
+		pipecatcallHandler: mockPipecatcall,
+	}
+
+	reqData := request.V1DataPipecatcallsPost{
+		ID:            uuid.FromStringOrNil("496365e2-88e6-11ea-956c-e3dfb6eaf1e8"),
+		CustomerID:    uuid.FromStringOrNil("5adbec2c-b48c-11f0-a0cb-e752c616594a"),
+		ActiveflowID:  uuid.FromStringOrNil("5b374a54-b48c-11f0-8c36-477d3f6baf0d"),
+		ReferenceType: pipecatcall.ReferenceTypeAICall,
+		ReferenceID:   uuid.FromStringOrNil("5b5bb704-b48c-11f0-819e-2ff9e60d5c3c"),
+	}
+	jsonData, _ := json.Marshal(reqData)
+
+	typedErr := cerrors.NotFound(commonoutline.ServiceNamePipecatManager, "PIPECATCALL_NOT_FOUND", "not found")
+	mockPipecatcall.EXPECT().Start(
+		gomock.Any(),
+		reqData.ID,
+		reqData.CustomerID,
+		reqData.ActiveflowID,
+		reqData.ReferenceType,
+		reqData.ReferenceID,
+		reqData.LLMType,
+		reqData.LLMMessages,
+		reqData.STTType,
+		reqData.STTLanguage,
+		reqData.TTSType,
+		reqData.TTSLanguage,
+		reqData.TTSVoiceID,
+	).Return(nil, typedErr)
+
+	req := &sock.Request{
+		URI:    "/v1/pipecatcalls",
+		Method: sock.RequestMethodPost,
+		Data:   jsonData,
+	}
+
+	resp, err := h.processV1PipecatcallsPost(context.Background(), req)
+	if err != nil {
+		t.Errorf("processV1PipecatcallsPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("processV1PipecatcallsPost() StatusCode = %v, want 404 (typed error must propagate)", resp.StatusCode)
+	}
+}
+
+// TestProcessV1PipecatcallsPost_HandlerPlainError asserts that a plain
+// error returned by pipecatcallHandler.Start surfaces as 500.
+func TestProcessV1PipecatcallsPost_HandlerPlainError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockPipecatcall := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:        mockSock,
+		pipecatcallHandler: mockPipecatcall,
+	}
+
+	reqData := request.V1DataPipecatcallsPost{
+		ID:            uuid.FromStringOrNil("496365e2-88e6-11ea-956c-e3dfb6eaf1e8"),
+		CustomerID:    uuid.FromStringOrNil("5adbec2c-b48c-11f0-a0cb-e752c616594a"),
+		ActiveflowID:  uuid.FromStringOrNil("5b374a54-b48c-11f0-8c36-477d3f6baf0d"),
+		ReferenceType: pipecatcall.ReferenceTypeAICall,
+		ReferenceID:   uuid.FromStringOrNil("5b5bb704-b48c-11f0-819e-2ff9e60d5c3c"),
+	}
+	jsonData, _ := json.Marshal(reqData)
+
+	mockPipecatcall.EXPECT().Start(
+		gomock.Any(),
+		reqData.ID,
+		reqData.CustomerID,
+		reqData.ActiveflowID,
+		reqData.ReferenceType,
+		reqData.ReferenceID,
+		reqData.LLMType,
+		reqData.LLMMessages,
+		reqData.STTType,
+		reqData.STTLanguage,
+		reqData.TTSType,
+		reqData.TTSLanguage,
+		reqData.TTSVoiceID,
+	).Return(nil, fmt.Errorf("internal failure"))
+
+	req := &sock.Request{
+		URI:    "/v1/pipecatcalls",
+		Method: sock.RequestMethodPost,
+		Data:   jsonData,
+	}
+
+	resp, err := h.processV1PipecatcallsPost(context.Background(), req)
+	if err != nil {
+		t.Errorf("processV1PipecatcallsPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("processV1PipecatcallsPost() StatusCode = %v, want 500", resp.StatusCode)
+	}
+}
+
+// TestProcessV1MessagesPost_HandlerTypedError asserts that a typed
+// cerrors.NotFound returned by pipecatcallHandler.SendMessage surfaces as 404.
+func TestProcessV1MessagesPost_HandlerTypedError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockPipecatcall := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:        mockSock,
+		pipecatcallHandler: mockPipecatcall,
+	}
+
+	pipecatcallID := uuid.FromStringOrNil("9bd7ed8e-b3ab-11f0-a12a-d3f1af50fa4a")
+	jsonData := []byte(`{"pipecatcall_id":"9bd7ed8e-b3ab-11f0-a12a-d3f1af50fa4a","message_id":"msg1","message_text":"hello","run_immediately":false,"audio_response":false}`)
+
+	typedErr := cerrors.NotFound(commonoutline.ServiceNamePipecatManager, "PIPECATCALL_NOT_FOUND", "not found")
+	mockPipecatcall.EXPECT().SendMessage(gomock.Any(), pipecatcallID, "msg1", "hello", false, false).Return(nil, typedErr)
+
+	req := &sock.Request{
+		URI:    "/v1/messages",
+		Method: sock.RequestMethodPost,
+		Data:   jsonData,
+	}
+
+	resp, err := h.processV1MessagesPost(context.Background(), req)
+	if err != nil {
+		t.Errorf("processV1MessagesPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("processV1MessagesPost() StatusCode = %v, want 404", resp.StatusCode)
+	}
+}
+
+// TestProcessV1MessagesPost_HandlerPlainError asserts that a plain error
+// returned by pipecatcallHandler.SendMessage surfaces as 500.
+func TestProcessV1MessagesPost_HandlerPlainError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockPipecatcall := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:        mockSock,
+		pipecatcallHandler: mockPipecatcall,
+	}
+
+	pipecatcallID := uuid.FromStringOrNil("9bd7ed8e-b3ab-11f0-a12a-d3f1af50fa4a")
+	jsonData := []byte(`{"pipecatcall_id":"9bd7ed8e-b3ab-11f0-a12a-d3f1af50fa4a","message_id":"msg1","message_text":"hello","run_immediately":false,"audio_response":false}`)
+
+	mockPipecatcall.EXPECT().SendMessage(gomock.Any(), pipecatcallID, "msg1", "hello", false, false).Return(nil, fmt.Errorf("send failed"))
+
+	req := &sock.Request{
+		URI:    "/v1/messages",
+		Method: sock.RequestMethodPost,
+		Data:   jsonData,
+	}
+
+	resp, err := h.processV1MessagesPost(context.Background(), req)
+	if err != nil {
+		t.Errorf("processV1MessagesPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("processV1MessagesPost() StatusCode = %v, want 500", resp.StatusCode)
+	}
+}
+
+// TestProcessV1PingGet_HandlerTypedError asserts that a typed error
+// returned by pipecatcallHandler.Ping surfaces as the typed status code.
+func TestProcessV1PingGet_HandlerTypedError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockPipecatcall := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:        mockSock,
+		pipecatcallHandler: mockPipecatcall,
+	}
+
+	typedErr := cerrors.NotFound(commonoutline.ServiceNamePipecatManager, "PIPECATCALL_NOT_FOUND", "not found")
+	mockPipecatcall.EXPECT().Ping(gomock.Any()).Return(nil, typedErr)
+
+	req := &sock.Request{
+		URI:    "/v1/ping",
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := h.processV1PingGet(context.Background(), req)
+	if err != nil {
+		t.Errorf("processV1PingGet() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 404 {
+		t.Errorf("processV1PingGet() StatusCode = %v, want 404", resp.StatusCode)
+	}
+}
+
+// TestProcessV1PingGet_HandlerPlainError asserts that a plain error
+// returned by pipecatcallHandler.Ping surfaces as 500.
+func TestProcessV1PingGet_HandlerPlainError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockPipecatcall := pipecatcallhandler.NewMockPipecatcallHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:        mockSock,
+		pipecatcallHandler: mockPipecatcall,
+	}
+
+	mockPipecatcall.EXPECT().Ping(gomock.Any()).Return(nil, fmt.Errorf("ping failed"))
+
+	req := &sock.Request{
+		URI:    "/v1/ping",
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := h.processV1PingGet(context.Background(), req)
+	if err != nil {
+		t.Errorf("processV1PingGet() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("processV1PingGet() StatusCode = %v, want 500", resp.StatusCode)
 	}
 }
 

--- a/bin-pipecat-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_messages.go
@@ -24,7 +24,7 @@ func (h *listenHandler) processV1MessagesPost(ctx context.Context, m *sock.Reque
 
 	tmp, err := h.pipecatcallHandler.SendMessage(ctx, req.PipecatcallID, req.MessageID, req.MessageText, req.RunImmediately, req.AudioResponse)
 	if err != nil {
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-pipecat-manager/pkg/listenhandler/v1_ping.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_ping.go
@@ -20,7 +20,7 @@ func (h *listenHandler) processV1PingGet(ctx context.Context, m *sock.Request) (
 	res, err := h.pipecatcallHandler.Ping(ctx)
 	if err != nil {
 		log.Debugf("Could not get ping result. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(res)

--- a/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
@@ -42,7 +42,7 @@ func (h *listenHandler) processV1PipecatcallsPost(ctx context.Context, m *sock.R
 	)
 	if err != nil {
 		log.Debugf("Could not create a pipecatcall. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-timeline-manager/pkg/listenhandler/main_test.go
+++ b/bin-timeline-manager/pkg/listenhandler/main_test.go
@@ -986,6 +986,167 @@ func TestListenHandler_Interface(t *testing.T) {
 	var _ ListenHandler = (*listenHandler)(nil)
 }
 
+// TestV1EventsPost_HandlerPlainError asserts that after the errorResponse
+// conversion a plain handler error surfaces as 500 (not some other code).
+// This locks in the default errorResponse behavior for converted call sites.
+func TestV1EventsPost_HandlerPlainError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	testID := uuid.Must(uuid.NewV4())
+	req := &request.V1DataEventsPost{
+		Publisher:  commonoutline.ServiceName("flow-manager"),
+		ResourceID: testID,
+		Events:     []string{"activeflow_*"},
+		PageSize:   10,
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockEvent.EXPECT().
+		List(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("database unavailable"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/events",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1EventsPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1EventsPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("v1EventsPost() StatusCode = %d, want 500 (plain error must map to 500 via errorResponse)", resp.StatusCode)
+	}
+}
+
+// TestV1AggregatedEventsPost_HandlerPlainError asserts that a plain handler
+// error surfaces as 500 via errorResponse.
+func TestV1AggregatedEventsPost_HandlerPlainError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	testID := uuid.Must(uuid.NewV4())
+	req := &request.V1DataAggregatedEventsPost{
+		ActiveflowID: testID,
+		PageSize:     10,
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockEvent.EXPECT().
+		AggregatedList(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("aggregation failed"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/aggregated-events",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1AggregatedEventsPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1AggregatedEventsPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("v1AggregatedEventsPost() StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+// TestV1SIPAnalysisPost_HandlerPlainErrorViaErrorResponse asserts that a plain
+// handler error surfaces as 500 via errorResponse (not simpleResponse).
+func TestV1SIPAnalysisPost_HandlerPlainErrorViaErrorResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPAnalysisPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockSIP.EXPECT().GetSIPAnalysis(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("homer unreachable"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/analysis",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPAnalysisPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPAnalysisPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("v1SIPAnalysisPost() StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+// TestV1SIPPcapPost_HandlerPlainErrorViaErrorResponse asserts that a plain
+// handler error surfaces as 500 via errorResponse.
+func TestV1SIPPcapPost_HandlerPlainErrorViaErrorResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockSIP := siphandler.NewMockSIPHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler: mockSock,
+		sipHandler:  mockSIP,
+	}
+
+	req := &request.V1SIPPcapPost{
+		SIPCallID: "test-call-id",
+		FromTime:  "2026-01-01T00:00:00Z",
+		ToTime:    "2026-01-01T01:00:00Z",
+	}
+	reqData, _ := json.Marshal(req)
+
+	mockSIP.EXPECT().GetPcap(gomock.Any(), req.SIPCallID, gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("pcap unavailable"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/sip/pcap",
+		Method: sock.RequestMethodPost,
+		Data:   reqData,
+	}
+
+	resp, err := handler.v1SIPPcapPost(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1SIPPcapPost() error = %v, want nil", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("v1SIPPcapPost() StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
 func TestProcessRequest_HandlerReturnsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/bin-timeline-manager/pkg/listenhandler/v1_aggregated_events.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_aggregated_events.go
@@ -27,7 +27,7 @@ func (h *listenHandler) v1AggregatedEventsPost(ctx context.Context, m *sock.Requ
 	result, err := h.eventHandler.AggregatedList(ctx, &req)
 	if err != nil {
 		log.Errorf("Could not list aggregated events. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// Marshal response

--- a/bin-timeline-manager/pkg/listenhandler/v1_events.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_events.go
@@ -27,7 +27,7 @@ func (h *listenHandler) v1EventsPost(ctx context.Context, m *sock.Request) (*soc
 	result, err := h.eventHandler.List(ctx, &req)
 	if err != nil {
 		log.Errorf("Could not list events. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// Marshal response

--- a/bin-timeline-manager/pkg/listenhandler/v1_sip.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_sip.go
@@ -43,7 +43,7 @@ func (h *listenHandler) v1SIPAnalysisPost(ctx context.Context, m *sock.Request) 
 	result, err := h.sipHandler.GetSIPAnalysis(ctx, req.SIPCallID, fromTime, toTime)
 	if err != nil {
 		log.Errorf("Could not get SIP analysis. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// Marshal response
@@ -89,7 +89,7 @@ func (h *listenHandler) v1SIPPcapPost(ctx context.Context, m *sock.Request) (*so
 	pcapData, err := h.sipHandler.GetPcap(ctx, req.SIPCallID, fromTime, toTime)
 	if err != nil {
 		log.Errorf("Could not get PCAP data. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	// Base64 encode PCAP data for JSON transport

--- a/bin-transcribe-manager/go.sum
+++ b/bin-transcribe-manager/go.sum
@@ -477,6 +477,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-transcribe-manager/pkg/listenhandler/v1_transcribes.go
+++ b/bin-transcribe-manager/pkg/listenhandler/v1_transcribes.go
@@ -91,7 +91,7 @@ func (h *listenHandler) processV1TranscribesGet(ctx context.Context, m *sock.Req
 	tmp, err := h.transcribeHandler.List(ctx, pageSize, pageToken, filters)
 	if err != nil {
 		log.Errorf("Could not get transcribes. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-transcribe-manager/pkg/listenhandler/v1_transcribes_test.go
+++ b/bin-transcribe-manager/pkg/listenhandler/v1_transcribes_test.go
@@ -1,6 +1,7 @@
 package listenhandler
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -488,6 +489,61 @@ func Test_processV1TranscribesIDStopPost_notFound(t *testing.T) {
 	}
 	if !reflect.DeepEqual(res, expectRes) {
 		t.Errorf("Wrong match.\nexepct: %v\ngot: %v", expectRes, res)
+	}
+}
+
+func Test_processV1TranscribesGet_errorMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		handlerErr     error
+		expectStatus   int
+		expectDataType string
+	}{
+		{
+			name:           "typed NotFound maps to 404",
+			handlerErr:     cerrors.NotFound(commonoutline.ServiceNameTranscribeManager, "TRANSCRIBE_NOT_FOUND", "no transcribes found"),
+			expectStatus:   404,
+			expectDataType: cerrors.DataTypeVoipbinError,
+		},
+		{
+			name:         "generic error maps to 500",
+			handlerErr:   fmt.Errorf("db error"),
+			expectStatus: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockTranscribe := transcribehandler.NewMockTranscribeHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:       mockSock,
+				transcribeHandler: mockTranscribe,
+			}
+
+			req := &sock.Request{
+				URI:    "/v1/transcribes?page_size=10&page_token=",
+				Method: sock.RequestMethodGet,
+				Data:   []byte(`{"customer_id":"079ffd84-7f68-11ed-ae05-430c9b75ab3b"}`),
+			}
+
+			mockTranscribe.EXPECT().List(gomock.Any(), uint64(10), gomock.Any(), gomock.Any()).Return(nil, tt.handlerErr)
+
+			res, err := h.processRequest(req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if res.StatusCode != tt.expectStatus {
+				t.Errorf("wrong status: expect %d, got %d", tt.expectStatus, res.StatusCode)
+			}
+			if tt.expectDataType != "" && res.DataType != tt.expectDataType {
+				t.Errorf("wrong data type: expect %s, got %s", tt.expectDataType, res.DataType)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Phase 3 Batch 3 (P3, final) of the listenhandler error-mapping work (follow-up to #955 / PR #959, per the audit in #960). Converts the remaining handler-call error swallows to the shared errorResponse helper, completing the monorepo sweep. Response-marshal 500s and request-parse 400s are left intact; no central-tail/main.go changes.

- bin-number-manager: Map handler errors at the listenhandler call site (errorResponse) for available-numbers/count so typed errors return their true status instead of 500 (v1_numbers.go already handled in #959)
- bin-transcribe-manager: Map handler errors at the listenhandler call site for transcribes list
- bin-pipecat-manager: Map handler errors at the listenhandler call site for pipecatcalls/messages/ping
- bin-timeline-manager: Map handler errors at the listenhandler call site for events/aggregated-events/sip for convention consistency (handlers currently emit plain errors → still 500)