### PR TITLE
NOJIRA-Fix-listenhandler-latent-errmap

### DIFF
--- a/bin-call-manager/pkg/listenhandler/v1_notfound_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_notfound_test.go
@@ -287,6 +287,114 @@ func Test_processV1OutboundConfigsGet_notFound(t *testing.T) {
 	}
 }
 
+// Test_processV1OutboundConfigsIDDelete_notFound verifies that when
+// outboundConfigHandler.Delete returns a typed cerrors.NotFound (the new
+// behaviour after the nil-row fix), processV1OutboundConfigsIDDelete produces
+// HTTP 404 instead of 200 with a null body.
+func Test_processV1OutboundConfigsIDDelete_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "DELETE non-existent outbound config returns 404",
+			request: &sock.Request{
+				URI:    "/v1/outbound_configs/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodDelete,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockOutboundConfig := outboundconfighandler.NewMockOutboundConfigHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:           mockSock,
+				callHandler:           mockCall,
+				outboundConfigHandler: mockOutboundConfig,
+			}
+
+			notFoundErr := cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"OUTBOUND_CONFIG_NOT_FOUND",
+				"The outbound config was not found.",
+			)
+			mockOutboundConfig.EXPECT().Delete(gomock.Any(), tt.id).Return(nil, notFoundErr)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1OutboundConfigsIDPut_notFound verifies that when
+// outboundConfigHandler.Update returns a typed cerrors.NotFound (the new
+// behaviour after the nil-row fix), processV1OutboundConfigsIDPut produces
+// HTTP 404 instead of 500.
+func Test_processV1OutboundConfigsIDPut_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "PUT non-existent outbound config returns 404",
+			request: &sock.Request{
+				URI:      "/v1/outbound_configs/00000000-0000-0000-0000-000000000099",
+				Method:   sock.RequestMethodPut,
+				DataType: "application/json",
+				Data:     []byte(`{"name":"updated"}`),
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockOutboundConfig := outboundconfighandler.NewMockOutboundConfigHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:           mockSock,
+				callHandler:           mockCall,
+				outboundConfigHandler: mockOutboundConfig,
+			}
+
+			notFoundErr := cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"OUTBOUND_CONFIG_NOT_FOUND",
+				"The outbound config was not found.",
+			)
+			mockOutboundConfig.EXPECT().Update(gomock.Any(), tt.id, gomock.Any()).Return(nil, notFoundErr)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
 // Test_processV1OutboundConfigsIDGet_notFound verifies that when
 // outboundConfigHandler.GetByID returns a typed cerrors.NotFound (the new
 // behaviour after the nil-row fix), processV1OutboundConfigsIDGet produces

--- a/bin-call-manager/pkg/listenhandler/v1_notfound_test.go
+++ b/bin-call-manager/pkg/listenhandler/v1_notfound_test.go
@@ -3,6 +3,8 @@ package listenhandler
 import (
 	"testing"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
@@ -273,6 +275,59 @@ func Test_processV1OutboundConfigsGet_notFound(t *testing.T) {
 			}
 
 			mockOutboundConfig.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+			if res.StatusCode != 404 {
+				t.Errorf("StatusCode mismatch. expected: 404, got: %d", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_processV1OutboundConfigsIDGet_notFound verifies that when
+// outboundConfigHandler.GetByID returns a typed cerrors.NotFound (the new
+// behaviour after the nil-row fix), processV1OutboundConfigsIDGet produces
+// HTTP 404 instead of 200 with a null body.
+func Test_processV1OutboundConfigsIDGet_notFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+		id      uuid.UUID
+	}{
+		{
+			name: "GET non-existent outbound config returns 404",
+			request: &sock.Request{
+				URI:    "/v1/outbound_configs/00000000-0000-0000-0000-000000000099",
+				Method: sock.RequestMethodGet,
+			},
+			id: uuid.FromStringOrNil("00000000-0000-0000-0000-000000000099"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCall := callhandler.NewMockCallHandler(mc)
+			mockOutboundConfig := outboundconfighandler.NewMockOutboundConfigHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:           mockSock,
+				callHandler:           mockCall,
+				outboundConfigHandler: mockOutboundConfig,
+			}
+
+			notFoundErr := cerrors.NotFound(
+				commonoutline.ServiceNameCallManager,
+				"OUTBOUND_CONFIG_NOT_FOUND",
+				"The outbound config was not found.",
+			)
+			mockOutboundConfig.EXPECT().GetByID(gomock.Any(), tt.id).Return(nil, notFoundErr)
 
 			res, err := h.processRequest(tt.request)
 			if err != nil {

--- a/bin-call-manager/pkg/outboundconfighandler/outbound_config.go
+++ b/bin-call-manager/pkg/outboundconfighandler/outbound_config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	outboundconfig "monorepo/bin-call-manager/models/outboundconfig"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // Delete soft-deletes the OutboundConfig identified by id and invalidates its cache entry.
@@ -62,8 +64,16 @@ func (h *outboundConfigHandler) GetByCustomerID(ctx context.Context, customerID 
 }
 
 // GetByID returns the OutboundConfig with the given id directly from DB.
+// Returns a typed NotFound error if the DB returns nil (row does not exist).
 func (h *outboundConfigHandler) GetByID(ctx context.Context, id uuid.UUID) (*outboundconfig.OutboundConfig, error) {
-	return h.db.OutboundConfigGetByID(ctx, id)
+	res, err := h.db.OutboundConfigGetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, cerrors.NotFound(commonoutline.ServiceNameCallManager, "OUTBOUND_CONFIG_NOT_FOUND", "The outbound config was not found.")
+	}
+	return res, nil
 }
 
 // List returns a page of OutboundConfigs for the given customerID.

--- a/bin-call-manager/pkg/outboundconfighandler/outbound_config.go
+++ b/bin-call-manager/pkg/outboundconfighandler/outbound_config.go
@@ -21,16 +21,17 @@ func (h *outboundConfigHandler) Delete(ctx context.Context, id uuid.UUID) (*outb
 	if err != nil {
 		return nil, fmt.Errorf("could not get outbound_config for delete: %w", err)
 	}
+	if c == nil {
+		return nil, cerrors.NotFound(commonoutline.ServiceNameCallManager, "OUTBOUND_CONFIG_NOT_FOUND", "The outbound config was not found.")
+	}
 
 	if err := h.db.OutboundConfigDelete(ctx, id); err != nil {
 		return nil, fmt.Errorf("could not delete outbound_config: %w", err)
 	}
 
-	if c != nil {
-		_ = h.cacheHandler.OutboundConfigDelete(ctx, c.CustomerID)
-		now := time.Now()
-		c.TMDelete = &now // reflect the deletion timestamp in the returned struct
-	}
+	_ = h.cacheHandler.OutboundConfigDelete(ctx, c.CustomerID)
+	now := time.Now()
+	c.TMDelete = &now // reflect the deletion timestamp in the returned struct
 
 	return c, nil
 }
@@ -108,7 +109,7 @@ func (h *outboundConfigHandler) Update(ctx context.Context, id uuid.UUID, req *o
 		return nil, fmt.Errorf("could not get outbound_config for update: %w", err)
 	}
 	if existing == nil {
-		return nil, fmt.Errorf("outbound_config not found: %s", id)
+		return nil, cerrors.NotFound(commonoutline.ServiceNameCallManager, "OUTBOUND_CONFIG_NOT_FOUND", "The outbound config was not found.")
 	}
 
 	if err := h.validateUpdateRequest(ctx, existing.CustomerID, req); err != nil {

--- a/bin-call-manager/pkg/outboundconfighandler/outbound_config_test.go
+++ b/bin-call-manager/pkg/outboundconfighandler/outbound_config_test.go
@@ -55,14 +55,14 @@ func Test_outboundConfigHandler_Delete(t *testing.T) {
 			wantErr:           true,
 		},
 		{
-			name:              "GetByID nil (not found)",
+			name:              "GetByID nil (not found) - returns typed not-found error, no delete called",
 			id:                uuid.FromStringOrNil("66666666-0000-0000-0000-000000000003"),
 			dbGetRes:          nil,
 			dbGetErr:          nil,
 			dbDelErr:          nil,
 			expectCacheDelete: false,
 			expectRes:         nil,
-			wantErr:           false,
+			wantErr:           true,
 		},
 	}
 
@@ -86,8 +86,8 @@ func Test_outboundConfigHandler_Delete(t *testing.T) {
 				Return(tt.dbGetRes, tt.dbGetErr).
 				Times(1)
 
-			if tt.dbGetErr == nil {
-				// OutboundConfigDelete is always called when GetByID returns no error
+			if tt.dbGetErr == nil && tt.dbGetRes != nil {
+				// OutboundConfigDelete is only called when GetByID returns a non-nil config
 				mockDB.EXPECT().
 					OutboundConfigDelete(ctx, tt.id).
 					Return(tt.dbDelErr).
@@ -615,20 +615,20 @@ func Test_outboundConfigHandler_Update(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "outbound_config not found",
-			id:   uuid.FromStringOrNil("55555555-0000-0000-0000-000000000004"),
-			req:  &outboundconfig.UpdateRequest{Name: &name},
+			name:        "outbound_config not found",
+			id:          uuid.FromStringOrNil("55555555-0000-0000-0000-000000000004"),
+			req:         &outboundconfig.UpdateRequest{Name: &name},
 			existingRes: nil,
 			existingErr: nil,
-			wantErr: true,
+			wantErr:     true,
 		},
 		{
-			name: "GetByID error",
-			id:   uuid.FromStringOrNil("55555555-0000-0000-0000-000000000005"),
-			req:  &outboundconfig.UpdateRequest{Name: &name},
+			name:        "GetByID error",
+			id:          uuid.FromStringOrNil("55555555-0000-0000-0000-000000000005"),
+			req:         &outboundconfig.UpdateRequest{Name: &name},
 			existingRes: nil,
 			existingErr: fmt.Errorf("connection refused"),
-			wantErr: true,
+			wantErr:     true,
 		},
 	}
 

--- a/bin-call-manager/pkg/outboundconfighandler/outbound_config_test.go
+++ b/bin-call-manager/pkg/outboundconfighandler/outbound_config_test.go
@@ -287,7 +287,7 @@ func Test_outboundConfigHandler_GetByID(t *testing.T) {
 			dbRes:   nil,
 			dbErr:   nil,
 			expect:  nil,
-			wantErr: false,
+			wantErr: true, // db returns (nil, nil) → handler returns typed NotFound error
 		},
 		{
 			name:    "db error",

--- a/bin-pipecat-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_messages.go
@@ -29,7 +29,7 @@ func (h *listenHandler) processV1MessagesPost(ctx context.Context, m *sock.Reque
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{

--- a/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_pipecatcalls.go
@@ -85,7 +85,7 @@ func (h *listenHandler) processV1PipecatcallsIDGet(ctx context.Context, m *sock.
 
 	data, err := json.Marshal(c)
 	if err != nil {
-		return simpleResponse(404), nil
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{
@@ -120,7 +120,7 @@ func (h *listenHandler) processV1PipecatcallsIDStopPost(ctx context.Context, m *
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		return simpleResponse(404), nil
+		return simpleResponse(500), nil
 	}
 
 	res := &sock.Response{


### PR DESCRIPTION
Fixes the two latent error-mapping bugs surfaced (but not fixed) during the Phase 2 audit (#960) of the listenhandler error-mapping work (follow-up to #955). The billing Paddle-webhook 500s noted in the audit are intentional retry signals and are deliberately left unchanged.

- bin-pipecat-manager: Return 500 (not 404) when response marshaling fails in pipecatcalls IDGet/IDStop and messages handlers (a serialization failure is internal, not a not-found); the route-not-found default remains 404
- bin-call-manager: Return a typed not-found from outboundConfigHandler.GetByID when the row is missing, so GET /outbound_configs/{id} for a non-existent id returns 404 instead of 200 with a null body (the db method's nil,nil contract, relied on by create/update, is unchanged)