### PR TITLE
NOJIRA-Fix-boilerplate-readmes

### DIFF
--- a/bin-campaign-manager/README.md
+++ b/bin-campaign-manager/README.md
@@ -1,94 +1,64 @@
-# campaign-manager
+# bin-campaign-manager
 
+Outbound calling campaign orchestration service for VoIPbin. Manages Campaign configuration, Outplan dial settings, and individual Campaigncall attempts, coordinating with `bin-call-manager` to place calls and `bin-flow-manager` to execute on-connect actions.
 
+## Key Concepts
 
-## Getting started
+- **Campaign**: Outbound campaign entity; statuses `stop`, `run`, `stopping`; references an outdial (target list), outplan, and optional queue
+- **Campaigncall**: Single call attempt; up to 5 destination slots with independent retry counters; references a Call or Activeflow
+- **Outplan**: Dialing configuration — `source` (caller ID), `dial_timeout`, `try_interval`, `max_try_count_0..4`; shared across campaigns
+- **Service level**: Percentage throttle (0–100) based on available agents in the linked queue; 0 means no dialing
+- **Next campaign chaining**: `next_campaign_id` enables sequential campaign execution after current campaign completes
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/campaigns` | Create campaign |
+| `GET /v1/campaigns` | List campaigns |
+| `GET /v1/campaigns/<id>` | Get campaign |
+| `PUT /v1/campaigns/<id>` | Update campaign |
+| `DELETE /v1/campaigns/<id>` | Delete campaign |
+| `POST /v1/campaigns/<id>/execute` | Execute one dial cycle |
+| `POST /v1/campaigns/<id>/start` | Start campaign |
+| `POST /v1/campaigns/<id>/stop` | Stop campaign |
+| `POST /v1/outplans` | Create outplan |
+| `GET /v1/outplans` | List outplans |
+| `GET /v1/outplans/<id>` | Get outplan |
+| `PUT /v1/outplans/<id>` | Update outplan |
+| `DELETE /v1/outplans/<id>` | Delete outplan |
+| `GET /v1/campaigncalls` | List campaigncalls |
+| `GET /v1/campaigncalls/<id>` | Get campaigncall |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — campaign, outplan, campaigncall records
+- **Redis** — campaign and campaigncall cache
+- **RabbitMQ** — listen queue `bin-manager.campaign-manager.request`; subscribes to `bin-manager.call-manager.event`
+- **bin-call-manager** — place outbound calls
+- **bin-outdial-manager** — fetch and update dial targets
+- **bin-queue-manager** — service level throttle check
 
+## Local Development
+
+```bash
+# Build
+cd bin-campaign-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# CLI tool (bypasses RabbitMQ)
+./bin/campaign-control campaign get --id <uuid>
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-campaign-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/voipbin/bin-manager/campaign-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Automatically merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!).  Thank you to [makeareadme.com](https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-<!-- Updated dependencies: 2026-02-20 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-conference-manager/README.md
+++ b/bin-conference-manager/README.md
@@ -1,93 +1,58 @@
-# conference-manager
+# bin-conference-manager
 
+Multi-party audio conference session management service for VoIPbin. Owns Conference and Conferencecall (participant) entities, coordinates with `bin-call-manager`'s confbridge for audio mixing, and handles conference lifecycle including recording and transcription.
 
+## Key Concepts
 
-## Getting started
+- **Conference**: Top-level session entity; types: `conference` (manual stop), `connect` (auto-stops when only 1 participant remains), `queue` (managed by queue-manager)
+- **Conferencecall**: A participant in a conference; tracks `reference_id` (call UUID) and join/leave status
+- **Confbridge**: Actual audio-mixing bridge owned by `bin-call-manager`; this service stores the `confbridge_id` only
+- **Recording**: Initiated/stopped via `bin-call-manager`; `recording_id` stored on the conference
+- **Transcription**: Live transcription via `bin-transcribe-manager`; `transcribe_id` stored on the conference
+- **Pre/post flows**: Optional flow IDs executed before participants speak and after conference ends
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/conferences` | Create conference |
+| `GET /v1/conferences` | List conferences |
+| `GET /v1/conferences/<id>` | Get conference |
+| `PUT /v1/conferences/<id>` | Update conference |
+| `DELETE /v1/conferences/<id>` | Delete conference |
+| `POST /v1/conferences/<id>/start` | Start conference |
+| `POST /v1/conferences/<id>/stop` | Stop conference |
+| `POST /v1/conferences/<id>/recording_start` | Start recording |
+| `POST /v1/conferences/<id>/recording_stop` | Stop recording |
+| `GET /v1/conferencecalls` | List participants |
+| `GET /v1/conferencecalls/<id>` | Get participant |
+| `POST /v1/conferencecalls/<id>/kick` | Kick participant |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — conference and conferencecall records
+- **Redis** — conference and conferencecall cache
+- **RabbitMQ** — listen queue `bin-manager.conference-manager.request`; subscribes to `bin-manager.call-manager.event`
+- **bin-call-manager** — confbridge create/destroy, recording start/stop
+- **bin-transcribe-manager** — transcription start/stop
 
+## Local Development
+
+```bash
+# Build
+cd bin-conference-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-conference-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/integrations/)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Automatically merge when pipeline succeeds](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/clusters/agent/)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!).  Thank you to [makeareadme.com](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-
-<!-- Updated dependencies: 2026-03-30 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-customer-manager/README.md
+++ b/bin-customer-manager/README.md
@@ -1,95 +1,57 @@
-# customer-manager
+# bin-customer-manager
 
+Foundational identity service for VoIPbin. Manages tenant organizations (customers) and their API credentials (access keys). All other services depend on customer context — this is the root of the VoIPbin tenant hierarchy.
 
+## Key Concepts
 
-## Getting started
+- **Customer**: Tenant organization entity; holds name, status, and billing account link
+- **AccessKey**: API credential scoped to a customer; used as `?accesskey=` query parameter on all API calls
+- **Cascade delete**: `customer_deleted` event triggers bulk cleanup in `bin-number-manager` and `bin-billing-manager`
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/customers` | Create customer |
+| `GET /v1/customers` | List customers |
+| `GET /v1/customers/<id>` | Get customer |
+| `PUT /v1/customers/<id>` | Update customer |
+| `DELETE /v1/customers/<id>` | Delete customer |
+| `POST /v1/accesskeys` | Create access key |
+| `GET /v1/accesskeys` | List access keys |
+| `GET /v1/accesskeys/<id>` | Get access key |
+| `DELETE /v1/accesskeys/<id>` | Delete access key |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — customer and accesskey records
+- **Redis** — customer and accesskey cache
+- **RabbitMQ** — listen queue `bin-manager.customer-manager.request`; publishes `customer_created`, `customer_updated`, `customer_deleted`
+- **bin-agent-manager** — username uniqueness check on customer create
+- **bin-billing-manager** — billing account link validation
 
+## Local Development
+
+```bash
+# Build
+cd bin-customer-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# CLI tool (bypasses RabbitMQ)
+./bin/customer-control customer get --id <uuid>
+./bin/customer-control customer list
+./bin/customer-control accesskey list --customer-id <uuid>
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-customer-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://gitlab.com/voipbin/bin-manager/customer-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Automatically merge when pipeline succeeds](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!).  Thank you to [makeareadme.com](https://www.makeareadme.com) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-
-<!-- Updated dependencies: 2026-03-30 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-message-manager/README.md
+++ b/bin-message-manager/README.md
@@ -1,94 +1,55 @@
-# message-manager
+# bin-message-manager
 
+SMS messaging service for VoIPbin. Sends messages via Telnyx and MessageBird, tracks per-target delivery status, and processes provider webhooks for delivery updates.
 
+## Key Concepts
 
-## Getting started
+- **Message**: Top-level outbound SMS record; references one or more targets
+- **Target**: Per-recipient delivery record with status tracking (`initiating`, `queued`, `sent`, `delivered`, `failed`)
+- **Provider dispatch**: MessageBird primary, Telnyx fallback; send is asynchronous (goroutine) — caller receives success after record creation
+- **Webhook**: Delivery status updates arrive from providers via `bin-hook-manager` → `POST /v1/hooks`
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/messages` | Send message (requires verified account) |
+| `GET /v1/messages` | List messages |
+| `GET /v1/messages/<id>` | Get message |
+| `DELETE /v1/messages/<id>` | Delete message |
+| `GET /v1/messagetargets` | List targets |
+| `GET /v1/messagetargets/<id>` | Get target |
+| `POST /v1/hooks` | Provider webhook handler |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — message and target records
+- **Redis** — message and target cache
+- **RabbitMQ** — listen queue `bin-manager.message-manager.request`
+- **bin-billing-manager** — balance validation before send
+- **bin-hook-manager** — routes inbound provider webhooks to this service
 
+## Local Development
+
+```bash
+# Build
+cd bin-message-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# CLI tool (bypasses RabbitMQ)
+./bin/message-control message list --customer_id <uuid>
+./bin/message-control message get --id <uuid>
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-message-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/voipbin/bin-manager/message-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Automatically merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!).  Thank you to [makeareadme.com](https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-<!-- Updated dependencies: 2026-02-20 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-outdial-manager/README.md
+++ b/bin-outdial-manager/README.md
@@ -1,94 +1,57 @@
-# outdial-manager
+# bin-outdial-manager
 
+Outbound dialing target management service for VoIPbin. Stores outdial containers, individual call targets (up to 5 destinations per target with independent retry counters), and per-attempt call records. Primary consumer is `bin-campaign-manager`.
 
+## Key Concepts
 
-## Getting started
+- **Outdial**: Container grouping a set of dial targets for a campaign
+- **OutdialTarget**: Single dial target with up to 5 destination slots (`destination_0`–`destination_4`); statuses: `idle` → `processing` → `done`
+- **OutdialTargetCall**: Per-attempt call record linking a target to a specific call UUID
+- **Available query**: Filters targets by per-destination try-count thresholds; used by campaign-manager for retry scheduling
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/outdials` | Create outdial |
+| `GET /v1/outdials` | List outdials |
+| `GET /v1/outdials/<id>` | Get outdial |
+| `PUT /v1/outdials/<id>` | Update outdial |
+| `DELETE /v1/outdials/<id>` | Delete outdial |
+| `POST /v1/outdials/<id>/targets` | Add target |
+| `GET /v1/outdials/<id>/targets` | List targets |
+| `GET /v1/outdials/<id>/targets/<target-id>` | Get target |
+| `PUT /v1/outdials/<id>/targets/<target-id>` | Update target |
+| `DELETE /v1/outdials/<id>/targets/<target-id>` | Delete target |
+| `GET /v1/outdials/<id>/targets/available` | Get next available targets |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — outdial, target, and call records
+- **Redis** — outdial and target cache
+- **RabbitMQ** — listen queue `bin-manager.outdial-manager.request`; publishes `outdial_created`, `outdial_updated`, `outdial_deleted`
 
+## Local Development
+
+```bash
+# Build
+cd bin-outdial-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# CLI tool (bypasses RabbitMQ)
+./bin/outdial-control outdial list --customer_id <uuid>
+./bin/outdial-control outdial get --id <uuid>
 ```
-cd existing_repo
-git remote add origin https://gitlab.com/pchero21/outdial-manager.git
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/pchero21/outdial-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Automatically merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!).  Thank you to [makeareadme.com](https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-<!-- Updated dependencies: 2026-03-30 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-queue-manager/README.md
+++ b/bin-queue-manager/README.md
@@ -1,95 +1,58 @@
-# queue-manager
+# bin-queue-manager
 
+Inbound call queue management service for VoIPbin. Holds callers in a waiting state, routes them to available agents using tag-based matching, and coordinates the conference bridge used to connect agent and caller.
 
+## Key Concepts
 
-## Getting started
+- **Queue**: Configuration entity — routing method, `tag_ids` (agent filter), `wait_timeout`, `service_timeout`
+- **Queuecall**: Single call waiting in a queue; status: `initiating` → `waiting` → `connecting` → `service` → `done` / `abandoned`
+- **Routing**: `random` method picks a random available agent whose tag IDs overlap with the queue's `tag_ids`
+- **Conference bridge**: When an agent is matched, a conference in `bin-conference-manager` bridges caller and agent
+- **Wait timeout**: Maximum time a caller waits before being abandoned; triggered by external scheduler
+- **Service timeout**: Maximum agent service duration; triggers forced disconnect via `timeout_service`
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/queues` | Create queue |
+| `GET /v1/queues` | List queues |
+| `GET /v1/queues/<id>` | Get queue |
+| `PUT /v1/queues/<id>` | Update queue |
+| `DELETE /v1/queues/<id>` | Delete queue |
+| `POST /v1/queuecalls` | Enqueue a call |
+| `GET /v1/queuecalls` | List queuecalls |
+| `GET /v1/queuecalls/<id>` | Get queuecall |
+| `DELETE /v1/queuecalls/<id>` | Remove from queue |
+| `POST /v1/queuecalls/<id>/timeout_wait` | Trigger wait timeout |
+| `POST /v1/queuecalls/<id>/timeout_service` | Trigger service timeout |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — queue and queuecall records
+- **Redis** — queue and queuecall cache
+- **RabbitMQ** — listen queue `bin-manager.queue-manager.request`; subscribes to `bin-manager.call-manager.event`, `bin-manager.agent-manager.event`
+- **bin-agent-manager** — fetch available agents for routing
+- **bin-conference-manager** — create conference bridge for agent-caller connection
+- **bin-call-manager** — call state tracking via events
 
+## Local Development
+
+```bash
+# Build
+cd bin-queue-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-queue-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://gitlab.com/voipbin/bin-manager/queue-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Automatically merge when pipeline succeeds](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!).  Thank you to [makeareadme.com](https://gitlab.com/-/experiment/new_project_readme_content:c434baf4327733a385ac3e01fbe37b88?https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-
-<!-- Updated dependencies: 2026-03-30 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-tag-manager/README.md
+++ b/bin-tag-manager/README.md
@@ -1,94 +1,51 @@
-# tag-manager
+# bin-tag-manager
 
+Lightweight CRUD service for managing customer-scoped tags in VoIPbin. Tags are labels that other services (contacts, queues, campaigns) attach to resources for categorization and routing. Handles event-driven cascading deletes when customers are removed.
 
+## Key Concepts
 
-## Getting started
+- **Tag**: Customer-scoped label with name and detail; referenced by agent `tag_ids`, queue `tag_ids`, and campaign filters
+- **Cascade delete**: Subscribes to `customer_deleted` event and bulk-deletes all tags for the removed customer
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/tags` | Create tag |
+| `GET /v1/tags` | List tags |
+| `GET /v1/tags/<id>` | Get tag |
+| `PUT /v1/tags/<id>` | Update tag |
+| `DELETE /v1/tags/<id>` | Delete tag |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — tag records (soft-delete via `tm_delete`)
+- **Redis** — tag cache
+- **RabbitMQ** — listen queue `bin-manager.tag-manager.request`; subscribes to `bin-manager.customer-manager.event`; publishes `tag_created`, `tag_updated`, `tag_deleted`
 
+## Local Development
+
+```bash
+# Build
+cd bin-tag-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# CLI tool (bypasses RabbitMQ)
+./bin/tag-control tag list --customer_id <uuid>
+./bin/tag-control tag get --id <uuid>
+./bin/tag-control tag create --customer_id <uuid> --name "my-tag"
+./bin/tag-control tag delete --id <uuid>
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-tag-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/voipbin/bin-manager/tag-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Set auto-merge](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!). Thank you to [makeareadme.com](https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-<!-- Updated dependencies: 2026-03-30 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)

--- a/bin-transfer-manager/README.md
+++ b/bin-transfer-manager/README.md
@@ -1,94 +1,51 @@
-# transfer-manager
+# bin-transfer-manager
 
+Call transfer orchestration service for VoIPbin. Handles attended and blind transfer operations, coordinating confbridge state and groupcall lifecycles with `bin-call-manager`.
 
+## Key Concepts
 
-## Getting started
+- **Attended transfer**: Transferer consults transferee before completing handoff; supports rollback if consultation fails
+- **Blind transfer**: Immediate handoff without consultation; confbridge uses `NoAutoLeave` flag to survive the transferer hangup
+- **Transfer state**: Entirely event-driven — advances only when `subscribehandler` receives call-manager events (`groupcall_progressing`, `groupcall_hangup`, `call_hangup`)
 
-To make it easy for you to get started with GitLab, here's a list of recommended next steps.
+## Public RPC Entrypoints
 
-Already a pro? Just edit this README.md and make it your own. Want to make it easy? [Use the template at the bottom](#editing-this-readme)!
+| Pattern | Operations |
+|---------|-----------|
+| `POST /v1/transfers` | Initiate transfer |
+| `GET /v1/transfers` | List transfers |
+| `GET /v1/transfers/<id>` | Get transfer |
+| `DELETE /v1/transfers/<id>` | Cancel transfer |
+| `POST /v1/transfers/<id>/complete` | Complete attended transfer |
 
-## Add your files
+## Dependencies
 
-- [ ] [Create](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#create-a-file) or [upload](https://docs.gitlab.com/ee/user/project/repository/web_editor.html#upload-a-file) files
-- [ ] [Add files using the command line](https://docs.gitlab.com/ee/gitlab-basics/add-file.html#add-a-file-using-the-command-line) or push an existing Git repository with the following command:
+- **MySQL** — transfer records (soft-delete via `tm_delete`)
+- **Redis** — transfer cache
+- **RabbitMQ** — listen queue `bin-manager.transfer-manager.request`; subscribes to `bin-manager.call-manager.event`
+- **bin-call-manager** — confbridge mute/unmute/flag manipulation, groupcall management
 
+## Local Development
+
+```bash
+# Build
+cd bin-transfer-manager
+go build -o ./bin/ ./cmd/...
+
+# Run all tests
+go test ./...
+
+# Verify before commit (mandatory)
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+
+# CLI tool (bypasses RabbitMQ)
+./bin/transfer-control transfer get-by-call --call_id <uuid>
+./bin/transfer-control transfer get-by-groupcall --groupcall_id <uuid>
 ```
-cd existing_repo
-git remote add origin https://monorepo/bin-transfer-manager
-git branch -M main
-git push -uf origin main
-```
 
-## Integrate with your tools
+## Further Reading
 
-- [ ] [Set up project integrations](https://gitlab.com/voipbin/bin-manager/transfer-manager/-/settings/integrations)
-
-## Collaborate with your team
-
-- [ ] [Invite team members and collaborators](https://docs.gitlab.com/ee/user/project/members/)
-- [ ] [Create a new merge request](https://docs.gitlab.com/ee/user/project/merge_requests/creating_merge_requests.html)
-- [ ] [Automatically close issues from merge requests](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
-- [ ] [Enable merge request approvals](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/)
-- [ ] [Automatically merge when pipeline succeeds](https://docs.gitlab.com/ee/user/project/merge_requests/merge_when_pipeline_succeeds.html)
-
-## Test and Deploy
-
-Use the built-in continuous integration in GitLab.
-
-- [ ] [Get started with GitLab CI/CD](https://docs.gitlab.com/ee/ci/quick_start/index.html)
-- [ ] [Analyze your code for known vulnerabilities with Static Application Security Testing(SAST)](https://docs.gitlab.com/ee/user/application_security/sast/)
-- [ ] [Deploy to Kubernetes, Amazon EC2, or Amazon ECS using Auto Deploy](https://docs.gitlab.com/ee/topics/autodevops/requirements.html)
-- [ ] [Use pull-based deployments for improved Kubernetes management](https://docs.gitlab.com/ee/user/clusters/agent/)
-- [ ] [Set up protected environments](https://docs.gitlab.com/ee/ci/environments/protected_environments.html)
-
-***
-
-# Editing this README
-
-When you're ready to make this README your own, just edit this file and use the handy template below (or feel free to structure it however you want - this is just a starting point!). Thank you to [makeareadme.com](https://www.makeareadme.com/) for this template.
-
-## Suggestions for a good README
-Every project is different, so consider which of these sections apply to yours. The sections used in the template are suggestions for most open source projects. Also keep in mind that while a README can be too long and detailed, too long is better than too short. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
-
-## Name
-Choose a self-explaining name for your project.
-
-## Description
-Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
-
-## Badges
-On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use Shields to add some to your README. Many services also have instructions for adding a badge.
-
-## Visuals
-Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method.
-
-## Installation
-Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Requirements subsection.
-
-## Usage
-Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
-
-## Support
-Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
-
-## Roadmap
-If you have ideas for releases in the future, it is a good idea to list them in the README.
-
-## Contributing
-State if you are open to contributions and what your requirements are for accepting them.
-
-For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
-
-You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
-
-## Authors and acknowledgment
-Show your appreciation to those who have contributed to the project.
-
-## License
-For open source projects, say how it is licensed.
-
-## Project status
-If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
-
-<!-- Updated dependencies: 2026-03-30 -->
+- [docs/architecture.md](docs/architecture.md)
+- [docs/domain.md](docs/domain.md)
+- [docs/dependencies.md](docs/dependencies.md)
+- [docs/operations.md](docs/operations.md)


### PR DESCRIPTION
Replace GitLab template boilerplate READMEs in 8 bin-* services with real service descriptions. Closes #888.

Each README now includes a one-paragraph service description, key concepts, public RPC entrypoint table, dependencies, and local dev commands. Content sourced from existing CLAUDE.md and docs/ in each service.

- bin-campaign-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-conference-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-customer-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-message-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-outdial-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-queue-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-tag-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide
- bin-transfer-manager: Replace GitLab boilerplate README with service description, RPC table, and dev guide