### PR TITLE
NOJIRA-Fix-confbridge-channel-join-err

### DIFF
--- a/bin-call-manager/pkg/confbridgehandler/start.go
+++ b/bin-call-manager/pkg/confbridgehandler/start.go
@@ -44,9 +44,10 @@ func (h *confbridgeHandler) StartContextIncoming(ctx context.Context, cn *channe
 	log.WithField("confbridge", cb).Debugf("Found confbridge. confbridge_id: %s", cb.ID)
 
 	// add the channel to the bridge
+	// Note: errors.Wrap(nil, msg) returns nil, so errJoin must be used explicitly here.
 	if errJoin := h.bridgeHandler.ChannelJoin(ctx, cb.BridgeID, channelID, "", false, false); errJoin != nil {
-		log.Errorf("Could not add the channel to the bridge. err: %v", err)
-		return errors.Wrap(err, "could not add the channel to the bridge")
+		log.Errorf("could not add the channel to the bridge. err: %v", errJoin)
+		return errors.Wrap(errJoin, "could not add the channel to the bridge")
 	}
 
 	return nil

--- a/bin-call-manager/pkg/confbridgehandler/start_test.go
+++ b/bin-call-manager/pkg/confbridgehandler/start_test.go
@@ -2,6 +2,7 @@ package confbridgehandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
@@ -87,3 +88,55 @@ func Test_StartContextIncoming(t *testing.T) {
 		})
 	}
 }
+
+func Test_StartContextIncoming_ChannelJoinError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockChannel := channelhandler.NewMockChannelHandler(mc)
+	mockBridge := bridgehandler.NewMockBridgeHandler(mc)
+
+	h := &confbridgeHandler{
+		db:             mockDB,
+		reqHandler:     mockReq,
+		notifyHandler:  mockNotify,
+		cache:          mockCache,
+		channelHandler: mockChannel,
+		bridgeHandler:  mockBridge,
+	}
+
+	ctx := context.Background()
+
+	cn := &channel.Channel{
+		ID:         "asterisk-conference-test-channel-001",
+		AsteriskID: "80:fa:5b:5e:da:81",
+		StasisData: map[channel.StasisDataType]string{
+			"call_id":       "b1000000-0000-0000-0000-000000000001",
+			"confbridge_id": "b2000000-0000-0000-0000-000000000002",
+		},
+	}
+
+	confbridgeID := uuid.FromStringOrNil("b2000000-0000-0000-0000-000000000002")
+	cb := &confbridge.Confbridge{
+		Identity: commonidentity.Identity{
+			ID: confbridgeID,
+		},
+		BridgeID: "b3000000-0000-0000-0000-000000000003",
+	}
+
+	joinErr := fmt.Errorf("bridge not found")
+
+	mockDB.EXPECT().ConfbridgeGet(ctx, confbridgeID).Return(cb, nil)
+	// ChannelJoin returns an error — this must NOT be silenced.
+	mockBridge.EXPECT().ChannelJoin(ctx, cb.BridgeID, cn.ID, "", false, false).Return(joinErr)
+
+	err := h.StartContextIncoming(ctx, cn)
+	if err == nil {
+		t.Error("Wrong match. expect: error, got: nil — ChannelJoin error was silenced")
+	}
+}
+

--- a/bin-call-manager/pkg/confbridgehandler/start_test.go
+++ b/bin-call-manager/pkg/confbridgehandler/start_test.go
@@ -10,6 +10,7 @@ import (
 	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-call-manager/models/channel"
@@ -22,13 +23,18 @@ import (
 
 func Test_StartContextIncoming(t *testing.T) {
 
+	joinErr := fmt.Errorf("bridge not found")
+
 	tests := []struct {
 		name string
 
 		channel *channel.Channel
 
-		responseConfbridge *confbridge.Confbridge
-		expectConfbridgeID uuid.UUID
+		responseConfbridge  *confbridge.Confbridge
+		expectConfbridgeID  uuid.UUID
+		responseChannelJoin error
+
+		expectError error
 	}{
 		{
 			name: "normal",
@@ -50,7 +56,36 @@ func Test_StartContextIncoming(t *testing.T) {
 				},
 				BridgeID: "a6e2e860-a3c7-11ed-9d27-8b42b68dfd08",
 			},
-			expectConfbridgeID: uuid.FromStringOrNil("a6c4e9c8-a3c7-11ed-8961-7390b2c3f45c"),
+			expectConfbridgeID:  uuid.FromStringOrNil("a6c4e9c8-a3c7-11ed-8961-7390b2c3f45c"),
+			responseChannelJoin: nil,
+
+			expectError: nil,
+		},
+		{
+			// Regression test: before the fix, ChannelJoin failures were silently swallowed
+			// because errors.Wrap(err, msg) used the outer `err` (nil) instead of errJoin.
+			// errors.Wrap(nil, msg) returns nil, so the function incorrectly returned nil.
+			name: "ChannelJoin error is propagated",
+
+			channel: &channel.Channel{
+				ID:         "asterisk-conference-test-channel-001",
+				AsteriskID: "80:fa:5b:5e:da:81",
+				StasisData: map[channel.StasisDataType]string{
+					"call_id":       "b1000000-0000-0000-0000-000000000001",
+					"confbridge_id": "b2000000-0000-0000-0000-000000000002",
+				},
+			},
+
+			responseConfbridge: &confbridge.Confbridge{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("b2000000-0000-0000-0000-000000000002"),
+				},
+				BridgeID: "b3000000-0000-0000-0000-000000000003",
+			},
+			expectConfbridgeID:  uuid.FromStringOrNil("b2000000-0000-0000-0000-000000000002"),
+			responseChannelJoin: joinErr,
+
+			expectError: joinErr,
 		},
 	}
 
@@ -79,64 +114,25 @@ func Test_StartContextIncoming(t *testing.T) {
 			ctx := context.Background()
 
 			mockDB.EXPECT().ConfbridgeGet(ctx, tt.expectConfbridgeID).Return(tt.responseConfbridge, nil)
-			mockBridge.EXPECT().ChannelJoin(ctx, tt.responseConfbridge.BridgeID, tt.channel.ID, "", false, false).Return(nil)
+			mockBridge.EXPECT().ChannelJoin(ctx, tt.responseConfbridge.BridgeID, tt.channel.ID, "", false, false).Return(tt.responseChannelJoin)
 
 			err := h.StartContextIncoming(ctx, tt.channel)
-			if err != nil {
-				t.Errorf("Wrong match. expect: ok, got: %v", err)
+
+			if tt.expectError != nil {
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: nil")
+					return
+				}
+				if !errors.Is(err, tt.expectError) {
+					t.Errorf("Wrong match. expect error wrapping %v, got: %v", tt.expectError, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Wrong match. expect: ok, got: %v", err)
+				}
 			}
 		})
 	}
 }
 
-func Test_StartContextIncoming_ChannelJoinError(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
-	mockDB := dbhandler.NewMockDBHandler(mc)
-	mockCache := cachehandler.NewMockCacheHandler(mc)
-	mockChannel := channelhandler.NewMockChannelHandler(mc)
-	mockBridge := bridgehandler.NewMockBridgeHandler(mc)
-
-	h := &confbridgeHandler{
-		db:             mockDB,
-		reqHandler:     mockReq,
-		notifyHandler:  mockNotify,
-		cache:          mockCache,
-		channelHandler: mockChannel,
-		bridgeHandler:  mockBridge,
-	}
-
-	ctx := context.Background()
-
-	cn := &channel.Channel{
-		ID:         "asterisk-conference-test-channel-001",
-		AsteriskID: "80:fa:5b:5e:da:81",
-		StasisData: map[channel.StasisDataType]string{
-			"call_id":       "b1000000-0000-0000-0000-000000000001",
-			"confbridge_id": "b2000000-0000-0000-0000-000000000002",
-		},
-	}
-
-	confbridgeID := uuid.FromStringOrNil("b2000000-0000-0000-0000-000000000002")
-	cb := &confbridge.Confbridge{
-		Identity: commonidentity.Identity{
-			ID: confbridgeID,
-		},
-		BridgeID: "b3000000-0000-0000-0000-000000000003",
-	}
-
-	joinErr := fmt.Errorf("bridge not found")
-
-	mockDB.EXPECT().ConfbridgeGet(ctx, confbridgeID).Return(cb, nil)
-	// ChannelJoin returns an error — this must NOT be silenced.
-	mockBridge.EXPECT().ChannelJoin(ctx, cb.BridgeID, cn.ID, "", false, false).Return(joinErr)
-
-	err := h.StartContextIncoming(ctx, cn)
-	if err == nil {
-		t.Error("Wrong match. expect: error, got: nil — ChannelJoin error was silenced")
-	}
-}
 


### PR DESCRIPTION
Fix ChannelJoin error silencing in confbridge StartContextIncoming that causes all extension-to-extension inbound calls to fail.

- bin-call-manager: Fix variable shadowing bug in pkg/confbridgehandler/start.go — errJoin was declared but outer err (nil) was used in errors.Wrap, causing ChannelJoin failures to silently return nil
- bin-call-manager: Add unit test Test_StartContextIncoming_ChannelJoinError to prevent regression