### PR TITLE
NOJIRA-Add-timeline-resource-correlation

### DIFF
--- a/bin-timeline-manager/docs/architecture.md
+++ b/bin-timeline-manager/docs/architecture.md
@@ -51,6 +51,7 @@ Requests arrive on queue `bin-manager.timeline-manager.request`. The listenhandl
 |--------|-------------|---------|
 | POST | `/v1/events` | `v1EventsPost` — list events with filters (publisher, resource ID, event-type wildcards) |
 | POST | `/v1/aggregated-events` | `v1AggregatedEventsPost` — aggregated event view |
+| GET | `/v1/correlations/<resource_id>` | `v1CorrelationsGet` — resolve a resource id to its activeflow and return all correlated resources grouped by publisher |
 | GET | `/v1/sip/analysis` | `v1SIPAnalysisGet` — SIP call analysis (via Homer) |
 | GET | `/v1/sip/pcap` | `v1SIPPcapGet` — SIP PCAP capture retrieval (via Homer) |
 

--- a/bin-timeline-manager/docs/domain.md
+++ b/bin-timeline-manager/docs/domain.md
@@ -33,6 +33,27 @@ API DTO for listing events (richer types used here, converted before DB call):
 | `PageSize` | `int` | Optional — results per page (default: 100, max: 1000) |
 | `PageToken` | `string` | Optional — opaque cursor for next page |
 
+### Resource Correlation
+
+A correlation graph links every resource that shares the same `activeflow_id`.
+`activeflow_id` is the universal correlation key across most VoIPBin resources
+(call, recording, confbridge, aicall, ai message, summary, transcribe,
+conferencecall, queuecall). Given any one resource id, the service reverse-looks
+up its `activeflow_id` (from the MATERIALIZED column) and returns all sibling
+resources grouped by publisher.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ResourceID` | `uuid.UUID` | The queried resource id |
+| `ResourceFound` | `bool` | Whether any event exists for the id (distinguishes "never seen" from "seen but no activeflow") |
+| `ActiveflowID` | `uuid.UUID` | The resolved activeflow; `uuid.Nil` when none |
+| `Truncated` | `bool` | `true` when the graph exceeded the 100-resource cap |
+| `Resources` | `[]PublisherGroup` | Deduplicated resources grouped by publisher, each with `event_types`, `first_seen`, `last_seen` |
+
+Known gap: `message-manager` (SMS) and `transfer-manager` resources do not carry
+`activeflow_id` in their event payloads, so they are not captured. If they later
+emit `activeflow_id`, they are picked up automatically (MATERIALIZED extraction).
+
 ## Key Business Rules
 
 ### Read-Only Query API

--- a/bin-timeline-manager/docs/operations.md
+++ b/bin-timeline-manager/docs/operations.md
@@ -10,6 +10,7 @@
 | SIP analysis returning 503 | Homer API unreachable | Check `homer_api_address` config and Homer service health |
 | 27 queues failing to subscribe | RabbitMQ connection dropped | Check RabbitMQ connectivity; service will reconnect automatically |
 | Migration failure at startup | Missing `migrations_path` or ClickHouse unavailable | Verify `CLICKHOUSE_ADDRESS` and `MIGRATIONS_PATH` env vars |
+| Correlation returns incomplete results for old events after deploy | Migration 000004 `MATERIALIZE COLUMN`/`MATERIALIZE INDEX` run as async background mutations; migrate marks success before they finish | Monitor `SELECT * FROM system.mutations WHERE is_done = 0 OR latest_fail_reason != ''`; wait for completion before relying on historical correlation |
 
 ## Debugging Guide
 

--- a/bin-timeline-manager/migrations/000004_add_correlation_skip_indexes.down.sql
+++ b/bin-timeline-manager/migrations/000004_add_correlation_skip_indexes.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events DROP INDEX IF EXISTS idx_resource_id;
+ALTER TABLE events DROP INDEX IF EXISTS idx_activeflow_id;

--- a/bin-timeline-manager/migrations/000004_add_correlation_skip_indexes.up.sql
+++ b/bin-timeline-manager/migrations/000004_add_correlation_skip_indexes.up.sql
@@ -1,0 +1,16 @@
+-- Backfill MATERIALIZED columns on existing parts. Columns added in 000002/000003
+-- only auto-compute for rows inserted after the ALTER; pre-existing parts may have
+-- empty resource_id / activeflow_id. MATERIALIZE COLUMN rewrites old parts so that
+-- historical events become correlatable.
+ALTER TABLE events MATERIALIZE COLUMN resource_id;
+ALTER TABLE events MATERIALIZE COLUMN activeflow_id;
+
+-- Data-skipping indexes for point lookups on resource_id / activeflow_id.
+-- The table is ORDER BY (event_type, timestamp), so filtering by these columns
+-- alone is a full scan without an index.
+ALTER TABLE events ADD INDEX IF NOT EXISTS idx_resource_id   resource_id   TYPE bloom_filter GRANULARITY 1;
+ALTER TABLE events ADD INDEX IF NOT EXISTS idx_activeflow_id activeflow_id TYPE bloom_filter GRANULARITY 1;
+
+-- Build the indexes over existing parts.
+ALTER TABLE events MATERIALIZE INDEX idx_resource_id;
+ALTER TABLE events MATERIALIZE INDEX idx_activeflow_id;

--- a/bin-timeline-manager/models/event/correlation.go
+++ b/bin-timeline-manager/models/event/correlation.go
@@ -1,0 +1,36 @@
+package event
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+)
+
+// CorrelatedRow is the raw scan target for the correlation aggregation query.
+// ClickHouse driver constraints require scanning LowCardinality(String) columns
+// (publisher, data_type) and the materialized resource_id into Go strings;
+// conversion to richer types happens at the eventhandler boundary.
+type CorrelatedRow struct {
+	Publisher  string
+	ResourceID string
+	DataType   string
+	EventTypes []string
+	FirstSeen  time.Time
+	LastSeen   time.Time
+}
+
+// CorrelatedResource is one deduplicated resource derived from events,
+// returned in the correlation graph.
+type CorrelatedResource struct {
+	ID         uuid.UUID `json:"id"`
+	DataType   string    `json:"data_type"`
+	EventTypes []string  `json:"event_types"`
+	FirstSeen  time.Time `json:"first_seen"`
+	LastSeen   time.Time `json:"last_seen"`
+}
+
+// PublisherGroup groups correlated resources by publisher (service name).
+type PublisherGroup struct {
+	Publisher string                `json:"publisher"`
+	Resources []*CorrelatedResource `json:"resources"`
+}

--- a/bin-timeline-manager/pkg/dbhandler/correlation.go
+++ b/bin-timeline-manager/pkg/dbhandler/correlation.go
@@ -1,0 +1,150 @@
+package dbhandler
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-timeline-manager/models/event"
+)
+
+// max_execution_time (seconds) applied to the correlation lookups via the
+// per-query context. These are point lookups backed by skip indexes; the
+// timeout guards against a pathological full scan. ClickHouse does not accept
+// positional bind parameters in the SETTINGS clause, so the limit is passed
+// through clickhouse.WithSettings on the query context instead.
+const (
+	correlationLookupTimeout = 5
+	correlationListTimeout   = 10
+)
+
+// withQueryTimeout returns a context carrying a ClickHouse max_execution_time
+// setting (in seconds) for a single query.
+func withQueryTimeout(ctx context.Context, seconds int) context.Context {
+	return clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_execution_time": seconds,
+	}))
+}
+
+// ResourceActiveflowIDGet returns the activeflow_id for a given resource_id.
+// Returns "" (no error) when no matching event with a non-empty activeflow_id exists.
+// ORDER BY timestamp ASC makes the result deterministic even if a resource_id were
+// (abnormally) associated with more than one activeflow.
+func (h *dbHandler) ResourceActiveflowIDGet(ctx context.Context, resourceID string) (string, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "ResourceActiveflowIDGet",
+		"resource_id": resourceID,
+	})
+
+	if h.conn == nil {
+		return "", errors.New("clickhouse connection not established")
+	}
+
+	query := `
+		SELECT activeflow_id
+		FROM events
+		WHERE resource_id = ?
+		  AND activeflow_id != ''
+		ORDER BY timestamp ASC
+		LIMIT 1
+	`
+
+	rows, err := h.conn.Query(withQueryTimeout(ctx, correlationLookupTimeout), query, resourceID)
+	if err != nil {
+		return "", errors.Wrap(err, "could not query resource activeflow_id")
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", errors.Wrap(err, "error iterating rows")
+		}
+		log.Debugf("No activeflow_id found for resource.")
+		return "", nil
+	}
+
+	var activeflowID string
+	if err := rows.Scan(&activeflowID); err != nil {
+		return "", errors.Wrap(err, "could not scan activeflow_id")
+	}
+
+	return activeflowID, nil
+}
+
+// ResourceExists reports whether any event row exists for the resource_id.
+// Used to distinguish "resource never seen" from "resource has no activeflow".
+func (h *dbHandler) ResourceExists(ctx context.Context, resourceID string) (bool, error) {
+	if h.conn == nil {
+		return false, errors.New("clickhouse connection not established")
+	}
+
+	query := `
+		SELECT 1
+		FROM events
+		WHERE resource_id = ?
+		LIMIT 1
+	`
+
+	rows, err := h.conn.Query(withQueryTimeout(ctx, correlationLookupTimeout), query, resourceID)
+	if err != nil {
+		return false, errors.Wrap(err, "could not query resource existence")
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return false, errors.Wrap(err, "error iterating rows")
+		}
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// CorrelatedResourceList returns deduplicated resources grouped by (publisher,
+// resource_id) for a given activeflow_id, aggregated at the ClickHouse layer.
+// limit caps the row count (callers pass maxResources+1 to detect truncation).
+func (h *dbHandler) CorrelatedResourceList(ctx context.Context, activeflowID string, limit int) ([]*event.CorrelatedRow, error) {
+	if h.conn == nil {
+		return nil, errors.New("clickhouse connection not established")
+	}
+
+	query := `
+		SELECT
+			publisher,
+			resource_id,
+			min(data_type)             AS data_type,
+			groupUniqArray(event_type) AS event_types,
+			min(timestamp)             AS first_seen,
+			max(timestamp)             AS last_seen
+		FROM events
+		WHERE activeflow_id = ?
+		  AND resource_id != ''
+		GROUP BY publisher, resource_id
+		ORDER BY first_seen ASC
+		LIMIT ?
+	`
+
+	rows, err := h.conn.Query(withQueryTimeout(ctx, correlationListTimeout), query, activeflowID, limit)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not query correlated resources")
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := []*event.CorrelatedRow{}
+	for rows.Next() {
+		var r event.CorrelatedRow
+		if err := rows.Scan(&r.Publisher, &r.ResourceID, &r.DataType, &r.EventTypes, &r.FirstSeen, &r.LastSeen); err != nil {
+			return nil, errors.Wrap(err, "could not scan correlated row")
+		}
+		result = append(result, &r)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error iterating rows")
+	}
+
+	return result, nil
+}

--- a/bin-timeline-manager/pkg/dbhandler/correlation_test.go
+++ b/bin-timeline-manager/pkg/dbhandler/correlation_test.go
@@ -1,0 +1,42 @@
+package dbhandler
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResourceActiveflowIDGet_NoConnection(t *testing.T) {
+	handler := &dbHandler{address: "localhost:9000", database: "test", conn: nil}
+
+	_, err := handler.ResourceActiveflowIDGet(context.Background(), "res-1")
+	if err == nil {
+		t.Fatal("expected error when conn is nil")
+	}
+	if err.Error() != "clickhouse connection not established" {
+		t.Errorf("error = %q, want %q", err.Error(), "clickhouse connection not established")
+	}
+}
+
+func TestResourceExists_NoConnection(t *testing.T) {
+	handler := &dbHandler{address: "localhost:9000", database: "test", conn: nil}
+
+	_, err := handler.ResourceExists(context.Background(), "res-1")
+	if err == nil {
+		t.Fatal("expected error when conn is nil")
+	}
+	if err.Error() != "clickhouse connection not established" {
+		t.Errorf("error = %q, want %q", err.Error(), "clickhouse connection not established")
+	}
+}
+
+func TestCorrelatedResourceList_NoConnection(t *testing.T) {
+	handler := &dbHandler{address: "localhost:9000", database: "test", conn: nil}
+
+	_, err := handler.CorrelatedResourceList(context.Background(), "af-1", 101)
+	if err == nil {
+		t.Fatal("expected error when conn is nil")
+	}
+	if err.Error() != "clickhouse connection not established" {
+		t.Errorf("error = %q, want %q", err.Error(), "clickhouse connection not established")
+	}
+}

--- a/bin-timeline-manager/pkg/dbhandler/main.go
+++ b/bin-timeline-manager/pkg/dbhandler/main.go
@@ -37,6 +37,9 @@ type DBHandler interface {
 	EventBatchInsert(ctx context.Context, rows []EventRow) error
 	EventList(ctx context.Context, publisher string, resourceID uuid.UUID, events []string, pageToken string, pageSize int) ([]*event.Event, error)
 	AggregatedEventList(ctx context.Context, activeflowID string, pageToken string, pageSize int) ([]*event.Event, error)
+	ResourceActiveflowIDGet(ctx context.Context, resourceID string) (string, error)
+	ResourceExists(ctx context.Context, resourceID string) (bool, error)
+	CorrelatedResourceList(ctx context.Context, activeflowID string, limit int) ([]*event.CorrelatedRow, error)
 	WaitForConnection(ctx context.Context) error
 }
 

--- a/bin-timeline-manager/pkg/dbhandler/mock_main.go
+++ b/bin-timeline-manager/pkg/dbhandler/mock_main.go
@@ -57,6 +57,21 @@ func (mr *MockDBHandlerMockRecorder) AggregatedEventList(ctx, activeflowID, page
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AggregatedEventList", reflect.TypeOf((*MockDBHandler)(nil).AggregatedEventList), ctx, activeflowID, pageToken, pageSize)
 }
 
+// CorrelatedResourceList mocks base method.
+func (m *MockDBHandler) CorrelatedResourceList(ctx context.Context, activeflowID string, limit int) ([]*event.CorrelatedRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CorrelatedResourceList", ctx, activeflowID, limit)
+	ret0, _ := ret[0].([]*event.CorrelatedRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CorrelatedResourceList indicates an expected call of CorrelatedResourceList.
+func (mr *MockDBHandlerMockRecorder) CorrelatedResourceList(ctx, activeflowID, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CorrelatedResourceList", reflect.TypeOf((*MockDBHandler)(nil).CorrelatedResourceList), ctx, activeflowID, limit)
+}
+
 // EventBatchInsert mocks base method.
 func (m *MockDBHandler) EventBatchInsert(ctx context.Context, rows []EventRow) error {
 	m.ctrl.T.Helper()
@@ -84,6 +99,36 @@ func (m *MockDBHandler) EventList(ctx context.Context, publisher string, resourc
 func (mr *MockDBHandlerMockRecorder) EventList(ctx, publisher, resourceID, events, pageToken, pageSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventList", reflect.TypeOf((*MockDBHandler)(nil).EventList), ctx, publisher, resourceID, events, pageToken, pageSize)
+}
+
+// ResourceActiveflowIDGet mocks base method.
+func (m *MockDBHandler) ResourceActiveflowIDGet(ctx context.Context, resourceID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourceActiveflowIDGet", ctx, resourceID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResourceActiveflowIDGet indicates an expected call of ResourceActiveflowIDGet.
+func (mr *MockDBHandlerMockRecorder) ResourceActiveflowIDGet(ctx, resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceActiveflowIDGet", reflect.TypeOf((*MockDBHandler)(nil).ResourceActiveflowIDGet), ctx, resourceID)
+}
+
+// ResourceExists mocks base method.
+func (m *MockDBHandler) ResourceExists(ctx context.Context, resourceID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourceExists", ctx, resourceID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResourceExists indicates an expected call of ResourceExists.
+func (mr *MockDBHandlerMockRecorder) ResourceExists(ctx, resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceExists", reflect.TypeOf((*MockDBHandler)(nil).ResourceExists), ctx, resourceID)
 }
 
 // WaitForConnection mocks base method.

--- a/bin-timeline-manager/pkg/eventhandler/correlation.go
+++ b/bin-timeline-manager/pkg/eventhandler/correlation.go
@@ -1,0 +1,134 @@
+package eventhandler
+
+import (
+	"context"
+	"sort"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-timeline-manager/models/event"
+	"monorepo/bin-timeline-manager/pkg/listenhandler/models/response"
+)
+
+// maxCorrelationResources caps the number of resources returned in a single
+// correlation graph. A single activeflow rarely links more than this; overflow
+// is signaled via the Truncated flag. Raising this requires a code change.
+const maxCorrelationResources = 100
+
+// ResourceCorrelationGet resolves a resource id to its activeflow and returns
+// the correlation graph of all resources sharing that activeflow, grouped by
+// publisher. Returns an empty graph (ResourceFound distinguishes the cases)
+// when the resource has no activeflow.
+func (h *eventHandler) ResourceCorrelationGet(ctx context.Context, resourceID uuid.UUID) (*response.V1DataResourceCorrelationGet, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "ResourceCorrelationGet",
+		"resource_id": resourceID,
+	})
+
+	if resourceID == uuid.Nil {
+		return nil, errors.New("resource_id is required")
+	}
+
+	// 1. resource_id -> activeflow_id reverse lookup (deterministic).
+	activeflowIDStr, err := h.db.ResourceActiveflowIDGet(ctx, resourceID.String())
+	if err != nil {
+		log.Errorf("Could not get activeflow_id for resource. err: %v", err)
+		return nil, errors.Wrap(err, "could not get activeflow_id for resource")
+	}
+
+	if activeflowIDStr == "" {
+		// No activeflow: either the resource was never seen, or it exists but
+		// carries no activeflow. ResourceExists distinguishes the two.
+		found, errExists := h.db.ResourceExists(ctx, resourceID.String())
+		if errExists != nil {
+			log.Errorf("Could not check resource existence. err: %v", errExists)
+			return nil, errors.Wrap(errExists, "could not check resource existence")
+		}
+		return &response.V1DataResourceCorrelationGet{
+			ResourceID:    resourceID,
+			ResourceFound: found,
+			ActiveflowID:  uuid.Nil,
+			Truncated:     false,
+			Resources:     []*event.PublisherGroup{},
+		}, nil
+	}
+
+	activeflowID, err := uuid.FromString(activeflowIDStr)
+	if err != nil {
+		log.Errorf("Could not parse activeflow_id. activeflow_id: %s, err: %v", activeflowIDStr, err)
+		return nil, errors.Wrap(err, "could not parse activeflow_id")
+	}
+
+	// 2. activeflow_id -> aggregated resource list (limit+1 to detect truncation).
+	rows, err := h.db.CorrelatedResourceList(ctx, activeflowIDStr, maxCorrelationResources+1)
+	if err != nil {
+		log.Errorf("Could not list correlated resources. err: %v", err)
+		return nil, errors.Wrap(err, "could not list correlated resources")
+	}
+
+	truncated := len(rows) > maxCorrelationResources
+	if truncated {
+		rows = rows[:maxCorrelationResources]
+	}
+
+	// 3. group by publisher with stable ordering.
+	groups := groupByPublisher(rows)
+
+	return &response.V1DataResourceCorrelationGet{
+		ResourceID:    resourceID,
+		ResourceFound: true,
+		ActiveflowID:  activeflowID,
+		Truncated:     truncated,
+		Resources:     groups,
+	}, nil
+}
+
+// groupByPublisher converts aggregated rows into publisher-grouped, stably
+// sorted output. Rows whose resource_id fails to parse as a UUID are skipped
+// (with a warning) so a single malformed payload does not fail the whole call.
+func groupByPublisher(rows []*event.CorrelatedRow) []*event.PublisherGroup {
+	log := logrus.WithField("func", "groupByPublisher")
+
+	byPublisher := map[string][]*event.CorrelatedResource{}
+	for _, r := range rows {
+		id, err := uuid.FromString(r.ResourceID)
+		if err != nil {
+			log.Warnf("Skipping row with unparseable resource_id. resource_id: %s, err: %v", r.ResourceID, err)
+			continue
+		}
+
+		eventTypes := make([]string, len(r.EventTypes))
+		copy(eventTypes, r.EventTypes)
+		sort.Strings(eventTypes)
+
+		byPublisher[r.Publisher] = append(byPublisher[r.Publisher], &event.CorrelatedResource{
+			ID:         id,
+			DataType:   r.DataType,
+			EventTypes: eventTypes,
+			FirstSeen:  r.FirstSeen,
+			LastSeen:   r.LastSeen,
+		})
+	}
+
+	publishers := make([]string, 0, len(byPublisher))
+	for p := range byPublisher {
+		publishers = append(publishers, p)
+	}
+	sort.Strings(publishers)
+
+	groups := make([]*event.PublisherGroup, 0, len(publishers))
+	for _, p := range publishers {
+		resources := byPublisher[p]
+		sort.SliceStable(resources, func(i, j int) bool {
+			return resources[i].FirstSeen.Before(resources[j].FirstSeen)
+		})
+		groups = append(groups, &event.PublisherGroup{
+			Publisher: p,
+			Resources: resources,
+		})
+	}
+
+	return groups
+}

--- a/bin-timeline-manager/pkg/eventhandler/correlation_test.go
+++ b/bin-timeline-manager/pkg/eventhandler/correlation_test.go
@@ -1,0 +1,326 @@
+package eventhandler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-timeline-manager/models/event"
+	"monorepo/bin-timeline-manager/pkg/dbhandler"
+)
+
+func TestResourceCorrelationGet_Validation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	_, err := handler.ResourceCorrelationGet(context.Background(), uuid.Nil)
+	if err == nil {
+		t.Fatal("expected error for nil resource_id")
+	}
+	if err.Error() != "resource_id is required" {
+		t.Errorf("ResourceCorrelationGet() error = %q, want %q", err.Error(), "resource_id is required")
+	}
+}
+
+func TestResourceCorrelationGet_NoActiveflow_ResourceFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return("", nil)
+	mockDB.EXPECT().ResourceExists(gomock.Any(), resourceID.String()).Return(true, nil)
+
+	res, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.ResourceFound {
+		t.Error("expected ResourceFound=true")
+	}
+	if res.ActiveflowID != uuid.Nil {
+		t.Errorf("expected ActiveflowID=nil, got %v", res.ActiveflowID)
+	}
+	if len(res.Resources) != 0 {
+		t.Errorf("expected empty resources, got %d", len(res.Resources))
+	}
+	if res.Truncated {
+		t.Error("expected Truncated=false")
+	}
+}
+
+func TestResourceCorrelationGet_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return("", nil)
+	mockDB.EXPECT().ResourceExists(gomock.Any(), resourceID.String()).Return(false, nil)
+
+	res, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ResourceFound {
+		t.Error("expected ResourceFound=false")
+	}
+	if len(res.Resources) != 0 {
+		t.Errorf("expected empty resources, got %d", len(res.Resources))
+	}
+}
+
+func TestResourceCorrelationGet_Success_GroupedAndSorted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	callID := uuid.Must(uuid.NewV4())
+	aicallID := uuid.Must(uuid.NewV4())
+
+	t0 := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return(activeflowID.String(), nil)
+	// ai-manager row first to verify publisher sorting puts call-manager before ai... no, alphabetical: ai-manager < call-manager
+	mockDB.EXPECT().CorrelatedResourceList(gomock.Any(), activeflowID.String(), maxCorrelationResources+1).Return([]*event.CorrelatedRow{
+		{
+			Publisher:  "call-manager",
+			ResourceID: callID.String(),
+			DataType:   "call",
+			EventTypes: []string{"call_progressing", "call_created"},
+			FirstSeen:  t0,
+			LastSeen:   t1,
+		},
+		{
+			Publisher:  "ai-manager",
+			ResourceID: aicallID.String(),
+			DataType:   "aicall",
+			EventTypes: []string{"aicall_initiating"},
+			FirstSeen:  t0,
+			LastSeen:   t1,
+		},
+	}, nil)
+
+	res, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.ResourceFound {
+		t.Error("expected ResourceFound=true")
+	}
+	if res.ActiveflowID != activeflowID {
+		t.Errorf("expected ActiveflowID=%v, got %v", activeflowID, res.ActiveflowID)
+	}
+	if res.Truncated {
+		t.Error("expected Truncated=false")
+	}
+	if len(res.Resources) != 2 {
+		t.Fatalf("expected 2 publisher groups, got %d", len(res.Resources))
+	}
+	// publishers sorted alphabetically: ai-manager before call-manager
+	if res.Resources[0].Publisher != "ai-manager" {
+		t.Errorf("expected first group ai-manager, got %s", res.Resources[0].Publisher)
+	}
+	if res.Resources[1].Publisher != "call-manager" {
+		t.Errorf("expected second group call-manager, got %s", res.Resources[1].Publisher)
+	}
+	// event_types sorted within resource
+	callRes := res.Resources[1].Resources[0]
+	if callRes.EventTypes[0] != "call_created" || callRes.EventTypes[1] != "call_progressing" {
+		t.Errorf("expected sorted event_types, got %v", callRes.EventTypes)
+	}
+}
+
+func TestResourceCorrelationGet_Truncation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+
+	// Return maxCorrelationResources+1 rows to trigger truncation.
+	rows := make([]*event.CorrelatedRow, maxCorrelationResources+1)
+	base := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	for i := range rows {
+		rows[i] = &event.CorrelatedRow{
+			Publisher:  "call-manager",
+			ResourceID: uuid.Must(uuid.NewV4()).String(),
+			DataType:   "call",
+			EventTypes: []string{"call_created"},
+			FirstSeen:  base.Add(time.Duration(i) * time.Second),
+			LastSeen:   base.Add(time.Duration(i) * time.Second),
+		}
+	}
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return(activeflowID.String(), nil)
+	mockDB.EXPECT().CorrelatedResourceList(gomock.Any(), activeflowID.String(), maxCorrelationResources+1).Return(rows, nil)
+
+	res, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Truncated {
+		t.Error("expected Truncated=true")
+	}
+	total := 0
+	for _, g := range res.Resources {
+		total += len(g.Resources)
+	}
+	if total != maxCorrelationResources {
+		t.Errorf("expected %d resources after truncation, got %d", maxCorrelationResources, total)
+	}
+}
+
+func TestResourceCorrelationGet_SkipsUnparseableResourceID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+	goodID := uuid.Must(uuid.NewV4())
+	base := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return(activeflowID.String(), nil)
+	mockDB.EXPECT().CorrelatedResourceList(gomock.Any(), activeflowID.String(), maxCorrelationResources+1).Return([]*event.CorrelatedRow{
+		{Publisher: "call-manager", ResourceID: "not-a-uuid", DataType: "call", EventTypes: []string{"call_created"}, FirstSeen: base, LastSeen: base},
+		{Publisher: "call-manager", ResourceID: goodID.String(), DataType: "call", EventTypes: []string{"call_created"}, FirstSeen: base, LastSeen: base},
+	}, nil)
+
+	res, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	total := 0
+	for _, g := range res.Resources {
+		total += len(g.Resources)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 valid resource (1 skipped), got %d", total)
+	}
+}
+
+func TestResourceCorrelationGet_DBError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return("", errors.New("clickhouse down"))
+
+	_, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err == nil {
+		t.Fatal("expected error from db failure")
+	}
+}
+
+func TestResourceCorrelationGet_ResourceExistsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return("", nil)
+	mockDB.EXPECT().ResourceExists(gomock.Any(), resourceID.String()).Return(false, errors.New("clickhouse down"))
+
+	_, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err == nil {
+		t.Fatal("expected error from ResourceExists failure")
+	}
+}
+
+func TestResourceCorrelationGet_CorrelatedListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return(activeflowID.String(), nil)
+	mockDB.EXPECT().CorrelatedResourceList(gomock.Any(), activeflowID.String(), maxCorrelationResources+1).Return(nil, errors.New("clickhouse down"))
+
+	_, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err == nil {
+		t.Fatal("expected error from CorrelatedResourceList failure")
+	}
+}
+
+func TestResourceCorrelationGet_UnparseableActiveflowID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return("garbage-not-a-uuid", nil)
+
+	_, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err == nil {
+		t.Fatal("expected error from unparseable activeflow_id")
+	}
+}
+
+func TestResourceCorrelationGet_ActiveflowFoundButEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	handler := NewEventHandler(mockDB)
+
+	resourceID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().ResourceActiveflowIDGet(gomock.Any(), resourceID.String()).Return(activeflowID.String(), nil)
+	mockDB.EXPECT().CorrelatedResourceList(gomock.Any(), activeflowID.String(), maxCorrelationResources+1).Return([]*event.CorrelatedRow{}, nil)
+
+	res, err := handler.ResourceCorrelationGet(context.Background(), resourceID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.ResourceFound {
+		t.Error("expected ResourceFound=true")
+	}
+	if res.ActiveflowID != activeflowID {
+		t.Errorf("expected ActiveflowID=%v, got %v", activeflowID, res.ActiveflowID)
+	}
+	if res.Truncated {
+		t.Error("expected Truncated=false")
+	}
+	if len(res.Resources) != 0 {
+		t.Errorf("expected empty resources, got %d", len(res.Resources))
+	}
+}

--- a/bin-timeline-manager/pkg/eventhandler/main.go
+++ b/bin-timeline-manager/pkg/eventhandler/main.go
@@ -5,6 +5,8 @@ package eventhandler
 import (
 	"context"
 
+	"github.com/gofrs/uuid"
+
 	"monorepo/bin-timeline-manager/pkg/dbhandler"
 	"monorepo/bin-timeline-manager/pkg/listenhandler/models/request"
 	"monorepo/bin-timeline-manager/pkg/listenhandler/models/response"
@@ -14,6 +16,7 @@ import (
 type EventHandler interface {
 	List(ctx context.Context, req *request.V1DataEventsPost) (*response.V1DataEventsPost, error)
 	AggregatedList(ctx context.Context, req *request.V1DataAggregatedEventsPost) (*response.V1DataAggregatedEventsPost, error)
+	ResourceCorrelationGet(ctx context.Context, resourceID uuid.UUID) (*response.V1DataResourceCorrelationGet, error)
 }
 
 type eventHandler struct {

--- a/bin-timeline-manager/pkg/eventhandler/mock_main.go
+++ b/bin-timeline-manager/pkg/eventhandler/mock_main.go
@@ -15,6 +15,7 @@ import (
 	response "monorepo/bin-timeline-manager/pkg/listenhandler/models/response"
 	reflect "reflect"
 
+	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -70,4 +71,19 @@ func (m *MockEventHandler) List(ctx context.Context, req *request.V1DataEventsPo
 func (mr *MockEventHandlerMockRecorder) List(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockEventHandler)(nil).List), ctx, req)
+}
+
+// ResourceCorrelationGet mocks base method.
+func (m *MockEventHandler) ResourceCorrelationGet(ctx context.Context, resourceID uuid.UUID) (*response.V1DataResourceCorrelationGet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourceCorrelationGet", ctx, resourceID)
+	ret0, _ := ret[0].(*response.V1DataResourceCorrelationGet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResourceCorrelationGet indicates an expected call of ResourceCorrelationGet.
+func (mr *MockEventHandlerMockRecorder) ResourceCorrelationGet(ctx, resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceCorrelationGet", reflect.TypeOf((*MockEventHandler)(nil).ResourceCorrelationGet), ctx, resourceID)
 }

--- a/bin-timeline-manager/pkg/listenhandler/main.go
+++ b/bin-timeline-manager/pkg/listenhandler/main.go
@@ -22,8 +22,11 @@ import (
 )
 
 var (
+	regUUID = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+
 	regV1Events           = regexp.MustCompile("/v1/events$")
 	regV1AggregatedEvents = regexp.MustCompile("/v1/aggregated-events$")
+	regV1Correlations     = regexp.MustCompile("/v1/correlations/" + regUUID + "$")
 	regV1SIPAnalysis      = regexp.MustCompile("/v1/sip/analysis$")
 	regV1SIPPcap          = regexp.MustCompile("/v1/sip/pcap$")
 )
@@ -146,6 +149,10 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1AggregatedEvents.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		requestType = "/aggregated-events"
 		response, err = h.v1AggregatedEventsPost(ctx, m)
+
+	case regV1Correlations.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
+		requestType = "/correlations"
+		response, err = h.v1CorrelationsGet(ctx, m)
 
 	case regV1SIPAnalysis.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		requestType = "/sip/analysis"

--- a/bin-timeline-manager/pkg/listenhandler/models/response/correlation.go
+++ b/bin-timeline-manager/pkg/listenhandler/models/response/correlation.go
@@ -1,0 +1,16 @@
+package response
+
+import (
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-timeline-manager/models/event"
+)
+
+// V1DataResourceCorrelationGet represents the correlation graph for a resource.
+type V1DataResourceCorrelationGet struct {
+	ResourceID    uuid.UUID               `json:"resource_id"`
+	ResourceFound bool                    `json:"resource_found"`
+	ActiveflowID  uuid.UUID               `json:"activeflow_id"`
+	Truncated     bool                    `json:"truncated"`
+	Resources     []*event.PublisherGroup `json:"resources"`
+}

--- a/bin-timeline-manager/pkg/listenhandler/v1_correlations.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_correlations.go
@@ -1,0 +1,49 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-common-handler/models/sock"
+)
+
+// v1CorrelationsGet handles GET /v1/correlations/<resource_id> request.
+// Returns the correlation graph of all resources sharing the resource's activeflow.
+func (h *listenHandler) v1CorrelationsGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "v1CorrelationsGet",
+		"request": m,
+	})
+
+	uriItems := strings.Split(m.URI, "/")
+	if len(uriItems) < 4 {
+		return simpleResponse(400), nil
+	}
+
+	resourceID := uuid.FromStringOrNil(uriItems[3])
+	if resourceID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	result, err := h.eventHandler.ResourceCorrelationGet(ctx, resourceID)
+	if err != nil {
+		log.Errorf("Could not get resource correlation. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshal response")
+	}
+
+	return &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}, nil
+}

--- a/bin-timeline-manager/pkg/listenhandler/v1_correlations_test.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_correlations_test.go
@@ -1,0 +1,189 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+	"monorepo/bin-timeline-manager/models/event"
+	"monorepo/bin-timeline-manager/pkg/eventhandler"
+	"monorepo/bin-timeline-manager/pkg/listenhandler/models/response"
+)
+
+func TestRegV1Correlations(t *testing.T) {
+	validID := uuid.Must(uuid.NewV4()).String()
+
+	tests := []struct {
+		name    string
+		uri     string
+		matches bool
+	}{
+		{name: "valid lowercase uuid", uri: "/v1/correlations/" + validID, matches: true},
+		{name: "uppercase uuid", uri: "/v1/correlations/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", matches: true},
+		{name: "no id", uri: "/v1/correlations/", matches: false},
+		{name: "no id no slash", uri: "/v1/correlations", matches: false},
+		{name: "trailing path", uri: "/v1/correlations/" + validID + "/extra", matches: false},
+		{name: "non-uuid", uri: "/v1/correlations/not-a-uuid", matches: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := regV1Correlations.MatchString(tt.uri)
+			if result != tt.matches {
+				t.Errorf("regV1Correlations.MatchString(%q) = %v, want %v", tt.uri, result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestV1CorrelationsGet_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	resourceID := uuid.Must(uuid.NewV4())
+	activeflowID := uuid.Must(uuid.NewV4())
+
+	expected := &response.V1DataResourceCorrelationGet{
+		ResourceID:    resourceID,
+		ResourceFound: true,
+		ActiveflowID:  activeflowID,
+		Resources:     []*event.PublisherGroup{},
+	}
+
+	mockEvent.EXPECT().ResourceCorrelationGet(gomock.Any(), resourceID).Return(expected, nil)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/correlations/" + resourceID.String(),
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := handler.v1CorrelationsGet(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1CorrelationsGet() error = %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if resp.DataType != "application/json" {
+		t.Errorf("DataType = %q, want application/json", resp.DataType)
+	}
+
+	var got response.V1DataResourceCorrelationGet
+	if err := json.Unmarshal(resp.Data, &got); err != nil {
+		t.Fatalf("could not unmarshal response body: %v", err)
+	}
+	if got.ResourceID != resourceID {
+		t.Errorf("body ResourceID = %v, want %v", got.ResourceID, resourceID)
+	}
+	if got.ActiveflowID != activeflowID {
+		t.Errorf("body ActiveflowID = %v, want %v", got.ActiveflowID, activeflowID)
+	}
+	if !got.ResourceFound {
+		t.Error("body ResourceFound = false, want true")
+	}
+}
+
+func TestV1CorrelationsGet_InvalidID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	// URI with a non-uuid id; handler should reject with 400 without calling eventHandler.
+	sockReq := &sock.Request{
+		URI:    "/v1/correlations/not-a-uuid",
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := handler.v1CorrelationsGet(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1CorrelationsGet() error = %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestV1CorrelationsGet_HandlerError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	resourceID := uuid.Must(uuid.NewV4())
+
+	mockEvent.EXPECT().ResourceCorrelationGet(gomock.Any(), resourceID).Return(nil, errors.New("clickhouse down"))
+
+	sockReq := &sock.Request{
+		URI:    "/v1/correlations/" + resourceID.String(),
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := handler.v1CorrelationsGet(context.Background(), sockReq)
+	if err != nil {
+		t.Fatalf("v1CorrelationsGet() error = %v", err)
+	}
+	if resp.StatusCode != 500 {
+		t.Errorf("StatusCode = %d, want 500", resp.StatusCode)
+	}
+}
+
+func TestProcessRequest_V1CorrelationsGet_Routing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(ctrl)
+	mockEvent := eventhandler.NewMockEventHandler(ctrl)
+
+	handler := &listenHandler{
+		sockHandler:  mockSock,
+		eventHandler: mockEvent,
+	}
+
+	resourceID := uuid.Must(uuid.NewV4())
+	expected := &response.V1DataResourceCorrelationGet{
+		ResourceID:    resourceID,
+		ResourceFound: true,
+		Resources:     []*event.PublisherGroup{},
+	}
+	mockEvent.EXPECT().ResourceCorrelationGet(gomock.Any(), resourceID).Return(expected, nil)
+
+	sockReq := &sock.Request{
+		URI:    "/v1/correlations/" + resourceID.String(),
+		Method: sock.RequestMethodGet,
+	}
+
+	resp, err := handler.processRequest(sockReq)
+	if err != nil {
+		t.Fatalf("processRequest() error = %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Add an internal RPC to bin-timeline-manager that resolves a single resource id to its activeflow and returns all correlated resources grouped by publisher. This reuses the existing ClickHouse event store, where activeflow_id and resource_id are already extracted as MATERIALIZED columns, so only the read path is added.

- bin-timeline-manager: Add GET /v1/correlations/<resource_id> listen handler and route
- bin-timeline-manager: Add eventhandler ResourceCorrelationGet with publisher grouping, stable sort, truncation, and unparseable-id skip
- bin-timeline-manager: Add dbhandler ResourceActiveflowIDGet, ResourceExists, CorrelatedResourceList with per-query max_execution_time via clickhouse.WithSettings
- bin-timeline-manager: Add migration 000004 with bloom_filter skip indexes on resource_id and activeflow_id plus MATERIALIZE COLUMN backfill
- bin-timeline-manager: Add response DTO, correlation models, unit tests, and operations doc note on async mutation monitoring
