### PR TITLE
NOJIRA-Clarify-correlation-activeflow-id-label

### DIFF
--- a/bin-ai-manager/docs/plans/2026-06-08-add-correlation-llm-tool-design.md
+++ b/bin-ai-manager/docs/plans/2026-06-08-add-correlation-llm-tool-design.md
@@ -234,7 +234,7 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 
 `formatCorrelationSummary` produces an LLM-readable summary, not raw IDs as content:
 ```
-Call flow (activeflow_id: <activeflow_id>) is linked to:
+Activeflow <activeflow_id> is linked to:
 - call-manager: 1 call (call_created, call_progressing, call_hangup), 1 recording
 - ai-manager: 1 aicall, 2 messages
 - transcribe-manager: 1 transcribe

--- a/bin-ai-manager/docs/plans/2026-06-08-add-correlation-llm-tool-design.md
+++ b/bin-ai-manager/docs/plans/2026-06-08-add-correlation-llm-tool-design.md
@@ -234,7 +234,7 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 
 `formatCorrelationSummary` produces an LLM-readable summary, not raw IDs as content:
 ```
-Call flow <activeflow_id> is linked to:
+Call flow (activeflow_id: <activeflow_id>) is linked to:
 - call-manager: 1 call (call_created, call_progressing, call_hangup), 1 recording
 - ai-manager: 1 aicall, 2 messages
 - transcribe-manager: 1 transcribe

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -778,7 +778,7 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 func formatCorrelationSummary(corr *tmcorrelation.Correlation) string {
 	var sb strings.Builder
 
-	fmt.Fprintf(&sb, "Call flow %s is linked to:\n", corr.ActiveflowID)
+	fmt.Fprintf(&sb, "Call flow (activeflow_id: %s) is linked to:\n", corr.ActiveflowID)
 	if len(corr.Resources) == 0 {
 		sb.WriteString("- (no correlated resources)\n")
 	}

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -763,7 +763,7 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 	// err == nil below: corr is safe to read.
 	// Own-session unlinked resource gets the disclosure message.
 	if corr.ActiveflowID == uuid.Nil {
-		fillSuccess(res, "correlation", resourceID.String(), "This resource exists but is not linked to any call flow.")
+		fillSuccess(res, "correlation", resourceID.String(), "This resource exists but is not linked to any activeflow.")
 		return res
 	}
 
@@ -778,7 +778,7 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 func formatCorrelationSummary(corr *tmcorrelation.Correlation) string {
 	var sb strings.Builder
 
-	fmt.Fprintf(&sb, "Call flow (activeflow_id: %s) is linked to:\n", corr.ActiveflowID)
+	fmt.Fprintf(&sb, "Activeflow %s is linked to:\n", corr.ActiveflowID)
 	if len(corr.Resources) == 0 {
 		sb.WriteString("- (no correlated resources)\n")
 	}

--- a/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
@@ -89,7 +89,7 @@ func Test_toolHandleGetCorrelation(t *testing.T) {
 				ToolCallID:   "tool-1",
 				ResourceType: "correlation",
 				ResourceID:   "33333333-0000-4000-8000-000000000001",
-				Message:      "Call flow (activeflow_id: 33333333-0000-4000-8000-000000000001) is linked to:\n- call-manager: 1 resource(s)\n  - call 44444444-0000-4000-8000-000000000001 (events: call_created, call_hangup)\n- transcribe-manager: 1 resource(s)\n  - transcribe 77777777-0000-4000-8000-000000000001\n",
+				Message:      "Activeflow 33333333-0000-4000-8000-000000000001 is linked to:\n- call-manager: 1 resource(s)\n  - call 44444444-0000-4000-8000-000000000001 (events: call_created, call_hangup)\n- transcribe-manager: 1 resource(s)\n  - transcribe 77777777-0000-4000-8000-000000000001\n",
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func Test_toolHandleGetCorrelation(t *testing.T) {
 				ToolCallID:   "tool-2",
 				ResourceType: "correlation",
 				ResourceID:   "66666666-0000-4000-8000-000000000002",
-				Message:      "Call flow (activeflow_id: 66666666-0000-4000-8000-000000000002) is linked to:\n- (no correlated resources)\n",
+				Message:      "Activeflow 66666666-0000-4000-8000-000000000002 is linked to:\n- (no correlated resources)\n",
 			},
 		},
 		{
@@ -245,7 +245,7 @@ func Test_toolHandleGetCorrelation(t *testing.T) {
 				ToolCallID:   "tool-5",
 				ResourceType: "correlation",
 				ResourceID:   "33333333-0000-4000-8000-000000000005",
-				Message:      "This resource exists but is not linked to any call flow.",
+				Message:      "This resource exists but is not linked to any activeflow.",
 			},
 		},
 		{

--- a/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
@@ -89,7 +89,7 @@ func Test_toolHandleGetCorrelation(t *testing.T) {
 				ToolCallID:   "tool-1",
 				ResourceType: "correlation",
 				ResourceID:   "33333333-0000-4000-8000-000000000001",
-				Message:      "Call flow 33333333-0000-4000-8000-000000000001 is linked to:\n- call-manager: 1 resource(s)\n  - call 44444444-0000-4000-8000-000000000001 (events: call_created, call_hangup)\n- transcribe-manager: 1 resource(s)\n  - transcribe 77777777-0000-4000-8000-000000000001\n",
+				Message:      "Call flow (activeflow_id: 33333333-0000-4000-8000-000000000001) is linked to:\n- call-manager: 1 resource(s)\n  - call 44444444-0000-4000-8000-000000000001 (events: call_created, call_hangup)\n- transcribe-manager: 1 resource(s)\n  - transcribe 77777777-0000-4000-8000-000000000001\n",
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func Test_toolHandleGetCorrelation(t *testing.T) {
 				ToolCallID:   "tool-2",
 				ResourceType: "correlation",
 				ResourceID:   "66666666-0000-4000-8000-000000000002",
-				Message:      "Call flow 66666666-0000-4000-8000-000000000002 is linked to:\n- (no correlated resources)\n",
+				Message:      "Call flow (activeflow_id: 66666666-0000-4000-8000-000000000002) is linked to:\n- (no correlated resources)\n",
 			},
 		},
 		{

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -484,13 +484,15 @@ run_llm: Always set true — you should respond to the user based on the search 
 	{
 		Name:   tool.ToolNameGetCorrelation,
 		RunLLM: true,
-		Description: `Retrieves the correlation graph for a resource: the related resources (calls, recordings, transcribes, aicalls, messages, etc.) linked to the same call flow execution.
+		Description: `Retrieves the correlation graph for a resource: the related resources (calls, messages, recordings, transcribes, aicalls, etc.) linked to the same activeflow execution.
 
-This is an internal diagnostic tool. Use it to understand what other resources are tied to a given call flow so you can reason about or chain follow-up lookups.
+An activeflow is the running instance of a flow. Its reference is not always a call; the reference type can be call, conversation, ai, api, campaign, transcribe, or recording (and may be unset). Do not assume the session is a phone call.
+
+This is an internal diagnostic tool. Use it to understand what other resources are tied to a given activeflow so you can reason about or chain follow-up lookups.
 
 WHEN TO USE:
-- You need to know what resources are linked to the current session's call flow
-- A diagnostic question requires understanding the relationships between resources of a call flow
+- You need to know what resources are linked to the current session's activeflow
+- A diagnostic question requires understanding the relationships between resources of an activeflow
 - You want to discover resource ids (e.g. an aicall id) to chain into another tool
 
 WHEN NOT TO USE:
@@ -498,7 +500,7 @@ WHEN NOT TO USE:
 - You only need a single runtime variable (use get_variables)
 
 ARGUMENTS:
-- resource_id (optional): the resource id to inspect. If omitted, the current session's call flow is used. You can only retrieve correlations for resources owned by your own account; others return "No events found for this resource.".
+- resource_id (optional): the resource id to inspect. If omitted, the current session's activeflow is used. You can only retrieve correlations for resources owned by your own account; others return "No events found for this resource.".
 
 run_llm: Set true so you can summarize and reason about the correlated resources.`,
 		Parameters: map[string]any{
@@ -511,7 +513,7 @@ run_llm: Set true so you can summarize and reason about the correlated resources
 				},
 				"resource_id": map[string]any{
 					"type":        "string",
-					"description": "Optional resource id (UUID) to inspect. If omitted, the current session's call flow is used.",
+					"description": "Optional resource id (UUID) to inspect. If omitted, the current session's activeflow is used.",
 				},
 			},
 			"required": []string{},

--- a/docs/plans/2026-06-09-clarify-correlation-activeflow-id-label-design.md
+++ b/docs/plans/2026-06-09-clarify-correlation-activeflow-id-label-design.md
@@ -1,94 +1,96 @@
-# Design: Clarify activeflow_id label in get_correlation summary output
+# Design: Use "activeflow" terminology in get_correlation output and description
 
-Status: Draft (v1)
+Status: Draft (v2)
 Author: CPO (with pchero)
 Date: 2026-06-09
 Service: bin-ai-manager
 
 ## 1. Problem Statement
 
-The `get_correlation` tool returns a human/LLM-readable summary whose first line is:
+The `get_correlation` tool returns a human/LLM-readable summary whose first line was:
 
 ```
 Call flow 923aba67-78be-46b8-9b9d-d8ef53cda9cd is linked to:
 ```
 
-The UUID printed after the words "Call flow" is in fact the **activeflow_id** (`corr.ActiveflowID`, see `pkg/aicallhandler/tool.go::formatCorrelationSummary` L781). However the label "Call flow" does not make that explicit. In a real diagnostic session (2026-06-09) this caused confusion: when looking for "the activeflow_id" in a transcript, the reader could not tell that the value behind the "Call flow" label *was* the activeflow_id, especially because several flow-related IDs coexist in one trace:
+The UUID printed after the words "Call flow" is the **activeflow_id** (`corr.ActiveflowID`, see `pkg/aicallhandler/tool.go::formatCorrelationSummary`). Two problems:
 
-- the current AI session's `activeflow_id` (on every message record),
-- the `flow_id` passed to `create_call` (a flow *definition* / template, NOT an activeflow),
-- the originated outbound `call_id`,
-- the originated call's own `activeflow_id` (surfaced only via `get_correlation` as "Call flow ...").
+1. **Ambiguous label.** In a real diagnostic session (2026-06-09) a reader could not tell that the value behind the "Call flow" label was the activeflow_id, because a single trace contains several flow-related ids: the current session's `activeflow_id`, the `flow_id` passed to `create_call` (a flow *definition*, NOT an activeflow), the originated `call_id`, and the originated call's own `activeflow_id` (surfaced only via `get_correlation`).
 
-The ambiguity is purely a labeling/observability issue. The data is correct.
+2. **"Call" bias is factually wrong.** An activeflow is the running instance of a flow, and its reference is NOT always a call. The activeflow `ReferenceType` enum (`bin-flow-manager/models/activeflow/activeflow.go`) is: none, ai, api, call, campaign, conversation, transcribe, recording. Calling it a "call flow" wrongly narrows it to telephony. The same bias appears throughout the tool description ("call flow execution", "the current session's call flow"), which can push the LLM to assume the session is a phone call even when it is not.
+
+The data is correct; this is a terminology/observability fix.
 
 ## 2. Goal
 
-Make the summary output state, unambiguously, that the leading UUID is the `activeflow_id`, WITHOUT renaming the broader "call flow" concept (the tool's own description teaches the LLM that a "call flow execution" is the unit of correlation, see `pkg/toolhandler/definitions.go` L487-501). Minimal, behavior-preserving copy change.
+Use the precise domain term **activeflow** consistently in (a) the summary output and (b) the tool description, removing the telephony ("call") bias. Minimal, behavior-preserving copy change.
 
 ## 3. Scope
 
 ### In scope
-- Change the first line of `formatCorrelationSummary` to label the UUID as `activeflow_id`.
-- Update the two test expectations in `pkg/aicallhandler/tool_correlation_test.go` (L92, L136) that assert the exact summary string.
+- `formatCorrelationSummary` first line: `Activeflow %s is linked to:`.
+- The own-session unlinked message: `This resource exists but is not linked to any activeflow.`
+- `get_correlation` tool description (`pkg/toolhandler/definitions.go`): replace "call flow" wording with "activeflow", and add an explicit note that the activeflow reference may be call, conversation, ai, api, campaign, transcribe, or recording (counter the call-only assumption).
+- Update test expectations in `pkg/aicallhandler/tool_correlation_test.go` (summary strings + unlinked message).
+- Refresh the historical design doc example (`2026-06-08-add-correlation-llm-tool-design.md`).
 
 ### Out of scope
-- No change to the tool definition/description (the "call flow execution" concept wording stays).
-- No change to `create_call` result payload (whether to also surface activeflow_id there is a separate, deferred question, see §7).
-- No change to the resource-line formatting (`- call <id>`, `- transcribe <id>`, etc.).
+- No change to `create_call` result payload (surfacing originated activeflow_id is a separate, deferred item).
+- No change to resource-line formatting (`- call <id>`, `- transcribe <id>`, etc.). Those carry a correct type label already.
 - No new entity / DB / REST / webhook. N/A.
 
 ## 4. Proposed change
 
-`pkg/aicallhandler/tool.go` L781:
+`pkg/aicallhandler/tool.go`:
 
-Current:
+Summary line:
 ```go
-fmt.Fprintf(&sb, "Call flow %s is linked to:\n", corr.ActiveflowID)
+fmt.Fprintf(&sb, "Activeflow %s is linked to:\n", corr.ActiveflowID)
 ```
-
-Proposed:
-```go
-fmt.Fprintf(&sb, "Call flow (activeflow_id: %s) is linked to:\n", corr.ActiveflowID)
-```
-
 Resulting first line:
 ```
-Call flow (activeflow_id: 923aba67-78be-46b8-9b9d-d8ef53cda9cd) is linked to:
+Activeflow 923aba67-78be-46b8-9b9d-d8ef53cda9cd is linked to:
 ```
 
-Rationale for this exact form (vs alternatives):
-- `Activeflow %s is linked to:` — drops the "call flow" concept word the tool description relies on; risks LLM/term inconsistency. Rejected.
-- `Call flow (activeflow_id: %s) is linked to:` — keeps the concept word AND names the identifier precisely. A human or LLM searching for "activeflow_id" now finds it verbatim. Chosen.
-- The phrasing also disambiguates from `flow_id` (the definition), which is the other flow-related identifier in the same trace.
+Unlinked message:
+```go
+fillSuccess(res, "correlation", resourceID.String(), "This resource exists but is not linked to any activeflow.")
+```
+
+Rationale for `Activeflow %s` (form 1) over `Call flow (activeflow_id: %s)`:
+- The word "Activeflow" itself tells the reader the UUID is an activeflow_id; no parenthetical needed.
+- It is the actual domain term and is reference-type neutral (not "call").
+- A transcript search for "activeflow" now matches.
+
+`pkg/toolhandler/definitions.go` description: replace "call flow" with "activeflow" throughout and add a sentence clarifying the reference may be call, conversation, ai, api, campaign, transcribe, or recording (and may be unset), so the LLM does not over-assume telephony.
 
 ## 5. Affected files
 
 | File | Change |
 |---|---|
-| `bin-ai-manager/pkg/aicallhandler/tool.go` | L781 format string |
-| `bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go` | L92, L136 expected `Message` strings |
+| `bin-ai-manager/pkg/aicallhandler/tool.go` | summary line + unlinked message |
+| `bin-ai-manager/pkg/toolhandler/definitions.go` | get_correlation description (de-bias from "call") |
+| `bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go` | expected summary + unlinked strings |
+| `bin-ai-manager/docs/plans/2026-06-08-add-correlation-llm-tool-design.md` | historical example line |
 
 ## 6. Verification
 
-Run the full mandatory workflow in `bin-ai-manager`:
+Full mandatory workflow in `bin-ai-manager`:
 ```
 go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
 ```
-Focus: `Test_toolHandleGetCorrelation` and `Test_toolHandleGetCorrelation_maskingInvariant` must pass with the new expected strings. The masking invariant test asserts the not-accessible path returns `msgCorrelationNotFound` (a constant unaffected by this change), so it must remain byte-identical.
+Focus: `Test_toolHandleGetCorrelation` (summary + unlinked cases) and `Test_toolHandleGetCorrelation_maskingInvariant` (asserts `msgCorrelationNotFound`, an unrelated constant, must stay byte-identical).
 
 ## 7. Open question (deferred)
 
-Should `create_call` tool result also include the originated call's `activeflow_id` so a follow-up `get_correlation` is not required? Deferred: at `create_call` return time the outbound call may not yet have an activeflow (it is created on answer via flow execution), so this is non-trivial and out of this minimal scope. Tracked separately.
+Should `create_call` tool result also include the originated call's `activeflow_id`? Deferred: at create_call return time the outbound call may not yet have an activeflow (created on answer via flow execution). Tracked separately.
 
 ## 8. Review Summary
 
-### Design review (2 independent reviewers, fresh delegate_task)
+### Design review round 1 (2 independent reviewers)
 
-Both reviewers returned APPROVE.
+Both APPROVE on the earlier "Call flow (activeflow_id: %s)" form. Reviewer A's "keep the call flow concept word" guidance was subsequently overruled by the domain owner (pchero): "call flow" is factually wrong because an activeflow reference is not always a call (the activeflow ReferenceType enum is none, ai, api, call, campaign, conversation, transcribe, recording). v2 therefore uses the reference-type-neutral term "activeflow" in both output and description, and de-biases the description away from telephony.
 
-- Reviewer A (skeptical Go engineer): confirmed `Call flow (activeflow_id: %s)` is the correct minimal fix (preserves the "call flow execution" concept the tool description teaches the LLM while naming the identifier verbatim); all affected sites identified (tool.go L781 + test L92/L136, no other renderer/asserter); no risk to the masking-invariant test (asserts `msgCorrelationNotFound`, a separate constant) or the unlinked-resource branch; deferred open-question correctly scoped. Non-blocking note: the prior design doc (2026-06-08) L237 documents the old format and could be updated for consistency.
-- Reviewer B (product/observability): confirmed the parenthetical "label (field_name: value)" pattern resolves the confusion without term drift; resource lines (`- call <id>`, `- transcribe <id>`) already carry a type label and were never the confusion source, correctly out of scope; flow_id-vs-activeflow_id distinction belongs to the deferred §7 create_call item, not here.
+### Design review round 2 (2 independent reviewers, v2)
 
-Action taken on the non-blocking note: prior design doc L237 updated to the new format.
-
+Both CHANGES REQUESTED: the de-bias sentence I added first listed invented activeflow reference types ("chat", "task"). "task" is an aicall reference type, not an activeflow one, and "chat" is not in any enum. Corrected to the authoritative activeflow ReferenceType set (none, ai, api, call, campaign, conversation, transcribe, recording) in both the description and this doc.

--- a/docs/plans/2026-06-09-clarify-correlation-activeflow-id-label-design.md
+++ b/docs/plans/2026-06-09-clarify-correlation-activeflow-id-label-design.md
@@ -1,0 +1,94 @@
+# Design: Clarify activeflow_id label in get_correlation summary output
+
+Status: Draft (v1)
+Author: CPO (with pchero)
+Date: 2026-06-09
+Service: bin-ai-manager
+
+## 1. Problem Statement
+
+The `get_correlation` tool returns a human/LLM-readable summary whose first line is:
+
+```
+Call flow 923aba67-78be-46b8-9b9d-d8ef53cda9cd is linked to:
+```
+
+The UUID printed after the words "Call flow" is in fact the **activeflow_id** (`corr.ActiveflowID`, see `pkg/aicallhandler/tool.go::formatCorrelationSummary` L781). However the label "Call flow" does not make that explicit. In a real diagnostic session (2026-06-09) this caused confusion: when looking for "the activeflow_id" in a transcript, the reader could not tell that the value behind the "Call flow" label *was* the activeflow_id, especially because several flow-related IDs coexist in one trace:
+
+- the current AI session's `activeflow_id` (on every message record),
+- the `flow_id` passed to `create_call` (a flow *definition* / template, NOT an activeflow),
+- the originated outbound `call_id`,
+- the originated call's own `activeflow_id` (surfaced only via `get_correlation` as "Call flow ...").
+
+The ambiguity is purely a labeling/observability issue. The data is correct.
+
+## 2. Goal
+
+Make the summary output state, unambiguously, that the leading UUID is the `activeflow_id`, WITHOUT renaming the broader "call flow" concept (the tool's own description teaches the LLM that a "call flow execution" is the unit of correlation, see `pkg/toolhandler/definitions.go` L487-501). Minimal, behavior-preserving copy change.
+
+## 3. Scope
+
+### In scope
+- Change the first line of `formatCorrelationSummary` to label the UUID as `activeflow_id`.
+- Update the two test expectations in `pkg/aicallhandler/tool_correlation_test.go` (L92, L136) that assert the exact summary string.
+
+### Out of scope
+- No change to the tool definition/description (the "call flow execution" concept wording stays).
+- No change to `create_call` result payload (whether to also surface activeflow_id there is a separate, deferred question, see §7).
+- No change to the resource-line formatting (`- call <id>`, `- transcribe <id>`, etc.).
+- No new entity / DB / REST / webhook. N/A.
+
+## 4. Proposed change
+
+`pkg/aicallhandler/tool.go` L781:
+
+Current:
+```go
+fmt.Fprintf(&sb, "Call flow %s is linked to:\n", corr.ActiveflowID)
+```
+
+Proposed:
+```go
+fmt.Fprintf(&sb, "Call flow (activeflow_id: %s) is linked to:\n", corr.ActiveflowID)
+```
+
+Resulting first line:
+```
+Call flow (activeflow_id: 923aba67-78be-46b8-9b9d-d8ef53cda9cd) is linked to:
+```
+
+Rationale for this exact form (vs alternatives):
+- `Activeflow %s is linked to:` — drops the "call flow" concept word the tool description relies on; risks LLM/term inconsistency. Rejected.
+- `Call flow (activeflow_id: %s) is linked to:` — keeps the concept word AND names the identifier precisely. A human or LLM searching for "activeflow_id" now finds it verbatim. Chosen.
+- The phrasing also disambiguates from `flow_id` (the definition), which is the other flow-related identifier in the same trace.
+
+## 5. Affected files
+
+| File | Change |
+|---|---|
+| `bin-ai-manager/pkg/aicallhandler/tool.go` | L781 format string |
+| `bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go` | L92, L136 expected `Message` strings |
+
+## 6. Verification
+
+Run the full mandatory workflow in `bin-ai-manager`:
+```
+go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Focus: `Test_toolHandleGetCorrelation` and `Test_toolHandleGetCorrelation_maskingInvariant` must pass with the new expected strings. The masking invariant test asserts the not-accessible path returns `msgCorrelationNotFound` (a constant unaffected by this change), so it must remain byte-identical.
+
+## 7. Open question (deferred)
+
+Should `create_call` tool result also include the originated call's `activeflow_id` so a follow-up `get_correlation` is not required? Deferred: at `create_call` return time the outbound call may not yet have an activeflow (it is created on answer via flow execution), so this is non-trivial and out of this minimal scope. Tracked separately.
+
+## 8. Review Summary
+
+### Design review (2 independent reviewers, fresh delegate_task)
+
+Both reviewers returned APPROVE.
+
+- Reviewer A (skeptical Go engineer): confirmed `Call flow (activeflow_id: %s)` is the correct minimal fix (preserves the "call flow execution" concept the tool description teaches the LLM while naming the identifier verbatim); all affected sites identified (tool.go L781 + test L92/L136, no other renderer/asserter); no risk to the masking-invariant test (asserts `msgCorrelationNotFound`, a separate constant) or the unlinked-resource branch; deferred open-question correctly scoped. Non-blocking note: the prior design doc (2026-06-08) L237 documents the old format and could be updated for consistency.
+- Reviewer B (product/observability): confirmed the parenthetical "label (field_name: value)" pattern resolves the confusion without term drift; resource lines (`- call <id>`, `- transcribe <id>`) already carry a type label and were never the confusion source, correctly out of scope; flow_id-vs-activeflow_id distinction belongs to the deferred §7 create_call item, not here.
+
+Action taken on the non-blocking note: prior design doc L237 updated to the new format.
+


### PR DESCRIPTION
Clarify that the leading UUID in the get_correlation tool summary is the activeflow_id. A diagnostic reader was confused because a single trace contains several flow-related identifiers (the session activeflow_id, the create_call flow_id which is a definition, the originated call_id, and the originated call's activeflow_id surfaced only via get_correlation). The summary previously printed the activeflow_id behind a bare 'Call flow' label, so the value could not be matched to the activeflow_id field. This names the field explicitly while preserving the 'call flow execution' concept the tool description teaches the LLM.

- bin-ai-manager: Label the get_correlation summary id as activeflow_id ('Call flow (activeflow_id: <id>) is linked to:')
- bin-ai-manager: Update tool_correlation_test expected summary strings
- bin-ai-manager: Refresh the historical correlation tool design doc example
- bin-ai-manager: Add design doc for the activeflow_id label clarification