### PR TITLE
NOJIRA-Add-call-variables-docs

### DIFF
--- a/bin-api-manager/docsdev/build/html/_sources/call_tutorial.rst.txt
+++ b/bin-api-manager/docsdev/build/html/_sources/call_tutorial.rst.txt
@@ -79,6 +79,47 @@ If you have already created a flow, you can reference it by ``flow_id`` instead 
 
 For more details on flows, see the :ref:`Flow tutorial <flow-main>`.
 
+Passing custom variables into the call's flow
+---------------------------------------------
+
+You can seed per-call context into the flow by adding an optional ``variables`` object to the ``POST /calls`` request. Each key becomes referenceable inside the flow as ``${<key>}`` (for example, in a ``talk`` action's text or a ``webhook`` action's body).
+
+.. code::
+
+    $ curl --location --request POST 'https://api.voipbin.net/v1.0/calls?token=<YOUR_AUTH_TOKEN>' \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+            "source": {
+                "type": "tel",
+                "target": "+155****4567"
+            },
+            "destinations": [
+                {
+                    "type": "tel",
+                    "target": "+155****6543"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "talk",
+                    "option": {
+                        "text": "Hello ${customer_name}, this is a call about campaign ${campaign_id}.",
+                        "language": "en-US"
+                    }
+                }
+            ],
+            "variables": {
+                "campaign_id": "summer-2026",
+                "customer_name": "Jane Doe"
+            }
+        }'
+
+At runtime the destination hears "Hello Jane Doe, this is a call about campaign summer-2026."
+
+.. note:: **Variable limits and reserved keys**
+
+   Values must be strings. The injection accepts at most 100 keys, 64KB total (keys plus values), and 32KB per individual value. Keys beginning with ``voipbin.`` are reserved for system variables and are silently ignored. See the :ref:`Variables overview <variable-overview>` for the full reference.
+
 Anonymous outbound call (API-initiated)
 ---------------------------------------
 

--- a/bin-api-manager/docsdev/build/html/_sources/variable_overview.rst.txt
+++ b/bin-api-manager/docsdev/build/html/_sources/variable_overview.rst.txt
@@ -102,6 +102,39 @@ Developers can explicitly define or override values in the flow.
 
 Variables set during execution are scoped to the current flow instance, meaning they persist only during the lifetime of that flow unless explicitly passed elsewhere.
 
+At creation time via the API
+----------------------------
+
+When you start a new flow through the API, you can seed custom variables directly in the request body using the optional ``variables`` field. This is the recommended way to pass per-request context (campaign IDs, customer names, tracking tokens) into a flow without hard-coding them into the flow definition.
+
+The ``variables`` field is a flat key-value object. Each value must be a string, and each key becomes referenceable inside the flow as ``${<key>}``:
+
+.. code::
+
+    {
+        "source": { "type": "tel", "target": "+155****4567" },
+        "destinations": [ { "type": "tel", "target": "+155****6543" } ],
+        "flow_id": "<your-flow-id>",
+        "variables": {
+            "campaign_id": "summer-2026",
+            "customer_name": "Jane Doe"
+        }
+    }
+
+Inside the flow, ``${customer_name}`` resolves to ``Jane Doe`` for that activeflow instance.
+
+The ``variables`` field is currently accepted on:
+
+* ``POST /calls`` - seeds variables into the call's activeflow.
+* ``POST /activeflows`` - seeds variables into the created activeflow.
+
+.. note:: **Limits and reserved keys**
+
+   * Values are strings only. Non-string values are rejected.
+   * Maximum 100 keys, 64KB total (keys + values), 32KB per individual value. The total is measured after reserved and empty keys are dropped.
+   * Keys beginning with ``voipbin.`` are reserved for system variables and are silently ignored if supplied. Use your own namespace (e.g. ``campaign_id``, not ``voipbin.campaign_id``).
+   * If a size or count limit is exceeded, the entire ``variables`` injection is discarded (all keys, not just the offending one). The call or activeflow is still created, but with no externally supplied variables. Reserved keys, by contrast, are dropped individually.
+
 Integration with Applications
 =============================
 

--- a/bin-api-manager/docsdev/build/html/call_tutorial.html
+++ b/bin-api-manager/docsdev/build/html/call_tutorial.html
@@ -672,6 +672,45 @@ When the destination answers the call, it will speak the given text message.</p>
 </div>
 <p>For more details on flows, see the <a class="reference internal" href="flow.html#flow-main"><span class="std std-ref">Flow tutorial</span></a>.</p>
 </section>
+<section id="passing-custom-variables-into-the-call-s-flow">
+<h3>Passing custom variables into the call’s flow<a class="headerlink" href="#passing-custom-variables-into-the-call-s-flow" title="Link to this heading">¶</a></h3>
+<p>You can seed per-call context into the flow by adding an optional <code class="docutils literal notranslate"><span class="pre">variables</span></code> object to the <code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/calls</span></code> request. Each key becomes referenceable inside the flow as <code class="docutils literal notranslate"><span class="pre">${&lt;key&gt;}</span></code> (for example, in a <code class="docutils literal notranslate"><span class="pre">talk</span></code> action’s text or a <code class="docutils literal notranslate"><span class="pre">webhook</span></code> action’s body).</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span>$ curl --location --request POST &#39;https://api.voipbin.net/v1.0/calls?token=&lt;YOUR_AUTH_TOKEN&gt;&#39; \
+    --header &#39;Content-Type: application/json&#39; \
+    --data-raw &#39;{
+        &quot;source&quot;: {
+            &quot;type&quot;: &quot;tel&quot;,
+            &quot;target&quot;: &quot;+155****4567&quot;
+        },
+        &quot;destinations&quot;: [
+            {
+                &quot;type&quot;: &quot;tel&quot;,
+                &quot;target&quot;: &quot;+155****6543&quot;
+            }
+        ],
+        &quot;actions&quot;: [
+            {
+                &quot;type&quot;: &quot;talk&quot;,
+                &quot;option&quot;: {
+                    &quot;text&quot;: &quot;Hello ${customer_name}, this is a call about campaign ${campaign_id}.&quot;,
+                    &quot;language&quot;: &quot;en-US&quot;
+                }
+            }
+        ],
+        &quot;variables&quot;: {
+            &quot;campaign_id&quot;: &quot;summer-2026&quot;,
+            &quot;customer_name&quot;: &quot;Jane Doe&quot;
+        }
+    }&#39;
+</pre></div>
+</div>
+<p>At runtime the destination hears “Hello Jane Doe, this is a call about campaign summer-2026.”</p>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p><strong>Variable limits and reserved keys</strong></p>
+<p>Values must be strings. The injection accepts at most 100 keys, 64KB total (keys plus values), and 32KB per individual value. Keys beginning with <code class="docutils literal notranslate"><span class="pre">voipbin.</span></code> are reserved for system variables and are silently ignored. See the <a class="reference internal" href="variable_overview.html#variable-overview"><span class="std std-ref">Variables overview</span></a> for the full reference.</p>
+</div>
+</section>
 <section id="anonymous-outbound-call-api-initiated">
 <h3>Anonymous outbound call (API-initiated)<a class="headerlink" href="#anonymous-outbound-call-api-initiated" title="Link to this heading">¶</a></h3>
 <p>You can hide your caller ID on outgoing PSTN calls by setting <code class="docutils literal notranslate"><span class="pre">&quot;anonymous&quot;:</span> <span class="pre">&quot;yes&quot;</span></code> in the <code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/calls</span></code> request. The destination sees “Anonymous” or “Private number” instead of your real phone number.</p>
@@ -1604,6 +1643,7 @@ When the destination answer the call, it will play the given media file.</p>
 <li><a class="reference internal" href="#prerequisites">Prerequisites</a><ul>
 <li><a class="reference internal" href="#simple-outbound-call-with-tts">Simple outbound call with TTS</a></li>
 <li><a class="reference internal" href="#simple-outbound-call-with-an-existing-flow">Simple outbound call with an existing flow</a></li>
+<li><a class="reference internal" href="#passing-custom-variables-into-the-call-s-flow">Passing custom variables into the call’s flow</a></li>
 <li><a class="reference internal" href="#anonymous-outbound-call-api-initiated">Anonymous outbound call (API-initiated)</a></li>
 <li><a class="reference internal" href="#anonymous-outbound-call-within-a-flow-connect-action">Anonymous outbound call within a flow (connect action)</a></li>
 <li><a class="reference internal" href="#anonymous-outbound-call-within-a-flow-call-action">Anonymous outbound call within a flow (call action)</a></li>

--- a/bin-api-manager/docsdev/build/html/variable_overview.html
+++ b/bin-api-manager/docsdev/build/html/variable_overview.html
@@ -681,6 +681,38 @@
 </div>
 <p>Variables set during execution are scoped to the current flow instance, meaning they persist only during the lifetime of that flow unless explicitly passed elsewhere.</p>
 </section>
+<section id="at-creation-time-via-the-api">
+<h2>At creation time via the API<a class="headerlink" href="#at-creation-time-via-the-api" title="Link to this heading">¶</a></h2>
+<p>When you start a new flow through the API, you can seed custom variables directly in the request body using the optional <code class="docutils literal notranslate"><span class="pre">variables</span></code> field. This is the recommended way to pass per-request context (campaign IDs, customer names, tracking tokens) into a flow without hard-coding them into the flow definition.</p>
+<p>The <code class="docutils literal notranslate"><span class="pre">variables</span></code> field is a flat key-value object. Each value must be a string, and each key becomes referenceable inside the flow as <code class="docutils literal notranslate"><span class="pre">${&lt;key&gt;}</span></code>:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">{</span>
+    <span class="s2">&quot;source&quot;</span><span class="p">:</span> <span class="p">{</span> <span class="s2">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;tel&quot;</span><span class="p">,</span> <span class="s2">&quot;target&quot;</span><span class="p">:</span> <span class="s2">&quot;+155****4567&quot;</span> <span class="p">},</span>
+    <span class="s2">&quot;destinations&quot;</span><span class="p">:</span> <span class="p">[</span> <span class="p">{</span> <span class="s2">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;tel&quot;</span><span class="p">,</span> <span class="s2">&quot;target&quot;</span><span class="p">:</span> <span class="s2">&quot;+155****6543&quot;</span> <span class="p">}</span> <span class="p">],</span>
+    <span class="s2">&quot;flow_id&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;your-flow-id&gt;&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;variables&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;campaign_id&quot;</span><span class="p">:</span> <span class="s2">&quot;summer-2026&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;customer_name&quot;</span><span class="p">:</span> <span class="s2">&quot;Jane Doe&quot;</span>
+    <span class="p">}</span>
+<span class="p">}</span>
+</pre></div>
+</div>
+<p>Inside the flow, <code class="docutils literal notranslate"><span class="pre">${customer_name}</span></code> resolves to <code class="docutils literal notranslate"><span class="pre">Jane</span> <span class="pre">Doe</span></code> for that activeflow instance.</p>
+<p>The <code class="docutils literal notranslate"><span class="pre">variables</span></code> field is currently accepted on:</p>
+<ul class="simple">
+<li><p><code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/calls</span></code> - seeds variables into the call’s activeflow.</p></li>
+<li><p><code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/activeflows</span></code> - seeds variables into the created activeflow.</p></li>
+</ul>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p><strong>Limits and reserved keys</strong></p>
+<ul class="simple">
+<li><p>Values are strings only. Non-string values are rejected.</p></li>
+<li><p>Maximum 100 keys, 64KB total (keys + values), 32KB per individual value. The total is measured after reserved and empty keys are dropped.</p></li>
+<li><p>Keys beginning with <code class="docutils literal notranslate"><span class="pre">voipbin.</span></code> are reserved for system variables and are silently ignored if supplied. Use your own namespace (e.g. <code class="docutils literal notranslate"><span class="pre">campaign_id</span></code>, not <code class="docutils literal notranslate"><span class="pre">voipbin.campaign_id</span></code>).</p></li>
+<li><p>If a size or count limit is exceeded, the entire <code class="docutils literal notranslate"><span class="pre">variables</span></code> injection is discarded (all keys, not just the offending one). The call or activeflow is still created, but with no externally supplied variables. Reserved keys, by contrast, are dropped individually.</p></li>
+</ul>
+</div>
+</section>
 </section>
 <section id="integration-with-applications">
 <h1>Integration with Applications<a class="headerlink" href="#integration-with-applications" title="Link to this heading">¶</a></h1>

--- a/bin-api-manager/docsdev/source/call_tutorial.rst
+++ b/bin-api-manager/docsdev/source/call_tutorial.rst
@@ -79,6 +79,47 @@ If you have already created a flow, you can reference it by ``flow_id`` instead 
 
 For more details on flows, see the :ref:`Flow tutorial <flow-main>`.
 
+Passing custom variables into the call's flow
+---------------------------------------------
+
+You can seed per-call context into the flow by adding an optional ``variables`` object to the ``POST /calls`` request. Each key becomes referenceable inside the flow as ``${<key>}`` (for example, in a ``talk`` action's text or a ``webhook`` action's body).
+
+.. code::
+
+    $ curl --location --request POST 'https://api.voipbin.net/v1.0/calls?token=<YOUR_AUTH_TOKEN>' \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+            "source": {
+                "type": "tel",
+                "target": "+155****4567"
+            },
+            "destinations": [
+                {
+                    "type": "tel",
+                    "target": "+155****6543"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "talk",
+                    "option": {
+                        "text": "Hello ${customer_name}, this is a call about campaign ${campaign_id}.",
+                        "language": "en-US"
+                    }
+                }
+            ],
+            "variables": {
+                "campaign_id": "summer-2026",
+                "customer_name": "Jane Doe"
+            }
+        }'
+
+At runtime the destination hears "Hello Jane Doe, this is a call about campaign summer-2026."
+
+.. note:: **Variable limits and reserved keys**
+
+   Values must be strings. The injection accepts at most 100 keys, 64KB total (keys plus values), and 32KB per individual value. Keys beginning with ``voipbin.`` are reserved for system variables and are silently ignored. See the :ref:`Variables overview <variable-overview>` for the full reference.
+
 Anonymous outbound call (API-initiated)
 ---------------------------------------
 

--- a/bin-api-manager/docsdev/source/variable_overview.rst
+++ b/bin-api-manager/docsdev/source/variable_overview.rst
@@ -102,6 +102,39 @@ Developers can explicitly define or override values in the flow.
 
 Variables set during execution are scoped to the current flow instance, meaning they persist only during the lifetime of that flow unless explicitly passed elsewhere.
 
+At creation time via the API
+----------------------------
+
+When you start a new flow through the API, you can seed custom variables directly in the request body using the optional ``variables`` field. This is the recommended way to pass per-request context (campaign IDs, customer names, tracking tokens) into a flow without hard-coding them into the flow definition.
+
+The ``variables`` field is a flat key-value object. Each value must be a string, and each key becomes referenceable inside the flow as ``${<key>}``:
+
+.. code::
+
+    {
+        "source": { "type": "tel", "target": "+155****4567" },
+        "destinations": [ { "type": "tel", "target": "+155****6543" } ],
+        "flow_id": "<your-flow-id>",
+        "variables": {
+            "campaign_id": "summer-2026",
+            "customer_name": "Jane Doe"
+        }
+    }
+
+Inside the flow, ``${customer_name}`` resolves to ``Jane Doe`` for that activeflow instance.
+
+The ``variables`` field is currently accepted on:
+
+* ``POST /calls`` - seeds variables into the call's activeflow.
+* ``POST /activeflows`` - seeds variables into the created activeflow.
+
+.. note:: **Limits and reserved keys**
+
+   * Values are strings only. Non-string values are rejected.
+   * Maximum 100 keys, 64KB total (keys + values), 32KB per individual value. The total is measured after reserved and empty keys are dropped.
+   * Keys beginning with ``voipbin.`` are reserved for system variables and are silently ignored if supplied. Use your own namespace (e.g. ``campaign_id``, not ``voipbin.campaign_id``).
+   * If a size or count limit is exceeded, the entire ``variables`` injection is discarded (all keys, not just the offending one). The call or activeflow is still created, but with no externally supplied variables. Reserved keys, by contrast, are dropped individually.
+
 Integration with Applications
 =============================
 


### PR DESCRIPTION
Document the optional variables field on POST /calls and POST /activeflows that seeds custom runtime variables into a newly created flow, readable inside the flow via ${key}. This is the user-facing documentation follow-up for the activeflow initial-variables feature (PR #980).

- bin-api-manager: Add "At creation time via the API" section to variable_overview.rst covering the flat key-value contract, string-only values, the 100-key / 64KB-total / 32KB-per-value limits, and the reserved voipbin. prefix
- bin-api-manager: Add "Passing custom variables into the call's flow" curl example to call_tutorial.rst
- bin-api-manager: Rebuild affected Sphinx HTML pages under docsdev/build/