### PR TITLE
NOJIRA-Add-get-resource-tool-design

### DIFF
--- a/bin-ai-manager/docs/domain.md
+++ b/bin-ai-manager/docs/domain.md
@@ -105,6 +105,9 @@ Tool definitions live in `pkg/toolhandler/definitions.go`. Only tools listed in 
 | `set_variables` | Write to flow context variables |
 | `get_variables` | Read from flow context variables |
 | `get_aicall_messages` | Retrieve conversation history |
+| `search_knowledge` | Query the AI's knowledge base (RAG) |
+| `get_correlation` | Retrieve the correlation graph (related resource ids) for an activeflow |
+| `get_resource` | Retrieve a curated summary of a single resource by type+id (call, groupcall, recording, transcribe incl. transcripts, summary, aicall incl. conversation history, conferencecall, queuecall); customer-ownership enforced |
 
 Tool execution flow:
 1. LLM in Pipecat emits a function call

--- a/bin-ai-manager/go.mod
+++ b/bin-ai-manager/go.mod
@@ -92,6 +92,7 @@ require (
 	monorepo/bin-flow-manager v0.0.0-20240403034140-ce82222fe7f4
 	monorepo/bin-message-manager v0.0.0-20240328053936-9008e28c2268
 	monorepo/bin-pipecat-manager v0.0.0-00010101000000-000000000000
+	monorepo/bin-queue-manager v0.0.0-20240402021210-adac880b81da
 	monorepo/bin-timeline-manager v0.0.0-00010101000000-000000000000
 	monorepo/bin-transcribe-manager v0.0.0-20240405044227-febd49f8b700
 )
@@ -161,7 +162,6 @@ require (
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0 // indirect
 	monorepo/bin-number-manager v0.0.0-20240328055052-ec1c723aa183 // indirect
 	monorepo/bin-outdial-manager v0.0.0-20240313064601-888fe8578646 // indirect
-	monorepo/bin-queue-manager v0.0.0-20240402021210-adac880b81da // indirect
 	monorepo/bin-rag-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-registrar-manager v0.0.0-20240402051305-cf14186e380d // indirect
 	monorepo/bin-route-manager v0.0.0-20240313065038-1498b922bb24 // indirect

--- a/bin-ai-manager/models/message/tool.go
+++ b/bin-ai-manager/models/message/tool.go
@@ -39,4 +39,5 @@ const (
 	FunctionCallNameStopService       FunctionCallName = "stop_service"
 	FunctionCallNameSearchKnowledge   FunctionCallName = "search_knowledge"
 	FunctionCallNameGetCorrelation    FunctionCallName = "get_correlation"
+	FunctionCallNameGetResource       FunctionCallName = "get_resource"
 )

--- a/bin-ai-manager/models/tool/main.go
+++ b/bin-ai-manager/models/tool/main.go
@@ -18,6 +18,7 @@ const (
 	ToolNameStopService       ToolName = "stop_service"
 	ToolNameSearchKnowledge   ToolName = "search_knowledge"
 	ToolNameGetCorrelation    ToolName = "get_correlation"
+	ToolNameGetResource       ToolName = "get_resource"
 )
 
 // AllToolNames returns all available tool names (excluding "all")
@@ -34,6 +35,7 @@ var AllToolNames = []ToolName{
 	ToolNameStopService,
 	ToolNameSearchKnowledge,
 	ToolNameGetCorrelation,
+	ToolNameGetResource,
 }
 
 // Tool defines a tool with its schema for LLM function calling.

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -63,6 +63,7 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		message.FunctionCallNameStopService:         h.toolHandleServiceStop,
 		message.FunctionCallNameSearchKnowledge:     h.toolHandleSearchKnowledge,
 		message.FunctionCallNameGetCorrelation:      h.toolHandleGetCorrelation,
+		message.FunctionCallNameGetResource:         h.toolHandleGetResource,
 	}
 
 	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()
@@ -788,6 +789,23 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 	return res
 }
 
+// correlationResourceLabel derives a human/LLM-readable resource-type label
+// from a resource's event types (e.g. "call_created" → "call",
+// "aicall_status_progressing" → "aicall"). The event envelope's data_type is
+// always "application/json" (the content type), so the event-type prefix is
+// the only usable label source. Empty event types fall back to the neutral
+// label "resource".
+func correlationResourceLabel(eventTypes []string) string {
+	if len(eventTypes) == 0 {
+		return "resource"
+	}
+	first := eventTypes[0]
+	if idx := strings.Index(first, "_"); idx > 0 {
+		return first[:idx]
+	}
+	return first
+}
+
 // formatCorrelationSummary renders an LLM-readable summary of a correlation
 // graph. It leads with prose grouped by publisher and includes compact resource
 // ids so the LLM can chain follow-up tool calls.
@@ -809,9 +827,9 @@ func formatCorrelationSummary(corr *tmcorrelation.Correlation) string {
 				continue
 			}
 			if len(r.EventTypes) > 0 {
-				fmt.Fprintf(&sb, "  - %s %s (events: %s)\n", r.DataType, r.ID, strings.Join(r.EventTypes, ", "))
+				fmt.Fprintf(&sb, "  - %s %s (events: %s)\n", correlationResourceLabel(r.EventTypes), r.ID, strings.Join(r.EventTypes, ", "))
 			} else {
-				fmt.Fprintf(&sb, "  - %s %s\n", r.DataType, r.ID)
+				fmt.Fprintf(&sb, "  - %s %s\n", correlationResourceLabel(r.EventTypes), r.ID)
 			}
 		}
 	}

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -796,12 +796,15 @@ func (h *aicallHandler) toolHandleGetCorrelation(ctx context.Context, c *aicall.
 // the only usable label source. Empty event types fall back to the neutral
 // label "resource".
 func correlationResourceLabel(eventTypes []string) string {
-	if len(eventTypes) == 0 {
+	if len(eventTypes) == 0 || eventTypes[0] == "" {
 		return "resource"
 	}
 	first := eventTypes[0]
 	if idx := strings.Index(first, "_"); idx > 0 {
 		return first[:idx]
+	}
+	if strings.HasPrefix(first, "_") {
+		return "resource"
 	}
 	return first
 }

--- a/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
@@ -89,7 +89,7 @@ func Test_toolHandleGetCorrelation(t *testing.T) {
 				ToolCallID:   "tool-1",
 				ResourceType: "correlation",
 				ResourceID:   "33333333-0000-4000-8000-000000000001",
-				Message:      "Activeflow 33333333-0000-4000-8000-000000000001 is linked to:\n- call-manager: 1 resource(s)\n  - call 44444444-0000-4000-8000-000000000001 (events: call_created, call_hangup)\n- transcribe-manager: 1 resource(s)\n  - transcribe 77777777-0000-4000-8000-000000000001\n",
+				Message:      "Activeflow 33333333-0000-4000-8000-000000000001 is linked to:\n- call-manager: 1 resource(s)\n  - call 44444444-0000-4000-8000-000000000001 (events: call_created, call_hangup)\n- transcribe-manager: 1 resource(s)\n  - resource 77777777-0000-4000-8000-000000000001\n",
 			},
 		},
 		{
@@ -665,6 +665,33 @@ func Test_resolveCorrelation(t *testing.T) {
 				if stderrors.Is(err, ErrCorrelationNotAccessible) {
 					t.Errorf("transient error must NOT match ErrCorrelationNotAccessible, got: %v", err)
 				}
+			}
+		})
+	}
+}
+
+// Test_correlationResourceLabel locks the OQ5 label derivation: event-type
+// prefix via first-underscore cut, with the neutral fallback for empty
+// event types. The envelope data_type is always "application/json" and must
+// never be used as the label.
+func Test_correlationResourceLabel(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventTypes []string
+		want       string
+	}{
+		{"call event", []string{"call_created", "call_hangup"}, "call"},
+		{"aicall multi-segment event", []string{"aicall_status_progressing"}, "aicall"},
+		{"conferencecall event", []string{"conferencecall_joined"}, "conferencecall"},
+		{"empty event types fallback", []string{}, "resource"},
+		{"nil event types fallback", nil, "resource"},
+		{"no underscore passes through", []string{"weird"}, "weird"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := correlationResourceLabel(tt.eventTypes); got != tt.want {
+				t.Errorf("correlationResourceLabel(%v) = %q, want %q", tt.eventTypes, got, tt.want)
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_correlation_test.go
@@ -696,3 +696,15 @@ func Test_correlationResourceLabel(t *testing.T) {
 		})
 	}
 }
+
+// Additional correlationResourceLabel edge cases (round-1 PR review L8):
+// empty-string and leading-underscore first event types must fall back to the
+// neutral label instead of rendering "" or "_x".
+func Test_correlationResourceLabel_edges(t *testing.T) {
+	if got := correlationResourceLabel([]string{""}); got != "resource" {
+		t.Errorf(`correlationResourceLabel([""]) = %q, want "resource"`, got)
+	}
+	if got := correlationResourceLabel([]string{"_oddball"}); got != "resource" {
+		t.Errorf(`correlationResourceLabel(["_oddball"]) = %q, want "resource"`, got)
+	}
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_resource.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_resource.go
@@ -257,6 +257,13 @@ func renderBodyLines(header string, lines []string, pagedOut bool, noun string) 
 		sep = ""
 	}
 
+	// Callers guard len(lines)==0 before calling; if a future caller passes
+	// an empty slice with pagedOut=true, fall back to the bare header rather
+	// than emitting a "most recent 0" marker.
+	if len(lines) == 0 {
+		return capSummaryRunes(header)
+	}
+
 	// Fast path: everything fits and nothing was paged out — no marker.
 	if !pagedOut {
 		full := header + sep + strings.Join(lines, "\n")

--- a/bin-ai-manager/pkg/aicallhandler/tool_resource.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_resource.go
@@ -1,0 +1,613 @@
+package aicallhandler
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	cmcall "monorepo/bin-call-manager/models/call"
+	cmgroupcall "monorepo/bin-call-manager/models/groupcall"
+	cmrecording "monorepo/bin-call-manager/models/recording"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	cfconferencecall "monorepo/bin-conference-manager/models/conferencecall"
+	qmqueuecall "monorepo/bin-queue-manager/models/queuecall"
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
+)
+
+// msgResourceNotFound is the single masked response for every path where the
+// caller is not allowed to see the resource: absent, cross-customer, or any
+// state in between. All such paths MUST return this byte-identical string so
+// the tool is not an existence oracle.
+const msgResourceNotFound = "Resource not found."
+
+// maxResourceSummaryRunes caps the WHOLE rendered message (metadata + body +
+// truncation marker) of every resource summary, in runes. Raising it requires
+// a code change.
+const maxResourceSummaryRunes = 4000
+
+// resourceListPageSize is the page size used for enrichment list fetches
+// (transcripts, aicall messages). One extra row is requested to detect that
+// more rows exist beyond the rendered page.
+const resourceListPageSize = 100
+
+// ErrResourceNotAccessible signals that the resource is absent or not owned by
+// the caller. The caller masks it behind msgResourceNotFound. Transient
+// failures are returned as wrapped ordinary errors and must NOT be masked
+// (existence is unknown; masking would make the LLM assert a false
+// "not found").
+var ErrResourceNotAccessible = stderrors.New("resource not accessible")
+
+// resourceFetchResult carries the owner of a fetched resource and a render
+// closure. ownerID is valid only when err == nil. render is invoked by the
+// caller ONLY after ownership has been validated; any enrichment fetch
+// (e.g. transcript list, aicall message list) happens inside render, never
+// before.
+type resourceFetchResult struct {
+	ownerID uuid.UUID
+	render  func(ctx context.Context) string
+}
+
+// resourceFetcher fetches the primary resource for a given id and returns its
+// owner plus a deferred renderer.
+type resourceFetcher func(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error)
+
+// mapResourceFetchers is the source of truth for the supported resource
+// types. The tool definition's JSON-schema enum is asserted equal to the
+// sorted keys of this map by a unit test so the two cannot drift.
+var mapResourceFetchers = map[string]resourceFetcher{
+	"call":           fetchResourceCall,
+	"groupcall":      fetchResourceGroupcall,
+	"recording":      fetchResourceRecording,
+	"transcribe":     fetchResourceTranscribe,
+	"summary":        fetchResourceSummary,
+	"aicall":         fetchResourceAIcall,
+	"conferencecall": fetchResourceConferencecall,
+	"queuecall":      fetchResourceQueuecall,
+}
+
+// SupportedResourceTypes returns the sorted list of resource types supported
+// by the get_resource tool. Exported so the toolhandler definition test can
+// assert the JSON-schema enum matches.
+func SupportedResourceTypes() []string {
+	res := make([]string, 0, len(mapResourceFetchers))
+	for k := range mapResourceFetchers {
+		res = append(res, k)
+	}
+	sort.Strings(res)
+	return res
+}
+
+// supportedResourceTypes is the human-readable list used in error messages.
+var supportedResourceTypes = strings.Join(SupportedResourceTypes(), ", ")
+
+// toolHandleGetResource retrieves the content of a single VoIPBin resource by
+// id and returns a curated, LLM-readable summary.
+//
+// Ownership validation and existence-oracle masking are delegated to
+// resolveResource. Every "cannot see this" path collapses to the single
+// msgResourceNotFound emission site below.
+//
+// CRITICAL: both branches inside the `if err` block MUST return. Falling
+// through would (a) for a cross-customer error expose a foreign resource
+// summary (IDOR), and (b) for the transient case render an invalid summary.
+// The returns are load-bearing.
+func (h *aicallHandler) toolHandleGetResource(ctx context.Context, c *aicall.AIcall, tc *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleGetResource",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool get_resource.")
+
+	res := newToolResult(tc.ID)
+
+	var args struct {
+		ResourceType string `json:"resource_type"`
+		ResourceID   string `json:"resource_id"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		// Pass the unmarshal error through (sibling precedent:
+		// toolHandleSearchKnowledge) so the LLM can self-correct its arguments.
+		fillFailed(res, errors.Wrap(err, "invalid arguments"))
+		return res
+	}
+
+	if args.ResourceType == "" {
+		fillFailed(res, fmt.Errorf("resource_type is required. supported: %s", supportedResourceTypes))
+		return res
+	}
+	fetcher, ok := mapResourceFetchers[args.ResourceType]
+	if !ok {
+		fillFailed(res, fmt.Errorf("unsupported resource_type: %s. supported: %s", args.ResourceType, supportedResourceTypes))
+		return res
+	}
+
+	resourceID, err := uuid.FromString(args.ResourceID)
+	if err != nil || resourceID == uuid.Nil {
+		fillFailed(res, fmt.Errorf("invalid resource_id"))
+		return res
+	}
+
+	summary, err := h.resolveResource(ctx, c.CustomerID, fetcher, resourceID)
+	if err != nil {
+		if stderrors.Is(err, ErrResourceNotAccessible) {
+			// Single masking site for ALL not-accessible paths.
+			// CRITICAL: this return is load-bearing (IDOR if fallen through).
+			fillSuccess(res, args.ResourceType, resourceID.String(), msgResourceNotFound)
+			return res
+		}
+		// Transient/infra failure: existence unknown, report honest tool
+		// failure. The cause is logged for operators but never reaches the LLM.
+		// CRITICAL: this return is load-bearing.
+		log.Errorf("Resource lookup failed. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+
+	fillSuccess(res, args.ResourceType, resourceID.String(), summary)
+	return res
+}
+
+// resolveResource fetches the primary resource, validates ownership, and only
+// then renders the summary (running any enrichment fetch). Mirrors the
+// resolveCorrelation two-tier error contract: ErrResourceNotAccessible for
+// absent/cross-customer (masked by the caller), wrapped ordinary errors for
+// transient failures (honest tool failure).
+func (h *aicallHandler) resolveResource(ctx context.Context, callerCustomerID uuid.UUID, fetcher resourceFetcher, resourceID uuid.UUID) (string, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "resolveResource",
+		"customer_id": callerCustomerID,
+		"resource_id": resourceID,
+	})
+
+	r, err := fetcher(ctx, h, resourceID)
+	if err != nil {
+		if stderrors.Is(err, requesthandler.ErrNotFound) {
+			// Absent. Mask.
+			return "", ErrResourceNotAccessible
+		}
+		// Transient: honest failure, no masking.
+		return "", errors.Wrap(err, "could not fetch resource")
+	}
+
+	if r.ownerID != callerCustomerID || r.ownerID == uuid.Nil {
+		// ownerID == uuid.Nil is treated as not-accessible (fail closed): a
+		// row with unset customer_id must never match any caller.
+		log.Warnf("Cross-customer resource access blocked. resource_owner: %s", r.ownerID)
+		return "", ErrResourceNotAccessible
+	}
+
+	// Ownership validated: only now render (and run any enrichment fetch).
+	return r.render(ctx), nil
+}
+
+// ---- rendering helpers ----
+
+// summaryBuilder accumulates labeled metadata lines for a resource summary.
+type summaryBuilder struct {
+	lines []string
+}
+
+func (b *summaryBuilder) add(label, value string) {
+	if value == "" {
+		return
+	}
+	b.lines = append(b.lines, fmt.Sprintf("%s: %s", label, value))
+}
+
+func (b *summaryBuilder) addUUID(label string, id uuid.UUID) {
+	if id == uuid.Nil {
+		return
+	}
+	b.add(label, id.String())
+}
+
+func (b *summaryBuilder) addTime(label string, t *time.Time) {
+	if t == nil || t.IsZero() {
+		return
+	}
+	b.add(label, t.UTC().Format(time.RFC3339))
+}
+
+func (b *summaryBuilder) String() string {
+	return strings.Join(b.lines, "\n")
+}
+
+// capSummaryRunes enforces the whole-message rune cap on a rendered summary.
+// Free-text overflow is hard-truncated mid-text with a generic marker.
+func capSummaryRunes(s string) string {
+	runes := []rune(s)
+	if len(runes) <= maxResourceSummaryRunes {
+		return s
+	}
+	marker := "\n...(truncated)"
+	keep := maxResourceSummaryRunes - len([]rune(marker))
+	if keep < 0 {
+		keep = 0
+	}
+	return string(runes[:keep]) + marker
+}
+
+// renderBodyLines appends a line-structured body (transcript lines, aicall
+// message lines) to a metadata header under the whole-message rune cap.
+// lines must be in chronological order. Truncation keeps the MOST RECENT
+// lines and drops the oldest; the marker is placed at the top of the block
+// (where the omitted earlier lines were). pagedOut indicates the source list
+// had more rows than the fetched page (page cap), which also forces the
+// marker. noun is "transcripts" or "messages".
+func renderBodyLines(header string, lines []string, pagedOut bool, noun string) string {
+	budget := maxResourceSummaryRunes - len([]rune(header)) - 1 // newline joining header/body
+
+	// Walk backwards keeping the newest lines that fit, reserving marker room.
+	marker := fmt.Sprintf("...(earlier %s omitted; showing the most recent %%d)", noun)
+	markerRoom := len([]rune(fmt.Sprintf(marker, len(lines)))) + 1
+
+	kept := make([]string, 0, len(lines))
+	used := 0
+	for i := len(lines) - 1; i >= 0; i-- {
+		lineLen := len([]rune(lines[i])) + 1
+		if used+lineLen > budget-markerRoom {
+			break
+		}
+		kept = append([]string{lines[i]}, kept...)
+		used += lineLen
+	}
+
+	truncated := pagedOut || len(kept) < len(lines)
+
+	if len(kept) == 0 && len(lines) > 0 {
+		// Degenerate case: even the newest single line cannot fit. Hard-cut
+		// it mid-text and still show it.
+		newest := []rune(lines[len(lines)-1])
+		room := budget - markerRoom
+		if room < 0 {
+			room = 0
+		}
+		if len(newest) > room {
+			newest = newest[:room]
+		}
+		degenerate := fmt.Sprintf("...(earlier %s omitted; showing the most recent 1, truncated)", noun)
+		return header + "\n" + degenerate + "\n" + string(newest)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(header)
+	sb.WriteString("\n")
+	if truncated {
+		fmt.Fprintf(&sb, marker+"\n", len(kept))
+	}
+	sb.WriteString(strings.Join(kept, "\n"))
+	return sb.String()
+}
+
+// ---- per-type fetchers ----
+
+func fetchResourceCall(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.CallV1CallGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return renderCall(r)
+		},
+	}, nil
+}
+
+func renderCall(r *cmcall.Call) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.add("direction", string(r.Direction))
+	b.add("source", r.Source.Target)
+	b.add("destination", r.Destination.Target)
+	b.addTime("created", r.TMCreate)
+	b.addTime("ringing", r.TMRinging)
+	b.addTime("progressing", r.TMProgressing)
+	b.addTime("hangup", r.TMHangup)
+	b.add("hangup_by", string(r.HangupBy))
+	b.add("hangup_reason", string(r.HangupReason))
+	if len(r.RecordingIDs) > 0 {
+		b.add("recordings", fmt.Sprintf("%d", len(r.RecordingIDs)))
+	}
+	b.addUUID("groupcall_id", r.GroupcallID)
+	return capSummaryRunes(b.String())
+}
+
+func fetchResourceGroupcall(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.CallV1GroupcallGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return renderGroupcall(r)
+		},
+	}, nil
+}
+
+func renderGroupcall(r *cmgroupcall.Groupcall) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.add("ring_method", string(r.RingMethod))
+	b.add("answer_method", string(r.AnswerMethod))
+	if r.Source != nil {
+		b.add("source", r.Source.Target)
+	}
+	b.add("destinations", fmt.Sprintf("%d", len(r.Destinations)))
+	b.addUUID("answered_call_id", r.AnswerCallID)
+	if len(r.CallIDs) > 0 {
+		ids := make([]string, len(r.CallIDs))
+		for i, cid := range r.CallIDs {
+			ids[i] = cid.String()
+		}
+		b.add("call_ids", strings.Join(ids, ", "))
+	}
+	return capSummaryRunes(b.String())
+}
+
+func fetchResourceRecording(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.CallV1RecordingGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return renderRecording(r)
+		},
+	}, nil
+}
+
+func renderRecording(r *cmrecording.Recording) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.add("format", string(r.Format))
+	b.add("reference_type", string(r.ReferenceType))
+	b.addUUID("reference_id", r.ReferenceID)
+	b.add("recording_name", r.RecordingName)
+	b.addTime("started", r.TMStart)
+	b.addTime("ended", r.TMEnd)
+	return capSummaryRunes(b.String())
+}
+
+func fetchResourceTranscribe(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.TranscribeV1TranscribeGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return h.renderTranscribe(ctx, r)
+		},
+	}, nil
+}
+
+// renderTranscribe renders the transcribe metadata followed by the transcript
+// body. It runs only after ownership has been validated; the transcript fetch
+// never happens for a foreign transcribe.
+func (h *aicallHandler) renderTranscribe(ctx context.Context, r *tmtranscribe.Transcribe) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.add("language", r.Language)
+	b.add("direction", string(r.Direction))
+	b.add("reference_type", string(r.ReferenceType))
+	b.addUUID("reference_id", r.ReferenceID)
+	b.add("provider", string(r.Provider))
+	header := b.String()
+
+	// page_size+1 to detect that more rows exist beyond the rendered page.
+	transcripts, err := h.reqHandler.TranscribeV1TranscriptList(ctx, "", resourceListPageSize+1, map[tmtranscript.Field]any{
+		tmtranscript.FieldTranscribeID: r.ID,
+		tmtranscript.FieldDeleted:      false,
+	})
+	if err != nil {
+		logrus.WithField("func", "renderTranscribe").Errorf("Could not list transcripts. transcribe_id: %s, err: %v", r.ID, err)
+		return capSummaryRunes(header + "\n(transcripts unavailable)")
+	}
+
+	pagedOut := len(transcripts) > resourceListPageSize
+	if pagedOut {
+		transcripts = transcripts[:resourceListPageSize]
+	}
+	if len(transcripts) == 0 {
+		return capSummaryRunes(header + "\n(no transcripts)")
+	}
+
+	// The dbhandler returns tm_create DESC (most recent first); reverse to
+	// chronological order for rendering.
+	lines := make([]string, 0, len(transcripts))
+	for i := len(transcripts) - 1; i >= 0; i-- {
+		lines = append(lines, renderTranscriptLine(&transcripts[i]))
+	}
+
+	return renderBodyLines(header, lines, pagedOut, "transcripts")
+}
+
+// renderTranscriptLine renders one transcript as "[in 00:00:03] hello".
+// TMTranscript encodes an offset from the zero time (0001-01-01 00:00:00 =
+// transcribe start).
+func renderTranscriptLine(t *tmtranscript.Transcript) string {
+	offset := "--:--:--"
+	if t.TMTranscript != nil && !t.TMTranscript.IsZero() {
+		d := t.TMTranscript.UTC().Sub(time.Time{})
+		offset = fmt.Sprintf("%02d:%02d:%02d", int(d.Hours()), int(d.Minutes())%60, int(d.Seconds())%60)
+	}
+	return fmt.Sprintf("[%s %s] %s", t.Direction, offset, t.Message)
+}
+
+func fetchResourceSummary(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.AIV1SummaryGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			b := &summaryBuilder{}
+			b.add("status", string(r.Status))
+			b.add("language", r.Language)
+			b.add("reference_type", string(r.ReferenceType))
+			b.addUUID("reference_id", r.ReferenceID)
+			b.add("content", r.Content)
+			return capSummaryRunes(b.String())
+		},
+	}, nil
+}
+
+func fetchResourceAIcall(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.AIV1AIcallGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return h.renderAIcall(ctx, r)
+		},
+	}, nil
+}
+
+// renderAIcall renders the aicall metadata followed by the curated
+// conversation history. It runs only after ownership has been validated; the
+// message fetch never happens for a foreign aicall.
+func (h *aicallHandler) renderAIcall(ctx context.Context, r *aicall.AIcall) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.add("reference_type", string(r.ReferenceType))
+	b.addUUID("reference_id", r.ReferenceID)
+	b.add("engine_model", string(r.AIEngineModel))
+	b.add("tts_type", string(r.AITTSType))
+	b.add("stt_type", string(r.AISTTType))
+	b.addTime("created", r.TMCreate)
+	b.addTime("ended", r.TMEnd)
+	header := b.String()
+
+	// page_size+1 to detect that more rows exist beyond the rendered page.
+	messages, err := h.messageHandler.List(ctx, resourceListPageSize+1, "", map[message.Field]any{
+		message.FieldAIcallID: r.ID,
+		message.FieldDeleted:  false,
+	})
+	if err != nil {
+		logrus.WithField("func", "renderAIcall").Errorf("Could not list aicall messages. aicall_id: %s, err: %v", r.ID, err)
+		return capSummaryRunes(header + "\n(messages unavailable)")
+	}
+
+	pagedOut := len(messages) > resourceListPageSize
+	if pagedOut {
+		messages = messages[:resourceListPageSize]
+	}
+
+	// The dbhandler returns tm_create DESC (most recent first); reverse to
+	// chronological order, then render via the role allowlist.
+	lines := make([]string, 0, len(messages))
+	for i := len(messages) - 1; i >= 0; i-- {
+		lines = append(lines, renderAIcallMessageLines(messages[i])...)
+	}
+	if len(lines) == 0 {
+		return capSummaryRunes(header + "\n(no messages)")
+	}
+
+	return renderBodyLines(header, lines, pagedOut, "messages")
+}
+
+// renderAIcallMessageLines renders one message into zero or more lines via an
+// ALLOWLIST with explicit precedence. Code fact: ToolHandle persists assistant
+// tool-call rows with Content == "", so the ToolCalls check must run before
+// the empty-content drop. Everything not explicitly allowed (system prompt
+// snapshots, notification, tool, function, empty role, empty content without
+// tool calls) is dropped. The Direction field is deliberately unused; role
+// labels carry the speaker.
+func renderAIcallMessageLines(m *message.Message) []string {
+	if m == nil {
+		return nil
+	}
+
+	switch m.Role {
+	case message.RoleAssistant:
+		var lines []string
+		if m.Content != "" {
+			lines = append(lines, fmt.Sprintf("[assistant] %s", m.Content))
+		}
+		for _, tcall := range m.ToolCalls {
+			lines = append(lines, fmt.Sprintf("[assistant called %s]", tcall.Function.Name))
+		}
+		return lines
+
+	case message.RoleUser:
+		if m.Content == "" {
+			return nil
+		}
+		return []string{fmt.Sprintf("[user] %s", m.Content)}
+
+	default:
+		return nil
+	}
+}
+
+func fetchResourceConferencecall(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.ConferenceV1ConferencecallGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return renderConferencecall(r)
+		},
+	}, nil
+}
+
+func renderConferencecall(r *cfconferencecall.Conferencecall) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.addUUID("conference_id", r.ConferenceID)
+	b.add("reference_type", string(r.ReferenceType))
+	b.addUUID("reference_id", r.ReferenceID)
+	b.addTime("created", r.TMCreate)
+	b.addTime("updated", r.TMUpdate)
+	return capSummaryRunes(b.String())
+}
+
+func fetchResourceQueuecall(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+	r, err := h.reqHandler.QueueV1QueuecallGet(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return &resourceFetchResult{
+		ownerID: r.CustomerID,
+		render: func(ctx context.Context) string {
+			return renderQueuecall(r)
+		},
+	}, nil
+}
+
+func renderQueuecall(r *qmqueuecall.Queuecall) string {
+	b := &summaryBuilder{}
+	b.add("status", string(r.Status))
+	b.addUUID("queue_id", r.QueueID)
+	b.add("routing_method", string(r.RoutingMethod))
+	if r.DurationWaiting > 0 {
+		b.add("duration_waiting_ms", fmt.Sprintf("%d", r.DurationWaiting))
+	}
+	if r.DurationService > 0 {
+		b.add("duration_service_ms", fmt.Sprintf("%d", r.DurationService))
+	}
+	b.addUUID("service_agent_id", r.ServiceAgentID)
+	b.addTime("created", r.TMCreate)
+	b.addTime("serviced", r.TMService)
+	b.addTime("ended", r.TMEnd)
+	return capSummaryRunes(b.String())
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_resource.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_resource.go
@@ -179,6 +179,11 @@ func (h *aicallHandler) resolveResource(ctx context.Context, callerCustomerID uu
 		// Transient: honest failure, no masking.
 		return "", errors.Wrap(err, "could not fetch resource")
 	}
+	if r == nil {
+		// Broken fetcher contract (nil result, nil error). Fail closed.
+		log.Warnf("Fetcher returned nil result without error; failing closed.")
+		return "", ErrResourceNotAccessible
+	}
 
 	if r.ownerID != callerCustomerID || r.ownerID == uuid.Nil {
 		// ownerID == uuid.Nil is treated as not-accessible (fail closed): a
@@ -244,13 +249,33 @@ func capSummaryRunes(s string) string {
 // lines and drops the oldest; the marker is placed at the top of the block
 // (where the omitted earlier lines were). pagedOut indicates the source list
 // had more rows than the fetched page (page cap), which also forces the
-// marker. noun is "transcripts" or "messages".
+// marker. noun is "transcripts" or "messages". The final return is passed
+// through capSummaryRunes as a hard safety net so no path can exceed the cap.
 func renderBodyLines(header string, lines []string, pagedOut bool, noun string) string {
-	budget := maxResourceSummaryRunes - len([]rune(header)) - 1 // newline joining header/body
+	sep := "\n"
+	if header == "" {
+		sep = ""
+	}
+
+	// Fast path: everything fits and nothing was paged out — no marker.
+	if !pagedOut {
+		full := header + sep + strings.Join(lines, "\n")
+		if len([]rune(full)) <= maxResourceSummaryRunes {
+			return full
+		}
+	}
+
+	budget := maxResourceSummaryRunes - len([]rune(header)) - len([]rune(sep))
 
 	// Walk backwards keeping the newest lines that fit, reserving marker room.
+	// Reserve for the LONGER (degenerate) marker variant so neither variant
+	// can push past the cap.
 	marker := fmt.Sprintf("...(earlier %s omitted; showing the most recent %%d)", noun)
+	degenerateMarker := fmt.Sprintf("...(earlier %s omitted; showing the most recent 1, truncated)", noun)
 	markerRoom := len([]rune(fmt.Sprintf(marker, len(lines)))) + 1
+	if dr := len([]rune(degenerateMarker)) + 1; dr > markerRoom {
+		markerRoom = dr
+	}
 
 	kept := make([]string, 0, len(lines))
 	used := 0
@@ -276,18 +301,17 @@ func renderBodyLines(header string, lines []string, pagedOut bool, noun string) 
 		if len(newest) > room {
 			newest = newest[:room]
 		}
-		degenerate := fmt.Sprintf("...(earlier %s omitted; showing the most recent 1, truncated)", noun)
-		return header + "\n" + degenerate + "\n" + string(newest)
+		return capSummaryRunes(header + sep + degenerateMarker + "\n" + string(newest))
 	}
 
 	var sb strings.Builder
 	sb.WriteString(header)
-	sb.WriteString("\n")
+	sb.WriteString(sep)
 	if truncated {
 		fmt.Fprintf(&sb, marker+"\n", len(kept))
 	}
 	sb.WriteString(strings.Join(kept, "\n"))
-	return sb.String()
+	return capSummaryRunes(sb.String())
 }
 
 // ---- per-type fetchers ----
@@ -517,6 +541,12 @@ func (h *aicallHandler) renderAIcall(ctx context.Context, r *aicall.AIcall) stri
 		lines = append(lines, renderAIcallMessageLines(messages[i])...)
 	}
 	if len(lines) == 0 {
+		if pagedOut {
+			// The newest page rendered nothing (all allowlist-dropped) but
+			// older rows exist beyond the page — say so instead of a
+			// misleading "(no messages)".
+			return capSummaryRunes(header + "\n(earlier messages exist beyond the fetched page)")
+		}
 		return capSummaryRunes(header + "\n(no messages)")
 	}
 

--- a/bin-ai-manager/pkg/aicallhandler/tool_resource_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_resource_test.go
@@ -1,0 +1,591 @@
+package aicallhandler
+
+import (
+	"context"
+	stderrors "errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/messagehandler"
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	cmcall "monorepo/bin-call-manager/models/call"
+	cmgroupcall "monorepo/bin-call-manager/models/groupcall"
+	cmrecording "monorepo/bin-call-manager/models/recording"
+	cfconferencecall "monorepo/bin-conference-manager/models/conferencecall"
+	qmqueuecall "monorepo/bin-queue-manager/models/queuecall"
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
+
+	amsummary "monorepo/bin-ai-manager/models/summary"
+)
+
+const (
+	trCustomerID = "22222222-0000-4000-8000-000000000001"
+	trForeignID  = "22222222-0000-4000-8000-000000000002"
+	trResourceID = "44444444-0000-4000-8000-000000000001"
+)
+
+func trNewAicall() *aicall.AIcall {
+	return &aicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("11111111-0000-4000-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil(trCustomerID),
+		},
+	}
+}
+
+func trNewTool(args string) *message.ToolCall {
+	return &message.ToolCall{
+		ID:   "tool-1",
+		Type: message.ToolTypeFunction,
+		Function: message.FunctionCall{
+			Name:      message.FunctionCallNameGetResource,
+			Arguments: args,
+		},
+	}
+}
+
+func trTime(s string) *time.Time {
+	t, _ := time.Parse(time.RFC3339, s)
+	return &t
+}
+
+func trIdentity(customerID string) commonidentity.Identity {
+	return commonidentity.Identity{
+		ID:         uuid.FromStringOrNil(trResourceID),
+		CustomerID: uuid.FromStringOrNil(customerID),
+	}
+}
+
+func summaryModelForeign() *amsummary.Summary {
+	return &amsummary.Summary{
+		Identity: trIdentity(trForeignID),
+		Status:   amsummary.StatusDone,
+		Content:  "foreign content",
+	}
+}
+
+func summaryModelOwnWithContent(content string) *amsummary.Summary {
+	return &amsummary.Summary{
+		Identity: trIdentity(trCustomerID),
+		Status:   amsummary.StatusDone,
+		Content:  content,
+	}
+}
+
+// Test_toolHandleGetResource_success exercises the success path per resource
+// type and asserts curated output: customer-meaningful fields present,
+// internal fields absent.
+func Test_toolHandleGetResource_success(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+
+		mockSetup func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler)
+
+		expectContains    []string
+		expectNotContains []string
+	}{
+		{
+			name: "call",
+			args: `{"resource_type": "call", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().CallV1CallGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&cmcall.Call{
+					Identity:     trIdentity(trCustomerID),
+					ChannelID:    "internal-channel-id",
+					BridgeID:     "internal-bridge-id",
+					Status:       cmcall.StatusHangup,
+					Direction:    cmcall.DirectionOutgoing,
+					Source:       commonaddress.Address{Target: "+821000000001"},
+					Destination:  commonaddress.Address{Target: "+821000000002"},
+					HangupBy:     cmcall.HangupByRemote,
+					HangupReason: cmcall.HangupReasonNormal,
+					TMCreate:     trTime("2026-06-11T01:00:00Z"),
+					TMHangup:     trTime("2026-06-11T01:05:00Z"),
+				}, nil)
+			},
+			expectContains:    []string{"status: hangup", "direction: outgoing", "source: +821000000001", "destination: +821000000002", "hangup_by: remote"},
+			expectNotContains: []string{"internal-channel-id", "internal-bridge-id"},
+		},
+		{
+			name: "groupcall",
+			args: `{"resource_type": "groupcall", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().CallV1GroupcallGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&cmgroupcall.Groupcall{
+					Identity:     trIdentity(trCustomerID),
+					Status:       cmgroupcall.StatusProgressing,
+					RingMethod:   cmgroupcall.RingMethodRingAll,
+					Source:       &commonaddress.Address{Target: "+821****0001"},
+					Destinations: []commonaddress.Address{{Target: "+821000000002"}, {Target: "+821000000003"}},
+					CallIDs:      []uuid.UUID{uuid.FromStringOrNil("55555555-0000-4000-8000-000000000001")},
+				}, nil)
+			},
+			expectContains: []string{"status: progressing", "ring_method: ring_all", "destinations: 2", "55555555-0000-4000-8000-000000000001"},
+		},
+		{
+			name: "recording",
+			args: `{"resource_type": "recording", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().CallV1RecordingGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&cmrecording.Recording{
+					Identity:      trIdentity(trCustomerID),
+					Status:        cmrecording.StatusEnded,
+					Format:        cmrecording.FormatWAV,
+					RecordingName: "my-recording",
+					Filenames:     []string{"/internal/storage/path.wav"},
+					AsteriskID:    "internal-asterisk-id",
+					TMStart:       trTime("2026-06-11T01:00:00Z"),
+					TMEnd:         trTime("2026-06-11T01:03:00Z"),
+				}, nil)
+			},
+			expectContains:    []string{"recording_name: my-recording", "format: wav"},
+			expectNotContains: []string{"/internal/storage/path.wav", "internal-asterisk-id"},
+		},
+		{
+			name: "transcribe with transcripts",
+			args: `{"resource_type": "transcribe", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().TranscribeV1TranscribeGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&tmtranscribe.Transcribe{
+					Identity: trIdentity(trCustomerID),
+					Status:   tmtranscribe.StatusDone,
+					Language: "en-US",
+					HostID:   uuid.FromStringOrNil("66666666-0000-4000-8000-000000000001"),
+				}, nil)
+				// dbhandler order: tm_create DESC (most recent first)
+				offset1 := time.Time{}.Add(3 * time.Second)
+				offset2 := time.Time{}.Add(8 * time.Second)
+				mockReq.EXPECT().TranscribeV1TranscriptList(gomock.Any(), "", uint64(resourceListPageSize+1), map[tmtranscript.Field]any{
+					tmtranscript.FieldTranscribeID: uuid.FromStringOrNil(trResourceID),
+					tmtranscript.FieldDeleted:      false,
+				}).Return([]tmtranscript.Transcript{
+					{Direction: tmtranscript.DirectionOut, Message: "how can I help", TMTranscript: &offset2},
+					{Direction: tmtranscript.DirectionIn, Message: "hello there", TMTranscript: &offset1},
+				}, nil)
+			},
+			// chronological order after reversal: in line precedes out line
+			expectContains:    []string{"status: done", "language: en-US", "[in 00:00:03] hello there", "[out 00:00:08] how can I help"},
+			expectNotContains: []string{"66666666-0000-4000-8000-000000000001"},
+		},
+		{
+			name: "aicall with conversation history",
+			args: `{"resource_type": "aicall", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&aicall.AIcall{
+					Identity:      trIdentity(trCustomerID),
+					Status:        aicall.StatusTerminated,
+					ReferenceType: aicall.ReferenceTypeCall,
+				}, nil)
+				// dbhandler order: tm_create DESC (most recent first)
+				mockMsg.EXPECT().List(gomock.Any(), uint64(resourceListPageSize+1), "", map[message.Field]any{
+					message.FieldAIcallID: uuid.FromStringOrNil(trResourceID),
+					message.FieldDeleted:  false,
+				}).Return([]*message.Message{
+					{Role: message.RoleAssistant, Content: "goodbye"},
+					{Role: message.RoleAssistant, Content: "", ToolCalls: []message.ToolCall{{Function: message.FunctionCall{Name: message.FunctionCallNameSendEmail}}}},
+					{Role: message.RoleTool, Content: `{"tool_call_id": "x", "result": "success"}`},
+					{Role: message.RoleUser, Content: "send me the report"},
+					{Role: message.RoleSystem, Content: "SECRET PROMPT SNAPSHOT"},
+				}, nil)
+			},
+			expectContains: []string{
+				"status: terminated",
+				"[user] send me the report",
+				"[assistant called send_email]",
+				"[assistant] goodbye",
+			},
+			expectNotContains: []string{"SECRET PROMPT SNAPSHOT", "tool_call_id"},
+		},
+		{
+			name: "conferencecall",
+			args: `{"resource_type": "conferencecall", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().ConferenceV1ConferencecallGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&cfconferencecall.Conferencecall{
+					Identity:     trIdentity(trCustomerID),
+					Status:       cfconferencecall.StatusJoined,
+					ConferenceID: uuid.FromStringOrNil("77777777-0000-4000-8000-000000000001"),
+				}, nil)
+			},
+			expectContains: []string{"status: joined", "conference_id: 77777777-0000-4000-8000-000000000001"},
+		},
+		{
+			name: "queuecall with nil timestamps omitted",
+			args: `{"resource_type": "queuecall", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				mockReq.EXPECT().QueueV1QueuecallGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(&qmqueuecall.Queuecall{
+					Identity:        trIdentity(trCustomerID),
+					Status:          qmqueuecall.StatusDone,
+					QueueID:         uuid.FromStringOrNil("88888888-0000-4000-8000-000000000001"),
+					DurationWaiting: 12000,
+					// TMService / TMEnd nil: must be omitted
+				}, nil)
+			},
+			expectContains:    []string{"status: done", "duration_waiting_ms: 12000"},
+			expectNotContains: []string{"serviced:", "ended:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockMsg := messagehandler.NewMockMessageHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq, messageHandler: mockMsg}
+
+			tt.mockSetup(mockReq, mockMsg)
+
+			res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(tt.args))
+
+			if res.Result != "success" {
+				t.Fatalf("expected success, got %s (message: %s)", res.Result, res.Message)
+			}
+			for _, want := range tt.expectContains {
+				if !strings.Contains(res.Message, want) {
+					t.Errorf("expected summary to contain %q. got:\n%s", want, res.Message)
+				}
+			}
+			for _, ban := range tt.expectNotContains {
+				if strings.Contains(res.Message, ban) {
+					t.Errorf("summary must NOT contain %q. got:\n%s", ban, res.Message)
+				}
+			}
+		})
+	}
+}
+
+// Test_toolHandleGetResource_maskingInvariant locks the existence-oracle
+// property per resource type: absent and cross-customer produce
+// byte-identical messageContent for the same fixed inputs.
+func Test_toolHandleGetResource_maskingInvariant(t *testing.T) {
+	rid := uuid.FromStringOrNil(trResourceID)
+
+	// per-type EXPECT setups: absent (ErrNotFound) and foreign owner
+	types := []struct {
+		resourceType string
+		setupAbsent  func(mockReq *requesthandler.MockRequestHandler)
+		setupForeign func(mockReq *requesthandler.MockRequestHandler)
+	}{
+		{
+			"call",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().CallV1CallGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().CallV1CallGet(gomock.Any(), rid).Return(&cmcall.Call{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+		{
+			"groupcall",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().CallV1GroupcallGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().CallV1GroupcallGet(gomock.Any(), rid).Return(&cmgroupcall.Groupcall{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+		{
+			"recording",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().CallV1RecordingGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().CallV1RecordingGet(gomock.Any(), rid).Return(&cmrecording.Recording{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+		{
+			"transcribe",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().TranscribeV1TranscribeGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				// NOTE: no TranscribeV1TranscriptList EXPECT — strict gomock
+				// fails the test if the enrichment fetch runs for a foreign
+				// transcribe (post-ownership contract).
+				m.EXPECT().TranscribeV1TranscribeGet(gomock.Any(), rid).Return(&tmtranscribe.Transcribe{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+		{
+			"summary",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().AIV1SummaryGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().AIV1SummaryGet(gomock.Any(), rid).Return(summaryModelForeign(), nil)
+			},
+		},
+		{
+			"aicall",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().AIV1AIcallGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				// NOTE: no messageHandler.List EXPECT — strict gomock fails
+				// if the message fetch runs for a foreign aicall.
+				m.EXPECT().AIV1AIcallGet(gomock.Any(), rid).Return(&aicall.AIcall{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+		{
+			"conferencecall",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().ConferenceV1ConferencecallGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().ConferenceV1ConferencecallGet(gomock.Any(), rid).Return(&cfconferencecall.Conferencecall{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+		{
+			"queuecall",
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().QueueV1QueuecallGet(gomock.Any(), rid).Return(nil, requesthandler.ErrNotFound)
+			},
+			func(m *requesthandler.MockRequestHandler) {
+				m.EXPECT().QueueV1QueuecallGet(gomock.Any(), rid).Return(&qmqueuecall.Queuecall{Identity: trIdentity(trForeignID)}, nil)
+			},
+		},
+	}
+
+	for _, tc := range types {
+		t.Run(tc.resourceType, func(t *testing.T) {
+			args := `{"resource_type": "` + tc.resourceType + `", "resource_id": "` + trResourceID + `"}`
+
+			run := func(setup func(*requesthandler.MockRequestHandler)) *messageContent {
+				mc := gomock.NewController(t)
+				defer mc.Finish()
+				mockReq := requesthandler.NewMockRequestHandler(mc)
+				mockMsg := messagehandler.NewMockMessageHandler(mc)
+				h := &aicallHandler{reqHandler: mockReq, messageHandler: mockMsg}
+				setup(mockReq)
+				return h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(args))
+			}
+
+			resAbsent := run(tc.setupAbsent)
+			resForeign := run(tc.setupForeign)
+
+			// Both must be the masked success response.
+			if resAbsent.Result != "success" || resAbsent.Message != msgResourceNotFound {
+				t.Fatalf("absent path not masked: %+v", resAbsent)
+			}
+			// Byte-identical: same fixed tc.ID + resource_type + resource_id.
+			if !messageContentEqual(resAbsent, resForeign) {
+				t.Errorf("masking invariant violated.\nabsent:  %+v\nforeign: %+v", resAbsent, resForeign)
+			}
+			// IDOR fall-through guard: no summary fragment in the foreign response.
+			if strings.Contains(resForeign.Message, "status:") {
+				t.Errorf("foreign response leaked a summary fragment: %s", resForeign.Message)
+			}
+		})
+	}
+}
+
+func messageContentEqual(a, b *messageContent) bool {
+	return a.ToolCallID == b.ToolCallID &&
+		a.Result == b.Result &&
+		a.Message == b.Message &&
+		a.ResourceType == b.ResourceType &&
+		a.ResourceID == b.ResourceID
+}
+
+// Test_toolHandleGetResource_errors covers transient failure, argument
+// validation, and graceful enrichment degradation.
+func Test_toolHandleGetResource_errors(t *testing.T) {
+	rid := uuid.FromStringOrNil(trResourceID)
+
+	t.Run("transient RPC error is honest, not masked", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		mockReq.EXPECT().CallV1CallGet(gomock.Any(), rid).Return(nil, stderrors.New("rabbitmq timeout"))
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "call", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "failed" {
+			t.Fatalf("expected failed, got %+v", res)
+		}
+		if res.Message != "resource lookup failed" {
+			t.Errorf("expected sanitized failure message, got %q", res.Message)
+		}
+	})
+
+	t.Run("unsupported resource_type", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		h := &aicallHandler{reqHandler: requesthandler.NewMockRequestHandler(mc), messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "channel", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "failed" || !strings.Contains(res.Message, "unsupported resource_type") || !strings.Contains(res.Message, "transcribe") {
+			t.Errorf("expected unsupported-type failure listing supported set, got %+v", res)
+		}
+	})
+
+	t.Run("empty resource_type", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		h := &aicallHandler{reqHandler: requesthandler.NewMockRequestHandler(mc), messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_id": "`+trResourceID+`"}`))
+		if res.Result != "failed" || !strings.Contains(res.Message, "resource_type is required") {
+			t.Errorf("expected resource_type-required failure, got %+v", res)
+		}
+	})
+
+	t.Run("invalid resource_id", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		h := &aicallHandler{reqHandler: requesthandler.NewMockRequestHandler(mc), messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "call", "resource_id": "not-a-uuid"}`))
+		if res.Result != "failed" || res.Message != "invalid resource_id" {
+			t.Errorf("expected invalid resource_id failure, got %+v", res)
+		}
+	})
+
+	t.Run("malformed JSON args", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		h := &aicallHandler{reqHandler: requesthandler.NewMockRequestHandler(mc), messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{not json`))
+		if res.Result != "failed" || !strings.Contains(res.Message, "invalid arguments") {
+			t.Errorf("expected invalid-arguments failure, got %+v", res)
+		}
+	})
+
+	t.Run("transcript list failure degrades gracefully", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		mockReq.EXPECT().TranscribeV1TranscribeGet(gomock.Any(), rid).Return(&tmtranscribe.Transcribe{
+			Identity: trIdentity(trCustomerID),
+			Status:   tmtranscribe.StatusDone,
+		}, nil)
+		mockReq.EXPECT().TranscribeV1TranscriptList(gomock.Any(), "", uint64(resourceListPageSize+1), gomock.Any()).Return(nil, stderrors.New("boom"))
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "transcribe", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" || !strings.Contains(res.Message, "(transcripts unavailable)") {
+			t.Errorf("expected graceful degradation, got %+v", res)
+		}
+	})
+
+	t.Run("aicall message list failure degrades gracefully", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		mockMsg := messagehandler.NewMockMessageHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: mockMsg}
+
+		mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), rid).Return(&aicall.AIcall{Identity: trIdentity(trCustomerID), Status: aicall.StatusTerminated}, nil)
+		mockMsg.EXPECT().List(gomock.Any(), gomock.Any(), "", gomock.Any()).Return(nil, stderrors.New("db down"))
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "aicall", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" || !strings.Contains(res.Message, "(messages unavailable)") {
+			t.Errorf("expected graceful degradation, got %+v", res)
+		}
+	})
+
+	t.Run("empty transcript list renders no transcripts", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		mockReq.EXPECT().TranscribeV1TranscribeGet(gomock.Any(), rid).Return(&tmtranscribe.Transcribe{Identity: trIdentity(trCustomerID)}, nil)
+		mockReq.EXPECT().TranscribeV1TranscriptList(gomock.Any(), "", uint64(resourceListPageSize+1), gomock.Any()).Return([]tmtranscript.Transcript{}, nil)
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "transcribe", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" || !strings.Contains(res.Message, "(no transcripts)") {
+			t.Errorf("expected (no transcripts), got %+v", res)
+		}
+	})
+
+	t.Run("nil owner customer id fails closed", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		// resource with unset customer_id; caller also crafted to Nil must NOT match
+		mockReq.EXPECT().CallV1CallGet(gomock.Any(), rid).Return(&cmcall.Call{}, nil)
+
+		caller := trNewAicall()
+		caller.CustomerID = uuid.Nil
+		res := h.toolHandleGetResource(context.Background(), caller, trNewTool(`{"resource_type": "call", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" || res.Message != msgResourceNotFound {
+			t.Errorf("expected masked fail-closed response, got %+v", res)
+		}
+	})
+}
+
+// Test_toolHandleGetResource_truncation locks the cap mechanics: most recent
+// lines kept, marker at the top of the block.
+func Test_toolHandleGetResource_truncation(t *testing.T) {
+	rid := uuid.FromStringOrNil(trResourceID)
+
+	t.Run("long summary content is hard-truncated with marker", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+		long := strings.Repeat("x", maxResourceSummaryRunes+500)
+		mockReq.EXPECT().AIV1SummaryGet(gomock.Any(), rid).Return(summaryModelOwnWithContent(long), nil)
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "summary", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" {
+			t.Fatalf("expected success, got %+v", res)
+		}
+		if got := len([]rune(res.Message)); got > maxResourceSummaryRunes {
+			t.Errorf("message exceeds cap: %d > %d", got, maxResourceSummaryRunes)
+		}
+		if !strings.Contains(res.Message, "...(truncated)") {
+			t.Errorf("expected truncation marker, got tail: %s", res.Message[len(res.Message)-40:])
+		}
+	})
+
+	t.Run("aicall message page cap keeps most recent with marker", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		mockMsg := messagehandler.NewMockMessageHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: mockMsg}
+
+		mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), rid).Return(&aicall.AIcall{Identity: trIdentity(trCustomerID)}, nil)
+
+		// 101 rows returned (DESC: index 0 is the newest) → page cap fires.
+		msgs := make([]*message.Message, resourceListPageSize+1)
+		for i := range msgs {
+			msgs[i] = &message.Message{Role: message.RoleUser, Content: "m" + string(rune('A'+i%26))}
+		}
+		msgs[0].Content = "NEWEST"
+		msgs[len(msgs)-1].Content = "OLDEST"
+		mockMsg.EXPECT().List(gomock.Any(), uint64(resourceListPageSize+1), "", gomock.Any()).Return(msgs, nil)
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "aicall", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" {
+			t.Fatalf("expected success, got %+v", res)
+		}
+		if !strings.Contains(res.Message, "earlier messages omitted; showing the most recent") {
+			t.Errorf("expected page-cap marker, got:\n%s", res.Message)
+		}
+		if !strings.Contains(res.Message, "NEWEST") {
+			t.Errorf("newest message must be kept")
+		}
+		if strings.Contains(res.Message, "OLDEST") {
+			t.Errorf("oldest (101st) message must be dropped by the page cap")
+		}
+		// marker must precede the kept lines (top of block)
+		if strings.Index(res.Message, "omitted") > strings.Index(res.Message, "NEWEST") {
+			t.Errorf("marker must be at the top of the block")
+		}
+	})
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_resource_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_resource_test.go
@@ -694,3 +694,62 @@ func Test_toolHandleGetResource_transcribePageCap(t *testing.T) {
 		t.Errorf("page cap must keep newest and drop the 101st oldest")
 	}
 }
+
+// Test_resolveResource_nilResultFailsClosed locks the broken-fetcher-contract
+// guard: a fetcher returning (nil, nil) must mask, not panic (round-2 L1).
+func Test_resolveResource_nilResultFailsClosed(t *testing.T) {
+	h := &aicallHandler{}
+	stub := func(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error) {
+		return nil, nil
+	}
+	_, err := h.resolveResource(context.Background(), uuid.FromStringOrNil(trCustomerID), stub, uuid.FromStringOrNil(trResourceID))
+	if !stderrors.Is(err, ErrResourceNotAccessible) {
+		t.Errorf("expected ErrResourceNotAccessible for nil fetch result, got %v", err)
+	}
+}
+
+// Test_renderAIcall_emptyRenders locks the empty-render branches: genuine
+// "(no messages)" vs pagedOut-but-all-dropped disclosure (round-2 L2).
+func Test_renderAIcall_emptyRenders(t *testing.T) {
+	rid := uuid.FromStringOrNil(trResourceID)
+
+	t.Run("no messages at all", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		mockMsg := messagehandler.NewMockMessageHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: mockMsg}
+
+		mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), rid).Return(&aicall.AIcall{Identity: trIdentity(trCustomerID)}, nil)
+		mockMsg.EXPECT().List(gomock.Any(), gomock.Any(), "", gomock.Any()).Return([]*message.Message{}, nil)
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "aicall", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" || !strings.Contains(res.Message, "(no messages)") {
+			t.Errorf("expected (no messages), got %+v", res)
+		}
+	})
+
+	t.Run("paged out but newest page all allowlist-dropped", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		mockMsg := messagehandler.NewMockMessageHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq, messageHandler: mockMsg}
+
+		mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), rid).Return(&aicall.AIcall{Identity: trIdentity(trCustomerID)}, nil)
+		// 101 rows, all tool-role → every line dropped, pagedOut true.
+		msgs := make([]*message.Message, resourceListPageSize+1)
+		for i := range msgs {
+			msgs[i] = &message.Message{Role: message.RoleTool, Content: "tool body"}
+		}
+		mockMsg.EXPECT().List(gomock.Any(), gomock.Any(), "", gomock.Any()).Return(msgs, nil)
+
+		res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "aicall", "resource_id": "`+trResourceID+`"}`))
+		if res.Result != "success" || !strings.Contains(res.Message, "(earlier messages exist beyond the fetched page)") {
+			t.Errorf("expected paged-out disclosure, got %+v", res)
+		}
+		if strings.Contains(res.Message, "(no messages)") {
+			t.Errorf("must not claim (no messages) when older rows exist")
+		}
+	})
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_resource_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_resource_test.go
@@ -3,6 +3,8 @@ package aicallhandler
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -167,11 +169,22 @@ func Test_toolHandleGetResource_success(t *testing.T) {
 				}).Return([]tmtranscript.Transcript{
 					{Direction: tmtranscript.DirectionOut, Message: "how can I help", TMTranscript: &offset2},
 					{Direction: tmtranscript.DirectionIn, Message: "hello there", TMTranscript: &offset1},
+					{Direction: tmtranscript.DirectionIn, Message: "very first words", TMTranscript: nil},
 				}, nil)
 			},
-			// chronological order after reversal: in line precedes out line
-			expectContains:    []string{"status: done", "language: en-US", "[in 00:00:03] hello there", "[out 00:00:08] how can I help"},
+			// chronological order after reversal; nil TMTranscript renders --:--:--
+			expectContains:    []string{"status: done", "language: en-US", "[in --:--:--] very first words", "[in 00:00:03] hello there", "[out 00:00:08] how can I help"},
 			expectNotContains: []string{"66666666-0000-4000-8000-000000000001"},
+		},
+		{
+			name: "summary",
+			args: `{"resource_type": "summary", "resource_id": "` + trResourceID + `"}`,
+			mockSetup: func(mockReq *requesthandler.MockRequestHandler, mockMsg *messagehandler.MockMessageHandler) {
+				s := summaryModelOwnWithContent("the caller asked about billing")
+				s.Language = "en-US"
+				mockReq.EXPECT().AIV1SummaryGet(gomock.Any(), uuid.FromStringOrNil(trResourceID)).Return(s, nil)
+			},
+			expectContains: []string{"status: done", "language: en-US", "content: the caller asked about billing"},
 		},
 		{
 			name: "aicall with conversation history",
@@ -188,8 +201,12 @@ func Test_toolHandleGetResource_success(t *testing.T) {
 					message.FieldDeleted:  false,
 				}).Return([]*message.Message{
 					{Role: message.RoleAssistant, Content: "goodbye"},
+					{Role: message.RoleAssistant, Content: "sending it now", ToolCalls: []message.ToolCall{{Function: message.FunctionCall{Name: message.FunctionCallNameSendMessage}}}},
 					{Role: message.RoleAssistant, Content: "", ToolCalls: []message.ToolCall{{Function: message.FunctionCall{Name: message.FunctionCallNameSendEmail}}}},
 					{Role: message.RoleTool, Content: `{"tool_call_id": "x", "result": "success"}`},
+					{Role: message.RoleNotification, Content: "internal notification body"},
+					{Role: message.RoleFunction, Content: "function role body"},
+					{Role: message.RoleNone, Content: "empty role body"},
 					{Role: message.RoleUser, Content: "send me the report"},
 					{Role: message.RoleSystem, Content: "SECRET PROMPT SNAPSHOT"},
 				}, nil)
@@ -198,9 +215,11 @@ func Test_toolHandleGetResource_success(t *testing.T) {
 				"status: terminated",
 				"[user] send me the report",
 				"[assistant called send_email]",
+				"[assistant] sending it now",
+				"[assistant called send_message]",
 				"[assistant] goodbye",
 			},
-			expectNotContains: []string{"SECRET PROMPT SNAPSHOT", "tool_call_id"},
+			expectNotContains: []string{"SECRET PROMPT SNAPSHOT", "tool_call_id", "internal notification body", "function role body", "empty role body"},
 		},
 		{
 			name: "conferencecall",
@@ -386,11 +405,7 @@ func Test_toolHandleGetResource_maskingInvariant(t *testing.T) {
 }
 
 func messageContentEqual(a, b *messageContent) bool {
-	return a.ToolCallID == b.ToolCallID &&
-		a.Result == b.Result &&
-		a.Message == b.Message &&
-		a.ResourceType == b.ResourceType &&
-		a.ResourceID == b.ResourceID
+	return reflect.DeepEqual(a, b)
 }
 
 // Test_toolHandleGetResource_errors covers transient failure, argument
@@ -588,4 +603,94 @@ func Test_toolHandleGetResource_truncation(t *testing.T) {
 			t.Errorf("marker must be at the top of the block")
 		}
 	})
+}
+
+// Test_renderBodyLines_capMechanics locks the rune-budget truncation
+// arithmetic directly: most-recent-kept line dropping, top-of-block marker,
+// the degenerate single-line hard-cut, and the absolute cap guarantee.
+func Test_renderBodyLines_capMechanics(t *testing.T) {
+	t.Run("rune budget drops oldest lines, marker at top", func(t *testing.T) {
+		header := "status: done"
+		// 200 lines x ~30 runes ≈ 6000 runes > 4000 cap
+		lines := make([]string, 200)
+		for i := range lines {
+			lines[i] = strings.Repeat("x", 25) + "L" + fmt.Sprintf("%03d", i)
+		}
+		out := renderBodyLines(header, lines, false, "messages")
+
+		if got := len([]rune(out)); got > maxResourceSummaryRunes {
+			t.Fatalf("output exceeds cap: %d > %d", got, maxResourceSummaryRunes)
+		}
+		if !strings.Contains(out, "earlier messages omitted; showing the most recent") {
+			t.Fatalf("expected truncation marker, got head: %.120s", out)
+		}
+		if !strings.Contains(out, "L199") {
+			t.Errorf("newest line must be kept")
+		}
+		if strings.Contains(out, "L000") {
+			t.Errorf("oldest line must be dropped")
+		}
+		if strings.Index(out, "omitted") > strings.Index(out, "L199") {
+			t.Errorf("marker must precede the kept lines")
+		}
+	})
+
+	t.Run("degenerate single oversized line is hard-cut and capped", func(t *testing.T) {
+		header := "status: done"
+		lines := []string{strings.Repeat("y", maxResourceSummaryRunes*2)}
+		out := renderBodyLines(header, lines, false, "transcripts")
+
+		if got := len([]rune(out)); got > maxResourceSummaryRunes {
+			t.Fatalf("degenerate output exceeds cap: %d > %d", got, maxResourceSummaryRunes)
+		}
+		if !strings.Contains(out, "showing the most recent 1, truncated") {
+			t.Errorf("expected degenerate marker, got head: %.150s", out)
+		}
+		if !strings.Contains(out, "yyyy") {
+			t.Errorf("hard-cut line content must still be shown")
+		}
+	})
+
+	t.Run("everything fits, no marker", func(t *testing.T) {
+		out := renderBodyLines("h: v", []string{"[user] hi", "[assistant] hello"}, false, "messages")
+		if strings.Contains(out, "omitted") {
+			t.Errorf("no marker expected when everything fits: %s", out)
+		}
+		if out != "h: v\n[user] hi\n[assistant] hello" {
+			t.Errorf("unexpected output: %q", out)
+		}
+	})
+}
+
+// Test_toolHandleGetResource_transcribePageCap exercises the transcribe leg of
+// the page-cap detection (duplicated per type, so the aicall test does not
+// protect this copy).
+func Test_toolHandleGetResource_transcribePageCap(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &aicallHandler{reqHandler: mockReq, messageHandler: messagehandler.NewMockMessageHandler(mc)}
+
+	rid := uuid.FromStringOrNil(trResourceID)
+	mockReq.EXPECT().TranscribeV1TranscribeGet(gomock.Any(), rid).Return(&tmtranscribe.Transcribe{Identity: trIdentity(trCustomerID)}, nil)
+
+	// 101 rows (DESC: index 0 newest) → page cap fires.
+	rows := make([]tmtranscript.Transcript, resourceListPageSize+1)
+	for i := range rows {
+		rows[i] = tmtranscript.Transcript{Direction: tmtranscript.DirectionIn, Message: "t" + fmt.Sprintf("%03d", i)}
+	}
+	rows[0].Message = "NEWEST"
+	rows[len(rows)-1].Message = "OLDEST"
+	mockReq.EXPECT().TranscribeV1TranscriptList(gomock.Any(), "", uint64(resourceListPageSize+1), gomock.Any()).Return(rows, nil)
+
+	res := h.toolHandleGetResource(context.Background(), trNewAicall(), trNewTool(`{"resource_type": "transcribe", "resource_id": "`+trResourceID+`"}`))
+	if res.Result != "success" {
+		t.Fatalf("expected success, got %+v", res)
+	}
+	if !strings.Contains(res.Message, "earlier transcripts omitted; showing the most recent") {
+		t.Errorf("expected page-cap marker, got:\n%.200s", res.Message)
+	}
+	if !strings.Contains(res.Message, "NEWEST") || strings.Contains(res.Message, "OLDEST") {
+		t.Errorf("page cap must keep newest and drop the 101st oldest")
+	}
 }

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -488,7 +488,7 @@ run_llm: Always set true — you should respond to the user based on the search 
 
 An activeflow is the running instance of a flow. Its reference is not always a call; the reference type can be call, conversation, ai, api, campaign, transcribe, or recording (and may be unset). Do not assume the session is a phone call.
 
-This is an internal diagnostic tool. Use it to understand what other resources are tied to a given activeflow so you can reason about or chain follow-up lookups.
+This is an internal diagnostic tool. Use it to understand what other resources are tied to a given activeflow so you can reason about or chain follow-up lookups. Use get_resource to fetch the content of a discovered resource.
 
 WHEN TO USE:
 - You need to know what resources are linked to the current session's activeflow
@@ -517,6 +517,52 @@ run_llm: Set true so you can summarize and reason about the correlated resources
 				},
 			},
 			"required": []string{},
+		},
+	},
+	{
+		Name:   tool.ToolNameGetResource,
+		RunLLM: true,
+		Description: `Retrieves the content of a single VoIPBin resource by its id and returns a readable summary.
+
+Use this as the follow-up to get_correlation: get_correlation returns the ids and types of resources linked to an activeflow; get_resource fetches the actual content of one of them. An activeflow's reference is not always a call; do not assume the session is a phone call.
+
+Supported resource types: call, groupcall, recording, transcribe, summary, aicall, conferencecall, queuecall. Derive the type from the event names shown by get_correlation: the type is the leading part of the event name (call_created means type call, transcribe_done means type transcribe, aicall_status_progressing means type aicall). Not every type get_correlation lists is retrievable here; unsupported types return an error listing the supported set. Transcript entries are retrieved via their parent transcribe id (type transcribe), not their own id. For transcribe, the response includes the transcript messages. For aicall, the response includes the session's conversation messages.
+
+WHEN TO USE:
+- You discovered a resource id (e.g. via get_correlation) and need its details
+- A diagnostic question requires the content of a related resource (e.g. what was said in a transcribed call, why a call ended, how long a caller waited in a queue)
+
+WHEN NOT TO USE:
+- A raw, unfiltered JSON dump of an aicall's messages (use get_aicall_messages; get_resource returns a curated readable summary)
+- Runtime variables (use get_variables)
+- Knowledge-base questions (use search_knowledge)
+
+ARGUMENTS:
+- resource_type (required): one of the supported types above.
+- resource_id (required): the resource id (UUID).
+
+You can only retrieve resources owned by your own account; others return "Resource not found.". A wrong resource_type for a correct id also returns "Resource not found." — retry with the type matching the event prefix before concluding the resource is gone.
+
+run_llm: Set true so you can reason about the resource content.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to reason about the resource content.",
+					"default":     true,
+				},
+				"resource_type": map[string]any{
+					"type":        "string",
+					"enum":        []string{"aicall", "call", "conferencecall", "groupcall", "queuecall", "recording", "summary", "transcribe"},
+					"description": "The type of the resource to retrieve.",
+				},
+				"resource_id": map[string]any{
+					"type":        "string",
+					"description": "The resource id (UUID) to retrieve.",
+				},
+			},
+			"required": []string{"resource_type", "resource_id"},
 		},
 	},
 	{

--- a/bin-ai-manager/pkg/toolhandler/definitions_resource_test.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions_resource_test.go
@@ -1,0 +1,54 @@
+package toolhandler
+
+import (
+	"sort"
+	"testing"
+
+	"monorepo/bin-ai-manager/models/tool"
+	"monorepo/bin-ai-manager/pkg/aicallhandler"
+)
+
+// TestGetResourceEnumMatchesFetchers locks the get_resource JSON-schema enum
+// in definitions.go to the aicallhandler fetcher table so the two cannot
+// drift when Phase 2 adds resource types.
+func TestGetResourceEnumMatchesFetchers(t *testing.T) {
+	// find the get_resource definition
+	var def *tool.Tool
+	for i := range toolDefinitions {
+		if toolDefinitions[i].Name == tool.ToolNameGetResource {
+			def = &toolDefinitions[i]
+			break
+		}
+	}
+	if def == nil {
+		t.Fatalf("get_resource tool definition not found in definitions.go")
+	}
+
+	props, ok := def.Parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("get_resource parameters has no properties map")
+	}
+	rt, ok := props["resource_type"].(map[string]any)
+	if !ok {
+		t.Fatalf("get_resource has no resource_type property")
+	}
+	enum, ok := rt["enum"].([]string)
+	if !ok {
+		t.Fatalf("resource_type enum is not []string: %T", rt["enum"])
+	}
+
+	gotEnum := make([]string, len(enum))
+	copy(gotEnum, enum)
+	sort.Strings(gotEnum)
+
+	want := aicallhandler.SupportedResourceTypes()
+
+	if len(gotEnum) != len(want) {
+		t.Fatalf("enum length %d != fetcher table length %d. enum: %v, fetchers: %v", len(gotEnum), len(want), gotEnum, want)
+	}
+	for i := range want {
+		if gotEnum[i] != want[i] {
+			t.Errorf("enum[%d] = %s, want %s (enum: %v, fetchers: %v)", i, gotEnum[i], want[i], gotEnum, want)
+		}
+	}
+}

--- a/bin-ai-manager/pkg/toolhandler/main_test.go
+++ b/bin-ai-manager/pkg/toolhandler/main_test.go
@@ -149,6 +149,7 @@ func TestAllToolNames(t *testing.T) {
 		tool.ToolNameStopService,
 		tool.ToolNameSearchKnowledge,
 		tool.ToolNameGetCorrelation,
+		tool.ToolNameGetResource,
 	}
 
 	if len(tool.AllToolNames) != len(expectedNames) {

--- a/docs/plans/2026-06-11-add-get-resource-tool-design.md
+++ b/docs/plans/2026-06-11-add-get-resource-tool-design.md
@@ -1,0 +1,666 @@
+# get_resource LLM Tool Design
+
+- Date: 2026-06-11
+- Service: bin-ai-manager (toolhandler / aicallhandler)
+- Status: v5 (review rounds 1-3 CHANGES REQUESTED applied; round 4 APPROVE)
+
+## 1. Problem Statement
+
+The `get_correlation` tool returns the correlation graph for an activeflow: an ID
+graph of related resources grouped by publisher (`call-manager: call <uuid>`,
+`transcribe-manager: transcribe <uuid>`, ...). It deliberately stops at IDs.
+
+There is no follow-up tool to retrieve the content of those resources. The only
+read tools today are `get_aicall_messages` (own session only), `get_variables`,
+and `search_knowledge` (RAG). An LLM that discovers a transcribe id via
+`get_correlation` cannot answer "what was said in that call" because it has no
+way to fetch the transcript. The chaining mechanism (run_llm=true sequential
+tool calling) exists and works; the missing piece is the second link.
+
+Goal: add a generic read tool `get_resource(resource_type, resource_id)` that
+fetches a single VoIPBin resource by id and returns a curated, LLM-readable
+text summary of its content.
+
+## 2. Scope
+
+### In scope (Phase 1)
+
+One new LLM function tool in bin-ai-manager. Supported resource types, all of
+which already have a single-resource Get RPC in bin-common-handler
+requesthandler and embed `commonidentity.Identity` (direct `CustomerID`):
+
+| resource_type | RPC | Source model |
+|---|---|---|
+| `call` | `CallV1CallGet` | bin-call-manager/models/call |
+| `groupcall` | `CallV1GroupcallGet` | bin-call-manager/models/groupcall |
+| `recording` | `CallV1RecordingGet` | bin-call-manager/models/recording |
+| `transcribe` | `TranscribeV1TranscribeGet` + `TranscribeV1TranscriptList` | bin-transcribe-manager/models/transcribe, transcript |
+| `summary` | `AIV1SummaryGet` | bin-ai-manager/models/summary |
+| `aicall` | `AIV1AIcallGet` | bin-ai-manager/models/aicall |
+| `conferencecall` | `ConferenceV1ConferencecallGet` | bin-conference-manager/models/conferencecall |
+| `queuecall` | `QueueV1QueuecallGet` | bin-queue-manager/models/queuecall |
+
+The `resource_type` values match each resource's event-type prefix as seen in
+`get_correlation` output (`call_created` → `call`, `transcribe_done` →
+`transcribe`, `aicall_status_progressing` → `aicall`, ...). NOTE (review round
+1, code-verified): the correlation graph's per-resource `DataType` field is NOT
+the model name — `notifyhandler.PublishEvent` stamps every event envelope with
+`data_type = "application/json"`, and timeline materializes that verbatim. The
+LLM therefore derives the type from the event-type prefix (which
+`formatCorrelationSummary` prints per resource), not from `data_type`. The
+chosen enum values (`call`, `groupcall`, `recording`, `transcribe`, `summary`,
+`aicall`, `conferencecall`, `queuecall`) are exactly the event-type prefixes of
+the eight publishers, verified against each `models/<type>/event.go`. The tool
+description spells the mapping out. A follow-up note: `formatCorrelationSummary`
+currently prints `r.DataType` per line, which renders as `application/json` —
+fixed IN THIS PR (see Open Question 5 and Implementation Order step 5b).
+
+### Out of scope (Phase 2+ or never)
+
+- `conversation`, `campaigncall`, `message` (SMS), `email`: not part of the
+  correlation graph today for SMS/transfer (no activeflow_id), or lower
+  diagnostic value. Add per demand; the dispatch table makes each addition
+  ~30 lines + tests.
+- `confbridge`, `channel`, `externalmedia`: internal plumbing resources.
+  Exposing them to an LLM has no customer-facing value and widens the surface.
+- `activeflow` itself: flow internals (current action, stack) are execution
+  state, not customer data. Revisit only with a concrete use case.
+- Recording media download / playback URLs. Metadata only.
+- List/search semantics ("all calls of last week"): this tool is strictly
+  single-resource point lookup. Listing is a different feature with paging and
+  cost concerns.
+- No new RPC, no DB change, no OpenAPI change, no RST docs change (internal
+  RPC-exposed tool only; tool definitions are auto-exposed via the existing
+  `GET /v1/tools`).
+
+## 3. Tool Definition
+
+### models/tool/main.go
+
+```go
+ToolNameGetResource ToolName = "get_resource"
+// + append to AllToolNames (both — TestAllToolNames hardcodes the set)
+```
+
+### models/message/tool.go
+
+```go
+FunctionCallNameGetResource FunctionCallName = "get_resource"
+```
+
+### pkg/toolhandler/definitions.go
+
+```go
+{
+    Name:   tool.ToolNameGetResource,
+    RunLLM: true,
+    Description: `Retrieves the content of a single VoIPBin resource by its id and returns a readable summary.
+
+Use this as the follow-up to get_correlation: get_correlation returns the ids and types of resources linked to an activeflow; get_resource fetches the actual content of one of them. An activeflow's reference is not always a call; do not assume the session is a phone call.
+
+Supported resource types: call, groupcall, recording, transcribe, summary, aicall, conferencecall, queuecall. Derive the type from the event names shown by get_correlation: the type is the leading part of the event name (call_created means type call, transcribe_done means type transcribe, aicall_status_progressing means type aicall). Not every type get_correlation lists is retrievable here; unsupported types return an error listing the supported set. Transcript entries are retrieved via their parent transcribe id (type transcribe), not their own id. For transcribe, the response includes the transcript messages.
+
+WHEN TO USE:
+- You discovered a resource id (e.g. via get_correlation) and need its details
+- A diagnostic question requires the content of a related resource (e.g. what was said in a transcribed call, why a call ended, how long a caller waited in a queue)
+
+WHEN NOT TO USE:
+- Messages of the current AI session (use get_aicall_messages)
+- Runtime variables (use get_variables)
+- Knowledge-base questions (use search_knowledge)
+
+ARGUMENTS:
+- resource_type (required): one of the supported types above.
+- resource_id (required): the resource id (UUID).
+
+You can only retrieve resources owned by your own account; others return "Resource not found.". A wrong resource_type for a correct id also returns "Resource not found." — retry with the type matching the event prefix before concluding the resource is gone.
+
+run_llm: Set true so you can reason about the resource content.`,
+    Parameters: map[string]any{
+        "type": "object",
+        "properties": map[string]any{
+            "run_llm": map[string]any{
+                "type":        "boolean",
+                "description": "Set true to reason about the resource content.",
+                "default":     true,
+            },
+            "resource_type": map[string]any{
+                "type":        "string",
+                "enum":        []string{"call", "groupcall", "recording", "transcribe", "summary", "aicall", "conferencecall", "queuecall"},
+                "description": "The type of the resource to retrieve.",
+            },
+            "resource_id": map[string]any{
+                "type":        "string",
+                "description": "The resource id (UUID) to retrieve.",
+            },
+        },
+        "required": []string{"resource_type", "resource_id"},
+    },
+},
+```
+
+Both arguments are required. Unlike `get_correlation` there is no own-session
+default: the tool is meaningless without a concrete target, and an LLM that
+wants "this session" should use `get_correlation` first.
+
+## 4. Handler Design (pkg/aicallhandler/tool_resource.go)
+
+### Dispatch entry
+
+Add `message.FunctionCallNameGetResource: h.toolHandleGetResource` to the
+`mapFunctions` map literal inside `ToolHandle` (a local literal rebuilt per
+call, not a package-level map).
+
+The existing `promAIcallToolExecuteTotal` metric auto-covers the new function
+name label. No new metrics.
+
+### Fetcher table
+
+Two-stage fetcher per resource type. Stage 1 fetches ONLY the primary resource
+(which carries `CustomerID`); stage 2 renders the summary and performs any
+enrichment RPC (transcript list). Stage 2 runs strictly AFTER the ownership
+check, so no foreign content (especially transcript text) is ever fetched or
+rendered for a cross-customer id (review round 1, Critical 1):
+
+```go
+// resourceFetchResult carries the owner of a fetched resource and a render
+// closure. ownerID is valid only when err == nil. render is invoked by the
+// caller ONLY after ownership has been validated; any enrichment RPC
+// (e.g. transcript list) happens inside render, never before.
+type resourceFetchResult struct {
+    ownerID uuid.UUID
+    render  func(ctx context.Context) string
+}
+
+type resourceFetcher func(ctx context.Context, h *aicallHandler, id uuid.UUID) (*resourceFetchResult, error)
+
+var mapResourceFetchers = map[string]resourceFetcher{
+    "call":           fetchResourceCall,
+    "groupcall":      fetchResourceGroupcall,
+    "recording":      fetchResourceRecording,
+    "transcribe":     fetchResourceTranscribe,
+    "summary":        fetchResourceSummary,
+    "aicall":         fetchResourceAIcall,
+    "conferencecall": fetchResourceConferencecall,
+    "queuecall":      fetchResourceQueuecall,
+}
+```
+
+The JSON-schema `enum`, the unsupported-type error string, and the description's
+supported-type list are all derived from (or asserted equal to) the sorted map
+keys by a unit test, so Phase 2 additions cannot drift (review round 1, Low 9).
+The error-string source is a single derived value:
+`var supportedResourceTypes = strings.Join(sortedFetcherKeys(), ", ")`.
+
+### Main handler flow
+
+```go
+func (h *aicallHandler) toolHandleGetResource(ctx, c, tc) *messageContent {
+    log := logrus.WithFields(logrus.Fields{
+        "func":      "toolHandleGetResource",
+        "aicall_id": c.ID,
+    })
+    res := newToolResult(tc.ID)
+
+    var args struct {
+        ResourceType string `json:"resource_type"`
+        ResourceID   string `json:"resource_id"`
+    }
+    if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+        // Pass the unmarshal error through (sibling precedent:
+        // toolHandleSearchKnowledge) so the LLM can self-correct its arguments.
+        fillFailed(res, errors.Wrap(err, "invalid arguments"))
+        return res
+    }
+
+    if args.ResourceType == "" {
+        fillFailed(res, fmt.Errorf("resource_type is required. supported: %s", supportedResourceTypes))
+        return res
+    }
+    fetcher, ok := mapResourceFetchers[args.ResourceType]
+    if !ok {
+        fillFailed(res, fmt.Errorf("unsupported resource_type: %s. supported: %s", args.ResourceType, supportedResourceTypes))
+        return res
+    }
+
+    resourceID, err := uuid.FromString(args.ResourceID)
+    if err != nil || resourceID == uuid.Nil {
+        fillFailed(res, fmt.Errorf("invalid resource_id"))
+        return res
+    }
+
+    summary, err := h.resolveResource(ctx, c.CustomerID, fetcher, resourceID)
+    if err != nil {
+        if stderrors.Is(err, ErrResourceNotAccessible) {
+            // Single masking site for ALL not-accessible paths.
+            // CRITICAL: this return is load-bearing (IDOR if fallen through).
+            fillSuccess(res, args.ResourceType, resourceID.String(), msgResourceNotFound)
+            return res
+        }
+        // Transient/infra failure: existence unknown, report honest tool failure.
+        // CRITICAL: this return is load-bearing (nil deref if fallen through).
+        log.Errorf("Resource lookup failed. err: %v", err) // operator signal; cause never reaches the LLM
+        fillFailed(res, fmt.Errorf("resource lookup failed"))
+        return res
+    }
+
+    fillSuccess(res, args.ResourceType, resourceID.String(), summary)
+    return res
+}
+```
+
+### Ownership/masking helper
+
+Mirrors the `resolveCorrelation` pattern (PR #975): error-returning helper,
+sentinel collapses every "cannot see" path to one masking site.
+
+```go
+// msgResourceNotFound is the single masked response for every path where the
+// caller is not allowed to see the resource: absent, cross-customer, or any
+// state in between. All such paths MUST return this byte-identical string so
+// the tool is not an existence oracle.
+const msgResourceNotFound = "Resource not found."
+
+// ErrResourceNotAccessible signals that the resource is absent or not owned by
+// the caller. The caller masks it. Transient failures are returned as wrapped
+// ordinary errors and must NOT be masked (existence is unknown; masking would
+// make the LLM assert a false "not found").
+var ErrResourceNotAccessible = stderrors.New("resource not accessible")
+
+func (h *aicallHandler) resolveResource(ctx context.Context, callerCustomerID uuid.UUID, fetcher resourceFetcher, resourceID uuid.UUID) (string, error) {
+    log := logrus.WithFields(logrus.Fields{
+        "func":        "resolveResource",
+        "customer_id": callerCustomerID,
+        "resource_id": resourceID,
+    })
+
+    r, err := fetcher(ctx, h, resourceID)
+    if err != nil {
+        if stderrors.Is(err, requesthandler.ErrNotFound) {
+            // Absent. Mask.
+            return "", ErrResourceNotAccessible
+        }
+        // Transient: honest failure, no masking.
+        return "", errors.Wrap(err, "could not fetch resource")
+    }
+
+    if r.ownerID != callerCustomerID || r.ownerID == uuid.Nil {
+        // ownerID == uuid.Nil is treated as not-accessible (fail closed): a
+        // row with unset customer_id must never match any caller.
+        log.Warnf("Cross-customer resource access blocked. resource_owner: %s", r.ownerID)
+        return "", ErrResourceNotAccessible
+    }
+
+    // Ownership validated: only now render (and run any enrichment RPC).
+    return r.render(ctx), nil
+}
+```
+
+### Error mapping contract (masked vs honest)
+
+Exactly one requesthandler sentinel maps to the masked path:
+`requesthandler.ErrNotFound` (upstream 404) → masked. Everything else
+(`ErrInternalServerError`, timeouts, circuit-breaker, and any other 4xx such as
+400) → honest `fillFailed`. Relationship to the resolveCorrelation precedent,
+stated precisely so future edits don't "fix" the split in the wrong direction:
+the TWO-TIER contract (not-accessible → masked sentinel; transient → honest
+fillFailed) is IDENTICAL to the precedent. The only difference is which errors
+land in the "not-accessible" tier: get_correlation additionally masks failures
+of its SECOND rpc (the FlowV1ActiveflowGet ownership lookup) because by that
+point the first RPC had already established existence, so an honest error
+would leak it. Here there is no second lookup — the single fetch IS the
+existence+ownership resolution, so a non-404 error carries no existence
+information (the resource was never resolved) and is reported honestly.
+Masking non-404 errors would convert infra blips into false "not found"
+assertions by the LLM. All eight target managers map a missing row
+(`dbhandler.ErrNotFound`)
+to RPC 404 — verified in each service's `pkg/listenhandler/main.go` error
+mapping (call, queue, transcribe, ai, conference; groupcall/recording ride
+call-manager's listenhandler). Implementation re-verifies this per RPC as a
+blocking step (Implementation Order step 0) and the per-type absent tests in
+section 10 lock it as a regression guard.
+
+Notes:
+
+- `requesthandler.ErrNotFound` is the canned sentinel the shared RPC client
+  returns for upstream 404 (`HttpStatusErrorMap`). Managers migrated to the
+  typed VoipbinError envelope still funnel through `errors.Is` matching; the
+  implementation must verify per target manager that a missing resource
+  surfaces as `ErrNotFound` (all eight Get RPCs are plain 404 paths today).
+- Soft-delete behavior follows each manager's RPC GET semantics; both outcomes
+  are acceptable for masking (a 404 on a deleted row masks identically to
+  absent; a returned deleted row still passes ownership). No per-manager
+  matrix is asserted in this design (review round 1, Medium 6).
+- The primary fetch happens BEFORE the ownership check by necessity (the
+  resource carries its own customer_id). It is an internal RPC, not observable
+  by the caller, and its content is never rendered for foreign owners; the
+  render closure (including the transcript enrichment RPC) runs only after
+  ownership passes.
+
+## 5. Security
+
+### IDOR
+
+Every supported model embeds `commonidentity.Identity`, so ownership is a
+direct field comparison: `resource.CustomerID != c.CustomerID` → reject. No
+detour via flow-manager (unlike get_correlation, where timeline had no
+customer_id). One comparison, one place (`resolveResource`).
+
+### Existence oracle
+
+All "cannot see" outcomes collapse to the byte-identical
+`msgResourceNotFound` via the single sentinel:
+
+| Path | Response |
+|---|---|
+| Resource absent (ErrNotFound) | masked `Resource not found.` |
+| Resource exists, other customer | masked `Resource not found.` (same bytes) |
+| Transient RPC failure | honest `fillFailed("resource lookup failed")` — NOT masked |
+
+Transient failures are deliberately not masked: existence is unknown, and
+masking would make the LLM confidently assert "that resource does not exist"
+during an infra blip. This matches the resolveCorrelation two-tier error
+contract. The residual timing difference (cross-customer does one successful
+RPC before rejecting) is not measurable through the LLM boundary;
+accept-with-note.
+
+### tool_names:["all"] reality
+
+Adding the definition exposes the tool to every AI configured with the `all`
+wildcard. As with get_correlation, exposure is not the control; the ownership
+check is. Do NOT add to `ConversationSafeTools` (unwired utility; adding would
+auto-expose later).
+
+### Masking-invariant regression test
+
+A dedicated test asserts that the reject paths (absent, cross-customer)
+produce `reflect.DeepEqual`-identical `messageContent`, so future edits cannot
+split the masked responses apart and recreate the oracle.
+
+## 6. Output Format (per-type curated summaries)
+
+Raw `json.Marshal` of the domain structs is prohibited: the models carry
+internal fields (channel_id, bridge_id, asterisk_id, dialroutes, host_id,
+filenames, confbridge_id...) that are infrastructure detail, token waste, and
+mild information leakage. Each fetcher renders a short labeled-line summary of
+customer-meaningful fields only. Timestamps render RFC3339; nil timestamps and
+zero UUIDs are omitted.
+
+- **call**: status, direction, source/destination (target only), created,
+  ringing/progressing/hangup timestamps, hangup_by, hangup_reason,
+  recording_ids count, groupcall_id (if set).
+- **groupcall**: status, ring_method, answer_method, source, destination count,
+  answered call id, call_ids.
+- **recording**: status, format, reference_type/reference_id, recording_name,
+  tm_start, tm_end. No filenames (storage paths are internal).
+- **transcribe**: status, language, direction, reference_type/reference_id,
+  provider, followed by the transcript body via `TranscribeV1TranscriptList`
+  (filters `FieldTranscribeID` + `FieldDeleted: false` — matching the
+  bin-api-manager servicehandler precedent, which passes
+  `{"transcribe_id": ..., "deleted": "false"}`; exact value encoding to be
+  verified during implementation). The dbhandler seeds the empty page token
+  with "now" and orders by `tm_create DESC` (code-verified), so a single page
+  is the MOST RECENT transcripts. Page-cap detection: request `page_size 101`;
+  if 101 rows return, more exist — render the most recent 100. The fetcher
+  reverses the page to chronological order before rendering. Line format
+  `[in 00:00:03] hello ...` using Direction (enum `in`/`out`/`both` — render
+  the literal value) and the TMTranscript offset. TMTranscript encodes an
+  offset from the zero time (`0001-01-01 00:00:00` = transcribe start, per the
+  model comment): normalize via `t.UTC()` then render `t.Sub(time.Time{})`
+  formatted `HH:MM:SS` (hours may exceed 24; render total hours; verify the
+  scan location against a real row during implementation). Nil TMTranscript
+  renders `[in --:--:--]`. Empty transcript list renders `(no transcripts)`.
+  Same-millisecond `tm_create` ties have no tiebreaker in the query —
+  rendering order within a tie is nondeterministic; tests must not depend on
+  tie order. Truncation: both the page cap and the 4000-rune cap keep the MOST
+  RECENT lines and drop the oldest; the marker template is
+  `...(earlier transcripts omitted; showing the most recent N)` (degenerate
+  single-line variant defined under cap mechanics below) — never
+  "first N", which would invert which end was cut. Transcript list failure
+  after a successful, ownership-validated transcribe fetch degrades
+  gracefully: metadata + a `(transcripts unavailable)` line, not a tool
+  failure.
+- **summary**: status, language, reference_type/reference_id, content. The
+  whole-message cap governs: content gets whatever budget remains after the
+  metadata lines; marker `...(truncated)`.
+- **aicall**: status, reference_type/reference_id, engine model, tts/stt type,
+  tm_create/tm_end. NOT the message history (that is get_aicall_messages'
+  job; for foreign aicalls exposing history would be a new data surface —
+  explicitly out of scope).
+- **conferencecall**: status, conference_id, reference_type/reference_id,
+  timestamps.
+- **queuecall**: status, queue_id, routing_method, duration_waiting,
+  duration_service, service_agent_id, tm_create/tm_service/tm_end.
+
+All copy uses domain-correct terminology: "activeflow" not "call flow"; no
+phrasing that assumes the session is a phone call (multi-channel platform;
+recurring de-bias rule).
+
+The global cap `maxResourceSummaryRunes = 4000` (const, rune-counted as the
+name says; code change to raise) applies to the WHOLE rendered message of
+every type — metadata + body + marker together can never exceed it. Cap
+mechanics, uniform across types:
+- Truncation is whole-line for line-structured bodies (transcripts): drop
+  oldest lines until the remainder + marker fits. The marker is placed at the
+  TOP of the transcript block (where the omitted earlier lines were), before
+  the chronological lines.
+- Degenerate case: if even the newest single line cannot fit the remaining
+  budget, hard-truncate that line mid-text and still show it; the transcript
+  marker then reads `...(earlier transcripts omitted; showing the most
+  recent 1, truncated)`.
+- Free-text bodies (summary content) hard-truncate mid-text with marker
+  `...(truncated)`.
+- Any OTHER type whose rendered message exceeds the cap (e.g. a groupcall
+  with hundreds of call_ids) hard-truncates with the same generic
+  `...(truncated)` marker appended at the cut.
+
+Note on self-RPC: `AIV1SummaryGet`/`AIV1AIcallGet` are bin-ai-manager calling
+itself over RabbitMQ. Deliberate: one uniform fetcher shape, circuit breaker
+included, no special-casing of local resources.
+
+## 7. Chaining / UX
+
+- `run_llm` defaults true: the tool exists to feed content back into the LLM.
+- Expected chain: `get_correlation` (1 call) → `get_resource` (1 call per
+  resource of interest). Depth 2 is acceptable: this is a diagnostic/back-office
+  pattern, predominantly text channels. Voice sessions pay ~1 extra LLM+RPC
+  round trip only when the AI actually chooses to drill down.
+- `get_correlation`'s description gains one sentence pointing at
+  `get_resource` as the follow-up ("Use get_resource to fetch the content of a
+  discovered resource."), closing the loop for the LLM. Same PR.
+
+## 8. Affected Services
+
+| Service | Change | Phase |
+|---|---|---|
+| bin-ai-manager | tool constant + AllToolNames, FunctionCallName, definitions.go entry (+1 sentence on get_correlation), dispatch entry, `tool_resource.go` (handler + fetchers + formatters), `formatCorrelationSummary` label fix in tool.go (OQ5), tests | 1 |
+| bin-common-handler | none (all 8 RPCs exist) | - |
+| others | none | - |
+
+Single-service PR. No schema, no migration, no OpenAPI, no RST.
+
+## 9. Implementation Order
+
+0. BLOCKING verification: per target RPC, confirm a missing resource surfaces
+   as `requesthandler.ErrNotFound` (trace each manager's listenhandler
+   error mapping; design-time check found all five listenhandlers map
+   `dbhandler.ErrNotFound` → 404). Confirm `FieldTranscribeID` filter and
+   `tm_create DESC` ordering of `TranscribeV1TranscriptList`. Confirm the
+   `FieldDeleted` value encoding (string "false" per the bin-api-manager
+   precedent vs typed bool). Confirm the dbhandler accepts `page_size 101`
+   (if a max page size < 101 exists, the page-cap detection scheme breaks —
+   fall back to page_size = max, render max-1 rows + marker when len == max,
+   keeping the marker truthful).
+1. `models/tool/main.go`: `ToolNameGetResource` + `AllToolNames` (fix
+   `TestAllToolNames` expected set).
+2. `models/message/tool.go`: `FunctionCallNameGetResource`.
+3. `pkg/aicallhandler/tool_resource.go`: sentinel, masking const,
+   `resolveResource`, fetcher table, per-type formatters.
+4. Dispatch entry: add the key to the `mapFunctions` map literal inside
+   `ToolHandle` (pkg/aicallhandler/tool.go — it is a local literal rebuilt per
+   call, not a package-level map).
+5. `pkg/toolhandler/definitions.go`: new entry + get_correlation cross-link
+   sentence.
+5b. OQ5 fix (settled: DERIVE, not drop): in `formatCorrelationSummary`
+   (`pkg/aicallhandler/tool.go` — same file as the correlation tool handler,
+   NOT definitions.go), replace the per-line `r.DataType` label with a label
+   derived from the resource's event types: take the first entry of the
+   already-sorted `r.EventTypes` slice and cut at the first underscore
+   (`call_created` → `call`, `aicall_status_progressing` → `aicall`,
+   `conferencecall_joined` → `conferencecall`). Scope of the rule's
+   correctness (round-4 verification): it is correct for every event type
+   that can actually MATERIALIZE as a correlation row — timeline requires a
+   top-level `id` (resource_id materialization) AND an `activeflow_id` in
+   the payload, which excludes the known non-conforming names
+   (`team_member_switched` has no top-level id;
+   `call.outbound_whitelist_rejected` publishes `call_id` not `id`;
+   `transcript_created` carries no activeflow_id). Watch item: a future
+   cross-prefix event carrying both fields would mislabel — verify none
+   exists at implementation time. If `EventTypes`
+   is empty, render the neutral label `resource`. Add a unit test for the
+   derivation (incl. empty-events fallback) in the existing correlation test
+   file.
+6. Tests (section 10).
+7. bin-ai-manager code docs: add the tool to `docs/domain.md` tool list (and
+   architecture.md if the tool table lives there). No RST (internal tool).
+8. Full verification workflow in bin-ai-manager.
+
+## 10. Test Plan (pkg/aicallhandler/tool_resource_test.go)
+
+Table-driven, gomock requesthandler. Cases:
+
+1. Success per resource type (8 cases; assert curated summary content, that
+   internal fields like channel_id/filenames never appear in the output, and
+   at least one case exercising nil-timestamp/zero-UUID omission).
+2. transcribe success including transcript lines (chronological order after
+   DESC reversal); transcript list error → metadata + `(transcripts
+   unavailable)`, still success; empty transcript list → `(no transcripts)`;
+   nil TMTranscript line rendering. Cross-customer transcribe: assert the
+   transcript list RPC is NEVER called (strict gomock, no EXPECT registered —
+   locks the post-ownership enrichment contract).
+3. Summary/transcript truncation at the 4000-rune cap with markers.
+4. Cross-customer → masked `msgResourceNotFound` (fillSuccess, not failure).
+5. Absent (RPC returns `requesthandler.ErrNotFound`) → masked, PER RESOURCE
+   TYPE (8 cases — guards the per-manager 404 assumption), byte-identical
+   to case 4 using the same fixed `tc.ID` AND the same fixed
+   resource_type/resource_id per compared pair (messageContent echoes both, so
+   DeepEqual requires identical inputs across the absent/cross-customer pair)
+   (`reflect.DeepEqual` masking-invariant assertion).
+6. Transient RPC error → `fillFailed("resource lookup failed")`, NOT masked.
+7. Unsupported resource_type → fillFailed listing supported types; empty
+   resource_type → dedicated `resource_type is required` message.
+8. Invalid/empty resource_id, malformed JSON args → fillFailed.
+9. Regression: cross-customer path emits no summary fragment (no IDOR
+   fall-through), transient path does not panic.
+10. Schema/enum drift guard: JSON-schema enum in definitions.go ==
+    sorted `mapResourceFetchers` keys. Mechanics: export a
+    `SupportedResourceTypes() []string` accessor from aicallhandler (sorted
+    map keys; also the source of the handler's error strings), and place the
+    equality test in toolhandler where the schema is visible. The description
+    prose is NOT string-asserted (prose churns); the enum + error-string legs
+    are.
+11. OQ5 derivation: `formatCorrelationSummary` label = first-underscore cut of
+    `EventTypes[0]`; empty EventTypes → `resource` (in the existing
+    correlation test file).
+
+## 11. Open Questions
+
+| # | Question | Recommendation | Owner |
+|---|---|---|---|
+| 1 | Should foreign (own-customer) aicall summaries include message history? | No. Keep aicall metadata-only in Phase 1; history via a future scoped extension of get_aicall_messages if demanded. | CEO/CTO |
+| 2 | Add `conversation` / `campaigncall` in Phase 1? | No. Correlation coverage for them is unverified (event payload activeflow_id); add in Phase 2 after verifying. | CPO |
+| 3 | Per-AI gating beyond tool_names? | No. Ownership check is the control, consistent with get_correlation precedent. | settled |
+| 4 | PII: resource content (transcripts, summaries) flows to the customer's own LLM engine. | No new exposure: the same engine already receives the live conversation. No action. | settled |
+| 5 | `formatCorrelationSummary` prints `r.DataType` per line, which is the envelope content-type (`application/json`), not the model name — it is the exact line the LLM reads to pick `resource_type`. | Fix IN THIS PR: derive the label via first-underscore cut of `EventTypes[0]` (empty → `resource`); see Implementation Order step 5b + test case 11. | settled (round 3) |
+| 6 | Phase 1 carries 8 types; the motivating chain needs ~5 (call, transcribe, recording, summary, queuecall). Trim to reduce PR size? | Keep 8 per pchero's explicit scope direction (aicall, conferencecall included). Each fetcher is small; architecture identical either way. | settled (pchero, 2026-06-11) |
+
+## Review Summary
+
+### Round 1 (delegate_task adversarial reviewer, CHANGES REQUESTED → v2)
+
+Critical/High fixes applied:
+- C1: fetchers restructured to two-stage (fetch owner-bearing resource →
+  ownership check → render closure runs enrichment RPC). Foreign transcript
+  content is never fetched; locked by a no-EXPECT gomock test.
+- H2: per-manager 404 mapping promoted to BLOCKING implementation step 0;
+  absent-path masking test now per resource type (8 cases).
+- H3: truncation marker fixed to "first N shown" (M unknowable from a single
+  page) — (superseded by Round 2 H1: marker direction was itself wrong);
+  transcript ordering verified in code (`tm_create DESC`) with explicit
+  reversal; `FieldTranscribeID` existence verified.
+
+Medium/Low fixes applied: TMTranscript offset rendering spec (zero-time
+subtraction, nil and empty-list rendering, direction enum); data_type
+misconception corrected (envelope data_type is `application/json`, not the
+model name — resource_type now defined via event-type prefix, tool description
+updated, correlation summary cosmetic issue logged as OQ5); soft-delete claim
+reworded to per-manager semantics; whole-message cap semantics; generic
+truncation markers; supported-type list drift guard (test); empty
+resource_type dedicated error; dispatch wiring described as local map literal;
+fixed tc.ID in masking-invariant test; nil-timestamp omission test; code-docs
+(domain.md) step added; self-RPC note; wrong-type-retry hint in description.
+
+### Round 2 (fresh delegate_task adversarial reviewer, CHANGES REQUESTED → v3)
+
+Architecture, security contract, and test plan confirmed sound. Findings were
+confined to Section 6 transcript semantics + description copy:
+- H1: truncation marker inverted which end was cut — the single DESC page is
+  the MOST RECENT 100, not the first. Marker fixed to
+  `...(earlier transcripts omitted; showing the most recent N)`; page-cap
+  detection specified (page_size 101 disambiguation).
+- M2: transcript list now filters `FieldDeleted: false` (bin-api-manager
+  servicehandler precedent) so customer-deleted transcripts never render.
+- M3: prefix-derivation rule defined in the description ("leading part of the
+  event name") + transcript-vs-transcribe near-miss closed ("transcript
+  entries are retrieved via their parent transcribe id").
+- L4: OQ5 (correlation summary's `application/json` DataType label) upgraded
+  to fix-in-this-PR.
+- L5: arg unmarshal error now passed through (sibling precedent) for LLM
+  self-correction.
+- L6/L7: tm_create tie nondeterminism noted (tests must not depend on tie
+  order); TMTranscript normalized via t.UTC() with implementation-time
+  verification against a real row.
+
+### Round 3 (fresh delegate_task adversarial reviewer, CHANGES REQUESTED → v4)
+
+Architecture/security again confirmed sound; findings were doc-coherence and
+spec-completeness:
+- H1: OQ5 fully specified — settled to DERIVE (first-underscore cut of
+  EventTypes[0], empty → `resource`), located in pkg/aicallhandler/tool.go
+  (NOT definitions.go), new Implementation Order step 5b, new test case 11,
+  OQ5 marked settled, Section 2 cross-reference updated.
+- M2: Sections 4/5 precedent characterization reconciled — the two-tier
+  contract is IDENTICAL to resolveCorrelation; the only difference is the
+  second-RPC (ownership lookup) failures that get_correlation additionally
+  masks, which this design has no equivalent of.
+- M3: cap mechanics unified — const renamed `maxResourceSummaryRunes`,
+  whole-message budget governs all types, whole-line truncation + top-of-block
+  marker for transcripts, degenerate single-line case defined, generic
+  `...(truncated)` marker for all other types, summary content budget =
+  remainder after metadata.
+- L4-L10: OQ5 owner settled; step-0 expanded (FieldDeleted encoding,
+  page_size 101 acceptance + fallback); masking-invariant test pins
+  resource_type/resource_id per compared pair; transient path logs the cause
+  (operator signal, never reaches the LLM); Round-1 H3 changelog annotated
+  superseded; ownerID==uuid.Nil fail-closed guard; drift-guard test mechanics
+  specified (exported SupportedResourceTypes(), prose leg excluded).
+
+### Round 4 (fresh delegate_task adversarial reviewer, APPROVE with notes → v5)
+
+Verdict APPROVE. Code-verified the OQ5 derivation against every publisher's
+event constants and timeline's materialization pipeline; security/masking
+contract confirmed with no constructible oracle or IDOR path. Notes applied:
+- M1: "first-underscore cut correct for every published event type" claim
+  scoped to events that can materialize as correlation rows (top-level `id` +
+  `activeflow_id` preconditions; known non-conforming names listed); future
+  cross-prefix event = watch item.
+- L2: page-cap fallback disambiguated (render max-1 + marker when len == max).
+- L3: `supportedResourceTypes` declaration added to the sketch.
+- L4: "the single marker" → "the marker template" (degenerate variant
+  cross-referenced).
+
+## 12. Checklist deltas vs the standard template
+
+DB schema / webhook events / flow variables / RabbitMQ action / Prometheus
+(new) / OpenAPI: N/A — internal tool addition reusing existing RPCs; existing
+`promAIcallToolExecuteTotal` covers execution counts by function label.

--- a/docs/plans/2026-06-11-add-get-resource-tool-design.md
+++ b/docs/plans/2026-06-11-add-get-resource-tool-design.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-06-11
 - Service: bin-ai-manager (toolhandler / aicallhandler)
-- Status: v6 (rounds 1-3 CHANGES REQUESTED applied; round 4 APPROVE; post-approval design change: aicall history INCLUDED per pchero — fresh re-review round pending)
+- Status: v7 (rounds 1-3 CHANGES REQUESTED applied; round 4 APPROVE; post-approval aicall-history change re-reviewed in round 5, fixes applied)
 
 ## 1. Problem Statement
 
@@ -367,6 +367,16 @@ contract. The residual timing difference (cross-customer does one successful
 RPC before rejecting) is not measurable through the LLM boundary;
 accept-with-note.
 
+Known sibling-tool caveat (honest scoping of the oracle claim): the
+pre-existing `get_aicall_messages` tool returns DISTINGUISHABLE honest errors
+for absent vs cross-customer aicall ids (it predates the masking convention).
+An LLM combining both tools can therefore still infer "exists but foreign"
+for aicall ids specifically — get_resource's masking protects content, but
+the existence-oracle property does not hold platform-wide until the sibling
+is aligned. Aligning `get_aicall_messages`' two failure paths behind a single
+masked response is logged as a follow-up (out of this PR's minimal-change
+scope; see Open Question 7).
+
 ### tool_names:["all"] reality
 
 Adding the definition exposes the tool to every AI configured with the `all`
@@ -434,16 +444,27 @@ zero UUIDs are omitted.
   fetched inside the render closure (post-ownership) via the LOCAL
   `h.messageHandler.List` (same call shape as `toolHandleGetAIcallMessages`:
   filter `FieldAIcallID`, page_size 101 for page-cap detection — messages are
-  local to bin-ai-manager, no RPC). Rendered roles: `user` and `assistant`
-  content as `[user] ...` / `[assistant] ...` lines; an assistant message
-  whose ToolCalls is non-empty renders a compact `[assistant called <name>]`
-  line per call. EXCLUDED from rendering: `system` (substituted prompt
-  snapshot — prompt engineering exposure has no place in a readable summary;
-  the full raw dump including system is already available via
-  get_aicall_messages, which validates the same ownership), `notification`,
-  `tool` result bodies (bulk; the assistant's visible reply reflects them),
-  and empty-content rows. Ordering/truncation identical to transcripts:
-  most recent kept, chronological render, marker
+  local to bin-ai-manager, no RPC, plus `FieldDeleted: false` — same
+  deleted-row exclusion as the transcribe leg; value encoding shares the
+  step-0 verification). Rendering is an ALLOWLIST with explicit precedence
+  (code fact: ToolHandle persists assistant tool-call rows with
+  `Content == ""`, so the checks must run in this order):
+  1. role == assistant AND len(ToolCalls) > 0: render one compact
+     `[assistant called <name>]` line per call (ToolCalls order); if Content
+     is ALSO non-empty, render the `[assistant] ...` content line first,
+     then the marker lines.
+  2. role == user or assistant with non-empty Content: `[user] ...` /
+     `[assistant] ...` line.
+  3. Everything else is dropped: system (substituted prompt snapshot —
+     prompt engineering exposure has no place in a readable summary; the
+     full raw dump including system is already available via
+     get_aicall_messages, which validates the same ownership), notification,
+     tool, function, empty role, and rows with empty Content and no
+     ToolCalls. The `Direction` field is deliberately unused for message
+     lines (role labels carry the speaker; do not graft transcript-style
+     `[in]` prefixes).
+  Ordering/truncation identical to transcripts (whole-line, most recent
+  kept, chronological render, page_size 101 detection), marker
   `...(earlier messages omitted; showing the most recent N)`.
 - **conferencecall**: status, conference_id, reference_type/reference_id,
   timestamps.
@@ -458,14 +479,14 @@ The global cap `maxResourceSummaryRunes = 4000` (const, rune-counted as the
 name says; code change to raise) applies to the WHOLE rendered message of
 every type — metadata + body + marker together can never exceed it. Cap
 mechanics, uniform across types:
-- Truncation is whole-line for line-structured bodies (transcripts): drop
-  oldest lines until the remainder + marker fits. The marker is placed at the
-  TOP of the transcript block (where the omitted earlier lines were), before
-  the chronological lines.
+- Truncation is whole-line for line-structured bodies (transcripts, aicall
+  messages): drop oldest lines until the remainder + marker fits. The marker
+  is placed at the TOP of the block (where the omitted earlier lines were),
+  before the chronological lines.
 - Degenerate case: if even the newest single line cannot fit the remaining
-  budget, hard-truncate that line mid-text and still show it; the transcript
-  marker then reads `...(earlier transcripts omitted; showing the most
-  recent 1, truncated)`.
+  budget, hard-truncate that line mid-text and still show it; the marker
+  then reads `...(earlier transcripts omitted; showing the most
+  recent 1, truncated)` (aicall messages: same variant with "messages").
 - Free-text bodies (summary content) hard-truncate mid-text with marker
   `...(truncated)`.
 - Any OTHER type whose rendered message exceeds the cap (e.g. a groupcall
@@ -508,7 +529,11 @@ Single-service PR. No schema, no migration, no OpenAPI, no RST.
    precedent vs typed bool). Confirm the dbhandler accepts `page_size 101`
    (if a max page size < 101 exists, the page-cap detection scheme breaks —
    fall back to page_size = max, render max-1 rows + marker when len == max,
-   keeping the marker truthful).
+   keeping the marker truthful). Same verification leg for the aicall message
+   list: confirm `messageHandler.List` ordering (`tm_create DESC` at the
+   dbhandler, empty token seeded with now — design-time verified at
+   dbhandler.MessageList; confirm the handler wrapper passes size through
+   unclamped) and the `FieldDeleted` encoding for messages.
 1. `models/tool/main.go`: `ToolNameGetResource` + `AllToolNames` (fix
    `TestAllToolNames` expected set).
 2. `models/message/tool.go`: `FunctionCallNameGetResource`.
@@ -556,13 +581,18 @@ Table-driven, gomock requesthandler. Cases:
    nil TMTranscript line rendering. Cross-customer transcribe: assert the
    transcript list RPC is NEVER called (strict gomock, no EXPECT registered —
    locks the post-ownership enrichment contract).
-2b. aicall success including conversation lines: user/assistant rendering,
-   compact `[assistant called <name>]` tool-call markers, system/notification/
-   tool-role and empty-content rows excluded from output (assert prompt text
-   never appears); message list error → metadata + `(messages unavailable)`,
-   still success; empty list → `(no messages)`. Cross-customer aicall: assert
-   the message list is NEVER fetched (mock messageHandler, no EXPECT — same
-   post-ownership contract as transcribe).
+2b. aicall success including conversation lines: allowlist precedence
+   (assistant+ToolCalls renders markers even with empty Content — the
+   persisted shape; assistant with both Content and ToolCalls renders content
+   line then markers), system/notification/tool/function/empty-role and
+   empty-content-no-toolcalls rows excluded (assert prompt text never
+   appears); message list error → metadata + `(messages unavailable)`, still
+   success; empty list → `(no messages)`; one aicall truncation/page-cap case
+   asserting the `...(earlier messages omitted; showing the most recent N)`
+   marker. Cross-customer aicall: assert the message list is NEVER fetched
+   (mock messageHandler, no EXPECT on List — note: tests must invoke
+   `toolHandleGetResource` directly, not via ToolHandle, since ToolHandle
+   itself calls messageHandler.Create before dispatch).
 3. Summary/transcript truncation at the 4000-rune cap with markers.
 4. Cross-customer → masked `msgResourceNotFound` (fillSuccess, not failure).
 5. Absent (RPC returns `requesthandler.ErrNotFound`) → masked, PER RESOURCE
@@ -598,6 +628,7 @@ Table-driven, gomock requesthandler. Cases:
 | 4 | PII: resource content (transcripts, summaries) flows to the customer's own LLM engine. | No new exposure: the same engine already receives the live conversation. No action. | settled |
 | 5 | `formatCorrelationSummary` prints `r.DataType` per line, which is the envelope content-type (`application/json`), not the model name — it is the exact line the LLM reads to pick `resource_type`. | Fix IN THIS PR: derive the label via first-underscore cut of `EventTypes[0]` (empty → `resource`); see Implementation Order step 5b + test case 11. | settled (round 3) |
 | 6 | Phase 1 carries 8 types; the motivating chain needs ~5 (call, transcribe, recording, summary, queuecall). Trim to reduce PR size? | Keep 8 per pchero's explicit scope direction (aicall, conferencecall included). Each fetcher is small; architecture identical either way. | settled (pchero, 2026-06-11) |
+| 7 | `get_aicall_messages` (pre-existing) returns distinguishable errors for absent vs cross-customer aicall ids — an existence oracle that coexists with get_resource's masking (see Section 5 caveat). Align its two failure paths behind one masked response? | Yes, as a small follow-up PR (behavior change to an existing tool's error copy; out of this PR's minimal-change scope). | CPO follow-up |
 
 ## Review Summary
 
@@ -702,6 +733,30 @@ aicalls the ai_messages table is the only record of the dialogue. Changes:
   case 2b) updated accordingly.
 Per the mandatory re-review rule, a fresh review round on the changed doc is
 required before implementation.
+
+### Round 5 (fresh delegate_task re-review of the v6 change, CHANGES REQUESTED → v7)
+
+Scope: the aicall-history change only; security core confirmed sound (curated
+render = strict subset of get_aicall_messages' existing raw dump, same
+ownership gate, enrichment post-ownership). Fixes applied:
+- H1: rendering rewritten as an ALLOWLIST with explicit precedence — code
+  fact that assistant tool-call rows persist with `Content == ""` made the
+  old "empty-content rows excluded" wording delete every marker; precedence
+  now: ToolCalls check first, both-non-empty case defined (content line then
+  markers), function/empty-role explicitly dropped, Direction explicitly
+  unused.
+- M2: Section 5 now honestly scopes the oracle claim — sibling
+  `get_aicall_messages` leaks absent-vs-foreign for aicall ids; alignment
+  logged as OQ7 follow-up (out of minimal-change scope).
+- M3: `FieldDeleted: false` added to the message list (was inconsistent with
+  the transcribe leg).
+- M4: step-0 gains the messagehandler verification leg (ordering design-time
+  verified at dbhandler.MessageList; wrapper clamp + FieldDeleted encoding to
+  confirm); test 2b gains the aicall truncation/page-cap case.
+- L5/L6/L7: allowlist wording airtight; cap-mechanics block covers both
+  line-structured bodies + message marker variant; test 2b notes direct
+  `toolHandleGetResource` invocation (ToolHandle calls messageHandler.Create
+  pre-dispatch, which would break the no-EXPECT trick).
 
 ## 12. Checklist deltas vs the standard template
 

--- a/docs/plans/2026-06-11-add-get-resource-tool-design.md
+++ b/docs/plans/2026-06-11-add-get-resource-tool-design.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-06-11
 - Service: bin-ai-manager (toolhandler / aicallhandler)
-- Status: v5 (review rounds 1-3 CHANGES REQUESTED applied; round 4 APPROVE)
+- Status: v6 (rounds 1-3 CHANGES REQUESTED applied; round 4 APPROVE; post-approval design change: aicall history INCLUDED per pchero — fresh re-review round pending)
 
 ## 1. Problem Statement
 
@@ -10,9 +10,12 @@ The `get_correlation` tool returns the correlation graph for an activeflow: an I
 graph of related resources grouped by publisher (`call-manager: call <uuid>`,
 `transcribe-manager: transcribe <uuid>`, ...). It deliberately stops at IDs.
 
-There is no follow-up tool to retrieve the content of those resources. The only
-read tools today are `get_aicall_messages` (own session only), `get_variables`,
-and `search_knowledge` (RAG). An LLM that discovers a transcribe id via
+There is no follow-up tool to retrieve the content of those resources. The
+read tools today are `get_aicall_messages` (single-purpose: raw JSON dump of
+one aicall's messages — it DOES accept an arbitrary aicall_id with a
+customer-ownership check, but returns the unfiltered marshal including system
+prompts, and covers no other resource type), `get_variables`, and
+`search_knowledge` (RAG). An LLM that discovers a transcribe id via
 `get_correlation` cannot answer "what was said in that call" because it has no
 way to fetch the transcript. The chaining mechanism (run_llm=true sequential
 tool calling) exists and works; the missing piece is the second link.
@@ -98,14 +101,14 @@ FunctionCallNameGetResource FunctionCallName = "get_resource"
 
 Use this as the follow-up to get_correlation: get_correlation returns the ids and types of resources linked to an activeflow; get_resource fetches the actual content of one of them. An activeflow's reference is not always a call; do not assume the session is a phone call.
 
-Supported resource types: call, groupcall, recording, transcribe, summary, aicall, conferencecall, queuecall. Derive the type from the event names shown by get_correlation: the type is the leading part of the event name (call_created means type call, transcribe_done means type transcribe, aicall_status_progressing means type aicall). Not every type get_correlation lists is retrievable here; unsupported types return an error listing the supported set. Transcript entries are retrieved via their parent transcribe id (type transcribe), not their own id. For transcribe, the response includes the transcript messages.
+Supported resource types: call, groupcall, recording, transcribe, summary, aicall, conferencecall, queuecall. Derive the type from the event names shown by get_correlation: the type is the leading part of the event name (call_created means type call, transcribe_done means type transcribe, aicall_status_progressing means type aicall). Not every type get_correlation lists is retrievable here; unsupported types return an error listing the supported set. Transcript entries are retrieved via their parent transcribe id (type transcribe), not their own id. For transcribe, the response includes the transcript messages. For aicall, the response includes the session's conversation messages.
 
 WHEN TO USE:
 - You discovered a resource id (e.g. via get_correlation) and need its details
 - A diagnostic question requires the content of a related resource (e.g. what was said in a transcribed call, why a call ended, how long a caller waited in a queue)
 
 WHEN NOT TO USE:
-- Messages of the current AI session (use get_aicall_messages)
+- A raw, unfiltered JSON dump of an aicall's messages (use get_aicall_messages; get_resource returns a curated readable summary)
 - Runtime variables (use get_variables)
 - Knowledge-base questions (use search_knowledge)
 
@@ -424,9 +427,24 @@ zero UUIDs are omitted.
   whole-message cap governs: content gets whatever budget remains after the
   metadata lines; marker `...(truncated)`.
 - **aicall**: status, reference_type/reference_id, engine model, tts/stt type,
-  tm_create/tm_end. NOT the message history (that is get_aicall_messages'
-  job; for foreign aicalls exposing history would be a new data surface —
-  explicitly out of scope).
+  tm_create/tm_end, followed by the CONVERSATION HISTORY (settled: include —
+  pchero, 2026-06-11; transcribe/summary are different resources, and for
+  chat/conversation-referenced aicalls the ai_messages table is the only
+  record of what was said). Mechanics mirror the transcribe body: messages
+  fetched inside the render closure (post-ownership) via the LOCAL
+  `h.messageHandler.List` (same call shape as `toolHandleGetAIcallMessages`:
+  filter `FieldAIcallID`, page_size 101 for page-cap detection — messages are
+  local to bin-ai-manager, no RPC). Rendered roles: `user` and `assistant`
+  content as `[user] ...` / `[assistant] ...` lines; an assistant message
+  whose ToolCalls is non-empty renders a compact `[assistant called <name>]`
+  line per call. EXCLUDED from rendering: `system` (substituted prompt
+  snapshot — prompt engineering exposure has no place in a readable summary;
+  the full raw dump including system is already available via
+  get_aicall_messages, which validates the same ownership), `notification`,
+  `tool` result bodies (bulk; the assistant's visible reply reflects them),
+  and empty-content rows. Ordering/truncation identical to transcripts:
+  most recent kept, chronological render, marker
+  `...(earlier messages omitted; showing the most recent N)`.
 - **conferencecall**: status, conference_id, reference_type/reference_id,
   timestamps.
 - **queuecall**: status, queue_id, routing_method, duration_waiting,
@@ -538,6 +556,13 @@ Table-driven, gomock requesthandler. Cases:
    nil TMTranscript line rendering. Cross-customer transcribe: assert the
    transcript list RPC is NEVER called (strict gomock, no EXPECT registered —
    locks the post-ownership enrichment contract).
+2b. aicall success including conversation lines: user/assistant rendering,
+   compact `[assistant called <name>]` tool-call markers, system/notification/
+   tool-role and empty-content rows excluded from output (assert prompt text
+   never appears); message list error → metadata + `(messages unavailable)`,
+   still success; empty list → `(no messages)`. Cross-customer aicall: assert
+   the message list is NEVER fetched (mock messageHandler, no EXPECT — same
+   post-ownership contract as transcribe).
 3. Summary/transcript truncation at the 4000-rune cap with markers.
 4. Cross-customer → masked `msgResourceNotFound` (fillSuccess, not failure).
 5. Absent (RPC returns `requesthandler.ErrNotFound`) → masked, PER RESOURCE
@@ -567,7 +592,7 @@ Table-driven, gomock requesthandler. Cases:
 
 | # | Question | Recommendation | Owner |
 |---|---|---|---|
-| 1 | Should foreign (own-customer) aicall summaries include message history? | No. Keep aicall metadata-only in Phase 1; history via a future scoped extension of get_aicall_messages if demanded. | CEO/CTO |
+| 1 | Should aicall summaries include conversation history? | YES (settled — pchero, 2026-06-11: "적극적으로 포함"; transcribe/summary are different resources, and chat/conversation aicalls have no transcribe). Curated rendering: user/assistant lines + compact tool-call markers; system/notification/tool bodies excluded. Note: `get_aicall_messages` already exposes the full raw dump (incl. system) cross-session with the same ownership check, so this adds no new data surface. | settled |
 | 2 | Add `conversation` / `campaigncall` in Phase 1? | No. Correlation coverage for them is unverified (event payload activeflow_id); add in Phase 2 after verifying. | CPO |
 | 3 | Per-AI gating beyond tool_names? | No. Ownership check is the control, consistent with get_correlation precedent. | settled |
 | 4 | PII: resource content (transcripts, summaries) flows to the customer's own LLM engine. | No new exposure: the same engine already receives the live conversation. No action. | settled |
@@ -658,6 +683,25 @@ contract confirmed with no constructible oracle or IDOR path. Notes applied:
 - L3: `supportedResourceTypes` declaration added to the sketch.
 - L4: "the single marker" → "the marker template" (degenerate variant
   cross-referenced).
+
+### Post-approval design change (pchero, 2026-06-11 → v6)
+
+OQ1 reversed from "metadata only" to "include conversation history" by pchero:
+transcribe/summary are DIFFERENT resources; for chat/conversation-referenced
+aicalls the ai_messages table is the only record of the dialogue. Changes:
+- aicall summary now renders user/assistant lines + compact tool-call markers
+  after the metadata block; system (prompt snapshot), notification, tool
+  bodies, and empty-content rows excluded.
+- Fetch is local `h.messageHandler.List` (no RPC), inside the render closure
+  (post-ownership), page-cap/truncation/ordering identical to transcripts.
+- Precedent note: `get_aicall_messages` already exposes the full raw dump
+  (including system) for any own-customer aicall_id with the same ownership
+  check — so this adds no new cross-session data surface; it is a curated
+  subset of an existing one.
+- Tool description, Problem Statement, WHEN-NOT-TO-USE, and test plan (new
+  case 2b) updated accordingly.
+Per the mandatory re-review rule, a fresh review round on the changed doc is
+required before implementation.
 
 ## 12. Checklist deltas vs the standard template
 


### PR DESCRIPTION
Add the get_resource LLM tool to bin-ai-manager: the follow-up to get_correlation that fetches the actual content of a correlated resource and returns a curated, LLM-readable summary. Design doc included (5 review rounds); implementation passed a 3-round PR review loop.

- bin-ai-manager: Add get_resource design document (docs/plans/2026-06-11-add-get-resource-tool-design.md)
- bin-ai-manager: Add get_resource tool supporting 8 resource types (call, groupcall, recording, transcribe, summary, aicall, conferencecall, queuecall) via existing requesthandler Get RPCs
- bin-ai-manager: Enforce two-stage fetch with post-ownership rendering (enrichment fetches never run for foreign resources) and existence-oracle masking (absent/cross-customer/nil-owner collapse to byte-identical "Resource not found.")
- bin-ai-manager: Include transcript body for transcribe and curated conversation history for aicall (role allowlist; system prompt snapshots never rendered)
- bin-ai-manager: Cap every summary at 4000 runes with most-recent-kept truncation and top-of-block markers
- bin-ai-manager: Fix formatCorrelationSummary resource label (was envelope data_type application/json; now derived from event-type prefix)
- bin-ai-manager: Cross-link get_resource from the get_correlation tool description
- bin-ai-manager: Add tests (per-type success, per-type masking invariant via reflect.DeepEqual, post-ownership no-EXPECT locks, truncation/page-cap mechanics, enum drift guard) and docs/domain.md tool table rows