### PR TITLE
NOJIRA-Fix-openapi-optional-flow-fields

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -10688,6 +10688,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "description": "Provide either flow_id or actions. If both are set, flow_id takes precedence and actions is ignored.",
                 "properties": {
                   "source": {
                     "$ref": "#/components/schemas/CommonAddress"
@@ -10699,13 +10700,19 @@
                     }
                   },
                   "flow_id": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "uuid",
+                    "x-go-type": "string",
+                    "description": "The flow to execute for the groupcall. Provide either flow_id or actions; if both are set, flow_id takes precedence and actions is ignored. The flow ID returned from the POST /flows or GET /flows response.",
+                    "example": "d4e5f6a7-b8c9-0123-4567-890abcdef012"
                   },
                   "actions": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                       "$ref": "#/components/schemas/FlowManagerAction"
-                    }
+                    },
+                    "description": "Inline actions used to build a temporary flow when flow_id is not provided. Provide either flow_id or actions."
                   },
                   "ring_method": {
                     "$ref": "#/components/schemas/CallManagerGroupcallRingMethod"
@@ -10717,8 +10724,6 @@
                 "required": [
                   "source",
                   "destinations",
-                  "flow_id",
-                  "actions",
                   "ring_method",
                   "answer_method"
                 ]
@@ -19437,15 +19442,17 @@
                   },
                   "on_end_flow_id": {
                     "type": "string",
-                    "description": "The ID of the flow to be executed when the transcription ends."
+                    "format": "uuid",
+                    "x-go-type": "string",
+                    "description": "The flow to execute when the transcription ends. The flow ID returned from the POST /flows or GET /flows response. If omitted, no follow-up flow is executed.",
+                    "example": "d4e5f6a7-b8c9-0123-4567-890abcdef012"
                   }
                 },
                 "required": [
                   "reference_type",
                   "reference_id",
                   "language",
-                  "direction",
-                  "on_end_flow_id"
+                  "direction"
                 ]
               }
             }

--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -10704,7 +10704,7 @@
                     "format": "uuid",
                     "x-go-type": "string",
                     "description": "The flow to execute for the groupcall. Provide either flow_id or actions; if both are set, flow_id takes precedence and actions is ignored. The flow ID returned from the POST /flows or GET /flows response.",
-                    "example": "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+                    "example": "c1d2e3f4-a5b6-7890-cdef-1234567890ab"
                   },
                   "actions": {
                     "type": "array",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -5934,12 +5934,15 @@ type GetGroupcallsParams struct {
 
 // PostGroupcallsJSONBody defines parameters for PostGroupcalls.
 type PostGroupcallsJSONBody struct {
-	Actions []FlowManagerAction `json:"actions"`
+	// Actions Inline actions used to build a temporary flow when flow_id is not provided. Provide either flow_id or actions.
+	Actions *[]FlowManagerAction `json:"actions,omitempty"`
 
 	// AnswerMethod Method to handle answered calls
 	AnswerMethod CallManagerGroupcallAnswerMethod `json:"answer_method"`
 	Destinations []CommonAddress                  `json:"destinations"`
-	FlowId       string                           `json:"flow_id"`
+
+	// FlowId The flow to execute for the groupcall. Provide either flow_id or actions; if both are set, flow_id takes precedence and actions is ignored. The flow ID returned from the POST /flows or GET /flows response.
+	FlowId *string `json:"flow_id,omitempty"`
 
 	// RingMethod Method used for dialing
 	RingMethod CallManagerGroupcallRingMethod `json:"ring_method"`
@@ -6889,8 +6892,8 @@ type PostTranscribesJSONBody struct {
 	// Language The language of the transcription.
 	Language string `json:"language"`
 
-	// OnEndFlowId The ID of the flow to be executed when the transcription ends.
-	OnEndFlowId string                               `json:"on_end_flow_id"`
+	// OnEndFlowId The flow to execute when the transcription ends. The flow ID returned from the POST /flows or GET /flows response. If omitted, no follow-up flow is executed.
+	OnEndFlowId *string                              `json:"on_end_flow_id,omitempty"`
 	Provider    *TranscribeManagerTranscribeProvider `json:"provider,omitempty"`
 
 	// ReferenceId The ID of the reference for the transcription.

--- a/bin-api-manager/server/groupcalls.go
+++ b/bin-api-manager/server/groupcalls.go
@@ -47,10 +47,15 @@ func (h *server) PostGroupcalls(c *gin.Context) {
 	for _, v := range req.Destinations {
 		destinations = append(destinations, ConvertCommonAddress(v))
 	}
-	flowID := uuid.FromStringOrNil(req.FlowId)
+	flowID := uuid.Nil
+	if req.FlowId != nil {
+		flowID = uuid.FromStringOrNil(*req.FlowId)
+	}
 	actions := []fmaction.Action{}
-	for _, v := range req.Actions {
-		actions = append(actions, ConvertFlowManagerAction(v))
+	if req.Actions != nil {
+		for _, v := range *req.Actions {
+			actions = append(actions, ConvertFlowManagerAction(v))
+		}
 	}
 
 	res, err := h.serviceHandler.GroupcallCreate(c.Request.Context(), a, source, destinations, flowID, actions, cmgroupcall.RingMethod(req.RingMethod), cmgroupcall.AnswerMethod(req.AnswerMethod))

--- a/bin-api-manager/server/transcribes.go
+++ b/bin-api-manager/server/transcribes.go
@@ -35,7 +35,10 @@ func (h *server) PostTranscribes(c *gin.Context) {
 	}
 
 	referenceID := uuid.FromStringOrNil(req.ReferenceId)
-	onEndFlowID := uuid.FromStringOrNil(req.OnEndFlowId)
+	onEndFlowID := uuid.Nil
+	if req.OnEndFlowId != nil {
+		onEndFlowID = uuid.FromStringOrNil(*req.OnEndFlowId)
+	}
 
 	var provider tmtranscribe.Provider
 	if req.Provider != nil {

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -8137,12 +8137,15 @@ type GetGroupcallsParams struct {
 
 // PostGroupcallsJSONBody defines parameters for PostGroupcalls.
 type PostGroupcallsJSONBody struct {
-	Actions []FlowManagerAction `json:"actions"`
+	// Actions Inline actions used to build a temporary flow when flow_id is not provided. Provide either flow_id or actions.
+	Actions *[]FlowManagerAction `json:"actions,omitempty"`
 
 	// AnswerMethod Method to handle answered calls
 	AnswerMethod CallManagerGroupcallAnswerMethod `json:"answer_method"`
 	Destinations []CommonAddress                  `json:"destinations"`
-	FlowId       string                           `json:"flow_id"`
+
+	// FlowId The flow to execute for the groupcall. Provide either flow_id or actions; if both are set, flow_id takes precedence and actions is ignored. The flow ID returned from the POST /flows or GET /flows response.
+	FlowId *string `json:"flow_id,omitempty"`
 
 	// RingMethod Method used for dialing
 	RingMethod CallManagerGroupcallRingMethod `json:"ring_method"`
@@ -9092,8 +9095,8 @@ type PostTranscribesJSONBody struct {
 	// Language The language of the transcription.
 	Language string `json:"language"`
 
-	// OnEndFlowId The ID of the flow to be executed when the transcription ends.
-	OnEndFlowId string                               `json:"on_end_flow_id"`
+	// OnEndFlowId The flow to execute when the transcription ends. The flow ID returned from the POST /flows or GET /flows response. If omitted, no follow-up flow is executed.
+	OnEndFlowId *string                              `json:"on_end_flow_id,omitempty"`
 	Provider    *TranscribeManagerTranscribeProvider `json:"provider,omitempty"`
 
 	// ReferenceId The ID of the reference for the transcription.

--- a/bin-openapi-manager/openapi/paths/groupcalls/main.yaml
+++ b/bin-openapi-manager/openapi/paths/groupcalls/main.yaml
@@ -54,7 +54,7 @@ post:
                 or actions; if both are set, flow_id takes precedence and
                 actions is ignored. The flow ID returned from the POST /flows
                 or GET /flows response.
-              example: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+              example: "c1d2e3f4-a5b6-7890-cdef-1234567890ab"
             actions:
               type: array
               minItems: 1

--- a/bin-openapi-manager/openapi/paths/groupcalls/main.yaml
+++ b/bin-openapi-manager/openapi/paths/groupcalls/main.yaml
@@ -35,6 +35,9 @@ post:
       application/json:
         schema:
           type: object
+          description: >-
+            Provide either flow_id or actions. If both are set, flow_id takes
+            precedence and actions is ignored.
           properties:
             source:
               $ref: '#/components/schemas/CommonAddress'
@@ -44,10 +47,22 @@ post:
                 $ref: '#/components/schemas/CommonAddress'
             flow_id:
               type: string
+              format: uuid
+              x-go-type: string
+              description: >-
+                The flow to execute for the groupcall. Provide either flow_id
+                or actions; if both are set, flow_id takes precedence and
+                actions is ignored. The flow ID returned from the POST /flows
+                or GET /flows response.
+              example: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
             actions:
               type: array
+              minItems: 1
               items:
                 $ref: '#/components/schemas/FlowManagerAction'
+              description: >-
+                Inline actions used to build a temporary flow when flow_id is
+                not provided. Provide either flow_id or actions.
             ring_method:
               $ref: '#/components/schemas/CallManagerGroupcallRingMethod'
             answer_method:
@@ -55,8 +70,6 @@ post:
           required:
             - source
             - destinations
-            - flow_id
-            - actions
             - ring_method
             - answer_method
   responses:

--- a/bin-openapi-manager/openapi/paths/transcribes/main.yaml
+++ b/bin-openapi-manager/openapi/paths/transcribes/main.yaml
@@ -51,13 +51,18 @@ post:
               $ref: '#/components/schemas/TranscribeManagerTranscribeProvider'
             on_end_flow_id:
               type: string
-              description: The ID of the flow to be executed when the transcription ends.
+              format: uuid
+              x-go-type: string
+              description: >-
+                The flow to execute when the transcription ends. The flow ID
+                returned from the POST /flows or GET /flows response. If
+                omitted, no follow-up flow is executed.
+              example: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
           required:
             - reference_type
             - reference_id
             - language
             - direction
-            - on_end_flow_id
   responses:
     '200':
       description: The created transcribe details.

--- a/docs/plans/2026-06-15-openapi-optional-flow-fields-design.md
+++ b/docs/plans/2026-06-15-openapi-optional-flow-fields-design.md
@@ -1,0 +1,179 @@
+# Design: Make flow-related request fields optional in the OpenAPI spec
+
+## Problem
+
+The OpenAPI spec marks several request-body fields as `required` that the
+backend handlers do NOT actually require at runtime. The spec is the source of
+truth for the generated Go types (`oapi-codegen`), the ReDoc/Swagger public
+docs, and any client SDKs. The mismatch means:
+
+- Public docs tell users a field is mandatory when it is not.
+- Generated request structs use value types (non-pointer) for fields the
+  handler treats as optional, forcing the handler to rely on zero-value
+  coercion (`uuid.FromStringOrNil("")` -> `uuid.Nil`).
+
+Two endpoints are affected:
+
+### 1. `POST /transcribes` — `on_end_flow_id`
+
+- Spec: `openapi/paths/transcribes/main.yaml` lists `on_end_flow_id` in
+  `required`.
+- Runtime: `server/transcribes.go:38` does
+  `onEndFlowID := uuid.FromStringOrNil(req.OnEndFlowId)` with no rejection when
+  empty. `pkg/servicehandler/transcribe.go` passes it through; `uuid.Nil` is a
+  valid "no follow-up flow" value.
+- Conclusion: `on_end_flow_id` is optional at runtime. (Already documented as
+  optional in the transcribe tutorial via PR #987.)
+
+### 2. `POST /groupcalls` — `flow_id` and `actions`
+
+- Spec: `openapi/paths/groupcalls/main.yaml` lists
+  `source, destinations, flow_id, actions, ring_method, answer_method` all in
+  `required`.
+- Runtime: `pkg/servicehandler/groupcall.go:152-163` uses `flow_id` if set,
+  otherwise builds a temp flow from `actions`. Neither is individually
+  mandatory; the caller provides one OR the other (flow_id wins if both set).
+- `server/groupcalls.go:50,52` reads `req.FlowId` (value string) and
+  `req.Actions` (value slice) with no rejection.
+- Conclusion: `flow_id` and `actions` are each optional at runtime (the real
+  constraint is "provide at least one", enforced implicitly, not a per-field
+  `required`).
+
+## Why not `oneOf`
+
+The spec rule file recommends `oneOf` for polymorphism, but:
+
+- `oneOf` is currently used NOWHERE in the spec (grep: 0 matches). Introducing
+  it for groupcall would be the first use and would change the oapi-codegen
+  output shape into a union type, forcing a handler rewrite of
+  `server/groupcalls.go`.
+- `oneOf` semantically means "exactly one", but the runtime does NOT enforce
+  exactly-one (both-empty passes through, both-set lets flow_id win). So `oneOf`
+  would itself be inaccurate to the code.
+- The accurate, minimal, code-truthful change is: remove these fields from
+  `required` (make them optional). This matches the handler exactly.
+
+## Change set
+
+### Spec (`bin-openapi-manager`)
+
+1. `openapi/paths/transcribes/main.yaml`:
+   - Remove `on_end_flow_id` from the `required` list (keep the property).
+   - Enrich the `on_end_flow_id` property. Use `x-go-type: string` alongside
+     `format: uuid` so oapi-codegen keeps the field as a Go `string` (NOT
+     `openapi_types.UUID`), matching the `gofrs/uuid.FromStringOrNil(string)`
+     handler usage. This mirrors the existing `start_member_id` precedent in
+     `paths/teams/main.yaml:48-53` (`format: uuid` + `x-go-type: string`
+     -> generated `string`):
+     ```yaml
+     on_end_flow_id:
+       type: string
+       format: uuid
+       x-go-type: string
+       description: >-
+         The flow to execute when the transcription ends. The flow ID returned
+         from the POST /flows or GET /flows response. If omitted, no follow-up
+         flow is executed.
+     ```
+
+2. `openapi/paths/groupcalls/main.yaml`:
+   - Remove `flow_id` and `actions` from the `required` list (keep both
+     properties).
+   - **Add descriptions that state the at-least-one constraint and the
+     precedence**, since "required removal alone" would wrongly imply both are
+     freely omittable. The real constraint ("provide flow_id OR actions;
+     flow_id wins") is not expressible by `required` and MUST live in the
+     description. Use `x-go-type: string` with `format: uuid` on `flow_id` for
+     the same reason as above:
+     ```yaml
+     flow_id:
+       type: string
+       format: uuid
+       x-go-type: string
+       description: >-
+         The flow to execute for the groupcall. Provide either flow_id or
+         actions; if both are set, flow_id takes precedence and actions is
+         ignored. The flow ID returned from the POST /flows or GET /flows
+         response.
+     actions:
+       type: array
+       minItems: 1
+       items:
+         $ref: '#/components/schemas/FlowManagerAction'
+       description: >-
+         Inline actions used to build a temporary flow when flow_id is not
+         provided. Provide either flow_id or actions.
+     ```
+   - Also add a request-body-level description on the POST schema for
+     discoverability (a reader scanning only one field still sees the rule):
+     `description: "Provide either flow_id or actions. If both are set, flow_id
+     takes precedence and actions is ignored."` on the request schema object.
+   - Keep `source`, `destinations`, `ring_method`, `answer_method` as required
+     (out of scope; see Open question).
+
+3. Regenerate: `cd bin-openapi-manager && go generate ./...` to update
+   `gens/models/gen.go`.
+
+### Generated types + handlers (`bin-api-manager`)
+
+4. `cd bin-api-manager && go generate ./...` to regenerate
+   `gens/openapi_server/gen.go`. Expected change: `OnEndFlowId`, `FlowId`
+   become `*string` (NOT `*openapi_types.UUID`, because of `x-go-type: string`);
+   `Actions` becomes `*[]FlowManagerAction`. Confirm the generated types are
+   exactly these before editing handlers; if any field comes out as a
+   `*openapi_types.UUID`, the `x-go-type: string` is missing and must be added.
+5. Adjust handlers to the established nil-check pattern already used in
+   `server/activeflows.go:90-99`:
+   - `server/transcribes.go:38`:
+     ```go
+     onEndFlowID := uuid.Nil
+     if req.OnEndFlowId != nil {
+         onEndFlowID = uuid.FromStringOrNil(*req.OnEndFlowId)
+     }
+     ```
+   - `server/groupcalls.go:50,52`:
+     ```go
+     flowID := uuid.Nil
+     if req.FlowId != nil {
+         flowID = uuid.FromStringOrNil(*req.FlowId)
+     }
+     actions := []fmaction.Action{}
+     if req.Actions != nil {
+         for _, v := range *req.Actions {
+             actions = append(actions, ConvertFlowManagerAction(v))
+         }
+     }
+     ```
+6. Handler unit tests for these endpoints build the request body as raw JSON
+   bytes (`reqBody: []byte(...)` passed to `c.BindJSON`), so the value-to-pointer
+   type flip does NOT break them. No test edits are expected; confirm via
+   `go test ./...` rather than pre-emptively editing tests.
+
+## Verification
+
+- `bin-openapi-manager`: `go generate ./...`, `go build ./...`.
+- `bin-api-manager`: full 5-step workflow — `go mod tidy && go mod vendor &&
+  go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
+- Confirm `gen.go` diff shows only the three fields flipping to pointer types
+  (no unrelated churn).
+- Confirm no other service consumes these specific generated request structs
+  (they are bin-api-manager server types).
+
+## Scope guard / non-goals
+
+- Do NOT touch the RST docs in this PR (already corrected in PRs #987/#990).
+- Do NOT introduce `oneOf`.
+- Do NOT change `ring_method`/`answer_method` requiredness in this PR unless a
+  reviewer flags it (see Open question).
+- Separate known mismatch, out of scope: `POST /transcribes` `direction` is
+  `required` in the spec but the handler ignores `req.Direction` and hardcodes
+  `DirectionBoth` (`server/transcribes.go:51`). Track as a follow-up ticket;
+  not addressed here.
+
+## Open question for reviewers
+
+`ring_method`/`answer_method` are `required` in the spec but the handler also
+accepts empty values (`RingMethodNone = ""`, `AnswerMethodNone = ""`). Should
+they also be made optional for full code-truth, or kept required as a
+"normal usage" guard? Default position: keep them required (out of scope), since
+this PR targets the flow_id/actions/on_end_flow_id mismatch specifically.


### PR DESCRIPTION
Make flow-related request fields optional in the OpenAPI spec to match the actual handler behavior. on_end_flow_id (POST /transcribes) and flow_id/actions (POST /groupcalls) were marked required, but the handlers treat them as optional at runtime (uuid.Nil / empty slice are valid values). Removing them from required fixes the public ReDoc/Swagger contract and the generated request types, and aligns the spec with the tutorials corrected in #987/#990.

oneOf was intentionally avoided: the runtime does not enforce exactly-one (both-empty passes, both-set lets flow_id win), so the at-least-one constraint is documented in the field and request-body descriptions instead. format: uuid is paired with x-go-type: string so the generated Go fields stay string (not openapi_types.UUID), matching the gofrs/uuid.FromStringOrNil handler usage.

- bin-openapi-manager: Remove on_end_flow_id from the POST /transcribes required list and add format/x-go-type/description/example
- bin-openapi-manager: Remove flow_id and actions from the POST /groupcalls required list, document the "provide either, flow_id wins" constraint on the fields and request body, add minItems and format/x-go-type
- bin-openapi-manager: Regenerate gens/models/gen.go (OnEndFlowId/FlowId become *string, Actions becomes *[]FlowManagerAction)
- bin-api-manager: Regenerate gens/openapi_server/gen.go and openapi_redoc bundle
- bin-api-manager: Adjust transcribes and groupcalls handlers to the nil-check pointer pattern used by activeflows
- monorepo: Add the design document under docs/plans