### PR TITLE
NOJIRA-Add-describe-action-tool

### DIFF
--- a/bin-ai-manager/models/message/tool.go
+++ b/bin-ai-manager/models/message/tool.go
@@ -40,4 +40,5 @@ const (
 	FunctionCallNameSearchKnowledge   FunctionCallName = "search_knowledge"
 	FunctionCallNameGetCorrelation    FunctionCallName = "get_correlation"
 	FunctionCallNameGetResource       FunctionCallName = "get_resource"
+	FunctionCallNameDescribeAction    FunctionCallName = "describe_action"
 )

--- a/bin-ai-manager/models/tool/main.go
+++ b/bin-ai-manager/models/tool/main.go
@@ -19,6 +19,7 @@ const (
 	ToolNameSearchKnowledge   ToolName = "search_knowledge"
 	ToolNameGetCorrelation    ToolName = "get_correlation"
 	ToolNameGetResource       ToolName = "get_resource"
+	ToolNameDescribeAction    ToolName = "describe_action"
 )
 
 // AllToolNames returns all available tool names (excluding "all")
@@ -36,6 +37,7 @@ var AllToolNames = []ToolName{
 	ToolNameSearchKnowledge,
 	ToolNameGetCorrelation,
 	ToolNameGetResource,
+	ToolNameDescribeAction,
 }
 
 // Tool defines a tool with its schema for LLM function calling.

--- a/bin-ai-manager/pkg/actioncatalog/main.go
+++ b/bin-ai-manager/pkg/actioncatalog/main.go
@@ -1,0 +1,312 @@
+package actioncatalog
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	fmaction "monorepo/bin-flow-manager/models/action"
+)
+
+// ErrUnknownActionType is returned by DescribeAction when the requested action
+// type is not in the catalog. The error message echoes the received value and
+// lists the valid types so an LLM can self-correct.
+var ErrUnknownActionType = errors.New("unknown action type")
+
+// ActionTypeEnum returns the JSON-schema enum of all flow action types, sourced
+// from the authoritative flow-manager action.TypeListAll. Both the create_call
+// "actions[].type" schema and the describe_action "action_type" schema use this
+// so the two enums cannot drift from each other or from flow-manager.
+func ActionTypeEnum() []string {
+	out := make([]string, len(fmaction.TypeListAll))
+	for i, t := range fmaction.TypeListAll {
+		out[i] = string(t)
+	}
+	return out
+}
+
+// actionOptionField describes a single option field of a flow action, for the
+// describe_action tool. Name MUST match the option struct's top-level json tag
+// (verified by TestActionCatalogFieldsMatchOptionStructs); Type and Description
+// are human-readable text condensed from option.go comments and the RST docs.
+type actionOptionField struct {
+	Name        string
+	Type        string
+	Required    bool
+	Description string
+}
+
+// actionCatalogEntry describes one flow action type for the LLM.
+type actionCatalogEntry struct {
+	Type    fmaction.Type
+	Summary string
+	Options []actionOptionField
+}
+
+// actionCatalog is the authoritative hand-authored catalog: one entry per
+// flow-manager action type. It is condensed from
+// bin-flow-manager/models/action/option.go (field names + comments) and the
+// user-facing bin-api-manager/docsdev/source/flow_struct_action.rst.
+//
+// DRIFT GUARDS:
+//   - TestActionCatalogMatchesTypeListAll: one entry per action.TypeListAll
+//     (no missing / extra / duplicate type).
+//   - TestActionCatalogFieldsMatchOptionStructs: each entry's option field
+//     Names equal the real option struct's top-level json fields (via
+//     action.OptionStructByType). Field TYPE/Description text is NOT machine
+//     checked; keep it in sync by hand when option.go changes.
+var actionCatalog = []actionCatalogEntry{
+	{Type: fmaction.TypeAMD, Summary: "Detect whether a human or an answering machine answered the call.", Options: []actionOptionField{
+		{Name: "machine_handle", Type: "string", Required: false, Description: "What to do if a machine answered: hangup or continue."},
+		{Name: "async", Type: "bool", Required: false, Description: "If false, the flow waits until AMD finishes before continuing."},
+	}},
+	{Type: fmaction.TypeAnswer, Summary: "Answer the incoming call.", Options: nil},
+	{Type: fmaction.TypeAISummary, Summary: "Generate an AI summary of a reference (e.g. a recording or transcribe).", Options: []actionOptionField{
+		{Name: "on_end_flow_id", Type: "uuid", Required: false, Description: "Flow id to run when the summary finishes."},
+		{Name: "reference_type", Type: "string", Required: true, Description: "Type of the resource to summarize."},
+		{Name: "reference_id", Type: "uuid", Required: true, Description: "Id of the resource to summarize."},
+		{Name: "language", Type: "string", Required: false, Description: "Output language (IETF locale, e.g. en-US)."},
+	}},
+	{Type: fmaction.TypeAITalk, Summary: "Start an AI voice conversation on the call.", Options: []actionOptionField{
+		{Name: "ai_id", Type: "uuid", Required: false, Description: "Deprecated; use assistance_type + assistance_id."},
+		{Name: "assistance_type", Type: "string", Required: true, Description: "\"ai\" or \"team\"."},
+		{Name: "assistance_id", Type: "uuid", Required: true, Description: "Id of the AI or team to converse with."},
+		{Name: "duration", Type: "int (seconds)", Required: false, Description: "Maximum AI talk duration in seconds."},
+	}},
+	{Type: fmaction.TypeAITask, Summary: "Run an AI task (non-conversational) on the call.", Options: []actionOptionField{
+		{Name: "ai_id", Type: "uuid", Required: false, Description: "Deprecated; use assistance_type + assistance_id."},
+		{Name: "assistance_type", Type: "string", Required: true, Description: "\"ai\" or \"team\"."},
+		{Name: "assistance_id", Type: "uuid", Required: true, Description: "Id of the AI or team to run the task."},
+	}},
+	{Type: fmaction.TypeBeep, Summary: "Play a beep tone on the call.", Options: nil},
+	{Type: fmaction.TypeBlock, Summary: "Internal grouping/block action.", Options: nil},
+	{Type: fmaction.TypeBranch, Summary: "Branch the flow to different actions based on a variable / received DTMF.", Options: []actionOptionField{
+		{Name: "variable", Type: "string", Required: false, Description: "Variable to branch on (defaults to received digits)."},
+		{Name: "default_target_id", Type: "uuid", Required: false, Description: "Action id to go to when no target matches."},
+		{Name: "target_ids", Type: "object (map of value -> action id)", Required: true, Description: "Map of matched value to the action id to jump to."},
+	}},
+	{Type: fmaction.TypeCall, Summary: "Originate one or more new outbound calls (each runs its own flow or actions).", Options: []actionOptionField{
+		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destinations to call."},
+		{Name: "flow_id", Type: "uuid", Required: false, Description: "Pre-built flow the new call runs (use flow_id OR actions)."},
+		{Name: "actions", Type: "array of action objects", Required: false, Description: "Inline actions the new call runs (use flow_id OR actions)."},
+		{Name: "chained", Type: "bool", Required: false, Description: "If true, the created calls hang up when the master call hangs up."},
+		{Name: "early_execution", Type: "bool", Required: false, Description: "If true, the created call runs its flow before being answered."},
+		{Name: "anonymous", Type: "string (yes|no|auto)", Required: false, Description: "Anonymous caller id on outbound PSTN."},
+	}},
+	{Type: fmaction.TypeConditionCallDigits, Summary: "Branch to a false target unless the call's received digits meet the condition.", Options: []actionOptionField{
+		{Name: "length", Type: "int", Required: false, Description: "Required digit length."},
+		{Name: "key", Type: "string", Required: false, Description: "Required finishing digit key."},
+		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
+	}},
+	{Type: fmaction.TypeConditionCallStatus, Summary: "Branch to a false target unless the call's status matches.", Options: []actionOptionField{
+		{Name: "status", Type: "string", Required: true, Description: "Call status to test for."},
+		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
+	}},
+	{Type: fmaction.TypeConditionDatetime, Summary: "Branch to a false target unless the current date/time matches the condition.", Options: []actionOptionField{
+		{Name: "condition", Type: "string", Required: true, Description: "Comparison operator."},
+		{Name: "minute", Type: "int (0-59)", Required: false, Description: "Minute component."},
+		{Name: "hour", Type: "int (0-23)", Required: false, Description: "Hour component."},
+		{Name: "day", Type: "int (1-31)", Required: false, Description: "Day of month."},
+		{Name: "month", Type: "int (1-12)", Required: false, Description: "Month."},
+		{Name: "weekdays", Type: "array of int (Sun=0..Sat=6)", Required: false, Description: "Allowed weekdays."},
+		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
+	}},
+	{Type: fmaction.TypeConditionVariable, Summary: "Branch to a false target unless a flow variable matches the condition.", Options: []actionOptionField{
+		{Name: "condition", Type: "string", Required: true, Description: "Comparison operator."},
+		{Name: "variable", Type: "string", Required: true, Description: "Variable name to test."},
+		{Name: "value_type", Type: "string", Required: true, Description: "Type of the value to compare (string/number/length)."},
+		{Name: "value_string", Type: "string", Required: false, Description: "String value to compare against."},
+		{Name: "value_number", Type: "number", Required: false, Description: "Numeric value to compare against."},
+		{Name: "value_length", Type: "int", Required: false, Description: "Length value to compare against."},
+		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
+	}},
+	{Type: fmaction.TypeConfbridgeJoin, Summary: "Join the call into a confbridge (advanced/internal).", Options: []actionOptionField{
+		{Name: "confbridge_id", Type: "uuid", Required: true, Description: "Confbridge id to join."},
+	}},
+	{Type: fmaction.TypeConferenceJoin, Summary: "Join the call into a conference.", Options: []actionOptionField{
+		{Name: "conference_id", Type: "uuid", Required: true, Description: "Conference id to join."},
+	}},
+	{Type: fmaction.TypeConnect, Summary: "Originate new call(s) and bridge them into the current call (transfer/connect).", Options: []actionOptionField{
+		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Endpoints to connect to."},
+		{Name: "early_media", Type: "bool", Required: false, Description: "If true, get early media from the destination."},
+		{Name: "relay_reason", Type: "bool", Required: false, Description: "If true, hang up the master call with the destination's hangup reason."},
+		{Name: "anonymous", Type: "string (yes|no|auto)", Required: false, Description: "Anonymous caller id on outbound PSTN."},
+	}},
+	{Type: fmaction.TypeConversationSend, Summary: "Send a message into a conversation (chat/SNS).", Options: []actionOptionField{
+		{Name: "conversation_id", Type: "uuid", Required: true, Description: "Conversation id to send into."},
+		{Name: "text", Type: "string", Required: true, Description: "Message text."},
+		{Name: "sync", Type: "bool", Required: false, Description: "Whether to send synchronously."},
+	}},
+	{Type: fmaction.TypeDigitsReceive, Summary: "Receive DTMF digits from the caller.", Options: []actionOptionField{
+		{Name: "duration", Type: "int (ms)", Required: false, Description: "DTMF receiving duration in milliseconds."},
+		{Name: "key", Type: "string", Required: false, Description: "Finishing key; not included in the resulting variable. If unset, no key finishes."},
+		{Name: "length", Type: "int", Required: false, Description: "Max number of DTMF events to gather before continuing."},
+	}},
+	{Type: fmaction.TypeDigitsSend, Summary: "Send DTMF tones on the call.", Options: []actionOptionField{
+		{Name: "digits", Type: "string", Required: true, Description: "Keys to send (0-9, A-D, #, *; max 100)."},
+		{Name: "duration", Type: "int (ms)", Required: false, Description: "DTMF tone duration per key (100-1000)."},
+		{Name: "interval", Type: "int (ms)", Required: false, Description: "Interval between keys (0-5000)."},
+	}},
+	{Type: fmaction.TypeEcho, Summary: "Echo the caller's audio back to them.", Options: []actionOptionField{
+		{Name: "duration", Type: "int", Required: false, Description: "Echo duration."},
+	}},
+	{Type: fmaction.TypeEmailSend, Summary: "Send an email.", Options: []actionOptionField{
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Email recipients."},
+		{Name: "subject", Type: "string", Required: true, Description: "Email subject."},
+		{Name: "content", Type: "string", Required: true, Description: "Email body (HTML or plain text)."},
+		{Name: "attachments", Type: "array of attachment objects {reference_type,reference_id}", Required: false, Description: "Optional attachments."},
+	}},
+	{Type: fmaction.TypeExternalMediaStart, Summary: "Start streaming external media (advanced/infra).", Options: []actionOptionField{
+		{Name: "external_host", Type: "string", Required: true, Description: "External media target host address."},
+		{Name: "encapsulation", Type: "string", Required: false, Description: "Encapsulation (default rtp)."},
+		{Name: "transport", Type: "string", Required: false, Description: "Transport (default udp)."},
+		{Name: "transport_data", Type: "string", Required: false, Description: "Transport-specific data."},
+		{Name: "connection_type", Type: "string", Required: false, Description: "Connection type (default client)."},
+		{Name: "format", Type: "string", Required: false, Description: "Audio format (default ulaw)."},
+		{Name: "direction_listen", Type: "string", Required: false, Description: "Listen direction."},
+		{Name: "direction_speak", Type: "string", Required: false, Description: "Speak direction."},
+		{Name: "data", Type: "string", Required: false, Description: "Data."},
+	}},
+	{Type: fmaction.TypeExternalMediaStop, Summary: "Stop external media streaming (advanced/infra).", Options: nil},
+	{Type: fmaction.TypeFetch, Summary: "Fetch the next actions from an external HTTP endpoint.", Options: []actionOptionField{
+		{Name: "event_url", Type: "string", Required: true, Description: "URL to fetch actions from."},
+		{Name: "event_method", Type: "string", Required: false, Description: "HTTP method."},
+	}},
+	{Type: fmaction.TypeFetchFlow, Summary: "Fetch and run the actions of another flow.", Options: []actionOptionField{
+		{Name: "flow_id", Type: "uuid", Required: true, Description: "Flow id whose actions to run."},
+	}},
+	{Type: fmaction.TypeGoto, Summary: "Jump to another action in the flow (optionally looping).", Options: []actionOptionField{
+		{Name: "target_id", Type: "uuid", Required: true, Description: "Action id to jump to."},
+		{Name: "loop_count", Type: "int", Required: false, Description: "Number of times to loop."},
+	}},
+	{Type: fmaction.TypeHangup, Summary: "Hang up the call.", Options: []actionOptionField{
+		{Name: "reason", Type: "string", Required: false, Description: "Hangup reason code."},
+		{Name: "reference_id", Type: "uuid", Required: false, Description: "Hang up with the same reason as this referenced call id (overrides reason)."},
+	}},
+	{Type: fmaction.TypeMessageSend, Summary: "Send an SMS text message.", Options: []actionOptionField{
+		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source phone number."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destination phone numbers."},
+		{Name: "text", Type: "string", Required: true, Description: "Message text."},
+	}},
+	{Type: fmaction.TypeMute, Summary: "Mute audio on the call.", Options: nil},
+	{Type: fmaction.TypePlay, Summary: "Play audio from one or more media URLs.", Options: []actionOptionField{
+		{Name: "stream_urls", Type: "array of string", Required: true, Description: "Media URLs to play."},
+	}},
+	{Type: fmaction.TypeQueueJoin, Summary: "Place the call into a queue.", Options: []actionOptionField{
+		{Name: "queue_id", Type: "uuid", Required: true, Description: "Queue id to join."},
+	}},
+	{Type: fmaction.TypeRecordingStart, Summary: "Start recording the call.", Options: []actionOptionField{
+		{Name: "format", Type: "string", Required: false, Description: "Audio format: wav, mp3, ogg."},
+		{Name: "end_of_silence", Type: "int (seconds)", Required: false, Description: "Max silence duration; 0 for no limit."},
+		{Name: "end_of_key", Type: "string", Required: false, Description: "DTMF input to terminate recording: none, any, *, #."},
+		{Name: "duration", Type: "int (seconds)", Required: false, Description: "Max recording duration; 0 for no limit."},
+		{Name: "beep_start", Type: "bool", Required: false, Description: "Play a beep when recording begins."},
+		{Name: "on_end_flow_id", Type: "uuid", Required: false, Description: "Flow id to run when recording ends."},
+	}},
+	{Type: fmaction.TypeRecordingStop, Summary: "Stop the current recording.", Options: nil},
+	{Type: fmaction.TypeSleep, Summary: "Pause the flow for a duration.", Options: []actionOptionField{
+		{Name: "duration", Type: "int (ms)", Required: true, Description: "Sleep duration in milliseconds."},
+	}},
+	{Type: fmaction.TypeStop, Summary: "Stop the flow execution.", Options: nil},
+	{Type: fmaction.TypeStreamEcho, Summary: "Stream-echo the caller's audio (advanced).", Options: []actionOptionField{
+		{Name: "duration", Type: "int", Required: false, Description: "Echo duration."},
+	}},
+	{Type: fmaction.TypeTalk, Summary: "Speak text to the call using TTS (SSML or plain text).", Options: []actionOptionField{
+		{Name: "text", Type: "string", Required: true, Description: "Text to read (SSML or plain text)."},
+		{Name: "language", Type: "string", Required: false, Description: "IETF locale, e.g. ko-KR, en-US."},
+		{Name: "provider", Type: "string", Required: false, Description: "TTS provider (gcp/aws)."},
+		{Name: "voice_id", Type: "string", Required: false, Description: "Provider-specific voice ID."},
+		{Name: "digits_handle", Type: "object", Required: false, Description: "What to do when DTMF digits are received during talk."},
+		{Name: "async", Type: "bool", Required: false, Description: "If true, the flow continues without waiting for talk to finish."},
+	}},
+	{Type: fmaction.TypeTranscribeStart, Summary: "Start live transcription of the call.", Options: []actionOptionField{
+		{Name: "language", Type: "string", Required: false, Description: "BCP47 language, e.g. en-US."},
+		{Name: "on_end_flow_id", Type: "uuid", Required: false, Description: "Flow id to run when transcription ends."},
+		{Name: "provider", Type: "string", Required: false, Description: "Transcribe provider (gcp/aws)."},
+		{Name: "direction", Type: "string", Required: false, Description: "in|out|both (default both)."},
+	}},
+	{Type: fmaction.TypeTranscribeStop, Summary: "Stop live transcription.", Options: nil},
+	{Type: fmaction.TypeTranscribeRecording, Summary: "Transcribe a recording.", Options: []actionOptionField{
+		{Name: "language", Type: "string", Required: false, Description: "BCP47 language, e.g. en-US."},
+		{Name: "on_end_flow_id", Type: "uuid", Required: false, Description: "Flow id to run when transcription ends."},
+		{Name: "provider", Type: "string", Required: false, Description: "Transcribe provider (gcp/aws)."},
+		{Name: "direction", Type: "string", Required: false, Description: "in|out|both (default both)."},
+	}},
+	{Type: fmaction.TypeVariableSet, Summary: "Set a flow variable.", Options: []actionOptionField{
+		{Name: "key", Type: "string", Required: true, Description: "Variable name."},
+		{Name: "value", Type: "string", Required: true, Description: "Variable value."},
+	}},
+	{Type: fmaction.TypeWebhookSend, Summary: "Send an HTTP webhook request.", Options: []actionOptionField{
+		{Name: "sync", Type: "bool", Required: false, Description: "Whether to wait for the response."},
+		{Name: "uri", Type: "string", Required: true, Description: "Target URL."},
+		{Name: "method", Type: "string", Required: false, Description: "POST/GET/PUT/DELETE."},
+		{Name: "data_type", Type: "string", Required: false, Description: "Content type, e.g. application/json."},
+		{Name: "data", Type: "string", Required: false, Description: "Request body."},
+	}},
+}
+
+// catalogByType is the O(1) lookup map, built once at package load from
+// actionCatalog. Duplicate Types would be a programming error; the build panics
+// so they are caught at startup (and by TestActionCatalogMatchesTypeListAll).
+var catalogByType = buildCatalogByType()
+
+func buildCatalogByType() map[fmaction.Type]actionCatalogEntry {
+	m := make(map[fmaction.Type]actionCatalogEntry, len(actionCatalog))
+	for _, e := range actionCatalog {
+		if _, dup := m[e.Type]; dup {
+			panic(fmt.Sprintf("duplicate action catalog entry for type %s", e.Type))
+		}
+		m[e.Type] = e
+	}
+	return m
+}
+
+// renderActionCatalogEntry renders a catalog entry to the compact readable text
+// returned by describe_action. This format is a load-bearing contract consumed
+// by the LLM; it is pinned by a golden test.
+func renderActionCatalogEntry(e actionCatalogEntry) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("action: %s\n", e.Type))
+	b.WriteString(fmt.Sprintf("summary: %s\n", e.Summary))
+	if len(e.Options) == 0 {
+		b.WriteString("options: this action takes no options.")
+		return b.String()
+	}
+	b.WriteString("options:\n")
+	lines := make([]string, 0, len(e.Options))
+	for _, o := range e.Options {
+		req := "optional"
+		if o.Required {
+			req = "required"
+		}
+		lines = append(lines, fmt.Sprintf("  - %s (%s, %s): %s", o.Name, o.Type, req, o.Description))
+	}
+	b.WriteString(strings.Join(lines, "\n"))
+	return b.String()
+}
+
+// sortedActionTypeList returns the action types as a sorted, comma-joined string
+// for use in error messages (so a wrong action_type self-corrects).
+func sortedActionTypeList() string {
+	out := ActionTypeEnum()
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}
+
+// DescribeAction returns the rendered option-field description for a flow action
+// type. On an unknown/empty type it returns an error wrapping ErrUnknownActionType
+// whose message echoes the received value and lists the valid types so the LLM
+// can self-correct. This is a pure, customer-agnostic, read-only lookup.
+func DescribeAction(actionType string) (string, error) {
+	if actionType == "" {
+		return "", fmt.Errorf("%w: action_type is required. valid types: %s", ErrUnknownActionType, sortedActionTypeList())
+	}
+	entry, ok := catalogByType[fmaction.Type(actionType)]
+	if !ok {
+		return "", fmt.Errorf("%w: %q. valid types: %s", ErrUnknownActionType, actionType, sortedActionTypeList())
+	}
+	return renderActionCatalogEntry(entry), nil
+}

--- a/bin-ai-manager/pkg/actioncatalog/main.go
+++ b/bin-ai-manager/pkg/actioncatalog/main.go
@@ -58,13 +58,13 @@ type actionCatalogEntry struct {
 //     checked; keep it in sync by hand when option.go changes.
 var actionCatalog = []actionCatalogEntry{
 	{Type: fmaction.TypeAMD, Summary: "Detect whether a human or an answering machine answered the call.", Options: []actionOptionField{
-		{Name: "machine_handle", Type: "string", Required: false, Description: "What to do if a machine answered: hangup or continue."},
+		{Name: "machine_handle", Type: "string (hangup|continue)", Required: false, Description: "What to do if a machine answered: \"hangup\" or \"continue\"."},
 		{Name: "async", Type: "bool", Required: false, Description: "If false, the flow waits until AMD finishes before continuing."},
 	}},
 	{Type: fmaction.TypeAnswer, Summary: "Answer the incoming call.", Options: nil},
 	{Type: fmaction.TypeAISummary, Summary: "Generate an AI summary of a reference (e.g. a recording or transcribe).", Options: []actionOptionField{
 		{Name: "on_end_flow_id", Type: "uuid", Required: false, Description: "Flow id to run when the summary finishes."},
-		{Name: "reference_type", Type: "string", Required: true, Description: "Type of the resource to summarize."},
+		{Name: "reference_type", Type: "string (call|conference|transcribe|recording)", Required: true, Description: "Type of the resource to summarize."},
 		{Name: "reference_id", Type: "uuid", Required: true, Description: "Id of the resource to summarize."},
 		{Name: "language", Type: "string", Required: false, Description: "Output language (IETF locale, e.g. en-US)."},
 	}},
@@ -101,11 +101,11 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
 	}},
 	{Type: fmaction.TypeConditionCallStatus, Summary: "Branch to a false target unless the call's status matches.", Options: []actionOptionField{
-		{Name: "status", Type: "string", Required: true, Description: "Call status to test for."},
+		{Name: "status", Type: "string (dialing|ringing|progressing|terminating|canceling|hangup)", Required: true, Description: "Call status to test for."},
 		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
 	}},
 	{Type: fmaction.TypeConditionDatetime, Summary: "Branch to a false target unless the current date/time matches the condition.", Options: []actionOptionField{
-		{Name: "condition", Type: "string", Required: true, Description: "Comparison operator."},
+		{Name: "condition", Type: "string (==|!=|>|>=|<|<=)", Required: true, Description: "Comparison operator."},
 		{Name: "minute", Type: "int (0-59)", Required: false, Description: "Minute component."},
 		{Name: "hour", Type: "int (0-23)", Required: false, Description: "Hour component."},
 		{Name: "day", Type: "int (1-31)", Required: false, Description: "Day of month."},
@@ -114,9 +114,9 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "false_target_id", Type: "uuid", Required: true, Description: "Action id to jump to when the condition is false."},
 	}},
 	{Type: fmaction.TypeConditionVariable, Summary: "Branch to a false target unless a flow variable matches the condition.", Options: []actionOptionField{
-		{Name: "condition", Type: "string", Required: true, Description: "Comparison operator."},
+		{Name: "condition", Type: "string (==|!=|>|>=|<|<=)", Required: true, Description: "Comparison operator."},
 		{Name: "variable", Type: "string", Required: true, Description: "Variable name to test."},
-		{Name: "value_type", Type: "string", Required: true, Description: "Type of the value to compare (string/number/length)."},
+		{Name: "value_type", Type: "string (string|number|length)", Required: true, Description: "Type of the value to compare."},
 		{Name: "value_string", Type: "string", Required: false, Description: "String value to compare against."},
 		{Name: "value_number", Type: "number", Required: false, Description: "Numeric value to compare against."},
 		{Name: "value_length", Type: "int", Required: false, Description: "Length value to compare against."},
@@ -219,7 +219,7 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "language", Type: "string", Required: false, Description: "IETF locale, e.g. ko-KR, en-US."},
 		{Name: "provider", Type: "string", Required: false, Description: "TTS provider (gcp/aws)."},
 		{Name: "voice_id", Type: "string", Required: false, Description: "Provider-specific voice ID."},
-		{Name: "digits_handle", Type: "object", Required: false, Description: "What to do when DTMF digits are received during talk."},
+		{Name: "digits_handle", Type: "string (next or empty)", Required: false, Description: "What to do when DTMF digits are received during talk: \"next\" moves to the next action; empty does nothing."},
 		{Name: "async", Type: "bool", Required: false, Description: "If true, the flow continues without waiting for talk to finish."},
 	}},
 	{Type: fmaction.TypeTranscribeStart, Summary: "Start live transcription of the call.", Options: []actionOptionField{

--- a/bin-ai-manager/pkg/actioncatalog/main.go
+++ b/bin-ai-manager/pkg/actioncatalog/main.go
@@ -87,8 +87,8 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "target_ids", Type: "object (map of value -> action id)", Required: true, Description: "Map of matched value to the action id to jump to."},
 	}},
 	{Type: fmaction.TypeCall, Summary: "Originate one or more new outbound calls (each runs its own flow or actions).", Options: []actionOptionField{
-		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id."},
-		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destinations to call."},
+		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id. type is one of tel, sip, extension, agent."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destinations to call. type is one of tel, sip, extension, agent, conference."},
 		{Name: "flow_id", Type: "uuid", Required: false, Description: "Pre-built flow the new call runs (use flow_id OR actions)."},
 		{Name: "actions", Type: "array of action objects", Required: false, Description: "Inline actions the new call runs (use flow_id OR actions)."},
 		{Name: "chained", Type: "bool", Required: false, Description: "If true, the created calls hang up when the master call hangs up."},
@@ -129,8 +129,8 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "conference_id", Type: "uuid", Required: true, Description: "Conference id to join."},
 	}},
 	{Type: fmaction.TypeConnect, Summary: "Originate new call(s) and bridge them into the current call (transfer/connect).", Options: []actionOptionField{
-		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id."},
-		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Endpoints to connect to."},
+		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id. type is one of tel, sip, extension, agent."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Endpoints to connect to. type is one of tel, sip, extension, agent, conference."},
 		{Name: "early_media", Type: "bool", Required: false, Description: "If true, get early media from the destination."},
 		{Name: "relay_reason", Type: "bool", Required: false, Description: "If true, hang up the master call with the destination's hangup reason."},
 		{Name: "anonymous", Type: "string (yes|no|auto)", Required: false, Description: "Anonymous caller id on outbound PSTN."},
@@ -154,7 +154,7 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "duration", Type: "int", Required: false, Description: "Echo duration."},
 	}},
 	{Type: fmaction.TypeEmailSend, Summary: "Send an email.", Options: []actionOptionField{
-		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Email recipients."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Email recipients. type is email."},
 		{Name: "subject", Type: "string", Required: true, Description: "Email subject."},
 		{Name: "content", Type: "string", Required: true, Description: "Email body (HTML or plain text)."},
 		{Name: "attachments", Type: "array of attachment objects {reference_type,reference_id}", Required: false, Description: "Optional attachments."},
@@ -187,8 +187,8 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "reference_id", Type: "uuid", Required: false, Description: "Hang up with the same reason as this referenced call id (overrides reason)."},
 	}},
 	{Type: fmaction.TypeMessageSend, Summary: "Send an SMS text message.", Options: []actionOptionField{
-		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source phone number."},
-		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destination phone numbers."},
+		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source phone number. type is tel."},
+		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destination phone numbers. type is tel."},
 		{Name: "text", Type: "string", Required: true, Description: "Message text."},
 	}},
 	{Type: fmaction.TypeMute, Summary: "Mute audio on the call.", Options: nil},

--- a/bin-ai-manager/pkg/actioncatalog/main_test.go
+++ b/bin-ai-manager/pkg/actioncatalog/main_test.go
@@ -1,0 +1,178 @@
+package actioncatalog
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	fmaction "monorepo/bin-flow-manager/models/action"
+)
+
+// TestActionCatalogMatchesTypeListAll locks the describe_action catalog's type
+// set to flow-manager action.TypeListAll: one entry per type, no missing, no
+// extra, no duplicate. It iterates the raw slice (not the lookup map) so a
+// duplicated entry is caught rather than silently deduped.
+func TestActionCatalogMatchesTypeListAll(t *testing.T) {
+	seen := map[fmaction.Type]bool{}
+	got := make([]string, 0, len(actionCatalog))
+	for _, e := range actionCatalog {
+		if seen[e.Type] {
+			t.Errorf("duplicate catalog entry for type %s", e.Type)
+			continue
+		}
+		seen[e.Type] = true
+		got = append(got, string(e.Type))
+	}
+	sort.Strings(got)
+
+	want := make([]string, len(fmaction.TypeListAll))
+	for i, ty := range fmaction.TypeListAll {
+		want[i] = string(ty)
+	}
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("catalog has %d unique types, TypeListAll has %d. catalog: %v, TypeListAll: %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("type[%d] = %s, want %s (catalog: %v, TypeListAll: %v)", i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// TestActionCatalogFieldsMatchOptionStructs verifies, for every action type,
+// that the catalog entry's option field NAMES equal the real option struct's
+// top-level json field names (via action.OptionStructByType). This closes the
+// stale-option-field gap automatically without codegen. Field TYPE/Description
+// text is NOT checked (reflection cannot read comments) and is maintained by
+// hand per the option.go sync note.
+func TestActionCatalogFieldsMatchOptionStructs(t *testing.T) {
+	for _, ty := range fmaction.TypeListAll {
+		entry, ok := catalogByType[ty]
+		if !ok {
+			t.Errorf("%s: no catalog entry (covered by TestActionCatalogMatchesTypeListAll)", ty)
+			continue
+		}
+
+		st, ok := fmaction.OptionStructByType[ty]
+		if !ok {
+			t.Errorf("%s: no entry in action.OptionStructByType", ty)
+			continue
+		}
+
+		wantFields := topLevelJSONFieldNames(reflect.TypeOf(st))
+		gotFields := map[string]bool{}
+		for _, o := range entry.Options {
+			gotFields[o.Name] = true
+		}
+
+		for name := range wantFields {
+			if !gotFields[name] {
+				t.Errorf("%s: option struct has json field %q but catalog entry does not list it", ty, name)
+			}
+		}
+		for name := range gotFields {
+			if !wantFields[name] {
+				t.Errorf("%s: catalog lists option %q but option struct has no such top-level json field", ty, name)
+			}
+		}
+	}
+}
+
+// topLevelJSONFieldNames returns the set of top-level json field names for a
+// struct type. It honors json tag semantics: drops the ",omitempty"/",string"
+// suffix, skips json:"-" fields, skips unexported fields, and falls back to the
+// Go field name when an exported field has no json tag. Non-struct types (e.g.
+// struct{}{} used for option-less actions) yield an empty set.
+func topLevelJSONFieldNames(rt reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	if rt == nil {
+		return out
+	}
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	if rt.Kind() != reflect.Struct {
+		return out
+	}
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.PkgPath != "" { // unexported
+			continue
+		}
+		tag, hasTag := f.Tag.Lookup("json")
+		name := f.Name
+		if hasTag {
+			parts := strings.Split(tag, ",")
+			if parts[0] == "-" {
+				continue
+			}
+			if parts[0] != "" {
+				name = parts[0]
+			}
+		}
+		out[name] = true
+	}
+	return out
+}
+
+// TestRenderActionCatalogEntry pins the exact rendered text for one
+// option-bearing and one option-less entry. The render format is a contract
+// consumed by the LLM, so accidental format changes must fail loudly.
+func TestRenderActionCatalogEntry(t *testing.T) {
+	optionBearing := actionCatalogEntry{
+		Type:    fmaction.TypeSleep,
+		Summary: "Pause the flow for a duration.",
+		Options: []actionOptionField{
+			{Name: "duration", Type: "int (ms)", Required: true, Description: "Sleep duration in milliseconds."},
+		},
+	}
+	wantBearing := "action: sleep\n" +
+		"summary: Pause the flow for a duration.\n" +
+		"options:\n" +
+		"  - duration (int (ms), required): Sleep duration in milliseconds."
+	if got := renderActionCatalogEntry(optionBearing); got != wantBearing {
+		t.Errorf("option-bearing render mismatch.\n got: %q\nwant: %q", got, wantBearing)
+	}
+
+	optionLess := actionCatalogEntry{
+		Type:    fmaction.TypeAnswer,
+		Summary: "Answer the incoming call.",
+		Options: nil,
+	}
+	wantLess := "action: answer\n" +
+		"summary: Answer the incoming call.\n" +
+		"options: this action takes no options."
+	if got := renderActionCatalogEntry(optionLess); got != wantLess {
+		t.Errorf("option-less render mismatch.\n got: %q\nwant: %q", got, wantLess)
+	}
+}
+
+// TestDescribeAction covers the exported lookup: success, unknown type, and
+// empty type (both error paths wrap ErrUnknownActionType with an echo + hint).
+func TestDescribeAction(t *testing.T) {
+	// success
+	got, err := DescribeAction("talk")
+	if err != nil {
+		t.Fatalf("DescribeAction(talk) unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "action: talk") || !strings.Contains(got, "text") {
+		t.Errorf("DescribeAction(talk) missing expected content: %q", got)
+	}
+
+	// unknown type
+	_, err = DescribeAction("not_a_real_action")
+	if err == nil {
+		t.Errorf("DescribeAction(unknown) expected error")
+	} else if !strings.Contains(err.Error(), "not_a_real_action") {
+		t.Errorf("unknown-type error should echo the value: %v", err)
+	}
+
+	// empty type
+	_, err = DescribeAction("")
+	if err == nil {
+		t.Errorf("DescribeAction(empty) expected error")
+	}
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -65,6 +65,7 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		message.FunctionCallNameSearchKnowledge:     h.toolHandleSearchKnowledge,
 		message.FunctionCallNameGetCorrelation:      h.toolHandleGetCorrelation,
 		message.FunctionCallNameGetResource:         h.toolHandleGetResource,
+		message.FunctionCallNameDescribeAction:      h.toolHandleDescribeAction,
 	}
 
 	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()

--- a/bin-ai-manager/pkg/aicallhandler/tool_describeaction.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_describeaction.go
@@ -1,0 +1,46 @@
+package aicallhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/actioncatalog"
+
+	"github.com/sirupsen/logrus"
+)
+
+// toolHandleDescribeAction handles the describe_action tool: it returns the
+// option-field schema for a given flow action type so the LLM can correctly
+// assemble create_call inline actions. It is a pure, customer-agnostic,
+// read-only lookup (no RPC, no DB, no aicall data needed).
+func (h *aicallHandler) toolHandleDescribeAction(ctx context.Context, c *aicall.AIcall, tool *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleDescribeAction",
+		"aicall_id": c.ID,
+	})
+
+	res := newToolResult(tool.ID)
+
+	var args struct {
+		ActionType string `json:"action_type"`
+	}
+	if errUnmarshal := json.Unmarshal([]byte(tool.Function.Arguments), &args); errUnmarshal != nil {
+		fillFailed(res, errUnmarshal)
+		return res
+	}
+
+	rendered, err := actioncatalog.DescribeAction(args.ActionType)
+	if err != nil {
+		// unknown/empty type: the error message already echoes the value + valid
+		// types, so the LLM can self-correct.
+		log.Debugf("describe_action lookup failed. action_type: %s, err: %v", args.ActionType, err)
+		fillFailed(res, err)
+		return res
+	}
+
+	log.Debugf("Described action. action_type: %s", args.ActionType)
+	fillSuccess(res, "action", args.ActionType, rendered)
+	return res
+}

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -2,6 +2,7 @@ package toolhandler
 
 import (
 	"monorepo/bin-ai-manager/models/tool"
+	"monorepo/bin-ai-manager/pkg/actioncatalog"
 )
 
 var toolDefinitions = []tool.Tool{
@@ -610,20 +611,9 @@ run_llm: Set true (default) to confirm verbally ("I've placed the call").`,
 						"type": "object",
 						"properties": map[string]any{
 							"type": map[string]any{
-								"type": "string",
-								"enum": []string{
-									"amd", "answer", "ai_summary", "ai_talk", "ai_task", "beep", "block",
-									"branch", "call", "condition_call_digits", "condition_call_status",
-									"condition_datetime", "condition_variable", "confbridge_join",
-									"conference_join", "connect", "conversation_send", "digits_receive",
-									"digits_send", "echo", "email_send", "external_media_start",
-									"external_media_stop", "fetch", "fetch_flow", "goto", "hangup",
-									"message_send", "mute", "play", "queue_join", "recording_start",
-									"recording_stop", "sleep", "stop", "stream_echo", "talk",
-									"transcribe_start", "transcribe_stop", "transcribe_recording",
-									"variable_set", "webhook_send",
-								},
-								"description": "Flow action type. Common ones: talk (speak text), play (play audio url), hangup, connect (bridge to another endpoint), variable_set, branch, goto, sleep, digits_receive. See the VoIPBin flow action reference for each type's option fields.",
+								"type":        "string",
+								"enum":        actioncatalog.ActionTypeEnum(),
+								"description": "Flow action type. Common ones: talk (speak text), play (play audio url), hangup, connect (bridge to another endpoint), variable_set, branch, goto, sleep, digits_receive. Use the describe_action tool to look up an action type's option fields before assembling it.",
 							},
 							"option": map[string]any{
 								"type":        "object",
@@ -687,6 +677,39 @@ run_llm: Set true (default) to confirm verbally ("I've placed the call").`,
 				},
 			},
 			"required": []string{"destinations"},
+		},
+	},
+	{
+		Name:   tool.ToolNameDescribeAction,
+		RunLLM: true,
+		Description: `Returns the option fields a given flow action type accepts, so you can correctly assemble actions for create_call's 'actions' parameter.
+
+WHEN TO USE:
+- Before assembling a create_call action whose options you are unsure of (e.g. connect, branch, condition_variable, talk, play)
+- To check the exact option field names and whether they are required
+
+WHEN NOT TO USE:
+- General conversation or knowledge-base questions (use search_knowledge)
+- You already know the action's options
+
+The action_type must be one of the create_call action types. The response lists each option field as 'name (type, required|optional): description'.
+
+run_llm: Set true so you can use the returned schema to build the action.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to use the returned schema to assemble the action.",
+					"default":     true,
+				},
+				"action_type": map[string]any{
+					"type":        "string",
+					"enum":        actioncatalog.ActionTypeEnum(),
+					"description": "The flow action type to describe (e.g. talk, connect, branch).",
+				},
+			},
+			"required": []string{"action_type"},
 		},
 	},
 }

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -625,7 +625,7 @@ run_llm: Set true (default) to confirm verbally ("I've placed the call").`,
 							},
 							"option": map[string]any{
 								"type":        "object",
-								"description": "Action-type-specific options. Shape depends on type. Call describe_action with this type to get the exact option fields. Omit for actions with no options (e.g. hangup).",
+								"description": "Action-type-specific options. Shape depends on type. Call describe_action with this type to get the exact option fields. Omit for actions with no options (e.g. answer).",
 							},
 						},
 						"required": []string{"type"},

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -610,6 +610,14 @@ run_llm: Set true (default) to confirm verbally ("I've placed the call").`,
 					"items": map[string]any{
 						"type": "object",
 						"properties": map[string]any{
+							"id": map[string]any{
+								"type":        "string",
+								"description": "Optional UUID you assign to this action so other actions can target it. Required only when a branch/goto/condition action must jump to it (referenced via target_id, false_target_id, default_target_id, or target_ids). If omitted, actions simply run in array order.",
+							},
+							"next_id": map[string]any{
+								"type":        "string",
+								"description": "Optional UUID of the action to run next instead of the following array item. Omit for normal linear flow.",
+							},
 							"type": map[string]any{
 								"type":        "string",
 								"enum":        actioncatalog.ActionTypeEnum(),
@@ -617,7 +625,7 @@ run_llm: Set true (default) to confirm verbally ("I've placed the call").`,
 							},
 							"option": map[string]any{
 								"type":        "object",
-								"description": "Action-type-specific options. Shape depends on type. e.g. talk -> {text, language, gender}. Omit for actions with no options (e.g. hangup).",
+								"description": "Action-type-specific options. Shape depends on type. Call describe_action with this type to get the exact option fields. Omit for actions with no options (e.g. hangup).",
 							},
 						},
 						"required": []string{"type"},
@@ -693,6 +701,8 @@ WHEN NOT TO USE:
 - You already know the action's options
 
 The action_type must be one of the create_call action types. The response lists each option field as 'name (type, required|optional): description'.
+
+When an option references a target action (target_id, false_target_id, default_target_id, target_ids), it refers to the 'id' field of another action in the same create_call 'actions' array. Assign that action an 'id' (any UUID) and use it as the target.
 
 run_llm: Set true so you can use the returned schema to build the action.`,
 		Parameters: map[string]any{

--- a/bin-ai-manager/pkg/toolhandler/main_test.go
+++ b/bin-ai-manager/pkg/toolhandler/main_test.go
@@ -150,6 +150,7 @@ func TestAllToolNames(t *testing.T) {
 		tool.ToolNameSearchKnowledge,
 		tool.ToolNameGetCorrelation,
 		tool.ToolNameGetResource,
+		tool.ToolNameDescribeAction,
 	}
 
 	if len(tool.AllToolNames) != len(expectedNames) {

--- a/bin-ai-manager/pkg/toolhandler/whitelist.go
+++ b/bin-ai-manager/pkg/toolhandler/whitelist.go
@@ -18,6 +18,7 @@ var ConversationSafeTools = map[tool.ToolName]bool{
 	tool.ToolNameStopService:       true,
 	tool.ToolNameGetAIcallMessages: true,
 	tool.ToolNameSearchKnowledge:   true,
+	tool.ToolNameDescribeAction:    true,
 }
 
 // FilterToolsForConversation returns the subset of names that are safe for a

--- a/bin-ai-manager/pkg/toolhandler/whitelist_test.go
+++ b/bin-ai-manager/pkg/toolhandler/whitelist_test.go
@@ -62,6 +62,7 @@ func Test_FilterToolsForConversation(t *testing.T) {
 				tool.ToolNameStopService,
 				tool.ToolNameGetAIcallMessages,
 				tool.ToolNameSearchKnowledge,
+				tool.ToolNameDescribeAction,
 			},
 		},
 		{
@@ -80,6 +81,7 @@ func Test_FilterToolsForConversation(t *testing.T) {
 				tool.ToolNameStopService,
 				tool.ToolNameGetAIcallMessages,
 				tool.ToolNameSearchKnowledge,
+				tool.ToolNameDescribeAction,
 			},
 		},
 		{

--- a/bin-flow-manager/models/action/option.go
+++ b/bin-flow-manager/models/action/option.go
@@ -1,5 +1,20 @@
 package action
 
+// SYNC NOTE: The OptionXxx structs below are the authoritative source for the
+// option fields each flow action accepts. They are mirrored, for the AI agent's
+// describe_action tool, by the hand-authored catalog in
+// bin-ai-manager/pkg/actioncatalog/main.go.
+//
+// When you ADD / REMOVE / RENAME an option field here, update that catalog or
+// the test TestActionCatalogFieldsMatchOptionStructs (in pkg/actioncatalog)
+// will fail. When you change a field's TYPE or MEANING (e.g. add an enum value,
+// reword a purpose), the reflection test does NOT catch it (it cannot read
+// comments); update the catalog's human-readable Type/Description text by hand,
+// and the user-facing docs in
+// bin-api-manager/docsdev/source/flow_struct_action.rst.
+//
+// See also OptionStructByType in option_registry.go.
+
 import (
 	"encoding/json"
 	commonaddress "monorepo/bin-common-handler/models/address"

--- a/bin-flow-manager/models/action/option_registry.go
+++ b/bin-flow-manager/models/action/option_registry.go
@@ -1,0 +1,70 @@
+package action
+
+// OptionStructByType maps each action Type to a zero-value of its option struct.
+//
+// It exists so that downstream consumers can reflect over an action's option
+// fields by type. Its primary consumer today is bin-ai-manager's describe_action
+// tool, whose hand-authored option catalog is verified against these structs by
+// the test TestActionCatalogFieldsMatchOptionStructs (in bin-ai-manager).
+//
+// SYNC NOTE (read before editing option.go):
+//   - Adding/removing/renaming an OptionXxx field changes what the LLM should be
+//     told. After such a change, update the ai-manager describe_action catalog
+//     (bin-ai-manager/pkg/toolhandler/action_catalog.go). The reflection test
+//     TestActionCatalogFieldsMatchOptionStructs will FAIL until the catalog's
+//     option field names match again.
+//   - Field TYPE / meaning changes (e.g. string->int, or a reworded purpose) are
+//     NOT caught by that test (reflection cannot read comments); update the
+//     catalog's human-readable Type/Description text by hand.
+//   - The same fields are documented for users in
+//     bin-api-manager/docsdev/source/flow_struct_action.rst, which may also need
+//     updating.
+//   - Adding a NEW action Type: add it to TypeListAll AND to this map, or the
+//     test TestActionCatalogMatchesTypeListAll / the field-parity test will fail.
+//
+// Actions that take no options (e.g. mute, stop) map to an empty struct{}{} —
+// they have zero top-level json fields, so their catalog entry has no options.
+var OptionStructByType = map[Type]any{
+	TypeAMD:                 OptionAMD{},
+	TypeAnswer:              OptionAnswer{},
+	TypeAISummary:           OptionAISummary{},
+	TypeAITalk:              OptionAITalk{},
+	TypeAITask:              OptionAITask{},
+	TypeBeep:                OptionBeep{},
+	TypeBlock:               OptionBlock{},
+	TypeBranch:              OptionBranch{},
+	TypeCall:                OptionCall{},
+	TypeConditionCallDigits: OptionConditionCallDigits{},
+	TypeConditionCallStatus: OptionConditionCallStatus{},
+	TypeConditionDatetime:   OptionConditionDatetime{},
+	TypeConditionVariable:   OptionConditionVariable{},
+	TypeConfbridgeJoin:      OptionConfbridgeJoin{},
+	TypeConferenceJoin:      OptionConferenceJoin{},
+	TypeConnect:             OptionConnect{},
+	TypeConversationSend:    OptionConversationSend{},
+	TypeDigitsReceive:       OptionDigitsReceive{},
+	TypeDigitsSend:          OptionDigitsSend{},
+	TypeEcho:                OptionEcho{},
+	TypeEmailSend:           OptionEmailSend{},
+	TypeExternalMediaStart:  OptionExternalMediaStart{},
+	TypeExternalMediaStop:   OptionExternalMediaStop{},
+	TypeFetch:               OptionFetch{},
+	TypeFetchFlow:           OptionFetchFlow{},
+	TypeGoto:                OptionGoto{},
+	TypeHangup:              OptionHangup{},
+	TypeMessageSend:         OptionMessageSend{},
+	TypeMute:                struct{}{}, // no options
+	TypePlay:                OptionPlay{},
+	TypeQueueJoin:           OptionQueueJoin{},
+	TypeRecordingStart:      OptionRecordingStart{},
+	TypeRecordingStop:       OptionRecordingStop{},
+	TypeSleep:               OptionSleep{},
+	TypeStop:                struct{}{}, // no options
+	TypeStreamEcho:          OptionStreamEcho{},
+	TypeTalk:                OptionTalk{},
+	TypeTranscribeStart:     OptionTranscribeStart{},
+	TypeTranscribeStop:      OptionTranscribeStop{},
+	TypeTranscribeRecording: OptionTranscribeRecording{},
+	TypeVariableSet:         OptionVariableSet{},
+	TypeWebhookSend:         OptionWebhookSend{},
+}

--- a/bin-flow-manager/models/action/option_registry.go
+++ b/bin-flow-manager/models/action/option_registry.go
@@ -10,7 +10,7 @@ package action
 // SYNC NOTE (read before editing option.go):
 //   - Adding/removing/renaming an OptionXxx field changes what the LLM should be
 //     told. After such a change, update the ai-manager describe_action catalog
-//     (bin-ai-manager/pkg/toolhandler/action_catalog.go). The reflection test
+//     (bin-ai-manager/pkg/actioncatalog/main.go). The reflection test
 //     TestActionCatalogFieldsMatchOptionStructs will FAIL until the catalog's
 //     option field names match again.
 //   - Field TYPE / meaning changes (e.g. string->int, or a reworded purpose) are

--- a/bin-flow-manager/models/action/option_registry_test.go
+++ b/bin-flow-manager/models/action/option_registry_test.go
@@ -1,0 +1,17 @@
+package action
+
+import "testing"
+
+// Test_OptionStructByType_CoversTypeListAll asserts every action Type in
+// TypeListAll has an entry in OptionStructByType (and no extra entries), so the
+// map cannot silently drift from the authoritative type list.
+func Test_OptionStructByType_CoversTypeListAll(t *testing.T) {
+	for _, ty := range TypeListAll {
+		if _, ok := OptionStructByType[ty]; !ok {
+			t.Errorf("OptionStructByType missing entry for type %s", ty)
+		}
+	}
+	if len(OptionStructByType) != len(TypeListAll) {
+		t.Errorf("OptionStructByType has %d entries, TypeListAll has %d (extra/duplicate entries?)", len(OptionStructByType), len(TypeListAll))
+	}
+}

--- a/docs/plans/2026-06-15-add-describe-action-tool-design.md
+++ b/docs/plans/2026-06-15-add-describe-action-tool-design.md
@@ -1,0 +1,348 @@
+# describe_action LLM tool design
+
+Date: 2026-06-15
+Service: bin-ai-manager
+Type: LLM tool (new) + flow-manager sync note
+Branch: NOJIRA-Add-describe-action-tool
+Follow-up to: #994 (option catalog for create_call inline actions; create_call
+shipped in PR #993)
+
+## 1. Problem Statement
+
+PR #993 let the AI assemble flow actions inline via `create_call`. The tool
+schema offers the full set of valid action TYPES (enum locked to flow-manager
+`action.TypeListAll`), but it does NOT tell the LLM each action's OPTION fields.
+The LLM must guess option shapes (e.g. that `talk` takes `{text, language}`,
+`connect` takes `{destinations}`, `branch` takes `{target_ids,
+default_target_id}`). This makes assembling a correct non-trivial flow
+unreliable.
+
+We want a way for the LLM to look up, on demand, what option fields a given
+action type accepts, without bloating every tool-call payload with all 42 option
+schemas.
+
+## 2. Scope
+
+### In scope (Phase 1)
+
+- A new LLM tool `describe_action(action_type)` in bin-ai-manager that returns a
+  compact, human/LLM-readable description of a single action type: its purpose
+  and its option fields (name, type, required/optional, one-line meaning).
+- A hand-authored compact catalog (one entry per action type) living in
+  bin-ai-manager, condensed from the canonical sources
+  (`bin-flow-manager/models/action/option.go` comments and the user-facing
+  `bin-api-manager/docsdev/source/flow_struct_action.rst`).
+- Two automated drift tests over the catalog: a type-set test asserting one
+  entry per `action.TypeListAll` type (no missing / extra / duplicate), and a
+  reflection-based field-parity test asserting each entry's option field NAMES
+  equal the real option struct's top-level json fields (closes the stale-field
+  gap without codegen). Plus a render golden test. See 3.4.
+- A new `action.OptionStructByType` map in flow-manager (Type -> zero-value
+  option struct) that the field-parity test reflects over, itself drift-guarded.
+- A sync note in `bin-flow-manager/models/action/option.go` telling future
+  editors that changing an option struct requires updating the ai-manager
+  describe_action catalog (naming the test that will fail), covering the residual
+  semantic-text drift that cannot be machine-checked.
+
+### Out of scope
+
+- Auto-GENERATING the catalog from option.go via reflection or AST/codegen.
+  Decision (owner, approach 2): reflection cannot read field comments (they are
+  dropped at compile time), and an AST/go:generate pipeline is heavier to
+  maintain than a hand-authored compact catalog at the current stage. NOTE the
+  distinction: v2 uses reflection only to VERIFY field names (a test), never to
+  generate catalog content — that is within approach 2.
+- A `list_flow_actions` tool. The action-type list is already exposed by the
+  `create_call` `actions[].type` enum; a separate listing tool is redundant.
+- Per-action option VALUE validation (e.g. checking a `goto.target_id` resolves).
+  That is flow-manager's runtime concern.
+- Deep nested-type expansion (e.g. fully expanding `commonaddress.Address` or
+  `email.Attachment` sub-fields). The catalog names the field and its shape at
+  one level ("destinations: array of address objects {type, target,
+  target_name}") rather than recursively documenting every nested model.
+
+## 3. Design
+
+### 3.1 Catalog data structure
+
+A package-level slice in bin-ai-manager (co-located with the tool handler),
+one entry per action type:
+
+```go
+// actionCatalogEntry describes a single flow action type for the LLM.
+type actionCatalogEntry struct {
+    Type        fmaction.Type        // the action type (e.g. fmaction.TypeTalk)
+    Summary     string               // one-line purpose
+    Options     []actionOptionField  // option fields; empty for option-less actions (e.g. answer)
+}
+
+type actionOptionField struct {
+    Name        string // json field name, e.g. "text" (MUST match the option struct's json tag)
+    Type        string // human type, e.g. "string", "int (ms)", "array of address {type,target}"
+    Required    bool   // whether the action is meaningless without it
+    Description string // one-line meaning, condensed from option.go / RST
+}
+```
+
+The catalog is the authoritative source slice (`actionCatalog []actionCatalogEntry`).
+A lookup map `map[fmaction.Type]actionCatalogEntry` is built ONCE from it via a
+package-level `var` initialized at load (or `sync.Once`), never lazily on the
+request path, so there is no concurrency hazard. The map build MUST reject
+duplicate Types (panic at init or via the drift test, see 3.4) so a duplicated
+catalog entry cannot silently shadow another.
+
+### 3.2 Tool definition (definitions.go)
+
+```
+Name: describe_action
+RunLLM: true
+Description: "Returns the option fields a given flow action type accepts, so you
+  can correctly assemble actions for create_call's 'actions' parameter. Call this
+  before assembling an action whose options you are unsure of (e.g. connect,
+  branch, talk, play). The action_type must be one of the create_call action
+  types."
+Parameters:
+  action_type (string, required, enum = same 42 types as create_call): the action
+    type to describe.
+  run_llm (boolean, default true)
+```
+
+The `action_type` enum is the same 42-value set as `create_call`. To avoid a
+THIRD hand-maintained copy of the 42 strings, both enums are built from a single
+shared helper (see 3.5).
+
+### 3.3 Handler (toolhandler or aicallhandler)
+
+`describe_action` is a pure, read-only, customer-agnostic lookup (it returns
+static schema text, touches no customer data and no RPC). It therefore does NOT
+need the aicall context the way create_call does. It can live as a toolhandler-
+level handler.
+
+Flow:
+1. Parse `action_type` from arguments.
+2. Look up the catalog entry. If not found (LLM passed a non-enum value), return
+   a `fillFailed` whose message ECHOES the received value and names the valid
+   types (so the LLM can self-correct a typo/casing). Because the schema enum
+   constrains it, this is a defense-in-depth branch.
+3. Render the entry to a compact readable string (summary + each option field as
+   `name (type, required|optional): description`). For option-less actions,
+   state "This action takes no options."
+4. `fillSuccess` with the rendered text.
+
+No RPC, no goroutine, no DB. Failure modes: empty/missing action_type -> fillFailed;
+unknown type -> fillFailed (with echo + valid-type hint).
+
+The render format is a load-bearing contract (it goes into the LLM prompt), so a
+GOLDEN test pins the exact rendered string for at least one option-bearing entry
+(e.g. talk) and one option-less entry, so accidental format changes are caught.
+
+### 3.4 Drift defense (the core of approach 2)
+
+Hand-authored catalogs drift from the source. Three layered defenses, the first
+two automated (no codegen — these VERIFY the hand-written catalog, they do not
+GENERATE it), the third a human backstop:
+
+1. **Type-set drift-lock test** `TestActionCatalogMatchesTypeListAll`: asserts the
+   multiset of `Type` values in the catalog equals `action.TypeListAll` exactly.
+   It iterates the raw `actionCatalog` SLICE (not the lookup map) and (a) rejects
+   duplicate Types explicitly, then (b) compares sorted length + per-index against
+   `TypeListAll`. Iterating the slice (not the map) is required so a duplicated
+   entry is caught rather than silently deduped. This catches MISSING / EXTRA /
+   DUPLICATE type entries.
+
+2. **Field-parity reflection test** `TestActionCatalogFieldsMatchOptionStructs`:
+   for each `action.TypeListAll` type, look up its option struct via a new
+   `action.OptionStructByType map[Type]any` (zero-value structs), reflect over the
+   struct's TOP-LEVEL json field names, and assert that set equals the set of
+   `Options[].Name` in the catalog entry. Reflection CAN read field names and json
+   tags (only comments are lost at compile time), so this closes the stale-FIELD
+   gap automatically. Rules:
+   - Compare TOP-LEVEL json field NAMES only (matches the catalog's deliberate
+     one-level, non-recursive scope; nested structs are named by shape in the
+     option field's `Type` string, not expanded). The test compares the NAME set,
+     not the `Type` string, so a field whose value is itself a struct/slice still
+     has a top-level json name (e.g. `destinations`) present in both sets.
+   - Honor json tag semantics: split on `,` to drop `omitempty`; skip `json:"-"`
+     fields; skip unexported fields (`PkgPath != ""`); for an exported field with
+     NO json tag, fall back to the Go field name (Go's default json key), so an
+     untagged field added later is still checked.
+   - The `OptionStructByType` map is itself drift-guarded: the same test asserts
+     every `TypeListAll` type has an entry in it, so the map cannot go stale
+     silently. All 42 option structs exist 1:1 with TypeListAll; an action with
+     no options maps to a zero-FIELD (empty) struct, NOT a missing entry, and its
+     catalog entry has an empty `Options`.
+
+   What this test does NOT catch (and the sync note therefore must cover): the
+   semantic TEXT fields the LLM reads — `Summary`, `Description`, `Required`, and
+   the human option `Type` string (e.g. if an option struct field changes from
+   `string` to `int`, the json NAME is unchanged so this test still passes; the
+   catalog `Type` string would go stale). These cannot be machine-checked against
+   comments and are the residual covered by defense 3.
+
+3. **Sync note in option.go**: a comment in
+   `bin-flow-manager/models/action/option.go` (and next to `OptionStructByType`)
+   instructing editors that changing an option struct's fields requires updating
+   the ai-manager describe_action catalog, naming the exact tests that will fail
+   (`TestActionCatalogFieldsMatchOptionStructs`) so a CI failure points straight
+   to the fix. The note also reminds editors that the user-facing RST
+   (`flow_struct_action.rst`) documents the same fields and may need updating.
+   This is the human backstop for the description text only.
+
+### 3.5 Single source for the 42-type enum
+
+`create_call` (definitions.go) and `describe_action` both need the 42-value
+`action_type` enum. To avoid a third hand-maintained copy, extract a helper that
+returns the enum as `[]string` from `action.TypeListAll`:
+
+```go
+// in toolhandler (or a shared spot)
+func actionTypeEnum() []string {
+    out := make([]string, len(fmaction.TypeListAll))
+    for i, t := range fmaction.TypeListAll {
+        out[i] = string(t)
+    }
+    return out
+}
+```
+
+Both `create_call` and `describe_action` use `actionTypeEnum()` for their schema
+enum. This makes the create_call enum self-syncing too (and the existing
+`TestCreateCallActionsEnumMatchesTypeListAll` keeps guarding it). NOTE: this
+changes create_call's enum from a hardcoded literal to the helper; the existing
+drift test still passes because it compares against TypeListAll either way.
+
+## 4. Catalog content sourcing
+
+Each entry condensed from, in priority order:
+1. `bin-flow-manager/models/action/option.go` field comments (authoritative field
+   names + meanings).
+2. `bin-api-manager/docsdev/source/flow_struct_action.rst` (user-facing prose,
+   examples) for the Summary line and clarifications.
+
+Option-less / internal action types (e.g. `answer`, `hangup`, `beep`, `echo`,
+`ai_summary`) still get an entry: Summary + "no options" (or their minimal
+options). Internal/infra types (`external_media_start`, `confbridge_join`, etc.)
+are included for completeness since they are in the enum, with a brief note that
+they are advanced/infra actions.
+
+## 5. Affected Services
+
+| Service | Change | Phase |
+|---|---|---|
+| bin-ai-manager | new describe_action tool: catalog data, tool definition, handler + render fn, drift-lock test (type-set), field-parity reflection test, render golden test; refactor create_call enum to shared `actionTypeEnum()` helper | 1 |
+| bin-flow-manager | new `OptionStructByType` map in models/action; sync note comment next to it and at option.go top | 1 |
+
+No DB migration. No RPC change. No OpenAPI change (internal LLM tool). Internal
+tool -> no RST `docsdev` update required.
+
+## 6. Tool registration
+
+Register `describe_action` in:
+- `models/tool/main.go`: `ToolNameDescribeAction` + add to `AllToolNames`.
+- `models/message/tool.go`: `FunctionCallNameDescribeAction` (if the dispatch
+  path requires it).
+- `toolhandler/definitions.go`: the tool definition.
+- the dispatch map (toolhandler or aicallhandler `ToolHandle` mapFunctions).
+- whitelist (`toolhandler/whitelist.go`) if tools are gated by a whitelist.
+
+(Confirm the exact 5 touch points against the create_call/get_resource
+registration during implementation.)
+
+## 7. Observability
+
+- Debug log on describe_action invocation (action_type requested). No metrics
+  (static lookup, no cost, no async).
+
+## 8. Security
+
+- describe_action returns only STATIC schema text (action option shapes). No
+  customer data, no RPC, no resource ids. No IDOR / ownership surface. It is
+  customer-agnostic by construction.
+- It does reveal the full set of action types and their option fields to any
+  caller, but that is public product documentation (already on docs.voipbin.net),
+  so there is no information-disclosure concern.
+
+## 9. Implementation Order
+
+1. flow-manager: add `OptionStructByType map[Type]any` + sync notes in
+   models/action/option.go.
+2. ai-manager: `actionTypeEnum()` helper; refactor create_call enum to use it
+   (keep `TestCreateCallActionsEnumMatchesTypeListAll` green).
+3. ai-manager: catalog data (one entry per TypeListAll type, fields matching the
+   option struct json tags).
+4. ai-manager: `ToolNameDescribeAction` registration (5 touch points).
+5. ai-manager: describe_action tool definition + handler + render function.
+6. ai-manager tests: type-set drift-lock, field-parity reflection, render golden.
+7. Full verification workflow in BOTH bin-flow-manager (new map + comment) and
+   bin-ai-manager (go mod tidy/vendor/generate/test/lint each).
+
+## 10. Open Questions
+
+| Question | Recommendation | Owner |
+|---|---|---|
+| Should the catalog expand nested model fields (Address, Attachment)? | No; describe one level + name the nested shape. Keep compact | CPO |
+| Should describe_action be in the default tool whitelist? | Yes; it is safe (static, read-only) and directly supports create_call assembly | CPO |
+| Phase 2 codegen from option.go AST? | Defer; revisit only if catalog drift becomes a recurring problem | CTO |
+
+## 11. Review Summary
+
+### v1 -> v2 (first design review round)
+
+Two independent design reviews (soundness + maintainability/drift) both returned
+CHANGES REQUESTED, converging on the same key gap. v2 applied:
+
+- **Field-parity reflection test added (the key finding).** Both reviewers
+  independently flagged that the v1 type-set test only catches missing/extra
+  TYPES, not stale option FIELDS — leaving the tool's whole reason for existing
+  (field accuracy) on a single human comment. Since reflection CAN read field
+  names + json tags (only comments are lost), v2 adds
+  `TestActionCatalogFieldsMatchOptionStructs` + a new flow-manager
+  `OptionStructByType` map. This VERIFIES (does not GENERATE) the hand-written
+  catalog, so it stays within the owner's approach-2 (no codegen) decision.
+- **Duplicate-Type masking fixed.** v2's type-set test iterates the raw slice and
+  explicitly rejects duplicate Types (the map-keyed comparison could silently
+  dedup a duplicated entry).
+- **OptionStructByType self-guarded.** The field-parity test asserts every
+  TypeListAll type has a map entry, so the new map cannot go stale silently.
+- **Failure-message quality.** describe_action's not-found path now echoes the
+  received value + names valid types for LLM self-correction; empty/missing
+  action_type is handled.
+- **Render golden test.** The rendered string is a prompt contract, so a golden
+  test pins it for one option-bearing + one option-less entry.
+- **Thread-safety / init clarified.** Lookup map built once at load (var/sync.Once),
+  never lazily on the request path.
+- **Sync note strengthened.** Names the exact failing test and reminds editors the
+  RST doc also documents the fields. Residual covered by the note is now only the
+  semantic text (Summary/Description/Required), which is genuinely un-checkable.
+- **PR reference corrected** (#993 shipped create_call; this is #994's catalog).
+
+Deferred (Open Questions): nested-model field expansion (no, one level);
+Phase-2 codegen from option.go AST (defer unless drift recurs).
+
+## Implementation Addendum (2026-06-15)
+
+During implementation a real import cycle surfaced: an existing `toolhandler`
+test imports `aicallhandler` (get_resource enum parity), and the dispatch handler
+lives in `aicallhandler`, which now needed to call the catalog. Putting the
+catalog in `toolhandler` would have created `toolhandler -> aicallhandler ->
+toolhandler` (test-time) cycle.
+
+Resolution: the catalog, `ActionTypeEnum()`, `DescribeAction()`, render, and the
+drift tests live in a new leaf package `bin-ai-manager/pkg/actioncatalog` that
+imports only `bin-flow-manager/models/action`. Both `toolhandler/definitions.go`
+(enum) and `aicallhandler/tool_describeaction.go` (handler) import it. No cycle.
+
+Type->option-struct mapping: `bin-flow-manager/models/action.OptionStructByType`
+plus a self-guard test `Test_OptionStructByType_CoversTypeListAll`. Two action
+types (`mute`, `stop`) have no option struct in flow-manager; they map to
+`struct{}{}` (zero top-level json fields), so the field-parity test treats them
+as option-less. Catalog entries for them are rendered "this action takes no
+options."
+
+Final touch points (5 confirmed):
+- `models/tool/main.go`: `ToolNameDescribeAction` + `AllToolNames`.
+- `models/message/tool.go`: `FunctionCallNameDescribeAction`.
+- `toolhandler/definitions.go`: the tool definition (+ create_call enum now uses
+  `actioncatalog.ActionTypeEnum()` instead of a hardcoded literal).
+- `aicallhandler/tool.go` mapFunctions + `aicallhandler/tool_describeaction.go`.
+- `toolhandler/whitelist.go`: added to `ConversationSafeTools`.


### PR DESCRIPTION
Add a describe_action LLM tool that lets the AI agent look up the option fields of any flow action type, so it can correctly assemble create_call inline actions without a pre-defined flow. The action-type enum and option catalog are sourced from / verified against flow-manager so they cannot silently drift.

- bin-flow-manager: Add OptionStructByType map (action Type -> option struct) with a self-guard test covering TypeListAll
- bin-flow-manager: Add a sync note at the OptionXxx edit site (option.go) pointing to the ai-manager catalog and the parity test
- bin-ai-manager: Add actioncatalog leaf package with a hand-authored option catalog for all 42 action types (one level deep), inlining real enum values (condition operators, call status, value_type, machine_handle, reference_type, digits_handle, address type)
- bin-ai-manager: Add the describe_action LLM tool (read-only, customer-agnostic) returning each action's option fields with type, required flag, and description
- bin-ai-manager: Source the create_call and describe_action action-type enum from flow-manager TypeListAll (removes the hardcoded literal)
- bin-ai-manager: Expose id/next_id on create_call actions[] items so branch/goto/condition jump targets are buildable inline
- bin-ai-manager: Add drift-lock tests (type-set parity, reflection field-parity, render golden, lookup success/unknown/empty)
- bin-ai-manager: Register describe_action in tool names, function-call names, the dispatch map, and the conversation whitelist