### PR TITLE
NOJIRA-upgrade-asterisk-to-23.4.0

### DIFF
--- a/bin-dbscheme-manager/asterisk_config/config/versions/e89e30cee53f_add_rtp_port_range_to_ps_endpoints.py
+++ b/bin-dbscheme-manager/asterisk_config/config/versions/e89e30cee53f_add_rtp_port_range_to_ps_endpoints.py
@@ -1,0 +1,26 @@
+"""add rtp_port_start and rtp_port_end to ps_endpoints
+
+Revision ID: e89e30cee53f
+Revises: bb6d54e22913
+Create Date: 2026-04-02 10:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e89e30cee53f'
+down_revision = 'bb6d54e22913'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('ps_endpoints',
+                  sa.Column('rtp_port_start', sa.Integer))
+    op.add_column('ps_endpoints',
+                  sa.Column('rtp_port_end', sa.Integer))
+
+
+def downgrade():
+    op.drop_column('ps_endpoints', 'rtp_port_end')
+    op.drop_column('ps_endpoints', 'rtp_port_start')


### PR DESCRIPTION
Sync the Asterisk RealTime DB schema to upstream 23.4.0 parity. Upstream Asterisk 23.4.0 adds exactly one ast-db-manage migration over 23.2.2; its down_revision chains onto the current single head bb6d54e22913, yielding a single linear head e89e30cee53f. The file is copied verbatim from upstream to preserve the exact revision ID and chain (the documented exception to the no-hand-written-migration rule, required for RTDB parity). Verified by a real alembic upgrade head over the full 130-file chain on a throwaway MariaDB, plus a downgrade/upgrade round-trip: rtp_port_start and rtp_port_end are created as nullable int on ps_endpoints and dropped in reverse on downgrade. Apply this migration before rolling out the Asterisk 23.4.0 image (companion monorepo-voip PR, same branch name).

- bin-dbscheme-manager: Add upstream Alembic migration e89e30cee53f adding rtp_port_start and rtp_port_end columns to ps_endpoints for Asterisk 23.4.0 parity