### PR TITLE
NOJIRA-Add-shared-NormalizeTarget-and-canonical-form-enforcement

### DIFF
--- a/bin-call-manager/pkg/callhandler/db.go
+++ b/bin-call-manager/pkg/callhandler/db.go
@@ -71,6 +71,18 @@ func (h *callHandler) Create(
 		callID = h.utilHandler.UUIDCreate()
 	}
 
+	// Canonicalize the stored source/destination through the shared address
+	// normalization authority so identity resolution is consistent across
+	// channels. NormalizeTarget is loss-proof (returns the original value on a
+	// non-normalizable input such as an "anonymous" caller-id), so the error is
+	// safely discarded. Nil-guard each pointer before dereferencing.
+	if source != nil {
+		source.Target, _ = commonaddress.NormalizeTarget(source.Type, source.Target)
+	}
+	if destination != nil {
+		destination.Target, _ = commonaddress.NormalizeTarget(destination.Type, destination.Target)
+	}
+
 	c := &call.Call{
 		Identity: commonidentity.Identity{
 			ID:         callID,

--- a/bin-call-manager/pkg/callhandler/db_test.go
+++ b/bin-call-manager/pkg/callhandler/db_test.go
@@ -860,3 +860,142 @@ func Test_UpdateMuteDirection(t *testing.T) {
 		})
 	}
 }
+
+func Test_Create_NormalizesAddress(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		id         uuid.UUID
+		customerID uuid.UUID
+
+		source      *commonaddress.Address
+		destination *commonaddress.Address
+
+		expectSourceTarget      string
+		expectDestinationTarget string
+
+		responseCall *call.Call
+	}{
+		{
+			"canonicalizes punctuated tel source and uppercase email destination",
+
+			uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0001"),
+			uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0002"),
+
+			&commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1 (555) 123-4567",
+			},
+			&commonaddress.Address{
+				Type:   commonaddress.TypeEmail,
+				Target: "User@Example.COM",
+			},
+
+			"+15551234567",
+			"user@example.com",
+
+			&call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0099"),
+					CustomerID: uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0002"),
+				},
+			},
+		},
+		{
+			"preserves no-digit tel source verbatim",
+
+			uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0101"),
+			uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0102"),
+
+			&commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "anonymous",
+			},
+			&commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1 (555) 123-4567",
+			},
+
+			"anonymous",
+			"+15551234567",
+
+			&call.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0199"),
+					CustomerID: uuid.FromStringOrNil("1a0c0e10-5d20-11ed-9f01-1ff0aa0c0102"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			h := &callHandler{
+				utilHandler:   mockUtil,
+				reqHandler:    mockReq,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+			}
+
+			ctx := context.Background()
+
+			// Assert the persisted *call.Call carries the canonical source/destination targets.
+			mockDB.EXPECT().CallCreate(ctx, gomock.Cond(func(x any) bool {
+				c, ok := x.(*call.Call)
+				if !ok {
+					return false
+				}
+				return c.Source.Target == tt.expectSourceTarget && c.Destination.Target == tt.expectDestinationTarget
+			})).Return(nil)
+			mockDB.EXPECT().CallGet(ctx, tt.id).Return(tt.responseCall, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseCall.CustomerID, call.EventTypeCallCreated, tt.responseCall)
+			mockReq.EXPECT().CallV1CallHealth(ctx, tt.responseCall.ID, defaultHealthDelay, 0).Return(nil)
+
+			_, err := h.Create(
+				ctx,
+
+				tt.id,
+				tt.customerID,
+				commonidentity.OwnerTypeAgent,
+				uuid.Nil,
+
+				"",
+				"",
+
+				uuid.Nil,
+				uuid.Nil,
+				uuid.Nil,
+
+				call.TypeFlow,
+
+				uuid.Nil,
+
+				tt.source,
+				tt.destination,
+
+				call.StatusRinging,
+				map[call.DataType]string{},
+
+				fmaction.Action{},
+				call.DirectionOutgoing,
+
+				uuid.Nil,
+				[]rmroute.Route{},
+
+				nil,
+			)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}

--- a/bin-call-manager/pkg/callhandler/start_test.go
+++ b/bin-call-manager/pkg/callhandler/start_test.go
@@ -120,7 +120,7 @@ func Test_Start_incoming_typeConferenceStart(t *testing.T) {
 				Type: commonaddress.TypeTel,
 			},
 			responseDestination: &commonaddress.Address{
-				Type:   commonaddress.TypeTel,
+				Type:   commonaddress.TypeConference,
 				Target: "bad943d8-9b59-11ea-b409-4ba263721f17",
 			},
 			responseUUIDCall:   uuid.FromStringOrNil("666ae678-5e55-11ed-8bbd-bbd66d73cbaf"),
@@ -199,7 +199,7 @@ func Test_Start_incoming_typeConferenceStart(t *testing.T) {
 					Type: commonaddress.TypeTel,
 				},
 				Destination: commonaddress.Address{
-					Type:   commonaddress.TypeTel,
+					Type:   commonaddress.TypeConference,
 					Target: "bad943d8-9b59-11ea-b409-4ba263721f17",
 				},
 				Status: call.StatusRinging,

--- a/bin-call-manager/pkg/groupcallhandler/db.go
+++ b/bin-call-manager/pkg/groupcallhandler/db.go
@@ -51,6 +51,17 @@ func (h *groupcallHandler) Create(
 		"anonymous":      anonymous,
 	})
 
+	// Canonicalize the stored source/destinations through the shared address
+	// normalization authority. NormalizeTarget is loss-proof, so the error is
+	// safely discarded. Nil-guard the source pointer; normalize destinations by
+	// index (range copy would discard the result).
+	if source != nil {
+		source.Target, _ = commonaddress.NormalizeTarget(source.Type, source.Target)
+	}
+	for i := range destinations {
+		destinations[i].Target, _ = commonaddress.NormalizeTarget(destinations[i].Type, destinations[i].Target)
+	}
+
 	// create groupcall
 	tmp := &groupcall.Groupcall{
 		Identity: commonidentity.Identity{

--- a/bin-call-manager/pkg/groupcallhandler/db_test.go
+++ b/bin-call-manager/pkg/groupcallhandler/db_test.go
@@ -740,3 +740,127 @@ func Test_UpdateStatus(t *testing.T) {
 		})
 	}
 }
+
+func Test_Create_NormalizesAddress(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		id         uuid.UUID
+		customerID uuid.UUID
+
+		source       *commonaddress.Address
+		destinations []commonaddress.Address
+
+		expectSourceTarget       string
+		expectDestinationTargets []string
+
+		responseGroupcall *groupcall.Groupcall
+	}{
+		{
+			"canonicalizes punctuated tel source and uppercase email destination",
+
+			uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0001"),
+			uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0002"),
+
+			&commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1 (555) 123-4567",
+			},
+			[]commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+1 (555) 987-6543",
+				},
+				{
+					Type:   commonaddress.TypeEmail,
+					Target: "User@Example.COM",
+				},
+			},
+
+			"+15551234567",
+			[]string{"+15559876543", "user@example.com"},
+
+			&groupcall.Groupcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0001"),
+					CustomerID: uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0002"),
+				},
+			},
+		},
+		{
+			"preserves no-digit tel source verbatim",
+
+			uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0101"),
+			uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0102"),
+
+			&commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "anonymous",
+			},
+			[]commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+1 (555) 987-6543",
+				},
+			},
+
+			"anonymous",
+			[]string{"+15559876543"},
+
+			&groupcall.Groupcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0101"),
+					CustomerID: uuid.FromStringOrNil("2b1d1f20-5d20-11ed-9f01-1ff0bb0c0102"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+			h := &groupcallHandler{
+				utilHandler:   mockUtil,
+				reqHandler:    mockReq,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			// Assert the persisted *groupcall.Groupcall carries canonical source/destinations targets.
+			mockDB.EXPECT().GroupcallCreate(ctx, gomock.Cond(func(x any) bool {
+				g, ok := x.(*groupcall.Groupcall)
+				if !ok {
+					return false
+				}
+				if g.Source.Target != tt.expectSourceTarget {
+					return false
+				}
+				if len(g.Destinations) != len(tt.expectDestinationTargets) {
+					return false
+				}
+				for i := range g.Destinations {
+					if g.Destinations[i].Target != tt.expectDestinationTargets[i] {
+						return false
+					}
+				}
+				return true
+			})).Return(nil)
+			mockDB.EXPECT().GroupcallGet(ctx, tt.responseGroupcall.ID).Return(tt.responseGroupcall, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseGroupcall.CustomerID, groupcall.EventTypeGroupcallCreated, tt.responseGroupcall)
+
+			_, err := h.Create(ctx, tt.id, tt.customerID, commonidentity.OwnerTypeAgent, uuid.Nil, uuid.Nil, tt.source, tt.destinations, []uuid.UUID{}, []uuid.UUID{}, uuid.Nil, uuid.Nil, groupcall.RingMethodRingAll, groupcall.AnswerMethodHangupOthers, "")
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}

--- a/bin-common-handler/models/address/normalize.go
+++ b/bin-common-handler/models/address/normalize.go
@@ -1,0 +1,145 @@
+package address
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Sentinel errors returned by NormalizeTarget. Callers may errors.Is on them.
+var (
+	// ErrUnknownType indicates addressType is not a known enum value. This is
+	// almost always a programming error (a misconfigured or empty Type at a call
+	// site). The original target is returned unchanged alongside this error.
+	ErrUnknownType = errors.New("unknown address type")
+
+	// ErrNotNormalizable indicates the type is known but the value cannot be
+	// reduced to a canonical form for it. This is a legitimate domain case, e.g.
+	// a tel carrier sentinel like "anonymous"/"Restricted" that contains no
+	// digit. The ORIGINAL value is returned unchanged; the caller may store it
+	// verbatim.
+	ErrNotNormalizable = errors.New("value not normalizable for type")
+)
+
+// NormalizeTarget returns the canonical form of target for addressType.
+// It is the single canonicalization authority for address targets across the
+// monorepo.
+//
+// Loss-proof contract: the first return value is ALWAYS safe to store. If the
+// input can be canonicalized, it is the canonical form with a nil error. If it
+// cannot, the ORIGINAL input is returned unchanged with a non-nil sentinel
+// error (ErrNotNormalizable for a known type, ErrUnknownType for an unknown
+// type). NormalizeTarget never blanks a meaningful non-empty input, so a caller
+// that discards the error never loses data.
+//
+// It is idempotent in both value and error class:
+//
+//	NormalizeTarget(t, NormalizeTarget(t, x)) returns the same value and error
+//	class as NormalizeTarget(t, x).
+//
+// NormalizeTarget does NOT validate. Callers run ValidateTarget separately on
+// the canonical form where validation is required (Normalize THEN Validate).
+func NormalizeTarget(addressType Type, target string) (string, error) {
+	switch addressType {
+	case TypeTel, TypeWhatsApp:
+		return normalizeTel(target)
+	case TypeEmail:
+		return normalizeEmail(target), nil
+	case TypeSIP:
+		return normalizeSIP(target), nil
+	case TypeNone, TypeAgent, TypeAI, TypeAITeam, TypeConference, TypeExtension, TypeLine:
+		// Opaque identifiers (UUIDs, names) with no sub-form to canonicalize.
+		// Identity normalization keeps them unchanged and idempotent.
+		return target, nil
+	default:
+		// Unknown type: return the original value (loss-proof) plus a sentinel.
+		return target, fmt.Errorf("%w: %s", ErrUnknownType, addressType)
+	}
+}
+
+// normalizeTel canonicalizes an E.164-style phone number (also used for
+// whatsapp identifiers, which are E.164 phone numbers).
+//
+// Order is load-bearing and matches the legacy bin-contact-manager
+// normalizeE164 loop: (1) trim whitespace FIRST, (2) keep a '+' only if it is at
+// index 0 of the trimmed string, (3) keep ASCII digits [0-9] only, strip
+// everything else. Trimming after the index-0 scan would drop a leading '+' on
+// whitespace-prefixed input.
+//
+// ASCII-only digits (not unicode.IsDigit): the downstream tel validator is the
+// ASCII regex ^\+[0-9]{7,15}$, so a retained non-ASCII digit would
+// normalize-pass then validate-fail. Pinning ASCII keeps normalization output
+// aligned with the validator's alphabet.
+//
+// Loss-proof: if the canonical form contains NO digit (e.g. a carrier sentinel
+// like "anonymous"/"Restricted", an alphanumeric sender id, a bare "+", or an
+// empty input), the ORIGINAL input is returned unchanged with ErrNotNormalizable
+// so a legitimate non-numeric telecom value is never blanked.
+func normalizeTel(target string) (string, error) {
+	src := strings.TrimSpace(target)
+
+	var b strings.Builder
+	hasDigit := false
+	for i, r := range src {
+		switch {
+		case r == '+' && i == 0:
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			hasDigit = true
+		}
+	}
+
+	if !hasDigit {
+		// No digit to canonicalize: preserve the original value verbatim.
+		return target, fmt.Errorf("%w: tel %q", ErrNotNormalizable, target)
+	}
+	return b.String(), nil
+}
+
+// normalizeEmail canonicalizes an email address by trimming surrounding
+// whitespace and lowercasing. This matches the existing contact-manager
+// behavior (trim+lowercase of the raw string). Display-name forms such as
+// "User <user@host>" are lowercased as-is; parsing them is a validation concern,
+// not a normalization one. Lossless: always returns a nil error.
+func normalizeEmail(target string) string {
+	return strings.ToLower(strings.TrimSpace(target))
+}
+
+// normalizeSIP canonicalizes a sip target. Per RFC 3261 the host part is
+// case-insensitive while the user part is case-sensitive, and param/header
+// values are case-sensitive.
+//
+// Steps: (1) trim the whole input; (2) locate the params boundary = the first
+// ';' or '?' (or end of string); (3) split the pre-boundary segment on its LAST
+// '@' so userinfo "user:pass@host" keeps the password verbatim and a '@' inside
+// a header/param value is not mistaken for the userinfo delimiter; (4) preserve
+// the user part verbatim; (5) lowercase only the host token (port digits are
+// safe); (6) preserve the ';params'/'?headers' tail verbatim. If there is no
+// '@' before the params boundary, the trimmed input is returned unchanged.
+// Lossless: always returns a nil error.
+func normalizeSIP(target string) string {
+	s := strings.TrimSpace(target)
+	if s == "" {
+		return ""
+	}
+
+	// Find the params/headers boundary.
+	boundary := len(s)
+	if i := strings.IndexAny(s, ";?"); i >= 0 {
+		boundary = i
+	}
+	head := s[:boundary] // user@host:port
+	tail := s[boundary:] // ;params / ?headers (preserved verbatim)
+
+	at := strings.LastIndex(head, "@")
+	if at < 0 {
+		// No userinfo delimiter before the params boundary; nothing to
+		// canonicalize safely, return the trimmed input unchanged.
+		return s
+	}
+
+	user := head[:at+1] // includes the trailing '@'
+	host := head[at+1:] // host[:port]
+	return user + strings.ToLower(host) + tail
+}

--- a/bin-common-handler/models/address/normalize_test.go
+++ b/bin-common-handler/models/address/normalize_test.go
@@ -1,0 +1,117 @@
+package address
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalizeTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		addressType Type
+		target      string
+		expect      string
+		expectErr   error // nil, ErrNotNormalizable, or ErrUnknownType
+	}{
+		// tel — canonicalizable
+		{"tel punctuation", TypeTel, "+1 (555) 123-4567", "+15551234567", nil},
+		{"tel idempotent", TypeTel, "+15551234567", "+15551234567", nil},
+		{"tel dashes and spaces", TypeTel, "  +1-555-123-4567  ", "+15551234567", nil},
+		{"tel leading ws keeps plus", TypeTel, "  +1555000  ", "+1555000", nil},
+		{"tel plus not index 0 dropped", TypeTel, "00+15551230", "0015551230", nil},
+		{"tel double plus", TypeTel, "++15551230", "+15551230", nil},
+		{"tel arabic-indic digit stripped", TypeTel, "+1\u0665\u0665\u0665123", "+1123", nil},
+		{"tel fullwidth digit stripped", TypeTel, "+1\uff15\uff15123", "+1123", nil},
+		{"tel internal plus", TypeTel, "+15+55", "+1555", nil},
+		{"tel tab newline ws", TypeTel, "\t+1555\n123\n", "+1555123", nil},
+		// tel — NOT canonicalizable (loss-proof: original preserved + ErrNotNormalizable)
+		{"tel anonymous sentinel", TypeTel, "anonymous", "anonymous", ErrNotNormalizable},
+		{"tel restricted sentinel", TypeTel, "Restricted", "Restricted", ErrNotNormalizable},
+		{"tel lone plus", TypeTel, "+", "+", ErrNotNormalizable},
+		{"tel empty", TypeTel, "", "", ErrNotNormalizable},
+		{"tel letters only", TypeTel, "abc", "abc", ErrNotNormalizable},
+
+		// whatsapp (reuses tel)
+		{"whatsapp spaces", TypeWhatsApp, "+1 555 123 4567", "+15551234567", nil},
+		{"whatsapp idempotent", TypeWhatsApp, "+15551234567", "+15551234567", nil},
+		{"whatsapp waID no plus preserved", TypeWhatsApp, "15551234567", "15551234567", nil},
+		{"whatsapp alphanumeric sender", TypeWhatsApp, "VOIPBIN", "VOIPBIN", ErrNotNormalizable},
+		{"whatsapp empty", TypeWhatsApp, "", "", ErrNotNormalizable},
+
+		// email — lossless (always nil)
+		{"email trim lower", TypeEmail, "  John@Example.COM ", "john@example.com", nil},
+		{"email idempotent", TypeEmail, "john@example.com", "john@example.com", nil},
+		{"email display name", TypeEmail, "Bob <Bob@Host.COM>", "bob <bob@host.com>", nil},
+		{"email uppercase local", TypeEmail, "JOHN@example.com", "john@example.com", nil},
+
+		// sip — lossless (always nil)
+		{"sip host lower", TypeSIP, "User@Example.COM", "User@example.com", nil},
+		{"sip with port", TypeSIP, "Alice@Host.com:5060", "Alice@host.com:5060", nil},
+		{"sip transport param", TypeSIP, "Alice@Host.com;transport=TCP", "Alice@host.com;transport=TCP", nil},
+		{"sip maddr param value preserved", TypeSIP, "Alice@Host.com;maddr=Relay.Example", "Alice@host.com;maddr=Relay.Example", nil},
+		{"sip userinfo password preserved", TypeSIP, "user:Pass@Host.com", "user:Pass@host.com", nil},
+		{"sip ipv6 host", TypeSIP, "Alice@[2001:DB8::1]:5060", "Alice@[2001:db8::1]:5060", nil},
+		{"sip at inside header", TypeSIP, "Alice@Host.com?Replaces=Call@ID", "Alice@host.com?Replaces=Call@ID", nil},
+		{"sip whole input trim", TypeSIP, " User@Host.com ", "User@host.com", nil},
+		{"sip no at", TypeSIP, "nobody", "nobody", nil},
+		{"sip empty", TypeSIP, "", "", nil},
+
+		// identity types — always nil, unchanged
+		{"line identity", TypeLine, "07d16b0a-302f-4db8-ae4a-a2c9a65f88b7", "07d16b0a-302f-4db8-ae4a-a2c9a65f88b7", nil},
+		{"agent identity", TypeAgent, "a04a1f51-2495-48a5-9012-8081aa90b902", "a04a1f51-2495-48a5-9012-8081aa90b902", nil},
+		{"ai identity", TypeAI, "some-ai-id", "some-ai-id", nil},
+		{"ai_team identity", TypeAITeam, "some-team-id", "some-team-id", nil},
+		{"conference identity", TypeConference, "34613ee5-5456-40fe-bb3b-395254270a9d", "34613ee5-5456-40fe-bb3b-395254270a9d", nil},
+		{"extension identity", TypeExtension, "2000", "2000", nil},
+		{"none identity", TypeNone, "anything", "anything", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeTarget(tt.addressType, tt.target)
+			if got != tt.expect {
+				t.Errorf("NormalizeTarget(%q, %q) = %q, want %q", tt.addressType, tt.target, got, tt.expect)
+			}
+			if tt.expectErr == nil {
+				if err != nil {
+					t.Errorf("NormalizeTarget(%q, %q) unexpected error: %v", tt.addressType, tt.target, err)
+				}
+			} else if !errors.Is(err, tt.expectErr) {
+				t.Errorf("NormalizeTarget(%q, %q) error = %v, want errors.Is %v", tt.addressType, tt.target, err, tt.expectErr)
+			}
+
+			// Loss-proof property: result is either the canonical form or the
+			// original input — never a blanked meaningful value. For a non-empty
+			// input, the result must be non-empty UNLESS the input was only
+			// whitespace fed to a lossless trim (email/sip).
+			if tt.target != "" && got == "" && tt.addressType != TypeEmail && tt.addressType != TypeSIP {
+				t.Errorf("NormalizeTarget(%q, %q) blanked a non-empty input", tt.addressType, tt.target)
+			}
+
+			// Idempotency: value AND error class are stable on a second apply.
+			again, againErr := NormalizeTarget(tt.addressType, got)
+			if again != got {
+				t.Errorf("NormalizeTarget not value-idempotent for %q: first=%q second=%q", tt.addressType, got, again)
+			}
+			// Error class must match between the two passes for the SAME value.
+			// (Note: the second pass runs on the already-canonical value, so a
+			// once-canonicalizable tel like "+15551234567" yields nil on pass 2;
+			// a never-canonicalizable tel like "anonymous" yields
+			// ErrNotNormalizable on both passes because the value is unchanged.)
+			if (err == nil) != (againErr == nil) && got == tt.target {
+				t.Errorf("NormalizeTarget error-class not idempotent for unchanged value %q: first=%v second=%v", got, err, againErr)
+			}
+		})
+	}
+}
+
+func TestNormalizeTarget_UnknownType(t *testing.T) {
+	got, err := NormalizeTarget(Type("unknown"), "some-value")
+	if !errors.Is(err, ErrUnknownType) {
+		t.Errorf("NormalizeTarget(unknown) error = %v, want errors.Is ErrUnknownType", err)
+	}
+	// Loss-proof: original value preserved, NOT blanked.
+	if got != "some-value" {
+		t.Errorf("NormalizeTarget(unknown) result = %q, want original %q", got, "some-value")
+	}
+}

--- a/bin-common-handler/models/address/validate.go
+++ b/bin-common-handler/models/address/validate.go
@@ -24,7 +24,7 @@ func ValidateTarget(addressType Type, target string) error {
 	switch addressType {
 	case TypeNone:
 		return nil
-	case TypeTel:
+	case TypeTel, TypeWhatsApp:
 		return validateTel(target)
 	case TypeEmail:
 		return validateEmail(target)

--- a/bin-common-handler/models/address/validate_test.go
+++ b/bin-common-handler/models/address/validate_test.go
@@ -21,6 +21,11 @@ func TestValidate(t *testing.T) {
 		{"tel with letters", Address{Type: TypeTel, Target: "+1415555abcd"}, true},
 		{"tel empty", Address{Type: TypeTel, Target: ""}, true},
 
+		// TypeWhatsApp (reuses tel E.164 rule)
+		{"whatsapp valid", Address{Type: TypeWhatsApp, Target: "+14155551234"}, false},
+		{"whatsapp missing plus", Address{Type: TypeWhatsApp, Target: "14155551234"}, true},
+		{"whatsapp empty", Address{Type: TypeWhatsApp, Target: ""}, true},
+
 		// TypeEmail
 		{"email valid", Address{Type: TypeEmail, Target: "user@example.com"}, false},
 		{"email valid with name", Address{Type: TypeEmail, Target: "User <user@example.com>"}, false},
@@ -78,6 +83,10 @@ func TestValidateTarget(t *testing.T) {
 		// TypeTel
 		{"tel valid", TypeTel, "+14155551234", false},
 		{"tel invalid", TypeTel, "14155551234", true},
+
+		// TypeWhatsApp
+		{"whatsapp valid", TypeWhatsApp, "+14155551234", false},
+		{"whatsapp invalid", TypeWhatsApp, "14155551234", true},
 
 		// TypeEmail
 		{"email valid", TypeEmail, "user@example.com", false},

--- a/bin-contact-manager/go.sum
+++ b/bin-contact-manager/go.sum
@@ -433,6 +433,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-contact-manager/pkg/contacthandler/contact.go
+++ b/bin-contact-manager/pkg/contacthandler/contact.go
@@ -5,38 +5,29 @@ import (
 	stderrors "errors"
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-contact-manager/models/contact"
 	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
 
-// normalizeE164 normalizes a phone number to E.164 format by stripping
-// all characters except digits and the leading '+'.
-// If the input is empty, it derives E.164 from the raw number.
+// normalizeE164 normalizes a phone number to E.164 canonical form. The source
+// is the e164 field if non-empty, otherwise the raw number (a contact-manager
+// model concern). The actual canonicalization is delegated to the shared
+// commonaddress.NormalizeTarget authority so every channel normalizes phone
+// targets identically. Tel normalization never returns an error.
 func normalizeE164(e164, number string) string {
-	src := strings.TrimSpace(e164)
-	if src == "" {
-		src = strings.TrimSpace(number)
+	src := e164
+	if strings.TrimSpace(src) == "" {
+		src = number
 	}
-	if src == "" {
-		return ""
-	}
-
-	var b strings.Builder
-	for i, r := range src {
-		if r == '+' && i == 0 {
-			b.WriteRune(r)
-		} else if unicode.IsDigit(r) {
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
+	out, _ := commonaddress.NormalizeTarget(commonaddress.TypeTel, src)
+	return out
 }
 
 // Create creates a new contact with optional phone numbers, emails, and tags
@@ -95,8 +86,8 @@ func (h *contactHandler) Create(ctx context.Context, c *contact.Contact) (*conta
 		e.ID = h.utilHandler.UUIDCreate()
 		e.CustomerID = c.CustomerID
 		e.ContactID = c.ID
-		// Normalize email to lowercase
-		e.Address = strings.ToLower(strings.TrimSpace(e.Address))
+		// Normalize email via the shared canonicalization authority
+		e.Address, _ = commonaddress.NormalizeTarget(commonaddress.TypeEmail, e.Address)
 
 		if e.IsPrimary {
 			if err := h.db.EmailResetPrimary(ctx, c.ID); err != nil {
@@ -210,6 +201,9 @@ func (h *contactHandler) Delete(ctx context.Context, id uuid.UUID) (*contact.Con
 
 // LookupByPhone finds a contact by phone number (E.164 format)
 func (h *contactHandler) LookupByPhone(ctx context.Context, customerID uuid.UUID, phoneE164 string) (*contact.Contact, error) {
+	// Canonicalize the lookup input so it matches the stored canonical form,
+	// closing the write/lookup normalization asymmetry.
+	phoneE164 = normalizeE164(phoneE164, "")
 	res, err := h.db.ContactLookupByPhone(ctx, customerID, phoneE164)
 	if err != nil {
 		if stderrors.Is(err, dbhandler.ErrNotFound) {
@@ -226,8 +220,8 @@ func (h *contactHandler) LookupByPhone(ctx context.Context, customerID uuid.UUID
 
 // LookupByEmail finds a contact by email address
 func (h *contactHandler) LookupByEmail(ctx context.Context, customerID uuid.UUID, email string) (*contact.Contact, error) {
-	// Normalize email to lowercase
-	email = strings.ToLower(strings.TrimSpace(email))
+	// Normalize email via the shared canonicalization authority
+	email, _ = commonaddress.NormalizeTarget(commonaddress.TypeEmail, email)
 	res, err := h.db.ContactLookupByEmail(ctx, customerID, email)
 	if err != nil {
 		if stderrors.Is(err, dbhandler.ErrNotFound) {
@@ -368,8 +362,8 @@ func (h *contactHandler) AddEmail(ctx context.Context, contactID uuid.UUID, e *c
 	e.ID = h.utilHandler.UUIDCreate()
 	e.CustomerID = c.CustomerID
 	e.ContactID = contactID
-	// Normalize email to lowercase
-	e.Address = strings.ToLower(strings.TrimSpace(e.Address))
+	// Normalize email via the shared canonicalization authority
+	e.Address, _ = commonaddress.NormalizeTarget(commonaddress.TypeEmail, e.Address)
 
 	// Enforce single primary: reset existing primaries before setting new one
 	if e.IsPrimary {
@@ -417,7 +411,7 @@ func (h *contactHandler) UpdateEmail(ctx context.Context, contactID, emailID uui
 	// Normalize email address if being updated
 	if address, ok := fields["address"]; ok {
 		if addrStr, isStr := address.(string); isStr {
-			fields["address"] = strings.ToLower(strings.TrimSpace(addrStr))
+			fields["address"], _ = commonaddress.NormalizeTarget(commonaddress.TypeEmail, addrStr)
 		}
 	}
 

--- a/bin-contact-manager/pkg/contacthandler/contact_test.go
+++ b/bin-contact-manager/pkg/contacthandler/contact_test.go
@@ -1618,6 +1618,40 @@ func Test_LookupByEmail_NormalizesEmail(t *testing.T) {
 	}
 }
 
+func Test_LookupByPhone_NormalizesInput(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := contactHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
+	responseContact := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222"),
+			CustomerID: customerID,
+		},
+	}
+
+	// Expect the canonical E.164 form, not the raw punctuated input.
+	mockDB.EXPECT().ContactLookupByPhone(ctx, customerID, "+15551234567").Return(responseContact, nil)
+
+	res, err := h.LookupByPhone(ctx, customerID, "+1 (555) 123-4567")
+	if err != nil {
+		t.Errorf("LookupByPhone() error = %v", err)
+	}
+	if res.ID != responseContact.ID {
+		t.Errorf("LookupByPhone() ID = %v, want %v", res.ID, responseContact.ID)
+	}
+}
+
 func Test_Create_WithDefaultSource(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()

--- a/bin-conversation-manager/pkg/conversationhandler/db.go
+++ b/bin-conversation-manager/pkg/conversationhandler/db.go
@@ -54,6 +54,13 @@ func (h *conversationHandler) GetOrCreateBySelfAndPeer(
 		"peer": peer,
 	})
 
+	// Canonicalize self/peer BEFORE the dedup lookup so the lookup key and the
+	// stored value share one canonical form. NormalizeTarget is loss-proof, so
+	// the error is discarded. DialogID is the provider wire/dedup key and is NOT
+	// normalized.
+	self.Target, _ = commonaddress.NormalizeTarget(self.Type, self.Target)
+	peer.Target, _ = commonaddress.NormalizeTarget(peer.Type, peer.Target)
+
 	res, err := h.db.ConversationGetBySelfAndPeer(ctx, self, peer)
 	if err != nil {
 		log.Debugf("Could not find conversation. Create a new conversation. err: %v", err)
@@ -111,6 +118,14 @@ func (h *conversationHandler) Create(
 	})
 
 	id := h.utilHandler.UUIDCreate()
+
+	// Canonicalize self/peer through the shared address normalization authority.
+	// Idempotent, so callers that already normalized (GetOrCreateBySelfAndPeer)
+	// pass through unchanged. Loss-proof, so the error is discarded. DialogID is
+	// the provider wire/dedup key and is NOT normalized.
+	self.Target, _ = commonaddress.NormalizeTarget(self.Type, self.Target)
+	peer.Target, _ = commonaddress.NormalizeTarget(peer.Type, peer.Target)
+
 	tmp := &conversation.Conversation{
 		Identity: commonidentity.Identity{
 			ID:         id,

--- a/bin-conversation-manager/pkg/conversationhandler/db_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/db_test.go
@@ -716,3 +716,125 @@ func Test_GetOrCreateBySelfAndPeer_Create(t *testing.T) {
 		t.Errorf("Wrong ID. expect: %s, got: %s", newID, res.ID)
 	}
 }
+
+// Test_GetOrCreateBySelfAndPeer_NormalizesSelfPeer is a regression test proving
+// that GetOrCreateBySelfAndPeer canonicalizes self.Target/peer.Target via
+// commonaddress.NormalizeTarget BEFORE the dedup lookup
+// (ConversationGetBySelfAndPeer). A punctuated tel target must reach the DB in
+// its canonical '+'-prefixed digit-only form so a caller's formatting variant
+// hits the same stored conversation. A whatsapp waID with no '+' must normalize
+// to itself (digit-only, idempotent, no '+' injected). DialogID is NOT
+// normalized and must pass through untouched.
+func Test_GetOrCreateBySelfAndPeer_NormalizesSelfPeer(t *testing.T) {
+	tests := []struct {
+		name string
+
+		dialogID string
+		self     commonaddress.Address
+		peer     commonaddress.Address
+
+		expectSelf commonaddress.Address
+		expectPeer commonaddress.Address
+	}{
+		{
+			name: "punctuated tel self and peer are canonicalized",
+
+			dialogID: "dialog-keep-me-untouched",
+			self: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: " +1 (650) 555-7890 ",
+			},
+			peer: commonaddress.Address{
+				Type:       commonaddress.TypeTel,
+				Target:     "+1-202-555-0123",
+				TargetName: "Peer Name",
+			},
+
+			expectSelf: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+16505557890",
+			},
+			expectPeer: commonaddress.Address{
+				Type:       commonaddress.TypeTel,
+				Target:     "+12025550123",
+				TargetName: "Peer Name",
+			},
+		},
+		{
+			name: "whatsapp waID without '+' normalizes to itself (idempotent, no '+' injected)",
+
+			dialogID: "wa-dialog-id",
+			self: commonaddress.Address{
+				Type:   commonaddress.TypeWhatsApp,
+				Target: "15551234567",
+			},
+			peer: commonaddress.Address{
+				Type:   commonaddress.TypeWhatsApp,
+				Target: "15559876543",
+			},
+
+			expectSelf: commonaddress.Address{
+				Type:   commonaddress.TypeWhatsApp,
+				Target: "15551234567",
+			},
+			expectPeer: commonaddress.Address{
+				Type:   commonaddress.TypeWhatsApp,
+				Target: "15559876543",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			h := &conversationHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+			}
+			ctx := context.Background()
+
+			customerID := uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440001")
+			conversationType := conversation.TypeMessage
+
+			expectedConv := &conversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440099"),
+					CustomerID: customerID,
+				},
+				Type:     conversationType,
+				DialogID: tt.dialogID,
+				Self:     tt.expectSelf,
+				Peer:     tt.expectPeer,
+			}
+
+			// Assert the dedup lookup receives the CANONICAL self/peer.
+			matchSelf := gomock.Cond(func(x any) bool {
+				a, ok := x.(commonaddress.Address)
+				return ok && reflect.DeepEqual(a, tt.expectSelf)
+			})
+			matchPeer := gomock.Cond(func(x any) bool {
+				a, ok := x.(commonaddress.Address)
+				return ok && reflect.DeepEqual(a, tt.expectPeer)
+			})
+			mockDB.EXPECT().ConversationGetBySelfAndPeer(ctx, matchSelf, matchPeer).Return(expectedConv, nil)
+
+			res, err := h.GetOrCreateBySelfAndPeer(ctx, customerID, conversationType, tt.dialogID, tt.self, tt.peer)
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if res.ID != expectedConv.ID {
+				t.Errorf("Wrong ID. expect: %s, got: %s", expectedConv.ID, res.ID)
+			}
+
+			// DialogID must pass through untouched (NOT normalized).
+			if res.DialogID != tt.dialogID {
+				t.Errorf("DialogID changed. expect: %q, got: %q", tt.dialogID, res.DialogID)
+			}
+		})
+	}
+}

--- a/bin-email-manager/pkg/emailhandler/email.go
+++ b/bin-email-manager/pkg/emailhandler/email.go
@@ -27,6 +27,14 @@ func (h *emailHandler) Create(
 	content string,
 	attachments []email.Attachment,
 ) (*email.Email, error) {
+	// Canonicalize destinations through the shared address normalization
+	// authority BEFORE validation (Normalize-then-Validate). Email normalization
+	// is lossless; the error is discarded. Normalize by index (range copy would
+	// discard the result).
+	for i := range destinations {
+		destinations[i].Target, _ = commonaddress.NormalizeTarget(destinations[i].Type, destinations[i].Target)
+	}
+
 	// validate destinations
 	for _, destination := range destinations {
 		if !h.validateEmailAddress(destination) {

--- a/bin-email-manager/pkg/emailhandler/email_test.go
+++ b/bin-email-manager/pkg/emailhandler/email_test.go
@@ -939,3 +939,139 @@ func Test_UpdateStatus_DBError(t *testing.T) {
 		})
 	}
 }
+
+// Test_Create_NormalizesDestinations is a regression test proving that
+// Create canonicalizes destination email Targets via
+// commonaddress.NormalizeTarget (lowercase + trim) BEFORE validation and
+// persist. An UPPERCASE/whitespace-padded email is lowercased and trimmed in
+// the persisted email (EmailCreate). TargetName (display name) is preserved
+// untouched.
+func Test_Create_NormalizesDestinations(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		customerID   uuid.UUID
+		activeflowID uuid.UUID
+		destinations []commonaddress.Address
+		subject      string
+		content      string
+		attachments  []email.Attachment
+
+		responseUUID                uuid.UUID
+		responseProviderReferenceID string
+
+		expectEmail *email.Email
+		expectRes   *email.Email
+	}{
+		{
+			name: "uppercase destination email is lowercased, display name preserved",
+
+			customerID:   uuid.FromStringOrNil("86e92dc4-0083-11f0-a8c4-0f10cc7d6102"),
+			activeflowID: uuid.FromStringOrNil("871bddaa-0083-11f0-8d2f-a32510551821"),
+			destinations: []commonaddress.Address{
+				{
+					Type:       commonaddress.TypeEmail,
+					Target:     "  Test.User@VoipBin.NET  ",
+					TargetName: "Test User",
+				},
+			},
+			subject: "test subject",
+			content: "test content",
+
+			responseUUID:                uuid.FromStringOrNil("8756a2dc-0083-11f0-a7bd-bf369e143079"),
+			responseProviderReferenceID: "877ba028-0083-11f0-9831-3b71bd00b552",
+
+			expectEmail: &email.Email{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("8756a2dc-0083-11f0-a7bd-bf369e143079"),
+					CustomerID: uuid.FromStringOrNil("86e92dc4-0083-11f0-a8c4-0f10cc7d6102"),
+				},
+				ActiveflowID: uuid.FromStringOrNil("871bddaa-0083-11f0-8d2f-a32510551821"),
+				ProviderType: email.ProviderTypeSendgrid,
+				Source:       defaultSource,
+				Destinations: []commonaddress.Address{
+					{
+						Type:       commonaddress.TypeEmail,
+						Target:     "test.user@voipbin.net",
+						TargetName: "Test User",
+					},
+				},
+				Status:  email.StatusInitiated,
+				Subject: "test subject",
+				Content: "test content",
+			},
+			expectRes: &email.Email{
+				Identity: identity.Identity{
+					ID:         uuid.FromStringOrNil("8756a2dc-0083-11f0-a7bd-bf369e143079"),
+					CustomerID: uuid.FromStringOrNil("86e92dc4-0083-11f0-a8c4-0f10cc7d6102"),
+				},
+				ActiveflowID: uuid.FromStringOrNil("871bddaa-0083-11f0-8d2f-a32510551821"),
+				ProviderType: email.ProviderTypeSendgrid,
+				Source:       defaultSource,
+				Destinations: []commonaddress.Address{
+					{
+						Type:       commonaddress.TypeEmail,
+						Target:     "test.user@voipbin.net",
+						TargetName: "Test User",
+					},
+				},
+				Status:  email.StatusInitiated,
+				Subject: "test subject",
+				Content: "test content",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockSendgrid := NewMockEngineSendgrid(mc)
+			mockMailgun := NewMockEngineMailgun(mc)
+
+			h := &emailHandler{
+				db:            mockDB,
+				reqHandler:    mockReq,
+				notifyHandler: mockNotify,
+				utilHandler:   mockUtil,
+
+				engineSendgrid: mockSendgrid,
+				engineMailgun:  mockMailgun,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(&cucustomer.Customer{
+				ID:                         tt.customerID,
+				IdentityVerificationStatus: cucustomer.IdentityVerificationStatusVerified,
+			}, nil)
+			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.customerID, bmbilling.ReferenceTypeEmail, "", len(tt.destinations)).Return(true, nil)
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+			// EmailCreate must receive the canonical (lowercased+trimmed)
+			// destination with the display name preserved.
+			mockDB.EXPECT().EmailCreate(ctx, tt.expectEmail).Return(nil)
+			mockDB.EXPECT().EmailGet(ctx, tt.responseUUID).Return(tt.expectEmail, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.expectEmail.CustomerID, email.EventTypeCreated, tt.expectEmail)
+
+			mockSendgrid.EXPECT().Send(ctx, tt.expectEmail).Return(tt.responseProviderReferenceID, nil)
+			mockDB.EXPECT().EmailUpdateProviderReferenceID(ctx, tt.expectEmail.ID, tt.responseProviderReferenceID).Return(nil)
+
+			res, err := h.Create(ctx, tt.customerID, tt.activeflowID, tt.destinations, tt.subject, tt.content, tt.attachments)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+
+			time.Sleep(100 * time.Millisecond)
+		})
+	}
+}

--- a/bin-message-manager/pkg/messagehandler/hook.go
+++ b/bin-message-manager/pkg/messagehandler/hook.go
@@ -8,6 +8,8 @@ import (
 
 	nmnumber "monorepo/bin-number-manager/models/number"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
+
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -86,6 +88,17 @@ func (h *messageHandler) hookTelnyx(ctx context.Context, data []byte) (*message.
 	source := hm.GetSource()
 	targets := hm.GetTargets()
 	text := hm.GetText()
+
+	// Canonicalize inbound source/targets through the shared address
+	// normalization authority. NormalizeTarget is loss-proof, so the error is
+	// discarded. Nil-guard the source pointer; normalize targets by index.
+	if source != nil {
+		source.Target, _ = commonaddress.NormalizeTarget(source.Type, source.Target)
+	}
+	for i := range targets {
+		targets[i].Destination.Target, _ = commonaddress.NormalizeTarget(targets[i].Destination.Type, targets[i].Destination.Target)
+	}
+
 	res, err := h.Create(ctx, uuid.Nil, num.CustomerID, source, targets, message.ProviderNameTelnyx, text, message.DirectionInbound)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "Could not create a message. number_id: %s, number: %s", num.ID, num.Number)

--- a/bin-message-manager/pkg/messagehandler/send.go
+++ b/bin-message-manager/pkg/messagehandler/send.go
@@ -31,6 +31,18 @@ func (h *messageHandler) Send(ctx context.Context, id uuid.UUID, customerID uuid
 		return nil, fmt.Errorf("customer identity verification required to send message")
 	}
 
+	// Canonicalize source/destinations through the shared address normalization
+	// authority so BOTH the persisted message and the provider wire value are in
+	// canonical form. NormalizeTarget is loss-proof (an alphanumeric/sentinel
+	// sender with no digit is preserved verbatim), so the error is discarded.
+	// Nil-guard the source pointer; normalize destinations by index.
+	if source != nil {
+		source.Target, _ = commonaddress.NormalizeTarget(source.Type, source.Target)
+	}
+	for i := range destinations {
+		destinations[i].Target, _ = commonaddress.NormalizeTarget(destinations[i].Type, destinations[i].Target)
+	}
+
 	// create targets
 	targets := []target.Target{}
 	for _, destination := range destinations {

--- a/bin-message-manager/pkg/messagehandler/send_test.go
+++ b/bin-message-manager/pkg/messagehandler/send_test.go
@@ -2,6 +2,7 @@ package messagehandler
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -165,6 +166,171 @@ func Test_Send(t *testing.T) {
 			mockDB.EXPECT().MessageUpdateTargets(ctx, tt.id, gomock.AnyOf(message.ProviderNameTelnyx, message.ProviderNameMessagebird), tt.responseSend).Return(nil)
 			mockDB.EXPECT().MessageGet(ctx, tt.id).Return(tt.responseMessage, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseMessage.CustomerID, message.EventTypeMessageUpdated, tt.responseMessage)
+
+			res, err := h.Send(ctx, tt.id, tt.customerID, tt.source, tt.destinations, tt.text)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			time.Sleep(time.Millisecond * 100)
+
+			if !reflect.DeepEqual(tt.responseMessage, res) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.responseMessage, res)
+			}
+		})
+	}
+}
+
+// Test_Send_NormalizesAddress proves Send canonicalizes the persisted source
+// and destination targets through commonaddress.NormalizeTarget before handing
+// them to Create -> db.MessageCreate. The assertion is pinned to the
+// synchronous persist call (MessageCreate), which runs BEFORE the async
+// provider goroutine, so the canonical values are inspected directly on the
+// *message.Message passed to the db. The loss-proof row proves an alphanumeric
+// tel sender ("VOIPBIN", no digit) is preserved verbatim instead of blanked.
+func Test_Send_NormalizesAddress(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		id           uuid.UUID
+		customerID   uuid.UUID
+		source       *commonaddress.Address
+		destinations []commonaddress.Address
+		text         string
+
+		responseMessage *message.Message
+
+		expectSource       *commonaddress.Address
+		expectDestinations []commonaddress.Address
+	}{
+		{
+			name: "punctuated tel source and destination are canonicalized",
+
+			id:         uuid.FromStringOrNil("a3b6f2d4-1c5e-4a7b-9d8f-0e1a2b3c4d5e"),
+			customerID: uuid.FromStringOrNil("feef3a64-4fab-46af-a61b-6a7ce31b84a9"),
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1 (555) 123-4567",
+			},
+			destinations: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+1.555.987.6543",
+				},
+			},
+			text: "hello world",
+
+			responseMessage: &message.Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("a3b6f2d4-1c5e-4a7b-9d8f-0e1a2b3c4d5e"),
+					CustomerID: uuid.FromStringOrNil("feef3a64-4fab-46af-a61b-6a7ce31b84a9"),
+				},
+			},
+
+			expectSource: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+15551234567",
+			},
+			expectDestinations: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+15559876543",
+				},
+			},
+		},
+		{
+			name: "alphanumeric tel sender is preserved verbatim (loss-proof)",
+
+			id:         uuid.FromStringOrNil("b4c7e3f5-2d6f-4b8c-8e9a-1f2b3c4d5e6f"),
+			customerID: uuid.FromStringOrNil("feef3a64-4fab-46af-a61b-6a7ce31b84a9"),
+			source: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "VOIPBIN",
+			},
+			destinations: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+1 (555) 123-4567",
+				},
+			},
+			text: "hello world",
+
+			responseMessage: &message.Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("b4c7e3f5-2d6f-4b8c-8e9a-1f2b3c4d5e6f"),
+					CustomerID: uuid.FromStringOrNil("feef3a64-4fab-46af-a61b-6a7ce31b84a9"),
+				},
+			},
+
+			expectSource: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "VOIPBIN",
+			},
+			expectDestinations: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+15551234567",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockBird := NewMockMessageHandlerMessagebird(mc)
+			mockTelnyx := NewMockMessageHandlerTelnyx(mc)
+
+			h := &messageHandler{
+				utilHandler:               mockUtil,
+				db:                        mockDB,
+				reqHandler:                mockReq,
+				notifyHandler:             mockNotify,
+				messageHandlerMessagebird: mockBird,
+				messageHandlerTelnyx:      mockTelnyx,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.customerID).Return(&cucustomer.Customer{
+				ID:                         tt.customerID,
+				IdentityVerificationStatus: cucustomer.IdentityVerificationStatusVerified,
+			}, nil)
+
+			mockReq.EXPECT().BillingV1AccountIsValidBalanceByCustomerID(ctx, tt.customerID, bmbilling.ReferenceTypeSMS, "", len(tt.destinations)).Return(true, nil)
+
+			// Capture-by-matcher: inspect the *message.Message persisted by the
+			// synchronous Create -> MessageCreate path and assert that BOTH the
+			// source and every destination target are in canonical form.
+			expectSource := tt.expectSource
+			expectDestinations := tt.expectDestinations
+			mockDB.EXPECT().MessageCreate(ctx, gomock.Cond(func(m *message.Message) bool {
+				if m.Source == nil || m.Source.Target != expectSource.Target {
+					return false
+				}
+				if len(m.Targets) != len(expectDestinations) {
+					return false
+				}
+				for i := range m.Targets {
+					if m.Targets[i].Destination.Target != expectDestinations[i].Target {
+						return false
+					}
+				}
+				return true
+			})).Return(nil)
+			mockDB.EXPECT().MessageGet(ctx, tt.id).Return(tt.responseMessage, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseMessage.CustomerID, message.EventTypeMessageCreated, tt.responseMessage)
+
+			// The async provider goroutine runs after persist; allow but do not
+			// require its calls so the focused persist assertion stays isolated.
+			mockTelnyx.EXPECT().SendMessage(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("ignored")).AnyTimes()
+			mockBird.EXPECT().SendMessage(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("ignored")).AnyTimes()
 
 			res, err := h.Send(ctx, tt.id, tt.customerID, tt.source, tt.destinations, tt.text)
 			if err != nil {

--- a/docs/plans/2026-06-21-add-shared-normalizetarget-design.md
+++ b/docs/plans/2026-06-21-add-shared-normalizetarget-design.md
@@ -1,0 +1,482 @@
+# Shared Address NormalizeTarget and Canonical-Form Enforcement
+
+- Issue: voipbin/monorepo#1002
+- Class: hardening / refactor (extract + promote an existing primitive; behavior-preserving for tel/email on ASCII inputs — non-ASCII digit handling deliberately tightened, see §3.1). Phase 2 (this revision) extends adoption to all channel resource managers.
+- Date: 2026-06-21
+
+## 0. Revision note (v4 — scope expansion)
+
+v1-v3 delivered the shared primitive + contact-manager adoption only, deferring
+the other channel managers. pchero directed (2026-06) that NormalizeTarget become
+a system-wide core principle: EVERY channel resource manager that stores a
+source/destination address must canonicalize it through the single shared
+authority, and test coverage must be maximized. This revision adds call /
+message / conversation / email-manager adoption at each manager's storage
+chokepoint, verified safe against every send/dispatch path.
+
+The earlier "defer because no contact_id yet" rationale was WRONG and is
+retracted: normalization is independent of contact resolution. Canonicalizing
+the STORED address has immediate value (data hygiene + consistent identity form)
+and must happen as early as possible, because any address persisted in raw form
+before normalization is introduced becomes a permanent mismatch.
+
+## 1. Problem Statement
+
+Identity resolution fragments across channels because there is no single
+normalization authority.
+
+Code-verified facts:
+
+- `bin-common-handler/models/address/validate.go`: `ValidateTarget(type, target)`
+  VALIDATES only, it does NOT normalize. The tel rule is the regex
+  `^\+[0-9]{7,15}$`, so different-but-valid forms (`+155****4567` vs a
+  space/punctuation-laden raw form) either both pass as distinct strings or the
+  raw form fails outright before it can be canonicalized.
+- email validation uses `net/mail.ParseAddress` (RFC 5322) which preserves case,
+  so `John@Example.COM` and `john@example.com` both pass but differ as strings.
+- The real normalizer historically lived ONLY inside `bin-contact-manager`.
+- `sip` / `line` / `whatsapp` / `ai` / `ai_team` have NO normalizer anywhere.
+- `whatsapp` (`TypeWhatsApp`) exists as an enum but had NO branch in
+  `ValidateTarget` — it fell through to `default` and ERRORED. Exposed-but-broken.
+- Every channel resource (Call.Source/Destination, Message source + targets,
+  Conversation Self/Peer, Email source/destinations) is a `commonaddress.Address`
+  (Type + Target), but NONE of call/message/conversation/email-manager normalizes
+  the address it persists. They store raw, untrusted, customer-supplied strings.
+
+Why it matters: two managers that store the same identifier in different forms
+produce distinct `target` values, so a future `LookupByAddress` MISS,
+`contact_id = NULL`, and a permanently fragmented Contact timeline. The canonical
+form must be enforced at every write boundary, not just contact-manager's.
+
+## 2. Scope
+
+In scope:
+
+1. New `bin-common-handler/models/address/NormalizeTarget(addressType Type,
+   target string) (string, error)` — the single canonicalization authority.
+   (Delivered in v1-v3, retained.)
+2. `whatsapp` promoted to a SUPPORTED channel in `ValidateTarget` (reuse tel
+   E.164 rule) + `NormalizeTarget` (reuse tel normalization). (Delivered.)
+3. contact-manager: write + `LookupByPhone`/`LookupByEmail` both pass through
+   `NormalizeTarget`; `LookupByPhone` input-normalization bug fixed. (Delivered.)
+4. **NEW: each channel resource manager canonicalizes the source/destination
+   address it stores, through the shared `NormalizeTarget`, at its creation
+   chokepoint:**
+   - **call-manager**: `callHandler.Create` (`pkg/callhandler/db.go`), normalize
+     `*source` and `*destination` before the struct literal.
+   - **message-manager**: at the resource entry — `messagehandler.Send` (outbound)
+     and `messagehandler.hookTelnyx` (inbound) — normalize `source` + each
+     `target.Destination` so BOTH the persisted Message and the provider wire
+     value are canonical.
+   - **conversation-manager**: `conversationHandler.GetOrCreateBySelfAndPeer`
+     (normalize `self`/`peer` BEFORE the dedup lookup so the lookup key and the
+     stored value are the same canonical form) and `conversationHandler.Create`
+     (covers the API-POST and line/whatsapp RPC-create paths).
+   - **email-manager**: `emailHandler.Create` destination loop, normalize each
+     destination `Target` BEFORE validation (Normalize-then-Validate).
+5. Golden-vector + idempotency contract tests for `NormalizeTarget` (delivered),
+   plus a per-manager regression test asserting the stored/forwarded address is
+   the canonical form, plus expanded golden vectors (see §4).
+
+Out of scope:
+
+- The CRM read model itself (`contact_interactions`, timeline, dedup). This issue
+  delivers the normalization primitive + its enforcement; the read model is later.
+- `line` / `ai` / `ai_team` normalization beyond identity. `line` and the
+  UUID/opaque-id types canonicalize to themselves (identity) so they remain
+  idempotent and never error. `ai`/`ai_team` validation is a separate concern
+  (see §3.1 asymmetry note).
+- `bin-agent-manager` address normalization. agent-manager DOES persist a
+  `commonaddress.Address` source/destination and looks it up via exact-match
+  (`AgentGetByCustomerIDAndAddress`, `json_contains`). It is deliberately NOT
+  normalized in this PR because the matching call-manager lookup
+  (`getAddressOwner` -> `AgentV1AgentGetByCustomerIDAndAddress`) runs on the RAW
+  pre-`Create` value by design (§3.3). Normalizing the agent STORE in isolation
+  would create a stored-vs-lookup-key mismatch and break the exact-match join.
+  Closing it correctly requires normalizing BOTH the agent store and the
+  call-manager agent lookup together (a larger, coordinated change), so it is
+  deferred to a dedicated follow-up rather than half-done here.
+- `bin-queue-manager` (queuecall source) and `bin-campaign-manager`
+  (outplan/campaigncall source/destination). These persist DERIVED copies that
+  ultimately flow into `callHandler.Create`, which re-normalizes at the canonical
+  chokepoint, so the canonical-form invariant holds at dispatch regardless. No
+  isolated normalization needed; covered transitively.
+
+## 3. Design
+
+### 3.1 NormalizeTarget contract (revised v5 — loss-proof + 2 sentinel errors)
+
+```go
+// Sentinel errors (callers may errors.Is on them):
+var (
+	// ErrUnknownType: addressType is not a known enum value (almost always a
+	// programming error — a misconfigured or empty Type at a call site).
+	ErrUnknownType = errors.New("unknown address type")
+	// ErrNotNormalizable: the type is known but the value cannot be reduced to a
+	// canonical form for it (a legitimate domain case, e.g. a tel carrier
+	// sentinel like "anonymous"/"Restricted" that contains no digits). The
+	// ORIGINAL value is returned unchanged; the caller may store it verbatim.
+	ErrNotNormalizable = errors.New("value not normalizable for type")
+)
+
+func NormalizeTarget(addressType Type, target string) (string, error)
+```
+
+**Loss-proof contract (the core principle):** the FIRST return value is ALWAYS
+a value safe to store. If the input can be canonicalized, it is the canonical
+form with `err == nil`. If it cannot, the ORIGINAL input is returned unchanged
+with a non-nil sentinel error. `NormalizeTarget` NEVER blanks a MEANINGFUL
+non-empty input (the sole "empty out" case is whitespace/empty input to the
+lossless email/sip trim, which is not data loss). A caller that discards the
+error (`out, _ := NormalizeTarget(...)`) therefore never loses real data; a
+caller that checks the error learns the value is not in canonical form.
+
+Per-type rules:
+
+| Type | Normalization | Error |
+|------|---------------|-------|
+| `tel` | trim; keep `+` only at index 0; keep ASCII `[0-9]` only. **If the result contains NO digit** (e.g. `anonymous`, `Restricted`, `+`, empty), return the ORIGINAL input unchanged. | `nil` if ≥1 digit; `ErrNotNormalizable` if no digit |
+| `whatsapp` | identical to `tel` | same as tel |
+| `email` | `strings.ToLower(strings.TrimSpace(target))` | always `nil` (lossless) |
+| `sip` | trim; params boundary first `;`/`?`; split pre-boundary on LAST `@`; preserve user; lowercase host token; preserve params tail; no `@` → trimmed input unchanged | always `nil` (lossless) |
+| `none`, `agent`, `conference`, `extension`, `line`, `ai`, `ai_team` | identity (input UNCHANGED, no trim) | always `nil` |
+| unknown | return the ORIGINAL `target` unchanged (NOT empty) | `ErrUnknownType` |
+
+Rationale for the tel no-digit rule (F2 fix): a raw tel `tel` Target may legitimately
+carry a non-numeric carrier sentinel for withheld/anonymous caller-ID
+(`anonymous`, `Restricted`, `unknown`). The old "strip to digits" rule blanked
+these to `""`, silently destroying telecom semantics on the STORED source. The
+no-digit guard preserves them verbatim and flags `ErrNotNormalizable` so the
+value is never canonicalized into nothing.
+
+Idempotency (value AND error are deterministic):
+`NormalizeTarget(t, NormalizeTarget(t, x).0)` returns the same value and the same
+error class as `NormalizeTarget(t, x)`. E.g. `("anonymous", ErrNotNormalizable)`
+on both passes; `("+155****4567", nil)` on both passes.
+
+ASCII-only digit rule (not `unicode.IsDigit`): the tel validator regex is ASCII
+`^\+[0-9]{7,15}$`. Pin ASCII `[0-9]`. Deliberate, documented, test-locked.
+
+`none` consistency: `ValidateTarget(TypeNone, _)` returns `nil`, so `none` is a
+no-error identity in BOTH functions. `ai` / `ai_team`: `NormalizeTarget` identity
+(no error), `ValidateTarget` errors via `default` (pre-existing, out of scope).
+
+### 3.2 Ordering: Normalize THEN Validate
+
+```
+canonical, err := NormalizeTarget(type, raw)   // 1. canonicalize
+if err != nil { ... }
+if err := ValidateTarget(type, canonical); err != nil { ... }  // 2. validate canonical
+// store / dispatch / lookup with `canonical`
+```
+
+A raw tel like `+1 (555) 123-4567` only passes the regex AFTER normalization
+strips punctuation. This ordering is invariant.
+
+### 3.3 Per-manager wiring
+
+Each manager normalizes at its own storage chokepoint (each resource owns its
+normalization, consistent with VoIPBin layering). NormalizeTarget is idempotent,
+so a value already canonical passes through unchanged.
+
+**Error-handling policy at every call site:** because NormalizeTarget is
+loss-proof (returns the original value on any error), call sites take the first
+return value unconditionally and discard the error with `_`. The value is always
+safe to store. (Rationale: `ErrNotNormalizable` is a normal domain case like a
+tel carrier sentinel, and `ErrUnknownType` cannot occur here because every call
+site passes a known constant or the resource's own validated `.Type`.) Sites
+that want observability MAY log on `ErrNotNormalizable`, but no site should
+branch on it for control flow.
+
+**Nil-pointer policy (F1):** several models hold the address by pointer
+(`Message.Source *commonaddress.Address`, call `*source`/`*destination`). Every
+call site MUST nil-guard before dereferencing: `if addr != nil { addr.Target, _ =
+NormalizeTarget(addr.Type, addr.Target) }`.
+
+**Value-slice policy (F7):** destinations held as a value slice
+(`message.Send` `[]commonaddress.Address`, email-manager `Destinations`) MUST be
+normalized BY INDEX (`destinations[i].Target, _ = NormalizeTarget(...)`), NEVER
+via `for _, d := range` (which mutates a copy and silently discards the result —
+a silent no-op that would skip normalization entirely).
+
+**ValidateTarget boundary (F6):** the normalize call sites here are storage
+write paths; they do NOT feed the normalized value into `ValidateTarget`. This
+matters because a loss-proof non-normalizable value (`anonymous`, bare `+`) and
+`whatsapp`/`ai`/`ai_team` targets would FAIL `ValidateTarget` (the regex rejects
+`anonymous`; `ValidateTarget` has no whatsapp/ai/ai_team case). The
+Normalize-then-Validate pipeline (§3.2) applies to USER-SUPPLIED OUTBOUND
+addresses validated at their own boundary, not to these stored-address
+canonicalization sites. No v5 site introduces a Normalize→Validate path on a
+non-normalizable or whatsapp value.
+
+**contact-manager** (delivered v1-v3): `normalizeE164` delegates to
+`NormalizeTarget(TypeTel, ...)`; email Create/AddEmail/UpdateEmail/LookupByEmail
+route through `NormalizeTarget(TypeEmail, ...)`; `LookupByPhone` normalizes its
+input. (The loss-proof revision only strengthens these — a contact phone that is
+all non-digit now stays verbatim instead of blanking.)
+
+**call-manager**: `callHandler.Create` (`pkg/callhandler/db.go:30`) is the SOLE
+writer of `Source`/`Destination`, reached by both `CreateCallOutgoing`
+(outgoing_call.go:294, also every groupcall leg via RPC) and `startCallTypeFlow`
+(start.go:623, incoming). Nil-guard then normalize `source.Target` and
+`destination.Target` (keyed on each address's own `.Type`) at the top of `Create`
+before the struct literal at db.go:99-100.
+
+- Send-path safety (verified): outgoing dial reads the PERSISTED destination
+  (`c.Destination.Target`) AFTER `Create`, so the dial string gets the canonical
+  form. tel goes into the provider SIP user part where E.164 is already assumed;
+  sip lowercases only the host while preserving `;transport=ws`/`;outbound_proxy=`
+  params. SAFE.
+- F2 protection: an incoming PSTN call with a withheld caller-ID
+  (source.Target = `anonymous` / `Restricted`) is preserved verbatim by the
+  loss-proof tel rule — the stored source keeps its telecom sentinel.
+- MUST NOT normalize in `channelhandler/address.go` or before the incoming
+  number-manager / trunk / extension lookups in `start*.go` — those lookups run
+  on the raw Asterisk value BEFORE `Create`. `getAddressOwner` and `getDialroutes`
+  also resolve on the raw pre-Create value (best-effort, errors only logged); the
+  stored canonical form differs from those lookup keys by design.
+
+**groupcall (call-manager, F5-codeverify gap):** `groupcallHandler.Create`
+(`pkg/groupcallhandler/db.go:68-69`) ALSO persists `Source`/`Destinations` on the
+Groupcall record. Per the "EVERY resource that stores an address canonicalizes
+it" principle, normalize `source` + each `destinations[i]` there too (nil-guard,
+keyed on `.Type`). Each dialed leg already re-normalizes at `callHandler.Create`,
+so routing is unaffected; this closes the stored-raw-address gap on the Groupcall
+record itself.
+
+**message-manager**: Message has `Source *commonaddress.Address` and
+`Targets []target.Target` where each `Target.Destination` is a
+`commonaddress.Address`. Normalize at the resource entry so BOTH storage and the
+provider wire are canonical:
+- `messagehandler.Send` (send.go): nil-guard + normalize `source`, normalize each
+  `destinations[i]` before building targets (send.go:~34).
+- `messagehandler.hookTelnyx` (hook.go): normalize the inbound source/targets
+  before `Create` (hook.go:~86).
+- Send-path safety (verified): providers (Telnyx/MessageBird) take
+  `destination.Target` verbatim as the `to`/`from` and EXPECT E.164. Normalizing
+  tel to `+`+digits yields exactly E.164. SAFE, and fixes punctuated-input rejects.
+- F3 protection: an alphanumeric SMS sender ID submitted as a `tel` source (e.g.
+  `from = "VOIPBIN"`) has no digits, so the loss-proof tel rule preserves it
+  verbatim instead of blanking the `from`. (Implementation MUST confirm whether
+  alphanumeric senders are modeled as `TypeTel`; if they are a distinct type the
+  point is moot, but the loss-proof guard protects either way.)
+- MUST NOT normalize inside the provider handlers, `requestexternal/*`, or the
+  async goroutine (data-race risk on shared slices).
+
+**conversation-manager**: Conversation has `Self`/`Peer commonaddress.Address`.
+The conversation Message model has NO address fields, so nothing to normalize
+there.
+- `conversationHandler.GetOrCreateBySelfAndPeer` (db.go:~56): normalize
+  `self`/`peer` BEFORE the `ConversationGetBySelfAndPeer` dedup lookup, so the
+  lookup key and the stored value share one canonical form.
+- `conversationHandler.Create` (db.go:~113): normalize `self`/`peer` before the
+  struct literal — covers the API-POST and line/whatsapp RPC-create paths.
+- F5 dedup-consistency (verified against code): SMS dispatch uses `Self`/`Peer`
+  (tel); LINE/WhatsApp dispatch + dedup use `conversation.DialogID`, NOT
+  Self/Peer. `line` Self/Peer are `TypeLine` → identity normalization (unchanged).
+  For `whatsapp`, the inbound hook (`whatsapphandler/hook.go:209-211`) ALWAYS sets
+  `peer.Target = waID` (Meta's `+`-less form) and dedups on `DialogID = waID`, so
+  tel normalization (which injects no `+`) leaves the hook path's peer unchanged
+  and consistent with DialogID. The ONLY path that can supply a `+`-prefixed
+  whatsapp peer is the customer-supplied API POST (`v1_conversations.go:107-110`,
+  `req.Peer`), which is a PRE-EXISTING ambiguity: that path keys dedup on its own
+  supplied DialogID, independent of peer normalization. Normalizing peer does NOT
+  create a new split — it cannot make two waID-hook conversations diverge (they
+  share the `+`-less form). Conclusion: normalization introduces NO new dedup bug;
+  the API-POST `+`-vs-waID ambiguity predates this change and is out of scope.
+  A regression test asserts the waID-hook peer normalizes to itself (idempotent,
+  no `+` injected).
+- MUST NOT normalize `conversation.DialogID` — provider wire target + LINE/WhatsApp
+  dedup key; leave verbatim.
+
+**email-manager**: Email has `Source *commonaddress.Address` and
+`Destinations []commonaddress.Address` (all `TypeEmail`).
+- `emailHandler.Create` (email.go:~31): normalize each `destinations[i].Target`
+  (by index, in place) BEFORE the existing `validateEmailAddress` check. Optionally
+  normalize the source defensively in `create` (today source = canonical constant).
+- Send-path safety (verified): SendGrid/Mailgun take the bare `.Target` verbatim;
+  email normalization is lossless (always `nil` error). SAFE.
+- MUST NOT pass the composite `"Name <addr>"` string to NormalizeTarget — normalize
+  only `.Target`, preserve `.TargetName`. MUST NOT normalize inside engine send funcs.
+
+### 3.4 Affected files
+
+| Service | File | Change |
+|---------|------|--------|
+| bin-common-handler | `models/address/normalize.go` (new, delivered) | `NormalizeTarget` + helpers |
+| bin-common-handler | `models/address/normalize_test.go` (new, delivered) | golden-vector + idempotency |
+| bin-common-handler | `models/address/validate.go` (delivered) | whatsapp branch |
+| bin-common-handler | `models/address/validate_test.go` (delivered) | whatsapp rows |
+| bin-contact-manager | `pkg/contacthandler/contact.go` (delivered) | delegate + lookups |
+| bin-contact-manager | `pkg/contacthandler/contact_test.go` (delivered) | LookupByPhone test |
+| bin-call-manager | `pkg/callhandler/db.go` | normalize source/destination in `Create` |
+| bin-call-manager | `pkg/callhandler/db_test.go` | normalization regression test |
+| bin-call-manager | `pkg/groupcallhandler/db.go` | normalize source/destinations in `Create` |
+| bin-call-manager | `pkg/groupcallhandler/db_test.go` | normalization regression test |
+| bin-message-manager | `pkg/messagehandler/send.go` | normalize source/destinations in `Send` |
+| bin-message-manager | `pkg/messagehandler/hook.go` | normalize inbound source/targets |
+| bin-message-manager | `pkg/messagehandler/*_test.go` | regression tests |
+| bin-conversation-manager | `pkg/conversationhandler/db.go` | normalize self/peer in GetOrCreate + Create |
+| bin-conversation-manager | `pkg/conversationhandler/db_test.go` | regression tests |
+| bin-email-manager | `pkg/emailhandler/email.go` | normalize destinations before validate |
+| bin-email-manager | `pkg/emailhandler/email_test.go` | regression test |
+
+## 4. Test Strategy (maximized — pchero directive)
+
+This normalizer is a core system principle; coverage must be exhaustive.
+
+### 4.1 Shared golden-vector table (`normalize_test.go`)
+
+Expand the table to cover every branch and adversarial edge, each row also run
+through the idempotency double-apply assertion:
+
+- tel: punctuation, dashes+spaces, leading-ws+`+`, `+` not at index 0, double
+  `+`, Arabic-Indic digit stripped, full-width digit stripped, **letters-only
+  (`anonymous`) → ORIGINAL unchanged + `ErrNotNormalizable`**, **lone `+` →
+  original + `ErrNotNormalizable`**, **empty → empty + `ErrNotNormalizable`**,
+  internal `+` mid-string, tab/newline whitespace, very long digit run,
+  already-canonical (idempotent, `nil`).
+- whatsapp: spaces, no-`+` waID form (digits preserved, no `+` injected, `nil`),
+  alphanumeric-only (`VOIPBIN`) → original + `ErrNotNormalizable`, empty,
+  already-canonical.
+- email: trim+lower, mixed-case domain, display-name form, leading/trailing ws,
+  already-lower (idempotent), uppercase local-part. All `nil` error.
+- sip: host lower, with port, `;transport` param preserved, `;maddr` value-case
+  preserved, userinfo `user:pass@host`, IPv6 `[2001:DB8::1]:5060`, `@`-inside-
+  header, whole-input trim, no-`@`, multiple `@` before boundary, empty,
+  already-canonical. All `nil` error.
+- identity types: line/agent/ai/ai_team/conference/extension/none all return
+  input unchanged (no trim), idempotent, `nil` error.
+- unknown type → ORIGINAL input unchanged + `ErrUnknownType` (NOT empty). Assert
+  via `errors.Is(err, address.ErrUnknownType)`.
+- Error-class idempotency: a second NormalizeTarget on the first result returns
+  the SAME error class (both passes `ErrNotNormalizable`, or both `nil`).
+- Loss-proof property test: for every row, assert the result is either the
+  canonical form OR byte-equal to the input — NEVER an empty string for a
+  non-empty input.
+
+### 4.2 Per-manager regression tests
+
+- **contact-manager** (delivered): `Test_LookupByPhone_NormalizesInput`,
+  `Test_LookupByEmail_NormalizesEmail`.
+- **call-manager**: in `db_test.go`, assert `Create` persists the canonical
+  Source/Destination — pass a punctuated tel destination + a mixed-case sip, and
+  a mixed-case email source, assert the stored `Source.Target`/`Destination.Target`
+  via the `CallCreate` gomock matcher. Add a row proving an already-canonical
+  input is unchanged (idempotency at the boundary).
+- **message-manager**: assert `Send` forwards the canonical destination to the
+  `MessageV1...`/provider call AND persists canonical targets; assert
+  `hookTelnyx` persists canonical inbound source/targets.
+- **conversation-manager**: assert `GetOrCreateBySelfAndPeer` performs the dedup
+  lookup with the CANONICAL self/peer (gomock arg match on
+  `ConversationGetBySelfAndPeer`), and that `Create` stores canonical self/peer;
+  assert `DialogID` is NOT altered.
+- **email-manager**: assert `Create` validates+stores canonical (lowercased)
+  destinations and preserves `TargetName`.
+
+All per-manager tests use strict gomock arg matchers on the persist/forward call
+so a regression in the normalization wiring fails the test.
+
+## 5. Verification
+
+Per CLAUDE.md, every touched service runs the full workflow before commit:
+`go mod tidy && go mod vendor && go generate ./... && go test ./... &&
+golangci-lint run -v --timeout 5m`. Touched services: bin-common-handler,
+bin-contact-manager, bin-call-manager, bin-message-manager,
+bin-conversation-manager, bin-email-manager.
+
+bin-common-handler is consumed by 37 services; the `NormalizeTarget` addition is
+purely additive. The `whatsapp` `ValidateTarget` branch is a behavior change
+(error->pass) for whatsapp inputs only, with no production caller (grep-verified:
+only the address package's own tests call ValidateTarget). A
+`for d in bin-*/; do (cd "$d" && go build ./...); done` sweep confirms no
+compile break.
+
+## 6. Sections marked N/A (hardening-class)
+
+Domain model / DB schema / new REST API / webhook events / flow variables /
+RabbitMQ actions / Prometheus metrics / PII-LLM: N/A. This issue adds no entity,
+table, endpoint, event, or external call. It extracts/promotes a pure-function
+primitive, fixes one lookup bug, and inserts canonicalization at existing
+storage boundaries.
+
+## 7. Open Questions
+
+| # | Question | Recommendation | Owner |
+|---|----------|----------------|-------|
+| 1 | message-manager: normalize at `Send` entry (canonical reaches provider too) vs only in `Create` (provider gets raw)? | Normalize at `Send`/`hook` entry — normalized tel = E.164 = what providers want, so it also fixes punctuated-input provider rejections. Safe. | CTO |
+| 2 | call-manager: normalize at `Create` chokepoint vs per-path entry? | `Create` chokepoint — sole writer, dial reads persisted value, incoming lookups stay upstream on raw input. | CTO |
+| 3 | Should normalization failure (unknown type) hard-fail the create, or fall back to raw? | For the known channel types in scope, NormalizeTarget never errors. Use the canonical value; on the impossible error path, keep the raw target and log (do not silently drop). | CPO |
+
+## 8. Review Summary
+
+### Round 1-2 (v1-v3, primitive + contact-manager) — both reviewers APPROVE
+(See git history of this doc.) tel order pinned, sip narrowed to host token,
+ASCII-digit pin documented, whatsapp behavior-change disclosed, ai/ai_team
+asymmetry documented.
+
+### v4 scope expansion (this revision)
+Recon (3 file-access subagents) mapped the storage chokepoint and send-path
+safety for call/message/conversation/email-manager; the highest-risk claim
+(call-manager `Create` is the sole Source/Destination writer; incoming routing
+lookups run upstream of `Create`) was re-verified directly against db.go.
+
+### v4 review round (2 reviewers: 1 code-verification + 1 adversarial)
+Code-verification reviewer: APPROVE, all per-manager insertion points + send-path
+safety claims TRUE against the repo, baselines green. Flagged the groupcall
+stored-address gap (Finding 5).
+Adversarial reviewer: CHANGES REQUESTED with HIGH-severity data-integrity issues.
+
+### v5 (this revision) — findings applied
+- (F1, HIGH) Nil-pointer: every call site nil-guards the pointer address before
+  deref. Documented as an explicit policy in §3.3.
+- (F2, HIGH) tel normalization corrupting carrier sentinels (`anonymous`):
+  NormalizeTarget is now LOSS-PROOF — tel/whatsapp with no digit returns the
+  ORIGINAL value + `ErrNotNormalizable`. Never blanks a non-empty input.
+- (F3, MEDIUM) Alphanumeric SMS sender ID: protected by the same loss-proof tel
+  rule (no-digit → preserved). Code-verified that message-manager source `.Type`
+  is caller-supplied, so loss-proof guards either modeling.
+- (F4, MEDIUM) Discarded-error data loss: contract changed so unknown type returns
+  the ORIGINAL value (not `""`) + `ErrUnknownType`. Two sentinel errors
+  (`ErrUnknownType`, `ErrNotNormalizable`) per pchero decision, `errors.Is`-able.
+- (F5, MEDIUM/code-verify) conversation whatsapp peer dedup: code-verified the
+  hook always uses the `+`-less waID and dedups on DialogID; normalization
+  introduces NO new split. The API-POST `+`-ambiguity predates this change and is
+  out of scope. groupcall stored-address gap: closed by also normalizing in
+  `groupcallHandler.Create`.
+- Error-handling policy: every call site discards the error (`_`) and stores the
+  loss-proof first value; sites MAY log on `ErrNotNormalizable`. Documented.
+
+Contract change note: the loss-proof + sentinel-error revision also strengthens
+the already-delivered contact-manager code (a non-digit phone now stays verbatim
+instead of blanking) and requires updating the v1-v3 `normalize.go` +
+`normalize_test.go` to the new contract before this lands.
+
+A fresh design re-review round on v5 follows (mandatory after the contract change).
+
+### v5 design re-review — APPROVE
+Fresh adversarial reviewer confirmed all 5 prior findings resolved by the
+loss-proof + sentinel-error contract, no new contradiction. Applied 3 advisory
+notes: value-slice by-index policy (F7), ValidateTarget boundary note (F6),
+loss-proof wording for whitespace-only email (F8).
+
+### Implementation + PR review loop (3 rounds, all APPROVE)
+Implementation: shared normalize.go updated to the loss-proof contract; adopted
+in 6 services at their storage chokepoints; per-manager regression tests added;
+one call start_test.go fixture corrected (UUID wrongly typed TypeTel ->
+TypeConference). Parent re-verified all 6 services (go test, cleared cache) and
+golangci-lint (0 new issues; one pre-existing SA5011 in email-manager
+listenhandler is untouched).
+- Round 1 (code-verification, ran all tests): APPROVE, 0 blocking. Confirmed
+  loss-proof contract in code, nil-guards, by-index slices, DialogID untouched,
+  Create chokepoint, async goroutine intact, gomock matchers assert canonical.
+- Round 2 (adversarial, analytic): APPROVE, 0 blocking. Walked normalizeTel/SIP
+  idempotency, SIP slice index safety (no panic), DialogID non-divergence,
+  contact-manager garbage-vs-empty (benign; number_e164 is a plain INDEX not
+  UNIQUE, code-verified), in-place mutation aliasing (safe, request-scoped).
+- Round 3 (final, code-verification): APPROVE. Acceptance criteria 1-5 all met.
+  error-discard pattern safe at all sites. Flagged agent-manager as an
+  intentionally-deferred address-storing manager (normalizing it in isolation
+  would break the deliberately-raw call-manager agent exact-match lookup);
+  documented in §2 Out-of-scope along with queue/campaign (covered transitively
+  via callHandler.Create re-normalization). PR body synced to the expanded scope.


### PR DESCRIPTION
Promote address normalization into a single shared NormalizeTarget authority in bin-common-handler and enforce canonical form at every channel resource manager's storage boundary, so identity resolution does not fragment across channels. Prerequisite extracted from the "small CRM" (Unified Contact + Interaction Timeline) design. Closes #1002.

- bin-common-handler: Add NormalizeTarget(type, target) to models/address as the single canonicalization authority. Loss-proof contract (returns the original value on a non-normalizable input) with two sentinel errors (ErrUnknownType, ErrNotNormalizable). tel/whatsapp E.164 strip with no-digit sentinel preservation, email trim+lowercase, sip host-token lowercasing with params preserved, identity for opaque-id types, idempotent, ASCII-digit pinned to match the tel validator
- bin-common-handler: Promote whatsapp to a supported channel in ValidateTarget by reusing the tel E.164 rule (it previously fell through to default and errored as an exposed-but-broken channel)
- bin-common-handler: Add golden-vector, idempotency, and loss-proof contract tests plus whatsapp validation rows
- bin-contact-manager: Delegate normalizeE164 to the shared NormalizeTarget, route all email normalization (Create, AddEmail, UpdateEmail, LookupByEmail) through it, and normalize the LookupByPhone input (closing the write/lookup normalization asymmetry)
- bin-call-manager: Normalize source/destination in callHandler.Create and source/destinations in groupcallHandler.Create; loss-proof preserves an anonymous/withheld caller-id; add normalization regression tests
- bin-message-manager: Normalize source/destinations in messagehandler.Send and inbound source/targets in hookTelnyx so both the persisted message and the provider wire value are canonical; add regression test
- bin-conversation-manager: Normalize self/peer before the dedup lookup in GetOrCreateBySelfAndPeer and in Create; leave DialogID verbatim; add regression test
- bin-email-manager: Normalize destinations before validation in Create (Normalize-then-Validate); add regression test
- docs: Add the shared NormalizeTarget design document (docs/plans/2026-06-21-add-shared-normalizetarget-design.md)