### PR TITLE
NOJIRA-Add-agent-address-normalization

### DIFF
--- a/bin-agent-manager/cmd/agent-control/main.go
+++ b/bin-agent-manager/cmd/agent-control/main.go
@@ -100,6 +100,10 @@ func initCommand() *cobra.Command {
 	cmdSub.AddCommand(cmdDelete())
 
 	cmdRoot.AddCommand(cmdSub)
+
+	// one-time operational backfill (not part of the agent CRUD group)
+	cmdSub.AddCommand(cmdNormalizeAddresses())
+
 	return cmdRoot
 }
 

--- a/bin-agent-manager/cmd/agent-control/normalize_addresses.go
+++ b/bin-agent-manager/cmd/agent-control/normalize_addresses.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
+
+	"monorepo/bin-agent-manager/internal/config"
+	"monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-agent-manager/pkg/cachehandler"
+	"monorepo/bin-agent-manager/pkg/dbhandler"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// backfillTokenLayout matches commonutilhandler ISO8601 layout used by AgentList
+// as the tm_create pagination cursor, so advancing the token stays consistent
+// with how the default token is generated.
+const backfillTokenLayout = "2006-01-02T15:04:05.000000Z"
+
+// backfillPageSize is intentionally large: a wide page makes a same-microsecond
+// tm_create straddle across a page boundary vanishingly unlikely, and the count
+// reconciliation turns "unlikely" into "verified".
+const backfillPageSize = 1000
+
+// addressChange records one agent whose stored addresses are not yet canonical.
+type addressChange struct {
+	agentID    uuid.UUID
+	original   []commonaddress.Address
+	normalized []commonaddress.Address
+}
+
+func cmdNormalizeAddresses() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "normalize-addresses",
+		Short: "One-time backfill: rewrite every agent's stored addresses to canonical form",
+		Long: "Scans all non-deleted agents, normalizes each address target via the shared " +
+			"commonaddress.NormalizeTarget (the same function the store/lookup paths use, so there " +
+			"is zero drift), and rewrites the agents whose stored values are not yet canonical.\n\n" +
+			"MUST be run inside a maintenance window with the agent-manager and call-manager RPC " +
+			"consumers stopped (see the design doc): the backfill assumes no concurrent agent " +
+			"mutation or by-address lookup.\n\n" +
+			"Defaults to --dry-run=true (preview only). Re-run with --dry-run=false to apply. " +
+			"The apply pass hard-fails if any canonical collision is detected; resolve the duplicate " +
+			"agents first, then re-run.",
+		RunE: runNormalizeAddresses,
+	}
+
+	cmd.Flags().Bool("dry-run", true, "Preview changes without writing (default true)")
+
+	return cmd
+}
+
+func runNormalizeAddresses(cmd *cobra.Command, args []string) error {
+	dryRun := viper.GetBool("dry-run")
+
+	ctx := context.Background()
+
+	sqlDB, err := commondatabasehandler.Connect(config.Get().DatabaseDSN)
+	if err != nil {
+		return errors.Wrap(err, "could not connect to the database")
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	cache := cachehandler.NewHandler(config.Get().RedisAddress, config.Get().RedisPassword, config.Get().RedisDatabase)
+	if errConnect := cache.Connect(); errConnect != nil {
+		return errors.Wrap(errConnect, "could not connect to the cache")
+	}
+
+	db := dbhandler.NewHandler(sqlDB, cache)
+
+	// 1. total non-deleted agent count (for completeness reconciliation)
+	total, err := countNonDeletedAgents(ctx, sqlDB)
+	if err != nil {
+		return errors.Wrap(err, "could not count agents")
+	}
+
+	// 2. full scan: collect changes + a global collision map, count visited
+	changes, collisions, visited, err := scanAgents(ctx, db)
+	if err != nil {
+		return errors.Wrap(err, "could not scan agents")
+	}
+
+	// 3. completeness reconciliation: a page-boundary skip would leave an agent
+	// raw and route-miss forever; fail loudly rather than silently miss it.
+	if visited != total {
+		return fmt.Errorf("scan completeness check failed: visited %d agents but %d non-deleted agents exist; aborting (no writes performed)", visited, total)
+	}
+
+	// 4. always report
+	fmt.Printf("mode: %s\n", dryRunLabel(dryRun))
+	fmt.Printf("agents scanned: %d (reconciled with table count %d)\n", visited, total)
+	fmt.Printf("agents needing normalization: %d\n", len(changes))
+	reportChanges(changes)
+	reportCollisions(collisions)
+
+	// 5. dry-run stops here
+	if dryRun {
+		fmt.Println("\ndry-run: no changes written. Re-run with --dry-run=false to apply.")
+		return nil
+	}
+
+	// 6. collision gate: hard-fail, no override. Committing a collision would
+	// leave two agents owning one canonical target -> nondeterministic routing.
+	if len(collisions) > 0 {
+		return fmt.Errorf("aborting apply: %d canonical collision(s) detected; resolve the duplicate agents, then re-run (no writes performed)", len(collisions))
+	}
+
+	// 7. apply: dump original then write canonical for each changed agent
+	applied := 0
+	for _, c := range changes {
+		fmt.Printf("apply agent_id=%s original=%s\n", c.agentID, formatAddresses(c.original))
+		if errSet := db.AgentSetAddresses(ctx, c.agentID, c.normalized); errSet != nil {
+			return errors.Wrapf(errSet, "could not set addresses for agent %s (applied %d before failure)", c.agentID, applied)
+		}
+		applied++
+	}
+
+	fmt.Printf("\napplied: %d agent(s) normalized.\n", applied)
+	return nil
+}
+
+// countNonDeletedAgents returns the number of non-deleted agents directly,
+// for the scan completeness reconciliation.
+func countNonDeletedAgents(ctx context.Context, sqlDB *sql.DB) (int, error) {
+	var n int
+	row := sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM agent_agents WHERE tm_delete IS NULL")
+	if err := row.Scan(&n); err != nil {
+		return 0, errors.Wrap(err, "could not scan count")
+	}
+	return n, nil
+}
+
+// scanAgents walks every non-deleted agent via the existing AgentList token
+// pagination, building the change set and a GLOBAL collision map keyed on
+// (customer_id, type, canonical_target) populated from every agent's
+// post-normalization addresses (so cross-page and already-canonical collisions
+// are caught).
+func scanAgents(ctx context.Context, db dbhandler.DBHandler) ([]addressChange, map[string][]uuid.UUID, int, error) {
+	filters := map[agent.Field]any{
+		agent.FieldDeleted: false,
+	}
+
+	changes := []addressChange{}
+	canonicalOwners := map[string][]uuid.UUID{}
+	visited := 0
+
+	token := "" // empty -> AgentList defaults to current time (newest first)
+	for {
+		agents, err := db.AgentList(ctx, backfillPageSize, token, filters)
+		if err != nil {
+			return nil, nil, 0, errors.Wrap(err, "could not list agents")
+		}
+		if len(agents) == 0 {
+			break
+		}
+
+		for _, a := range agents {
+			visited++
+
+			normalized := normalizeAddresses(a.Addresses)
+
+			// record canonical ownership for collision detection
+			for _, addr := range normalized {
+				key := collisionKey(a.CustomerID, addr)
+				canonicalOwners[key] = append(canonicalOwners[key], a.ID)
+			}
+
+			if addressesDiffer(a.Addresses, normalized) {
+				changes = append(changes, addressChange{
+					agentID:    a.ID,
+					original:   a.Addresses,
+					normalized: normalized,
+				})
+			}
+		}
+
+		if len(agents) < backfillPageSize {
+			break
+		}
+
+		// advance the cursor to the oldest tm_create of this page
+		last := agents[len(agents)-1]
+		if last.TMCreate == nil {
+			// defensive: cannot advance safely; stop to avoid an infinite loop
+			break
+		}
+		token = last.TMCreate.UTC().Format(backfillTokenLayout)
+	}
+
+	// reduce the ownership map to genuine collisions (a canonical owned by >1 agent)
+	collisions := map[string][]uuid.UUID{}
+	for key, owners := range canonicalOwners {
+		uniqueOwners := dedupeUUIDs(owners)
+		if len(uniqueOwners) > 1 {
+			collisions[key] = uniqueOwners
+		}
+	}
+
+	return changes, collisions, visited, nil
+}
+
+// normalizeAddresses returns a normalized copy of addresses (per element, keyed
+// on each element's own type). Loss-proof: the error is discarded because the
+// first return value is always safe to store.
+func normalizeAddresses(addresses []commonaddress.Address) []commonaddress.Address {
+	out := make([]commonaddress.Address, len(addresses))
+	copy(out, addresses)
+	for i := range out {
+		out[i].Target, _ = commonaddress.NormalizeTarget(out[i].Type, out[i].Target)
+	}
+	return out
+}
+
+func addressesDiffer(a, b []commonaddress.Address) bool {
+	if len(a) != len(b) {
+		return true
+	}
+	for i := range a {
+		if a[i].Type != b[i].Type || a[i].Target != b[i].Target {
+			return true
+		}
+	}
+	return false
+}
+
+func collisionKey(customerID uuid.UUID, addr commonaddress.Address) string {
+	return fmt.Sprintf("%s\x00%s\x00%s", customerID, addr.Type, addr.Target)
+}
+
+func dedupeUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := map[uuid.UUID]struct{}{}
+	out := []uuid.UUID{}
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func dryRunLabel(dryRun bool) string {
+	if dryRun {
+		return "dry-run (preview only)"
+	}
+	return "apply"
+}
+
+func reportChanges(changes []addressChange) {
+	if len(changes) == 0 {
+		return
+	}
+	fmt.Println("\nplanned changes (agent_id: type raw -> canonical):")
+	for _, c := range changes {
+		for i := range c.original {
+			if c.original[i].Type == c.normalized[i].Type && c.original[i].Target == c.normalized[i].Target {
+				continue
+			}
+			fmt.Printf("  %s: %s %q -> %q\n", c.agentID, c.original[i].Type, c.original[i].Target, c.normalized[i].Target)
+		}
+	}
+}
+
+func reportCollisions(collisions map[string][]uuid.UUID) {
+	if len(collisions) == 0 {
+		fmt.Println("\ncollisions: none")
+		return
+	}
+	fmt.Printf("\ncollisions: %d (a canonical (customer,type,target) owned by >1 agent)\n", len(collisions))
+
+	keys := make([]string, 0, len(collisions))
+	for k := range collisions {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		parts := strings.SplitN(k, "\x00", 3)
+		owners := collisions[k]
+		ownerStrs := make([]string, len(owners))
+		for i, o := range owners {
+			ownerStrs[i] = o.String()
+		}
+		fmt.Printf("  customer=%s type=%s target=%q owners=[%s]\n", parts[0], parts[1], parts[2], strings.Join(ownerStrs, ", "))
+	}
+}
+
+func formatAddresses(addresses []commonaddress.Address) string {
+	parts := make([]string, len(addresses))
+	for i, a := range addresses {
+		parts[i] = fmt.Sprintf("{%s:%s}", a.Type, a.Target)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}

--- a/bin-agent-manager/cmd/agent-control/normalize_addresses.go
+++ b/bin-agent-manager/cmd/agent-control/normalize_addresses.go
@@ -111,6 +111,13 @@ func runNormalizeAddresses(cmd *cobra.Command, args []string) error {
 		if visited == total {
 			break
 		}
+		// visited > total cannot be fixed by a larger page (page-grow only
+		// recovers under-counting from a same-tm_create boundary skip). It
+		// signals concurrent agent creation/deletion during the scan, i.e. the
+		// maintenance-window consumer stop was not in effect. Abort immediately.
+		if visited > total {
+			return fmt.Errorf("scan over-counted: visited %d agents but only %d non-deleted exist; concurrent mutation likely (consumers not stopped). Aborting (no writes performed)", visited, total)
+		}
 		if attempt >= backfillMaxScanRetries {
 			return fmt.Errorf("scan completeness check failed after %d attempts: visited %d agents but %d non-deleted agents exist; aborting (no writes performed)", attempt+1, visited, total)
 		}
@@ -213,7 +220,9 @@ func scanAgents(ctx context.Context, db dbhandler.DBHandler, pageSize uint64) ([
 		// advance the cursor to the oldest tm_create of this page
 		last := agents[len(agents)-1]
 		if last.TMCreate == nil {
-			// defensive: cannot advance safely; stop to avoid an infinite loop
+			// defensive: cannot advance safely; stop to avoid an infinite loop.
+			// The count reconciliation will catch the resulting short scan.
+			fmt.Printf("warning: agent %s has a nil tm_create; stopping scan early (completeness check will flag it)\n", last.ID)
 			break
 		}
 		token = last.TMCreate.UTC().Format(backfillTokenLayout)

--- a/bin-agent-manager/cmd/agent-control/normalize_addresses.go
+++ b/bin-agent-manager/cmd/agent-control/normalize_addresses.go
@@ -31,6 +31,13 @@ const backfillTokenLayout = "2006-01-02T15:04:05.000000Z"
 // reconciliation turns "unlikely" into "verified".
 const backfillPageSize = 1000
 
+// backfillPageGrowthFactor / backfillMaxScanRetries bound the page-size growth
+// used to recover from a same-tm_create page-boundary skip (count mismatch).
+const (
+	backfillPageGrowthFactor = 10
+	backfillMaxScanRetries   = 3
+)
+
 // addressChange records one agent whose stored addresses are not yet canonical.
 type addressChange struct {
 	agentID    uuid.UUID
@@ -83,16 +90,32 @@ func runNormalizeAddresses(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "could not count agents")
 	}
 
-	// 2. full scan: collect changes + a global collision map, count visited
-	changes, collisions, visited, err := scanAgents(ctx, db)
-	if err != nil {
-		return errors.Wrap(err, "could not scan agents")
-	}
+	// 2. full scan: collect changes + a global collision map, count visited.
+	// AgentList paginates on a strict `tm_create < token` cursor with no
+	// tie-breaker, so a cluster of rows sharing one microsecond that straddles a
+	// page boundary could skip an agent. The count reconciliation (step 3) would
+	// catch that as visited != total. Rather than dead-end there, retry the whole
+	// scan with a larger page so the equal-tm_create cluster fits inside one page.
+	pageSize := uint64(backfillPageSize)
+	var changes []addressChange
+	var collisions map[string][]uuid.UUID
+	var visited int
+	for attempt := 0; ; attempt++ {
+		changes, collisions, visited, err = scanAgents(ctx, db, pageSize)
+		if err != nil {
+			return errors.Wrap(err, "could not scan agents")
+		}
 
-	// 3. completeness reconciliation: a page-boundary skip would leave an agent
-	// raw and route-miss forever; fail loudly rather than silently miss it.
-	if visited != total {
-		return fmt.Errorf("scan completeness check failed: visited %d agents but %d non-deleted agents exist; aborting (no writes performed)", visited, total)
+		// 3. completeness reconciliation: a page-boundary skip would leave an
+		// agent raw and route-miss forever; never write on a mismatch.
+		if visited == total {
+			break
+		}
+		if attempt >= backfillMaxScanRetries {
+			return fmt.Errorf("scan completeness check failed after %d attempts: visited %d agents but %d non-deleted agents exist; aborting (no writes performed)", attempt+1, visited, total)
+		}
+		pageSize *= backfillPageGrowthFactor
+		fmt.Printf("scan visited %d but table has %d; retrying with larger page size %d (same-tm_create boundary)\n", visited, total, pageSize)
 	}
 
 	// 4. always report
@@ -144,7 +167,7 @@ func countNonDeletedAgents(ctx context.Context, sqlDB *sql.DB) (int, error) {
 // (customer_id, type, canonical_target) populated from every agent's
 // post-normalization addresses (so cross-page and already-canonical collisions
 // are caught).
-func scanAgents(ctx context.Context, db dbhandler.DBHandler) ([]addressChange, map[string][]uuid.UUID, int, error) {
+func scanAgents(ctx context.Context, db dbhandler.DBHandler, pageSize uint64) ([]addressChange, map[string][]uuid.UUID, int, error) {
 	filters := map[agent.Field]any{
 		agent.FieldDeleted: false,
 	}
@@ -155,7 +178,7 @@ func scanAgents(ctx context.Context, db dbhandler.DBHandler) ([]addressChange, m
 
 	token := "" // empty -> AgentList defaults to current time (newest first)
 	for {
-		agents, err := db.AgentList(ctx, backfillPageSize, token, filters)
+		agents, err := db.AgentList(ctx, pageSize, token, filters)
 		if err != nil {
 			return nil, nil, 0, errors.Wrap(err, "could not list agents")
 		}
@@ -183,7 +206,7 @@ func scanAgents(ctx context.Context, db dbhandler.DBHandler) ([]addressChange, m
 			}
 		}
 
-		if len(agents) < backfillPageSize {
+		if uint64(len(agents)) < pageSize {
 			break
 		}
 

--- a/bin-agent-manager/cmd/agent-control/normalize_addresses_test.go
+++ b/bin-agent-manager/cmd/agent-control/normalize_addresses_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+)
+
+func Test_normalizeAddresses(t *testing.T) {
+	tests := []struct {
+		name string
+
+		addresses []commonaddress.Address
+
+		expectChanged bool
+	}{
+		{
+			name: "tel with punctuation is canonicalized",
+			addresses: []commonaddress.Address{
+				{Type: commonaddress.TypeTel, Target: "+1-555-0100"},
+			},
+			expectChanged: true,
+		},
+		{
+			name: "already canonical tel is unchanged",
+			addresses: []commonaddress.Address{
+				{Type: commonaddress.TypeTel, Target: mustNorm(commonaddress.TypeTel, "+1-555-0100")},
+			},
+			expectChanged: false,
+		},
+		{
+			name: "extension (opaque) is unchanged",
+			addresses: []commonaddress.Address{
+				{Type: commonaddress.TypeExtension, Target: "49b41028-2d8d-11ef-b38d-27dd55f2bb71"},
+			},
+			expectChanged: false,
+		},
+		{
+			name: "sip host token is lowercased, params preserved",
+			addresses: []commonaddress.Address{
+				{Type: commonaddress.TypeSIP, Target: "Alice@EXAMPLE.com;transport=TCP"},
+			},
+			expectChanged: true,
+		},
+		{
+			name: "mixed types: tel changes, extension stays",
+			addresses: []commonaddress.Address{
+				{Type: commonaddress.TypeTel, Target: "+1 (555) 0100"},
+				{Type: commonaddress.TypeExtension, Target: "49b41028-2d8d-11ef-b38d-27dd55f2bb71"},
+			},
+			expectChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeAddresses(tt.addresses)
+
+			// per-element it must equal NormalizeTarget applied to that element
+			for i := range tt.addresses {
+				want, _ := commonaddress.NormalizeTarget(tt.addresses[i].Type, tt.addresses[i].Target)
+				if got[i].Target != want {
+					t.Errorf("element %d: got %q, want %q", i, got[i].Target, want)
+				}
+				if got[i].Type != tt.addresses[i].Type {
+					t.Errorf("element %d: type changed from %s to %s", i, tt.addresses[i].Type, got[i].Type)
+				}
+			}
+
+			if addressesDiffer(tt.addresses, got) != tt.expectChanged {
+				t.Errorf("addressesDiffer mismatch. expect changed=%v", tt.expectChanged)
+			}
+		})
+	}
+}
+
+func Test_normalizeAddresses_doesNotMutateInput(t *testing.T) {
+	input := []commonaddress.Address{
+		{Type: commonaddress.TypeTel, Target: "+1-555-0100"},
+	}
+	original := input[0].Target
+
+	_ = normalizeAddresses(input)
+
+	if input[0].Target != original {
+		t.Errorf("input was mutated: got %q, want %q", input[0].Target, original)
+	}
+}
+
+func Test_collisionDetection(t *testing.T) {
+	// two distinct raw tels that collapse to the same canonical, on two
+	// different agents of the same customer => collision
+	customerID := uuid.FromStringOrNil("91aed1d4-7fe2-11ec-848d-97c8e986acfc")
+	agentA := uuid.FromStringOrNil("464a277e-2d8d-11ef-8bc6-d7b95604d6f6")
+	agentB := uuid.FromStringOrNil("8e3b890a-2fd7-11ef-b442-133f59be8b36")
+
+	rawA, _ := commonaddress.NormalizeTarget(commonaddress.TypeTel, "+1-555-0100")
+	rawB, _ := commonaddress.NormalizeTarget(commonaddress.TypeTel, "+15550100")
+
+	if rawA != rawB {
+		t.Fatalf("test premise broken: %q != %q", rawA, rawB)
+	}
+
+	canonicalOwners := map[string][]uuid.UUID{}
+	addrA := commonaddress.Address{Type: commonaddress.TypeTel, Target: rawA}
+	addrB := commonaddress.Address{Type: commonaddress.TypeTel, Target: rawB}
+	keyA := collisionKey(customerID, addrA)
+	keyB := collisionKey(customerID, addrB)
+	canonicalOwners[keyA] = append(canonicalOwners[keyA], agentA)
+	canonicalOwners[keyB] = append(canonicalOwners[keyB], agentB)
+
+	if keyA != keyB {
+		t.Fatalf("collision keys should match for the same canonical: %q != %q", keyA, keyB)
+	}
+
+	owners := dedupeUUIDs(canonicalOwners[keyA])
+	if len(owners) != 2 {
+		t.Errorf("expected 2 distinct owners (a collision), got %d", len(owners))
+	}
+}
+
+func Test_collisionKey_differentCustomersDoNotCollide(t *testing.T) {
+	customerA := uuid.FromStringOrNil("91aed1d4-7fe2-11ec-848d-97c8e986acfc")
+	customerB := uuid.FromStringOrNil("9129ad1a-2fd5-11ef-af80-1f74bf8dbf2b")
+	addr := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+15550100"}
+
+	if collisionKey(customerA, addr) == collisionKey(customerB, addr) {
+		t.Errorf("same canonical target on different customers must not share a collision key")
+	}
+}
+
+func mustNorm(addressType commonaddress.Type, target string) string {
+	res, _ := commonaddress.NormalizeTarget(addressType, target)
+	return res
+}

--- a/bin-agent-manager/pkg/agenthandler/agent.go
+++ b/bin-agent-manager/pkg/agenthandler/agent.go
@@ -65,7 +65,12 @@ func (h *agentHandler) GetByCustomerIDAndAddress(ctx context.Context, customerID
 		"address":     addr,
 	})
 
-	res, err := h.db.AgentGetByCustomerIDAndAddress(ctx, customerID, addr)
+	// normalize the lookup key so it matches the canonical stored target
+	// (loss-proof + idempotent; error discarded, original kept on non-normalizable)
+	normalized := *addr
+	normalized.Target, _ = commonaddress.NormalizeTarget(normalized.Type, normalized.Target)
+
+	res, err := h.db.AgentGetByCustomerIDAndAddress(ctx, customerID, &normalized)
 	if err != nil {
 		log.Errorf("Could not get agents info. err: %v", err)
 		return nil, err
@@ -107,6 +112,12 @@ func (h *agentHandler) Create(ctx context.Context, customerID uuid.UUID, usernam
 		"permission":  permission,
 	})
 	log.Debug("Creating a new user.")
+
+	// normalize the stored addresses so they are canonical at rest (loss-proof +
+	// idempotent), keeping store == normalized(lookup key) for the exact-match join
+	for i := range addresses {
+		addresses[i].Target, _ = commonaddress.NormalizeTarget(addresses[i].Type, addresses[i].Target)
+	}
 
 	// check resource limit
 	rpcStart := time.Now()
@@ -372,6 +383,13 @@ func (h *agentHandler) UpdateAddresses(ctx context.Context, id uuid.UUID, addres
 		return nil, errors.Wrap(err, "could not get the agent")
 	}
 	log.WithField("agent", a).Debugf("Found agent info. agent_id: %s", a.ID)
+
+	// normalize the addresses up front (loss-proof + idempotent) so the
+	// validation/dup-check loop below and the persisted values are all canonical,
+	// keeping store == normalized(lookup key) for the exact-match join
+	for i := range addresses {
+		addresses[i].Target, _ = commonaddress.NormalizeTarget(addresses[i].Type, addresses[i].Target)
+	}
 
 	// validate the addresses
 	for _, address := range addresses {

--- a/bin-agent-manager/pkg/agenthandler/agent_test.go
+++ b/bin-agent-manager/pkg/agenthandler/agent_test.go
@@ -22,6 +22,14 @@ import (
 	"monorepo/bin-agent-manager/pkg/dbhandler"
 )
 
+// mustNormalize returns the canonical form of target for addressType using the
+// shared normalizer, so tests assert against the real canonicalization rather
+// than hardcoded digit literals.
+func mustNormalize(addressType commonaddress.Type, target string) string {
+	res, _ := commonaddress.NormalizeTarget(addressType, target)
+	return res
+}
+
 func Test_List(t *testing.T) {
 
 	tests := []struct {
@@ -137,6 +145,62 @@ func Test_Create(t *testing.T) {
 				Addresses:    []commonaddress.Address{},
 				DirectID:     uuid.FromStringOrNil("d1e2f3a4-b5c6-7890-abcd-ef1234567890"),
 				DirectHash:   "direct_hash_value",
+			},
+			expectedRes: &agent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("ac810dc4-298c-11ee-984c-ebb7811c4114"),
+				},
+			},
+		},
+		{
+			name: "addresses are normalized before persist",
+
+			customerID: uuid.FromStringOrNil("91aed1d4-7fe2-11ec-848d-97c8e986acfc"),
+			username:   "test-norm@voipbin.net",
+			password:   "test1password",
+			agentName:  "test norm name",
+			detail:     "test norm detail",
+			ringMethod: agent.RingMethodRingAll,
+			permission: agent.PermissionNone,
+			tags:       []uuid.UUID{},
+			addresses: []commonaddress.Address{
+				{Type: commonaddress.TypeTel, Target: "+1-555-0100"},
+				{Type: commonaddress.TypeExtension, Target: "ac810dc4-298c-11ee-984c-ebb7811c4114"},
+			},
+
+			responseUUID: uuid.FromStringOrNil("ac810dc4-298c-11ee-984c-ebb7811c4114"),
+			responseHash: "hash_string",
+			responseDirect: &dmdirect.Direct{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("d1e2f3a4-b5c6-7890-abcd-ef1234567890"),
+				},
+				Hash: "direct_hash_value",
+			},
+			responseAgent: &agent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("ac810dc4-298c-11ee-984c-ebb7811c4114"),
+				},
+			},
+			expectedAgent: &agent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("ac810dc4-298c-11ee-984c-ebb7811c4114"),
+					CustomerID: uuid.FromStringOrNil("91aed1d4-7fe2-11ec-848d-97c8e986acfc"),
+				},
+				Username:     "test-norm@voipbin.net",
+				PasswordHash: "hash_string",
+				Name:         "test norm name",
+				Detail:       "test norm detail",
+				RingMethod:   agent.RingMethodRingAll,
+				Status:       agent.StatusOffline,
+				Permission:   agent.PermissionNone,
+				TagIDs:       []uuid.UUID{},
+				// tel canonicalized (punctuation stripped); extension UUID kept verbatim
+				Addresses: []commonaddress.Address{
+					{Type: commonaddress.TypeTel, Target: mustNormalize(commonaddress.TypeTel, "+1-555-0100")},
+					{Type: commonaddress.TypeExtension, Target: "ac810dc4-298c-11ee-984c-ebb7811c4114"},
+				},
+				DirectID:   uuid.FromStringOrNil("d1e2f3a4-b5c6-7890-abcd-ef1234567890"),
+				DirectHash: "direct_hash_value",
 			},
 			expectedRes: &agent.Agent{
 				Identity: commonidentity.Identity{
@@ -384,6 +448,8 @@ func Test_GetByCustomerIDAndAddress(t *testing.T) {
 		customerID uuid.UUID
 		address    *commonaddress.Address
 
+		expectFilterAddress *commonaddress.Address
+
 		responseAgent *agent.Agent
 	}{
 		{
@@ -393,6 +459,35 @@ func Test_GetByCustomerIDAndAddress(t *testing.T) {
 			address: &commonaddress.Address{
 				Type:   commonaddress.TypeExtension,
 				Target: "d4116ac2-2d88-11ef-9795-8393fdf24d82",
+			},
+
+			// extension is opaque: lookup key is unchanged
+			expectFilterAddress: &commonaddress.Address{
+				Type:   commonaddress.TypeExtension,
+				Target: "d4116ac2-2d88-11ef-9795-8393fdf24d82",
+			},
+
+			responseAgent: &agent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("d3eaf9d2-2d88-11ef-9997-7bea6cbbf856"),
+				},
+			},
+		},
+		{
+			name: "tel lookup key is normalized before the db query",
+
+			customerID: uuid.FromStringOrNil("d3aab1b0-2d88-11ef-ba6a-afc97b6c3b32"),
+			address: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1-555-0100",
+			},
+
+			// the DB must be queried with the canonical target so it matches
+			// the canonical stored value (expected target computed at runtime
+			// from the shared normalizer to avoid hardcoding digit literals)
+			expectFilterAddress: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: mustNormalize(commonaddress.TypeTel, "+1-555-0100"),
 			},
 
 			responseAgent: &agent.Agent{
@@ -419,7 +514,7 @@ func Test_GetByCustomerIDAndAddress(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			mockDB.EXPECT().AgentGetByCustomerIDAndAddress(ctx, tt.customerID, tt.address).Return(tt.responseAgent, nil)
+			mockDB.EXPECT().AgentGetByCustomerIDAndAddress(ctx, tt.customerID, tt.expectFilterAddress).Return(tt.responseAgent, nil)
 
 			res, err := h.GetByCustomerIDAndAddress(ctx, tt.customerID, tt.address)
 			if err != nil {
@@ -788,6 +883,8 @@ func Test_UpdateAddresses(t *testing.T) {
 		id        uuid.UUID
 		addresses []commonaddress.Address
 
+		expectedAddresses []commonaddress.Address
+
 		responseAgent     *agent.Agent
 		responseExtension *rmextension.Extension
 	}{
@@ -796,6 +893,14 @@ func Test_UpdateAddresses(t *testing.T) {
 
 			id: uuid.FromStringOrNil("464a277e-2d8d-11ef-8bc6-d7b95604d6f6"),
 			addresses: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeExtension,
+					Target: "49b41028-2d8d-11ef-b38d-27dd55f2bb71",
+				},
+			},
+
+			// extension is opaque: unchanged by normalization
+			expectedAddresses: []commonaddress.Address{
 				{
 					Type:   commonaddress.TypeExtension,
 					Target: "49b41028-2d8d-11ef-b38d-27dd55f2bb71",
@@ -811,6 +916,33 @@ func Test_UpdateAddresses(t *testing.T) {
 			responseExtension: &rmextension.Extension{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("49b41028-2d8d-11ef-b38d-27dd55f2bb71"),
+					CustomerID: uuid.FromStringOrNil("49d90a72-2d8d-11ef-b208-fb6caaa88ae9"),
+				},
+			},
+		},
+		{
+			name: "tel address is normalized before validation, dup-check and persist",
+
+			id: uuid.FromStringOrNil("464a277e-2d8d-11ef-8bc6-d7b95604d6f6"),
+			addresses: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: "+1-555-0100",
+				},
+			},
+
+			// tel canonicalized: the dup-check and AgentSetAddresses must both
+			// see the canonical form
+			expectedAddresses: []commonaddress.Address{
+				{
+					Type:   commonaddress.TypeTel,
+					Target: mustNormalize(commonaddress.TypeTel, "+1-555-0100"),
+				},
+			},
+
+			responseAgent: &agent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("464a277e-2d8d-11ef-8bc6-d7b95604d6f6"),
 					CustomerID: uuid.FromStringOrNil("49d90a72-2d8d-11ef-b208-fb6caaa88ae9"),
 				},
 			},
@@ -834,7 +966,8 @@ func Test_UpdateAddresses(t *testing.T) {
 			ctx := context.Background()
 
 			mockDB.EXPECT().AgentGet(ctx, tt.id).Return(tt.responseAgent, nil)
-			for _, addr := range tt.addresses {
+			for i := range tt.expectedAddresses {
+				addr := tt.expectedAddresses[i]
 				switch addr.Type {
 				case commonaddress.TypeExtension:
 					mockReq.EXPECT().RegistrarV1ExtensionGet(ctx, uuid.FromStringOrNil(addr.Target)).Return(tt.responseExtension, nil)
@@ -842,7 +975,7 @@ func Test_UpdateAddresses(t *testing.T) {
 
 				mockDB.EXPECT().AgentGetByCustomerIDAndAddress(ctx, tt.responseAgent.CustomerID, &addr).Return(nil, dbhandler.ErrNotFound)
 			}
-			mockDB.EXPECT().AgentSetAddresses(ctx, tt.id, tt.addresses).Return(nil)
+			mockDB.EXPECT().AgentSetAddresses(ctx, tt.id, tt.expectedAddresses).Return(nil)
 			mockDB.EXPECT().AgentGet(ctx, tt.id).Return(tt.responseAgent, nil)
 			mockNotify.EXPECT().PublishEvent(ctx, agent.EventTypeAgentUpdated, tt.responseAgent)
 

--- a/bin-call-manager/pkg/callhandler/start.go
+++ b/bin-call-manager/pkg/callhandler/start.go
@@ -704,7 +704,11 @@ func (h *callHandler) getAddressOwner(ctx context.Context, customerID uuid.UUID,
 			return commonidentity.OwnerTypeNone, uuid.Nil, err
 		}
 	} else {
-		tmp, err = h.reqHandler.AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, customerID, *addr)
+		// normalize the lookup key so it matches the canonical stored target
+		// (loss-proof + idempotent; original kept on non-normalizable)
+		normalized := *addr
+		normalized.Target, _ = commonaddress.NormalizeTarget(normalized.Type, normalized.Target)
+		tmp, err = h.reqHandler.AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, customerID, normalized)
 		if err != nil {
 			log.Errorf("Could not get agent info. err: %v", err)
 			return commonidentity.OwnerTypeNone, uuid.Nil, nil

--- a/bin-call-manager/pkg/callhandler/start_test.go
+++ b/bin-call-manager/pkg/callhandler/start_test.go
@@ -1166,9 +1166,10 @@ func Test_getAddressOwner(t *testing.T) {
 
 		responseAgent *amagent.Agent
 
-		expectAgentID      uuid.UUID
-		expectResOwnerType commonidentity.OwnerType
-		expectResOwnerID   uuid.UUID
+		expectAgentID       uuid.UUID
+		expectFilterAddress commonaddress.Address
+		expectResOwnerType  commonidentity.OwnerType
+		expectResOwnerID    uuid.UUID
 	}{
 		{
 			name: "normal - address type is agent",
@@ -1197,6 +1198,37 @@ func Test_getAddressOwner(t *testing.T) {
 			address: &commonaddress.Address{
 				Type:   commonaddress.TypeTel,
 				Target: "+123456789",
+			},
+
+			// already canonical: normalize is a no-op, so input == lookup key
+			expectFilterAddress: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: mustNormalizeStart(commonaddress.TypeTel, "+123456789"),
+			},
+
+			responseAgent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("91e8e824-2fd5-11ef-a8d1-6f57a27e6c6f"),
+					CustomerID: uuid.FromStringOrNil("9129ad1a-2fd5-11ef-af80-1f74bf8dbf2b"),
+				},
+			},
+
+			expectResOwnerType: commonidentity.OwnerTypeAgent,
+			expectResOwnerID:   uuid.FromStringOrNil("91e8e824-2fd5-11ef-a8d1-6f57a27e6c6f"),
+		},
+		{
+			name: "raw tel address is normalized before the lookup",
+
+			customerID: uuid.FromStringOrNil("9129ad1a-2fd5-11ef-af80-1f74bf8dbf2b"),
+			address: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1-234-567-89",
+			},
+
+			// the RPC lookup key must be the canonical form
+			expectFilterAddress: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: mustNormalizeStart(commonaddress.TypeTel, "+1-234-567-89"),
 			},
 
 			responseAgent: &amagent.Agent{
@@ -1234,7 +1266,7 @@ func Test_getAddressOwner(t *testing.T) {
 			if tt.expectAgentID != uuid.Nil {
 				mockReq.EXPECT().AgentV1AgentGet(ctx, tt.expectAgentID).Return(tt.responseAgent, nil)
 			} else {
-				mockReq.EXPECT().AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, tt.customerID, *tt.address).Return(tt.responseAgent, nil)
+				mockReq.EXPECT().AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, tt.customerID, tt.expectFilterAddress).Return(tt.responseAgent, nil)
 			}
 
 			resOwnerType, resOwnerID, err := h.getAddressOwner(ctx, tt.customerID, tt.address)
@@ -1250,4 +1282,11 @@ func Test_getAddressOwner(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mustNormalizeStart returns the canonical target via the shared normalizer so
+// tests assert against real canonicalization rather than hardcoded literals.
+func mustNormalizeStart(addressType commonaddress.Type, target string) string {
+	res, _ := commonaddress.NormalizeTarget(addressType, target)
+	return res
 }

--- a/bin-call-manager/pkg/groupcallhandler/dial.go
+++ b/bin-call-manager/pkg/groupcallhandler/dial.go
@@ -264,7 +264,11 @@ func (h *groupcallHandler) getAddressOwner(ctx context.Context, customerID uuid.
 			return commonidentity.OwnerTypeNone, uuid.Nil, err
 		}
 	} else {
-		tmp, err = h.reqHandler.AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, customerID, *addr)
+		// normalize the lookup key so it matches the canonical stored target
+		// (loss-proof + idempotent; original kept on non-normalizable)
+		normalized := *addr
+		normalized.Target, _ = commonaddress.NormalizeTarget(normalized.Type, normalized.Target)
+		tmp, err = h.reqHandler.AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, customerID, normalized)
 		if err != nil {
 			log.Errorf("Could not get agent info. err: %v", err)
 			return commonidentity.OwnerTypeNone, uuid.Nil, nil

--- a/bin-call-manager/pkg/groupcallhandler/dial_test.go
+++ b/bin-call-manager/pkg/groupcallhandler/dial_test.go
@@ -448,9 +448,10 @@ func Test_getAddressOwner(t *testing.T) {
 
 		responseAgent *amagent.Agent
 
-		expectAgentID      uuid.UUID
-		expectResOwnerType commonidentity.OwnerType
-		expectResOwnerID   uuid.UUID
+		expectAgentID       uuid.UUID
+		expectFilterAddress commonaddress.Address
+		expectResOwnerType  commonidentity.OwnerType
+		expectResOwnerID    uuid.UUID
 	}{
 		{
 			name: "normal - address type is agent",
@@ -478,7 +479,38 @@ func Test_getAddressOwner(t *testing.T) {
 			customerID: uuid.FromStringOrNil("8e5ddef6-2fd7-11ef-82a7-235a64789cf8"),
 			address: &commonaddress.Address{
 				Type:   commonaddress.TypeTel,
-				Target: "+123456789",
+				Target: "+123****6789",
+			},
+
+			// already canonical: normalize is a no-op, so input == lookup key
+			expectFilterAddress: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: mustNormalizeDial(commonaddress.TypeTel, "+123****6789"),
+			},
+
+			responseAgent: &amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("8e7f4af0-2fd7-11ef-9c3a-53f59238b991"),
+					CustomerID: uuid.FromStringOrNil("8e5ddef6-2fd7-11ef-82a7-235a64789cf8"),
+				},
+			},
+
+			expectResOwnerType: commonidentity.OwnerTypeAgent,
+			expectResOwnerID:   uuid.FromStringOrNil("8e7f4af0-2fd7-11ef-9c3a-53f59238b991"),
+		},
+		{
+			name: "raw tel address is normalized before the lookup",
+
+			customerID: uuid.FromStringOrNil("8e5ddef6-2fd7-11ef-82a7-235a64789cf8"),
+			address: &commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: "+1-234-567-89",
+			},
+
+			// the RPC lookup key must be the canonical form
+			expectFilterAddress: commonaddress.Address{
+				Type:   commonaddress.TypeTel,
+				Target: mustNormalizeDial(commonaddress.TypeTel, "+1-234-567-89"),
 			},
 
 			responseAgent: &amagent.Agent{
@@ -512,7 +544,7 @@ func Test_getAddressOwner(t *testing.T) {
 			if tt.expectAgentID != uuid.Nil {
 				mockReq.EXPECT().AgentV1AgentGet(ctx, tt.expectAgentID).Return(tt.responseAgent, nil)
 			} else {
-				mockReq.EXPECT().AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, tt.customerID, *tt.address).Return(tt.responseAgent, nil)
+				mockReq.EXPECT().AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, tt.customerID, tt.expectFilterAddress).Return(tt.responseAgent, nil)
 			}
 
 			resOwnerType, resOwnerID, err := h.getAddressOwner(ctx, tt.customerID, tt.address)
@@ -528,4 +560,11 @@ func Test_getAddressOwner(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mustNormalizeDial returns the canonical target via the shared normalizer so
+// tests assert against real canonicalization rather than hardcoded literals.
+func mustNormalizeDial(addressType commonaddress.Type, target string) string {
+	res, _ := commonaddress.NormalizeTarget(addressType, target)
+	return res
 }

--- a/docs/plans/2026-06-21-add-agent-address-normalization-design.md
+++ b/docs/plans/2026-06-21-add-agent-address-normalization-design.md
@@ -152,15 +152,17 @@ Subcommand behavior:
   RPC and the cross-agent dup-check (which would REJECT a backfill write the
   moment normalization creates a collision — exactly the rows we need to write and
   then surface).
-- **Full-scan completeness (count reconciliation).** `AgentList` uses a strict
-  `tm_create < token` cursor (microsecond resolution). To guarantee no agent is
-  skipped at a page boundary where multiple rows share an identical `tm_create`,
-  the subcommand (a) SELECTs the total non-deleted agent COUNT before the scan,
-  (b) counts agents actually visited during the scan, and (c) FAILS LOUDLY if the
-  two disagree. A skipped agent would otherwise stay raw and route-miss forever
-  after the window closes, and a second dry-run using the same pagination would
-  not detect it. (Using a large page size makes a same-microsecond straddle
-  vanishingly unlikely; the count check turns "unlikely" into "verified".)
+- **Full-scan completeness (count reconciliation + page-grow retry).** `AgentList`
+  uses a strict `tm_create < token` cursor (microsecond resolution) with no
+  tie-breaker. To guarantee no agent is skipped at a page boundary where multiple
+  rows share an identical `tm_create`, the subcommand (a) SELECTs the total
+  non-deleted agent COUNT before the scan, (b) counts agents actually visited
+  during the scan, and (c) on a mismatch RETRIES the whole scan with a larger page
+  size (so an equal-`tm_create` cluster fits inside one page), up to a bounded
+  number of retries, and only then FAILS LOUDLY. This converts the count check
+  from a potential dead-end into a self-healing guard. A skipped agent would
+  otherwise stay raw and route-miss forever after the window closes, and a second
+  dry-run using the same pagination would not detect it.
 - **`--dry-run` (default true).** First pass logs every intended change
   (`agent_id`, `type`, raw -> canonical), the full collision report, and the
   count reconciliation, WITHOUT writing. The operator inspects, then re-runs with

--- a/docs/plans/2026-06-21-add-agent-address-normalization-design.md
+++ b/docs/plans/2026-06-21-add-agent-address-normalization-design.md
@@ -1,0 +1,442 @@
+# Agent Address Normalization (symmetric store + lookup) with backfill migration
+
+- Follow-up to: voipbin/monorepo#1002 (shared NormalizeTarget)
+- Class: hardening / refactor + data migration
+- Date: 2026-06-21
+
+## 1. Problem Statement
+
+Issue #1002 promoted a shared `commonaddress.NormalizeTarget` and adopted it in
+6 services, but DEFERRED `bin-agent-manager` because agent addresses are matched
+by EXACT byte-for-byte JSON comparison, and normalizing only one side of that
+match would break it.
+
+Code-verified facts:
+
+- `bin-agent-manager/models/agent/agent.go:27`: `Addresses []commonaddress.Address`
+  persisted as a JSON column (`addresses json`).
+- The agent-by-address lookup is an EXACT match:
+  `bin-dbscheme-manager`-managed `agents.addresses` is queried via
+  `dbhandler/agent.go:328`
+  `json_contains(addresses, JSON_OBJECT('type', ?, 'target', ?))` with args
+  `(address.Type, address.Target)`. Any difference in the stored vs. queried
+  `target` string yields a MISS.
+- The lookup key is passed RAW from call-manager:
+  `bin-call-manager/pkg/callhandler/start.go:707` and
+  `bin-call-manager/pkg/groupcallhandler/dial.go:267` both call
+  `AgentV1AgentGetByCustomerIDAndAddress(ctx, 1000, customerID, *addr)` with the
+  unnormalized address (the `addr.Type == TypeAgent` branch uses an agent UUID via
+  `AgentV1AgentGet` and is NOT an address match).
+- Today neither the store nor the lookup normalizes, so they are CONSISTENTLY raw
+  (matching works by luck of identical formatting). Introducing normalization on
+  only one side breaks live agent call routing.
+
+Why it matters: agent addresses are a LIVE call-routing key. An inbound/outbound
+call resolves its owner agent by this exact-match join; a normalization
+asymmetry would silently route-miss (agent stops receiving calls).
+
+## 2. Scope
+
+In scope (the symmetric set — ALL must land together):
+
+1. Normalize the agent address STORE:
+   - `agenthandler.Create` (agent.go:102): normalize each `addresses[i].Target`
+     before persist.
+   - `agenthandler.UpdateAddresses` (agent.go:360): normalize each
+     `addresses[i].Target` BEFORE the validation/dup-check loop (agent.go:377),
+     so the internal `GetByCustomerIDAndAddress` dup-check (agent.go:412) also
+     uses the normalized form.
+2. Normalize the agent address LOOKUP KEY:
+   - `agenthandler.GetByCustomerIDAndAddress` (agent.go:61): normalize the
+     incoming `address.Target` before the DB call (covers the RPC entry +
+     the internal dup-check caller).
+   - `bin-call-manager/pkg/callhandler/start.go` `getAddressOwner` (start.go:689):
+     normalize `addr.Target` before the `AgentV1AgentGetByCustomerIDAndAddress`
+     call (the non-Agent-UUID branch only).
+   - `bin-call-manager/pkg/groupcallhandler/dial.go` `getAddressOwner`
+     (dial.go:249): same.
+3. BACKFILL (Go one-shot CLI subcommand `agent-control agent normalize-addresses`):
+   normalize the `target` of every existing agent's `addresses` JSON so stored
+   values match the new normalized lookup key. Without this, EXISTING agents
+   route-miss until their addresses are next edited. The subcommand REUSES the
+   real `commonaddress.NormalizeTarget` (zero drift), scans all agents via the
+   existing `AgentList` token pagination, and rewrites changed addresses via the
+   existing `AgentSetAddresses` chokepoint (so cache invalidation runs).
+4. Tests: agent-manager store + lookup normalization regression tests;
+   call-manager getAddressOwner normalization regression tests (both handlers).
+
+Out of scope:
+
+- The shared `NormalizeTarget` primitive itself (delivered in #1002).
+- Re-normalizing other managers (done in #1002).
+- Changing the exact-match `json_contains` mechanism (kept; backfill makes it
+  correct rather than replacing it with a slow app-level compare).
+- An Alembic data migration / Python port of NormalizeTarget (REJECTED, see §3.3):
+  any non-Go reimplementation reintroduces a drift-vs-Go risk that the CLI
+  subcommand structurally eliminates.
+
+## 3. Design
+
+### 3.1 Normalization call (identical on all 5 code sites)
+
+```go
+// loss-proof, idempotent; error discarded (original returned on non-normalizable)
+addr.Target, _ = commonaddress.NormalizeTarget(addr.Type, addr.Target)
+```
+
+- Value slices (`agent.Addresses`, the agent store paths) normalized BY INDEX.
+- The lookup key in call-manager is `*addr` (pointer); normalize `addr.Target`
+  before passing `*addr` to the RPC. Do NOT normalize the `addr.Type == TypeAgent`
+  branch (agent UUID, opaque — NormalizeTarget would identity it anyway, but leave
+  it untouched for clarity).
+- `TypeAgent`/opaque types are identity-normalized, so an address whose Type is
+  e.g. `tel`/`sip` is the only one whose `target` actually changes — exactly the
+  routing keys we need consistent.
+
+### 3.2 The symmetry invariant (the load-bearing correctness point)
+
+The match is `stored.target == normalize(lookup.target)` ONLY IF
+`stored.target == normalize(stored.target)`. So:
+
+- New/updated agents: store-side normalization (scope 1) guarantees
+  `stored.target` is already canonical.
+- Existing agents: the backfill (scope 3) rewrites `stored.target` to canonical.
+- Every lookup caller (scope 2): normalizes the key to canonical.
+
+All three legs are required; any one missing reintroduces a route-miss class.
+Because `NormalizeTarget` is idempotent, re-running the backfill or
+double-normalizing a caller is safe.
+
+### 3.3 Backfill: Go one-shot CLI subcommand (zero-drift)
+
+The backfill is a new cobra subcommand on the EXISTING `agent-control` CLI:
+`agent-control agent normalize-addresses`. The `cmd/agent-control` binary is
+already built into the deployed agent-manager image (the Dockerfile runs
+`go build -o /app/bin/ ./cmd/...`, confirmed), so the backfill ships with the
+release and is executed once by an operator via `kubectl exec` / a one-off Job
+against staging then prod. No separate build or deploy artifact.
+
+Why CLI subcommand, not an Alembic Python port (decision):
+
+- **Zero drift by construction.** The subcommand calls the SAME
+  `commonaddress.NormalizeTarget` that the store and lookup paths call. There is
+  no second implementation to keep in parity. An Alembic migration runs in a
+  `python:3.11-slim` image with no Go toolchain, forcing a Python reimplementation
+  of the tel/whatsapp/email/sip + identity rules (loss-proof no-digit, sip
+  host-token-only lowercasing, ASCII-only digit strip). Any byte divergence
+  between that port and Go produces a stored canonical that differs from the Go
+  lookup key and silently defeats the backfill. The CLI subcommand eliminates that
+  entire failure class.
+- **Reuses existing chokepoints.** It scans all agents through the existing
+  `AgentList(ctx, size, token, filters)` token pagination (`tm_create`-keyed,
+  `deleted=false` filter, customer-agnostic) and writes changed agents through the
+  existing `AgentSetAddresses` path, so cache invalidation and JSON marshaling
+  behave exactly as the live service.
+- **Per-element by the element's own `type`.** Agents can hold mixed-type
+  addresses (e.g. a `tel` alongside an `extension`). NormalizeTarget is called per
+  array element keyed on that element's `Type`, so opaque targets (extension,
+  agent UUID) are identity-normalized and never corrupted.
+
+Subcommand behavior:
+
+- **DB + cache wiring.** `AgentSetAddresses` is a `dbhandler.DBHandler` method,
+  NOT on the `agenthandler.AgentHandler` interface. The subcommand constructs the
+  `dbhandler` directly via `dbhandler.NewHandler(sqlDB, cache)` (the same
+  constructor the service uses), which requires a real `cachehandler` — the
+  subcommand also builds the Redis cache via `cachehandler.NewHandler(addr, pw,
+  db)` (the existing `initCache` pattern), so the id-keyed cache invalidation in
+  `AgentSetAddresses` actually runs and live reads (after consumers resume) see
+  the canonical value. The kubectl-exec / one-off-pod environment therefore needs
+  Redis reachability (runbook note). It deliberately does NOT route writes through
+  `agenthandler.UpdateAddresses`, because that path runs the extension registrar
+  RPC and the cross-agent dup-check (which would REJECT a backfill write the
+  moment normalization creates a collision — exactly the rows we need to write and
+  then surface).
+- **Full-scan completeness (count reconciliation).** `AgentList` uses a strict
+  `tm_create < token` cursor (microsecond resolution). To guarantee no agent is
+  skipped at a page boundary where multiple rows share an identical `tm_create`,
+  the subcommand (a) SELECTs the total non-deleted agent COUNT before the scan,
+  (b) counts agents actually visited during the scan, and (c) FAILS LOUDLY if the
+  two disagree. A skipped agent would otherwise stay raw and route-miss forever
+  after the window closes, and a second dry-run using the same pagination would
+  not detect it. (Using a large page size makes a same-microsecond straddle
+  vanishingly unlikely; the count check turns "unlikely" into "verified".)
+- **`--dry-run` (default true).** First pass logs every intended change
+  (`agent_id`, `type`, raw -> canonical), the full collision report, and the
+  count reconciliation, WITHOUT writing. The operator inspects, then re-runs with
+  `--dry-run=false` to apply.
+- **Collision gate (hard-fail, no override).** The apply pass (`--dry-run=false`)
+  REFUSES to run if the collision count is > 0. There is no override flag: an
+  override would simply recommit the HIGH#2 dual-ownership state by another path
+  (two agents sharing one canonical -> nondeterministic routing). Collisions are
+  resolved by the operator (editing the duplicate agents) and then the apply is
+  re-run; the gate is a hard precondition, not a warning.
+- **Global collision detection (not per-page).** Collisions are tracked in a
+  single map keyed `(customer_id, type, canonical_target)` accumulated across the
+  ENTIRE scan, populated from the POST-normalization value of EVERY agent's every
+  address (not just the agents that changed). This catches collisions that span
+  two different pagination pages, and collisions between an already-canonical
+  agent and a freshly-normalized one.
+- **Original dump (recovery path).** Because normalization is irreversible (raw
+  formatting is lost) and there is no undo subcommand, the apply pass writes each
+  agent's PRE-change `addresses` JSON to a log/dump (agent_id + original array)
+  before mutating, giving the operator a manual reconstruction path.
+- **Only writes changed agents.** An agent whose every address is already
+  canonical is skipped (no AgentSetAddresses call), bounding write volume to the
+  genuinely-raw rows. Combined with NormalizeTarget idempotency, this is what
+  makes a re-run / partial-failure resume safe — no separate write-time CAS guard
+  is needed (the §3.4 consumer stop already removes all concurrency).
+- **No reverse.** A normalization backfill is not cleanly reversible. There is no
+  "undo" subcommand. The operational rollback is the code revert, constrained by
+  the §3.5 forward-only guard.
+
+Why collisions must be cleared (nondeterministic routing): the by-address lookup
+`AgentGetByCustomerIDAndAddress` (dbhandler/agent.go) issues a `json_contains`
+query with NO `ORDER BY` and takes the first row. If two agents share a canonical
+target, the routing owner returned is whatever row MySQL yields first —
+nondeterministic. The same nondeterminism leaks into `UpdateAddresses`' dup-check
+(`ag.ID != a.ID`), which can wrongly block a colliding agent from editing its own
+addresses. Collision is therefore a real defect, not a cosmetic one; the gate
+forces an operator decision before any canonical collapse is committed.
+
+This is run by a human against staging then prod (AI prohibition on prod
+mutation). Local validation uses a populated throwaway DB with `--dry-run` then
+`--dry-run=false`.
+
+### 3.4 Transition / deploy ordering (RPC consumers stopped, not "drained")
+
+Per CEO decision a brief downtime is acceptable. v5 spends that downtime to
+ELIMINATE the transient window. The earlier "deploy live, then backfill while
+serving" ordering is REJECTED: it creates a live read-modify-write race vs
+concurrent `UpdateAddresses` (lost-update) and a uniqueness-bypass that can leave
+two agents permanently owning the same canonical address (HIGH#1, HIGH#2). Both
+vanish only if NO agent-mutating and NO by-address-lookup work runs during the
+backfill.
+
+Concrete stop mechanism (VoIPBin is RabbitMQ RPC, not an HTTP LB, so "drain" is
+not self-evident). The by-address RPC has exactly two production producers
+(call-manager `start.go` + `dial.go` getAddressOwner, established in review), and
+the agent-mutating producers are the agent-manager write RPCs. To guarantee zero
+concurrency we STOP the RPC CONSUMERS, not "drain traffic":
+
+```
+1. Merge PR (5 code sites normalized + agent-control normalize-addresses subcommand).
+2. Open a maintenance window. Scale the agent-manager Deployment consumers and the
+   call-manager (routing) consumers to ZERO replicas (or otherwise stop their RPC
+   consumption). NOTE: stopping the by-address lookup path means inbound call
+   routing is OFFLINE for the window — this is full telephony downtime for agent
+   routing, not a partial degrade. This is the accepted-downtime cost.
+3. Deploy the normalized code (new replicas with normalization + the subcommand).
+   Keep their consumers stopped until after backfill, OR run the backfill from a
+   one-off pod/job that does NOT consume RPCs (the subcommand talks to the DB
+   directly and consumes nothing).
+4. Run the backfill against the now-quiescent DB:
+   a. `agent-control agent normalize-addresses --dry-run` -> inspect the
+      raw->canonical diff, the collision report, and the before/after agent COUNT
+      reconciliation (§3.3 completeness check).
+   b. If collisions > 0, STOP and resolve duplicates first (apply hard-fails on
+      collisions; there is NO override — see §3.3). Collisions make routing
+      nondeterministic, so they MUST be cleared inside the window.
+   c. `--dry-run=false` to apply, then re-run `--dry-run` to confirm a clean
+      (zero-change, zero-collision, count-reconciled) second pass.
+5. Restore consumers (scale back up). Every agent address is canonical; store ==
+   lookup key for both existing and new agents.
+```
+
+Because all three legs (store, lookup, backfill) land before consumers resume,
+there is no window in which one side is normalized and the other is not. The
+downtime is the stop+deploy+backfill duration, paid once.
+
+Runbook notes (non-blocking, from convergence review):
+- Before the window, re-confirm the by-address RPC has no producers beyond the two
+  call-manager `getAddressOwner` sites (so the consumer-stop list stays complete
+  if new callers were added since this design).
+- The backfill pod/exec environment needs BOTH MySQL and Redis reachability
+  (DB scan/write + the `SELECT COUNT` reconciliation + id-keyed cache invalidation).
+- The pre-change original dump can be large for high agent counts; prefer a
+  structured file artifact over inline logs when the changed-row count is high.
+
+### 3.5 Rollback guard (mandatory runbook note)
+
+Once the backfill has rewritten stored addresses to canonical form, rolling the
+CODE back to a version that does NOT normalize the lookup key would make raw
+lookup keys miss the canonical stored values — an unrecoverable break (raw form
+is gone). Therefore:
+
+- The lookup-key normalization is FORWARD-ONLY. The deploy runbook MUST state:
+  "do not roll the agent-manager / call-manager code back below the
+  agent-address-normalization release." A revert is only safe BEFORE the backfill
+  runs (stored values still raw, raw keys still match).
+- `NormalizeTarget` is idempotent, so re-applying the release after a revert is
+  safe.
+
+### 3.6 Affected files
+
+| Service | File | Change |
+|---------|------|--------|
+| bin-agent-manager | `pkg/agenthandler/agent.go` | normalize store in Create + UpdateAddresses (by index, before the validation/dup-check loop); normalize lookup key in GetByCustomerIDAndAddress |
+| bin-agent-manager | `pkg/agenthandler/agent_test.go` | store + lookup normalization regression tests (incl. extension identity) |
+| bin-call-manager | `pkg/callhandler/start.go` | normalize lookup key in getAddressOwner (address-match branch only; TypeAgent UUID branch untouched) |
+| bin-call-manager | `pkg/callhandler/start_test.go` | regression test |
+| bin-call-manager | `pkg/groupcallhandler/dial.go` | normalize lookup key in getAddressOwner (address-match branch only) |
+| bin-call-manager | `pkg/groupcallhandler/dial_test.go` | regression test |
+| bin-agent-manager | `cmd/agent-control/main.go` | new `normalize-addresses` subcommand: construct `dbhandler` + Redis `cachehandler` directly, full-scan via AgentList pagination with before/after COUNT reconciliation, NormalizeTarget per element by type, global `(customer_id,type,canonical)` collision map, `--dry-run` (default true), collision gate (hard-fail, no override), pre-change original dump, write changed via AgentSetAddresses |
+
+## 4. Test Strategy
+
+- agent-manager: assert `Create`/`UpdateAddresses` persist canonical
+  `Addresses[i].Target` (gomock matcher on the db create/set-addresses call);
+  assert `GetByCustomerIDAndAddress` issues the DB query with the canonical
+  target (gomock arg match). Include a `tel` punctuated case, a `sip` host-case
+  case (host token lowercased, `;params`/`?headers` preserved verbatim), and an
+  opaque/UUID identity case (extension/agent untouched).
+- call-manager: assert `getAddressOwner` (both start.go and dial.go) calls
+  `AgentV1AgentGetByCustomerIDAndAddress` with the canonical address; assert the
+  `TypeAgent` UUID branch is unchanged (still `AgentV1AgentGet` by id).
+- backfill: the subcommand reuses the real `NormalizeTarget`, so there is NO
+  second normalizer to golden-vector. Validation is operational: run with
+  `--dry-run` against a local populated throwaway DB, confirm the previewed
+  raw -> canonical diffs and collision report are correct, then `--dry-run=false`
+  and re-run `--dry-run` to confirm a clean (no-change) second pass (idempotency).
+
+## 5. Verification
+
+Per CLAUDE.md, run the full workflow in bin-agent-manager and bin-call-manager.
+For the backfill subcommand: build via the standard agent-manager verification
+(`go build ./cmd/...` is exercised by the workflow), then run
+`agent-control agent normalize-addresses --dry-run` against a LOCAL throwaway DB
+only (never staging/prod — AI prohibition), confirm the diff + collision report,
+apply with `--dry-run=false`, and confirm an idempotent clean second pass. A human
+runs it against staging/prod.
+
+## 6. Sections marked N/A (hardening-class)
+
+New domain model / REST API / webhook / flow vars / RabbitMQ action / Prometheus
+/ PII-LLM: N/A. This adds no entity or endpoint; it inserts an existing
+pure-function at 5 sites and backfills one JSON column.
+
+## 7. Open Questions (resolved)
+
+| # | Question | Decision | Owner |
+|---|----------|----------|-------|
+| 1 | Backfill mechanism? | Go one-shot CLI subcommand `agent-control agent normalize-addresses`, reusing the real `NormalizeTarget` (zero drift). The agent-control binary already ships in the deployed image (`go build ./cmd/...`). Alembic Python-port REJECTED: a non-Go reimplementation reintroduces a parity/drift risk the CLI structurally removes. | CEO/CTO |
+| 2 | downgrade() reversibility? | No-op (irreversible); the operational rollback is the code revert, constrained by the §3.5 forward-only guard | CTO |
+| 3 | Deploy ordering / downtime? | CEO accepted a brief downtime: code-first then immediate backfill (§3.4). Zero-downtime dual-key expand/contract rejected as over-engineering. | CEO/CTO |
+| 4 | agent_addresses normalized table instead of JSON column? | NO. Keep the JSON column; table normalization is explicitly out of scope (CEO decision). | CEO |
+
+## 8. Review Summary
+
+### Round 1 (2 reviewers: code-verification + adversarial) — both CHANGES REQUESTED
+
+Code-verification reviewer: symmetric store+lookup set verified COMPLETE against
+the repo (5 sites; the two call-manager getAddressOwner methods are the ONLY
+production callers of the by-address RPC; agent-manager's single
+GetByCustomerIDAndAddress chokepoint covers RPC entry + internal dup-check; cache
+is id-keyed not address-keyed, no other store/match site missed). Blocker: the
+"Go command" backfill is infeasible (python:3.11-slim migration image, no Go
+toolchain; backfill only runs in human staging/prod upgrade against a populated
+DB).
+
+Adversarial reviewer: core normalization + symmetry invariant + script-driven
+backfill + idempotency all sound. Blockers: (HIGH) deploy-ordering transient
+break is unavoidable under single-key EXACT match — recommended dual-key
+expand/contract for zero-downtime; (HIGH) no-op downgrade + code rollback =
+silent unrecoverable break. Plus MEDIUM: pin backfill to deployed normalizer +
+mirror ErrNotNormalizable, confirm extension->identity, log post-normalize
+collisions; LOW: address-branch-only placement, slice-by-index mutation test.
+
+### v2 (this revision) — findings applied
+- Backfill = Python port embedded in `upgrade()`, per-element by `type`, parity
+  tested vs Go golden vectors (resolves code-verify HIGH + fidelity MEDIUM).
+- Deploy: CEO accepted brief downtime -> code-first + immediate backfill (§3.4);
+  dual-key expand/contract rejected as over-engineering (resolves adversarial
+  HIGH #1 per CEO decision).
+- Rollback guard §3.5: lookup-normalization is forward-only; runbook must forbid
+  rolling below this release post-backfill (resolves adversarial HIGH #2).
+- Collision logging in the migration (MEDIUM).
+- extension identity test + lookup normalization in the address-match branch only
+  / TypeAgent UUID branch untouched / store normalize by index (MEDIUM + LOW).
+- agent_addresses table: explicitly out of scope (CEO).
+
+A fresh re-review round on v2 follows (mandatory after the material change).
+
+### v3 (this revision) — backfill mechanism changed per CEO decision
+
+The CEO chose a Go one-shot CLI subcommand over the Alembic Python-port (the SQL
+/ pure-query alternative was also weighed and rejected for the same drift reason:
+reproducing sip host-token-only lowercasing and the loss-proof no-digit rule
+byte-for-byte in SQL is fragile). Changes:
+
+- §2 scope item 3 + §3.3: backfill is now `agent-control agent
+  normalize-addresses`, reusing the real `NormalizeTarget` (zero drift by
+  construction). Scans via existing `AgentList` pagination, writes via existing
+  `AgentSetAddresses` chokepoint, `--dry-run` default-true preview, per-element
+  by type, collision logging on both passes.
+- Confirmed the agent-control binary already ships in the deployed image
+  (Dockerfile `go build -o /app/bin/ ./cmd/...`), so no new deploy artifact;
+  operator runs it via `kubectl exec`.
+- §3.6 affected-files: dropped the bin-dbscheme-manager Alembic file, added the
+  cmd/agent-control subcommand row.
+- §4/§5: validation is operational (dry-run preview + idempotent second pass on a
+  local throwaway DB), not golden-vector parity (no second normalizer exists).
+- §7 Q1 updated; §2 out-of-scope now explicitly rejects the Alembic/Python port.
+
+A fresh re-review round on v3 follows (mandatory after this material change).
+
+### v4 (this revision) — round-1 review findings applied
+
+Round 1 (2 fresh reviewers): code-verification APPROVE (one accuracy note);
+adversarial CHANGES REQUESTED (HIGH 2 + MEDIUM 3 + LOW 3). All applied:
+
+- **HIGH#1 (live backfill lost-update race) + HIGH#2 (uniqueness-bypass ->
+  permanent dual-ownership):** root cause was "backfill while serving live
+  traffic". §3.4 rewritten to run deploy + backfill inside ONE drained
+  maintenance window (CEO downtime spent to remove the transient window entirely,
+  not just bound it). With no agent-mutating/lookup traffic during the window,
+  both HIGH findings are structurally impossible.
+- **MEDIUM#3 (collision -> nondeterministic routing, log-only insufficient):**
+  added a collision GATE — apply refuses with collisions present unless
+  `--allow-collisions`; documented the `ORDER BY`-less first-row nondeterminism
+  and the dup-check self-block in §3.3.
+- **MEDIUM#4 (collision detection scope):** specified a GLOBAL
+  `(customer_id,type,canonical)` map over the whole scan, populated from every
+  agent's post-normalization addresses (cross-page, incl. already-canonical).
+- **MEDIUM#5 (dry-run/apply TOCTOU):** subsumed by the drained window; plus a
+  write-time re-read guard and a confirm-clean second dry-run pass.
+- **code-verify accuracy note + LOW#6:** §3.3 now states the subcommand wires
+  `dbhandler` directly (AgentSetAddresses is not on the agenthandler interface)
+  and writes a pre-change original `addresses` dump as a manual recovery path.
+- **LOW#7:** §4 test strategy adds a sip host-case + `;params` preservation case.
+
+A fresh re-review round on v4 follows (mandatory after this material change).
+
+### v5 (this revision) — round-2 review findings applied
+
+Round 2 (2 fresh reviewers): implementability APPROVE (each code change verified
+implementable against the repo: signatures, interfaces, pagination loop, no mock
+regen, test feasibility); adversarial CHANGES REQUESTED (HIGH 1 + MEDIUM 1 +
+LOW 3). Applied:
+
+- **HIGH#1 (drain mechanism unspecified for RabbitMQ):** §3.4 no longer
+  hand-waves "drain traffic". It now specifies STOPPING the RPC consumers
+  (scale agent-manager + call-manager consumers to zero / run the backfill from a
+  non-consuming one-off pod) and explicitly states that stopping the by-address
+  lookup path means inbound agent-call routing is fully offline for the window
+  (the accepted-downtime cost). The zero-concurrency guarantee is now enforceable.
+- **MEDIUM#2 (pagination completeness — same-`tm_create` page-boundary skip):**
+  added before/after non-deleted-agent COUNT reconciliation that FAILS LOUDLY on
+  mismatch (a same-microsecond straddle would otherwise leave an agent raw and a
+  second dry-run, using the same cursor, would not catch it).
+- **LOW#3 (`--allow-collisions` footgun):** removed. The collision gate is now a
+  hard-fail with no override; collisions are resolved by editing the duplicate
+  agents, then the apply is re-run.
+- **LOW#4 (write-time re-read guard over-engineering):** removed. With consumers
+  stopped there is no concurrency to guard; resume safety rests on
+  NormalizeTarget idempotency + "only write changed agents".
+- **LOW#5 (Redis cachehandler wiring not mentioned):** §3.3 now states the
+  subcommand builds the Redis `cachehandler` (existing `initCache` pattern) so
+  `AgentSetAddresses` cache invalidation runs; runbook needs Redis reachability.
+- LOW#6 (global collision map memory): confirmed non-issue at current scale.
+
+This is the second consecutive material change, so a fresh re-review round on v5
+follows (mandatory).


### PR DESCRIPTION
Normalize agent endpoint addresses symmetrically at store and lookup, and add a one-time CLI backfill so existing stored addresses become canonical. This closes the agent-manager case that was deferred from the shared NormalizeTarget work (#1002), because agent addresses are matched by exact byte-for-byte json_contains and normalizing only one side of that match would break live call routing.

- bin-agent-manager: normalize stored addresses by index in agenthandler.Create and UpdateAddresses (before the validation/dup-check loop) so persisted values are canonical
- bin-agent-manager: normalize the lookup key in agenthandler.GetByCustomerIDAndAddress (local copy) before the DB query
- bin-agent-manager: add agent-control "normalize-addresses" subcommand: a one-time backfill that reuses the real NormalizeTarget (zero drift), scans all agents via AgentList token pagination with before/after COUNT reconciliation (page-grow retry on a same-tm_create boundary skip, fast-abort on visited>total), builds a global (customer_id,type,canonical) collision map with a hard-fail gate, defaults to --dry-run, dumps each pre-change addresses array, and writes changed agents via AgentSetAddresses
- bin-agent-manager: add store/lookup normalization regression tests and backfill unit tests
- bin-call-manager: normalize the lookup key in callhandler.getAddressOwner (address-match branch only; TypeAgent UUID branch untouched)
- bin-call-manager: normalize the lookup key in groupcallhandler.getAddressOwner (address-match branch only)
- bin-call-manager: add getAddressOwner normalization regression tests