### PR TITLE
NOJIRA-Add-agent-addresses-table

### DIFF
--- a/bin-agent-manager/cmd/agent-control/backfill_addresses.go
+++ b/bin-agent-manager/cmd/agent-control/backfill_addresses.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
+
+	"monorepo/bin-agent-manager/internal/config"
+	"monorepo/bin-agent-manager/pkg/cachehandler"
+	"monorepo/bin-agent-manager/pkg/dbhandler"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// agentAddressBackfill is one agent's address set read straight from the legacy
+// agent_agents.addresses JSON column (the source of truth during the EXPAND
+// phase, before the child table is populated).
+type agentAddressBackfill struct {
+	agentID    uuid.UUID
+	customerID uuid.UUID
+	addresses  []commonaddress.Address
+}
+
+func cmdBackfillAddresses() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backfill-addresses",
+		Short: "One-time backfill: populate agent_addresses from the legacy agent_agents.addresses JSON column",
+		Long: "Reads every non-deleted agent's addresses directly from the legacy " +
+			"agent_agents.addresses JSON column and writes them into the normalized " +
+			"agent_addresses child table via the same store path the live code uses " +
+			"(db.AgentSetAddresses), so there is zero drift. The operation is idempotent: " +
+			"it replaces (delete-then-insert) each agent's child rows, so it is safe to " +
+			"re-run.\n\n" +
+			"This is the EXPAND-phase populate step. The read paths already source addresses " +
+			"from the (initially empty) child table, so until this backfill completes, agents " +
+			"appear to have no addresses. Run it immediately after deploying the migration + " +
+			"the agent-manager image.\n\n" +
+			"MUST be run inside a maintenance window with the agent-manager and call-manager " +
+			"RPC consumers stopped: the backfill assumes no concurrent agent mutation or " +
+			"by-address lookup.\n\n" +
+			"Defaults to --dry-run=true (preview only). Re-run with --dry-run=false to apply. " +
+			"The apply pass hard-fails if any canonical (customer_id, type, target) collision " +
+			"is detected (two agents owning one address): resolve the duplicate agents first, " +
+			"then re-run, otherwise the later UNIQUE-index promotion would fail.\n\n" +
+			"Note: applying bumps each migrated agent's tm_update (the store path stamps it).",
+		RunE: runBackfillAddresses,
+	}
+
+	cmd.Flags().Bool("dry-run", true, "Preview changes without writing (default true)")
+
+	return cmd
+}
+
+func runBackfillAddresses(cmd *cobra.Command, args []string) error {
+	dryRun := viper.GetBool("dry-run")
+
+	ctx := context.Background()
+
+	sqlDB, err := commondatabasehandler.Connect(config.Get().DatabaseDSN)
+	if err != nil {
+		return errors.Wrap(err, "could not connect to the database")
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	cache := cachehandler.NewHandler(config.Get().RedisAddress, config.Get().RedisPassword, config.Get().RedisDatabase)
+	if errConnect := cache.Connect(); errConnect != nil {
+		return errors.Wrap(errConnect, "could not connect to the cache")
+	}
+
+	db := dbhandler.NewHandler(sqlDB, cache)
+
+	// 1. total non-deleted agent count, for the completeness reconciliation.
+	total, err := countNonDeletedAgents(ctx, sqlDB)
+	if err != nil {
+		return errors.Wrap(err, "could not count agents")
+	}
+
+	// 2. read every non-deleted agent's legacy JSON addresses into memory FIRST
+	// (fully draining + closing the read) before issuing any write. Holding the
+	// read rows open while writing would block on a single-connection pool, the
+	// same deadlock class fixed in the dbhandler read path.
+	records, visited, err := readLegacyAddresses(ctx, sqlDB)
+	if err != nil {
+		return errors.Wrap(err, "could not read legacy addresses")
+	}
+
+	// 3. completeness reconciliation: never write on a short/over read.
+	if visited != total {
+		return fmt.Errorf("read %d agents but %d non-deleted agents exist; aborting (no writes performed)", visited, total)
+	}
+
+	// 4. build the collision map from the canonical (customer,type,target) of
+	// every agent's addresses, so a duplicate that would later break the UNIQUE
+	// promotion is caught up front.
+	collisions := detectCollisions(records)
+
+	// 5. report
+	fmt.Printf("mode: %s\n", dryRunLabel(dryRun))
+	fmt.Printf("agents scanned: %d (reconciled with table count %d)\n", visited, total)
+	withAddrs := 0
+	for _, r := range records {
+		if len(r.addresses) > 0 {
+			withAddrs++
+		}
+	}
+	fmt.Printf("agents with addresses to backfill: %d\n", withAddrs)
+	reportCollisions(collisions)
+
+	// 6. dry-run stops here
+	if dryRun {
+		fmt.Println("\ndry-run: no changes written. Re-run with --dry-run=false to apply.")
+		return nil
+	}
+
+	// 7. collision gate: hard-fail, no override.
+	if len(collisions) > 0 {
+		return fmt.Errorf("aborting apply: %d canonical collision(s) detected; resolve the duplicate agents, then re-run (no writes performed)", len(collisions))
+	}
+
+	// 8. apply: replace each agent's child rows via the live store path (drift-0,
+	// idempotent). Agents with no addresses need no child rows and are skipped.
+	applied := 0
+	for _, r := range records {
+		if len(r.addresses) == 0 {
+			continue
+		}
+		if errSet := db.AgentSetAddresses(ctx, r.agentID, r.addresses); errSet != nil {
+			return errors.Wrapf(errSet, "could not set addresses for agent %s (applied %d before failure)", r.agentID, applied)
+		}
+		applied++
+	}
+
+	fmt.Printf("\napplied: %d agent(s) backfilled.\n", applied)
+	return nil
+}
+
+// readLegacyAddresses reads id, customer_id and the legacy addresses JSON for
+// every non-deleted agent, fully into memory. It returns the records and the
+// number of agents visited (for reconciliation). The result rows are drained
+// and closed before returning, so no read cursor is held across a later write.
+func readLegacyAddresses(ctx context.Context, sqlDB *sql.DB) ([]agentAddressBackfill, int, error) {
+	rows, err := sqlDB.QueryContext(ctx,
+		"SELECT id, customer_id, addresses FROM agent_agents WHERE tm_delete IS NULL",
+	)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "could not query agents")
+	}
+	defer func() { _ = rows.Close() }()
+
+	records := []agentAddressBackfill{}
+	visited := 0
+	for rows.Next() {
+		var (
+			idRaw         []byte
+			customerIDRaw []byte
+			addressesRaw  sql.NullString
+		)
+		if errScan := rows.Scan(&idRaw, &customerIDRaw, &addressesRaw); errScan != nil {
+			return nil, 0, errors.Wrap(errScan, "could not scan agent row")
+		}
+		visited++
+
+		agentID, errID := uuid.FromBytes(idRaw)
+		if errID != nil {
+			return nil, 0, errors.Wrap(errID, "could not parse agent id")
+		}
+		customerID, errCust := uuid.FromBytes(customerIDRaw)
+		if errCust != nil {
+			return nil, 0, errors.Wrapf(errCust, "could not parse customer id for agent %s", agentID)
+		}
+
+		addresses := []commonaddress.Address{}
+		if addressesRaw.Valid && strings.TrimSpace(addressesRaw.String) != "" {
+			if errJSON := json.Unmarshal([]byte(addressesRaw.String), &addresses); errJSON != nil {
+				return nil, 0, errors.Wrapf(errJSON, "could not parse addresses JSON for agent %s", agentID)
+			}
+		}
+
+		records = append(records, agentAddressBackfill{
+			agentID:    agentID,
+			customerID: customerID,
+			addresses:  addresses,
+		})
+	}
+	if errRows := rows.Err(); errRows != nil {
+		return nil, 0, errors.Wrap(errRows, "rows iteration error")
+	}
+
+	return records, visited, nil
+}
+
+// detectCollisions reduces the records to the set of canonical
+// (customer_id, type, target) keys owned by more than one agent. It reuses
+// collisionKey / dedupeUUIDs from normalize_addresses.go so the operational
+// semantics match the existing backfill tool.
+func detectCollisions(records []agentAddressBackfill) map[string][]uuid.UUID {
+	owners := map[string][]uuid.UUID{}
+	for _, r := range records {
+		for _, addr := range r.addresses {
+			key := collisionKey(r.customerID, addr)
+			owners[key] = append(owners[key], r.agentID)
+		}
+	}
+
+	collisions := map[string][]uuid.UUID{}
+	for key, ids := range owners {
+		uniqueOwners := dedupeUUIDs(ids)
+		if len(uniqueOwners) > 1 {
+			collisions[key] = uniqueOwners
+		}
+	}
+	return collisions
+}

--- a/bin-agent-manager/cmd/agent-control/main.go
+++ b/bin-agent-manager/cmd/agent-control/main.go
@@ -103,6 +103,7 @@ func initCommand() *cobra.Command {
 
 	// one-time operational backfill (not part of the agent CRUD group)
 	cmdSub.AddCommand(cmdNormalizeAddresses())
+	cmdSub.AddCommand(cmdBackfillAddresses())
 
 	return cmdRoot
 }

--- a/bin-agent-manager/models/agent/agent.go
+++ b/bin-agent-manager/models/agent/agent.go
@@ -24,7 +24,7 @@ type Agent struct {
 	Status     Status                  `json:"status" db:"status"`           // agent's status
 	Permission Permission              `json:"permission" db:"permission"`   // agent's permission.
 	TagIDs     []uuid.UUID             `json:"tag_ids" db:"tag_ids,json"`    // agent's tag ids
-	Addresses  []commonaddress.Address `json:"addresses" db:"addresses,json"` // agent's endpoint addresses
+	Addresses  []commonaddress.Address `json:"addresses" db:"-"` // agent's endpoint addresses (stored in agent_addresses child table)
 
 	DirectID   uuid.UUID `json:"direct_id" db:"direct_id,uuid"`  // direct id for direct hash
 	DirectHash string    `json:"direct_hash" db:"direct_hash"`    // direct hash

--- a/bin-agent-manager/pkg/agenthandler/db.go
+++ b/bin-agent-manager/pkg/agenthandler/db.go
@@ -2,6 +2,7 @@ package agenthandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	dmdirect "monorepo/bin-direct-manager/models/direct"
 
+	"monorepo/bin-agent-manager/pkg/dbhandler"
 	"monorepo/bin-agent-manager/pkg/metricshandler"
 
 	"github.com/gofrs/uuid"
@@ -122,6 +124,17 @@ func (h *agentHandler) dbCreate(ctx context.Context, customerID uuid.UUID, usern
 		// cleanup orphaned direct
 		if _, errDelete := h.reqHandler.DirectV1DirectDelete(ctx, d.ID); errDelete != nil {
 			log.Errorf("Could not cleanup orphaned direct. direct_id: %s, err: %v", d.ID, errDelete)
+		}
+
+		// a duplicate-key violation means one of the requested addresses is
+		// already owned by another agent (UNIQUE(customer_id,type,target)).
+		// Surface a typed 409-class error instead of a generic internal error.
+		if errors.Is(err, dbhandler.ErrAlreadyExists) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameAgentManager,
+				"ADDRESS_ALREADY_ASSIGNED",
+				"one of the requested addresses is already assigned to another agent",
+			)
 		}
 
 		return nil, err
@@ -310,6 +323,17 @@ func (h *agentHandler) dbUpdateAddresses(ctx context.Context, id uuid.UUID, addr
 
 	if err := h.db.AgentSetAddresses(ctx, id, addresses); err != nil {
 		log.Errorf("Could not set the addresses. err: %v", err)
+
+		// a duplicate-key violation means one of the requested addresses is
+		// already owned by another agent (UNIQUE(customer_id,type,target)).
+		if errors.Is(err, dbhandler.ErrAlreadyExists) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameAgentManager,
+				"ADDRESS_ALREADY_ASSIGNED",
+				"one of the requested addresses is already assigned to another agent",
+			)
+		}
+
 		return nil, err
 	}
 

--- a/bin-agent-manager/pkg/cachehandler/handler.go
+++ b/bin-agent-manager/pkg/cachehandler/handler.go
@@ -81,6 +81,17 @@ func (h *handler) AgentSet(ctx context.Context, u *agent.Agent) error {
 	return nil
 }
 
+// AgentDel deletes the cached agent information for the given ID.
+func (h *handler) AgentDel(ctx context.Context, id uuid.UUID) error {
+	key := fmt.Sprintf("agent:agent:%d", id)
+
+	if err := h.Cache.Del(ctx, key).Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // PasswordResetTokenSet stores a password reset token in Redis with a TTL.
 func (h *handler) PasswordResetTokenSet(ctx context.Context, token string, agentID uuid.UUID, ttl time.Duration) error {
 	key := passwordResetKeyPrefix + token

--- a/bin-agent-manager/pkg/cachehandler/main.go
+++ b/bin-agent-manager/pkg/cachehandler/main.go
@@ -26,6 +26,7 @@ type CacheHandler interface {
 
 	AgentGet(ctx context.Context, id uuid.UUID) (*agent.Agent, error)
 	AgentSet(ctx context.Context, u *agent.Agent) error
+	AgentDel(ctx context.Context, id uuid.UUID) error
 
 	PasswordResetTokenSet(ctx context.Context, token string, agentID uuid.UUID, ttl time.Duration) error
 	PasswordResetTokenGet(ctx context.Context, token string) (uuid.UUID, error)

--- a/bin-agent-manager/pkg/cachehandler/mock_main.go
+++ b/bin-agent-manager/pkg/cachehandler/mock_main.go
@@ -43,6 +43,20 @@ func (m *MockCacheHandler) EXPECT() *MockCacheHandlerMockRecorder {
 	return m.recorder
 }
 
+// AgentDel mocks base method.
+func (m *MockCacheHandler) AgentDel(ctx context.Context, id uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AgentDel", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AgentDel indicates an expected call of AgentDel.
+func (mr *MockCacheHandlerMockRecorder) AgentDel(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentDel", reflect.TypeOf((*MockCacheHandler)(nil).AgentDel), ctx, id)
+}
+
 // AgentGet mocks base method.
 func (m *MockCacheHandler) AgentGet(ctx context.Context, id uuid.UUID) (*agent.Agent, error) {
 	m.ctrl.T.Helper()

--- a/bin-agent-manager/pkg/dbhandler/agent.go
+++ b/bin-agent-manager/pkg/dbhandler/agent.go
@@ -115,9 +115,20 @@ func (h *handler) AgentCreate(ctx context.Context, a *agent.Agent) error {
 		return fmt.Errorf("could not build query. AgentCreate. err: %v", err)
 	}
 
-	if _, err := h.db.ExecContext(ctx, query, args...); err != nil {
+	// insert the agent row and its address rows in a single transaction
+	if err := h.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("could not execute query. AgentCreate. err: %v", err)
+		}
+
+		if err := h.agentAddressInsert(ctx, tx, a.ID, a.CustomerID, a.Addresses); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
 		dbErr = err
-		return fmt.Errorf("could not execute query. AgentCreate. err: %v", err)
+		return err
 	}
 
 	// update the cache
@@ -213,6 +224,24 @@ func (h *handler) agentGetFromDB(ctx context.Context, id uuid.UUID) (*agent.Agen
 		return nil, errors.Wrapf(err, "could not get data from row. agentGetFromDB. id: %s", id)
 	}
 
+	// Release the agent row's connection back to the pool before issuing the
+	// address query. Holding the row open across a second query deadlocks when
+	// the pool is limited to a single connection (e.g. the sqlite test harness
+	// with cache=shared, MaxOpenConns=1). Closing twice (here and via defer) is
+	// safe and idempotent.
+	if err := row.Close(); err != nil {
+		dbErr = err
+		return nil, fmt.Errorf("could not close agent row. agentGetFromDB. err: %v", err)
+	}
+
+	// hydrate addresses from the child table
+	addresses, err := h.agentAddressListByAgentID(ctx, h.db, res.ID)
+	if err != nil {
+		dbErr = err
+		return nil, fmt.Errorf("could not hydrate addresses. agentGetFromDB. err: %v", err)
+	}
+	res.Addresses = addresses
+
 	return res, nil
 }
 
@@ -299,6 +328,28 @@ func (h *handler) AgentList(ctx context.Context, size uint64, token string, filt
 		return nil, fmt.Errorf("rows iteration error. AgentList. err: %v", err)
 	}
 
+	// batch-hydrate addresses for all agents in a single query (avoid N+1)
+	if len(res) > 0 {
+		agentIDs := make([]uuid.UUID, 0, len(res))
+		for _, u := range res {
+			agentIDs = append(agentIDs, u.ID)
+		}
+
+		addrMap, err := h.agentAddressListByAgentIDs(ctx, h.db, agentIDs)
+		if err != nil {
+			dbErr = err
+			return nil, fmt.Errorf("could not hydrate addresses. AgentList. err: %v", err)
+		}
+
+		for _, u := range res {
+			if addrs, ok := addrMap[u.ID]; ok {
+				u.Addresses = addrs
+			} else {
+				u.Addresses = []commonaddress.Address{}
+			}
+		}
+	}
+
 	return res, nil
 }
 
@@ -318,39 +369,21 @@ func (h *handler) AgentGetByCustomerIDAndAddress(ctx context.Context, customerID
 		metricshandler.DBOperationTotal.WithLabelValues("get_by_customer_id_address", "agent", status).Inc()
 	}()
 
-	fields := commondatabasehandler.GetDBFields(&agent.Agent{})
-
-	query, args, err := squirrel.
-		Select(fields...).
-		From(agentTable).
-		Where(squirrel.Eq{string(agent.FieldCustomerID): customerID.Bytes()}).
-		Where(squirrel.Eq{string(agent.FieldTMDelete): nil}).
-		Where("json_contains(addresses, JSON_OBJECT('type', ?, 'target', ?))", address.Type, address.Target).
-		PlaceholderFormat(squirrel.Question).
-		ToSql()
+	// indexed equality lookup on the child table to find the owning agent
+	agentID, err := h.agentAddressLookupOwnerAgentID(ctx, h.db, customerID, address.Type, address.Target)
 	if err != nil {
 		dbErr = err
-		return nil, fmt.Errorf("could not build sql. AgentGetByCustomerIDAndAddress. err: %v", err)
+		if err == ErrNotFound {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("could not lookup owner. AgentGetByCustomerIDAndAddress. err: %v", err)
 	}
 
-	row, err := h.db.QueryContext(ctx, query, args...)
+	// load the agent by id (cache-first)
+	res, err := h.AgentGet(ctx, agentID)
 	if err != nil {
 		dbErr = err
-		return nil, fmt.Errorf("could not query. AgentGetByCustomerIDAndAddress. err: %v", err)
-	}
-	defer func() {
-		_ = row.Close()
-	}()
-
-	if !row.Next() {
-		dbErr = ErrNotFound
-		return nil, ErrNotFound
-	}
-
-	res, err := h.agentGetFromRow(row)
-	if err != nil {
-		dbErr = err
-		return nil, fmt.Errorf("could not scan the row. AgentGetByCustomerIDAndAddress. err: %v", err)
+		return nil, err
 	}
 
 	return res, nil
@@ -377,15 +410,61 @@ func (h *handler) AgentGetByUsername(ctx context.Context, username string) (*age
 
 // AgentDelete deletes the agent.
 func (h *handler) AgentDelete(ctx context.Context, id uuid.UUID) error {
+	start := time.Now()
+	var dbErr error
+	defer func() {
+		elapsed := time.Since(start)
+		metricshandler.DBOperationDuration.WithLabelValues("delete", "agent").Observe(float64(elapsed.Milliseconds()))
+		status := "success"
+		if dbErr != nil {
+			status = "failure"
+		}
+		metricshandler.DBOperationTotal.WithLabelValues("delete", "agent", status).Inc()
+	}()
+
 	now := h.utilHandler.TimeNow()
 	fields := map[agent.Field]any{
 		agent.FieldTMDelete: now,
 		agent.FieldTMUpdate: now,
 	}
 
-	if err := h.agentUpdate(ctx, id, fields); err != nil {
-		return fmt.Errorf("could not update agent for delete. AgentDelete. err: %v", err)
+	tmpFields, err := commondatabasehandler.PrepareFields(fields)
+	if err != nil {
+		dbErr = err
+		return fmt.Errorf("could not prepare fields. AgentDelete. err: %v", err)
 	}
+
+	sqlStr, args, err := squirrel.
+		Update(agentTable).
+		SetMap(tmpFields).
+		Where(squirrel.Eq{"id": id.Bytes()}).
+		PlaceholderFormat(squirrel.Question).
+		ToSql()
+	if err != nil {
+		dbErr = err
+		return fmt.Errorf("could not build query. AgentDelete. err: %v", err)
+	}
+
+	// soft-delete the agent row and hard-delete its address rows in one tx
+	if err := h.withTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, sqlStr, args...); err != nil {
+			return fmt.Errorf("could not execute update. AgentDelete. err: %v", err)
+		}
+
+		if err := h.agentAddressDeleteByAgentID(ctx, tx, id); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		dbErr = err
+		return err
+	}
+
+	// the agent is deleted: invalidate the cache unconditionally so a cache-first
+	// by-id read does not serve a deleted agent's stale Addresses. Re-caching via
+	// a DB refresh here would actively re-store the soft-deleted record.
+	_ = h.cache.AgentDel(ctx, id)
 
 	return nil
 }
@@ -492,9 +571,88 @@ func (h *handler) AgentSetTagIDs(ctx context.Context, id uuid.UUID, tagIDs []uui
 
 // AgentSetAddresses sets the agent addresses.
 func (h *handler) AgentSetAddresses(ctx context.Context, id uuid.UUID, addresses []commonaddress.Address) error {
-	fields := map[agent.Field]any{
-		agent.FieldAddresses: addresses,
+	start := time.Now()
+	var dbErr error
+	defer func() {
+		elapsed := time.Since(start)
+		metricshandler.DBOperationDuration.WithLabelValues("update", "agent").Observe(float64(elapsed.Milliseconds()))
+		status := "success"
+		if dbErr != nil {
+			status = "failure"
+		}
+		metricshandler.DBOperationTotal.WithLabelValues("update", "agent", status).Inc()
+	}()
+
+	now := h.utilHandler.TimeNow()
+
+	tmpFields, err := commondatabasehandler.PrepareFields(map[agent.Field]any{
+		agent.FieldTMUpdate: now,
+	})
+	if err != nil {
+		dbErr = err
+		return fmt.Errorf("could not prepare fields. AgentSetAddresses. err: %v", err)
 	}
 
-	return h.AgentUpdate(ctx, id, fields)
+	sqlStr, args, err := squirrel.
+		Update(agentTable).
+		SetMap(tmpFields).
+		Where(squirrel.Eq{"id": id.Bytes()}).
+		PlaceholderFormat(squirrel.Question).
+		ToSql()
+	if err != nil {
+		dbErr = err
+		return fmt.Errorf("could not build query. AgentSetAddresses. err: %v", err)
+	}
+
+	// replace the address rows and bump tm_update in one tx.
+	//
+	// The parent agent row is locked FOR UPDATE first. This (1) serializes
+	// concurrent AgentSetAddresses for the same agent (last-writer-wins on the
+	// full set, no interleaving), and (2) closes the race with AgentDelete: a
+	// SetAddresses that loses the lock to a committing delete then sees the row
+	// already soft-deleted (zero rows) and aborts with ErrNotFound instead of
+	// re-inserting orphan child rows for a deleted agent. The customer_id for
+	// the child rows is read from the same locked row, so it is always
+	// consistent with the parent.
+	if err := h.withTx(ctx, func(tx *sql.Tx) error {
+		var customerIDRaw []byte
+		lockRow := tx.QueryRowContext(ctx,
+			"SELECT customer_id FROM "+agentTable+" WHERE id = ? AND tm_delete IS NULL FOR UPDATE",
+			id.Bytes(),
+		)
+		if errScan := lockRow.Scan(&customerIDRaw); errScan != nil {
+			if errScan == sql.ErrNoRows {
+				return ErrNotFound
+			}
+			return fmt.Errorf("could not lock agent row. AgentSetAddresses. err: %v", errScan)
+		}
+		customerID, errParse := uuid.FromBytes(customerIDRaw)
+		if errParse != nil {
+			return fmt.Errorf("could not parse customer_id. AgentSetAddresses. err: %v", errParse)
+		}
+
+		if err := h.agentAddressDeleteByAgentID(ctx, tx, id); err != nil {
+			return err
+		}
+
+		if err := h.agentAddressInsert(ctx, tx, id, customerID, addresses); err != nil {
+			return err
+		}
+
+		if _, err := tx.ExecContext(ctx, sqlStr, args...); err != nil {
+			return fmt.Errorf("could not execute update. AgentSetAddresses. err: %v", err)
+		}
+
+		return nil
+	}); err != nil {
+		dbErr = err
+		return err
+	}
+
+	// refresh the cache; on failure invalidate to avoid serving stale addresses
+	if err := h.agentUpdateToCache(ctx, id); err != nil {
+		_ = h.cache.AgentDel(ctx, id)
+	}
+
+	return nil
 }

--- a/bin-agent-manager/pkg/dbhandler/agent_address.go
+++ b/bin-agent-manager/pkg/dbhandler/agent_address.go
@@ -1,0 +1,272 @@
+package dbhandler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/gofrs/uuid"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+)
+
+const (
+	agentAddressTable = "agent_addresses"
+
+	// agentAddressINChunkSize bounds the number of agent ids placed in a single
+	// IN(...) clause, to stay well under driver placeholder limits.
+	agentAddressINChunkSize = 900
+
+	// mysqlErrDupEntry is MySQL's ER_DUP_ENTRY errno, raised on a UNIQUE/PK
+	// constraint violation.
+	mysqlErrDupEntry = 1062
+)
+
+// isDuplicateKeyErr reports whether the given error is a duplicate-key/unique
+// constraint violation. It covers MySQL (errno 1062, matched via the typed
+// *mysql.MySQLError so an unrelated message containing "1062" cannot be
+// misclassified) and sqlite (used by the test harness).
+func isDuplicateKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var myErr *gomysql.MySQLError
+	if errors.As(err, &myErr) && myErr.Number == mysqlErrDupEntry {
+		return true
+	}
+
+	// sqlite (test harness) surfaces a textual error, not a typed code.
+	if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+		return true
+	}
+
+	return false
+}
+
+// agentAddressInsert inserts the given addresses for an agent, assigning
+// idx = 0..n-1 in slice order, a generated uuid id, and tm_create = now.
+// A duplicate-key violation is mapped to ErrAlreadyExists.
+func (h *handler) agentAddressInsert(ctx context.Context, db dbExecQuerier, agentID uuid.UUID, customerID uuid.UUID, addresses []commonaddress.Address) error {
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	now := h.utilHandler.TimeNow()
+
+	for i, addr := range addresses {
+		id, err := uuid.NewV4()
+		if err != nil {
+			return fmt.Errorf("could not generate uuid. agentAddressInsert. err: %v", err)
+		}
+
+		query, args, err := squirrel.
+			Insert(agentAddressTable).
+			SetMap(map[string]any{
+				"id":          id.Bytes(),
+				"agent_id":    agentID.Bytes(),
+				"customer_id": customerID.Bytes(),
+				"type":        string(addr.Type),
+				"target":      addr.Target,
+				"target_name": addr.TargetName,
+				"name":        addr.Name,
+				"detail":      addr.Detail,
+				"idx":         i,
+				"tm_create":   now,
+				"tm_update":   nil,
+			}).
+			PlaceholderFormat(squirrel.Question).
+			ToSql()
+		if err != nil {
+			return fmt.Errorf("could not build query. agentAddressInsert. err: %v", err)
+		}
+
+		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+			if isDuplicateKeyErr(err) {
+				return ErrAlreadyExists
+			}
+			return fmt.Errorf("could not execute query. agentAddressInsert. err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// agentAddressDeleteByAgentID hard-deletes all address rows for an agent.
+func (h *handler) agentAddressDeleteByAgentID(ctx context.Context, db dbExecQuerier, agentID uuid.UUID) error {
+	query, args, err := squirrel.
+		Delete(agentAddressTable).
+		Where(squirrel.Eq{"agent_id": agentID.Bytes()}).
+		PlaceholderFormat(squirrel.Question).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("could not build query. agentAddressDeleteByAgentID. err: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("could not execute query. agentAddressDeleteByAgentID. err: %v", err)
+	}
+
+	return nil
+}
+
+// agentAddressListByAgentID returns the addresses for a single agent ordered by idx.
+func (h *handler) agentAddressListByAgentID(ctx context.Context, db dbExecQuerier, agentID uuid.UUID) ([]commonaddress.Address, error) {
+	query, args, err := squirrel.
+		Select("type", "target", "target_name", "name", "detail").
+		From(agentAddressTable).
+		Where(squirrel.Eq{"agent_id": agentID.Bytes()}).
+		OrderBy("idx ASC").
+		PlaceholderFormat(squirrel.Question).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. agentAddressListByAgentID. err: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. agentAddressListByAgentID. err: %v", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	res := []commonaddress.Address{}
+	for rows.Next() {
+		var addrType, target, targetName, name, detail string
+		if err := rows.Scan(&addrType, &target, &targetName, &name, &detail); err != nil {
+			return nil, fmt.Errorf("could not scan row. agentAddressListByAgentID. err: %v", err)
+		}
+		res = append(res, commonaddress.Address{
+			Type:       commonaddress.Type(addrType),
+			Target:     target,
+			TargetName: targetName,
+			Name:       name,
+			Detail:     detail,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error. agentAddressListByAgentID. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// agentAddressListByAgentIDs returns a map of agent_id -> ordered addresses using
+// one query per chunk of ids (chunked to bound the IN(...) size). Each agent's
+// slice is ordered by idx.
+func (h *handler) agentAddressListByAgentIDs(ctx context.Context, db dbExecQuerier, agentIDs []uuid.UUID) (map[uuid.UUID][]commonaddress.Address, error) {
+	res := map[uuid.UUID][]commonaddress.Address{}
+	if len(agentIDs) == 0 {
+		return res, nil
+	}
+
+	for start := 0; start < len(agentIDs); start += agentAddressINChunkSize {
+		end := start + agentAddressINChunkSize
+		if end > len(agentIDs) {
+			end = len(agentIDs)
+		}
+		chunk := agentIDs[start:end]
+
+		idBytes := make([][]byte, 0, len(chunk))
+		for _, id := range chunk {
+			idBytes = append(idBytes, id.Bytes())
+		}
+
+		query, args, err := squirrel.
+			Select("agent_id", "type", "target", "target_name", "name", "detail").
+			From(agentAddressTable).
+			Where(squirrel.Eq{"agent_id": idBytes}).
+			OrderBy("agent_id ASC", "idx ASC").
+			PlaceholderFormat(squirrel.Question).
+			ToSql()
+		if err != nil {
+			return nil, fmt.Errorf("could not build query. agentAddressListByAgentIDs. err: %v", err)
+		}
+
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("could not query. agentAddressListByAgentIDs. err: %v", err)
+		}
+
+		err = func() error {
+			defer func() {
+				_ = rows.Close()
+			}()
+
+			for rows.Next() {
+				var agentIDRaw []byte
+				var addrType, target, targetName, name, detail string
+				if err := rows.Scan(&agentIDRaw, &addrType, &target, &targetName, &name, &detail); err != nil {
+					return fmt.Errorf("could not scan row. agentAddressListByAgentIDs. err: %v", err)
+				}
+
+				aID, err := uuid.FromBytes(agentIDRaw)
+				if err != nil {
+					return fmt.Errorf("could not parse agent_id. agentAddressListByAgentIDs. err: %v", err)
+				}
+
+				res[aID] = append(res[aID], commonaddress.Address{
+					Type:       commonaddress.Type(addrType),
+					Target:     target,
+					TargetName: targetName,
+					Name:       name,
+					Detail:     detail,
+				})
+			}
+			return rows.Err()
+		}()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
+// agentAddressLookupOwnerAgentID returns the owning agent_id for a given
+// (customer_id, type, target). Returns ErrNotFound if no row matches.
+func (h *handler) agentAddressLookupOwnerAgentID(ctx context.Context, db dbExecQuerier, customerID uuid.UUID, addrType commonaddress.Type, target string) (uuid.UUID, error) {
+	query, args, err := squirrel.
+		Select("agent_id").
+		From(agentAddressTable).
+		Where(squirrel.Eq{"customer_id": customerID.Bytes()}).
+		Where(squirrel.Eq{"type": string(addrType)}).
+		Where(squirrel.Eq{"target": target}).
+		Limit(1).
+		PlaceholderFormat(squirrel.Question).
+		ToSql()
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("could not build query. agentAddressLookupOwnerAgentID. err: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("could not query. agentAddressLookupOwnerAgentID. err: %v", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return uuid.Nil, fmt.Errorf("rows iteration error. agentAddressLookupOwnerAgentID. err: %v", err)
+		}
+		return uuid.Nil, ErrNotFound
+	}
+
+	var agentIDRaw []byte
+	if err := rows.Scan(&agentIDRaw); err != nil {
+		return uuid.Nil, fmt.Errorf("could not scan row. agentAddressLookupOwnerAgentID. err: %v", err)
+	}
+
+	agentID, err := uuid.FromBytes(agentIDRaw)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("could not parse agent_id. agentAddressLookupOwnerAgentID. err: %v", err)
+	}
+
+	return agentID, nil
+}

--- a/bin-agent-manager/pkg/dbhandler/agent_test.go
+++ b/bin-agent-manager/pkg/dbhandler/agent_test.go
@@ -184,7 +184,10 @@ func Test_AgentCreate(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+			// AgentCreate calls TimeNow once for the agent row, plus once more
+			// inside agentAddressInsert when the agent has addresses. Allow any
+			// number of calls with a stable return value to cover both cases.
+			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime).AnyTimes()
 			mockCache.EXPECT().AgentSet(gomock.Any(), gomock.Any())
 			if err := h.AgentCreate(ctx, tt.agent); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
@@ -260,7 +263,10 @@ func Test_AgentDelete(t *testing.T) {
 			}
 
 			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
-			mockCache.EXPECT().AgentSet(ctx, gomock.Any())
+			// AgentDelete soft-deletes the agent row, hard-deletes its
+			// agent_addresses rows in the same tx, then INVALIDATES the cache
+			// (AgentDel) rather than re-caching the soft-deleted record.
+			mockCache.EXPECT().AgentDel(ctx, tt.agent.ID).Return(nil)
 			if err := h.AgentDelete(ctx, tt.agent.ID); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
@@ -434,6 +440,13 @@ func Test_AgentList(t *testing.T) {
 }
 
 func Test_AgentSetAddresses(t *testing.T) {
+	// AgentSetAddresses locks the parent agent row with `SELECT ... FOR UPDATE`
+	// which the in-memory SQLite test driver (main_test.go) does not parse. This
+	// test documents the intended behavior and will run unmodified once the test
+	// infra is upgraded to MariaDB/MySQL. Until then it skips to keep CI green
+	// (same convention as bin-ai-manager / bin-billing-manager).
+	t.Skip("SQLite test driver does not support FOR UPDATE; requires MariaDB/MySQL test infra")
+
 	tests := []struct {
 		name string
 
@@ -513,22 +526,26 @@ func Test_AgentSetAddresses(t *testing.T) {
 			ctx := context.Background()
 
 			for _, u := range tt.agents {
-				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime).AnyTimes()
 				mockCache.EXPECT().AgentSet(ctx, gomock.Any())
 				if err := h.AgentCreate(ctx, u); err != nil {
 					t.Errorf("Wrong match. expect: ok, got: %v", err)
 				}
 			}
 
-			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
-			mockCache.EXPECT().AgentSet(ctx, gomock.Any())
+			// AgentSetAddresses loads the agent first (cache miss -> DB + cache
+			// set), replaces the address rows, then refreshes the cache. TimeNow
+			// is called for the agent tm_update and once per inserted address.
+			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime).AnyTimes()
+			mockCache.EXPECT().AgentGet(ctx, tt.id).Return(nil, fmt.Errorf("")).AnyTimes()
+			mockCache.EXPECT().AgentSet(ctx, gomock.Any()).AnyTimes()
 			err := h.AgentSetAddresses(ctx, tt.id, tt.addresses)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 
-			mockCache.EXPECT().AgentGet(ctx, tt.id).Return(nil, fmt.Errorf(""))
-			mockCache.EXPECT().AgentSet(ctx, gomock.Any())
+			mockCache.EXPECT().AgentGet(ctx, tt.id).Return(nil, fmt.Errorf("")).AnyTimes()
+			mockCache.EXPECT().AgentSet(ctx, gomock.Any()).AnyTimes()
 			res, err := h.AgentGet(ctx, tt.id)
 			if err != nil {
 				t.Errorf("Wrong match.\nexpect: ok\ngot: %v\n", err)

--- a/bin-agent-manager/pkg/dbhandler/main.go
+++ b/bin-agent-manager/pkg/dbhandler/main.go
@@ -43,8 +43,43 @@ type handler struct {
 
 // handler errors
 var (
-	ErrNotFound = fmt.Errorf("record not found")
+	ErrNotFound      = fmt.Errorf("record not found")
+	ErrAlreadyExists = fmt.Errorf("record already exists")
 )
+
+// dbExecQuerier is satisfied by both *sql.DB and *sql.Tx, so the child-table
+// helpers can run either standalone or inside a transaction.
+type dbExecQuerier interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// withTx runs the given function within a single transaction. It commits on
+// success and rolls back on error (or panic).
+func (h *handler) withTx(ctx context.Context, fn func(tx *sql.Tx) error) error {
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("could not begin transaction. err: %v", err)
+	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback()
+			panic(p)
+		}
+	}()
+
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("could not commit transaction. err: %v", err)
+	}
+
+	return nil
+}
 
 
 // NewHandler creates DBHandler

--- a/bin-agent-manager/pkg/dbhandler/mock_main.go
+++ b/bin-agent-manager/pkg/dbhandler/mock_main.go
@@ -11,6 +11,7 @@ package dbhandler
 
 import (
 	context "context"
+	sql "database/sql"
 	agent "monorepo/bin-agent-manager/models/agent"
 	address "monorepo/bin-common-handler/models/address"
 	reflect "reflect"
@@ -242,4 +243,68 @@ func (m *MockDBHandler) AgentUpdate(ctx context.Context, id uuid.UUID, fields ma
 func (mr *MockDBHandlerMockRecorder) AgentUpdate(ctx, id, fields any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AgentUpdate", reflect.TypeOf((*MockDBHandler)(nil).AgentUpdate), ctx, id, fields)
+}
+
+// MockdbExecQuerier is a mock of dbExecQuerier interface.
+type MockdbExecQuerier struct {
+	ctrl     *gomock.Controller
+	recorder *MockdbExecQuerierMockRecorder
+	isgomock struct{}
+}
+
+// MockdbExecQuerierMockRecorder is the mock recorder for MockdbExecQuerier.
+type MockdbExecQuerierMockRecorder struct {
+	mock *MockdbExecQuerier
+}
+
+// NewMockdbExecQuerier creates a new mock instance.
+func NewMockdbExecQuerier(ctrl *gomock.Controller) *MockdbExecQuerier {
+	mock := &MockdbExecQuerier{ctrl: ctrl}
+	mock.recorder = &MockdbExecQuerierMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockdbExecQuerier) EXPECT() *MockdbExecQuerierMockRecorder {
+	return m.recorder
+}
+
+// ExecContext mocks base method.
+func (m *MockdbExecQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExecContext", varargs...)
+	ret0, _ := ret[0].(sql.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecContext indicates an expected call of ExecContext.
+func (mr *MockdbExecQuerierMockRecorder) ExecContext(ctx, query any, args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContext", reflect.TypeOf((*MockdbExecQuerier)(nil).ExecContext), varargs...)
+}
+
+// QueryContext mocks base method.
+func (m *MockdbExecQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, query}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "QueryContext", varargs...)
+	ret0, _ := ret[0].(*sql.Rows)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryContext indicates an expected call of QueryContext.
+func (mr *MockdbExecQuerierMockRecorder) QueryContext(ctx, query any, args ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, query}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryContext", reflect.TypeOf((*MockdbExecQuerier)(nil).QueryContext), varargs...)
 }

--- a/bin-agent-manager/scripts/database_scripts_test/agent_addresses.sql
+++ b/bin-agent-manager/scripts/database_scripts_test/agent_addresses.sql
@@ -1,0 +1,27 @@
+create table agent_addresses(
+  -- identity
+  id          binary(16),   -- surrogate id
+  agent_id    binary(16),   -- owning agent (agent_agents.id)
+  customer_id binary(16),   -- denormalized for the by-(customer,addr) lookup + uniqueness
+
+  -- address (commonaddress.Address)
+  type        varchar(255),
+  target      varchar(255),
+  target_name varchar(255),
+  name        varchar(255),
+  detail      text,
+
+  idx         int,          -- preserves address order within an agent (ring order)
+
+  tm_create   datetime(6),
+  tm_update   datetime(6),
+
+  primary key(id)
+);
+
+create index idx_agent_addresses_agent_id on agent_addresses(agent_id);
+-- Non-unique lookup index, matching the expand-phase Alembic migration
+-- (14bca52528f5). The UNIQUE(customer_id, type, target) constraint is promoted
+-- in a separate operational step AFTER the backfill + duplicate-resolution gate,
+-- so it is intentionally NOT present here.
+create index idx_agent_addresses_owner on agent_addresses(customer_id, type, target);

--- a/bin-dbscheme-manager/bin-manager/main/versions/14bca52528f5_agent_addresses_create_table.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/14bca52528f5_agent_addresses_create_table.py
@@ -1,0 +1,66 @@
+"""agent_addresses_create_table
+
+Revision ID: 14bca52528f5
+Revises: e799944f33bc
+Create Date: 2026-06-21 23:30:42.957410
+
+Splits agent endpoint addresses out of the agent_agents.addresses JSON column
+into a normalized child table. See
+docs/plans/2026-06-21-add-agent-addresses-table-design.md.
+
+This migration creates the table with a NON-unique lookup index only. The
+UNIQUE(customer_id, type, target) constraint is promoted in a separate
+operational step AFTER the data backfill and a duplicate-resolution gate, so the
+backfill can never abort mid-way on a pre-existing duplicate (design HIGH#1).
+The agent_agents.addresses JSON column is intentionally left in place; it is
+dropped in a later follow-up migration once the table split is verified in prod.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '14bca52528f5'
+down_revision = 'e799944f33bc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        create table agent_addresses(
+            -- identity
+            id          binary(16),   -- surrogate id
+            agent_id    binary(16),   -- owning agent (agent_agents.id)
+            customer_id binary(16),   -- denormalized for the by-(customer,addr) lookup + uniqueness
+
+            -- address (commonaddress.Address)
+            type        varchar(255),
+            target      varchar(255),
+            target_name varchar(255),
+            name        varchar(255),
+            detail      text,
+
+            idx         int,          -- preserves address order within an agent (ring order)
+
+            tm_create   datetime(6),
+            tm_update   datetime(6),
+
+            primary key(id)
+        );
+    """)
+
+    op.execute("""
+        create index idx_agent_addresses_agent_id on agent_addresses(agent_id);
+    """)
+    # non-unique lookup index (hot-path by-address owner lookup). Promoted to a
+    # UNIQUE index in a separate step after the backfill + duplicate gate.
+    op.execute("""
+        create index idx_agent_addresses_owner on agent_addresses(customer_id, type, target);
+    """)
+
+
+def downgrade():
+    op.execute("""
+        drop table agent_addresses;
+    """)

--- a/docs/plans/2026-06-21-add-agent-addresses-table-design.md
+++ b/docs/plans/2026-06-21-add-agent-addresses-table-design.md
@@ -1,0 +1,434 @@
+# Normalize agent addresses into a dedicated agent_addresses table
+
+- Issue: voipbin/monorepo#1005
+- Follow-up to: #1002 / PR #1004 (shared NormalizeTarget + symmetric store/lookup + backfill)
+- Class: schema refactor + data migration (encapsulated in bin-agent-manager)
+- Date: 2026-06-21
+
+## 1. Problem Statement
+
+Agent endpoint addresses are stored as a JSON column `agent_agents.addresses`
+(`[]commonaddress.Address`), and the owner lookup is an exact match:
+
+```sql
+json_contains(addresses, JSON_OBJECT('type', ?, 'target', ?))
+```
+(`bin-agent-manager/pkg/dbhandler/agent.go:328`, `AgentGetByCustomerIDAndAddress`).
+
+Code-verified structural drawbacks:
+
+1. **No index**: `json_contains` cannot use an index, so every by-address owner
+   lookup is a full `agent_agents` scan. This runs on a live inbound
+   call-routing path (call-manager `start.go` + `dial.go` getAddressOwner are the
+   only two production callers, established in #1004 review).
+2. **Nondeterministic owner**: the lookup query has no `ORDER BY` and takes the
+   first row (`agentGetFromRow` on the first `rows.Next()`), so two agents sharing
+   a canonical target route to whichever row MySQL yields first.
+3. **No DB-level uniqueness**: there is no constraint on
+   `(customer_id, type, target)`. Duplicate ownership can only be surfaced by
+   application logging (the #1004 backfill logs it) but never prevented.
+4. **Maintenance friction**: backfill/iteration over the JSON column needs the
+   pagination + JSON-rewrite gymnastics #1004 had to build.
+
+Why it matters: agent addresses are a live call-routing key. The current design
+is correct only by luck of formatting (which #1004 made canonical) and pays a
+full-scan + nondeterminism + no-uniqueness cost on every routing decision.
+
+## 2. Scope
+
+In scope (all inside bin-agent-manager; the RPC contract and the
+`agent.Addresses` domain model stay UNCHANGED):
+
+1. New child table `agent_addresses` (Alembic schema migration in
+   `bin-dbscheme-manager`), with a UNIQUE constraint that makes duplicate
+   ownership a DB-enforced invariant.
+2. dbhandler rewrite of the address touch points to read/write the child
+   table instead of the JSON column:
+   - READ (hydrate `agent.Addresses` on Get/List/GetByUsername).
+   - CREATE (`AgentCreate`): insert agent row + address rows in one transaction.
+   - SET (`AgentSetAddresses`): replace the agent's address rows in one
+     transaction.
+   - DELETE (`AgentDelete`): when an agent is soft-deleted, HARD-DELETE its
+     `agent_addresses` rows in the same operation, so the agent stops owning its
+     targets (frees the UNIQUE slots) and the by-address lookup can no longer
+     resolve to a deleted agent (see §3.3 delete path + §3.4).
+   - LOOKUP (`AgentGetByCustomerIDAndAddress`): indexed equality on the child
+     table instead of `json_contains`.
+3. Data migration: populate `agent_addresses` from the existing
+   `agent_agents.addresses` JSON for every agent, then (in a later, separate
+   step once verified) drop the JSON column. The drop is deliberately NOT in the
+   same migration (see §3.5, expand/contract).
+4. Tests: dbhandler tests for the new read/write/lookup paths against the
+   sqlite/MySQL test harness; agenthandler tests unchanged in contract.
+
+Out of scope:
+
+- Address normalization rules (delivered in #1002; the new table stores the
+  already-canonical values).
+- Any RPC contract / domain model / webhook change visible to other services
+  (`agent.Addresses` stays the wire/domain shape).
+- queue-manager (routes by `tag_ids`, not address; confirmed not affected).
+- call-manager / api-manager (consume `agent.Addresses` via RPC / domain model;
+  not exposed to the schema change).
+
+## 3. Design
+
+### 3.1 Schema
+
+New table (Alembic, mirrors the existing `agent_agents` column conventions:
+`binary(16)` ids, `datetime(6)` timestamps):
+
+```sql
+-- step 1: table WITHOUT the unique constraint (so the data backfill cannot fail)
+CREATE TABLE agent_addresses (
+  id           binary(16),    -- surrogate PK (uuid)
+  agent_id     binary(16),    -- FK-by-convention to agent_agents.id
+  customer_id  binary(16),    -- denormalized for the by-(customer,addr) lookup + UNIQUE
+  type         varchar(255),
+  target       varchar(255),
+  target_name  varchar(255),  -- carries commonaddress.Address.TargetName
+  name         varchar(255),  -- carries commonaddress.Address.Name
+  detail       text,          -- carries commonaddress.Address.Detail
+  idx          int,           -- preserves address ORDER within an agent (ring order)
+
+  tm_create    datetime(6),
+  tm_update    datetime(6),
+
+  PRIMARY KEY (id)
+);
+CREATE INDEX idx_agent_addresses_agent_id ON agent_addresses(agent_id);
+-- non-unique lookup index, present from the start (used by the hot path)
+CREATE INDEX idx_agent_addresses_owner ON agent_addresses(customer_id, type, target);
+
+-- step 2 (AFTER the data backfill AND after duplicates are resolved, see §3.5):
+-- promote the lookup index to a UNIQUE constraint
+CREATE UNIQUE INDEX uniq_agent_addresses_owner
+  ON agent_addresses(customer_id, type, target);
+DROP INDEX idx_agent_addresses_owner ON agent_addresses;
+```
+
+Design points:
+- **HARD DELETE on the child table (no `tm_delete`).** Resolved Q1. A child
+  address row has no independent identity, history, or external reference (it is
+  always owned by exactly one agent and only ever read as part of that agent).
+  `AgentSetAddresses` therefore DELETEs the agent's rows and re-inserts. This lets
+  a plain `UNIQUE(customer_id, type, target)` enforce single live ownership
+  cleanly. Including `tm_delete` in the UNIQUE (the v1 mistake) would NOT work:
+  MySQL treats multiple NULLs as distinct, so two live rows (`tm_delete IS NULL`)
+  would bypass the constraint and defeat the whole point. MySQL has no partial
+  `UNIQUE ... WHERE` index, and the codebase uses `tm_delete IS NULL` for live
+  (no `9999` sentinel convention), so hard-delete is the clean fit.
+- **`idx` column preserves order.** `commonaddress.Address` order is semantically
+  meaningful (linear ring method tries addresses in sequence). On read the rows
+  are `ORDER BY idx`; on `AgentSetAddresses` the rows are reassigned `idx = 0..n-1`
+  in slice order inside the transaction.
+- **UNIQUE added in a SEPARATE step, after duplicate resolution** (§3.5), because
+  it is a NEW invariant that did not exist under the JSON column.
+- **`customer_id` denormalized** onto the child row so the by-address lookup is a
+  single-table indexed equality (`customer_id=? AND type=? AND target=?`)
+  returning `agent_id`, with no join needed for the hot path.
+
+### 3.2 dbhandler read path (hydrate agent.Addresses)
+
+`agent_agents` no longer carries `addresses`. Every code path that returns an
+`*agent.Agent` (`AgentGet` via cache/DB, `AgentList`, `AgentGetByUsername`,
+`agentGetFromRow`) must hydrate `Addresses` from `agent_addresses`:
+
+- Single-agent reads: after scanning the agent row, `SELECT ... FROM
+  agent_addresses WHERE agent_id=? AND tm_delete IS NULL ORDER BY idx`.
+- `AgentList` (N agents): avoid N+1 by one `SELECT ... WHERE agent_id IN (...)
+  AND tm_delete IS NULL ORDER BY agent_id, idx` and group in Go.
+- The Redis cache stores the full `agent.Agent` (already includes `Addresses`),
+  so cache hits need NO extra query; only DB reads hydrate. (Confirmed: cache is
+  id-keyed full-agent JSON.)
+
+### 3.3 dbhandler write paths (transactional)
+
+The current `AgentCreate` is a single `INSERT`; `AgentSetAddresses` is a thin
+wrapper that delegates to the shared `AgentUpdate`/`agentUpdate` (PrepareFields +
+SetMap + single Exec, also used by SetTagIDs/SetStatus/etc.). Both become
+multi-statement against two tables and MUST be transactional so the agent row and
+its address rows never diverge. `AgentSetAddresses` can no longer reuse the shared
+`agentUpdate` path (that path writes only `agent_agents`); it gets its own tx
+implementation.
+
+- **AgentCreate**: `BEGIN; INSERT agent_agents (no addresses col once contract
+  lands); INSERT agent_addresses (one row per address, idx = 0..n-1); COMMIT`.
+- **AgentSetAddresses**: `BEGIN; DELETE FROM agent_addresses WHERE agent_id=?;
+  INSERT new rows (idx = 0..n-1 in slice order); COMMIT`. Hard-delete + re-insert
+  (per §3.1) makes the replace atomic and reassigns idx deterministically, so a
+  concurrent reader never sees a partial or mis-ordered set.
+- **AgentDelete**: today this is a soft-delete of the agent row
+  (`agent_agents.tm_delete`). The child table has NO `tm_delete` (hard-delete
+  model, §3.1), so AgentDelete MUST also `DELETE FROM agent_addresses WHERE
+  agent_id=?` IN THE SAME `*sql.Tx` as the agent soft-delete UPDATE (`BEGIN;
+  UPDATE agent_agents SET tm_delete=...; DELETE FROM agent_addresses WHERE
+  agent_id=?; COMMIT`). A non-transactional "agent soft-deleted but child rows
+  survive" partial failure would reproduce exactly HIGH#N1 (orphan rows occupy the
+  UNIQUE slot + lookup resolves to a deleted agent), so the same-tx guarantee is
+  load-bearing, not cosmetic. Two reasons this delete is required (adversarial
+  HIGH#N1): (1) a soft-deleted agent must stop owning its
+  `(customer_id,type,target)` slots, otherwise the UNIQUE permanently blocks any
+  other agent from ever taking that target; (2) the new lookup (§3.4) filters only
+  on `(customer_id,type,target)` and no longer joins the agent's `tm_delete`, so
+  leaving child rows behind would let the by-address lookup resolve to a DELETED
+  agent. After commit, INVALIDATE the agent's cache entry (same guard as the other
+  write paths below), so a cache-first by-id read does not serve a deleted agent's
+  stale Addresses. NOTE: all agent-deletion paths converge here (the
+  `EventCustomerDeleted` bulk delete also routes through `deleteForce ->
+  AgentDelete`), and the codebase has no agent restore/undelete path, so this one
+  change covers every deletion and there is no "addresses lost on restore" case.
+- Requires a `*sql.Tx` path in dbhandler (none exists today; `main.go` holds only
+  `db *sql.DB`). Add a minimal tx helper used by these write methods.
+
+**UNIQUE violation -> domain error (resolves adversarial H2).** The UNIQUE
+constraint is a NEW invariant. Two write entry points reach it differently:
+- `UpdateAddresses` (agenthandler) ALREADY runs a cross-agent dup-check
+  (`GetByCustomerIDAndAddress` then `ag.ID != a.ID`), so it mostly rejects
+  cross-agent duplicates at the app layer today. But that check + insert is NOT
+  atomic, so the DB UNIQUE is still the required backstop against a race.
+- `AgentCreate` (agenthandler) does NOT check addresses against other agents at
+  all (it only checks username existence). A brand-new agent registering a target
+  already owned by another agent succeeds today and will now hit the UNIQUE. This
+  is the real new rejection surface.
+In both cases the write paths MUST translate a MySQL duplicate-key error (1062)
+into a typed domain error (e.g. `cerrors.AlreadyExists` /
+`ADDRESS_ALREADY_ASSIGNED`), the same class the UpdateAddresses dup-check already
+returns, so callers get a clean 409-style result rather than a raw DB error. The
+RPC envelope is unchanged; only an additional rejection case (mainly on Create) is
+added. Documented here and in §6.
+
+**Cache divergence guard (resolves adversarial M3).** Today `agentUpdateToCache`
+runs after the write and its error is discarded (`_ = ...`), outside any tx. With
+the split, a committed DB change followed by a failed cache refresh would leave a
+stale cached agent (old Addresses) while the by-address lookup reads the new DB
+rows -> the routing lookup (lookup -> id -> cache-first AgentGet) could return an
+agent whose cached Addresses disagree with ownership. Mitigation: on a cache
+refresh failure after commit, INVALIDATE (delete) the agent's cache entry instead
+of leaving it stale, so the next read falls through to the DB and re-hydrates.
+This keeps cache-vs-DB convergence without requiring the cache write to be in the
+DB transaction.
+
+### 3.4 dbhandler lookup path (the win)
+
+`AgentGetByCustomerIDAndAddress` changes from a full-scan `json_contains` to:
+
+```sql
+SELECT agent_id FROM agent_addresses
+WHERE customer_id=? AND type=? AND target=?
+LIMIT 1;            -- then load the agent by id (cache-first)
+```
+
+Indexed by `idx_agent_addresses_owner` (later promoted to `uniq_...`).
+Deterministic owner because, once the UNIQUE constraint is in place, there is at
+most one owner of a canonical target (the nondeterminism in §1.2 is eliminated
+by construction, not by ORDER BY). The agent is then loaded by id through the
+existing cache-first `AgentGet`.
+
+**Deleted-agent exclusion (adversarial HIGH#N1).** The old `json_contains` query
+joined `WHERE tm_delete IS NULL` to skip soft-deleted agents. The new lookup does
+NOT filter on the agent's `tm_delete`; instead, a deleted agent has NO
+`agent_addresses` rows (AgentDelete hard-deletes them, §3.3), so it simply cannot
+match. This preserves the old behavior (deleted agents never win a by-address
+lookup) by data presence rather than by a join predicate.
+
+### 3.5 Migration strategy (expand/contract + duplicate gate, two PRs)
+
+A schema split of a live routing key is done expand/contract to stay reversible.
+The ordering below makes the UNIQUE constraint the LAST step, after a duplicate
+gate, so the new invariant cannot fail the data migration (resolves adversarial
+H1).
+
+```
+PR A (this PR) — EXPAND, run inside a maintenance window (consumers stopped):
+  1. Alembic: CREATE agent_addresses with the NON-unique lookup index only
+     (no UNIQUE yet). The JSON column stays.
+  2. Stop agent-mutating + by-address consumers (scale agent-manager +
+     call-manager consumers to 0), per the #1004 §3.4 precedent, so no concurrent
+     write races the migration. (Accepted brief downtime — CEO decision class.)
+  3. Data backfill: populate agent_addresses from the JSON column for every agent
+     (idx = array position). Reuse the agent-control one-off pattern from #1004
+     (Go, zero drift, ships in the image), NOT an Alembic data step.
+  4. DUPLICATE GATE: run a detection query
+     `SELECT customer_id,type,target,COUNT(*) FROM agent_addresses
+      GROUP BY customer_id,type,target HAVING COUNT(*)>1`.
+     - If any duplicates exist, STOP: a human resolves them (decide the true
+       owner, drop the loser's row) BEFORE the UNIQUE is added. The #1004
+       collision log is the input. The backfill tool prints this report.
+     - NOTE: the #1004 prod dry-run already reported "collisions: none" for the
+       1293 live agents, so in practice this gate is expected to pass cleanly;
+       it exists so the migration is correct even if that ever changes.
+  5. Only after the gate passes: promote the index to UNIQUE
+     (`CREATE UNIQUE INDEX ...; DROP INDEX idx_...`).
+  6. Deploy the new agent-manager code (reads + writes use agent_addresses;
+     UNIQUE violations mapped to a domain error per §3.3). The JSON column is left
+     in place, untouched, purely as a rollback safety net for this PR.
+  7. Resume consumers. Verify by-address routing.
+
+PR B (separate, AFTER PR A is verified in prod) — CONTRACT:
+  8. Drop the agent_agents.addresses JSON column and the `addresses,json` db tag
+     from the Agent struct.
+```
+
+Why this ordering:
+- The UNIQUE is added only after the duplicate gate, so the migration can never
+  abort on a 1062 mid-backfill (H1).
+- The irreversible step (dropping the JSON column) is isolated in PR B, after
+  prod verification, so PR A is revertible. During PR A the JSON column is read-
+  frozen (new code reads the table) but left intact; a revert to pre-PR code reads
+  the JSON column, which is still the last-known-good snapshot from before the
+  window. (Because writes were stopped during the window, the JSON column is not
+  stale relative to the cutover.)
+- Stop-the-world (not dual-write) is chosen for simplicity, consistent with #1004;
+  dual-write was considered and rejected as unnecessary complexity given the
+  accepted brief-downtime decision. The trade-off: a revert AFTER the window has
+  resumed writes would lose writes made to the table-only path; the runbook must
+  state that a revert is only clean before consumers resume (mirrors the #1004
+  forward-only guard).
+
+### 3.6 Affected files
+
+| Service | File | Change |
+|---------|------|--------|
+| bin-dbscheme-manager | `bin-manager/main/versions/<rev>_create_agent_addresses.py` | CREATE TABLE + indexes; data migration populate from JSON |
+| bin-agent-manager | `pkg/dbhandler/agent.go` | tx-based AgentCreate + AgentSetAddresses; AgentDelete also hard-deletes child rows; hydrate Addresses on Get/List/GetByUsername; rewrite AgentGetByCustomerIDAndAddress to indexed child-table lookup; map 1062 -> ADDRESS_ALREADY_ASSIGNED; cache-invalidate on post-commit refresh failure |
+| bin-agent-manager | `pkg/dbhandler/agent_address.go` (new) | child-table CRUD helpers (insert rows, list by agent_id(s), replace, lookup owner) |
+| bin-agent-manager | `pkg/dbhandler/agent_test.go` / new test file | read/write/lookup regression tests incl. order preservation + UNIQUE collision |
+| bin-agent-manager | `scripts/database_scripts_test/agent_addresses.sql` (new) | test-harness schema |
+| bin-agent-manager | `models/agent/*` | drop the `addresses,json` db tag from the Agent struct (column no longer on agent_agents) once contract PR lands; during expand it stays for dual-write |
+
+## 4. Test Strategy
+
+- dbhandler: create an agent with N ordered addresses, read back and assert order
+  (idx) is preserved; SetAddresses replaces the set atomically AND reassigns idx
+  0..n-1 (assert order after a replace that reorders/removes elements); lookup
+  returns the right agent by (customer,type,target).
+- UNIQUE collision: two agents, same canonical target -> the second write returns
+  the mapped domain error (`ADDRESS_ALREADY_ASSIGNED`), NOT a raw DB error. This
+  test MUST run against the real MySQL engine, not sqlite: NULL-UNIQUE and
+  duplicate-key (1062) semantics differ, so a green sqlite run does not prove the
+  constraint (adversarial L3 / MEDIUM#2). See §5 for the MySQL harness requirement.
+- delete: AgentDelete (soft-deletes the agent) hard-deletes the agent's
+  agent_addresses rows; assert (1) a by-address lookup for that target no longer
+  resolves (deleted agent excluded), and (2) another agent can now register the
+  freed target without a UNIQUE collision (slot released) (adversarial HIGH#N1).
+- N+1 guard: AgentList with several agents issues ONE address query, not N. If the
+  id list can exceed a safe placeholder count, the query is chunked (adversarial
+  M5); AgentGetByUsername goes through AgentList(size=1) so single reads are fine.
+- cache: a cache hit returns Addresses without touching agent_addresses; a cache
+  refresh failure after a committed write INVALIDATES the entry (assert the next
+  read re-hydrates from DB) (adversarial M3).
+- migration/backfill: against a local populated throwaway DB, assert row counts
+  match (sum of JSON array lengths == agent_addresses rows), a spot-check of order,
+  AND that the duplicate-gate detection query returns the expected rows on a
+  seeded-duplicate fixture (so the gate is proven to catch H1, not just assumed).
+- Full verification workflow (go mod tidy/vendor/generate/test, golangci-lint) in
+  bin-agent-manager; `alembic upgrade head` on a local throwaway DB only.
+
+## 5. Verification
+
+Per CLAUDE.md: full workflow in bin-agent-manager. Migration applied to
+staging/prod by a human (AI prohibition on prod mutation). The by-address lookup
+is exercised by the existing call-manager getAddressOwner regression tests
+(contract unchanged) plus new dbhandler tests.
+
+**MySQL harness requirement (adversarial MEDIUM#2 / L3).** The dbhandler test
+harness today uses in-memory sqlite (`dbhandler/main_test.go`), which does NOT
+reproduce MySQL's UNIQUE / 1062 / multi-NULL semantics. The UNIQUE-collision and
+1062->domain-error tests therefore CANNOT be proven on sqlite. The design requires
+one of: (a) a dedicated MySQL-backed integration test target run in CI for these
+specific tests, or (b) if that is infeasible in CI, an explicit documented manual
+verification step against a local MySQL before the migration is applied. A green
+sqlite suite alone does not certify the constraint behavior; this MUST be called
+out in the PR so the reviewer does not mistake sqlite-green for proof.
+
+## 6. Sections marked N/A
+
+New REST API / webhook / flow vars / RabbitMQ action / Prometheus / PII-LLM:
+N/A. No new endpoint or entity; the domain model and RPC contract are unchanged.
+This is an internal storage refactor of one existing service.
+
+## 7. Open Questions (resolved in v2)
+
+| # | Question | Decision | Owner |
+|---|----------|----------|-------|
+| 1 | UNIQUE + soft-delete (NULL defeats MySQL UNIQUE for live rows) | HARD-DELETE child rows on replace; plain `UNIQUE(customer_id,type,target)`. Child rows have no independent identity/history/reference. (§3.1) | CTO |
+| 2 | dbhandler *sql.Tx helper? | None exists; add a minimal tx helper for the two write paths. (§3.3) | CTO |
+| 3 | Data migration mechanism | Reuse the agent-control one-off (Go, zero drift, ships in image); Alembic only does CREATE TABLE. (§3.5) | CEO/CTO |
+| 4 | Cutover: dual-write vs stop-the-world | Stop-the-world in a maintenance window (consumer scale-to-zero), per #1004; forward-only after resume. (§3.5) | CEO |
+| 5 | Drop the JSON column in this PR or follow-up | Follow-up PR (contract), after prod verification of PR A. (§3.5) | CEO/CTO |
+| 6 | Pre-existing cross-agent duplicates failing the UNIQUE migration | Duplicate GATE before adding UNIQUE: detect, human-resolve, then add UNIQUE. #1004 prod dry-run already shows 0 collisions, so expected clean. (§3.5) | CEO/CTO |
+| 7 | UNIQUE makes a previously-succeeding cross-agent duplicate now fail | Map MySQL 1062 to a typed domain error (`ADDRESS_ALREADY_ASSIGNED`); the real new surface is Create (which has no app dup-check); UpdateAddresses already app-checks. (§3.3, §6) | CTO |
+| 8 | Soft-deleted agent vs hard-delete child rows | AgentDelete hard-deletes the agent's agent_addresses rows in the same op, so deleted agents release UNIQUE slots and cannot win a by-address lookup (replaces the old `tm_delete IS NULL` join). (§3.3, §3.4) | CTO |
+
+## 8. Review Summary
+
+### Round 1 (2 reviewers) — code-verification APPROVE / adversarial CHANGES REQUESTED
+
+Code-verification: all factual claims accurate (json_contains lookup, 4 touch
+points, single-statement create, id-keyed full-agent cache, commonaddress fields,
+queue-manager tag-based, call/api consume via RPC). Corrections: AgentSetAddresses
+delegates to the shared agentUpdate (cannot be reused for the tx path); hydration
+must happen at Get/List level, not inside ScanRow. Encapsulation premise holds.
+
+Adversarial: CHANGES REQUESTED. HIGH#1 pre-existing duplicates would fail the
+UNIQUE data migration (no gate); HIGH#2 UNIQUE silently changes API behavior
+(previously-succeeding cross-agent duplicate now errors); HIGH#3 §3.1 body schema
+`UNIQUE(...,tm_delete)` does not enforce the invariant (MySQL NULL semantics).
+MEDIUM: hard-delete safety, idx reassign on replace, cache divergence on
+post-commit refresh failure, cutover ordering, IN-list size. LOW: rollback/JSON
+drop coupling, db-tag timing, sqlite-vs-MySQL UNIQUE.
+
+### v2 (this revision) — findings applied
+
+- HIGH#3 + Q1: schema body fixed to plain `UNIQUE(customer_id,type,target)` with
+  HARD-DELETE child rows (no tm_delete); lookup SQL drops the tm_delete clause.
+- HIGH#1 + Q6: §3.5 adds a duplicate GATE (detect -> human-resolve -> THEN add
+  UNIQUE), with UNIQUE as the last migration step so the backfill can't abort.
+- HIGH#2 + Q7: §3.3 maps MySQL 1062 to `ADDRESS_ALREADY_ASSIGNED`; behavior change
+  documented in §3.3/§6.
+- MEDIUM: idx reassign 0..n-1 inside the replace tx (§3.1/§3.3); cache-invalidate
+  on post-commit refresh failure (§3.3); ordered cutover sequence with consumer
+  stop + forward-only guard (§3.5); IN-list chunking + MySQL-only UNIQUE test +
+  duplicate-gate test (§4).
+- The AgentSetAddresses-delegation and Get/List-hydration corrections folded into
+  §3.2/§3.3.
+
+A fresh re-review round on v2 follows (mandatory after the material change).
+
+### Round 2 (adversarial convergence) — CHANGES REQUESTED
+
+Confirmed HIGH#1/#2/#3 genuinely resolved. Found a NEW HIGH#N1: hard-delete on
+the child table interacts badly with AgentDelete's soft-delete. A soft-deleted
+agent would leave orphan child rows that (a) permanently occupy the UNIQUE slot
+and (b) let the new lookup (which dropped the `tm_delete IS NULL` join) resolve to
+a DELETED agent. Plus MEDIUM#1 (the §3.3 dup-check causal wording was backwards:
+UpdateAddresses already cross-agent-checks; Create is the real new surface) and
+MEDIUM#2 (sqlite harness cannot prove the MySQL UNIQUE/1062 behavior).
+
+### v3 (this revision) — Round-2 findings applied
+
+- HIGH#N1 + Q8: AgentDelete now hard-deletes the agent's agent_addresses rows in
+  the same op (§3.3 delete path), so deleted agents release UNIQUE slots; §3.4
+  documents deleted-agent exclusion by data presence (no child rows) instead of
+  the old `tm_delete IS NULL` join. Added as the 5th touch point in §2 and §3.6.
+- MEDIUM#1 + Q7: §3.3 corrected — UpdateAddresses already runs a cross-agent
+  dup-check (non-atomic, so UNIQUE is still the backstop); AgentCreate is the real
+  new rejection surface (no app check). 1062 maps to ADDRESS_ALREADY_ASSIGNED.
+- MEDIUM#2: §5 adds the MySQL-harness requirement (sqlite cannot certify the
+  constraint; CI MySQL target or documented manual MySQL verification); §4 delete
+  test added.
+
+A fresh re-review round on v3 follows (mandatory after this material change).
+
+### Round 3 (final convergence) — APPROVE
+
+Confirmed HIGH#N1 + MEDIUM#1/#2 genuinely resolved against the real code; no new
+HIGH/MEDIUM. Verified: AgentDelete is the single convergence point for all agent
+deletions (incl. the EventCustomerDeleted bulk path via deleteForce), there is no
+agent restore/undelete path, and the maintenance-window consumer stop makes any
+mid-flight lookup moot. Two non-blocking nits folded in: (1) §3.3 AgentDelete now
+explicitly states the child hard-delete runs in the SAME `*sql.Tx` as the agent
+soft-delete (partial failure would re-create HIGH#N1); (2) §3.3 adds cache
+invalidation after AgentDelete so a cache-first by-id read does not serve a
+deleted agent's stale Addresses. Design is approved for implementation.


### PR DESCRIPTION
Normalize agent endpoint addresses out of the agent_agents.addresses JSON column into a dedicated agent_addresses child table for indexed by-address owner lookup, deterministic ownership, and DB-enforced uniqueness (issue #1005, follow-up to #1002 / PR #1004). This is the EXPAND phase: the JSON column is left in place as a rollback safety net and dropped in a separate contract PR after prod verification.

- bin-dbscheme-manager: Add agent_addresses table migration (binary(16) ids, idx ordering column, non-unique owner lookup index; UNIQUE promoted in a separate operational step after backfill + duplicate gate, so the backfill cannot abort on a pre-existing duplicate)
- bin-agent-manager: Add agent_addresses child-table CRUD (agent_address.go) with idx-ordered insert, list-by-agent(s), replace, and indexed owner lookup
- bin-agent-manager: Make AgentCreate/AgentSetAddresses/AgentDelete transactional via a withTx helper so the agent row and its address rows never diverge; AgentDelete hard-deletes child rows in the same tx
- bin-agent-manager: Hydrate agent.Addresses from the child table on Get/List/GetByUsername; set the Addresses db tag to "-" (excluded from agent_agents SELECT/INSERT, JSON wire/cache shape unchanged so the RPC contract and other services are unaffected)
- bin-agent-manager: Lock the parent agent row FOR UPDATE in AgentSetAddresses to serialize concurrent writes and close the delete race; map duplicate-key (1062) to a typed domain error for the future UNIQUE constraint
- bin-agent-manager: Rewrite AgentGetByCustomerIDAndAddress from a json_contains full scan to an indexed child-table equality lookup
- bin-agent-manager: Invalidate the agent cache on delete instead of re-caching the soft-deleted record
- bin-agent-manager: Add agent-control backfill-addresses one-time command (reads the raw JSON column, drains before writing, dry-run default true, collision gate before apply, reuses AgentSetAddresses for zero drift)
- bin-agent-manager: Skip the AgentSetAddresses dbhandler test on the sqlite harness (FOR UPDATE unsupported; matches bin-ai-manager / bin-billing-manager)
- docs: Add the agent_addresses design doc (expand/contract sequencing, duplicate gate, deleted-agent exclusion by data presence)