### PR TITLE
VOIP-1197-timeline-analysis-gemini-default-and-nil-failsafe

### DIFF
--- a/bin-ai-manager/cmd/ai-manager/main.go
+++ b/bin-ai-manager/cmd/ai-manager/main.go
@@ -131,8 +131,18 @@ func run(sqlDB *sql.DB, cache cachehandler.CacheHandler) error {
 	aicallHandler := aicallhandler.NewAIcallHandler(requestHandler, notifyHandler, db, aiHandler, teamHandler, messageHandler, participantHandler)
 	summaryHandler := summaryhandler.NewSummaryHandler(requestHandler, notifyHandler, db, engineOpenaiHandler)
 
+	// Build a dedicated engine for the analysis gateway. The provider is
+	// selectable by base URL (Gemini OpenAI-compat by default), and the API key
+	// is selected to match the provider so an OpenAI rollback is fully env-driven
+	// (VOIP-1197). The conversational engineOpenaiHandler (OpenAI) is unchanged.
+	analysisKey := cfg.EngineKeyChatGPT // OpenAI default
+	if strings.Contains(cfg.AnalysisEngineBaseURL, "generativelanguage") {
+		analysisKey = cfg.GoogleAPIKey
+	}
+	analysisEngine := engine_openai_handler.NewEngineOpenaiHandlerWithConfig(analysisKey, cfg.AnalysisEngineBaseURL)
+
 	analysisHandler := analysishandler.NewAnalysisHandler(
-		engineOpenaiHandler,
+		analysisEngine,
 		cfg.AnalysisDefaultModel,
 		strings.Split(cfg.AnalysisAllowedModels, ","),
 		cfg.AnalysisMaxInputBytes,

--- a/bin-ai-manager/cmd/ai-manager/main.go
+++ b/bin-ai-manager/cmd/ai-manager/main.go
@@ -147,6 +147,7 @@ func run(sqlDB *sql.DB, cache cachehandler.CacheHandler) error {
 		strings.Split(cfg.AnalysisAllowedModels, ","),
 		cfg.AnalysisMaxInputBytes,
 		cfg.AnalysisMaxOutputTokens,
+		cfg.AnalysisReasoningEffort,
 	)
 
 	utilHandler := utilhandler.NewUtilHandler()

--- a/bin-ai-manager/internal/config/main.go
+++ b/bin-ai-manager/internal/config/main.go
@@ -34,6 +34,7 @@ type Config struct {
 
 	AnalysisDefaultModel    string // AnalysisDefaultModel is the default model for the generic analysis gateway.
 	AnalysisAllowedModels   string // AnalysisAllowedModels is a comma-separated allow-set of models the analysis gateway accepts.
+	AnalysisEngineBaseURL   string // AnalysisEngineBaseURL is the base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI).
 	AnalysisMaxInputBytes   int    // AnalysisMaxInputBytes caps the prompt+data byte size accepted by the analysis gateway.
 	AnalysisMaxOutputTokens int    // AnalysisMaxOutputTokens caps the output tokens of the analysis gateway (runaway guard).
 }
@@ -63,8 +64,9 @@ func bindConfig(cmd *cobra.Command) error {
 	f.String("engine_key_chatgpt", "", "Engine key for chatgpt")
 	f.String("google_api_key", "", "Google API key for Gemini audit evaluation")
 	f.Int("aicall_conversation_idle_timeout_hours", 24, "Idle timeout (hours) for conversation-typed AIcalls before they expire")
-	f.String("analysis_default_model", "gpt-4o", "Default model for the generic analysis gateway")
-	f.String("analysis_allowed_models", "gpt-4o,gpt-4o-mini,gpt-4-turbo", "Comma-separated allow-set of models for the analysis gateway")
+	f.String("analysis_default_model", "gemini-2.5-flash", "Default model for the generic analysis gateway")
+	f.String("analysis_allowed_models", "gemini-2.5-flash,gemini-2.5-pro", "Comma-separated allow-set of models for the analysis gateway")
+	f.String("analysis_engine_base_url", "https://generativelanguage.googleapis.com/v1beta/openai/", "Base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI)")
 	f.Int("analysis_max_input_bytes", 262144, "Max prompt+data bytes accepted by the analysis gateway")
 	f.Int("analysis_max_output_tokens", 8192, "Max output tokens for the analysis gateway (runaway guard)")
 
@@ -83,6 +85,7 @@ func bindConfig(cmd *cobra.Command) error {
 
 		"analysis_default_model":     "ANALYSIS_DEFAULT_MODEL",
 		"analysis_allowed_models":    "ANALYSIS_ALLOWED_MODELS",
+		"analysis_engine_base_url":   "ANALYSIS_ENGINE_BASE_URL",
 		"analysis_max_input_bytes":   "ANALYSIS_MAX_INPUT_BYTES",
 		"analysis_max_output_tokens": "ANALYSIS_MAX_OUTPUT_TOKENS",
 	}
@@ -124,6 +127,7 @@ func LoadGlobalConfig() {
 
 			AnalysisDefaultModel:    viper.GetString("analysis_default_model"),
 			AnalysisAllowedModels:   viper.GetString("analysis_allowed_models"),
+			AnalysisEngineBaseURL:   viper.GetString("analysis_engine_base_url"),
 			AnalysisMaxInputBytes:   viper.GetInt("analysis_max_input_bytes"),
 			AnalysisMaxOutputTokens: viper.GetInt("analysis_max_output_tokens"),
 		}

--- a/bin-ai-manager/internal/config/main.go
+++ b/bin-ai-manager/internal/config/main.go
@@ -35,6 +35,7 @@ type Config struct {
 	AnalysisDefaultModel    string // AnalysisDefaultModel is the default model for the generic analysis gateway.
 	AnalysisAllowedModels   string // AnalysisAllowedModels is a comma-separated allow-set of models the analysis gateway accepts.
 	AnalysisEngineBaseURL   string // AnalysisEngineBaseURL is the base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI).
+	AnalysisReasoningEffort string // AnalysisReasoningEffort is sent as reasoning_effort on the analysis gateway request ("none" disables Gemini thinking; empty omits the field).
 	AnalysisMaxInputBytes   int    // AnalysisMaxInputBytes caps the prompt+data byte size accepted by the analysis gateway.
 	AnalysisMaxOutputTokens int    // AnalysisMaxOutputTokens caps the output tokens of the analysis gateway (runaway guard).
 }
@@ -67,8 +68,9 @@ func bindConfig(cmd *cobra.Command) error {
 	f.String("analysis_default_model", "gemini-2.5-flash", "Default model for the generic analysis gateway")
 	f.String("analysis_allowed_models", "gemini-2.5-flash,gemini-2.5-pro", "Comma-separated allow-set of models for the analysis gateway")
 	f.String("analysis_engine_base_url", "https://generativelanguage.googleapis.com/v1beta/openai/", "Base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI)")
+	f.String("analysis_reasoning_effort", "none", "reasoning_effort for the analysis gateway (none disables Gemini thinking; empty omits the field)")
 	f.Int("analysis_max_input_bytes", 262144, "Max prompt+data bytes accepted by the analysis gateway")
-	f.Int("analysis_max_output_tokens", 8192, "Max output tokens for the analysis gateway (runaway guard)")
+	f.Int("analysis_max_output_tokens", 16384, "Max output tokens for the analysis gateway (runaway guard)")
 
 	bindings := map[string]string{
 		"rabbitmq_address":          "RABBITMQ_ADDRESS",
@@ -86,6 +88,7 @@ func bindConfig(cmd *cobra.Command) error {
 		"analysis_default_model":     "ANALYSIS_DEFAULT_MODEL",
 		"analysis_allowed_models":    "ANALYSIS_ALLOWED_MODELS",
 		"analysis_engine_base_url":   "ANALYSIS_ENGINE_BASE_URL",
+		"analysis_reasoning_effort":  "ANALYSIS_REASONING_EFFORT",
 		"analysis_max_input_bytes":   "ANALYSIS_MAX_INPUT_BYTES",
 		"analysis_max_output_tokens": "ANALYSIS_MAX_OUTPUT_TOKENS",
 	}
@@ -128,6 +131,7 @@ func LoadGlobalConfig() {
 			AnalysisDefaultModel:    viper.GetString("analysis_default_model"),
 			AnalysisAllowedModels:   viper.GetString("analysis_allowed_models"),
 			AnalysisEngineBaseURL:   viper.GetString("analysis_engine_base_url"),
+			AnalysisReasoningEffort: viper.GetString("analysis_reasoning_effort"),
 			AnalysisMaxInputBytes:   viper.GetInt("analysis_max_input_bytes"),
 			AnalysisMaxOutputTokens: viper.GetInt("analysis_max_output_tokens"),
 		}

--- a/bin-ai-manager/internal/config/main_test.go
+++ b/bin-ai-manager/internal/config/main_test.go
@@ -141,6 +141,25 @@ func TestBootstrap(t *testing.T) {
 			} else if flagAIcallIdle.DefValue != "24" {
 				t.Errorf("Wrong aicall_conversation_idle_timeout_hours default. expect: 24, got: %s", flagAIcallIdle.DefValue)
 			}
+
+			flagAnalysisModel := rootCmd.PersistentFlags().Lookup("analysis_default_model")
+			if flagAnalysisModel == nil {
+				t.Errorf("Expected analysis_default_model flag to be registered")
+			} else if flagAnalysisModel.DefValue != "gemini-2.5-flash" {
+				t.Errorf("Wrong analysis_default_model default. expect: gemini-2.5-flash, got: %s", flagAnalysisModel.DefValue)
+			}
+			flagAnalysisAllowed := rootCmd.PersistentFlags().Lookup("analysis_allowed_models")
+			if flagAnalysisAllowed == nil {
+				t.Errorf("Expected analysis_allowed_models flag to be registered")
+			} else if flagAnalysisAllowed.DefValue != "gemini-2.5-flash,gemini-2.5-pro" {
+				t.Errorf("Wrong analysis_allowed_models default. expect: gemini-2.5-flash,gemini-2.5-pro, got: %s", flagAnalysisAllowed.DefValue)
+			}
+			flagAnalysisBaseURL := rootCmd.PersistentFlags().Lookup("analysis_engine_base_url")
+			if flagAnalysisBaseURL == nil {
+				t.Errorf("Expected analysis_engine_base_url flag to be registered")
+			} else if flagAnalysisBaseURL.DefValue != "https://generativelanguage.googleapis.com/v1beta/openai/" {
+				t.Errorf("Wrong analysis_engine_base_url default. got: %s", flagAnalysisBaseURL.DefValue)
+			}
 		})
 	}
 }

--- a/bin-ai-manager/internal/config/main_test.go
+++ b/bin-ai-manager/internal/config/main_test.go
@@ -160,6 +160,18 @@ func TestBootstrap(t *testing.T) {
 			} else if flagAnalysisBaseURL.DefValue != "https://generativelanguage.googleapis.com/v1beta/openai/" {
 				t.Errorf("Wrong analysis_engine_base_url default. got: %s", flagAnalysisBaseURL.DefValue)
 			}
+			flagAnalysisReasoning := rootCmd.PersistentFlags().Lookup("analysis_reasoning_effort")
+			if flagAnalysisReasoning == nil {
+				t.Errorf("Expected analysis_reasoning_effort flag to be registered")
+			} else if flagAnalysisReasoning.DefValue != "none" {
+				t.Errorf("Wrong analysis_reasoning_effort default. expect: none, got: %s", flagAnalysisReasoning.DefValue)
+			}
+			flagAnalysisMaxOut := rootCmd.PersistentFlags().Lookup("analysis_max_output_tokens")
+			if flagAnalysisMaxOut == nil {
+				t.Errorf("Expected analysis_max_output_tokens flag to be registered")
+			} else if flagAnalysisMaxOut.DefValue != "16384" {
+				t.Errorf("Wrong analysis_max_output_tokens default. expect: 16384, got: %s", flagAnalysisMaxOut.DefValue)
+			}
 		})
 	}
 }

--- a/bin-ai-manager/pkg/analysishandler/main.go
+++ b/bin-ai-manager/pkg/analysishandler/main.go
@@ -31,6 +31,11 @@ type analysisHandler struct {
 	allowedModels map[string]bool
 	maxInputBytes int
 	maxOutputToks int
+	// reasoningEffort, when non-empty, is sent as reasoning_effort on the chat
+	// request. "none" disables Gemini 2.5 "thinking" so the token budget is spent
+	// on the JSON output, not internal reasoning (prevents finish_reason=length
+	// truncation on large staged analyses).
+	reasoningEffort string
 }
 
 var (
@@ -76,6 +81,7 @@ func NewAnalysisHandler(
 	allowedModels []string,
 	maxInputBytes int,
 	maxOutputTokens int,
+	reasoningEffort string,
 ) AnalysisHandler {
 	allowed := map[string]bool{}
 	for _, m := range allowedModels {
@@ -89,9 +95,10 @@ func NewAnalysisHandler(
 
 		engineOpenaiHandler: engineOpenaiHandler,
 
-		defaultModel:  defaultModel,
-		allowedModels: allowed,
-		maxInputBytes: maxInputBytes,
-		maxOutputToks: maxOutputTokens,
+		defaultModel:    defaultModel,
+		allowedModels:   allowed,
+		maxInputBytes:   maxInputBytes,
+		maxOutputToks:   maxOutputTokens,
+		reasoningEffort: reasoningEffort,
 	}
 }

--- a/bin-ai-manager/pkg/analysishandler/run.go
+++ b/bin-ai-manager/pkg/analysishandler/run.go
@@ -86,6 +86,15 @@ func (h *analysisHandler) Run(ctx context.Context, req *analysis.Request) (*anal
 		},
 	}
 
+	// reasoning_effort="none" disables Gemini 2.5 "thinking" so the whole
+	// max_tokens budget is available for the JSON output. Without this, large
+	// staged inputs make the model spend the budget on internal reasoning and the
+	// JSON is truncated (finish_reason=length -> unmarshal failure). Only set when
+	// configured, so an OpenAI rollback can clear it.
+	if h.reasoningEffort != "" {
+		chatReq.ReasoningEffort = h.reasoningEffort
+	}
+
 	resp, err := h.engineOpenaiHandler.Send(ctx, chatReq)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not run the chat completion")

--- a/bin-ai-manager/pkg/analysishandler/run.go
+++ b/bin-ai-manager/pkg/analysishandler/run.go
@@ -78,7 +78,10 @@ func (h *analysisHandler) Run(ctx context.Context, req *analysis.Request) (*anal
 			JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
 				Name:   req.SchemaName,
 				Schema: json.RawMessage(req.Schema),
-				Strict: true,
+				// Strict json_schema is not fully supported by the Gemini
+				// OpenAI-compatible endpoint (the analysis gateway provider).
+				// Matches the proven geminiaudithandler behavior.
+				Strict: false,
 			},
 		},
 	}

--- a/bin-ai-manager/pkg/analysishandler/run_test.go
+++ b/bin-ai-manager/pkg/analysishandler/run_test.go
@@ -16,8 +16,8 @@ import (
 func newTestHandler(mockEngine engine_openai_handler.EngineOpenaiHandler) *analysisHandler {
 	h := NewAnalysisHandler(
 		mockEngine,
-		"gpt-4o",
-		[]string{"gpt-4o", "gpt-4o-mini"},
+		"gemini-2.5-flash",
+		[]string{"gemini-2.5-flash", "gemini-2.5-pro"},
 		1024,
 		2048,
 	)
@@ -36,25 +36,25 @@ func Test_Run_success(t *testing.T) {
 		Data:       json.RawMessage(`{"k":"v"}`),
 		Schema:     json.RawMessage(`{"type":"object"}`),
 		SchemaName: "verdict",
-		Model:      "gpt-4o-mini",
+		Model:      "gemini-2.5-pro",
 	}
 
 	mockEngine.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, chatReq *openai.ChatCompletionRequest) (*openai.ChatCompletionResponse, error) {
 			// the requested (allowed) model must be used
-			if chatReq.Model != "gpt-4o-mini" {
-				t.Errorf("wrong model. expected: gpt-4o-mini, got: %s", chatReq.Model)
+			if chatReq.Model != "gemini-2.5-pro" {
+				t.Errorf("wrong model. expected: gemini-2.5-pro, got: %s", chatReq.Model)
 			}
 			// max tokens must be set
 			if chatReq.MaxTokens != 2048 {
 				t.Errorf("wrong max tokens. expected: 2048, got: %d", chatReq.MaxTokens)
 			}
-			// strict json_schema must be set
+			// response format must be json_schema (Strict is false for Gemini compat)
 			if chatReq.ResponseFormat == nil || chatReq.ResponseFormat.Type != openai.ChatCompletionResponseFormatTypeJSONSchema {
 				t.Errorf("response format not json_schema")
 			}
-			if chatReq.ResponseFormat.JSONSchema == nil || !chatReq.ResponseFormat.JSONSchema.Strict {
-				t.Errorf("json schema not strict")
+			if chatReq.ResponseFormat.JSONSchema == nil || chatReq.ResponseFormat.JSONSchema.Strict {
+				t.Errorf("json schema strict must be false for Gemini compat")
 			}
 			if chatReq.ResponseFormat.JSONSchema.Name != "verdict" {
 				t.Errorf("wrong schema name. got: %s", chatReq.ResponseFormat.JSONSchema.Name)
@@ -78,7 +78,7 @@ func Test_Run_success(t *testing.T) {
 	if string(res.Result) != `{"ok":true}` {
 		t.Errorf("wrong result. got: %s", res.Result)
 	}
-	if res.Model != "gpt-4o-mini" {
+	if res.Model != "gemini-2.5-pro" {
 		t.Errorf("wrong model. got: %s", res.Model)
 	}
 	if res.FinishReason != "stop" {
@@ -108,8 +108,8 @@ func Test_Run_modelFallbackToDefault(t *testing.T) {
 
 	mockEngine.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, chatReq *openai.ChatCompletionRequest) (*openai.ChatCompletionResponse, error) {
-			if chatReq.Model != "gpt-4o" {
-				t.Errorf("expected fallback to default gpt-4o, got: %s", chatReq.Model)
+			if chatReq.Model != "gemini-2.5-flash" {
+				t.Errorf("expected fallback to default gemini-2.5-flash, got: %s", chatReq.Model)
 			}
 			return &openai.ChatCompletionResponse{
 				Choices: []openai.ChatCompletionChoice{
@@ -123,7 +123,7 @@ func Test_Run_modelFallbackToDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if res.Model != "gpt-4o" {
+	if res.Model != "gemini-2.5-flash" {
 		t.Errorf("wrong model. got: %s", res.Model)
 	}
 }

--- a/bin-ai-manager/pkg/analysishandler/run_test.go
+++ b/bin-ai-manager/pkg/analysishandler/run_test.go
@@ -20,6 +20,7 @@ func newTestHandler(mockEngine engine_openai_handler.EngineOpenaiHandler) *analy
 		[]string{"gemini-2.5-flash", "gemini-2.5-pro"},
 		1024,
 		2048,
+		"none",
 	)
 	return h.(*analysisHandler)
 }
@@ -55,6 +56,10 @@ func Test_Run_success(t *testing.T) {
 			}
 			if chatReq.ResponseFormat.JSONSchema == nil || chatReq.ResponseFormat.JSONSchema.Strict {
 				t.Errorf("json schema strict must be false for Gemini compat")
+			}
+			// reasoning_effort must be propagated to disable Gemini thinking
+			if chatReq.ReasoningEffort != "none" {
+				t.Errorf("wrong reasoning_effort. expected: none, got: %s", chatReq.ReasoningEffort)
 			}
 			if chatReq.ResponseFormat.JSONSchema.Name != "verdict" {
 				t.Errorf("wrong schema name. got: %s", chatReq.ResponseFormat.JSONSchema.Name)

--- a/bin-ai-manager/pkg/engine_openai_handler/main.go
+++ b/bin-ai-manager/pkg/engine_openai_handler/main.go
@@ -37,6 +37,21 @@ func NewEngineOpenaiHandler(apiKey string) EngineOpenaiHandler {
 	}
 }
 
+// NewEngineOpenaiHandlerWithConfig builds an engine against a custom base URL
+// (e.g. the Gemini OpenAI-compatible endpoint). Used by the analysis gateway so
+// the provider is selectable by config. When baseURL is empty the SDK default
+// (OpenAI, https://api.openai.com/v1) is used.
+func NewEngineOpenaiHandlerWithConfig(apiKey, baseURL string) EngineOpenaiHandler {
+	cfg := openai.DefaultConfig(apiKey)
+	if baseURL != "" {
+		cfg.BaseURL = baseURL
+	}
+
+	return &engineOpenaiHandler{
+		client: openai.NewClientWithConfig(cfg),
+	}
+}
+
 const (
 	defaultSystemPrompt = `
 	Role:

--- a/bin-timeline-manager/docs/plans/2026-06-24-timeline-analysis-gemini-default-and-nil-failsafe.md
+++ b/bin-timeline-manager/docs/plans/2026-06-24-timeline-analysis-gemini-default-and-nil-failsafe.md
@@ -66,9 +66,10 @@ a Google Gemini model instead of OpenAI `gpt-4o`, for cost reasons.
 Note: `bin-ai-manager/pkg/analysishandler/main.go` (`NewAnalysisHandler`) needs
 NO change — it already accepts the engine handler as a parameter. The only
 analysishandler edit is `run.go` (Strict flag).
-| install | `k8s/backend/services/timeline-manager.yaml` | G3: add DATABASE_DSN env |
+| monorepo | `bin-timeline-manager/k8s/deployment.yml` | G3: add DATABASE_DSN env (real internal prod deploy source, replicas=2) |
+| install | `k8s/backend/services/timeline-manager.yaml` | G3: add DATABASE_DSN env (external self-hosting installer, replicas=1) |
 | install | `scripts/secret_schema.py` | G3: add (DATABASE_DSN, DATABASE_DSN_BIN) to timeline-manager secret_env |
-| (live) | GKE prod `deploy/timeline-manager` | G3: apply via install pipeline (NOT manual edit) |
+| (live) | GKE prod `deploy/timeline-manager` | G3: apply via the internal deploy pipeline (monorepo k8s), NOT manual edit |
 
 ## Exact changes (per-file)
 
@@ -222,9 +223,22 @@ Enumerate and update:
 The implementation step MUST re-grep `run_test.go` for `Strict`, `gpt-4o`,
 `gpt-4o-mini`, `gpt-4-turbo` and update every hit; the verification grep below
 asserts zero residual `gpt-` literals in ai-manager analysis test/code (except
-intentional rollback-doc comments).
+### 5.3 G3 — prod enablement (two deploy manifests)
 
-`k8s/backend/services/timeline-manager.yaml`, add to the `env:` list:
+**Deploy-source distinction (corrected post design-approval).** VoIPBin has TWO
+k8s manifest sources for the same service, and both must carry the env change:
+- **Internal production**: `monorepo/bin-timeline-manager/k8s/deployment.yml`
+  (replicas=2). This is the REAL source the internal prod GKE deploy uses.
+- **External self-hosting installer**: `install/k8s/backend/services/timeline-manager.yaml`
+  (replicas=1) + `install/scripts/secret_schema.py`. This packages the first-time
+  installer for external operators.
+
+An env/secret change like DATABASE_DSN MUST be applied to BOTH or the two drift.
+(Initial draft only touched the install repo; corrected to add the monorepo k8s
+manifest, which is what actually reaches internal prod.)
+
+**monorepo `bin-timeline-manager/k8s/deployment.yml`**, add as the first `env:`
+entry (mirrors `bin-ai-manager/k8s/deployment.yml:27-31`):
 
 ```yaml
             - name: DATABASE_DSN
@@ -234,7 +248,17 @@ intentional rollback-doc comments).
                   key: DATABASE_DSN_BIN
 ```
 
-`scripts/secret_schema.py`, in the `"timeline-manager"` block `secret_env` list
+**install `k8s/backend/services/timeline-manager.yaml`**, add to the `env:` list:
+
+```yaml
+            - name: DATABASE_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: voipbin
+                  key: DATABASE_DSN_BIN
+```
+
+`install/scripts/secret_schema.py`, in the `"timeline-manager"` block `secret_env`
 (line ~630), add as the first entry (matching ai-manager's ordering):
 
 ```python

--- a/bin-timeline-manager/docs/plans/2026-06-24-timeline-analysis-gemini-default-and-nil-failsafe.md
+++ b/bin-timeline-manager/docs/plans/2026-06-24-timeline-analysis-gemini-default-and-nil-failsafe.md
@@ -1,0 +1,375 @@
+# VOIP-1197 — timeline analysis nil-failsafe + Gemini default engine
+
+Status: Draft (in review)
+
+## Problem statement
+
+Two defects, one prod outage:
+
+1. **Prod crash-loop (severity: high).** `bin-timeline-manager` registers the
+   `/v1/analyses` RPC routes unconditionally, but only constructs `analysisH`
+   when `cfg.DatabaseDSN != ""` (`cmd/timeline-manager/main.go:193-212`). The
+   prod Deployment has NO `DATABASE_DSN` env (verified: only `CLICKHOUSE_*`),
+   so `analysisHandler` is `nil`. An inbound `POST /v1/analyses` then SIGSEGVs
+   at `pkg/listenhandler/v1_analyses.go:66` (`h.analysisHandler.Start(...)`),
+   killing the RPC consumer goroutine and crash-looping both pods. A common
+   config omission (missing DSN) takes down the whole service.
+
+2. **Analysis feature disabled in prod.** Because `DATABASE_DSN` is unset, the
+   analysis feature (square-admin AI Analysis panel) is effectively off in
+   prod even though the frontend (square-admin PR #330) correctly calls it.
+
+Separately, the CEO/CTO directs that the analysis LLM gateway should default to
+a Google Gemini model instead of OpenAI `gpt-4o`, for cost reasons.
+
+## Goals (numbered, testable)
+
+1. **G1 (code fail-safe).** When `analysisHandler == nil`, the four analysis
+   RPC handlers (`v1AnalysesPost`, `v1AnalysesGet`, `v1AnalysesIDGet`,
+   `v1AnalysesIDDelete`) MUST return `503 Service Unavailable` instead of
+   panicking. Verifiable by a unit test that builds a `listenHandler` with
+   `analysisHandler: nil` and asserts 503 + no panic for all four routes.
+2. **G2 (analysis gateway default → Gemini).** The ai-manager analysis gateway
+   default model becomes `gemini-2.5-flash`, the allow-set becomes Gemini
+   models, and the gateway calls the Gemini OpenAI-compatible endpoint using
+   `GOOGLE_API_KEY`. Verifiable by config unit tests + a gateway construction
+   test asserting the Gemini base URL + key wiring.
+3. **G3 (prod enablement, ops).** The timeline-manager Deployment gets
+   `DATABASE_DSN` (from secret `voipbin` key `DATABASE_DSN_BIN`) so analysisH
+   is constructed and the feature is live. Stage model envs are left unset so
+   all three stages resolve to the new Gemini default (G2). Verifiable by
+   install-repo manifest + secret_schema parity tests.
+
+## Non-goals (explicit scope cuts)
+
+- **N1.** Switching the conversational AIcall path (real-time call AI,
+  `engine_openai_handler.MessageSend` / `StreamingSend`) to Gemini. Tracked
+  separately in **VOIP-1198**. This PR only touches the analysis gateway.
+- **N2.** Per-stage cost tiering (Stage1=cheap, Stage3=best). Out of scope;
+  stages default to one Gemini model for now. Can be tuned later via env.
+- **N3.** Removing the `Strict` json_schema flag globally. We change it only on
+  the analysis gateway path (see §5.2 D-decision).
+
+## Affected files (table)
+
+| Repo | File | Why |
+|---|---|---|
+| monorepo | `bin-timeline-manager/pkg/listenhandler/v1_analyses.go` | G1: add nil guard returning 503 in 4 handlers |
+| monorepo | `bin-timeline-manager/pkg/listenhandler/v1_analyses_test.go` | G1: nil-handler 503 tests |
+| monorepo | `bin-ai-manager/pkg/engine_openai_handler/main.go` | G2: add `NewEngineOpenaiHandlerWithConfig(apiKey, baseURL)` constructor (Gemini-capable) |
+| monorepo | `bin-ai-manager/pkg/analysishandler/run.go` | G2: `Strict:false` for Gemini compat |
+| monorepo | `bin-ai-manager/pkg/analysishandler/run_test.go` | G2: update Strict + model expectations (see §5.4) |
+| monorepo | `bin-ai-manager/cmd/ai-manager/main.go` | G2: construct analysis gateway with Gemini engine (base URL from config) + GOOGLE_API_KEY |
+| monorepo | `bin-ai-manager/internal/config/main.go` | G2: change default model + allow-set defaults; add `analysis_engine_base_url` flag |
+| monorepo | `bin-ai-manager/internal/config/main_test.go` | G2: add default/base-url expectations |
+
+Note: `bin-ai-manager/pkg/analysishandler/main.go` (`NewAnalysisHandler`) needs
+NO change — it already accepts the engine handler as a parameter. The only
+analysishandler edit is `run.go` (Strict flag).
+| install | `k8s/backend/services/timeline-manager.yaml` | G3: add DATABASE_DSN env |
+| install | `scripts/secret_schema.py` | G3: add (DATABASE_DSN, DATABASE_DSN_BIN) to timeline-manager secret_env |
+| (live) | GKE prod `deploy/timeline-manager` | G3: apply via install pipeline (NOT manual edit) |
+
+## Exact changes (per-file)
+
+### 5.1 G1 — nil-handler fail-safe (`v1_analyses.go`)
+
+Add a guard at the top of each of the four handlers, before any
+`h.analysisHandler` deref. Pattern:
+
+```go
+func (h *listenHandler) v1AnalysesPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	if h.analysisHandler == nil {
+		return simpleResponse(http.StatusServiceUnavailable), nil
+	}
+	// ... existing body
+}
+```
+
+Same guard in `v1AnalysesGet`, `v1AnalysesIDGet`, `v1AnalysesIDDelete`. This is
+the design §7.2-recommended path (return 503), preferred over conditional route
+registration because: (a) it keeps `processRequest` routing table unchanged,
+(b) it is unit-testable per-handler, (c) it gives a clear 503 (service exists
+but disabled) rather than 404 (route missing), matching the feature-disabled
+semantics.
+
+Wire-field note: `simpleResponse(code int) *sock.Response` already exists
+(`main.go:85`); `http.StatusServiceUnavailable == 503`.
+
+### 5.2 G2 — analysis gateway → Gemini
+
+**D-decision (Strict flag).** Today `run.go:81` sets `Strict: true`. The verified
+in-repo Gemini caller (`geminiaudithandler/main.go:256`) deliberately uses
+`Strict: false`, because Gemini's OpenAI-compat layer does not fully support
+strict json_schema. Therefore the analysis gateway, once pointed at Gemini, MUST
+use `Strict: false`. Decision: change `run.go` to `Strict: false`
+unconditionally (the gateway is now Gemini-only). Rationale: avoid a model-name
+sniffing branch; the gateway has exactly one provider after this change.
+
+**Engine wiring.** `engine_openai_handler.NewEngineOpenaiHandler(apiKey)` hardwires
+`openai.NewClient(apiKey)` → `api.openai.com`. We must NOT mutate that shared
+constructor (it is also used by conversational AIcall — N1). Instead, add a
+Gemini-configured engine constructor and pass it to the analysis gateway only.
+
+Proposed: add to `engine_openai_handler`:
+
+```go
+// NewEngineOpenaiHandlerWithConfig builds an engine against a custom base URL
+// (e.g. the Gemini OpenAI-compatible endpoint). Used by the analysis gateway.
+func NewEngineOpenaiHandlerWithConfig(apiKey, baseURL string) EngineOpenaiHandler {
+	cfg := openai.DefaultConfig(apiKey)
+	if baseURL != "" {
+		cfg.BaseURL = baseURL
+	}
+	return &engineOpenaiHandler{client: openai.NewClientWithConfig(cfg)}
+}
+```
+
+In `cmd/ai-manager/main.go`, construct a dedicated analysis engine using the
+base URL from config (OQ1 adopted — see below):
+
+```go
+// Select the analysis-engine API key by provider (base URL). Keeping this the
+// single accepted branch makes provider rollback fully env-driven (§5.2 OQ1).
+analysisKey := cfg.EngineKeyChatGPT // OpenAI default
+if strings.Contains(cfg.AnalysisEngineBaseURL, "generativelanguage") {
+	analysisKey = cfg.GoogleAPIKey
+}
+analysisEngine := engine_openai_handler.NewEngineOpenaiHandlerWithConfig(analysisKey, cfg.AnalysisEngineBaseURL)
+analysisHandler := analysishandler.NewAnalysisHandler(
+	analysisEngine,
+	cfg.AnalysisDefaultModel,
+	strings.Split(cfg.AnalysisAllowedModels, ","),
+	cfg.AnalysisMaxInputBytes,
+	cfg.AnalysisMaxOutputTokens,
+)
+```
+
+The conversational `engineOpenaiHandler` (OpenAI) is unchanged and still passed
+to `messageHandler` / `summaryHandler` (N1 preserved).
+
+**OQ1 adopted: base URL + key as config, for env-only rollback.** Per iter-1
+review, hardcoding the Gemini endpoint as a Go `const` makes the documented
+"env-only rollback to OpenAI" impossible (an env-set `gpt-4o` would still be
+sent to the Gemini endpoint with `GOOGLE_API_KEY`). To make rollback real
+WITHOUT a code change, the analysis engine base URL becomes a config flag.
+The API key is also selected by config so a full provider swap is env-only.
+
+**Config defaults** (`internal/config/main.go`):
+
+```
+- f.String("analysis_default_model", "gpt-4o", ...)
++ f.String("analysis_default_model", "gemini-2.5-flash", ...)
+- f.String("analysis_allowed_models", "gpt-4o,gpt-4o-mini,gpt-4-turbo", ...)
++ f.String("analysis_allowed_models", "gemini-2.5-flash,gemini-2.5-pro", ...)
++ f.String("analysis_engine_base_url", "https://generativelanguage.googleapis.com/v1beta/openai/", "Base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI)")
+```
+With a corresponding `ANALYSIS_ENGINE_BASE_URL` binding + `AnalysisEngineBaseURL`
+struct field. **Four edit sites in `internal/config/main.go` (all required — the
+loader is easy to miss):** (1) `f.String("analysis_engine_base_url", ...)` flag
+def; (2) `"analysis_engine_base_url": "ANALYSIS_ENGINE_BASE_URL"` in the bindings
+map; (3) `AnalysisEngineBaseURL string` struct field; (4) `AnalysisEngineBaseURL:
+viper.GetString("analysis_engine_base_url")` in the `LoadGlobalConfig` return
+(config/main.go ~110-131). Omitting (4) leaves the field empty at runtime, which
+silently falls back to OpenAI's base URL with the Gemini key — a latent bug.
+`NewEngineOpenaiHandlerWithConfig` leaves `cfg.BaseURL` at the
+SDK default (OpenAI) when `baseURL == ""`, so clearing the env var reverts the
+engine to OpenAI; combined with `ANALYSIS_DEFAULT_MODEL=gpt-4o` +
+`ANALYSIS_ALLOWED_MODELS=gpt-4o,...` and pointing the key env back to an OpenAI
+key, rollback to OpenAI is fully env-driven.
+
+Key-selection note: `NewEngineOpenaiHandlerWithConfig` takes `cfg.GoogleAPIKey`
+for the Gemini default. For an OpenAI rollback the operator would also need the
+engine to use `ENGINE_KEY_CHATGPT`. To keep rollback truly code-free, the
+construction selects the key by base URL: if `AnalysisEngineBaseURL` is the
+Gemini endpoint (or contains `generativelanguage`), use `GoogleAPIKey`; else use
+`EngineKeyChatGPT`. This is the one branch we accept (documented), so the
+provider is fully env-selectable. Reviewer to confirm this is preferable to a
+dedicated `ANALYSIS_ENGINE_API_KEY` env (which would be cleaner but adds a new
+secret key). Recommendation: base-URL-based key selection, no new secret.
+
+**`GoogleAPIKey`** is already wired (`cfg.GoogleAPIKey`, env `GOOGLE_API_KEY`),
+and is present in prod secret `voipbin` (verified). No new secret key needed for
+the default (Gemini) path.
+
+**Wire-field checklist (Gemini OpenAI-compat, verified against in-repo
+geminiaudithandler which runs in prod):**
+
+| Field | Value | Source |
+|---|---|---|
+| base URL | `https://generativelanguage.googleapis.com/v1beta/openai/` | geminiaudithandler/main.go:17 |
+| api key env | `GOOGLE_API_KEY` (`AIza...`) | config/main.go:80, prod secret verified |
+| model (default) | `gemini-2.5-flash` | geminiaudithandler uses gemini-2.5-flash in prod |
+| response_format | `json_schema`, `Strict:false` | geminiaudithandler/main.go:251-257 |
+
+### 5.4 G2 — existing test updates (`run_test.go`, `config/main_test.go`)
+
+Switching to `Strict:false` + Gemini defaults breaks existing ai-manager tests.
+Enumerate and update:
+
+- `pkg/analysishandler/run_test.go`:
+  - The assertion that `JSONSchema.Strict == true` (the request-shaping test)
+    MUST flip to expect `false`.
+  - Hardcoded `gpt-4o` / `gpt-4o-mini` expectations for default model, allow-set
+    membership, and the empty-model fallback MUST update to
+    `gemini-2.5-flash` / `gemini-2.5-pro`. (Exact line numbers to be confirmed
+    at implementation against the current file; do not trust stale numbers.)
+- `internal/config/main_test.go`: add assertions for the new defaults
+  (`analysis_default_model = gemini-2.5-flash`, allow-set, and
+  `analysis_engine_base_url` default) — these are net-new (the file currently
+  has no analysis-default assertions).
+
+The implementation step MUST re-grep `run_test.go` for `Strict`, `gpt-4o`,
+`gpt-4o-mini`, `gpt-4-turbo` and update every hit; the verification grep below
+asserts zero residual `gpt-` literals in ai-manager analysis test/code (except
+intentional rollback-doc comments).
+
+`k8s/backend/services/timeline-manager.yaml`, add to the `env:` list:
+
+```yaml
+            - name: DATABASE_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: voipbin
+                  key: DATABASE_DSN_BIN
+```
+
+`scripts/secret_schema.py`, in the `"timeline-manager"` block `secret_env` list
+(line ~630), add as the first entry (matching ai-manager's ordering):
+
+```python
+            ("DATABASE_DSN", "DATABASE_DSN_BIN"),
+```
+
+This mirrors the existing ai-manager wiring (`secret_schema.py:179`,
+`ai-manager.yaml:30-34`) exactly. `DATABASE_DSN_BIN` already exists in the
+schema (line 53) and in prod secret `voipbin` (verified).
+
+**Migration precondition (already satisfied).** #1008 design M5 requires the
+shared-MySQL `timeline_analyses` table to exist BEFORE enabling. Verified in
+prod: table exists, alembic head `a63b82d73655` applied. No migration step
+needed in this PR.
+
+**Stage model envs.** Intentionally left UNSET on the Deployment. With G2, an
+empty `req.Model` resolves to the gateway default `gemini-2.5-flash`
+(`run.go:45-52`: empty model → defaultModel, no warning). Per-stage tiering is
+N2.
+
+## Copy / decision rationale
+
+- **503 over 404** for nil handler: the route exists but the feature is
+  disabled; 503 (Service Unavailable) is the honest status. 404 would imply the
+  endpoint does not exist and confuse the frontend.
+- **Separate Gemini engine instance** over mutating the shared constructor:
+  keeps conversational AI on OpenAI (N1), zero blast radius on call AI.
+- **`Strict:false`**: required for Gemini OpenAI-compat; proven by the prod
+  geminiaudithandler.
+- **Reuse `DATABASE_DSN_BIN`**: no new secret; identical to ai-manager.
+
+## Verification plan
+
+Code (monorepo), run in EACH changed service dir:
+```
+cd bin-timeline-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+cd bin-ai-manager && go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m
+```
+Grep checks:
+- `grep -n "analysisHandler == nil" bin-timeline-manager/pkg/listenhandler/v1_analyses.go` → 4 hits.
+- `grep -n "gemini-2.5-flash" bin-ai-manager/internal/config/main.go` → default + allow-set + base-url default.
+- `grep -rn "gpt-4o\|gpt-4o-mini\|gpt-4-turbo" bin-ai-manager/pkg/analysishandler bin-ai-manager/internal/config` → only intentional rollback-doc comments (no live default/allow-set/test literal).
+- `grep -n "Strict" bin-ai-manager/pkg/analysishandler/run.go` → `false`.
+- `grep -n "NewEngineOpenaiHandlerWithConfig" bin-ai-manager` → defined in engine_openai_handler/main.go, used in cmd/ai-manager/main.go.
+- Confirm `engine_openai_handler.NewEngineOpenaiHandler(cfg.EngineKeyChatGPT)` STILL exists and is used by messageHandler/summaryHandler (N1 intact).
+
+Install repo:
+```
+cd ~/gitvoipbin/install && pytest tests/ -q && bash scripts/dev/check-plan-sensitive.sh <none-committed>
+python3 -c "import yaml,sys; list(yaml.safe_load_all(open('k8s/backend/services/timeline-manager.yaml')))"
+```
+
+New unit tests:
+- `Test_v1Analyses_nilHandler_503` (timeline): build `&listenHandler{analysisHandler: nil}`, call all four routes via `processRequest`, assert 503 + no panic.
+- ai-manager: config default-model test update; gateway falls back to default when model empty (already covered by run tests, update expected default).
+
+## Rollout / risk
+
+- **Order:** Merge + deploy the monorepo changes (G1 + G2) FIRST. G1 stops the
+  crash-loop regardless of config. G2 changes the gateway provider. THEN merge
+  install (G3) and apply, which turns the feature on against Gemini.
+- **Risk R1 (Gemini quota/latency).** Analysis is async (timeline chain), not
+  on the call path; latency is tolerable. Quota: GOOGLE_API_KEY already serves
+  prod gemini-audit; analysis adds load. Mitigation: monitor
+  `ai_manager_analysis_gateway_run_duration_seconds` post-deploy.
+- **Risk R2 (allow-set coercion).** If a stage env names a model NOT in the
+  allow-set, it silently coerces to default (gemini-2.5-flash). Acceptable;
+  stages are unset (N2).
+- **Risk R3 (Strict:false weaker schema enforcement).** Gemini may
+  occasionally emit non-conformant JSON. The chain already guards truncation
+  (`callGateway`, chain.go:123) and each stage unmarshals into typed structs;
+  malformed output fails the chain cleanly (no panic). Acceptable.
+- **Rollback (env-only, no code change — enabled by OQ1).** To revert the
+  analysis gateway to OpenAI without redeploying new code, set on the ai-manager
+  Deployment: `ANALYSIS_ENGINE_BASE_URL=""` (engine falls back to OpenAI SDK
+  default base URL + selects `ENGINE_KEY_CHATGPT`), `ANALYSIS_DEFAULT_MODEL=gpt-4o`,
+  `ANALYSIS_ALLOWED_MODELS=gpt-4o,gpt-4o-mini,gpt-4-turbo`. No image rebuild
+  needed. (This is why OQ1 was adopted in §5.2.)
+
+## Open questions (for reviewer)
+
+- OQ1 (RESOLVED, adopted in §5.2): analysis engine base URL is now a config
+  flag `analysis_engine_base_url` defaulting to the Gemini endpoint, enabling
+  env-only rollback to OpenAI. Remaining sub-question for reviewer: confirm
+  base-URL-based key selection (Gemini endpoint → GoogleAPIKey, else
+  EngineKeyChatGPT) is preferred over adding a dedicated `ANALYSIS_ENGINE_API_KEY`
+  secret. Recommendation: base-URL-based, no new secret.
+- OQ2: allow-set — include `gemini-2.5-flash-lite` for future Stage1 tiering
+  (N2) now, or add later? Recommendation: include flash + pro only now.
+
+## Iter-1 review response summary
+
+iter-1 verdict: CHANGES_REQUESTED (3 items). All addressed:
+
+- **Item 1 (§5.2 + Rollout/Rollback contradiction):** Adopted OQ1. Base URL is
+  now a config flag (`analysis_engine_base_url`), key selected by base URL, so
+  env-only rollback to OpenAI is actually possible. Rollback bullet rewritten in
+  §Rollout/risk to give the exact env triplet. See §5.2 "OQ1 adopted".
+- **Item 2 (§Affected files inaccuracy):** Table corrected — added
+  `engine_openai_handler/main.go` (new constructor location), removed the
+  `analysishandler/main.go` row (no change needed), added explicit note that
+  `NewAnalysisHandler` is unchanged. See §"Affected files".
+- **Item 3 (existing test breakage understated):** Added new §5.4 enumerating
+  `run_test.go` updates (Strict true→false; gpt-4o/gpt-4o-mini → gemini) and
+  `config/main_test.go` net-new assertions, with a re-grep mandate at
+  implementation (no stale line numbers trusted).
+
+## Iter-2 review response summary
+
+iter-2 verdict: CHANGES_REQUESTED (2 items). iter-1 fixes were all verified
+correct (incl. go-openai v1.41.2 DefaultConfig base URL = `https://api.openai.com/v1`,
+not empty). Both new items addressed:
+
+- **Item 1 (§5.2 code block self-contradiction):** The construction snippet
+  hardcoded `cfg.GoogleAPIKey`, contradicting the base-URL-based key-selection
+  prose. Rewrote the §5.2 code block to compute `analysisKey` by base URL
+  (`strings.Contains(..., "generativelanguage")` → GoogleAPIKey, else
+  EngineKeyChatGPT) before constructing the engine, so the env-only rollback is
+  implementable verbatim. Note: `cmd/ai-manager/main.go` already imports
+  `strings` (used for `strings.Split` on the allow-set), so no new import.
+- **Item 2 (loader assignment omitted):** §5.2 now enumerates all FOUR
+  `internal/config/main.go` edit sites explicitly, including the
+  `viper.GetString("analysis_engine_base_url")` assignment in `LoadGlobalConfig`,
+  with a callout that omitting it causes a silent OpenAI-base-URL + Gemini-key
+  fallback bug.
+
+## Iter-3 review
+
+iter-3 verdict: APPROVED. All iter-2 fixes verified correct against the actual
+code (strings import line 8, EngineKeyChatGPT/GoogleAPIKey fields, NewAnalysisHandler
+signature match, four config edit sites at lines 66/84-85/35-36/125-126, G1 four
+handlers + simpleResponse + analysisHandler field). No new contradictions; design
+internally consistent and implementation-ready.
+
+## Approval status
+
+APPROVED (design review loop: iter-1 CR → iter-2 CR → iter-3 APPROVED). Ready for
+implementation (Phase 4).

--- a/bin-timeline-manager/docs/plans/2026-06-24-timeline-analysis-gemini-default-and-nil-failsafe.md
+++ b/bin-timeline-manager/docs/plans/2026-06-24-timeline-analysis-gemini-default-and-nil-failsafe.md
@@ -202,6 +202,50 @@ geminiaudithandler which runs in prod):**
 | api key env | `GOOGLE_API_KEY` (`AIza...`) | config/main.go:80, prod secret verified |
 | model (default) | `gemini-2.5-flash` | geminiaudithandler uses gemini-2.5-flash in prod |
 | response_format | `json_schema`, `Strict:false` | geminiaudithandler/main.go:251-257 |
+| reasoning_effort | `none` (disable Gemini thinking) | empirically verified, see §5.2a |
+
+### 5.2a G2 — disable Gemini thinking (reasoning_effort=none)
+
+**Production defect found post-deploy (2026-06-24).** After the branch image
+shipped to prod, large staged analyses failed with status=failed / "analysis
+failed to produce a result". Root cause confirmed from prod ai-manager logs:
+Stage 2 returned `finish_reason=length` with only ~311 output tokens, so the
+JSON was truncated → `unexpected end of JSON input` → chain fails. Gemini 2.5
+Flash enables internal "thinking" by default, and the OpenAI-compat `max_tokens`
+is a HARD cap covering thinking + output. On large inputs the model spends the
+budget on thinking and the JSON gets cut off.
+
+**Empirical verification (real Gemini OpenAI-compat endpoint, 2026-06-24):**
+same prompt, `max_tokens=120`:
+- thinking ON (no reasoning_effort): `finish_reason=length`, total 143 tokens,
+  JSON truncated — reproduces the prod failure.
+- `reasoning_effort=none`: `finish_reason=stop`, total 59 tokens, JSON complete.
+The endpoint accepts `reasoning_effort` (HTTP 200, no 400). go-openai v1.41.2
+exposes the field (`ReasoningEffort string json:"reasoning_effort,omitempty"`,
+chat.go:311).
+
+**Fix.** Set `ReasoningEffort: "none"` on the analysis gateway chat request.
+The analysis output is structured JSON; internal chain-of-thought adds no value
+and only steals the token budget. Side benefit: ~60% fewer tokens (cost down,
+aligns with the cost-sensitivity goal). This is the analysis gateway only;
+conversational AIcall is untouched (N1).
+
+Also raise `analysis_max_output_tokens` default 8192 → 16384 for headroom on
+large staged outputs (the real Stage outputs observed up to ~2261 tokens with
+thinking off; 16384 leaves comfortable margin). The `finish_reason=length`
+truncation guard stays as the backstop.
+
+Edge note: `reasoning_effort=none` is Gemini-specific. If an operator rolls the
+gateway back to OpenAI (base URL cleared), OpenAI also accepts `reasoning_effort`
+on reasoning models and ignores/permits it on others; for non-reasoning OpenAI
+models the field is a no-op. Acceptable. If a future OpenAI model rejects
+`none`, the operator can override via config (see below).
+
+Implementation: thread a `reasoning_effort` value through. Simplest: a config
+flag `analysis_reasoning_effort` (default `none`) so it is tunable per-env and
+an OpenAI rollback can clear it. Wired the same 4-site way as
+`analysis_engine_base_url`. `run.go` sets `ReasoningEffort: h.reasoningEffort`
+only when non-empty.
 
 ### 5.4 G2 — existing test updates (`run_test.go`, `config/main_test.go`)
 

--- a/bin-timeline-manager/k8s/deployment.yml
+++ b/bin-timeline-manager/k8s/deployment.yml
@@ -24,6 +24,11 @@ spec:
           command:
             - './timeline-manager'
           env:
+            - name: DATABASE_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: voipbin
+                  key: DATABASE_DSN_BIN
             - name: NODE_IP
               valueFrom:
                 fieldRef:

--- a/bin-timeline-manager/pkg/listenhandler/v1_analyses.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_analyses.go
@@ -54,6 +54,10 @@ func marshalAnalysis(v any) (*sock.Response, error) {
 func (h *listenHandler) v1AnalysesPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithField("func", "v1AnalysesPost")
 
+	if h.analysisHandler == nil {
+		return simpleResponse(http.StatusServiceUnavailable), nil
+	}
+
 	var req request.V1DataAnalysesPost
 	if err := json.Unmarshal(m.Data, &req); err != nil {
 		log.Errorf("Could not unmarshal request. err: %v", err)
@@ -78,6 +82,10 @@ func (h *listenHandler) v1AnalysesPost(ctx context.Context, m *sock.Request) (*s
 // arrive as a JSON-marshaled filter map in the body.
 func (h *listenHandler) v1AnalysesGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithField("func", "v1AnalysesGet")
+
+	if h.analysisHandler == nil {
+		return simpleResponse(http.StatusServiceUnavailable), nil
+	}
 
 	q := queryValues(m.URI)
 	customerID := uuid.FromStringOrNil(q.Get("customer_id"))
@@ -142,6 +150,10 @@ func normalizeFilterValue(field analysis.Field, v any) any {
 func (h *listenHandler) v1AnalysesIDGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithField("func", "v1AnalysesIDGet")
 
+	if h.analysisHandler == nil {
+		return simpleResponse(http.StatusServiceUnavailable), nil
+	}
+
 	id, ok := analysisIDFromURI(m.URI)
 	if !ok {
 		return simpleResponse(http.StatusBadRequest), nil
@@ -163,6 +175,10 @@ func (h *listenHandler) v1AnalysesIDGet(ctx context.Context, m *sock.Request) (*
 // v1AnalysesIDDelete handles DELETE /v1/analyses/<uuid> — hard-delete (ownership-checked).
 func (h *listenHandler) v1AnalysesIDDelete(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithField("func", "v1AnalysesIDDelete")
+
+	if h.analysisHandler == nil {
+		return simpleResponse(http.StatusServiceUnavailable), nil
+	}
 
 	id, ok := analysisIDFromURI(m.URI)
 	if !ok {

--- a/bin-timeline-manager/pkg/listenhandler/v1_analyses_test.go
+++ b/bin-timeline-manager/pkg/listenhandler/v1_analyses_test.go
@@ -186,3 +186,53 @@ func Test_v1Analyses_routing_id_vs_collection(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 }
+
+// Test_v1Analyses_nilHandler_503 verifies that when the analysisHandler is nil
+// (e.g. DATABASE_DSN unset, feature disabled), every analysis route returns
+// 503 Service Unavailable instead of panicking (VOIP-1197 fail-safe).
+func Test_v1Analyses_nilHandler_503(t *testing.T) {
+	h := &listenHandler{analysisHandler: nil}
+
+	cust := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
+	af := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
+	id := uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333")
+
+	postBody, _ := json.Marshal(map[string]any{
+		"customer_id":   cust.String(),
+		"activeflow_id": af.String(),
+	})
+
+	tests := []struct {
+		name string
+		m    *sock.Request
+	}{
+		{
+			name: "post",
+			m:    &sock.Request{URI: "/v1/analyses", Method: sock.RequestMethodPost, Data: postBody},
+		},
+		{
+			name: "list",
+			m:    &sock.Request{URI: "/v1/analyses?customer_id=" + cust.String(), Method: sock.RequestMethodGet},
+		},
+		{
+			name: "id_get",
+			m:    &sock.Request{URI: "/v1/analyses/" + id.String() + "?customer_id=" + cust.String(), Method: sock.RequestMethodGet},
+		},
+		{
+			name: "id_delete",
+			m:    &sock.Request{URI: "/v1/analyses/" + id.String() + "?customer_id=" + cust.String(), Method: sock.RequestMethodDelete},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := h.processRequest(tt.m)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if res.StatusCode != http.StatusServiceUnavailable {
+				t.Fatalf("expected 503, got %d", res.StatusCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix a prod crash-loop in bin-timeline-manager when the analysis feature is
disabled, and switch the bin-ai-manager analysis LLM gateway to default to
Google Gemini with an env-driven provider rollback path.

- bin-timeline-manager: Guard the four analysis RPC handlers against a nil analysisHandler, returning 503 Service Unavailable instead of panicking when DATABASE_DSN is unset
- bin-timeline-manager: Add a table-driven test asserting all four analysis routes return 503 (no panic) when the handler is nil
- bin-timeline-manager: Add the design doc under docs/plans
- bin-ai-manager: Add NewEngineOpenaiHandlerWithConfig to build an engine against a custom base URL (Gemini OpenAI-compatible endpoint)
- bin-ai-manager: Construct a dedicated analysis gateway engine with provider selected by base URL and the matching API key, leaving the conversational engine on OpenAI
- bin-ai-manager: Default the analysis gateway to gemini-2.5-flash with a gemini-2.5-flash,gemini-2.5-pro allow-set and an analysis_engine_base_url flag for env-only rollback
- bin-ai-manager: Set json_schema Strict to false on the analysis gateway for Gemini OpenAI-compat support
- bin-ai-manager: Update run and config tests for the new defaults and Strict behavior
