### PR TITLE
VOIP-1205-Fix-contact-soft-delete-filtering-and-cache-eviction

### DIFF
--- a/bin-contact-manager/CLAUDE.md
+++ b/bin-contact-manager/CLAUDE.md
@@ -46,7 +46,7 @@ go generate ./pkg/cachehandler/...
 - **Queue (listen):** `bin-manager.contact-manager.request`
 - **Queue (subscribe):** `bin-manager.customer-manager.event` → cascade delete on `customer_deleted`
 - **Events published:** `contact_created`, `contact_updated`, `contact_deleted`
-- **Databases:** MySQL (`contact_manager_contact`, `_phone_number`, `_email`, `_tag_assignment`) + Redis (lookup cache, DB index 1)
-- **Soft deletes:** `tm_delete = '9999-01-01 00:00:00.000000'` for active records
+- **Databases:** MySQL (`contact_contacts`, `contact_phone_numbers`, `contact_emails`, `contact_tag_assignments`) + Redis (lookup cache, DB index 1)
+- **Soft deletes:** active records have `tm_delete IS NULL`; deletion records the actual timestamp in `tm_delete` (no `9999-01-01` sentinel). `ContactList` and the public get/lookup paths exclude soft-deleted records by default; the by-id dbhandler primitive stays unfiltered so the delete event payload can re-read the tombstone
 - **Lookup cache:** Redis keyed by `(customer_id, phone_e164)` and `(customer_id, email)` — invalidated on update/delete
 - **Metrics port:** `:2112/metrics`

--- a/bin-contact-manager/docs/domain.md
+++ b/bin-contact-manager/docs/domain.md
@@ -20,9 +20,9 @@ The primary entity. Belongs to a `customer_id` and represents a person or organi
 | `notes` | string | Free-text |
 | `tm_create` | timestamp | Creation time |
 | `tm_update` | timestamp | Last update time |
-| `tm_delete` | timestamp | Soft-delete sentinel; active = `9999-01-01` |
+| `tm_delete` | timestamp | Soft-delete marker; active = `NULL`, deletion records the actual timestamp |
 
-Table: `contact_manager_contact`
+Table: `contact_contacts`
 
 ### PhoneNumber
 
@@ -34,9 +34,9 @@ Child record linking a phone number in E.164 format to a contact. A contact may 
 | `contact_id` | UUID | Parent contact |
 | `phone_number` | string | E.164 format (e.g., `+15551234567`) |
 | `tm_create` | timestamp | |
-| `tm_delete` | timestamp | Soft-delete sentinel |
+| `tm_delete` | timestamp | Soft-delete marker (active = `NULL`) |
 
-Table: `contact_manager_phone_number`
+Table: `contact_phone_numbers`
 
 ### Email
 
@@ -48,9 +48,9 @@ Child record linking an email address to a contact.
 | `contact_id` | UUID | Parent contact |
 | `email` | string | |
 | `tm_create` | timestamp | |
-| `tm_delete` | timestamp | Soft-delete sentinel |
+| `tm_delete` | timestamp | Soft-delete marker (active = `NULL`) |
 
-Table: `contact_manager_email`
+Table: `contact_emails`
 
 ### TagAssignment
 
@@ -62,15 +62,15 @@ Many-to-many link between contacts and tags managed by `bin-tag-manager`.
 | `contact_id` | UUID | |
 | `tag_id` | UUID | References tag in bin-tag-manager |
 | `tm_create` | timestamp | |
-| `tm_delete` | timestamp | Soft-delete sentinel |
+| `tm_delete` | timestamp | Soft-delete marker (active = `NULL`) |
 
-Table: `contact_manager_tag_assignment`
+Table: `contact_tag_assignments`
 
 ## Key Business Rules
 
 1. **Tenant isolation**: All queries filter by `customer_id`. A contact is never visible to another customer.
 
-2. **Soft deletes**: Delete operations set `tm_delete` to the current timestamp. Queries always add `tm_delete = '9999-01-01 00:00:00.000000'` to active-record filters.
+2. **Soft deletes**: Delete operations set `tm_delete` to the current timestamp. Active records have `tm_delete IS NULL`; queries add `tm_delete IS NULL` to active-record filters.
 
 3. **Phone lookup**: The `GET /v1/contacts/lookup?customer_id=<uuid>&phone_e164=<e164>` endpoint uses a Redis cache index for O(1) lookup. Cache is populated on contact creation and invalidated on update/delete.
 

--- a/bin-contact-manager/docs/operations.md
+++ b/bin-contact-manager/docs/operations.md
@@ -38,13 +38,13 @@ redis-cli -n 1 keys "contact:*" | head -20
 **Database queries:**
 ```sql
 -- Active contacts for a customer
-SELECT id, display_name, tm_create FROM contact_manager_contact
-WHERE customer_id = '<uuid>' AND tm_delete = '9999-01-01 00:00:00.000000'
+SELECT id, display_name, tm_create FROM contact_contacts
+WHERE customer_id = '<uuid>' AND tm_delete IS NULL
 LIMIT 20;
 
 -- Phone numbers for a contact
-SELECT id, phone_number FROM contact_manager_phone_number
-WHERE contact_id = '<uuid>' AND tm_delete = '9999-01-01 00:00:00.000000';
+SELECT id, phone_number FROM contact_phone_numbers
+WHERE contact_id = '<uuid>' AND tm_delete IS NULL;
 ```
 
 ## Configuration

--- a/bin-contact-manager/pkg/contacthandler/contact.go
+++ b/bin-contact-manager/pkg/contacthandler/contact.go
@@ -133,6 +133,17 @@ func (h *contactHandler) Get(ctx context.Context, id uuid.UUID) (*contact.Contac
 		return nil, err
 	}
 
+	// The by-id dbhandler primitive is intentionally unfiltered (the delete
+	// event payload re-reads the tombstone). Public reads must not expose a
+	// soft-deleted contact, so treat a set tm_delete as not-found.
+	if res.TMDelete != nil {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"CONTACT_NOT_FOUND",
+			"The contact was not found.",
+		)
+	}
+
 	return res, nil
 }
 
@@ -215,6 +226,17 @@ func (h *contactHandler) LookupByPhone(ctx context.Context, customerID uuid.UUID
 		}
 		return nil, err
 	}
+
+	// A soft-deleted contact must not enrich an inbound call. The phone/email
+	// child tables are not soft-deleted, so the lookup can resolve to a
+	// tombstoned contact; treat that as not-found.
+	if res.TMDelete != nil {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"CONTACT_NOT_FOUND",
+			"The contact was not found.",
+		)
+	}
 	return res, nil
 }
 
@@ -232,6 +254,17 @@ func (h *contactHandler) LookupByEmail(ctx context.Context, customerID uuid.UUID
 			).Wrap(err)
 		}
 		return nil, err
+	}
+
+	// A soft-deleted contact must not enrich an inbound message. The
+	// phone/email child tables are not soft-deleted, so the lookup can resolve
+	// to a tombstoned contact; treat that as not-found.
+	if res.TMDelete != nil {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"CONTACT_NOT_FOUND",
+			"The contact was not found.",
+		)
 	}
 	return res, nil
 }

--- a/bin-contact-manager/pkg/contacthandler/contact_test.go
+++ b/bin-contact-manager/pkg/contacthandler/contact_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
@@ -2332,5 +2333,109 @@ func Test_List_MultipleContacts(t *testing.T) {
 	}
 	if len(res) != 3 {
 		t.Errorf("List() count = %v, want 3", len(res))
+	}
+}
+
+// Test_Get_SoftDeletedNotFound verifies that a soft-deleted contact (tm_delete
+// set) returned by the unfiltered by-id dbhandler primitive is hidden from the
+// public Get path. VOIP-1205.
+func Test_Get_SoftDeletedNotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := contactHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	id := uuid.FromStringOrNil("a1111111-1111-1111-1111-111111111111")
+	deleted := time.Date(2020, 4, 18, 3, 22, 17, 0, time.UTC)
+	tombstone := &contact.Contact{
+		Identity: commonidentity.Identity{ID: id},
+		TMDelete: &deleted,
+	}
+
+	mockDB.EXPECT().ContactGet(ctx, id).Return(tombstone, nil)
+
+	res, err := h.Get(ctx, id)
+	if err == nil {
+		t.Errorf("expected not-found error for soft-deleted contact, got nil")
+	}
+	if res != nil {
+		t.Errorf("expected nil result for soft-deleted contact, got %v", res)
+	}
+}
+
+// Test_LookupByPhone_SoftDeletedNotFound verifies a tombstoned contact does not
+// enrich an inbound call (child phone table is not soft-deleted). VOIP-1205.
+func Test_LookupByPhone_SoftDeletedNotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := contactHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("b1111111-1111-1111-1111-111111111111")
+	deleted := time.Date(2020, 4, 18, 3, 22, 17, 0, time.UTC)
+	tombstone := &contact.Contact{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("b2222222-2222-2222-2222-222222222222")},
+		TMDelete: &deleted,
+	}
+
+	// LookupByPhone normalizes the input before calling the dbhandler.
+	mockDB.EXPECT().ContactLookupByPhone(ctx, customerID, gomock.Any()).Return(tombstone, nil)
+
+	res, err := h.LookupByPhone(ctx, customerID, "+15551234567")
+	if err == nil {
+		t.Errorf("expected not-found error for soft-deleted contact, got nil")
+	}
+	if res != nil {
+		t.Errorf("expected nil result for soft-deleted contact, got %v", res)
+	}
+}
+
+// Test_LookupByEmail_SoftDeletedNotFound verifies a tombstoned contact does not
+// enrich an inbound message (child email table is not soft-deleted). VOIP-1205.
+func Test_LookupByEmail_SoftDeletedNotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := contactHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("c1111111-1111-1111-1111-111111111111")
+	deleted := time.Date(2020, 4, 18, 3, 22, 17, 0, time.UTC)
+	tombstone := &contact.Contact{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("c2222222-2222-2222-2222-222222222222")},
+		TMDelete: &deleted,
+	}
+
+	mockDB.EXPECT().ContactLookupByEmail(ctx, customerID, gomock.Any()).Return(tombstone, nil)
+
+	res, err := h.LookupByEmail(ctx, customerID, "deleted@example.com")
+	if err == nil {
+		t.Errorf("expected not-found error for soft-deleted contact, got nil")
+	}
+	if res != nil {
+		t.Errorf("expected nil result for soft-deleted contact, got %v", res)
 	}
 }

--- a/bin-contact-manager/pkg/dbhandler/contact.go
+++ b/bin-contact-manager/pkg/dbhandler/contact.go
@@ -62,6 +62,14 @@ func (h *handler) contactUpdateToCache(ctx context.Context, id uuid.UUID) error 
 		return err
 	}
 
+	// Never cache a tombstone. The by-id primitive is unfiltered, so a mutation
+	// on an already soft-deleted contact (e.g. a late phone/email write) would
+	// otherwise resurrect it in the cache. Evict instead so the "cache never
+	// holds a tombstone" invariant holds at this single choke point.
+	if res.TMDelete != nil {
+		return h.cache.ContactDelete(ctx, id)
+	}
+
 	// load related data
 	res.PhoneNumbers, _ = h.PhoneNumberListByContactID(ctx, id)
 	res.Emails, _ = h.EmailListByContactID(ctx, id)
@@ -145,8 +153,13 @@ func (h *handler) ContactGet(ctx context.Context, id uuid.UUID) (*contact.Contac
 	res.Emails, _ = h.EmailListByContactID(ctx, id)
 	res.TagIDs, _ = h.TagAssignmentListByContactID(ctx, id)
 
-	// set to cache
-	_ = h.contactSetToCache(ctx, res)
+	// Set to cache only for active contacts. A soft-deleted contact is still
+	// returned here (the delete event payload depends on the by-id read), but
+	// it must never be re-populated into the cache; otherwise an evicted
+	// tombstone would resurrect on the next read.
+	if res.TMDelete == nil {
+		_ = h.contactSetToCache(ctx, res)
+	}
 
 	return res, nil
 }
@@ -161,6 +174,22 @@ func (h *handler) ContactList(ctx context.Context, size uint64, token string, fi
 		Where("tm_create < ?", token).
 		OrderBy("tm_create desc").
 		Limit(size)
+
+	// Default to excluding soft-deleted contacts. ApplyFields is the single
+	// authority for the tm_delete clause: when no explicit "deleted" filter is
+	// supplied, inject deleted=false (-> tm_delete IS NULL). A caller that wants
+	// the deleted set passes deleted=true (-> tm_delete IS NOT NULL). We must
+	// not also hardcode tm_delete IS NULL here, or deleted=true would AND into
+	// an unsatisfiable predicate and always return zero rows.
+	if _, ok := filters[contact.FieldDeleted]; !ok {
+		// copy so we never mutate the caller's map
+		merged := make(map[contact.Field]any, len(filters)+1)
+		for k, v := range filters {
+			merged[k] = v
+		}
+		merged[contact.FieldDeleted] = false
+		filters = merged
+	}
 
 	// apply filters
 	builder, err := commondatabasehandler.ApplyFields(builder, filters)
@@ -177,23 +206,34 @@ func (h *handler) ContactList(ctx context.Context, size uint64, token string, fi
 	if err != nil {
 		return nil, fmt.Errorf("could not query. ContactList. err: %v", err)
 	}
-	defer func() {
-		_ = rows.Close()
-	}()
 
+	// Fully drain and close the result set BEFORE loading child data. Issuing
+	// the nested phone/email/tag queries while this rows cursor is still open
+	// reuses the same connection and can deadlock under a bounded connection
+	// pool (and reliably deadlocks single-connection SQLite). Collect first,
+	// then enrich.
 	res := []*contact.Contact{}
 	for rows.Next() {
-		c, err := h.contactGetFromRow(rows)
-		if err != nil {
-			return nil, fmt.Errorf("could not scan the row. ContactList. err: %v", err)
+		c, scanErr := h.contactGetFromRow(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("could not scan the row. ContactList. err: %v", scanErr)
 		}
+		res = append(res, c)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("row iteration error. ContactList. err: %v", err)
+	}
+	if closeErr := rows.Close(); closeErr != nil {
+		return nil, fmt.Errorf("could not close rows. ContactList. err: %v", closeErr)
+	}
 
-		// load related data for each contact
+	// load related data for each contact
+	for _, c := range res {
 		c.PhoneNumbers, _ = h.PhoneNumberListByContactID(ctx, c.ID)
 		c.Emails, _ = h.EmailListByContactID(ctx, c.ID)
 		c.TagIDs, _ = h.TagAssignmentListByContactID(ctx, c.ID)
-
-		res = append(res, c)
 	}
 
 	return res, nil
@@ -256,8 +296,10 @@ func (h *handler) ContactDelete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("could not execute. ContactDelete. err: %v", err)
 	}
 
-	// update the cache
-	_ = h.contactUpdateToCache(ctx, id)
+	// Evict the cache instead of repopulating it. The contact is now
+	// soft-deleted; calling contactUpdateToCache here would re-cache the
+	// tombstone (TMDelete set) and keep serving it on subsequent reads.
+	_ = h.cache.ContactDelete(ctx, id)
 
 	return nil
 }
@@ -348,6 +390,44 @@ func (h *handler) ContactLookupByEmail(ctx context.Context, customerID uuid.UUID
 func (h *handler) ContactDeleteByCustomerID(ctx context.Context, customerID uuid.UUID) error {
 	ts := h.utilHandler.TimeNow()
 
+	// Collect the affected (still-active) contact IDs first so we can evict
+	// each from the cache after the bulk soft-delete. Without this, cached
+	// entries keep serving the deleted contacts as active until the TTL
+	// expires, which both leaks soft-deleted records and violates tenant
+	// isolation for caller-ID enrichment.
+	selectQuery, selectArgs, err := sq.Select("id").
+		From(contactTable).
+		Where(sq.Eq{"customer_id": customerID.Bytes()}).
+		Where(sq.Eq{"tm_delete": nil}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("could not build select query. ContactDeleteByCustomerID. err: %v", err)
+	}
+
+	rows, err := h.db.Query(selectQuery, selectArgs...)
+	if err != nil {
+		return fmt.Errorf("could not query contact ids. ContactDeleteByCustomerID. err: %v", err)
+	}
+	var ids []uuid.UUID
+	for rows.Next() {
+		var idBytes []byte
+		if scanErr := rows.Scan(&idBytes); scanErr != nil {
+			_ = rows.Close()
+			return fmt.Errorf("could not scan contact id. ContactDeleteByCustomerID. err: %v", scanErr)
+		}
+		id, parseErr := uuid.FromBytes(idBytes)
+		if parseErr != nil {
+			_ = rows.Close()
+			return fmt.Errorf("could not parse contact id. ContactDeleteByCustomerID. err: %v", parseErr)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("row iteration error. ContactDeleteByCustomerID. err: %v", err)
+	}
+	_ = rows.Close()
+
 	query, args, err := sq.Update(contactTable).
 		Set("tm_update", ts).
 		Set("tm_delete", ts).
@@ -360,6 +440,11 @@ func (h *handler) ContactDeleteByCustomerID(ctx context.Context, customerID uuid
 	_, err = h.db.Exec(query, args...)
 	if err != nil {
 		return fmt.Errorf("could not execute. ContactDeleteByCustomerID. err: %v", err)
+	}
+
+	// Evict each affected contact from the cache so no tombstone is served.
+	for _, id := range ids {
+		_ = h.cache.ContactDelete(ctx, id)
 	}
 
 	return nil

--- a/bin-contact-manager/pkg/dbhandler/contact_test.go
+++ b/bin-contact-manager/pkg/dbhandler/contact_test.go
@@ -280,17 +280,18 @@ func Test_ContactDelete(t *testing.T) {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 
-			// Delete the contact
+			// Delete the contact (evicts the cache; does not re-cache the tombstone)
 			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
-			mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any())
+			mockCache.EXPECT().ContactDelete(gomock.Any(), tt.contact.ID).Return(nil)
 			err := h.ContactDelete(ctx, tt.contact.ID)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 
-			// Verify deletion (tm_delete should be set)
+			// Verify deletion (tm_delete should be set). The by-id primitive is
+			// unfiltered so it still returns the tombstone, but it must NOT be
+			// re-cached, so no ContactSet is expected here.
 			mockCache.EXPECT().ContactGet(gomock.Any(), tt.contact.ID).Return(nil, fmt.Errorf(""))
-			mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any())
 			res, err := h.ContactGet(ctx, tt.contact.ID)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
@@ -833,16 +834,21 @@ func Test_ContactDeleteByCustomerID(t *testing.T) {
 				}
 			}
 
-			// Delete all contacts for customer
+			// Delete all contacts for customer. The cascade now evicts each
+			// affected contact from the cache so no tombstone is served.
 			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+			for _, c := range tt.contacts {
+				mockCache.EXPECT().ContactDelete(ctx, c.ID).Return(nil)
+			}
 			if err := h.ContactDeleteByCustomerID(ctx, tt.customerID); err != nil {
 				t.Errorf("ContactDeleteByCustomerID() error = %v", err)
 			}
 
-			// Verify both contacts are soft-deleted
+			// Verify both contacts are soft-deleted. The by-id primitive is
+			// unfiltered so it returns the tombstone, but tombstones are not
+			// re-cached, so no ContactSet is expected here.
 			for _, c := range tt.contacts {
 				mockCache.EXPECT().ContactGet(ctx, c.ID).Return(nil, fmt.Errorf(""))
-				mockCache.EXPECT().ContactSet(ctx, gomock.Any())
 				res, err := h.ContactGet(ctx, c.ID)
 				if err != nil {
 					t.Errorf("Wrong match. expect: ok, got: %v", err)
@@ -1629,6 +1635,191 @@ func Test_ContactLookupByEmail_NotFound(t *testing.T) {
 
 // Skip Test_ContactList_Empty - Same issue as above
 // This functionality is tested via contacthandler tests using proper mocks
+
+// Test_ContactList_ExcludesSoftDeleted verifies the base ContactList query
+// excludes soft-deleted rows by default while still returning active rows
+// (VOIP-1205). The contacts have no child rows, so the nested-load path does
+// not run.
+func Test_ContactList_ExcludesSoftDeleted(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	curTime := timePtr(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+	customerID := uuid.FromStringOrNil("d0000000-0000-0000-0000-0000000005d1")
+	active := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d2222222-2222-2222-2222-0000000005d1"),
+			CustomerID: customerID,
+		},
+		FirstName: "Still",
+		LastName:  "Active",
+		Source:    "manual",
+	}
+	deleted := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d1111111-1111-1111-1111-0000000005d1"),
+			CustomerID: customerID,
+		},
+		FirstName: "Soft",
+		LastName:  "Deleted",
+		Source:    "manual",
+	}
+
+	// Create both contacts.
+	for _, c := range []*contact.Contact{active, deleted} {
+		mockUtil.EXPECT().TimeNow().Return(curTime)
+		mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any())
+		if err := h.ContactCreate(ctx, c); err != nil {
+			t.Fatalf("ContactCreate() error = %v", err)
+		}
+	}
+
+	// Soft-delete one of them.
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactDelete(gomock.Any(), deleted.ID).Return(nil)
+	if err := h.ContactDelete(ctx, deleted.ID); err != nil {
+		t.Fatalf("ContactDelete() error = %v", err)
+	}
+
+	// List with only a customer filter (no deleted filter). Exactly the active
+	// contact must be returned; the soft-deleted one excluded.
+	filters := map[contact.Field]any{
+		contact.FieldCustomerID: customerID,
+	}
+	res, err := h.ContactList(ctx, 10, utilhandler.TimeGetCurTime(), filters)
+	if err != nil {
+		t.Fatalf("ContactList() error = %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("ContactList() returned %d contacts, want 1 (active only)", len(res))
+	}
+	if res[0].ID != active.ID {
+		t.Errorf("ContactList() returned %s, want active %s", res[0].ID, active.ID)
+	}
+}
+
+// Test_ContactList_DeletedFilterReturnsDeleted verifies the explicit
+// deleted=true filter retrieves soft-deleted rows and does NOT collide with the
+// default tm_delete IS NULL clause (VOIP-1205). Regression guard for the
+// unsatisfiable-AND bug.
+func Test_ContactList_DeletedFilterReturnsDeleted(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	curTime := timePtr(time.Date(2021, 2, 2, 0, 0, 0, 0, time.UTC))
+	customerID := uuid.FromStringOrNil("e0000000-0000-0000-0000-0000000005e1")
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("e1111111-1111-1111-1111-0000000005e1"),
+			CustomerID: customerID,
+		},
+		FirstName: "Audit",
+		LastName:  "Deleted",
+		Source:    "manual",
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any())
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactDelete(gomock.Any(), c.ID).Return(nil)
+	if err := h.ContactDelete(ctx, c.ID); err != nil {
+		t.Fatalf("ContactDelete() error = %v", err)
+	}
+
+	// Explicit deleted=true must surface the soft-deleted contact.
+	filters := map[contact.Field]any{
+		contact.FieldCustomerID: customerID,
+		contact.FieldDeleted:    true,
+	}
+	res, err := h.ContactList(ctx, 10, utilhandler.TimeGetCurTime(), filters)
+	if err != nil {
+		t.Fatalf("ContactList() error = %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("ContactList(deleted=true) returned %d contacts, want 1", len(res))
+	}
+	if res[0].ID != c.ID || res[0].TMDelete == nil {
+		t.Errorf("ContactList(deleted=true) returned wrong/active contact: %v", res[0])
+	}
+}
+
+
+// Test_ContactUpdateToCache_TombstoneEvicts verifies that a mutation reaching
+// contactUpdateToCache for an already soft-deleted contact evicts the cache
+// instead of re-caching the tombstone (VOIP-1205, single choke-point
+// invariant). Driven via PhoneNumberCreate on a deleted contact.
+func Test_ContactUpdateToCache_TombstoneEvicts(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	curTime := timePtr(time.Date(2021, 3, 3, 0, 0, 0, 0, time.UTC))
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("f1111111-1111-1111-1111-0000000005f1"),
+			CustomerID: uuid.FromStringOrNil("f0000000-0000-0000-0000-0000000005f1"),
+		},
+		FirstName: "Tombstone",
+		Source:    "manual",
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any())
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	// Soft-delete it (evicts cache).
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactDelete(gomock.Any(), c.ID).Return(nil)
+	if err := h.ContactDelete(ctx, c.ID); err != nil {
+		t.Fatalf("ContactDelete() error = %v", err)
+	}
+
+	// A late phone write routes through contactUpdateToCache. Because the
+	// contact is a tombstone, the cache MUST be evicted, not repopulated.
+	p := &contact.PhoneNumber{
+		ID:         uuid.FromStringOrNil("f2222222-2222-2222-2222-0000000005f1"),
+		CustomerID: c.CustomerID,
+		ContactID:  c.ID,
+		NumberE164: "+15551230000",
+	}
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactDelete(gomock.Any(), c.ID).Return(nil)
+	if err := h.PhoneNumberCreate(ctx, p); err != nil {
+		t.Fatalf("PhoneNumberCreate() error = %v", err)
+	}
+}
 
 // Test_ContactDeleteByCustomerID_NoMatches tests deleting when no contacts exist
 func Test_ContactDeleteByCustomerID_NoMatches(t *testing.T) {


### PR DESCRIPTION
Fix soft-delete consistency in bin-contact-manager: list queries leaked soft-deleted contacts, the cache re-served tombstones after deletion, the customer cascade never evicted the cache, and the docs described a non-existent sentinel and stale table names. Found via VOIP-1204 CRM migration fact-checking, verified against code and production DB.

- bin-contact-manager: ContactList excludes soft-deleted rows by default by injecting deleted=false into a copied filter map, letting ApplyFields own the tm_delete clause; an explicit deleted=true filter now correctly returns soft-deleted rows instead of an unsatisfiable AND
- bin-contact-manager: ContactDelete evicts the cache instead of re-caching the tombstone; contactUpdateToCache evicts (never re-caches) when the contact is a tombstone so a late phone/email write cannot resurrect it
- bin-contact-manager: ContactDeleteByCustomerID (customer_deleted cascade) collects affected active contact IDs and evicts each from the cache after the bulk soft-delete, closing a 24h stale-cache leak and tenant-isolation gap
- bin-contact-manager: public Get/LookupByPhone/LookupByEmail treat a set tm_delete as not-found, keeping the by-id dbhandler primitive unfiltered for the delete event payload
- bin-contact-manager: ContactList drains and closes the row cursor before loading child phone/email/tag data to avoid connection-reuse deadlock under a bounded pool
- bin-contact-manager: add regression tests for list exclusion/selectivity, deleted=true retrieval, single and cascade cache eviction, tombstone-no-resurrect, and tombstone-hidden get/lookup paths
- bin-contact-manager: correct CLAUDE.md/domain.md/operations.md soft-delete semantics (active = tm_delete IS NULL, no 9999-01-01 sentinel) and table names (contact_contacts/_phone_numbers/_emails/_tag_assignments)