### PR TITLE
NOJIRA-Docs-conversation-whatsapp-direction

### DIFF
--- a/bin-conversation-manager/CLAUDE.md
+++ b/bin-conversation-manager/CLAUDE.md
@@ -1,6 +1,6 @@
 # bin-conversation-manager
 
-Multi-channel conversation management service. Handles SMS/MMS and LINE messaging threads, inbound/outbound message delivery, and platform account credentials.
+Multi-channel conversation management service. Handles SMS/MMS, LINE, and WhatsApp messaging threads, incoming/outgoing message delivery, and platform account credentials.
 
 > Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md).
 
@@ -13,11 +13,11 @@ Multi-channel conversation management service. Handles SMS/MMS and LINE messagin
 
 ## Key concepts
 
-- **Account** — platform credentials (LINE channel secret/token, SMS provider); type: `sms` | `line`
-- **Conversation** — thread between two parties identified by `(account_id, dialog_id)`; type: `message` | `line`
-- **Message** — individual message; direction `inbound`/`outbound`, status `progressing`/`done`/`failed`
-- **DialogID** — external platform conversation identifier (LINE chatroom ID, SMS thread)
-- Inbound LINE messages arrive via `POST /v1/hooks`; inbound SMS/MMS arrive via `message-manager` event subscription
+- **Account** — platform credentials (LINE channel secret/token, SMS provider, WhatsApp Meta credentials); type: `sms` | `line` | `whatsapp`
+- **Conversation** — thread between two parties identified by `(account_id, dialog_id)`; type: `message` | `line` | `whatsapp`
+- **Message** — individual message; direction `incoming`/`outgoing`, status `progressing`/`done`/`failed`
+- **DialogID** — external platform conversation identifier (LINE chatroom ID, WhatsApp recipient phone, SMS thread)
+- Incoming LINE/WhatsApp messages arrive via `POST /v1/hooks`; incoming SMS/MMS arrive via `message-manager` event subscription
 
 ## Common commands
 

--- a/bin-conversation-manager/README.md
+++ b/bin-conversation-manager/README.md
@@ -1,5 +1,5 @@
 # conversation-manager
 
-Manages multi-channel conversations (SMS/MMS, LINE messaging) and their messages, handling bidirectional communication with external messaging platforms.
+Manages multi-channel conversations (SMS/MMS, LINE, WhatsApp) and their messages, handling bidirectional communication with external messaging platforms.
 
 <!-- Updated dependencies: 2026-03-30 -->

--- a/bin-conversation-manager/docs/architecture.md
+++ b/bin-conversation-manager/docs/architecture.md
@@ -2,16 +2,17 @@
 
 ## Component Overview
 
-`bin-conversation-manager` manages multi-channel conversation threads (SMS/MMS, LINE messaging) and their messages. It handles bidirectional communication with external platforms and maintains conversation state across interactions.
+`bin-conversation-manager` manages multi-channel conversation threads (SMS/MMS, LINE, WhatsApp) and their messages. It handles bidirectional communication with external platforms and maintains conversation state across interactions.
 
 ```
 cmd/conversation-manager/main.go
     ├── pkg/dbhandler            (MySQL + Redis cache via Squirrel SQL builder)
     ├── pkg/cachehandler         (Redis operations)
     ├── pkg/accounthandler       (messaging platform credentials)
-    ├── pkg/conversationhandler  (conversation business logic + webhook processing)
+    ├── pkg/conversationhandler  (conversation business logic + webhook processing + execute-mode dispatch)
     ├── pkg/messagehandler       (message create/send/status)
     ├── pkg/linehandler          (LINE Bot SDK v7 integration)
+    ├── pkg/whatsapphandler      (WhatsApp Meta Cloud API integration)
     ├── pkg/smshandler           (SMS/MMS via message-manager RPC)
     ├── pkg/listenhandler        (RabbitMQ RPC router)
     └── pkg/subscribehandler     (event consumer from message-manager)
@@ -27,10 +28,11 @@ cmd/conversation-manager/main.go
 | Transport | `pkg/listenhandler` | Receives RPC requests from `bin-manager.conversation-manager.request`; routes by URI regex |
 | Transport | `pkg/subscribehandler` | Consumes `message_created` events from message-manager (inbound SMS/MMS) |
 | Transport | notifyhandler (bin-common-handler) | Publishes conversation/message events to exchange |
-| Domain | `pkg/conversationhandler` | Create/get/update conversations; process platform webhooks; event handling |
+| Domain | `pkg/conversationhandler` | Create/get/update conversations; process platform webhooks; execute-mode dispatch (agent vs flow); event handling |
 | Domain | `pkg/messagehandler` | Create message records; dispatch outbound messages; status tracking |
-| Domain | `pkg/accounthandler` | CRUD for platform credentials (LINE channel secret/token, SMS credentials) |
+| Domain | `pkg/accounthandler` | CRUD for platform credentials (LINE channel secret/token, SMS credentials, WhatsApp Meta credentials) |
 | Platform | `pkg/linehandler` | LINE Bot SDK: webhook signature verification, message send/receive |
+| Platform | `pkg/whatsapphandler` | WhatsApp Meta Cloud API: HMAC webhook validation, hub challenge verification, message send/receive |
 | Platform | `pkg/smshandler` | SMS/MMS sending via RPC to message-manager |
 | Data | `pkg/dbhandler` | MySQL CRUD using Squirrel SQL builder |
 | Data | `pkg/cachehandler` | Redis cache for account/conversation lookups |
@@ -45,12 +47,11 @@ ListenHandler routes over `bin-manager.conversation-manager.request`:
 | `GET/PUT/DELETE /v1/accounts/<uuid>` | Get / update / delete account |
 | `POST /v1/accounts` | Create messaging platform account |
 | `GET /v1/conversations?` | List conversations (paginated) |
-| `GET/PUT/DELETE /v1/conversations/<uuid>` | Get / update / delete conversation |
+| `GET/PUT /v1/conversations/<uuid>` | Get / update conversation |
 | `POST /v1/conversations` | Create conversation |
 | `GET /v1/hooks` | Meta hub challenge verification (WhatsApp) |
 | `POST /v1/hooks` | Incoming platform webhook (LINE, WhatsApp, etc.) |
 | `GET /v1/messages?` | List messages (paginated) |
-| `GET /v1/messages/<uuid>` | Get message |
 | `POST /v1/messages` | Create message record |
 | `POST /v1/messages/create` | Create and send message |
 
@@ -60,7 +61,7 @@ SubscribeHandler (`pkg/subscribehandler/`) consumes:
 
 | Queue | Event | Action |
 |-------|-------|--------|
-| `bin-manager.message-manager.event` | `message_created` | Create or update conversation record; create inbound message; publish conversation/message events |
+| `bin-manager.message-manager.event` | `message_created` | Create or update conversation record; create incoming message; publish conversation/message events |
 
 ## Events Published
 
@@ -68,15 +69,30 @@ Exchange: `bin-manager.conversation-manager.event`
 
 | Event type | Trigger |
 |-----------|---------|
+| `account.EventTypeAccountCreated` | New platform account created |
+| `account.EventTypeAccountUpdated` | Account credentials/metadata updated |
+| `account.EventTypeAccountDeleted` | Account deleted |
 | `conversation.EventTypeConversationCreated` | New conversation thread created |
 | `conversation.EventTypeConversationUpdated` | Conversation metadata updated |
 | `message.EventTypeMessageCreated` | New message added to conversation |
 | `message.EventTypeMessageDeleted` | Message deleted |
 | `message.EventTypeMessageUpdated` | Message status updated |
 
+## Inbound Dispatch: Execute Mode
+
+Every inbound message (LINE/WhatsApp webhook or SMS event) is dispatched by `conversationhandler` based on the conversation's owner snapshot (`pkg/conversationhandler/execute_mode.go`). The snapshot loaded by the inbound handler is authoritative: the dispatch path resolves the mode from the in-hand snapshot and never re-fetches the conversation (per-type flow runners fetch only the account or number, never the conversation).
+
+| Mode | Condition | Action |
+|------|-----------|--------|
+| `ExecuteModeAgent` | `OwnerType == agent` and `OwnerID != uuid.Nil` | No flow triggered. The agent UI receives the new message via the `message_created` event filtered on `OwnerID`. Logging only. |
+| `ExecuteModeFlow` | otherwise | Resolve the per-type flow source and start an activeflow. LINE/WhatsApp use `account.MessageFlowID`; SMS uses `number.MessageFlowID` resolved from `self.target`. A `uuid.Nil` flow id is a no-op. |
+
+`ExecuteModeNone` is reserved (not currently produced by `getExecuteMode`). The flow integration creates an activeflow (`reference_type=conversation`), injects conversation variables, and executes it.
+
 ## External Webhook Processing
 
-The service receives inbound webhooks from external platforms via the `POST /v1/hooks` endpoint:
+The service receives inbound webhooks from external platforms via the `POST /v1/hooks` endpoint. The account type (resolved from the `account_id` in the URI) selects the platform handler:
 
-- **LINE**: Webhook from LINE Bot platform; `pkg/linehandler/hook.go` verifies signature, parses payload, creates conversation and message records
-- Hook URI pattern in LINE config: `/v1.0/conversation/accounts/<account_id>`
+- **LINE**: `pkg/linehandler/hook.go` verifies the channel signature, parses the payload, and produces conversation/message records.
+- **WhatsApp**: `pkg/whatsapphandler/hook.go` validates the Meta `X-Hub-Signature-256` HMAC (using `app_secret` from `provider_data`), parses the Cloud API payload, and produces conversation/message records. `GET /v1/hooks` answers the Meta hub challenge (`hub.mode`/`hub.verify_token`/`hub.challenge`) via `whatsapphandler.VerifyWebhook`. On signature failure the payload is discarded without persistence, and the endpoint still returns 200 so Meta does not retry a forged request (duplicate valid-signature deliveries are deduplicated by transaction/wamid, not by the 200).
+- Hook URI pattern in the platform account config: `/v1.0/conversation/accounts/<account_id>`

--- a/bin-conversation-manager/docs/dependencies.md
+++ b/bin-conversation-manager/docs/dependencies.md
@@ -44,6 +44,7 @@ All resolved via `replace` directives in `go.mod`.
 | Redis | Cache for account/conversation lookups |
 | RabbitMQ | RPC transport and event pub/sub |
 | LINE Bot SDK v7 (`github.com/line/line-bot-sdk-go/v7`) | LINE platform webhook verification and message delivery |
+| Meta Graph API (`graph.facebook.com`, v19.0) | WhatsApp Cloud API message delivery; inbound webhook HMAC validation and hub challenge verification (called over plain `net/http`, no SDK) |
 
 ## RabbitMQ Queue Names
 

--- a/bin-conversation-manager/docs/domain.md
+++ b/bin-conversation-manager/docs/domain.md
@@ -13,8 +13,8 @@ Platform-specific credentials for sending messages. Stored in `conversation_acco
 ### Conversation
 A communication thread between two parties. Persisted in `conversation_conversations` table.
 
-- `type`: `message` (SMS/MMS) | `line` (LINE)
-- `dialog_id` — external platform conversation identifier (LINE chatroom ID, SMS thread ID)
+- `type`: `message` (SMS/MMS) | `line` (LINE) | `whatsapp` (WhatsApp)
+- `dialog_id` — external platform conversation identifier (LINE chatroom ID, WhatsApp recipient phone, SMS thread ID)
 - `self` — platform address of the VoIPbin-side participant (e.g., phone number, LINE user ID)
 - `peer` — platform address of the customer/end user
 
@@ -23,9 +23,9 @@ A conversation is uniquely identified by `(account_id, dialog_id)`.
 ### Message
 Individual message within a conversation. Persisted in `conversation_messages` table.
 
-- `direction`: `inbound` | `outbound`
+- `direction`: `incoming` | `outgoing`
 - `status`: `progressing` | `done` | `failed`
-- `reference_type` — source resource type
+- `reference_type` — source resource type: `message` (SMS/MMS) | `line` | `whatsapp`
 - `transaction_id` — external platform message ID for dedup
 - `medias` — JSON array of media attachments
 
@@ -34,22 +34,25 @@ Media attachment metadata for messages. Stored in `conversation_medias` table.
 
 ## Message Flows
 
-### Incoming Message (LINE webhook)
+### Incoming Message (LINE / WhatsApp webhook)
 ```
-LINE platform → POST /v1/hooks
-    → conversationhandler.Hook() (parse account_id from URI)
-    → linehandler.Hook() (verify signature, parse payload)
+LINE / WhatsApp platform → POST /v1/hooks
+    → conversationhandler.Hook() (parse account_id from URI, select handler by account type)
+    → linehandler.Hook() / whatsapphandler.Hook() (verify signature, parse payload)
     → find or create Conversation by (account_id, dialog_id)
-    → create Message record (direction=inbound)
+    → create Message record (direction=incoming)
     → publish conversation_created + message_created events
+    → execute-mode dispatch (agent: no-op; flow: start activeflow via account.MessageFlowID)
 ```
+
+WhatsApp note: inbound signature is validated as HMAC-SHA256 (`X-Hub-Signature-256`, `sha256=` prefix) keyed on `provider_data.app_secret`. The handler is fail-closed: an empty `app_secret` rejects the request.
 
 ### Outgoing Message (API)
 ```
 Caller → POST /v1/messages/create
     → messagehandler.CreateSend()
-    → create Message record (direction=outbound, status=progressing)
-    → linehandler.Send() or smshandler.Send()
+    → create Message record (direction=outgoing, status=progressing)
+    → linehandler.Send() / whatsapphandler.Send() / smshandler.Send()
     → update Message status to done or failed
     → publish message_created event
 ```
@@ -60,8 +63,9 @@ message-manager publishes message_created event
     → subscribehandler processes event
     → conversationhandler.Event()
     → find or create Conversation by phone numbers
-    → create Message record (direction=inbound)
+    → create Message record (direction=incoming)
     → publish conversation_created + message_created events
+    → execute-mode dispatch (agent: no-op; flow: start activeflow via number.MessageFlowID)
 ```
 
 ## Flow Integration Variables


### PR DESCRIPTION
Refresh bin-conversation-manager documentation so it matches the shipped code. The WhatsApp channel (added in #929/#933) was fully implemented but absent from the README, service CLAUDE.md, and architecture/dependencies docs, and the message direction terminology in domain.md did not match the Direction enum the code persists to the database.

- bin-conversation-manager: Add WhatsApp to README, CLAUDE.md, architecture, domain, and dependencies docs
- bin-conversation-manager: Document whatsapphandler component, Meta Cloud API dependency, and POST/GET /v1/hooks WhatsApp HMAC + hub-challenge handling
- bin-conversation-manager: Add Execute Mode (agent vs flow) inbound dispatch section to architecture docs
- bin-conversation-manager: Fix message direction docs from inbound/outbound to incoming/outgoing to match the Direction enum and DB values