### PR TITLE
VOIP-1206-contact-crm-dbscheme-migration

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/ac5d4e18060c_contact_crm_create_tables.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/ac5d4e18060c_contact_crm_create_tables.py
@@ -1,0 +1,152 @@
+"""contact_crm_create_tables
+
+Revision ID: ac5d4e18060c
+Revises: 4579f211877c
+Create Date: 2026-06-26 17:58:15.407482
+
+Creates the 3 new tables for the contact-axis unified interaction timeline
+(lightweight CRM). See docs/plans/2026-06-26-add-contact-crm-interaction-timeline-design.md
+(VOIP-1204). This is implementation step 1 (VOIP-1206), the prerequisite for
+M1 address migration (VOIP-1207), projection handlers (VOIP-1208), and the
+read API (VOIP-1209).
+
+Tables:
+  1. contact_addresses     - permanent identifier mapping (merges
+                             contact_phone_numbers + contact_emails). Hard-delete,
+                             no tm_delete, mirrors agent_addresses (2026-06-21).
+  2. contact_interactions  - immutable append-only fact log. No tm_delete in v1
+                             (append-only; deletion added later via expand-contract).
+  3. contact_resolutions   - manual attribution (positive/negative). Append-only
+                             with tm_delete retraction (NULL = active).
+
+is_primary uniqueness (§3.1): "one primary per CONTACT" (not per type) is enforced
+by a STORED generated column `primary_contact_uk = IF(is_primary=1, contact_id, NULL)`
+with a UNIQUE index on (customer_id, primary_contact_uk). Non-primary rows store
+NULL, which is distinct under MySQL UNIQUE, so only one is_primary=true row is
+allowed per (customer_id, contact_id). A CHECK (is_primary=0 OR contact_id IS NOT
+NULL) forbids an unresolved (contact_id NULL) address from being primary, which
+would otherwise compute primary_contact_uk=NULL and escape the UNIQUE. This is a
+NEW pattern for VoIPBin; the MariaDB-build -> mysqldump -> MySQL-8.0-import round
+trip (generated column + UNIQUE + CHECK) is verified at implementation (VOIP-1206).
+
+NOTE on cross-engine data dumps: contact_addresses has a STORED generated column.
+A `mysqldump` of POPULATED data from MariaDB into MySQL 8.0 must use
+`--complete-insert` (explicit column list), otherwise MySQL 8.0 rejects the
+generated column value with ERROR 3105. The build pipeline dumps an EMPTY schema,
+so this does not affect the build; it matters only for future data migrations /
+backups crossing the MariaDB->MySQL boundary.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ac5d4e18060c'
+down_revision = '4579f211877c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ------------------------------------------------------------------
+    # contact_addresses - permanent identifier mapping (hard-delete)
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE contact_addresses (
+            id          BINARY(16) NOT NULL,
+            customer_id BINARY(16) NOT NULL,
+            contact_id  BINARY(16) DEFAULT NULL,   -- NULL = unresolved
+
+            -- address (commonaddress.Address): target is normalized (join key)
+            type        VARCHAR(255) NOT NULL DEFAULT '',
+            target      VARCHAR(255) NOT NULL DEFAULT '',
+            target_name VARCHAR(255) NOT NULL DEFAULT '',
+            is_primary  TINYINT(1)   NOT NULL DEFAULT 0,
+
+            -- "one primary per contact" enforcement: only is_primary=1 rows carry
+            -- a value; non-primary rows are NULL (distinct under UNIQUE).
+            primary_contact_uk BINARY(16)
+                GENERATED ALWAYS AS (IF(is_primary = 1, contact_id, NULL)) STORED,
+
+            -- hard-delete (no tm_delete), mirrors agent_addresses
+            tm_create   DATETIME(6),
+            tm_update   DATETIME(6),
+
+            PRIMARY KEY (id),
+            INDEX        idx_contact_addresses_contact (contact_id),
+            UNIQUE INDEX idx_contact_addresses_identifier (customer_id, type, target),
+            UNIQUE INDEX idx_contact_addresses_primary (customer_id, primary_contact_uk),
+
+            -- an unresolved address (contact_id NULL) must not be primary, else
+            -- primary_contact_uk computes to NULL and escapes the UNIQUE above.
+            CONSTRAINT chk_contact_addresses_primary_resolved
+                CHECK (is_primary = 0 OR contact_id IS NOT NULL)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+    """)
+
+    # ------------------------------------------------------------------
+    # contact_interactions - immutable append-only fact log
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE contact_interactions (
+            id          BINARY(16) NOT NULL,
+            customer_id BINARY(16) NOT NULL,
+
+            direction   VARCHAR(255) NOT NULL DEFAULT '',   -- inbound / outbound
+
+            -- raw remote endpoint as the event carried it (match key). Identity
+            -- is computed at read time against contact_addresses, never stored.
+            peer_type   VARCHAR(255) NOT NULL DEFAULT '',
+            peer_target VARCHAR(255) NOT NULL DEFAULT '',   -- normalized
+
+            -- origin channel discriminator + origin record id (state/body fetched
+            -- at read time via (reference_type, reference_id)). reference_id is
+            -- NOT NULL: it is half the idempotency key, and MySQL treats NULL as
+            -- distinct under UNIQUE, so a nullable reference_id would defeat
+            -- dedup. Every projected channel carries an origin id (call_id,
+            -- message_id, conversation_message_id, aicall_id).
+            reference_type VARCHAR(255) NOT NULL DEFAULT '',
+            reference_id   BINARY(16)   NOT NULL,
+
+            tm_interaction DATETIME(6),   -- origin event time (display sort / sessionize)
+            tm_create      DATETIME(6),   -- projection insert time (pagination cursor)
+
+            PRIMARY KEY (id),
+            -- idempotency (at-least-once); the bare triple distinguishes SMS fan-out.
+            UNIQUE INDEX idx_contact_interactions_idem (reference_type, reference_id, peer_target),
+            -- automatic peer-match lookup (read-time IN-match)
+            INDEX        idx_contact_interactions_peer (customer_id, peer_type, peer_target),
+            -- pagination cursor (tm_create DESC + id tie-breaker)
+            INDEX        idx_contact_interactions_cursor (customer_id, tm_create)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+    """)
+
+    # ------------------------------------------------------------------
+    # contact_resolutions - manual attribution (append-only, tm_delete retraction)
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE contact_resolutions (
+            id             BINARY(16) NOT NULL,
+            customer_id    BINARY(16) NOT NULL,
+            contact_id     BINARY(16) NOT NULL,   -- the contact this is attributed to
+            interaction_id BINARY(16) NOT NULL,   -- single-row grain
+
+            resolution_type  VARCHAR(255) NOT NULL DEFAULT '',  -- positive / negative
+            resolved_by_type VARCHAR(255) NOT NULL DEFAULT '',  -- agent / system / rule
+            resolved_by_id   BINARY(16)   DEFAULT NULL,          -- nil for system
+
+            tm_create DATETIME(6),
+            tm_update DATETIME(6),
+            tm_delete DATETIME(6),   -- soft-delete = attribution retraction (NULL = active)
+
+            PRIMARY KEY (id),
+            INDEX idx_contact_resolutions_contact (customer_id, contact_id, tm_delete),
+            INDEX idx_contact_resolutions_interaction (customer_id, interaction_id, tm_delete)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+    """)
+
+
+def downgrade():
+    op.execute("""DROP TABLE IF EXISTS contact_resolutions;""")
+    op.execute("""DROP TABLE IF EXISTS contact_interactions;""")
+    op.execute("""DROP TABLE IF EXISTS contact_addresses;""")

--- a/bin-dbscheme-manager/docs/schema-ownership.md
+++ b/bin-dbscheme-manager/docs/schema-ownership.md
@@ -28,9 +28,12 @@ All tables below are in the `voipbin` MySQL database managed by `bin-manager/`. 
 | campaign_outplans | bin-campaign-manager | Campaign outbound dial plans |
 | conference_conferences | bin-conference-manager | Conference room definitions |
 | conference_conferencecalls | bin-conference-manager | Per-participant conference legs |
+| contact_addresses | bin-contact-manager | Unified contact identifier mapping (CRM, merges phone/email) |
 | contact_contacts | bin-contact-manager | Contact book entries |
 | contact_emails | bin-contact-manager | Email addresses for contacts |
+| contact_interactions | bin-contact-manager | Append-only cross-channel interaction fact log (CRM) |
 | contact_phone_numbers | bin-contact-manager | Phone numbers for contacts |
+| contact_resolutions | bin-contact-manager | Manual interaction-to-contact attribution (CRM) |
 | contact_tag_assignments | bin-contact-manager | Tag-to-contact associations |
 | conversation_accounts | bin-conversation-manager | Messaging channel accounts |
 | conversation_conversations | bin-conversation-manager | Conversation threads |

--- a/docs/plans/2026-06-26-add-contact-crm-interaction-timeline-design.md
+++ b/docs/plans/2026-06-26-add-contact-crm-interaction-timeline-design.md
@@ -59,10 +59,13 @@ contact_id    binary(16)   nullable (NULL = unresolved)
 type          varchar      tel / email / sip / line / whatsapp ...
 target        varchar      normalized identifier (join key)
 target_name   varchar      display name (optional)
-is_primary    bool         one per type
+is_primary    bool         one per contact
 tm_create, tm_update
 
 unique(customer_id, type, target)   -- identifier dedup (matches agent_addresses)
+unique(customer_id, primary_contact_uk)  -- one primary per contact (generated col)
+index(contact_id)                   -- read-time address-set expansion (§5.1)
+check(is_primary = 0 OR contact_id IS NOT NULL)  -- unresolved cannot be primary
 ```
 
 - Holds **only re-identifiable permanent identifiers**. `web_session` is NOT an
@@ -80,13 +83,22 @@ unique(customer_id, type, target)   -- identifier dedup (matches agent_addresses
   contact_interactions, which IS an immutable fact and is append-only. Hard-delete
   also avoids the MySQL "NULL is distinct in UNIQUE" trap that a
   `tm_delete`-in-unique scheme creates (active rows would not actually be deduped).
-- **is_primary uniqueness.** Because there is no soft-delete, "one primary per
-  type" is enforced over active rows directly (all rows are active), via a
-  generated-column UNIQUE on `(customer_id, type)` restricted to `is_primary=true`.
-  No `tm_delete` interaction to reason about. Note: this is a NEW pattern for
-  VoIPBin (no existing table uses an `is_primary` generated-column UNIQUE;
-  `agent_addresses` has no `is_primary`), so MySQL generated-column UNIQUE
-  compatibility must be confirmed at implementation (tracked in §9).
+- **is_primary uniqueness.** "One primary **per contact**" (not per type: a
+  contact has a single primary contact point, whichever channel it is), enforced
+  over active rows directly (all rows are active, since there is no soft-delete),
+  via a STORED generated column `primary_contact_uk = IF(is_primary=1,
+  contact_id, NULL)` with a UNIQUE index on `(customer_id, primary_contact_uk)`.
+  Non-primary rows store NULL, which is distinct under MySQL UNIQUE, so only one
+  `is_primary=true` row is allowed per `(customer_id, contact_id)`. No `tm_delete`
+  interaction to reason about. Note: this is a NEW pattern for VoIPBin (no existing
+  table uses an `is_primary` generated-column UNIQUE; `agent_addresses` has no
+  `is_primary`). Compatibility was verified at implementation (VOIP-1206) across
+  the full build pipeline: the column and UNIQUE are created on MariaDB (build
+  engine), survive `mysqldump`, and re-import cleanly on MySQL 8.0 (runtime
+  engine). A second-primary insert is rejected (`Duplicate entry`), multiple
+  non-primary rows are allowed (NULL distinct), and re-pointing the primary is a
+  two-statement clear→set within one transaction (MySQL UNIQUE is immediate, not
+  deferrable, so a single CASE UPDATE is order-dependent and unsafe).
 - Late-binding note: hard-deleting an address breaks automatic re-matching of past
   interactions to that address. This is not a loss, because `peer_target` is stored
   raw on each interaction; re-registering the address re-establishes the match at
@@ -104,11 +116,15 @@ direction       varchar      inbound / outbound
 peer_type       varchar      raw remote endpoint type  (match key)
 peer_target     varchar      raw remote endpoint, normalized  (match key)
 reference_type  varchar      origin channel (= channel discriminator)
-reference_id    binary(16)   origin record id (state/body fetched at read time)
+reference_id    binary(16)   NOT NULL: origin record id (state/body fetched at read time)
 tm_interaction  datetime     origin event time (display sort / sessionize basis)
 tm_create       datetime     projection insert time (pagination cursor)
 
-unique(reference_type, reference_id, peer_target)
+unique(reference_type, reference_id, peer_target)   -- idempotency (reference_id
+                                                    -- NOT NULL so NULL never
+                                                    -- defeats dedup)
+index(customer_id, peer_type, peer_target)          -- read-time peer IN-match (§5.1)
+index(customer_id, tm_create)                       -- pagination cursor (§5.3)
 ```
 
 Two tables carry no `tm_delete`, for different reasons: contact_addresses because
@@ -496,11 +512,14 @@ interpretation never damages the event.
    can drop peers under the current single-peer-per-row + unique model. Specify
    whether multi-party produces one row per peer and how duplicate peers are
    de-duplicated, before those flows are projected.
-7. is_primary generated-column UNIQUE (§3.1) is a new pattern for VoIPBin (no
-   existing table uses it). Confirm the exact MySQL generated-column UNIQUE form
-   (e.g. a stored generated column that is `(customer_id, type)` when
-   `is_primary=true` else NULL, with a UNIQUE index on it) compiles and behaves on
-   the production MySQL version before relying on it.
+7. ~~is_primary generated-column UNIQUE (§3.1) is a new pattern for VoIPBin.~~
+   **RESOLVED (VOIP-1206).** Implemented as a STORED generated column
+   `primary_contact_uk = IF(is_primary=1, contact_id, NULL)` with
+   `UNIQUE(customer_id, primary_contact_uk)` ("one primary per contact"). Verified
+   end-to-end across the build pipeline: created on MariaDB (build engine),
+   survives `mysqldump`, re-imports cleanly on MySQL 8.0 (runtime engine);
+   second-primary insert rejected, multiple non-primary rows allowed (NULL
+   distinct), primary re-point is a two-statement clear→set in one transaction.
 
 ## 10. Scope out (v1)
 


### PR DESCRIPTION
Add the 3 new tables for the contact-axis unified interaction timeline (CRM v1), implementation step 1 of VOIP-1204. Schema only; no Go code. The generated-column UNIQUE + CHECK was verified end-to-end across the build pipeline (MariaDB 12.3 create, mysqldump, MySQL 8.0 import) and fixes from two independent review rounds are baked in (reference_id NOT NULL, primary-resolved CHECK).

- bin-dbscheme-manager: Add Alembic migration ac5d4e18060c creating contact_addresses, contact_interactions, contact_resolutions
- bin-dbscheme-manager: contact_addresses merges phone/email into a normalized address table; hard-delete (no tm_delete), unique(customer_id,type,target), mirrors agent_addresses
- bin-dbscheme-manager: Enforce one-primary-per-contact via STORED generated column primary_contact_uk = IF(is_primary=1, contact_id, NULL) with unique(customer_id, primary_contact_uk)
- bin-dbscheme-manager: Add CHECK(is_primary=0 OR contact_id IS NOT NULL) so an unresolved address cannot escape the primary unique
- bin-dbscheme-manager: contact_interactions is append-only with reference_id NOT NULL and unique(reference_type,reference_id,peer_target) for at-least-once idempotency
- bin-dbscheme-manager: contact_resolutions carries tm_delete (soft-delete retraction) for manual positive/negative attribution
- bin-dbscheme-manager: Verified the generated column + UNIQUE + CHECK round-trip across the build pipeline (MariaDB 12.3 create -> mysqldump -> MySQL 8.0 import)
- bin-dbscheme-manager: Register the 3 tables in docs/schema-ownership.md
- docs: Correct design doc 3.1 is_primary to per-contact, document the CHECK and reference_id NOT NULL, mark open item 7 resolved