### PR TITLE
VOIP-1210-email-conversation-outbound

### DIFF
--- a/bin-conversation-manager/cmd/conversation-manager/main.go
+++ b/bin-conversation-manager/cmd/conversation-manager/main.go
@@ -174,6 +174,7 @@ func runSubscribe(
 
 	subscribeTargets := []string{
 		string(commonoutline.QueueNameMessageEvent),
+		string(commonoutline.QueueNameEmailEvent),
 	}
 
 	subHandler := subscribehandler.NewSubscribeHandler(

--- a/bin-conversation-manager/go.mod
+++ b/bin-conversation-manager/go.mod
@@ -79,6 +79,7 @@ require (
 	go.uber.org/mock v0.6.0
 	monorepo/bin-agent-manager v0.0.0-20240328054741-55144017eccd
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
+	monorepo/bin-email-manager v0.0.0-00010101000000-000000000000
 	monorepo/bin-flow-manager v0.0.0-20240403034140-ce82222fe7f4
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0
 	monorepo/bin-message-manager v0.0.0-20240328053936-9008e28c2268
@@ -125,7 +126,6 @@ require (
 	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984 // indirect
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000 // indirect
-	monorepo/bin-email-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-outdial-manager v0.0.0-20240313064601-888fe8578646 // indirect
 	monorepo/bin-pipecat-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-queue-manager v0.0.0-20240402021210-adac880b81da // indirect

--- a/bin-conversation-manager/models/conversation/conversation.go
+++ b/bin-conversation-manager/models/conversation/conversation.go
@@ -71,4 +71,5 @@ const (
 	TypeMessage  Type = "message" // sms, mms
 	TypeLine     Type = "line"
 	TypeWhatsApp Type = "whatsapp"
+	TypeEmail    Type = "email" // outbound email
 )

--- a/bin-conversation-manager/models/message/message.go
+++ b/bin-conversation-manager/models/message/message.go
@@ -23,8 +23,9 @@ type Message struct {
 
 	TransactionID string `json:"transaction_id,omitempty" db:"transaction_id"` // uniq id for message's transaction
 
-	Text   string        `json:"text,omitempty" db:"text"`
-	Medias []media.Media `json:"medias,omitempty" db:"medias,json"`
+	Text    string        `json:"text,omitempty" db:"text"`
+	Subject string        `json:"subject,omitempty" db:"subject"` // email subject; empty for non-email messages
+	Medias  []media.Media `json:"medias,omitempty" db:"medias,json"`
 
 	TMCreate *time.Time `json:"tm_create" db:"tm_create"`
 	TMUpdate *time.Time `json:"tm_update" db:"tm_update"`
@@ -48,8 +49,9 @@ const (
 
 	FieldTransactionID Field = "transaction_id"
 
-	FieldText   Field = "text"
-	FieldMedias Field = "medias" // Stored as JSON
+	FieldText    Field = "text"
+	FieldSubject Field = "subject"
+	FieldMedias  Field = "medias" // Stored as JSON
 
 	FieldTMCreate Field = "tm_create"
 	FieldTMUpdate Field = "tm_update"
@@ -86,4 +88,5 @@ const (
 	ReferenceTypeMessage   ReferenceType = "message" // sms, mms
 	ReferenceTypeLine      ReferenceType = "line"
 	ReferenceTypeWhatsApp  ReferenceType = "whatsapp"
+	ReferenceTypeEmail     ReferenceType = "email"
 )

--- a/bin-conversation-manager/pkg/conversationhandler/email.go
+++ b/bin-conversation-manager/pkg/conversationhandler/email.go
@@ -1,0 +1,117 @@
+package conversationhandler
+
+import (
+	"context"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	emmemail "monorepo/bin-email-manager/models/email"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-conversation-manager/models/conversation"
+	"monorepo/bin-conversation-manager/models/media"
+	"monorepo/bin-conversation-manager/models/message"
+)
+
+// EmailEventSent records a sent email as an outgoing conversation message.
+//
+// Outbound-only: the email-manager email_created event fires before the
+// provider send is attempted, so the conversation message is recorded at
+// status=progressing and is never updated afterward (the conversation message
+// is an immutable send-time fact log, mirroring the SMS absorption path; the
+// service does not subscribe to email_updated/email_deleted).
+//
+// One email may have multiple destinations; each destination yields its own
+// (self, peer) conversation and its own outgoing message. Idempotency is keyed
+// on a composite transaction_id of email.ID + ":" + normalized(peer), unique
+// per (email, recipient), so a re-delivered event is a no-op.
+func (h *conversationHandler) EmailEventSent(ctx context.Context, e *emmemail.Email) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":     "EmailEventSent",
+		"email_id": e.ID,
+	})
+
+	// Source is a pointer and may be nil on a deserialized event. Skip without
+	// side effects rather than dereferencing a nil address.
+	if e.Source == nil {
+		log.Debugf("Email has no source address. Skipping.")
+		return nil
+	}
+	self := *e.Source
+
+	// Process each destination independently. A failure on one recipient must
+	// not drop the remaining recipients of the same email: the subscribe
+	// consumer is at-most-once (the message is acked before processing), so an
+	// early return here would permanently lose the un-attempted destinations.
+	// Per-destination errors are logged and accumulated; the first error is
+	// returned at the end for observability only.
+	var firstErr error
+	for _, destination := range e.Destinations {
+		peer := destination
+
+		// Composite dedup key: unique per (email, recipient).
+		normalizedPeer, _ := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+		txID := e.ID.String() + ":" + normalizedPeer
+
+		// Idempotency: skip if a message already exists for this (email, peer).
+		existing, errGet := h.db.MessageGetsByTransactionID(ctx, txID, "", 1)
+		if errGet != nil {
+			log.Errorf("Could not check existing message. transaction_id: %s, err: %v", txID, errGet)
+			if firstErr == nil {
+				firstErr = errors.Wrapf(errGet, "could not check existing message. transaction_id: %s", txID)
+			}
+			continue
+		}
+		if len(existing) > 0 {
+			log.Debugf("Message already exists for this email destination. Skipping. transaction_id: %s", txID)
+			continue
+		}
+
+		// Locate or create the conversation thread for this (self, peer) pair.
+		cv, errConv := h.GetOrCreateBySelfAndPeer(
+			ctx,
+			e.CustomerID,
+			conversation.TypeEmail,
+			"", // email has no external dialog id; same as SMS
+			self,
+			peer,
+		)
+		if errConv != nil {
+			log.Errorf("Could not get conversation. email_id: %s, err: %v", e.ID, errConv)
+			if firstErr == nil {
+				firstErr = errors.Wrapf(errConv, "could not get conversation. email_id: %s", e.ID)
+			}
+			continue
+		}
+
+		// Create the outgoing conversation message. PK is auto-generated
+		// (id=uuid.Nil); reference_id points at the source email; status is
+		// progressing because the email has not yet been sent at email_created.
+		convMsg, errMsg := h.messageHandler.Create(
+			ctx,
+			uuid.Nil,
+			e.CustomerID,
+			cv.ID,
+			message.DirectionOutgoing,
+			message.StatusProgressing,
+			message.ReferenceTypeEmail,
+			e.ID,
+			txID,
+			e.Content,
+			e.Subject,
+			[]media.Media{},
+		)
+		if errMsg != nil {
+			log.Errorf("Could not create a message. email_id: %s, err: %v", e.ID, errMsg)
+			if firstErr == nil {
+				firstErr = errors.Wrapf(errMsg, "could not create a message. email_id: %s", e.ID)
+			}
+			continue
+		}
+		log.WithField("message_id", convMsg.ID).Debugf("Created an email conversation message. message_id: %s", convMsg.ID)
+	}
+
+	return firstErr
+}

--- a/bin-conversation-manager/pkg/conversationhandler/email_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/email_test.go
@@ -1,0 +1,275 @@
+package conversationhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	emmemail "monorepo/bin-email-manager/models/email"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-conversation-manager/models/conversation"
+	"monorepo/bin-conversation-manager/models/media"
+	"monorepo/bin-conversation-manager/models/message"
+	"monorepo/bin-conversation-manager/pkg/dbhandler"
+	"monorepo/bin-conversation-manager/pkg/messagehandler"
+)
+
+func Test_EmailEventSent(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		email *emmemail.Email
+
+		// per-destination existing-message lookups (in order); empty slice = no existing
+		existingByDest [][]*message.Message
+		// per-destination conversation returned by ConversationGetBySelfAndPeer
+		conversationByDest []*conversation.Conversation
+
+		expectCreateCount int
+	}{
+		{
+			name: "single destination, new outgoing message",
+
+			email: &emmemail.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111"),
+					CustomerID: uuid.FromStringOrNil("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+				},
+				Source: &commonaddress.Address{
+					Type:   commonaddress.TypeEmail,
+					Target: "sender@voipbin.net",
+				},
+				Destinations: []commonaddress.Address{
+					{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+				},
+				Subject: "Hello",
+				Content: "This is the body.",
+			},
+
+			existingByDest: [][]*message.Message{
+				{},
+			},
+			conversationByDest: []*conversation.Conversation{
+				{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000001")}},
+			},
+
+			expectCreateCount: 1,
+		},
+		{
+			name: "multi destination fan-out produces N messages",
+
+			email: &emmemail.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222"),
+					CustomerID: uuid.FromStringOrNil("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+				},
+				Source: &commonaddress.Address{
+					Type:   commonaddress.TypeEmail,
+					Target: "sender@voipbin.net",
+				},
+				Destinations: []commonaddress.Address{
+					{Type: commonaddress.TypeEmail, Target: "a@example.com"},
+					{Type: commonaddress.TypeEmail, Target: "b@example.com"},
+				},
+				Subject: "Bulk",
+				Content: "Body",
+			},
+
+			existingByDest: [][]*message.Message{
+				{},
+				{},
+			},
+			conversationByDest: []*conversation.Conversation{
+				{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000002")}},
+				{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000003")}},
+			},
+
+			expectCreateCount: 2,
+		},
+		{
+			name: "duplicate event is a no-op (existing message found)",
+
+			email: &emmemail.Email{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333"),
+					CustomerID: uuid.FromStringOrNil("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+				},
+				Source: &commonaddress.Address{
+					Type:   commonaddress.TypeEmail,
+					Target: "sender@voipbin.net",
+				},
+				Destinations: []commonaddress.Address{
+					{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+				},
+				Subject: "Hello",
+				Content: "Body",
+			},
+
+			existingByDest: [][]*message.Message{
+				{
+					{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("e0000000-0000-0000-0000-000000000001")}},
+				},
+			},
+			conversationByDest: nil,
+
+			expectCreateCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+			h := &conversationHandler{
+				db:             mockDB,
+				messageHandler: mockMessage,
+			}
+
+			ctx := context.Background()
+
+			for i, dest := range tt.email.Destinations {
+				normalizedPeer, _ := commonaddress.NormalizeTarget(dest.Type, dest.Target)
+				txID := tt.email.ID.String() + ":" + normalizedPeer
+
+				mockDB.EXPECT().
+					MessageGetsByTransactionID(ctx, txID, "", uint64(1)).
+					Return(tt.existingByDest[i], nil)
+
+				if len(tt.existingByDest[i]) > 0 {
+					// dedup hit: no conversation lookup, no create
+					continue
+				}
+
+				// GetOrCreateBySelfAndPeer locates an existing conversation
+				cv := tt.conversationByDest[i]
+				mockDB.EXPECT().
+					ConversationGetBySelfAndPeer(ctx, gomock.Any(), gomock.Any()).
+					Return(cv, nil)
+
+				mockMessage.EXPECT().
+					Create(
+						ctx,
+						uuid.Nil,
+						tt.email.CustomerID,
+						cv.ID,
+						message.DirectionOutgoing,
+						message.StatusProgressing,
+						message.ReferenceTypeEmail,
+						tt.email.ID,
+						txID,
+						tt.email.Content,
+						tt.email.Subject,
+						[]media.Media{},
+					).
+					Return(&message.Message{Identity: commonidentity.Identity{ID: uuid.Must(uuid.NewV4())}}, nil)
+			}
+
+			if err := h.EmailEventSent(ctx, tt.email); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EmailEventSent_partialFailureContinues(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("55555555-5555-5555-5555-555555555555"),
+			CustomerID: uuid.FromStringOrNil("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+		},
+		Source: &commonaddress.Address{
+			Type:   commonaddress.TypeEmail,
+			Target: "sender@voipbin.net",
+		},
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "fail@example.com"},
+			{Type: commonaddress.TypeEmail, Target: "ok@example.com"},
+		},
+		Subject: "Partial",
+		Content: "Body",
+	}
+
+	cvA := &conversation.Conversation{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000098")}}
+	cvOK := &conversation.Conversation{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("c0000000-0000-0000-0000-000000000099")}}
+
+	// Both destinations are looked up for dedup; neither has an existing message.
+	mockDB.EXPECT().MessageGetsByTransactionID(ctx, gomock.Any(), "", uint64(1)).Return([]*message.Message{}, nil).Times(2)
+
+	// Both destinations resolve a conversation (GetOrCreateBySelfAndPeer finds one).
+	gomock.InOrder(
+		mockDB.EXPECT().
+			ConversationGetBySelfAndPeer(ctx, gomock.Any(), gomock.Any()).
+			Return(cvA, nil),
+		mockDB.EXPECT().
+			ConversationGetBySelfAndPeer(ctx, gomock.Any(), gomock.Any()).
+			Return(cvOK, nil),
+	)
+
+	// First destination's message Create fails; the loop must continue to the
+	// second destination rather than aborting the whole email. Second succeeds.
+	gomock.InOrder(
+		mockMessage.EXPECT().
+			Create(ctx, uuid.Nil, e.CustomerID, cvA.ID, message.DirectionOutgoing, message.StatusProgressing, message.ReferenceTypeEmail, e.ID, gomock.Any(), e.Content, e.Subject, []media.Media{}).
+			Return(nil, fmt.Errorf("boom")),
+		mockMessage.EXPECT().
+			Create(ctx, uuid.Nil, e.CustomerID, cvOK.ID, message.DirectionOutgoing, message.StatusProgressing, message.ReferenceTypeEmail, e.ID, gomock.Any(), e.Content, e.Subject, []media.Media{}).
+			Return(&message.Message{Identity: commonidentity.Identity{ID: uuid.Must(uuid.NewV4())}}, nil),
+	)
+
+	// A partial failure is surfaced as a non-nil error (observability only),
+	// but the second destination was still processed.
+	if err := h.EmailEventSent(ctx, e); err == nil {
+		t.Errorf("Wrong match. expect: error, got: nil")
+	}
+}
+
+func Test_EmailEventSent_nilSource(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	// nil Source: no DB or message-handler calls expected (mc.Finish asserts this).
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("44444444-4444-4444-4444-444444444444"),
+			CustomerID: uuid.FromStringOrNil("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+		},
+		Source: nil,
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+		},
+	}
+
+	if err := h.EmailEventSent(ctx, e); err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+}

--- a/bin-conversation-manager/pkg/conversationhandler/event_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/event_test.go
@@ -126,6 +126,7 @@ func Test_Event_eventSMS_single_target(t *testing.T) {
 				tt.expectedMessageReferenceID,
 				"",
 				tt.expectedMessageText,
+				"",
 				[]media.Media{},
 			).Return(&message.Message{}, nil)
 			mockReq.EXPECT().NumberV1NumberList(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.responseNumbers, nil)

--- a/bin-conversation-manager/pkg/conversationhandler/main.go
+++ b/bin-conversation-manager/pkg/conversationhandler/main.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	emmemail "monorepo/bin-email-manager/models/email"
+
 	"monorepo/bin-conversation-manager/models/conversation"
 	"monorepo/bin-conversation-manager/models/media"
 	"monorepo/bin-conversation-manager/models/message"
@@ -43,6 +45,7 @@ type ConversationHandler interface {
 	Hook(ctx context.Context, uri string, method string, signature string, data []byte) error
 	HookVerify(ctx context.Context, uri string, mode string, verifyToken string, challenge string) (string, error)
 	Event(ctx context.Context, conversationType conversation.Type, data []byte) error
+	EmailEventSent(ctx context.Context, e *emmemail.Email) error
 
 	MessageSend(ctx context.Context, conversationID uuid.UUID, text string, medias []media.Media) (*message.Message, error)
 }

--- a/bin-conversation-manager/pkg/conversationhandler/message.go
+++ b/bin-conversation-manager/pkg/conversationhandler/message.go
@@ -130,6 +130,7 @@ func (h *conversationHandler) MessageEventReceived(ctx context.Context, m *mmmes
 			m.ID,
 			"",
 			m.Text,
+			"",
 			[]media.Media{},
 		)
 		if err != nil {
@@ -196,6 +197,7 @@ func (h *conversationHandler) MessageEventSent(ctx context.Context, m *mmmessage
 				m.ID,
 				"",
 				m.Text,
+				"",
 				[]media.Media{},
 			)
 			if err != nil {

--- a/bin-conversation-manager/pkg/conversationhandler/message_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/message_test.go
@@ -432,6 +432,7 @@ func Test_MessageEventReceived(t *testing.T) {
 				tt.incoming.ID,
 				"",
 				tt.incoming.Text,
+				"",
 				[]media.Media{},
 			).Return(tt.responseConvMessage, nil)
 

--- a/bin-conversation-manager/pkg/conversationhandler/mock_conversationhandler.go
+++ b/bin-conversation-manager/pkg/conversationhandler/mock_conversationhandler.go
@@ -15,6 +15,7 @@ import (
 	conversation "monorepo/bin-conversation-manager/models/conversation"
 	media "monorepo/bin-conversation-manager/models/media"
 	message "monorepo/bin-conversation-manager/models/message"
+	email "monorepo/bin-email-manager/models/email"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -58,6 +59,20 @@ func (m *MockConversationHandler) Create(ctx context.Context, customerID uuid.UU
 func (mr *MockConversationHandlerMockRecorder) Create(ctx, customerID, name, detail, conversationType, dialogID, self, peer any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockConversationHandler)(nil).Create), ctx, customerID, name, detail, conversationType, dialogID, self, peer)
+}
+
+// EmailEventSent mocks base method.
+func (m *MockConversationHandler) EmailEventSent(ctx context.Context, e *email.Email) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EmailEventSent", ctx, e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EmailEventSent indicates an expected call of EmailEventSent.
+func (mr *MockConversationHandlerMockRecorder) EmailEventSent(ctx, e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmailEventSent", reflect.TypeOf((*MockConversationHandler)(nil).EmailEventSent), ctx, e)
 }
 
 // Event mocks base method.

--- a/bin-conversation-manager/pkg/listenhandler/v1_messages.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_messages.go
@@ -125,6 +125,7 @@ func (h *listenHandler) processV1MessagesCreatePost(ctx context.Context, m *sock
 		req.ReferenceID,
 		req.TransactionID,
 		req.Text,
+		"",
 		req.Medias,
 	)
 	if err != nil {

--- a/bin-conversation-manager/pkg/listenhandler/v1_messages_test.go
+++ b/bin-conversation-manager/pkg/listenhandler/v1_messages_test.go
@@ -328,6 +328,7 @@ func Test_processV1MessagesCreatePost(t *testing.T) {
 				tt.expectedReferenceID,
 				tt.expectedTransactionID,
 				tt.expectedText,
+				"",
 				tt.expectedMedias,
 			).Return(tt.responseMessage, tt.responseErr)
 			res, err := h.processRequest(tt.request)

--- a/bin-conversation-manager/pkg/messagehandler/db.go
+++ b/bin-conversation-manager/pkg/messagehandler/db.go
@@ -29,6 +29,7 @@ func (h *messageHandler) Create(
 	referenceID uuid.UUID,
 	transactionID string,
 	text string,
+	subject string,
 	medias []media.Media,
 ) (*message.Message, error) {
 	log := logrus.WithFields(logrus.Fields{
@@ -61,8 +62,9 @@ func (h *messageHandler) Create(
 		ReferenceID:   referenceID,
 		TransactionID: transactionID,
 
-		Text:   text,
-		Medias: medias,
+		Text:    text,
+		Subject: subject,
+		Medias:  medias,
 	}
 
 	if errCreate := h.db.MessageCreate(ctx, m); errCreate != nil {

--- a/bin-conversation-manager/pkg/messagehandler/db_test.go
+++ b/bin-conversation-manager/pkg/messagehandler/db_test.go
@@ -98,7 +98,7 @@ func Test_Create(t *testing.T) {
 			mockDB.EXPECT().MessageCreate(ctx, tt.expectMessage).Return(nil)
 			mockDB.EXPECT().MessageGet(ctx, tt.responseUUID).Return(tt.responseMessage, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.responseMessage.CustomerID, message.EventTypeMessageCreated, tt.responseMessage)
-			res, err := h.Create(ctx, uuid.Nil, tt.customerID, tt.conversationID, tt.direction, tt.status, tt.referenceType, tt.referenceID, tt.transactionID, tt.text, tt.medias)
+			res, err := h.Create(ctx, uuid.Nil, tt.customerID, tt.conversationID, tt.direction, tt.status, tt.referenceType, tt.referenceID, tt.transactionID, tt.text, "", tt.medias)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-conversation-manager/pkg/messagehandler/main.go
+++ b/bin-conversation-manager/pkg/messagehandler/main.go
@@ -33,6 +33,7 @@ type MessageHandler interface {
 		referenceID uuid.UUID,
 		transactionID string,
 		text string,
+		subject string,
 		medias []media.Media,
 	) (*message.Message, error)
 	Delete(ctx context.Context, id uuid.UUID) (*message.Message, error)

--- a/bin-conversation-manager/pkg/messagehandler/mock_messagehandler.go
+++ b/bin-conversation-manager/pkg/messagehandler/mock_messagehandler.go
@@ -45,18 +45,18 @@ func (m *MockMessageHandler) EXPECT() *MockMessageHandlerMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockMessageHandler) Create(ctx context.Context, id, customerID, conversationID uuid.UUID, direction message.Direction, status message.Status, referenceType message.ReferenceType, referenceID uuid.UUID, transactionID, text string, medias []media.Media) (*message.Message, error) {
+func (m *MockMessageHandler) Create(ctx context.Context, id, customerID, conversationID uuid.UUID, direction message.Direction, status message.Status, referenceType message.ReferenceType, referenceID uuid.UUID, transactionID, text, subject string, medias []media.Media) (*message.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, id, customerID, conversationID, direction, status, referenceType, referenceID, transactionID, text, medias)
+	ret := m.ctrl.Call(m, "Create", ctx, id, customerID, conversationID, direction, status, referenceType, referenceID, transactionID, text, subject, medias)
 	ret0, _ := ret[0].(*message.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockMessageHandlerMockRecorder) Create(ctx, id, customerID, conversationID, direction, status, referenceType, referenceID, transactionID, text, medias any) *gomock.Call {
+func (mr *MockMessageHandlerMockRecorder) Create(ctx, id, customerID, conversationID, direction, status, referenceType, referenceID, transactionID, text, subject, medias any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockMessageHandler)(nil).Create), ctx, id, customerID, conversationID, direction, status, referenceType, referenceID, transactionID, text, medias)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockMessageHandler)(nil).Create), ctx, id, customerID, conversationID, direction, status, referenceType, referenceID, transactionID, text, subject, medias)
 }
 
 // Delete mocks base method.

--- a/bin-conversation-manager/pkg/messagehandler/send.go
+++ b/bin-conversation-manager/pkg/messagehandler/send.go
@@ -61,6 +61,7 @@ func (h *messageHandler) sendSMS(ctx context.Context, cv *conversation.Conversat
 		messageID,
 		"",
 		text,
+		"",
 		medias,
 	)
 	if err != nil {
@@ -100,6 +101,7 @@ func (h *messageHandler) sendWhatsApp(ctx context.Context, cv *conversation.Conv
 		uuid.Nil,
 		"",
 		text,
+		"",
 		[]media.Media{},
 	)
 	if err != nil {
@@ -158,6 +160,7 @@ func (h *messageHandler) sendLine(ctx context.Context, cv *conversation.Conversa
 		uuid.Nil,
 		"",
 		text,
+		"",
 		medias,
 	)
 	if err != nil {

--- a/bin-conversation-manager/pkg/subscribehandler/emailmanager.go
+++ b/bin-conversation-manager/pkg/subscribehandler/emailmanager.go
@@ -1,0 +1,34 @@
+package subscribehandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+	emmemail "monorepo/bin-email-manager/models/email"
+
+	"github.com/sirupsen/logrus"
+)
+
+// processEventEmailEmailCreated handles the email-manager's email_created event.
+//
+// Each sent email is recorded as an outgoing conversation message (outbound-only).
+func (h *subscribeHandler) processEventEmailEmailCreated(ctx context.Context, m *sock.Event) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":  "processEventEmailEmailCreated",
+		"event": m,
+	})
+
+	e := &emmemail.Email{}
+	if err := json.Unmarshal([]byte(m.Data), e); err != nil {
+		log.Errorf("Could not unmarshal the data. err: %v", err)
+		return err
+	}
+
+	if errEvent := h.conversationHandler.EmailEventSent(ctx, e); errEvent != nil {
+		log.Errorf("Could not handle the event correctly. err: %v", errEvent)
+		return errEvent
+	}
+
+	return nil
+}

--- a/bin-conversation-manager/pkg/subscribehandler/main.go
+++ b/bin-conversation-manager/pkg/subscribehandler/main.go
@@ -12,6 +12,8 @@ import (
 
 	mmmessage "monorepo/bin-message-manager/models/message"
 
+	emmemail "monorepo/bin-email-manager/models/email"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
@@ -23,6 +25,7 @@ import (
 const (
 	publisherCustomerManager = "customer-manager"
 	publisherMessageManager  = "message-manager"
+	publisherEmailManager    = "email-manager"
 )
 
 // SubscribeHandler interface
@@ -137,6 +140,10 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 	// message-manager
 	case m.Publisher == publisherMessageManager && (m.Type == string(mmmessage.EventTypeMessageCreated)):
 		err = h.processEventMessageMessageCreated(ctx, m)
+
+	// email-manager
+	case m.Publisher == publisherEmailManager && (m.Type == emmemail.EventTypeCreated):
+		err = h.processEventEmailEmailCreated(ctx, m)
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// No handler found

--- a/bin-conversation-manager/pkg/subscribehandler/main_test.go
+++ b/bin-conversation-manager/pkg/subscribehandler/main_test.go
@@ -7,6 +7,7 @@ import (
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	commonsock "monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
+	emmemail "monorepo/bin-email-manager/models/email"
 	mmmessage "monorepo/bin-message-manager/models/message"
 
 	"github.com/gofrs/uuid"
@@ -75,6 +76,42 @@ func Test_processEvent_MessageManagerMessageCreated(t *testing.T) {
 	}
 
 	mockConversation.EXPECT().Event(gomock.Any(), conversation.TypeMessage, gomock.Any()).Return(nil)
+
+	h.processEvent(event)
+}
+
+func Test_processEvent_EmailManagerEmailCreated(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockAccount := accounthandler.NewMockAccountHandler(mc)
+	mockConversation := conversationhandler.NewMockConversationHandler(mc)
+
+	h := &subscribeHandler{
+		sockHandler:         mockSock,
+		accountHandler:      mockAccount,
+		conversationHandler: mockConversation,
+	}
+
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440011"),
+			CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440012"),
+		},
+		Subject: "test subject",
+		Content: "test body",
+	}
+
+	data, _ := json.Marshal(e)
+
+	event := &commonsock.Event{
+		Publisher: publisherEmailManager,
+		Type:      emmemail.EventTypeCreated,
+		Data:      json.RawMessage(data),
+	}
+
+	mockConversation.EXPECT().EmailEventSent(gomock.Any(), gomock.Any()).Return(nil)
 
 	h.processEvent(event)
 }

--- a/bin-conversation-manager/scripts/database_scripts_test/table_conversation_messages.sql
+++ b/bin-conversation-manager/scripts/database_scripts_test/table_conversation_messages.sql
@@ -13,6 +13,7 @@ create table conversation_messages(
   transaction_id  varchar(255),
 
   text    text,
+  subject varchar(255),
   medias  json,
 
   -- timestamps

--- a/bin-dbscheme-manager/bin-manager/main/versions/4579f211877c_conversation_messages_add_column_subject.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/4579f211877c_conversation_messages_add_column_subject.py
@@ -1,0 +1,24 @@
+"""conversation_messages_add_column_subject
+
+Revision ID: 4579f211877c
+Revises: a63b82d73655
+Create Date: 2026-06-27 00:42:00.770618
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4579f211877c'
+down_revision = 'a63b82d73655'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""alter table conversation_messages add subject varchar(255) not null default '' after text;""")
+
+
+def downgrade():
+    op.execute("""alter table conversation_messages drop column subject;""")


### PR DESCRIPTION
Integrate email as an outbound-only conversation channel in bin-conversation-manager. Each email the platform sends (consumed from the email-manager email_created event) is recorded as an immutable outgoing conversation message, so a customer's email history appears alongside their SMS/LINE/WhatsApp threads. This reuses the same event-absorption pattern that already brings SMS into conversations. Design doc: docs/plans/2026-06-26-email-conversation-outbound-design.md (VOIP-1210).

Outbound-only by decision: email-manager has no inbound-receive capability, so there is no incoming email, no flow trigger, no hooks path. The conversation message is an immutable send-time fact log (no cascade on email_updated/email_deleted, identical to SMS which only subscribes to message_created). Status is fixed at progressing because email_created fires before the provider send. Multi-destination emails fan out to N per-peer threads, deduped on composite transaction_id = email.ID + peer.

- bin-conversation-manager: Add conversation TypeEmail and message ReferenceTypeEmail enum values
- bin-conversation-manager: Add subject field to Message model and conversation_messages test schema
- bin-conversation-manager: Add subject parameter to messageHandler.Create and update all callers
- bin-conversation-manager: Subscribe to email-manager event queue and route email_created to EmailEventSent
- bin-conversation-manager: Add EmailEventSent handler (nil-guard source, per-destination fan-out, composite transaction_id dedup, progressing status)
- bin-conversation-manager: Add table-driven tests for EmailEventSent (new, fan-out, dedup, nil-source)
- bin-dbscheme-manager: Add alembic migration for conversation_messages.subject column