### PR TITLE
VOIP-1212-conversation-openapi-enum-parity

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -24533,13 +24533,15 @@
           "",
           "message",
           "line",
-          "whatsapp"
+          "whatsapp",
+          "email"
         ],
         "x-enum-varnames": [
           "ConversationManagerConversationTypeNone",
           "ConversationManagerConversationTypeMessage",
           "ConversationManagerConversationTypeLine",
-          "ConversationManagerConversationTypeWhatsApp"
+          "ConversationManagerConversationTypeWhatsApp",
+          "ConversationManagerConversationTypeEmail"
         ]
       },
       "ConversationManagerConversation": {
@@ -24721,34 +24723,36 @@
       },
       "ConversationManagerMessageReferenceType": {
         "type": "string",
-        "description": "Type of reference associated with the message (e.g., call, campaign).",
-        "example": "call",
+        "description": "Source channel that produced the message.",
+        "example": "message",
         "enum": [
-          "none",
-          "call",
-          "campaign"
+          "",
+          "message",
+          "line",
+          "whatsapp",
+          "email"
         ],
         "x-enum-varnames": [
           "ConversationManagerMessageReferenceTypeNone",
-          "ConversationManagerMessageReferenceTypeCall",
-          "ConversationManagerMessageReferenceTypeCampaign"
+          "ConversationManagerMessageReferenceTypeMessage",
+          "ConversationManagerMessageReferenceTypeLine",
+          "ConversationManagerMessageReferenceTypeWhatsApp",
+          "ConversationManagerMessageReferenceTypeEmail"
         ]
       },
       "ConversationManagerMessageStatus": {
         "type": "string",
-        "description": "Status of the message.",
-        "example": "sent",
+        "description": "Delivery status of the message.",
+        "example": "done",
         "enum": [
-          "sending",
-          "sent",
-          "failed",
-          "received"
+          "progressing",
+          "done",
+          "failed"
         ],
         "x-enum-varnames": [
-          "ConversationManagerMessageStatusSending",
-          "ConversationManagerMessageStatusSent",
-          "ConversationManagerMessageStatusFailed",
-          "ConversationManagerMessageStatusReceived"
+          "ConversationManagerMessageStatusProgressing",
+          "ConversationManagerMessageStatusDone",
+          "ConversationManagerMessageStatusFailed"
         ]
       },
       "ConversationManagerMessage": {
@@ -24783,12 +24787,12 @@
           "status": {
             "$ref": "#/components/schemas/ConversationManagerMessageStatus",
             "description": "Current delivery status of the message.",
-            "example": "sent"
+            "example": "done"
           },
           "reference_type": {
             "$ref": "#/components/schemas/ConversationManagerMessageReferenceType",
-            "description": "Type of reference associated with the message.",
-            "example": "call"
+            "description": "Source channel that produced the message.",
+            "example": "message"
           },
           "reference_id": {
             "type": "string",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -527,6 +527,7 @@ const (
 
 // Defines values for ConversationManagerConversationType.
 const (
+	ConversationManagerConversationTypeEmail    ConversationManagerConversationType = "email"
 	ConversationManagerConversationTypeLine     ConversationManagerConversationType = "line"
 	ConversationManagerConversationTypeMessage  ConversationManagerConversationType = "message"
 	ConversationManagerConversationTypeNone     ConversationManagerConversationType = ""
@@ -554,17 +555,18 @@ const (
 
 // Defines values for ConversationManagerMessageReferenceType.
 const (
-	ConversationManagerMessageReferenceTypeCall     ConversationManagerMessageReferenceType = "call"
-	ConversationManagerMessageReferenceTypeCampaign ConversationManagerMessageReferenceType = "campaign"
-	ConversationManagerMessageReferenceTypeNone     ConversationManagerMessageReferenceType = "none"
+	ConversationManagerMessageReferenceTypeEmail    ConversationManagerMessageReferenceType = "email"
+	ConversationManagerMessageReferenceTypeLine     ConversationManagerMessageReferenceType = "line"
+	ConversationManagerMessageReferenceTypeMessage  ConversationManagerMessageReferenceType = "message"
+	ConversationManagerMessageReferenceTypeNone     ConversationManagerMessageReferenceType = ""
+	ConversationManagerMessageReferenceTypeWhatsApp ConversationManagerMessageReferenceType = "whatsapp"
 )
 
 // Defines values for ConversationManagerMessageStatus.
 const (
-	ConversationManagerMessageStatusFailed   ConversationManagerMessageStatus = "failed"
-	ConversationManagerMessageStatusReceived ConversationManagerMessageStatus = "received"
-	ConversationManagerMessageStatusSending  ConversationManagerMessageStatus = "sending"
-	ConversationManagerMessageStatusSent     ConversationManagerMessageStatus = "sent"
+	ConversationManagerMessageStatusDone        ConversationManagerMessageStatus = "done"
+	ConversationManagerMessageStatusFailed      ConversationManagerMessageStatus = "failed"
+	ConversationManagerMessageStatusProgressing ConversationManagerMessageStatus = "progressing"
 )
 
 // Defines values for CustomerManagerCustomerIdentityVerificationStatus.
@@ -2838,10 +2840,10 @@ type ConversationManagerMessage struct {
 	// ReferenceId The unique identifier of the referenced resource. The actual resource type is determined by reference_type. Returned from the corresponding resource endpoint.
 	ReferenceId *string `json:"reference_id,omitempty"`
 
-	// ReferenceType Type of reference associated with the message (e.g., call, campaign).
+	// ReferenceType Source channel that produced the message.
 	ReferenceType *ConversationManagerMessageReferenceType `json:"reference_type,omitempty"`
 
-	// Status Status of the message.
+	// Status Delivery status of the message.
 	Status *ConversationManagerMessageStatus `json:"status,omitempty"`
 
 	// Text The message content.
@@ -2860,10 +2862,10 @@ type ConversationManagerMessage struct {
 // ConversationManagerMessageDirection Direction of the message (incoming or outgoing).
 type ConversationManagerMessageDirection string
 
-// ConversationManagerMessageReferenceType Type of reference associated with the message (e.g., call, campaign).
+// ConversationManagerMessageReferenceType Source channel that produced the message.
 type ConversationManagerMessageReferenceType string
 
-// ConversationManagerMessageStatus Status of the message.
+// ConversationManagerMessageStatus Delivery status of the message.
 type ConversationManagerMessageStatus string
 
 // CustomerManagerAccesskey defines model for CustomerManagerAccesskey.

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -1532,6 +1532,7 @@ func (e ConversationManagerAccountType) Valid() bool {
 
 // Defines values for ConversationManagerConversationType.
 const (
+	ConversationManagerConversationTypeEmail    ConversationManagerConversationType = "email"
 	ConversationManagerConversationTypeLine     ConversationManagerConversationType = "line"
 	ConversationManagerConversationTypeMessage  ConversationManagerConversationType = "message"
 	ConversationManagerConversationTypeNone     ConversationManagerConversationType = ""
@@ -1541,6 +1542,8 @@ const (
 // Valid indicates whether the value is a known member of the ConversationManagerConversationType enum.
 func (e ConversationManagerConversationType) Valid() bool {
 	switch e {
+	case ConversationManagerConversationTypeEmail:
+		return true
 	case ConversationManagerConversationTypeLine:
 		return true
 	case ConversationManagerConversationTypeMessage:
@@ -1613,19 +1616,25 @@ func (e ConversationManagerMessageDirection) Valid() bool {
 
 // Defines values for ConversationManagerMessageReferenceType.
 const (
-	ConversationManagerMessageReferenceTypeCall     ConversationManagerMessageReferenceType = "call"
-	ConversationManagerMessageReferenceTypeCampaign ConversationManagerMessageReferenceType = "campaign"
-	ConversationManagerMessageReferenceTypeNone     ConversationManagerMessageReferenceType = "none"
+	ConversationManagerMessageReferenceTypeEmail    ConversationManagerMessageReferenceType = "email"
+	ConversationManagerMessageReferenceTypeLine     ConversationManagerMessageReferenceType = "line"
+	ConversationManagerMessageReferenceTypeMessage  ConversationManagerMessageReferenceType = "message"
+	ConversationManagerMessageReferenceTypeNone     ConversationManagerMessageReferenceType = ""
+	ConversationManagerMessageReferenceTypeWhatsApp ConversationManagerMessageReferenceType = "whatsapp"
 )
 
 // Valid indicates whether the value is a known member of the ConversationManagerMessageReferenceType enum.
 func (e ConversationManagerMessageReferenceType) Valid() bool {
 	switch e {
-	case ConversationManagerMessageReferenceTypeCall:
+	case ConversationManagerMessageReferenceTypeEmail:
 		return true
-	case ConversationManagerMessageReferenceTypeCampaign:
+	case ConversationManagerMessageReferenceTypeLine:
+		return true
+	case ConversationManagerMessageReferenceTypeMessage:
 		return true
 	case ConversationManagerMessageReferenceTypeNone:
+		return true
+	case ConversationManagerMessageReferenceTypeWhatsApp:
 		return true
 	default:
 		return false
@@ -1634,22 +1643,19 @@ func (e ConversationManagerMessageReferenceType) Valid() bool {
 
 // Defines values for ConversationManagerMessageStatus.
 const (
-	ConversationManagerMessageStatusFailed   ConversationManagerMessageStatus = "failed"
-	ConversationManagerMessageStatusReceived ConversationManagerMessageStatus = "received"
-	ConversationManagerMessageStatusSending  ConversationManagerMessageStatus = "sending"
-	ConversationManagerMessageStatusSent     ConversationManagerMessageStatus = "sent"
+	ConversationManagerMessageStatusDone        ConversationManagerMessageStatus = "done"
+	ConversationManagerMessageStatusFailed      ConversationManagerMessageStatus = "failed"
+	ConversationManagerMessageStatusProgressing ConversationManagerMessageStatus = "progressing"
 )
 
 // Valid indicates whether the value is a known member of the ConversationManagerMessageStatus enum.
 func (e ConversationManagerMessageStatus) Valid() bool {
 	switch e {
+	case ConversationManagerMessageStatusDone:
+		return true
 	case ConversationManagerMessageStatusFailed:
 		return true
-	case ConversationManagerMessageStatusReceived:
-		return true
-	case ConversationManagerMessageStatusSending:
-		return true
-	case ConversationManagerMessageStatusSent:
+	case ConversationManagerMessageStatusProgressing:
 		return true
 	default:
 		return false
@@ -5055,10 +5061,10 @@ type ConversationManagerMessage struct {
 	// ReferenceId The unique identifier of the referenced resource. The actual resource type is determined by reference_type. Returned from the corresponding resource endpoint.
 	ReferenceId *string `json:"reference_id,omitempty"`
 
-	// ReferenceType Type of reference associated with the message (e.g., call, campaign).
+	// ReferenceType Source channel that produced the message.
 	ReferenceType *ConversationManagerMessageReferenceType `json:"reference_type,omitempty"`
 
-	// Status Status of the message.
+	// Status Delivery status of the message.
 	Status *ConversationManagerMessageStatus `json:"status,omitempty"`
 
 	// Text The message content.
@@ -5077,10 +5083,10 @@ type ConversationManagerMessage struct {
 // ConversationManagerMessageDirection Direction of the message (incoming or outgoing).
 type ConversationManagerMessageDirection string
 
-// ConversationManagerMessageReferenceType Type of reference associated with the message (e.g., call, campaign).
+// ConversationManagerMessageReferenceType Source channel that produced the message.
 type ConversationManagerMessageReferenceType string
 
-// ConversationManagerMessageStatus Status of the message.
+// ConversationManagerMessageStatus Delivery status of the message.
 type ConversationManagerMessageStatus string
 
 // CustomerManagerAccesskey defines model for CustomerManagerAccesskey.

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -3588,11 +3588,13 @@ components:
         - message
         - line
         - whatsapp
+        - email
       x-enum-varnames:
         - ConversationManagerConversationTypeNone
         - ConversationManagerConversationTypeMessage
         - ConversationManagerConversationTypeLine
         - ConversationManagerConversationTypeWhatsApp
+        - ConversationManagerConversationTypeEmail
     ConversationManagerConversation:
       type: object
       properties:
@@ -3743,30 +3745,32 @@ components:
         - ConversationManagerMessageDirectionIncoming
     ConversationManagerMessageReferenceType:
       type: string
-      description: Type of reference associated with the message (e.g., call, campaign).
-      example: "call"
+      description: Source channel that produced the message.
+      example: "message"
       enum:
-        - none
-        - call
-        - campaign
+        - ""
+        - message
+        - line
+        - whatsapp
+        - email
       x-enum-varnames:
         - ConversationManagerMessageReferenceTypeNone
-        - ConversationManagerMessageReferenceTypeCall
-        - ConversationManagerMessageReferenceTypeCampaign
+        - ConversationManagerMessageReferenceTypeMessage
+        - ConversationManagerMessageReferenceTypeLine
+        - ConversationManagerMessageReferenceTypeWhatsApp
+        - ConversationManagerMessageReferenceTypeEmail
     ConversationManagerMessageStatus:
       type: string
-      description: Status of the message.
-      example: "sent"
+      description: Delivery status of the message.
+      example: "done"
       enum:
-        - sending
-        - sent
+        - progressing
+        - done
         - failed
-        - received
       x-enum-varnames:
-        - ConversationManagerMessageStatusSending
-        - ConversationManagerMessageStatusSent
+        - ConversationManagerMessageStatusProgressing
+        - ConversationManagerMessageStatusDone
         - ConversationManagerMessageStatusFailed
-        - ConversationManagerMessageStatusReceived
     ConversationManagerMessage:
       type: object
       properties:
@@ -3795,11 +3799,11 @@ components:
         status:
           $ref: '#/components/schemas/ConversationManagerMessageStatus'
           description: Current delivery status of the message.
-          example: "sent"
+          example: "done"
         reference_type:
           $ref: '#/components/schemas/ConversationManagerMessageReferenceType'
-          description: Type of reference associated with the message.
-          example: "call"
+          description: Source channel that produced the message.
+          example: "message"
         reference_id:
           type: string
           format: uuid


### PR DESCRIPTION
Align the conversation message and conversation OpenAPI enums with the actual WebhookMessage wire contract produced by bin-conversation-manager. The REST handler (bin-api-manager conversation_message.go) returns ConvertWebhookMessage output, whose status/reference_type/type values are the internal enums, but the spec listed invented values that never matched any real response. Verified end-to-end against models/message/webhook.go and the api-manager servicehandler.

- bin-openapi-manager: ConversationManagerMessageStatus sending/sent/failed/received -> progressing/done/failed
- bin-openapi-manager: ConversationManagerMessageReferenceType none/call/campaign -> ""/message/line/whatsapp/email
- bin-openapi-manager: ConversationManagerConversationType add email (whatsapp already present)
- bin-openapi-manager: Fix ConversationManagerMessage status/reference_type field examples to valid enum literals
- bin-openapi-manager: Regenerate gens/models/gen.go
- bin-api-manager: Regenerate gens/openapi_server/gen.go and redoc artifacts

subject and transaction_id are intentionally NOT added: WebhookMessage does not expose them. No handler logic changed (enum types are plain string aliases). Frontend (square-admin api.ts) sync tracked separately in SQUARE-4.