### PR TITLE
VOIP-1216-fix-availablenumber-schema-swap

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -26496,25 +26496,6 @@
         }
       },
       "NumberManagerAvailableNumber": {
-        "type": "string",
-        "description": "A feature supported by the phone number.",
-        "example": "voice",
-        "enum": [
-          "emergency",
-          "fax",
-          "mms",
-          "sms",
-          "voice"
-        ],
-        "x-enum-varnames": [
-          "NumberManagerAvailableNumberFeatureEmergency",
-          "NumberManagerAvailableNumberFeatureFax",
-          "NumberManagerAvailableNumberFeatureMMS",
-          "NumberManagerAvailableNumberFeatureSMS",
-          "NumberManagerAvailableNumberFeatureVoice"
-        ]
-      },
-      "NumberManagerAvailableNumberFeature": {
         "type": "object",
         "properties": {
           "number": {
@@ -26545,6 +26526,25 @@
             "description": "The list of features supported by the number."
           }
         }
+      },
+      "NumberManagerAvailableNumberFeature": {
+        "type": "string",
+        "description": "A feature supported by the phone number.",
+        "example": "voice",
+        "enum": [
+          "emergency",
+          "fax",
+          "mms",
+          "sms",
+          "voice"
+        ],
+        "x-enum-varnames": [
+          "NumberManagerAvailableNumberFeatureEmergency",
+          "NumberManagerAvailableNumberFeatureFax",
+          "NumberManagerAvailableNumberFeatureMMS",
+          "NumberManagerAvailableNumberFeatureSMS",
+          "NumberManagerAvailableNumberFeatureVoice"
+        ]
       },
       "NumberManagerNumberType": {
         "type": "string",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -772,13 +772,13 @@ const (
 	MessageManagerTargetStatusSent       MessageManagerTargetStatus = "sent"
 )
 
-// Defines values for NumberManagerAvailableNumber.
+// Defines values for NumberManagerAvailableNumberFeature.
 const (
-	NumberManagerAvailableNumberFeatureEmergency NumberManagerAvailableNumber = "emergency"
-	NumberManagerAvailableNumberFeatureFax       NumberManagerAvailableNumber = "fax"
-	NumberManagerAvailableNumberFeatureMMS       NumberManagerAvailableNumber = "mms"
-	NumberManagerAvailableNumberFeatureSMS       NumberManagerAvailableNumber = "sms"
-	NumberManagerAvailableNumberFeatureVoice     NumberManagerAvailableNumber = "voice"
+	NumberManagerAvailableNumberFeatureEmergency NumberManagerAvailableNumberFeature = "emergency"
+	NumberManagerAvailableNumberFeatureFax       NumberManagerAvailableNumberFeature = "fax"
+	NumberManagerAvailableNumberFeatureMMS       NumberManagerAvailableNumberFeature = "mms"
+	NumberManagerAvailableNumberFeatureSMS       NumberManagerAvailableNumberFeature = "sms"
+	NumberManagerAvailableNumberFeatureVoice     NumberManagerAvailableNumberFeature = "voice"
 )
 
 // Defines values for NumberManagerNumberProviderName.
@@ -3722,11 +3722,8 @@ type MessageManagerTarget struct {
 // MessageManagerTargetStatus The status of the message for the target.
 type MessageManagerTargetStatus string
 
-// NumberManagerAvailableNumber A feature supported by the phone number.
-type NumberManagerAvailableNumber string
-
-// NumberManagerAvailableNumberFeature defines model for NumberManagerAvailableNumberFeature.
-type NumberManagerAvailableNumberFeature struct {
+// NumberManagerAvailableNumber defines model for NumberManagerAvailableNumber.
+type NumberManagerAvailableNumber struct {
 	// Country The country where the number is available.
 	Country *string `json:"country,omitempty"`
 
@@ -3742,6 +3739,9 @@ type NumberManagerAvailableNumberFeature struct {
 	// Region The region within the country.
 	Region *string `json:"region,omitempty"`
 }
+
+// NumberManagerAvailableNumberFeature A feature supported by the phone number.
+type NumberManagerAvailableNumberFeature string
 
 // NumberManagerMetadata Configuration flags for a number. Controls platform behavior
 // such as RTP packet capture for debugging audio issues on this specific number.

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -2271,17 +2271,17 @@ func (e MessageManagerTargetStatus) Valid() bool {
 	}
 }
 
-// Defines values for NumberManagerAvailableNumber.
+// Defines values for NumberManagerAvailableNumberFeature.
 const (
-	NumberManagerAvailableNumberFeatureEmergency NumberManagerAvailableNumber = "emergency"
-	NumberManagerAvailableNumberFeatureFax       NumberManagerAvailableNumber = "fax"
-	NumberManagerAvailableNumberFeatureMMS       NumberManagerAvailableNumber = "mms"
-	NumberManagerAvailableNumberFeatureSMS       NumberManagerAvailableNumber = "sms"
-	NumberManagerAvailableNumberFeatureVoice     NumberManagerAvailableNumber = "voice"
+	NumberManagerAvailableNumberFeatureEmergency NumberManagerAvailableNumberFeature = "emergency"
+	NumberManagerAvailableNumberFeatureFax       NumberManagerAvailableNumberFeature = "fax"
+	NumberManagerAvailableNumberFeatureMMS       NumberManagerAvailableNumberFeature = "mms"
+	NumberManagerAvailableNumberFeatureSMS       NumberManagerAvailableNumberFeature = "sms"
+	NumberManagerAvailableNumberFeatureVoice     NumberManagerAvailableNumberFeature = "voice"
 )
 
-// Valid indicates whether the value is a known member of the NumberManagerAvailableNumber enum.
-func (e NumberManagerAvailableNumber) Valid() bool {
+// Valid indicates whether the value is a known member of the NumberManagerAvailableNumberFeature enum.
+func (e NumberManagerAvailableNumberFeature) Valid() bool {
 	switch e {
 	case NumberManagerAvailableNumberFeatureEmergency:
 		return true
@@ -5943,11 +5943,8 @@ type MessageManagerTarget struct {
 // MessageManagerTargetStatus The status of the message for the target.
 type MessageManagerTargetStatus string
 
-// NumberManagerAvailableNumber A feature supported by the phone number.
-type NumberManagerAvailableNumber string
-
-// NumberManagerAvailableNumberFeature defines model for NumberManagerAvailableNumberFeature.
-type NumberManagerAvailableNumberFeature struct {
+// NumberManagerAvailableNumber defines model for NumberManagerAvailableNumber.
+type NumberManagerAvailableNumber struct {
 	// Country The country where the number is available.
 	Country *string `json:"country,omitempty"`
 
@@ -5963,6 +5960,9 @@ type NumberManagerAvailableNumberFeature struct {
 	// Region The region within the country.
 	Region *string `json:"region,omitempty"`
 }
+
+// NumberManagerAvailableNumberFeature A feature supported by the phone number.
+type NumberManagerAvailableNumberFeature string
 
 // NumberManagerMetadata Configuration flags for a number. Controls platform behavior
 // such as RTP packet capture for debugging audio issues on this specific number.

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -5309,22 +5309,6 @@ components:
 # Number Manager
 #########################################
     NumberManagerAvailableNumber:
-      type: string
-      description: A feature supported by the phone number.
-      example: "voice"
-      enum:
-        - emergency
-        - fax
-        - mms
-        - sms
-        - voice
-      x-enum-varnames:
-        - NumberManagerAvailableNumberFeatureEmergency
-        - NumberManagerAvailableNumberFeatureFax
-        - NumberManagerAvailableNumberFeatureMMS
-        - NumberManagerAvailableNumberFeatureSMS
-        - NumberManagerAvailableNumberFeatureVoice
-    NumberManagerAvailableNumberFeature:
       type: object
       properties:
         number:
@@ -5348,6 +5332,22 @@ components:
           items:
             $ref: '#/components/schemas/NumberManagerAvailableNumberFeature'
           description: The list of features supported by the number.
+    NumberManagerAvailableNumberFeature:
+      type: string
+      description: A feature supported by the phone number.
+      example: "voice"
+      enum:
+        - emergency
+        - fax
+        - mms
+        - sms
+        - voice
+      x-enum-varnames:
+        - NumberManagerAvailableNumberFeatureEmergency
+        - NumberManagerAvailableNumberFeatureFax
+        - NumberManagerAvailableNumberFeatureMMS
+        - NumberManagerAvailableNumberFeatureSMS
+        - NumberManagerAvailableNumberFeatureVoice
 
     NumberManagerNumberType:
       type: string


### PR DESCRIPTION
Fix swapped schema bodies for NumberManagerAvailableNumber and NumberManagerAvailableNumberFeature in the OpenAPI spec. The two definitions had their bodies swapped relative to their names: NumberManagerAvailableNumber was a string enum and NumberManagerAvailableNumberFeature was the available-number object, and the features array self-referenced the object. The Go source of truth (bin-number-manager/models/availablenumber) is correct; only the spec was wrong. Found during the VOIP-1214 contract parity audit (OpenAPI axis), the only real code<->OpenAPI drift across 50 matched webhook structs. The RST docs (availablenumber_struct.rst) were already correct, so no RST change is needed.

- bin-openapi-manager: Swap NumberManagerAvailableNumber (now the object: number, country, region, postal_code, features) and NumberManagerAvailableNumberFeature (now the string enum: emergency/fax/mms/sms/voice) so schema bodies match their names and the Go code
- bin-openapi-manager: Regenerate gens/models/gen.go (AvailableNumber is now a struct, Feature is a string enum, features array no longer self-references the object)
- bin-api-manager: Regenerate gens/openapi_server/gen.go and gens/openapi_redoc (openapi.json, api.html) to reflect the corrected schemas