### PR TITLE
VOIP-1207-fix-alembic-multiple-heads

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/bbcf80d332eb_contact_crm_m1_migrate_addresses.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/bbcf80d332eb_contact_crm_m1_migrate_addresses.py
@@ -1,7 +1,7 @@
 """contact_crm_m1_migrate_addresses
 
 Revision ID: bbcf80d332eb
-Revises: ac5d4e18060c
+Revises: 04e92612d9c7
 Create Date: 2026-06-27 22:27:18.763159
 
 VOIP-1207 (CRM M1). Migrates the legacy normalized child tables
@@ -49,7 +49,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'bbcf80d332eb'
-down_revision = 'ac5d4e18060c'
+down_revision = '04e92612d9c7'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Resolve the Alembic multiple-head fork created when VOIP-1207 and VOIP-1215 both branched off ac5d4e18060c (VOIP-1206) and merged independently, which made `alembic upgrade head` fail with "Multiple head revisions are present". Relink the VOIP-1207 migration onto VOIP-1215 to restore a single linear head.

- bin-dbscheme-manager: Change bbcf80d332eb down_revision from ac5d4e18060c to 04e92612d9c7 so the chain is ac5d4e18060c -> 04e92612d9c7 -> bbcf80d332eb with a single head; the two migrations touch disjoint tables (contact_addresses vs conversation_messages) so the ordering is data-safe. Verified on a throwaway MySQL 8.0: single head, full upgrade chain applies, downgrade/re-upgrade round-trips, and the seeded-data invariants (one primary per contact, cross-contact email dedup, lowercase normalization) all hold.

Environment state confirmed (alembic current = 04e92612d9c7 on target DB): bbcf80d332eb is not yet applied. After this PR merges, alembic upgrade head applies bbcf80d332eb directly with no manual intervention required.