### PR TITLE
VOIP-1208-contact-crm-projection-handlers

### DIFF
--- a/bin-contact-manager/cmd/contact-manager/main.go
+++ b/bin-contact-manager/cmd/contact-manager/main.go
@@ -155,6 +155,8 @@ func runSubscribe(sockHandler sockhandler.SockHandler, contactHandler contacthan
 
 	subscribeTargets := []string{
 		string(commonoutline.QueueNameCustomerEvent),
+		string(commonoutline.QueueNameCallEvent),           // call_created -> CRM interaction timeline
+		string(commonoutline.QueueNameConversationEvent),   // conversation_message_created -> CRM interaction timeline
 	}
 	subHandler := subscribehandler.NewSubscribeHandler(sockHandler, string(commonoutline.QueueNameContactSubscribe), subscribeTargets, contactHandler)
 

--- a/bin-contact-manager/go.mod
+++ b/bin-contact-manager/go.mod
@@ -75,7 +75,9 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	go.uber.org/mock v0.6.0
+	monorepo/bin-call-manager v0.0.0-20240403030948-51eb7c33cf9a
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
+	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984
 )
 
@@ -115,10 +117,8 @@ require (
 	monorepo/bin-agent-manager v0.0.0-20240328054741-55144017eccd // indirect
 	monorepo/bin-ai-manager v0.0.0-20240313050825-1c666b883013 // indirect
 	monorepo/bin-billing-manager v0.0.0-20240408051040-600f0028fbab // indirect
-	monorepo/bin-call-manager v0.0.0-20240403030948-51eb7c33cf9a // indirect
 	monorepo/bin-campaign-manager v0.0.0-20240313031908-f098e3fb6f12 // indirect
 	monorepo/bin-conference-manager v0.0.0-20240329045829-45dc5f4e4e76 // indirect
-	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4 // indirect
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-email-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-flow-manager v0.0.0-20240403034140-ce82222fe7f4 // indirect

--- a/bin-contact-manager/models/interaction/interaction.go
+++ b/bin-contact-manager/models/interaction/interaction.go
@@ -1,0 +1,43 @@
+package interaction
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+)
+
+// Interaction is an immutable append-only fact in the CRM interaction timeline.
+// It records that a channel-level event (call or conversation message) touched a
+// particular remote endpoint (peer). Identity resolution (peer -> contact_id) is
+// done at read time (VOIP-1209), not projection time.
+type Interaction struct {
+	ID         uuid.UUID `json:"id"          db:"id,uuid"`
+	CustomerID uuid.UUID `json:"customer_id"  db:"customer_id,uuid"`
+
+	// Direction of the interaction from our perspective ("incoming"/"outgoing").
+	Direction string `json:"direction" db:"direction"`
+
+	// Remote endpoint (the peer's address — match key for read-time contact resolution).
+	// peer_target is stored normalized via commonaddress.NormalizeTarget so it is
+	// bit-identical to contact_addresses.target.
+	PeerType   string `json:"peer_type"   db:"peer_type"`
+	PeerTarget string `json:"peer_target" db:"peer_target"`
+
+	// Our local endpoint (for attribution: which number/account received/sent).
+	// Not in the idempotency unique; not indexed (attribution only).
+	LocalType   string `json:"local_type"   db:"local_type"`
+	LocalTarget string `json:"local_target" db:"local_target"`
+
+	// Origin channel record. State and body are fetched at read time via
+	// (reference_type, reference_id).
+	ReferenceType string    `json:"reference_type" db:"reference_type"`
+	ReferenceID   uuid.UUID `json:"reference_id"   db:"reference_id,uuid"`
+
+	// TMInteraction is the origin event time, used for display sort.
+	// Nullable: may be nil when the origin event omits TMCreate (e.g. call events
+	// with omitempty). Stored as NULL in that case — do not dereference.
+	TMInteraction *time.Time `json:"tm_interaction" db:"tm_interaction"`
+
+	// TMCreate is the projection insert time, used as the pagination cursor.
+	TMCreate *time.Time `json:"tm_create" db:"tm_create"`
+}

--- a/bin-contact-manager/pkg/contacthandler/interaction.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction.go
@@ -1,0 +1,119 @@
+package contacthandler
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	call "monorepo/bin-call-manager/models/call"
+	message "monorepo/bin-conversation-manager/models/message"
+
+	"monorepo/bin-contact-manager/models/interaction"
+)
+
+// deriveEndpoints resolves which address is the remote peer and which is our
+// local endpoint based on the call/message direction.
+//
+//   - incoming: the remote party is the source (they called/wrote us)
+//   - outgoing: the remote party is the destination (we called/wrote them)
+//   - unknown:  both are zero values; the caller should still persist the row
+//     (the direction column itself carries the raw value for diagnostics).
+func deriveEndpoints(direction string, source, dest commonaddress.Address) (peer commonaddress.Address, local commonaddress.Address) {
+	switch direction {
+	case "incoming":
+		return source, dest
+	case "outgoing":
+		return dest, source
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}
+	}
+}
+
+// EventCallCreated projects a call-created webhook event into the CRM
+// interaction timeline.
+func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMessage) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "EventCallCreated",
+		"call_id":   m.ID,
+		"direction": m.Direction,
+	})
+
+	peer, local := deriveEndpoints(string(m.Direction), m.Source, m.Destination)
+
+	peerTarget, err := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+	if err != nil {
+		log.WithError(err).Warnf("could not normalize peer target; storing raw value. peer_type: %s peer_target: %s", peer.Type, peer.Target)
+		peerTarget = peer.Target
+	}
+
+	localTarget, err := commonaddress.NormalizeTarget(local.Type, local.Target)
+	if err != nil {
+		log.WithError(err).Warnf("could not normalize local target; storing raw value. local_type: %s local_target: %s", local.Type, local.Target)
+		localTarget = local.Target
+	}
+
+	id := h.utilHandler.UUIDCreate()
+	now := h.utilHandler.TimeNow()
+
+	i := interaction.Interaction{
+		ID:            id,
+		CustomerID:    m.CustomerID,
+		Direction:     string(m.Direction),
+		PeerType:      string(peer.Type),
+		PeerTarget:    peerTarget,
+		LocalType:     string(local.Type),
+		LocalTarget:   localTarget,
+		ReferenceType: "call",
+		ReferenceID:   m.ID,
+		TMInteraction: m.TMCreate,
+		TMCreate:      now,
+	}
+
+	return h.db.InteractionCreate(ctx, &i)
+}
+
+// EventConversationMessageCreated projects a conversation-message-created
+// webhook event into the CRM interaction timeline.
+func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m *message.WebhookMessage) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":       "EventConversationMessageCreated",
+		"message_id": m.ID,
+		"direction":  m.Direction,
+	})
+
+	peer, local := deriveEndpoints(string(m.Direction), m.Source, m.Destination)
+
+	peerTarget, err := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+	if err != nil {
+		log.WithError(err).Warnf("could not normalize peer target; storing raw value. peer_type: %s peer_target: %s", peer.Type, peer.Target)
+		peerTarget = peer.Target
+	}
+
+	localTarget, err := commonaddress.NormalizeTarget(local.Type, local.Target)
+	if err != nil {
+		log.WithError(err).Warnf("could not normalize local target; storing raw value. local_type: %s local_target: %s", local.Type, local.Target)
+		localTarget = local.Target
+	}
+
+	id := h.utilHandler.UUIDCreate()
+	now := h.utilHandler.TimeNow()
+
+	// m.ID comes from the embedded commonidentity.Identity; use it directly.
+	i := interaction.Interaction{
+		ID:            id,
+		CustomerID:    m.CustomerID,
+		Direction:     string(m.Direction),
+		PeerType:      string(peer.Type),
+		PeerTarget:    peerTarget,
+		LocalType:     string(local.Type),
+		LocalTarget:   localTarget,
+		ReferenceType: "conversation_message",
+		ReferenceID:   m.ID,
+		TMInteraction: m.TMCreate,
+		TMCreate:      now,
+	}
+
+	return h.db.InteractionCreate(ctx, &i)
+}

--- a/bin-contact-manager/pkg/contacthandler/interaction_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_test.go
@@ -101,6 +101,41 @@ func Test_EventCallCreated(t *testing.T) {
 				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC); return &t }(),
 			},
 		},
+		{
+			name: "unknown direction - zero peer/local, row still created",
+
+			message: &callmodel.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aa000003-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("aa000003-0000-0000-0000-000000000002"),
+				},
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "someSrc",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "someDst",
+				},
+				Direction: "", // unknown direction (DirectionNond)
+			},
+
+			responseUUID:    uuid.FromStringOrNil("bb000003-0000-0000-0000-000000000001"),
+			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC); return &t }(),
+
+			expectInteraction: &interaction.Interaction{
+				ID:            uuid.FromStringOrNil("bb000003-0000-0000-0000-000000000001"),
+				CustomerID:    uuid.FromStringOrNil("aa000003-0000-0000-0000-000000000002"),
+				Direction:     "",
+				PeerType:      "",
+				PeerTarget:    "",
+				LocalType:     "",
+				LocalTarget:   "",
+				ReferenceType: "call",
+				ReferenceID:   uuid.FromStringOrNil("aa000003-0000-0000-0000-000000000001"),
+				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC); return &t }(),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-contact-manager/pkg/contacthandler/interaction_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_test.go
@@ -1,0 +1,208 @@
+package contacthandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	callmodel "monorepo/bin-call-manager/models/call"
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+	convmsg "monorepo/bin-conversation-manager/models/message"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+func Test_EventCallCreated(t *testing.T) {
+	tests := []struct {
+		name string
+
+		message *callmodel.WebhookMessage
+
+		responseUUID uuid.UUID
+		responseCurTime *time.Time
+
+		expectInteraction *interaction.Interaction
+	}{
+		{
+			name: "incoming call - peer=source, local=destination",
+
+			message: &callmodel.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aa000001-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("aa000001-0000-0000-0000-000000000002"),
+				},
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "peerTelIncoming",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "localTelIncoming",
+				},
+				Direction: callmodel.DirectionIncoming,
+			},
+
+			responseUUID:    uuid.FromStringOrNil("bb000001-0000-0000-0000-000000000001"),
+			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC); return &t }(),
+
+			expectInteraction: &interaction.Interaction{
+				ID:            uuid.FromStringOrNil("bb000001-0000-0000-0000-000000000001"),
+				CustomerID:    uuid.FromStringOrNil("aa000001-0000-0000-0000-000000000002"),
+				Direction:     "incoming",
+				PeerType:      "tel",
+				PeerTarget:    "peerTelIncoming",
+				LocalType:     "tel",
+				LocalTarget:   "localTelIncoming",
+				ReferenceType: "call",
+				ReferenceID:   uuid.FromStringOrNil("aa000001-0000-0000-0000-000000000001"),
+				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC); return &t }(),
+			},
+		},
+		{
+			name: "outgoing call - peer=destination, local=source",
+
+			message: &callmodel.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aa000002-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("aa000002-0000-0000-0000-000000000002"),
+				},
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "localTelOutgoing",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "peerTelOutgoing",
+				},
+				Direction: callmodel.DirectionOutgoing,
+			},
+
+			responseUUID:    uuid.FromStringOrNil("bb000002-0000-0000-0000-000000000001"),
+			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC); return &t }(),
+
+			expectInteraction: &interaction.Interaction{
+				ID:            uuid.FromStringOrNil("bb000002-0000-0000-0000-000000000001"),
+				CustomerID:    uuid.FromStringOrNil("aa000002-0000-0000-0000-000000000002"),
+				Direction:     "outgoing",
+				PeerType:      "tel",
+				PeerTarget:    "peerTelOutgoing",
+				LocalType:     "tel",
+				LocalTarget:   "localTelOutgoing",
+				ReferenceType: "call",
+				ReferenceID:   uuid.FromStringOrNil("aa000002-0000-0000-0000-000000000001"),
+				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC); return &t }(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			h := contactHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+				utilHandler:   mockUtil,
+			}
+			ctx := context.Background()
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+			mockDB.EXPECT().InteractionCreate(ctx, tt.expectInteraction).Return(nil)
+
+			if err := h.EventCallCreated(ctx, tt.message); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EventConversationMessageCreated(t *testing.T) {
+	tests := []struct {
+		name string
+
+		message *convmsg.WebhookMessage
+
+		responseUUID    uuid.UUID
+		responseCurTime *time.Time
+
+		expectInteraction *interaction.Interaction
+	}{
+		{
+			name: "incoming LINE message - peer=source, local=destination",
+
+			message: &convmsg.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("cc000001-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("cc000001-0000-0000-0000-000000000002"),
+				},
+				Direction: convmsg.DirectionIncoming,
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeLine,
+					Target: "Ud871bcaf7c3ad13d2a0b0d78a42a287f",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeLine,
+					Target: "",
+				},
+			},
+
+			responseUUID:    uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001"),
+			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC); return &t }(),
+
+			expectInteraction: &interaction.Interaction{
+				ID:            uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001"),
+				CustomerID:    uuid.FromStringOrNil("cc000001-0000-0000-0000-000000000002"),
+				Direction:     "incoming",
+				PeerType:      "line",
+				PeerTarget:    "Ud871bcaf7c3ad13d2a0b0d78a42a287f",
+				LocalType:     "line",
+				LocalTarget:   "",
+				ReferenceType: "conversation_message",
+				ReferenceID:   uuid.FromStringOrNil("cc000001-0000-0000-0000-000000000001"),
+				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC); return &t }(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			h := contactHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+				utilHandler:   mockUtil,
+			}
+			ctx := context.Background()
+
+			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+			mockDB.EXPECT().InteractionCreate(ctx, tt.expectInteraction).Return(nil)
+
+			if err := h.EventConversationMessageCreated(ctx, tt.message); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}

--- a/bin-contact-manager/pkg/contacthandler/main.go
+++ b/bin-contact-manager/pkg/contacthandler/main.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	callmodel "monorepo/bin-call-manager/models/call"
+	convmsg "monorepo/bin-conversation-manager/models/message"
 	"monorepo/bin-contact-manager/models/contact"
 	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
@@ -44,6 +46,10 @@ type ContactHandler interface {
 
 	// Event handlers
 	EventCustomerDeleted(ctx context.Context, c *cmcustomer.Customer) error
+
+	// Projection event handlers (CRM interaction timeline)
+	EventCallCreated(ctx context.Context, m *callmodel.WebhookMessage) error
+	EventConversationMessageCreated(ctx context.Context, m *convmsg.WebhookMessage) error
 }
 
 type contactHandler struct {

--- a/bin-contact-manager/pkg/contacthandler/mock_main.go
+++ b/bin-contact-manager/pkg/contacthandler/mock_main.go
@@ -11,7 +11,9 @@ package contacthandler
 
 import (
 	context "context"
+	call "monorepo/bin-call-manager/models/call"
 	contact "monorepo/bin-contact-manager/models/contact"
+	message "monorepo/bin-conversation-manager/models/message"
 	customer "monorepo/bin-customer-manager/models/customer"
 	reflect "reflect"
 
@@ -116,6 +118,34 @@ func (m *MockContactHandler) Delete(ctx context.Context, id uuid.UUID) (*contact
 func (mr *MockContactHandlerMockRecorder) Delete(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockContactHandler)(nil).Delete), ctx, id)
+}
+
+// EventCallCreated mocks base method.
+func (m_2 *MockContactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMessage) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "EventCallCreated", ctx, m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EventCallCreated indicates an expected call of EventCallCreated.
+func (mr *MockContactHandlerMockRecorder) EventCallCreated(ctx, m any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventCallCreated", reflect.TypeOf((*MockContactHandler)(nil).EventCallCreated), ctx, m)
+}
+
+// EventConversationMessageCreated mocks base method.
+func (m_2 *MockContactHandler) EventConversationMessageCreated(ctx context.Context, m *message.WebhookMessage) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "EventConversationMessageCreated", ctx, m)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EventConversationMessageCreated indicates an expected call of EventConversationMessageCreated.
+func (mr *MockContactHandlerMockRecorder) EventConversationMessageCreated(ctx, m any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventConversationMessageCreated", reflect.TypeOf((*MockContactHandler)(nil).EventConversationMessageCreated), ctx, m)
 }
 
 // EventCustomerDeleted mocks base method.

--- a/bin-contact-manager/pkg/dbhandler/interaction.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction.go
@@ -1,0 +1,49 @@
+package dbhandler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	sq "github.com/Masterminds/squirrel"
+	mysql_driver "github.com/go-sql-driver/mysql"
+
+	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
+
+	"monorepo/bin-contact-manager/models/interaction"
+)
+
+const (
+	interactionTable = "contact_interactions"
+)
+
+// InteractionCreate inserts an Interaction row into contact_interactions.
+// It is idempotent: a duplicate-key error (MySQL errno 1062) is silently
+// ignored so the caller does not need to guard against at-least-once delivery.
+func (h *handler) InteractionCreate(ctx context.Context, i *interaction.Interaction) error {
+	fields, err := commondatabasehandler.PrepareFields(i)
+	if err != nil {
+		return fmt.Errorf("could not prepare fields. InteractionCreate. err: %v", err)
+	}
+
+	query, args, err := sq.Insert(interactionTable).SetMap(fields).ToSql()
+	if err != nil {
+		return fmt.Errorf("could not build query. InteractionCreate. err: %v", err)
+	}
+
+	_, err = h.db.Exec(query, args...)
+	if err != nil {
+		// Idempotent: ignore duplicate-key errors so at-least-once event
+		// delivery (e.g. RabbitMQ requeue on crash) does not surface errors.
+		// MySQL errno 1062 in production; SQLite UNIQUE constraint in tests.
+		if me, ok := err.(*mysql_driver.MySQLError); ok && me.Number == 1062 {
+			return nil
+		}
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return nil
+		}
+		return fmt.Errorf("could not create interaction. InteractionCreate. err: %v", err)
+	}
+
+	return nil
+}

--- a/bin-contact-manager/pkg/dbhandler/interaction_test.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction_test.go
@@ -1,0 +1,113 @@
+package dbhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/pkg/cachehandler"
+)
+
+func Test_InteractionCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		interaction *interaction.Interaction
+	}{
+		{
+			name: "normal incoming call",
+
+			interaction: &interaction.Interaction{
+				ID:            uuid.FromStringOrNil("a1b2c3d4-0001-0001-0001-000000000001"),
+				CustomerID:    uuid.FromStringOrNil("a1b2c3d4-0001-0001-0001-000000000002"),
+				Direction:     "incoming",
+				PeerType:      "tel",
+				PeerTarget:    "peerTarget-call-incoming",
+				LocalType:     "tel",
+				LocalTarget:   "localTarget-call-incoming",
+				ReferenceType: "call",
+				ReferenceID:   uuid.FromStringOrNil("a1b2c3d4-0001-0001-0001-000000000003"),
+				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC); return &t }(),
+			},
+		},
+		{
+			name: "outgoing conversation message LINE",
+
+			interaction: &interaction.Interaction{
+				ID:            uuid.FromStringOrNil("b1b2c3d4-0002-0002-0002-000000000001"),
+				CustomerID:    uuid.FromStringOrNil("b1b2c3d4-0002-0002-0002-000000000002"),
+				Direction:     "outgoing",
+				PeerType:      "line",
+				PeerTarget:    "Ud871bcaf7c3ad13d2a0b0d78a42a287f",
+				LocalType:     "line",
+				LocalTarget:   "",
+				ReferenceType: "conversation_message",
+				ReferenceID:   uuid.FromStringOrNil("b1b2c3d4-0002-0002-0002-000000000003"),
+				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC); return &t }(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			// InteractionCreate does NOT call utilHandler or cache.
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+			ctx := context.Background()
+
+			if err := h.InteractionCreate(ctx, tt.interaction); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_InteractionCreate_duplicate(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	i := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("c1b2c3d4-0003-0003-0003-000000000001"),
+		CustomerID:    uuid.FromStringOrNil("c1b2c3d4-0003-0003-0003-000000000002"),
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "uniquePeerTarget-idem-001",
+		LocalType:     "tel",
+		LocalTarget:   "uniqueLocalTarget-idem-001",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("c1b2c3d4-0003-0003-0003-000000000003"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC); return &t }(),
+	}
+
+	// first insert
+	if err := h.InteractionCreate(ctx, i); err != nil {
+		t.Fatalf("first insert failed: %v", err)
+	}
+
+	// duplicate insert — must NOT error (idempotent at-least-once guard)
+	if err := h.InteractionCreate(ctx, i); err != nil {
+		t.Errorf("duplicate insert should be idempotent (no error), got: %v", err)
+	}
+}

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/models/interaction"
 	"monorepo/bin-contact-manager/pkg/cachehandler"
 )
 
@@ -47,6 +48,9 @@ type DBHandler interface {
 	TagAssignmentCreate(ctx context.Context, contactID, tagID uuid.UUID) error
 	TagAssignmentDelete(ctx context.Context, contactID, tagID uuid.UUID) error
 	TagAssignmentListByContactID(ctx context.Context, contactID uuid.UUID) ([]uuid.UUID, error)
+
+	// Interaction operations
+	InteractionCreate(ctx context.Context, i *interaction.Interaction) error
 }
 
 // handler database handler

--- a/bin-contact-manager/pkg/dbhandler/mock_main.go
+++ b/bin-contact-manager/pkg/dbhandler/mock_main.go
@@ -12,6 +12,7 @@ package dbhandler
 import (
 	context "context"
 	contact "monorepo/bin-contact-manager/models/contact"
+	interaction "monorepo/bin-contact-manager/models/interaction"
 	reflect "reflect"
 
 	uuid "github.com/gofrs/uuid"
@@ -242,6 +243,20 @@ func (m *MockDBHandler) EmailUpdate(ctx context.Context, id uuid.UUID, fields ma
 func (mr *MockDBHandlerMockRecorder) EmailUpdate(ctx, id, fields any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmailUpdate", reflect.TypeOf((*MockDBHandler)(nil).EmailUpdate), ctx, id, fields)
+}
+
+// InteractionCreate mocks base method.
+func (m *MockDBHandler) InteractionCreate(ctx context.Context, i *interaction.Interaction) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionCreate", ctx, i)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InteractionCreate indicates an expected call of InteractionCreate.
+func (mr *MockDBHandlerMockRecorder) InteractionCreate(ctx, i any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionCreate", reflect.TypeOf((*MockDBHandler)(nil).InteractionCreate), ctx, i)
 }
 
 // PhoneNumberCreate mocks base method.

--- a/bin-contact-manager/pkg/subscribehandler/callmanager.go
+++ b/bin-contact-manager/pkg/subscribehandler/callmanager.go
@@ -1,0 +1,20 @@
+package subscribehandler
+
+import (
+	"context"
+	"encoding/json"
+
+	callmodel "monorepo/bin-call-manager/models/call"
+	"monorepo/bin-common-handler/models/sock"
+)
+
+// processEventCallManagerCallCreated handles the call-manager's call_created event
+// and projects it into the CRM interaction timeline.
+func (h *subscribeHandler) processEventCallManagerCallCreated(ctx context.Context, m *sock.Event) error {
+	var payload callmodel.WebhookMessage
+	if err := json.Unmarshal(m.Data, &payload); err != nil {
+		return err
+	}
+
+	return h.contactHandler.EventCallCreated(ctx, &payload)
+}

--- a/bin-contact-manager/pkg/subscribehandler/conversationmanager.go
+++ b/bin-contact-manager/pkg/subscribehandler/conversationmanager.go
@@ -1,0 +1,20 @@
+package subscribehandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+	convmsg "monorepo/bin-conversation-manager/models/message"
+)
+
+// processEventConversationManagerMessageCreated handles the conversation-manager's
+// conversation_message_created event and projects it into the CRM interaction timeline.
+func (h *subscribeHandler) processEventConversationManagerMessageCreated(ctx context.Context, m *sock.Event) error {
+	var payload convmsg.WebhookMessage
+	if err := json.Unmarshal(m.Data, &payload); err != nil {
+		return err
+	}
+
+	return h.contactHandler.EventConversationMessageCreated(ctx, &payload)
+}

--- a/bin-contact-manager/pkg/subscribehandler/main.go
+++ b/bin-contact-manager/pkg/subscribehandler/main.go
@@ -16,12 +16,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	call "monorepo/bin-call-manager/models/call"
+	convmsg "monorepo/bin-conversation-manager/models/message"
 	"monorepo/bin-contact-manager/pkg/contacthandler"
 )
 
 // list of publishers
 const (
-	publisherCustomerManager = string(commonoutline.ServiceNameCustomerManager)
+	publisherCustomerManager     = string(commonoutline.ServiceNameCustomerManager)
+	publisherCallManager         = string(commonoutline.ServiceNameCallManager)
+	publisherConversationManager = string(commonoutline.ServiceNameConversationManager)
 )
 
 // SubscribeHandler interface
@@ -132,6 +136,22 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 	// customer deleted - cleanup all contacts for this customer
 	case m.Publisher == publisherCustomerManager && (m.Type == string(cmcustomer.EventTypeCustomerDeleted)):
 		err = h.processEventCMCustomerDeleted(ctx, m)
+
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+	// call-manager events
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+
+	// call created - project into CRM interaction timeline
+	case m.Publisher == publisherCallManager && m.Type == call.EventTypeCallCreated:
+		err = h.processEventCallManagerCallCreated(ctx, m)
+
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+	// conversation-manager events
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+
+	// conversation message created - project into CRM interaction timeline
+	case m.Publisher == publisherConversationManager && m.Type == string(convmsg.EventTypeMessageCreated):
+		err = h.processEventConversationManagerMessageCreated(ctx, m)
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// No handler found

--- a/bin-contact-manager/pkg/subscribehandler/main.go
+++ b/bin-contact-manager/pkg/subscribehandler/main.go
@@ -150,7 +150,7 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 
 	// conversation message created - project into CRM interaction timeline
-	case m.Publisher == publisherConversationManager && m.Type == string(convmsg.EventTypeMessageCreated):
+	case m.Publisher == publisherConversationManager && m.Type == convmsg.EventTypeMessageCreated:
 		err = h.processEventConversationManagerMessageCreated(ctx, m)
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/bin-contact-manager/pkg/subscribehandler/subscribehandler_test.go
+++ b/bin-contact-manager/pkg/subscribehandler/subscribehandler_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
 
+	callmodel "monorepo/bin-call-manager/models/call"
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	convmsg "monorepo/bin-conversation-manager/models/message"
 	"monorepo/bin-contact-manager/pkg/contacthandler"
 )
 
@@ -331,7 +335,71 @@ func Test_processEvent_UnknownPublisher(t *testing.T) {
 	h.processEvent(event)
 }
 
-func Test_processEvent_UnknownEventType(t *testing.T) {
+func Test_processEventCallManagerCallCreated(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockContact := contacthandler.NewMockContactHandler(mc)
+	h := &subscribeHandler{sockHandler: mockSock, contactHandler: mockContact}
+	ctx := context.Background()
+
+	payload := callmodel.WebhookMessage{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("e1b2c3d4-0001-0001-0001-000000000001"),
+			CustomerID: uuid.FromStringOrNil("e1b2c3d4-0001-0001-0001-000000000002"),
+		},
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "srcTel"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "dstTel"},
+		Direction:   callmodel.DirectionIncoming,
+	}
+	data, _ := json.Marshal(payload)
+	event := &sock.Event{
+		Publisher: publisherCallManager,
+		Type:      callmodel.EventTypeCallCreated,
+		Data:      data,
+	}
+
+	mockContact.EXPECT().EventCallCreated(ctx, gomock.Any()).Return(nil)
+
+	if err := h.processEventCallManagerCallCreated(ctx, event); err != nil {
+		t.Errorf("processEventCallManagerCallCreated() error = %v", err)
+	}
+}
+
+func Test_processEventConversationManagerMessageCreated(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockContact := contacthandler.NewMockContactHandler(mc)
+	h := &subscribeHandler{sockHandler: mockSock, contactHandler: mockContact}
+	ctx := context.Background()
+
+	payload := convmsg.WebhookMessage{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("f1b2c3d4-0002-0002-0002-000000000001"),
+			CustomerID: uuid.FromStringOrNil("f1b2c3d4-0002-0002-0002-000000000002"),
+		},
+		Source:      commonaddress.Address{Type: commonaddress.TypeLine, Target: "lineUser"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeLine, Target: ""},
+		Direction:   convmsg.DirectionIncoming,
+	}
+	data, _ := json.Marshal(payload)
+	event := &sock.Event{
+		Publisher: publisherConversationManager,
+		Type:      string(convmsg.EventTypeMessageCreated),
+		Data:      data,
+	}
+
+	mockContact.EXPECT().EventConversationMessageCreated(ctx, gomock.Any()).Return(nil)
+
+	if err := h.processEventConversationManagerMessageCreated(ctx, event); err != nil {
+		t.Errorf("processEventConversationManagerMessageCreated() error = %v", err)
+	}
+}
+
+func Test_processEvent_UnknownEventType2(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
@@ -346,7 +414,7 @@ func Test_processEvent_UnknownEventType(t *testing.T) {
 	// Known publisher but unknown event type - should be ignored silently
 	event := &sock.Event{
 		Publisher: publisherCustomerManager,
-		Type:      "unknown_event_type",
+		Type:      "unknown_event_type_2",
 		Data:      json.RawMessage(`{}`),
 	}
 

--- a/bin-contact-manager/scripts/database_scripts_test/contacts.sql
+++ b/bin-contact-manager/scripts/database_scripts_test/contacts.sql
@@ -94,3 +94,21 @@ create table contact_tag_assignments(
 
   primary key(contact_id, tag_id)
 );
+
+create table contact_interactions(
+  id             binary(16)    not null,
+  customer_id    binary(16)    not null,
+  direction      varchar(255)  not null default '',
+  peer_type      varchar(255)  not null default '',
+  peer_target    varchar(255)  not null default '',
+  local_type     varchar(255)  not null default '',
+  local_target   varchar(255)  not null default '',
+  reference_type varchar(255)  not null default '',
+  reference_id   binary(16)    not null,
+  tm_interaction datetime(6),
+  tm_create      datetime(6),
+  primary key(id)
+);
+create unique index idx_contact_interactions_idem on contact_interactions(reference_type, reference_id, peer_target);
+create index idx_contact_interactions_peer on contact_interactions(customer_id, peer_type, peer_target);
+create index idx_contact_interactions_cursor on contact_interactions(customer_id, tm_create);

--- a/bin-dbscheme-manager/bin-manager/main/versions/adb8daac2bb0_contact_interactions_add_local_type_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/adb8daac2bb0_contact_interactions_add_local_type_.py
@@ -1,0 +1,49 @@
+"""contact_interactions_add_local_type_local_target
+
+Revision ID: adb8daac2bb0
+Revises: bbcf80d332eb
+Create Date: 2026-06-28
+
+Adds local_type and local_target to contact_interactions (VOIP-1208).
+
+The original table (VOIP-1206, ac5d4e18060c) stored only the remote party
+(peer_type / peer_target) because read-time identity resolution only needs the
+peer. However, the local endpoint (our number / LINE official account / email)
+is also a first-class immutable fact carried by the event at projection time.
+Omitting it under the no-backfill policy would cause permanent data loss for
+any future per-number/per-channel inbound attribution use case.
+
+Decision A (VOIP-1208 scope): scoped here because the projection handler fills
+these values; keeping schema change and handler in the same work unit.
+
+Both columns:
+- NOT NULL DEFAULT '' (consistent with peer_type / peer_target convention).
+- NOT in the idempotency unique (same event always has same local; widening
+  the unique would add no dedup benefit).
+- No index (not used as match key or cursor; attribution only).
+- downgrade drops both columns.
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'adb8daac2bb0'
+down_revision = 'bbcf80d332eb'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE contact_interactions
+            ADD COLUMN local_type   VARCHAR(255) NOT NULL DEFAULT '' AFTER peer_target,
+            ADD COLUMN local_target VARCHAR(255) NOT NULL DEFAULT '' AFTER local_type;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE contact_interactions
+            DROP COLUMN local_target,
+            DROP COLUMN local_type;
+    """)

--- a/docs/plans/2026-06-28-VOIP-1208-contact-crm-projection-handlers.md
+++ b/docs/plans/2026-06-28-VOIP-1208-contact-crm-projection-handlers.md
@@ -1,0 +1,275 @@
+# VOIP-1208: contact-manager CRM projection handlers
+
+- Issue: VOIP-1208
+- Parent: VOIP-1204 (CRM interaction timeline)
+- Class: event subscription + DB model + schema migration + handler
+- Service: bin-contact-manager (+ bin-dbscheme-manager migration)
+- Date: 2026-06-28
+
+## 1. Goal
+
+bin-contact-manager subscribes to two channel-native creation events and appends one
+row per event (per fan-out recipient for SMS) to `contact_interactions`. This is
+the write side of the CRM timeline; identity resolution (peer → contact_id) is
+read-time (VOIP-1209), not projection-time.
+
+## 2. Canonical reference decision (option 가, pchero confirmed)
+
+Subscribe to exactly TWO event sources:
+
+| subscribed event            | reference_type      | reference_id                | queue constant              |
+|-----------------------------|---------------------|-----------------------------|-----------------------------|
+| `call_created`              | `"call"`            | `call.WebhookMessage.ID`    | `QueueNameCallEvent`        |
+| `conversation_message_created` | `"conversation_message"` | `convmsg.WebhookMessage.ID` | `QueueNameConversationEvent` |
+
+**NOT subscribed (and why):**
+- `message_created` (message-manager SMS): conversation-manager already subscribes
+  to `message_created` and re-emits `conversation_message_created` for every SMS
+  thread. Subscribing to both would double-count every inbound SMS. The
+  conversation-manager is the canonical unifier for all text channels
+  (SMS/LINE/WhatsApp/email). Code confirmed: `grep QueueNameMessageEvent
+  bin-conversation-manager/cmd` shows conversation-manager consuming it.
+- `aicall_status_initializing`: out of scope until VOIP-1213 wraps web/task-direct
+  AIcall into the conversation layer (currently Backlog). Clean coverage gap;
+  documented explicitly here so it is not a silent miss.
+
+**Coverage by channel after this PR:**
+- Inbound/outbound voice call: ✓ (call_created)
+- Inbound/outbound SMS: ✓ (conversation_message_created — SMS flows through
+  conversation-manager as reference_type='message' or 'line'/'whatsapp' depending
+  on channel)
+- LINE / WhatsApp / outbound email: ✓ (conversation_message_created)
+- Web/task-direct AIcall: ✗ (VOIP-1213 dependency, not yet wrapped)
+
+## 3. Schema migration (bin-dbscheme-manager, decision A)
+
+Add `local_type` and `local_target` to `contact_interactions` (decision A:
+scoped into VOIP-1208 because projection fills them; same work unit).
+
+Current head: `bbcf80d332eb`. New migration chains onto it.
+
+```sql
+ALTER TABLE contact_interactions
+    ADD COLUMN local_type   VARCHAR(255) NOT NULL DEFAULT '' AFTER peer_target,
+    ADD COLUMN local_target VARCHAR(255) NOT NULL DEFAULT '' AFTER local_type;
+```
+
+Rationale: local endpoint (our number / LINE official account) is a first-class
+immutable fact the event carries. With no-backfill policy, omitting the column
+now = permanent data loss. Mirrors conversation-manager (VOIP-1215) which stores
+both source/destination. Use case: per-number/per-channel inbound attribution.
+- `local_type`/`local_target` are NOT in the idempotency unique
+  (same event always has same local; adding local to the unique would widen it
+  unnecessarily without dedup benefit).
+- No index on local columns (not used as match key or cursor; attribution only).
+- downgrade drops both columns.
+
+**contact_interactions final column set (migration complete):**
+```
+id             BINARY(16)    NOT NULL  PK
+customer_id    BINARY(16)    NOT NULL
+direction      VARCHAR(255)  NOT NULL DEFAULT ''
+peer_type      VARCHAR(255)  NOT NULL DEFAULT ''
+peer_target    VARCHAR(255)  NOT NULL DEFAULT ''  -- normalized, match key
+local_type     VARCHAR(255)  NOT NULL DEFAULT ''  -- NEW
+local_target   VARCHAR(255)  NOT NULL DEFAULT ''  -- NEW
+reference_type VARCHAR(255)  NOT NULL DEFAULT ''
+reference_id   BINARY(16)    NOT NULL
+tm_interaction DATETIME(6)                         -- origin event time (display sort)
+tm_create      DATETIME(6)                         -- projection insert time (cursor)
+UNIQUE(reference_type, reference_id, peer_target)  -- idempotency
+INDEX(customer_id, peer_type, peer_target)         -- read-time peer match
+INDEX(customer_id, tm_create)                      -- pagination cursor
+```
+
+## 4. peer / local extraction rule
+
+Absolute coords (source/destination from event) → relative coords (peer/local):
+
+```
+incoming: peer = source,      local = destination
+outgoing: peer = destination, local = source
+```
+
+Both call and conversation_message use `"incoming"`/`"outgoing"` direction values
+(verified in code: `call.DirectionIncoming = "incoming"`,
+`convmsg.DirectionIncoming = "incoming"`).
+
+peer_type  = peer.Type   (commonaddress.Address.Type, e.g. "tel"/"line"/"whatsapp")
+peer_target = NormalizeTarget(peer.Type, peer.Target)  ← MUST use this, bit-identical to contact_addresses.target
+local_type  = local.Type
+local_target = NormalizeTarget(local.Type, local.Target) — error on unknown type: log + store raw target, do not drop the row
+
+**Unknown direction guard:** if Direction == "" (DirectionNond/empty), log a warning
+and store peer_type/peer_target = "", local_type/local_target = "" (zero values).
+Do NOT drop the row; the reference fact is still valid. This is a graceful fallback
+for any future malformed event.
+
+## 5. New code to create (nothing pre-exists)
+
+### 5.1 models/interaction/interaction.go (new package)
+
+```go
+package interaction
+
+import (
+    "github.com/gofrs/uuid"
+    commonaddress "monorepo/bin-common-handler/models/address"
+    "time"
+)
+
+// Interaction is an immutable append-only fact in the CRM interaction timeline.
+// It records that a channel-level event (call or conversation message) touched a
+// particular remote endpoint (peer). Identity resolution (peer → contact) is done
+// at read time.
+type Interaction struct {
+    ID         uuid.UUID `json:"id"          db:"id,uuid"`
+    CustomerID uuid.UUID `json:"customer_id"  db:"customer_id,uuid"`
+
+    Direction string `json:"direction"  db:"direction"`  // "incoming" / "outgoing"
+
+    // Remote endpoint (the peer's address — match key for contact resolution).
+    // peer_target is stored normalized via commonaddress.NormalizeTarget.
+    PeerType   string `json:"peer_type"   db:"peer_type"`
+    PeerTarget string `json:"peer_target" db:"peer_target"`
+
+    // Our local endpoint (for attribution: which number/account received/sent).
+    LocalType   string `json:"local_type"   db:"local_type"`
+    LocalTarget string `json:"local_target" db:"local_target"`
+
+    // Origin channel record. State and body are fetched at read time.
+    ReferenceType string    `json:"reference_type" db:"reference_type"`
+    ReferenceID   uuid.UUID `json:"reference_id"   db:"reference_id,uuid"`
+
+    TMInteraction *time.Time `json:"tm_interaction" db:"tm_interaction"` // origin event time
+    TMCreate      *time.Time `json:"tm_create"      db:"tm_create"`      // projection insert time
+}
+```
+
+### 5.2 pkg/dbhandler/main.go — add InteractionCreate
+
+```go
+InteractionCreate(ctx context.Context, i *interaction.Interaction) error
+```
+
+Implementation: squirrel INSERT, idempotency duplicate is a no-op (not an error).
+On `errno 1062` (duplicate key), return nil (idempotent).
+
+### 5.3 pkg/dbhandler/interaction.go (new file)
+
+Implements `InteractionCreate`. Uses squirrel, no cache (append-only facts).
+
+### 5.4 pkg/contacthandler/main.go — add event handlers
+
+```go
+EventCallCreated(ctx context.Context, m *callwebhook.WebhookMessage) error
+EventConversationMessageCreated(ctx context.Context, m *convmsgwebhook.WebhookMessage) error
+```
+
+Implementation pattern (both):
+1. Extract peer/local from source/destination + direction (§4 rule).
+2. NormalizeTarget for peer_target (and local_target). On error: log, use raw target.
+3. Build Interaction{} with UUIDCreate() for ID, TimeNow() for TMCreate.
+   TMInteraction = event.TMCreate. **nil guard required**: if event.TMCreate == nil
+   (can happen for call events due to omitempty), set TMInteraction = nil (store as
+   NULL — the column is nullable). Do NOT dereference a nil pointer.
+4. Call db.InteractionCreate(ctx, &i). On duplicate: silently return nil.
+
+### 5.5 pkg/subscribehandler/ — two new handler files
+
+**subscribehandler/callmanager.go:**
+```go
+publisherCallManager = string(commonoutline.ServiceNameCallManager)
+
+func (h *subscribeHandler) processEventCallManagerCallCreated(ctx context.Context, m *sock.Event) error {
+    var payload callwebhook.WebhookMessage
+    if err := json.Unmarshal(m.Data, &payload); err != nil {
+        return err
+    }
+    return h.contactHandler.EventCallCreated(ctx, &payload)
+}
+```
+
+**subscribehandler/conversationmanager.go:**
+```go
+publisherConversationManager = string(commonoutline.ServiceNameConversationManager)
+
+func (h *subscribeHandler) processEventConversationManagerMessageCreated(ctx context.Context, m *sock.Event) error {
+    var payload convmsgwebhook.WebhookMessage
+    if err := json.Unmarshal(m.Data, &payload); err != nil {
+        return err
+    }
+    return h.contactHandler.EventConversationMessageCreated(ctx, &payload)
+}
+```
+
+**subscribehandler/main.go — add cases to switch:**
+```go
+case m.Publisher == publisherCallManager && m.Type == call.EventTypeCallCreated:
+    err = h.processEventCallManagerCallCreated(ctx, m)
+case m.Publisher == publisherConversationManager && m.Type == string(convmsg.EventTypeMessageCreated):
+    err = h.processEventConversationManagerMessageCreated(ctx, m)
+```
+
+### 5.6 cmd/contact-manager/main.go — add queues to subscribeTargets
+
+```go
+subscribeTargets := []string{
+    string(commonoutline.QueueNameCustomerEvent),
+    string(commonoutline.QueueNameCallEvent),           // NEW: "bin-manager.call-manager.event"
+    string(commonoutline.QueueNameConversationEvent),   // NEW: "bin-manager.conversation-manager.event"
+}
+```
+
+### 5.7 scripts/database_scripts_test/contacts.sql — add contact_interactions DDL
+
+Match the final column set (§3) for unit test DB.
+
+## 6. Idempotency
+
+`UNIQUE(reference_type, reference_id, peer_target)` is the DB-level dedup guard.
+- `reference_id NOT NULL` (code-verified: every projected channel has an origin id).
+- `peer_target` normalized → bit-identical to contact_addresses.target.
+- On 1062 (duplicate): return nil, do NOT error. This is the at-least-once delivery
+  absorber.
+- `local_type/local_target` NOT in the unique (same event = same local, no
+  dedup benefit; adding would widen the unique unnecessarily).
+
+## 7. Imports needed (new in bin-contact-manager)
+
+- `callwebhook "monorepo/bin-call-manager/models/call"` (WebhookMessage is in the `call` package)
+- `convmsg "monorepo/bin-conversation-manager/models/message"` (WebhookMessage + EventTypeMessageCreated)
+- `call "monorepo/bin-call-manager/models/call"` (EventTypeCallCreated, DirectionIncoming, DirectionOutgoing)
+- `commonaddress "monorepo/bin-common-handler/models/address"` (NormalizeTarget)
+- `commonoutline "monorepo/bin-common-handler/models/outline"` (QueueNameCallEvent, QueueNameConversationEvent, ServiceNameCallManager, ServiceNameConversationManager)
+
+Note: bin-contact-manager.go.mod already depends on bin-common-handler. Need to
+verify bin-call-manager and bin-conversation-manager are in go.mod; if not, add.
+
+## 8. Test plan
+
+- `InteractionCreate`: normal insert, duplicate key → no-op (verify 1062 absorbed).
+- `EventCallCreated`: incoming call → peer=source, local=destination; outgoing →
+  peer=destination, local=source; unknown direction → zero peer/local, row still
+  created. nil TMCreate → TMInteraction stored as nil (no panic).
+- `EventConversationMessageCreated`: incoming/outgoing cases, NormalizeTarget applied,
+  reference_type="conversation_message", reference_id=message ID.
+- subscribehandler: publisher+type routing directs to correct processEvent function.
+  json.Unmarshal error returns error (not silently ignored).
+- NormalizeTarget error path: log + use raw target, row created (not dropped).
+
+## 9. Implementation checklist (mandatory steps)
+
+- [ ] `alembic revision` to generate migration (never hand-pick ID), fill upgrade/downgrade
+- [ ] `bin-contact-manager/scripts/database_scripts_test/contacts.sql` — add contact_interactions DDL with all columns including local_type/local_target
+- [ ] `go generate ./...` in bin-contact-manager after modifying DBHandler and ContactHandler interfaces (regenerates mock_main.go in both dbhandler and contacthandler packages)
+- [ ] Full verification workflow: `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`
+
+## 10. Out of scope
+
+- aicall_status_initializing subscription (VOIP-1213 dependency).
+- Identity resolution peer → contact_id (VOIP-1209 read API).
+- message_created direct subscription (deliberately excluded, see §2).
+- Backfill of historical interactions (VOIP-1204 §7.2 decision: no backfill).
+- contact_interactions DELETE / GET / LIST (append-only in v1; read-time query is
+  VOIP-1209's job).


### PR DESCRIPTION
Project channel-native creation events into the CRM interaction timeline (contact_interactions). Subscribes to call_created (call-manager) and conversation_message_created (conversation-manager, which unifies all text channels: SMS/LINE/WhatsApp/email). Does NOT subscribe to message_created directly to avoid double-counting inbound SMS that flows through both managers. Web/task-direct AIcall coverage deferred to VOIP-1213.

Each projected row records direction, peer endpoint (remote party, match key for read-time contact resolution in VOIP-1209), and local endpoint (our number/account, for per-number/per-channel inbound attribution). Both peer_target and local_target are normalized via commonaddress.NormalizeTarget so peer_target is bit-identical to contact_addresses.target (read-time IN-match invariant). Idempotency: UNIQUE(reference_type, reference_id, peer_target) absorbs at-least-once RabbitMQ redelivery; errno 1062 / SQLite UNIQUE constraint returns nil.

Canonical reference decision (option 가): subscribe to conversation_message_created only (not message_created) because conversation-manager already unifies SMS/LINE/WhatsApp/outbound-email. Verified: grep QueueNameMessageEvent bin-conversation-manager/cmd/ confirms conversation-manager consumes message_created and re-emits conversation_message_created. No double-count.

- bin-dbscheme-manager: Add migration adb8daac2bb0 adding local_type/local_target VARCHAR(255) NOT NULL DEFAULT  to contact_interactions (chains off bbcf80d332eb, i.e. VOIP-1207); downgrade drops both columns
- bin-contact-manager: Add models/interaction/interaction.go (Interaction model, 11 DB columns, append-only, no cache)
- bin-contact-manager: Add DBHandler.InteractionCreate; implement in pkg/dbhandler/interaction.go with duplicate-key no-op (MySQL errno 1062 + SQLite UNIQUE constraint)
- bin-contact-manager: Add ContactHandler.EventCallCreated and EventConversationMessageCreated; implement in pkg/contacthandler/interaction.go with shared deriveEndpoints helper (incoming: peer=source,local=dest; outgoing: peer=dest,local=source; unknown direction: zero values, row still persisted) and NormalizeTarget for both peer/local targets
- bin-contact-manager: Add subscribehandler/callmanager.go (processEventCallManagerCallCreated) and conversationmanager.go (processEventConversationManagerMessageCreated); wire new cases into subscribehandler/main.go switch
- bin-contact-manager: Add QueueNameCallEvent and QueueNameConversationEvent to subscribeTargets in cmd/contact-manager/main.go
- bin-contact-manager: Add contact_interactions DDL (with local_type/local_target) to test schema SQL; add dbhandler tests (normal, duplicate idempotent), contacthandler tests (incoming/outgoing/unknown-direction), and subscribehandler dispatch tests for new event arms; regenerate mocks

Known scope-out: web/task-direct AIcall sessions do not flow through conversation-manager (VOIP-1213 Backlog); aicall_status_initializing subscription deferred until VOIP-1213 wraps AIcall into the conversation layer. Identity resolution (peer -> contact_id) is VOIP-1209 read API.