### PR TITLE
VOIP-1209-contact-crm-read-api-and-resolution

### DIFF
--- a/bin-common-handler/pkg/requesthandler/contact_interactions.go
+++ b/bin-common-handler/pkg/requesthandler/contact_interactions.go
@@ -1,0 +1,183 @@
+package requesthandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
+)
+
+// ContactV1InteractionGet sends a request to contact-manager to get a single interaction.
+func (r *requestHandler) ContactV1InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*cminteraction.Interaction, error) {
+	uri := fmt.Sprintf("/v1/interactions/%s", id)
+
+	m, err := json.Marshal(map[string]string{"customer_id": customerID.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodGet, "contact/interactions/<id>", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cminteraction.Interaction
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
+// ContactV1InteractionList lists interactions from contact-manager.
+// Exactly one of (peerType+peerTarget), contactID, or addressID should be non-zero.
+func (r *requestHandler) ContactV1InteractionList(
+	ctx context.Context,
+	customerID uuid.UUID,
+	size uint64,
+	token string,
+	peerType, peerTarget string,
+	contactID, addressID uuid.UUID,
+) (*cminteraction.InteractionListResponse, error) {
+	u := url.Values{}
+	if peerType != "" {
+		u.Set("peer_type", peerType)
+	}
+	if peerTarget != "" {
+		u.Set("peer_target", peerTarget)
+	}
+	if contactID != uuid.Nil {
+		u.Set("contact_id", contactID.String())
+	}
+	if addressID != uuid.Nil {
+		u.Set("address_id", addressID.String())
+	}
+	if size > 0 {
+		u.Set("page_size", fmt.Sprintf("%d", size))
+	}
+	if token != "" {
+		u.Set("page_token", token)
+	}
+
+	uri := "/v1/interactions?" + u.Encode()
+
+	m, err := json.Marshal(map[string]string{"customer_id": customerID.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodGet, "contact/interactions", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cminteraction.InteractionListResponse
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
+// ContactV1InteractionListUnresolved lists unresolved interactions from contact-manager.
+// sinceDays specifies the lookback window in days (e.g. 7 → ?since=7d). 0 uses default (30d).
+func (r *requestHandler) ContactV1InteractionListUnresolved(
+	ctx context.Context,
+	customerID uuid.UUID,
+	size uint64,
+	token string,
+	sinceDays int,
+) (*cminteraction.InteractionListResponse, error) {
+	u := url.Values{}
+	if sinceDays > 0 {
+		u.Set("since", fmt.Sprintf("%dd", sinceDays))
+	}
+	if size > 0 {
+		u.Set("page_size", fmt.Sprintf("%d", size))
+	}
+	if token != "" {
+		u.Set("page_token", token)
+	}
+
+	uri := "/v1/interactions/unresolved"
+	if len(u) > 0 {
+		uri = uri + "?" + u.Encode()
+	}
+
+	m, err := json.Marshal(map[string]string{"customer_id": customerID.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodGet, "contact/interactions/unresolved", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cminteraction.InteractionListResponse
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
+// ContactV1ResolutionCreate creates a resolution in contact-manager.
+func (r *requestHandler) ContactV1ResolutionCreate(
+	ctx context.Context,
+	interactionID, customerID, contactID uuid.UUID,
+	resolutionType, resolvedByType string,
+	resolvedByID uuid.UUID,
+) (*cmresolution.Resolution, error) {
+	uri := fmt.Sprintf("/v1/interactions/%s/resolutions", interactionID)
+
+	data := &cmrequest.V1DataInteractionsResolutionsPost{
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		ResolutionType: resolutionType,
+		ResolvedByType: resolvedByType,
+		ResolvedByID:   resolvedByID,
+	}
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodPost, "contact/interactions/<id>/resolutions", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cmresolution.Resolution
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
+// ContactV1ResolutionDelete soft-deletes a resolution in contact-manager.
+func (r *requestHandler) ContactV1ResolutionDelete(
+	ctx context.Context,
+	customerID uuid.UUID,
+	interactionID, resolutionID uuid.UUID,
+) error {
+	uri := fmt.Sprintf("/v1/interactions/%s/resolutions/%s", interactionID, resolutionID)
+
+	m, err := json.Marshal(cmrequest.V1DataInteractionsResolutionsIDDelete{CustomerID: customerID})
+	if err != nil {
+		return err
+	}
+
+	_, err = r.sendRequestContact(ctx, uri, sock.RequestMethodDelete, "contact/interactions/<id>/resolutions/<rid>", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	return err
+}

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -48,6 +48,8 @@ import (
 	cfconferencecall "monorepo/bin-conference-manager/models/conferencecall"
 
 	cmcontact "monorepo/bin-contact-manager/models/contact"
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
 	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
 
 	cvaccount "monorepo/bin-conversation-manager/models/account"
@@ -910,6 +912,13 @@ type RequestHandler interface {
 	// contact-manager tags
 	ContactV1TagAdd(ctx context.Context, contactID uuid.UUID, tagID uuid.UUID) (*cmcontact.Contact, error)
 	ContactV1TagRemove(ctx context.Context, contactID uuid.UUID, tagID uuid.UUID) (*cmcontact.Contact, error)
+
+	// contact-manager interactions (CRM v1 read API, VOIP-1209)
+	ContactV1InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*cminteraction.Interaction, error)
+	ContactV1InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, contactID, addressID uuid.UUID) (*cminteraction.InteractionListResponse, error)
+	ContactV1InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, sinceDays int) (*cminteraction.InteractionListResponse, error)
+	ContactV1ResolutionCreate(ctx context.Context, interactionID, customerID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*cmresolution.Resolution, error)
+	ContactV1ResolutionDelete(ctx context.Context, customerID uuid.UUID, interactionID, resolutionID uuid.UUID) error
 
 	// direct-manager directs
 	DirectV1DirectCreate(ctx context.Context, customerID uuid.UUID, resourceType string, resourceID uuid.UUID) (*dmdirect.Direct, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -45,6 +45,8 @@ import (
 	conference "monorepo/bin-conference-manager/models/conference"
 	conferencecall "monorepo/bin-conference-manager/models/conferencecall"
 	contact "monorepo/bin-contact-manager/models/contact"
+	interaction "monorepo/bin-contact-manager/models/interaction"
+	resolution "monorepo/bin-contact-manager/models/resolution"
 	request "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
 	account0 "monorepo/bin-conversation-manager/models/account"
 	conversation "monorepo/bin-conversation-manager/models/conversation"
@@ -3545,6 +3547,51 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1EmailUpdate(ctx, contactID, e
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1EmailUpdate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1EmailUpdate), ctx, contactID, emailID, fields)
 }
 
+// ContactV1InteractionGet mocks base method.
+func (m *MockRequestHandler) ContactV1InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1InteractionGet", ctx, customerID, id)
+	ret0, _ := ret[0].(*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1InteractionGet indicates an expected call of ContactV1InteractionGet.
+func (mr *MockRequestHandlerMockRecorder) ContactV1InteractionGet(ctx, customerID, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1InteractionGet", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1InteractionGet), ctx, customerID, id)
+}
+
+// ContactV1InteractionList mocks base method.
+func (m *MockRequestHandler) ContactV1InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID) (*interaction.InteractionListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1InteractionList", ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+	ret0, _ := ret[0].(*interaction.InteractionListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1InteractionList indicates an expected call of ContactV1InteractionList.
+func (mr *MockRequestHandlerMockRecorder) ContactV1InteractionList(ctx, customerID, size, token, peerType, peerTarget, contactID, addressID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1InteractionList", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1InteractionList), ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+}
+
+// ContactV1InteractionListUnresolved mocks base method.
+func (m *MockRequestHandler) ContactV1InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, sinceDays int) (*interaction.InteractionListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1InteractionListUnresolved", ctx, customerID, size, token, sinceDays)
+	ret0, _ := ret[0].(*interaction.InteractionListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1InteractionListUnresolved indicates an expected call of ContactV1InteractionListUnresolved.
+func (mr *MockRequestHandlerMockRecorder) ContactV1InteractionListUnresolved(ctx, customerID, size, token, sinceDays any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1InteractionListUnresolved", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1InteractionListUnresolved), ctx, customerID, size, token, sinceDays)
+}
+
 // ContactV1PhoneNumberCreate mocks base method.
 func (m *MockRequestHandler) ContactV1PhoneNumberCreate(ctx context.Context, contactID uuid.UUID, number, phoneType string, isPrimary bool) (*contact.Contact, error) {
 	m.ctrl.T.Helper()
@@ -3588,6 +3635,35 @@ func (m *MockRequestHandler) ContactV1PhoneNumberUpdate(ctx context.Context, con
 func (mr *MockRequestHandlerMockRecorder) ContactV1PhoneNumberUpdate(ctx, contactID, phoneNumberID, fields any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1PhoneNumberUpdate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1PhoneNumberUpdate), ctx, contactID, phoneNumberID, fields)
+}
+
+// ContactV1ResolutionCreate mocks base method.
+func (m *MockRequestHandler) ContactV1ResolutionCreate(ctx context.Context, interactionID, customerID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1ResolutionCreate", ctx, interactionID, customerID, contactID, resolutionType, resolvedByType, resolvedByID)
+	ret0, _ := ret[0].(*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1ResolutionCreate indicates an expected call of ContactV1ResolutionCreate.
+func (mr *MockRequestHandlerMockRecorder) ContactV1ResolutionCreate(ctx, interactionID, customerID, contactID, resolutionType, resolvedByType, resolvedByID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1ResolutionCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1ResolutionCreate), ctx, interactionID, customerID, contactID, resolutionType, resolvedByType, resolvedByID)
+}
+
+// ContactV1ResolutionDelete mocks base method.
+func (m *MockRequestHandler) ContactV1ResolutionDelete(ctx context.Context, customerID, interactionID, resolutionID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1ResolutionDelete", ctx, customerID, interactionID, resolutionID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ContactV1ResolutionDelete indicates an expected call of ContactV1ResolutionDelete.
+func (mr *MockRequestHandlerMockRecorder) ContactV1ResolutionDelete(ctx, customerID, interactionID, resolutionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1ResolutionDelete", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1ResolutionDelete), ctx, customerID, interactionID, resolutionID)
 }
 
 // ContactV1TagAdd mocks base method.

--- a/bin-contact-manager/models/interaction/list_response.go
+++ b/bin-contact-manager/models/interaction/list_response.go
@@ -1,0 +1,16 @@
+package interaction
+
+// InteractionListResponse is the response envelope for all interaction list
+// endpoints (GET /v1/interactions, GET /v1/interactions/unresolved).
+//
+// This type lives in models/interaction (not pkg/contacthandler) to avoid a
+// circular import: pkg/contacthandler imports bin-common-handler/pkg/requesthandler,
+// and bin-common-handler/pkg/requesthandler must import this type to deserialise
+// responses. Placing it here keeps the import boundary at the models layer.
+//
+// NextPageToken is empty when no further pages exist. Callers forward it
+// verbatim as page_token on the next request; no client-side decoding is needed.
+type InteractionListResponse struct {
+	Items         []*Interaction `json:"items"`
+	NextPageToken string         `json:"next_page_token"`
+}

--- a/bin-contact-manager/models/resolution/resolution.go
+++ b/bin-contact-manager/models/resolution/resolution.go
@@ -1,0 +1,48 @@
+package resolution
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+)
+
+// Resolution records a manual attribution (positive) or suppression (negative)
+// of a contact_interaction to a contact. It is append-only with soft-delete
+// retraction: correction = tm_delete (retract existing) + new row (re-attribute).
+//
+// See VOIP-1204 §3.3 and VOIP-1209 for full design context.
+type Resolution struct {
+	ID             uuid.UUID  `json:"id"               db:"id,uuid"`
+	CustomerID     uuid.UUID  `json:"customer_id"      db:"customer_id,uuid"`
+	ContactID      uuid.UUID  `json:"contact_id"       db:"contact_id,uuid"`
+	InteractionID  uuid.UUID  `json:"interaction_id"   db:"interaction_id,uuid"`
+	ResolutionType string     `json:"resolution_type"  db:"resolution_type"`
+	ResolvedByType string     `json:"resolved_by_type" db:"resolved_by_type"`
+	ResolvedByID   uuid.UUID  `json:"resolved_by_id"   db:"resolved_by_id,uuid"`
+	TMCreate       *time.Time `json:"tm_create"        db:"tm_create"`
+	TMUpdate       *time.Time `json:"tm_update"        db:"tm_update"`
+	TMDelete       *time.Time `json:"tm_delete"        db:"tm_delete"`
+}
+
+// Resolution type constants.
+const (
+	// ResolutionTypePositive attaches an interaction to a contact (manual
+	// attribution that automatic peer-matching missed).
+	ResolutionTypePositive = "positive"
+
+	// ResolutionTypeNegative suppresses an interaction from a contact (removes
+	// a wrong automatic match). Negative always wins over positive for the same
+	// (contact_id, interaction_id) — set-MINUS semantics, never LWW.
+	ResolutionTypeNegative = "negative"
+)
+
+// ResolvedBy type constants.
+const (
+	ResolvedByTypeAgent  = "agent"
+	ResolvedByTypeSystem = "system"
+	ResolvedByTypeRule   = "rule"
+)
+
+// ResolvedByIDSystem is the canonical resolved_by_id for system/rule
+// resolutions where no agent is involved.
+var ResolvedByIDSystem = uuid.Nil

--- a/bin-contact-manager/pkg/contacthandler/interaction_read.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_read.go
@@ -1,0 +1,314 @@
+package contacthandler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	stderrors "errors"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/models/resolution"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// interactionInternalCap is the maximum number of automatic peer-match
+// interactions fetched per contactID read path (STEP 2 of set-MINUS algorithm).
+// Contacts with >5000 automatic interactions may see incomplete results on the
+// ?contact_id= path in v1; a cursor-walk implementation is the M2 solution.
+const interactionInternalCap uint64 = 5000
+
+// InteractionGet returns a single interaction, scoped to customerID.
+func (h *contactHandler) InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error) {
+	res, err := h.db.InteractionGet(ctx, id)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"INTERACTION_NOT_FOUND",
+				"The interaction was not found.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+
+	// Tenant guard: never expose another customer's data.
+	if res.CustomerID != customerID {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"INTERACTION_NOT_FOUND",
+			"The interaction was not found.",
+		)
+	}
+
+	return res, nil
+}
+
+// InteractionList is the main timeline read path.
+// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero.
+func (h *contactHandler) InteractionList(
+	ctx context.Context,
+	customerID uuid.UUID,
+	size uint64,
+	token string,
+	peerType, peerTarget string,
+	contactID uuid.UUID,
+	addressID uuid.UUID,
+) (*interaction.InteractionListResponse, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":       "InteractionList",
+		"customerID": customerID,
+	})
+
+	if size == 0 {
+		size = 20
+	}
+
+	switch {
+	case peerType != "" || peerTarget != "":
+		// Direct peer path
+		items, err := h.db.InteractionList(ctx, customerID, size+1, token, peerType, peerTarget, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not list interactions by peer. InteractionList. err: %v", err)
+		}
+		return buildListResponse(items, size), nil
+
+	case contactID != uuid.Nil:
+		return h.interactionListByContact(ctx, log, customerID, contactID, size, token)
+
+	case addressID != uuid.Nil:
+		return h.interactionListByAddress(ctx, customerID, addressID, size, token)
+
+	default:
+		return nil, cerrors.InvalidArgument(
+			commonoutline.ServiceNameContactManager,
+			"INVALID_FILTER",
+			"At least one filter (peer_type+peer_target, contact_id, or address_id) is required.",
+		)
+	}
+}
+
+// interactionListByContact implements the set-MINUS algorithm (design §7.1).
+func (h *contactHandler) interactionListByContact(
+	ctx context.Context,
+	log *logrus.Entry,
+	customerID, contactID uuid.UUID,
+	size uint64,
+	token string,
+) (*interaction.InteractionListResponse, error) {
+	// STEP 0: Existence + tenant check.
+	c, err := h.db.ContactGet(ctx, contactID)
+	if err != nil || c == nil || c.TMDelete != nil || c.CustomerID != customerID {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"CONTACT_NOT_FOUND",
+			"The contact was not found.",
+		)
+	}
+
+	// STEP 1: Expand address set.
+	addressPairs, err := h.db.AddressListByContact(ctx, customerID, contactID)
+	if err != nil {
+		return nil, fmt.Errorf("could not list addresses. interactionListByContact. err: %v", err)
+	}
+
+	// STEP 2: Fetch ALL automatic peer matches (internal cap, not caller page size).
+	var automatic []*interaction.Interaction
+	if len(addressPairs) > 0 {
+		automatic, err = h.db.InteractionList(ctx, customerID, interactionInternalCap, "", "", "", addressPairs)
+		if err != nil {
+			return nil, fmt.Errorf("could not list interactions by address set. interactionListByContact. err: %v", err)
+		}
+	}
+	// If addressPairs is empty → automatic stays nil (short-circuit, no IN() query).
+
+	// STEP 3: Fetch active resolutions.
+	resolutions, err := h.db.ResolutionListByContact(ctx, customerID, contactID)
+	if err != nil {
+		return nil, fmt.Errorf("could not list resolutions. interactionListByContact. err: %v", err)
+	}
+
+	// STEP 4: Set-MINUS combination.
+	positiveIDs := make(map[uuid.UUID]bool)
+	negativeIDs := make(map[uuid.UUID]bool)
+	for _, r := range resolutions {
+		switch r.ResolutionType {
+		case resolution.ResolutionTypePositive:
+			positiveIDs[r.InteractionID] = true
+		case resolution.ResolutionTypeNegative:
+			negativeIDs[r.InteractionID] = true
+		}
+	}
+
+	automaticIDs := make(map[uuid.UUID]bool)
+	merged := make(map[uuid.UUID]*interaction.Interaction)
+	for _, i := range automatic {
+		automaticIDs[i.ID] = true
+		merged[i.ID] = i
+	}
+
+	// include = (automaticIDs | positiveIDs) - negativeIDs
+	for id := range negativeIDs {
+		delete(merged, id)
+	}
+
+	// STEP 5: Load positive-only interactions not in automatic set.
+	var missingIDs []uuid.UUID
+	for id := range positiveIDs {
+		if !automaticIDs[id] {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+	if len(missingIDs) > 0 {
+		extra, extraErr := h.db.InteractionListByIDs(ctx, customerID, missingIDs)
+		if extraErr != nil {
+			return nil, fmt.Errorf("could not list interactions by IDs. interactionListByContact. err: %v", extraErr)
+		}
+		for _, i := range extra {
+			if !negativeIDs[i.ID] {
+				merged[i.ID] = i
+			}
+		}
+	}
+
+	// STEP 6: Sort, apply caller cursor, slice.
+	all := make([]*interaction.Interaction, 0, len(merged))
+	for _, i := range merged {
+		all = append(all, i)
+	}
+	sort.Slice(all, func(a, b int) bool {
+		ta := all[a].TMCreate
+		tb := all[b].TMCreate
+		if ta == nil && tb == nil {
+			return all[a].ID.String() > all[b].ID.String()
+		}
+		if ta == nil {
+			return false
+		}
+		if tb == nil {
+			return true
+		}
+		if ta.Equal(*tb) {
+			return all[a].ID.String() > all[b].ID.String()
+		}
+		return ta.After(*tb)
+	})
+
+	// Apply cursor if provided.
+	if token != "" {
+		cursorTime, cursorID, decErr := dbhandler.DecodePageToken(token)
+		if decErr != nil {
+			log.WithError(decErr).Warn("invalid page token; starting from head")
+		} else {
+			found := false
+			for i, item := range all {
+				if item.TMCreate == nil {
+					// nil-TMCreate items sort last. When a cursor is active and
+					// we encounter a nil-TMCreate item, we have passed all
+					// timestamped items. The nil-TMCreate tail is beyond the
+					// cursor position (latest = head), so start from this point.
+					all = all[i:]
+					found = true
+					break
+				}
+				if item.TMCreate.Before(cursorTime) || (item.TMCreate.Equal(cursorTime) && item.ID.String() < cursorID.String()) {
+					all = all[i:]
+					found = true
+					break
+				}
+			}
+			if !found {
+				// All items are newer than or equal to cursor, with valid timestamps.
+				// No items remain past the cursor — return empty.
+				all = nil
+			}
+		}
+	}
+
+	return buildListResponse(all, size), nil
+}
+
+// interactionListByAddress implements the ?address_id= filter path.
+func (h *contactHandler) interactionListByAddress(
+	ctx context.Context,
+	customerID, addressID uuid.UUID,
+	size uint64,
+	token string,
+) (*interaction.InteractionListResponse, error) {
+	ap, err := h.db.AddressGetByID(ctx, customerID, addressID)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"ADDRESS_NOT_FOUND",
+				"The address was not found.",
+			)
+		}
+		return nil, fmt.Errorf("could not get address. interactionListByAddress. err: %v", err)
+	}
+
+	items, err := h.db.InteractionList(ctx, customerID, size+1, token, "", "", []dbhandler.AddressPair{ap})
+	if err != nil {
+		return nil, fmt.Errorf("could not list interactions by address. interactionListByAddress. err: %v", err)
+	}
+	return buildListResponse(items, size), nil
+}
+
+// buildListResponse slices items to size and builds the next page token.
+func buildListResponse(items []*interaction.Interaction, size uint64) *interaction.InteractionListResponse {
+	hasMore := uint64(len(items)) > size
+	if hasMore {
+		items = items[:size]
+	}
+
+	var nextToken string
+	if hasMore && len(items) > 0 {
+		last := items[len(items)-1]
+		if tok := dbhandler.EncodePageToken(last.TMCreate, last.ID); tok != "" {
+			nextToken = tok
+		}
+		// If tok == "" (nil TMCreate), cursor cannot be encoded — pagination stops here.
+		// In production this should not occur (InteractionCreate always sets TMCreate).
+		// Future: enforce TMCreate NOT NULL at the DB schema level.
+	}
+
+	return &interaction.InteractionListResponse{
+		Items:         items,
+		NextPageToken: nextToken,
+	}
+}
+
+// InteractionListUnresolved returns interactions with zero-contact attribution.
+// Predicate: NOT auto-matched to any address AND NOT positive-resolved AND peer_type != web_session.
+// Supports pagination (size + token).
+func (h *contactHandler) InteractionListUnresolved(
+	ctx context.Context,
+	customerID uuid.UUID,
+	size uint64,
+	token string,
+	since time.Time,
+) (*interaction.InteractionListResponse, error) {
+	if size == 0 {
+		size = 100
+	}
+	if size > 500 {
+		return nil, cerrors.InvalidArgument(
+			commonoutline.ServiceNameContactManager,
+			"INVALID_PAGE_SIZE",
+			"page_size must be at most 500 for the unresolved endpoint.",
+		)
+	}
+
+	items, err := h.db.InteractionListUnresolved(ctx, customerID, size+1, token, since)
+	if err != nil {
+		return nil, fmt.Errorf("could not list unresolved interactions. InteractionListUnresolved. err: %v", err)
+	}
+	return buildListResponse(items, size), nil
+}

--- a/bin-contact-manager/pkg/contacthandler/main.go
+++ b/bin-contact-manager/pkg/contacthandler/main.go
@@ -4,6 +4,7 @@ package contacthandler
 
 import (
 	"context"
+	"time"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -16,6 +17,8 @@ import (
 	callmodel "monorepo/bin-call-manager/models/call"
 	convmsg "monorepo/bin-conversation-manager/models/message"
 	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/models/resolution"
 	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
 
@@ -50,6 +53,17 @@ type ContactHandler interface {
 	// Projection event handlers (CRM interaction timeline)
 	EventCallCreated(ctx context.Context, m *callmodel.WebhookMessage) error
 	EventConversationMessageCreated(ctx context.Context, m *convmsg.WebhookMessage) error
+
+	// Interaction read operations (CRM v1 read API, VOIP-1209)
+	InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error)
+	InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string,
+		peerType, peerTarget string, contactID uuid.UUID, addressID uuid.UUID) (*interaction.InteractionListResponse, error)
+	InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) (*interaction.InteractionListResponse, error)
+
+	// Resolution operations (CRM v1 attribution, VOIP-1209)
+	ResolutionCreate(ctx context.Context, customerID, contactID, interactionID uuid.UUID,
+		resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error)
+	ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error
 }
 
 type contactHandler struct {

--- a/bin-contact-manager/pkg/contacthandler/mock_main.go
+++ b/bin-contact-manager/pkg/contacthandler/mock_main.go
@@ -13,9 +13,12 @@ import (
 	context "context"
 	call "monorepo/bin-call-manager/models/call"
 	contact "monorepo/bin-contact-manager/models/contact"
+	interaction "monorepo/bin-contact-manager/models/interaction"
+	resolution "monorepo/bin-contact-manager/models/resolution"
 	message "monorepo/bin-conversation-manager/models/message"
 	customer "monorepo/bin-customer-manager/models/customer"
 	reflect "reflect"
+	time "time"
 
 	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -177,6 +180,51 @@ func (mr *MockContactHandlerMockRecorder) Get(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockContactHandler)(nil).Get), ctx, id)
 }
 
+// InteractionGet mocks base method.
+func (m *MockContactHandler) InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionGet", ctx, customerID, id)
+	ret0, _ := ret[0].(*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionGet indicates an expected call of InteractionGet.
+func (mr *MockContactHandlerMockRecorder) InteractionGet(ctx, customerID, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionGet", reflect.TypeOf((*MockContactHandler)(nil).InteractionGet), ctx, customerID, id)
+}
+
+// InteractionList mocks base method.
+func (m *MockContactHandler) InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID) (*interaction.InteractionListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionList", ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+	ret0, _ := ret[0].(*interaction.InteractionListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionList indicates an expected call of InteractionList.
+func (mr *MockContactHandlerMockRecorder) InteractionList(ctx, customerID, size, token, peerType, peerTarget, contactID, addressID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionList", reflect.TypeOf((*MockContactHandler)(nil).InteractionList), ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+}
+
+// InteractionListUnresolved mocks base method.
+func (m *MockContactHandler) InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) (*interaction.InteractionListResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionListUnresolved", ctx, customerID, size, token, since)
+	ret0, _ := ret[0].(*interaction.InteractionListResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionListUnresolved indicates an expected call of InteractionListUnresolved.
+func (mr *MockContactHandlerMockRecorder) InteractionListUnresolved(ctx, customerID, size, token, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionListUnresolved", reflect.TypeOf((*MockContactHandler)(nil).InteractionListUnresolved), ctx, customerID, size, token, since)
+}
+
 // List mocks base method.
 func (m *MockContactHandler) List(ctx context.Context, size uint64, token string, filters map[contact.Field]any) ([]*contact.Contact, error) {
 	m.ctrl.T.Helper()
@@ -265,6 +313,35 @@ func (m *MockContactHandler) RemoveTag(ctx context.Context, contactID, tagID uui
 func (mr *MockContactHandlerMockRecorder) RemoveTag(ctx, contactID, tagID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTag", reflect.TypeOf((*MockContactHandler)(nil).RemoveTag), ctx, contactID, tagID)
+}
+
+// ResolutionCreate mocks base method.
+func (m *MockContactHandler) ResolutionCreate(ctx context.Context, customerID, contactID, interactionID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolutionCreate", ctx, customerID, contactID, interactionID, resolutionType, resolvedByType, resolvedByID)
+	ret0, _ := ret[0].(*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolutionCreate indicates an expected call of ResolutionCreate.
+func (mr *MockContactHandlerMockRecorder) ResolutionCreate(ctx, customerID, contactID, interactionID, resolutionType, resolvedByType, resolvedByID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolutionCreate", reflect.TypeOf((*MockContactHandler)(nil).ResolutionCreate), ctx, customerID, contactID, interactionID, resolutionType, resolvedByType, resolvedByID)
+}
+
+// ResolutionDelete mocks base method.
+func (m *MockContactHandler) ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolutionDelete", ctx, customerID, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResolutionDelete indicates an expected call of ResolutionDelete.
+func (mr *MockContactHandlerMockRecorder) ResolutionDelete(ctx, customerID, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolutionDelete", reflect.TypeOf((*MockContactHandler)(nil).ResolutionDelete), ctx, customerID, id)
 }
 
 // Update mocks base method.

--- a/bin-contact-manager/pkg/contacthandler/resolution.go
+++ b/bin-contact-manager/pkg/contacthandler/resolution.go
@@ -1,0 +1,106 @@
+package contacthandler
+
+import (
+	"context"
+	"fmt"
+
+	stderrors "errors"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-contact-manager/models/resolution"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// ResolutionCreate creates a new resolution for an interaction.
+//
+// Validates:
+//  1. The interaction must exist and belong to customerID (tenant guard).
+//  2. No existing active resolution of the SAME type for (contact_id, interaction_id).
+//     A positive + negative coexisting is allowed. Two positives or two negatives are rejected.
+//     This is application-level dedup (no DB UNIQUE due to MySQL NULL semantics + soft-delete).
+//     Concurrent creates may slip through; v1 accepts this as a UX nuisance, not data corruption.
+func (h *contactHandler) ResolutionCreate(
+	ctx context.Context,
+	customerID, contactID, interactionID uuid.UUID,
+	resolutionType, resolvedByType string,
+	resolvedByID uuid.UUID,
+) (*resolution.Resolution, error) {
+	// 1. Verify the interaction exists and belongs to this customer.
+	iact, err := h.db.InteractionGet(ctx, interactionID)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"INTERACTION_NOT_FOUND",
+				"The interaction was not found.",
+			).Wrap(err)
+		}
+		return nil, fmt.Errorf("could not get interaction. ResolutionCreate. err: %v", err)
+	}
+	if iact.CustomerID != customerID {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"INTERACTION_NOT_FOUND",
+			"The interaction was not found.",
+		)
+	}
+
+	// 2. Check for existing active resolution of the same type.
+	existing, err := h.db.ResolutionListByInteraction(ctx, customerID, interactionID)
+	if err != nil {
+		return nil, fmt.Errorf("could not list resolutions. ResolutionCreate. err: %v", err)
+	}
+	for _, r := range existing {
+		if r.ContactID == contactID && r.ResolutionType == resolutionType {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameContactManager,
+				"RESOLUTION_ALREADY_EXISTS",
+				fmt.Sprintf("An active %s resolution for this (contact_id, interaction_id) already exists.", resolutionType),
+			)
+		}
+	}
+
+	// 3. Create.
+	id := h.utilHandler.UUIDCreate()
+	now := h.utilHandler.TimeNow()
+
+	r := &resolution.Resolution{
+		ID:             id,
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolutionType,
+		ResolvedByType: resolvedByType,
+		ResolvedByID:   resolvedByID,
+		TMCreate:       now,
+		TMUpdate:       now,
+	}
+
+	if createErr := h.db.ResolutionCreate(ctx, r); createErr != nil {
+		return nil, fmt.Errorf("could not create resolution. ResolutionCreate. err: %v", createErr)
+	}
+
+	return r, nil
+}
+
+// ResolutionDelete soft-deletes a resolution.
+// Validates that the resolution exists and belongs to customerID.
+// Cross-tenant guard is enforced in dbhandler (WHERE customer_id = ?).
+func (h *contactHandler) ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error {
+	if err := h.db.ResolutionDelete(ctx, customerID, id); err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"RESOLUTION_NOT_FOUND",
+				"The resolution was not found or is already deleted.",
+			).Wrap(err)
+		}
+		return fmt.Errorf("could not delete resolution. ResolutionDelete. err: %v", err)
+	}
+
+	return nil
+}

--- a/bin-contact-manager/pkg/dbhandler/address.go
+++ b/bin-contact-manager/pkg/dbhandler/address.go
@@ -112,3 +112,70 @@ func (h *handler) addressResetPrimaryForContact(_ context.Context, contactID uui
 
 	return nil
 }
+
+// AddressListByContact returns all (type, target) pairs for a contact.
+// contact_addresses has no soft-delete.
+func (h *handler) AddressListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]AddressPair, error) {
+	query, args, err := sq.Select("type", "target").
+		From(addressTable).
+		Where(sq.Eq{
+			"customer_id": customerID.Bytes(),
+			"contact_id":  contactID.Bytes(),
+		}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. AddressListByContact. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. AddressListByContact. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []AddressPair
+	for rows.Next() {
+		var ap AddressPair
+		if scanErr := rows.Scan(&ap.Type, &ap.Target); scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. AddressListByContact. err: %v", scanErr)
+		}
+		res = append(res, ap)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. AddressListByContact. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// AddressGetByID returns the (type, target) for a single address row,
+// scoped to customerID to prevent cross-tenant PII disclosure.
+// Returns ErrNotFound if absent or belongs to a different customer.
+func (h *handler) AddressGetByID(ctx context.Context, customerID, id uuid.UUID) (AddressPair, error) {
+	query, args, err := sq.Select("type", "target").
+		From(addressTable).
+		Where(sq.Eq{"id": id.Bytes()}).
+		Where(sq.Eq{"customer_id": customerID.Bytes()}).
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return AddressPair{}, fmt.Errorf("could not build query. AddressGetByID. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return AddressPair{}, fmt.Errorf("could not query. AddressGetByID. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return AddressPair{}, ErrNotFound
+	}
+
+	var ap AddressPair
+	if err := rows.Scan(&ap.Type, &ap.Target); err != nil {
+		return AddressPair{}, fmt.Errorf("could not scan the row. AddressGetByID. err: %v", err)
+	}
+
+	return ap, nil
+}

--- a/bin-contact-manager/pkg/dbhandler/address_test.go
+++ b/bin-contact-manager/pkg/dbhandler/address_test.go
@@ -1,0 +1,155 @@
+package dbhandler
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/pkg/cachehandler"
+)
+
+// insertTestAddress inserts a row directly into contact_addresses (explicit SQL,
+// no PrepareFields, avoids the generated primary_contact_uk column).
+func insertTestAddress(t *testing.T, db *sql.DB, id, customerID, contactID uuid.UUID, addrType, target string) {
+	t.Helper()
+	q := `INSERT INTO contact_addresses (id, customer_id, contact_id, type, target, is_primary, tm_create)
+		  VALUES (?,?,?,?,?,?,?)`
+	_, err := db.Exec(q,
+		id.Bytes(), customerID.Bytes(), contactID.Bytes(),
+		addrType, target,
+		0, // is_primary = false
+		time.Date(2026, 6, 28, 9, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05.000000"),
+	)
+	if err != nil {
+		t.Fatalf("insertTestAddress() error = %v", err)
+	}
+}
+
+func Test_AddressListByContact(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("ab1b2c3d-0001-0001-0001-000000000001")
+	contactID := uuid.FromStringOrNil("ab1b2c3d-0001-0001-0001-000000000002")
+
+	// Create the parent contact first
+	mockUtil.EXPECT().TimeNow().Return(timePtr(time.Date(2026, 6, 28, 9, 0, 0, 0, time.UTC)))
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         contactID,
+			CustomerID: customerID,
+		},
+		FirstName: "Address",
+		LastName:  "List",
+		Source:    "manual",
+	}
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	// Insert two addresses directly (no AddressCreate yet)
+	addrID1 := uuid.FromStringOrNil("ab1b2c3d-0001-0001-0001-000000000003")
+	addrID2 := uuid.FromStringOrNil("ab1b2c3d-0001-0001-0001-000000000004")
+	insertTestAddress(t, dbTest, addrID1, customerID, contactID, "tel", "+15551001001")
+	insertTestAddress(t, dbTest, addrID2, customerID, contactID, "email", "test@example.com")
+
+	// AddressListByContact → both returned
+	res, err := h.AddressListByContact(ctx, customerID, contactID)
+	if err != nil {
+		t.Fatalf("AddressListByContact() error = %v", err)
+	}
+	if len(res) < 2 {
+		t.Errorf("AddressListByContact() len = %d, want >= 2", len(res))
+	}
+
+	// Verify types present
+	types := make(map[string]string)
+	for _, ap := range res {
+		types[ap.Type] = ap.Target
+	}
+	if types["tel"] != "+15551001001" {
+		t.Errorf("AddressListByContact() tel target = %q, want +15551001001", types["tel"])
+	}
+	if types["email"] != "test@example.com" {
+		t.Errorf("AddressListByContact() email target = %q, want test@example.com", types["email"])
+	}
+}
+
+func Test_AddressGetByID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("ab1b2c3d-0002-0002-0002-000000000001")
+	contactID := uuid.FromStringOrNil("ab1b2c3d-0002-0002-0002-000000000002")
+	addrID := uuid.FromStringOrNil("ab1b2c3d-0002-0002-0002-000000000003")
+
+	// Create the parent contact
+	mockUtil.EXPECT().TimeNow().Return(timePtr(time.Date(2026, 6, 28, 9, 0, 0, 0, time.UTC)))
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         contactID,
+			CustomerID: customerID,
+		},
+		FirstName: "Address",
+		LastName:  "GetByID",
+		Source:    "manual",
+	}
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	insertTestAddress(t, dbTest, addrID, customerID, contactID, "tel", "+15551002002")
+
+	// found case
+	ap, err := h.AddressGetByID(ctx, customerID, addrID)
+	if err != nil {
+		t.Fatalf("AddressGetByID() error = %v", err)
+	}
+	if ap.Type != "tel" {
+		t.Errorf("AddressGetByID() Type = %q, want tel", ap.Type)
+	}
+	if ap.Target != "+15551002002" {
+		t.Errorf("AddressGetByID() Target = %q, want +15551002002", ap.Target)
+	}
+
+	// not found: wrong id
+	_, err = h.AddressGetByID(ctx, customerID, uuid.FromStringOrNil("ab1b2c3d-ffff-ffff-ffff-ffffffffffff"))
+	if err != ErrNotFound {
+		t.Errorf("AddressGetByID() expected ErrNotFound, got: %v", err)
+	}
+
+	// not found: wrong customerID (cross-tenant guard)
+	wrongCustomer := uuid.FromStringOrNil("ab1b2c3d-eeee-eeee-eeee-eeeeeeeeeeee")
+	_, err = h.AddressGetByID(ctx, wrongCustomer, addrID)
+	if err != ErrNotFound {
+		t.Errorf("AddressGetByID() cross-tenant: expected ErrNotFound, got: %v", err)
+	}
+}

--- a/bin-contact-manager/pkg/dbhandler/interaction.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction.go
@@ -2,11 +2,16 @@ package dbhandler
 
 import (
 	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	mysql_driver "github.com/go-sql-driver/mysql"
+	"github.com/gofrs/uuid"
 
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
 
@@ -16,6 +21,13 @@ import (
 const (
 	interactionTable = "contact_interactions"
 )
+
+// AddressPair is a (type, target) pair used for multi-column IN expansion.
+// Exported so contacthandler and tests can construct slices.
+type AddressPair struct {
+	Type   string
+	Target string
+}
 
 // InteractionCreate inserts an Interaction row into contact_interactions.
 // It is idempotent: a duplicate-key error (MySQL errno 1062) is silently
@@ -46,4 +58,297 @@ func (h *handler) InteractionCreate(ctx context.Context, i *interaction.Interact
 	}
 
 	return nil
+}
+
+// interactionGetFromRow scans a single row into an Interaction struct.
+func interactionGetFromRow(rows *sql.Rows) (*interaction.Interaction, error) {
+	res := &interaction.Interaction{}
+	if err := commondatabasehandler.ScanRow(rows, res); err != nil {
+		return nil, fmt.Errorf("could not scan the row. interactionGetFromRow. err: %v", err)
+	}
+	return res, nil
+}
+
+// InteractionGet fetches a single interaction by ID.
+// Returns ErrNotFound if absent.
+func (h *handler) InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error) {
+	columns := commondatabasehandler.GetDBFields(&interaction.Interaction{})
+
+	query, args, err := sq.Select(columns...).
+		From(interactionTable).
+		Where(sq.Eq{"id": id.Bytes()}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. InteractionGet. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. InteractionGet. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		return nil, ErrNotFound
+	}
+
+	res, err := interactionGetFromRow(rows)
+	if err != nil {
+		return nil, fmt.Errorf("could not scan the row. InteractionGet. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// pageTokenJSON is the wire format for the cursor token.
+type pageTokenJSON struct {
+	TMCreate string `json:"tm_create"`
+	ID       string `json:"id"`
+}
+
+// encodePageToken encodes a (tm_create, id) cursor as base64(json(...)).
+// Returns "" if tm is nil (rows without tm_create cannot be used as a cursor).
+func encodePageToken(tm *time.Time, id uuid.UUID) string {
+	if tm == nil {
+		return ""
+	}
+	p := pageTokenJSON{
+		TMCreate: tm.UTC().Format(time.RFC3339Nano),
+		ID:       id.String(),
+	}
+	b, _ := json.Marshal(p)
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// EncodePageToken is the exported wrapper for contacthandler and tests.
+func EncodePageToken(tm *time.Time, id uuid.UUID) string {
+	return encodePageToken(tm, id)
+}
+
+// decodePageToken decodes a base64(json(...)) cursor back to (time.Time, uuid.UUID, error).
+func decodePageToken(token string) (time.Time, uuid.UUID, error) {
+	b, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("base64 decode: %w", err)
+	}
+	var p pageTokenJSON
+	if err := json.Unmarshal(b, &p); err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("json unmarshal: %w", err)
+	}
+	tm, err := time.Parse(time.RFC3339Nano, p.TMCreate)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("time parse: %w", err)
+	}
+	id, err := uuid.FromString(p.ID)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("uuid parse: %w", err)
+	}
+	return tm, id, nil
+}
+
+// DecodePageToken is the exported wrapper for contacthandler and tests.
+func DecodePageToken(token string) (time.Time, uuid.UUID, error) {
+	return decodePageToken(token)
+}
+
+// InteractionList returns a page of interactions.
+// Filter mode: either (peerType+peerTarget) OR addressSet (multi-column IN).
+// If both peerType/peerTarget are empty AND addressSet is empty → returns nil, nil immediately.
+// Pagination: cursor is base64(json({"tm_create":"RFC3339Nano","id":"uuid"})), DESC order.
+func (h *handler) InteractionList(
+	ctx context.Context,
+	customerID uuid.UUID,
+	size uint64,
+	token string,
+	peerType, peerTarget string,
+	addressSet []AddressPair,
+) ([]*interaction.Interaction, error) {
+	// 1. If all filters empty → return nil, nil
+	if peerType == "" && peerTarget == "" && len(addressSet) == 0 {
+		return nil, nil
+	}
+
+	columns := commondatabasehandler.GetDBFields(&interaction.Interaction{})
+
+	builder := sq.Select(columns...).
+		From(interactionTable).
+		Where(sq.Eq{"customer_id": customerID.Bytes()})
+
+	// 3. Apply peer filter OR addressSet multi-column IN
+	if peerType != "" || peerTarget != "" {
+		builder = builder.Where(sq.Eq{"peer_type": peerType, "peer_target": peerTarget})
+	} else if len(addressSet) > 0 {
+		// Build: (peer_type=? AND peer_target=?) OR ...
+		// Using OR expansion for SQLite compatibility (SQLite doesn't support multi-column IN).
+		or := sq.Or{}
+		for _, ap := range addressSet {
+			or = append(or, sq.Eq{"peer_type": ap.Type, "peer_target": ap.Target})
+		}
+		builder = builder.Where(or)
+	}
+
+	// 4. Apply cursor if token != ""
+	if token != "" {
+		cursorTime, cursorID, err := decodePageToken(token)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode page token. InteractionList. err: %v", err)
+		}
+		builder = builder.Where(
+			sq.Expr("(tm_create < ? OR (tm_create = ? AND id < ?))",
+				cursorTime, cursorTime, cursorID.Bytes(),
+			),
+		)
+	}
+
+	// 5. ORDER BY tm_create DESC, id DESC
+	// LIMIT is `size` (no internal +1). Callers pass `size+1` to probe for hasMore.
+	// buildListResponse owns the trim+token logic.
+	builder = builder.
+		OrderBy("tm_create DESC, id DESC").
+		Limit(size)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. InteractionList. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. InteractionList. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []*interaction.Interaction
+	for rows.Next() {
+		item, scanErr := interactionGetFromRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. InteractionList. err: %v", scanErr)
+		}
+		res = append(res, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. InteractionList. err: %v", err)
+	}
+
+	// Return up to size+1 rows. The extra row signals hasMore to buildListResponse.
+	// Do NOT trim here — the caller owns the trim+token logic.
+	return res, nil
+}
+
+// InteractionListByIDs fetches interactions for a given set of IDs,
+// scoped to customerID (tenant guard).
+func (h *handler) InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	columns := commondatabasehandler.GetDBFields(&interaction.Interaction{})
+
+	idBytes := make([]interface{}, len(ids))
+	for i, id := range ids {
+		b := id.Bytes()
+		idBytes[i] = b
+	}
+
+	query, args, err := sq.Select(columns...).
+		From(interactionTable).
+		Where(sq.Eq{"customer_id": customerID.Bytes()}).
+		Where(sq.Eq{"id": idBytes}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. InteractionListByIDs. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. InteractionListByIDs. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []*interaction.Interaction
+	for rows.Next() {
+		item, scanErr := interactionGetFromRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. InteractionListByIDs. err: %v", scanErr)
+		}
+		res = append(res, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. InteractionListByIDs. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// InteractionListUnresolved returns interactions that have zero-contact attribution:
+//   - NOT auto-matched to any active contact_address for this customer
+//   - NOT positively resolved to any contact
+//   - peer_type != 'web_session'
+//
+// Supports pagination (size + token) and a since lower bound on tm_create.
+func (h *handler) InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, error) {
+	columns := commondatabasehandler.GetDBFields(&interaction.Interaction{})
+	cols := make([]string, len(columns))
+	for i, c := range columns {
+		cols[i] = "i." + c
+	}
+
+	// Build the unresolved predicate using NOT EXISTS subqueries.
+	// Outer query scans contact_interactions (i) for the customer since the given time.
+	baseSQL := fmt.Sprintf(`
+SELECT %s
+FROM contact_interactions i
+WHERE i.customer_id = ?
+  AND i.peer_type != 'web_session'
+  AND i.tm_create >= ?
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_addresses a
+      WHERE a.customer_id = i.customer_id
+        AND a.type = i.peer_type
+        AND a.target = i.peer_target
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_resolutions r
+      WHERE r.customer_id = i.customer_id
+        AND r.interaction_id = i.id
+        AND r.resolution_type = 'positive'
+        AND r.tm_delete IS NULL
+  )`,
+		strings.Join(cols, ", "),
+	)
+
+	args := []interface{}{customerID.Bytes(), since}
+
+	// Cursor pagination.
+	if token != "" {
+		cursorTime, cursorID, err := decodePageToken(token)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode page token. InteractionListUnresolved. err: %v", err)
+		}
+		baseSQL += " AND (i.tm_create < ? OR (i.tm_create = ? AND i.id < ?))"
+		args = append(args, cursorTime, cursorTime, cursorID.Bytes())
+	}
+
+	baseSQL += " ORDER BY i.tm_create DESC, i.id DESC LIMIT ?"
+	args = append(args, size)
+
+	rows, err := h.db.Query(baseSQL, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. InteractionListUnresolved. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []*interaction.Interaction
+	for rows.Next() {
+		item, scanErr := interactionGetFromRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. InteractionListUnresolved. err: %v", scanErr)
+		}
+		res = append(res, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. InteractionListUnresolved. err: %v", err)
+	}
+
+	return res, nil
 }

--- a/bin-contact-manager/pkg/dbhandler/interaction_test.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction_test.go
@@ -111,3 +111,388 @@ func Test_InteractionCreate_duplicate(t *testing.T) {
 		t.Errorf("duplicate insert should be idempotent (no error), got: %v", err)
 	}
 }
+
+func Test_InteractionGet(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	tm := func() *time.Time { t := time.Date(2026, 6, 28, 14, 0, 0, 0, time.UTC); return &t }()
+	i := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0001-0001-0001-000000000001"),
+		CustomerID:    uuid.FromStringOrNil("e1b2c3d4-0001-0001-0001-000000000002"),
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+15550001001",
+		LocalType:     "tel",
+		LocalTarget:   "+15559990001",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0001-0001-0001-000000000003"),
+		TMCreate:      tm,
+	}
+
+	if err := h.InteractionCreate(ctx, i); err != nil {
+		t.Fatalf("InteractionCreate() error = %v", err)
+	}
+
+	// get by ID → verify fields
+	got, err := h.InteractionGet(ctx, i.ID)
+	if err != nil {
+		t.Fatalf("InteractionGet() error = %v", err)
+	}
+	if got.ID != i.ID {
+		t.Errorf("InteractionGet() ID = %v, want %v", got.ID, i.ID)
+	}
+	if got.PeerTarget != i.PeerTarget {
+		t.Errorf("InteractionGet() PeerTarget = %v, want %v", got.PeerTarget, i.PeerTarget)
+	}
+	if got.Direction != i.Direction {
+		t.Errorf("InteractionGet() Direction = %v, want %v", got.Direction, i.Direction)
+	}
+
+	// get non-existent ID → verify ErrNotFound
+	_, err = h.InteractionGet(ctx, uuid.FromStringOrNil("e1b2c3d4-ffff-ffff-ffff-ffffffffffff"))
+	if err != ErrNotFound {
+		t.Errorf("InteractionGet() expected ErrNotFound, got: %v", err)
+	}
+}
+
+func Test_InteractionList_byPeer(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("e1b2c3d4-0002-0002-0002-000000000001")
+	peerType := "tel"
+	peerTarget := "+15550002001"
+
+	i1 := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0002-0002-0002-000000000002"),
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      peerType,
+		PeerTarget:    peerTarget,
+		LocalType:     "tel",
+		LocalTarget:   "+15559990002",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0002-0002-0002-000000000003"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 15, 0, 0, 0, time.UTC); return &t }(),
+	}
+	i2 := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0002-0002-0002-000000000004"),
+		CustomerID:    customerID,
+		Direction:     "outgoing",
+		PeerType:      peerType,
+		PeerTarget:    peerTarget,
+		LocalType:     "tel",
+		LocalTarget:   "+15559990002",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0002-0002-0002-000000000005"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 16, 0, 0, 0, time.UTC); return &t }(),
+	}
+
+	if err := h.InteractionCreate(ctx, i1); err != nil {
+		t.Fatalf("InteractionCreate(i1) error = %v", err)
+	}
+	if err := h.InteractionCreate(ctx, i2); err != nil {
+		t.Fatalf("InteractionCreate(i2) error = %v", err)
+	}
+
+	// InteractionList with peerType+peerTarget → both returned
+	res, err := h.InteractionList(ctx, customerID, 10, "", peerType, peerTarget, nil)
+	if err != nil {
+		t.Fatalf("InteractionList() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Errorf("InteractionList() len = %d, want 2", len(res))
+	}
+
+	// InteractionList with wrong peer → empty
+	res, err = h.InteractionList(ctx, customerID, 10, "", peerType, "+19990000000", nil)
+	if err != nil {
+		t.Fatalf("InteractionList() wrong peer error = %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("InteractionList() wrong peer len = %d, want 0", len(res))
+	}
+}
+
+func Test_InteractionList_byAddressSet(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("e1b2c3d4-0003-0003-0003-000000000001")
+
+	i1 := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0003-0003-0003-000000000002"),
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+15550003001",
+		LocalType:     "tel",
+		LocalTarget:   "+15559990003",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0003-0003-0003-000000000003"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 17, 0, 0, 0, time.UTC); return &t }(),
+	}
+	i2 := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0003-0003-0003-000000000004"),
+		CustomerID:    customerID,
+		Direction:     "outgoing",
+		PeerType:      "line",
+		PeerTarget:    "Ufake12345",
+		LocalType:     "line",
+		LocalTarget:   "",
+		ReferenceType: "conversation_message",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0003-0003-0003-000000000005"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 18, 0, 0, 0, time.UTC); return &t }(),
+	}
+
+	if err := h.InteractionCreate(ctx, i1); err != nil {
+		t.Fatalf("InteractionCreate(i1) error = %v", err)
+	}
+	if err := h.InteractionCreate(ctx, i2); err != nil {
+		t.Fatalf("InteractionCreate(i2) error = %v", err)
+	}
+
+	// InteractionList with addressSet containing both pairs → both returned
+	bothPairs := []AddressPair{
+		{Type: "tel", Target: "+15550003001"},
+		{Type: "line", Target: "Ufake12345"},
+	}
+	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", bothPairs)
+	if err != nil {
+		t.Fatalf("InteractionList() both pairs error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Errorf("InteractionList() both pairs len = %d, want 2", len(res))
+	}
+
+	// InteractionList with addressSet containing only first pair → 1 returned
+	onePair := []AddressPair{
+		{Type: "tel", Target: "+15550003001"},
+	}
+	res, err = h.InteractionList(ctx, customerID, 10, "", "", "", onePair)
+	if err != nil {
+		t.Fatalf("InteractionList() one pair error = %v", err)
+	}
+	if len(res) != 1 {
+		t.Errorf("InteractionList() one pair len = %d, want 1", len(res))
+	}
+}
+
+func Test_InteractionList_empty(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("e1b2c3d4-0004-0004-0004-000000000001")
+
+	// InteractionList with all-empty filters → no error, nil result
+	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", nil)
+	if err != nil {
+		t.Fatalf("InteractionList() empty filters error = %v", err)
+	}
+	if res != nil {
+		t.Errorf("InteractionList() empty filters expected nil, got %v", res)
+	}
+}
+
+func Test_InteractionListByIDs(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("e1b2c3d4-0005-0005-0005-000000000001")
+	wrongCustomerID := uuid.FromStringOrNil("e1b2c3d4-0005-0005-0005-000000000099")
+
+	i1 := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0005-0005-0005-000000000002"),
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+15550005001",
+		LocalType:     "tel",
+		LocalTarget:   "+15559990005",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0005-0005-0005-000000000003"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 19, 0, 0, 0, time.UTC); return &t }(),
+	}
+	i2 := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0005-0005-0005-000000000004"),
+		CustomerID:    customerID,
+		Direction:     "outgoing",
+		PeerType:      "tel",
+		PeerTarget:    "+15550005002",
+		LocalType:     "tel",
+		LocalTarget:   "+15559990005",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0005-0005-0005-000000000005"),
+		TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 20, 0, 0, 0, time.UTC); return &t }(),
+	}
+
+	if err := h.InteractionCreate(ctx, i1); err != nil {
+		t.Fatalf("InteractionCreate(i1) error = %v", err)
+	}
+	if err := h.InteractionCreate(ctx, i2); err != nil {
+		t.Fatalf("InteractionCreate(i2) error = %v", err)
+	}
+
+	// list by their IDs → both returned
+	res, err := h.InteractionListByIDs(ctx, customerID, []uuid.UUID{i1.ID, i2.ID})
+	if err != nil {
+		t.Fatalf("InteractionListByIDs() error = %v", err)
+	}
+	if len(res) != 2 {
+		t.Errorf("InteractionListByIDs() len = %d, want 2", len(res))
+	}
+
+	// list with wrong customerID → empty (tenant guard)
+	res, err = h.InteractionListByIDs(ctx, wrongCustomerID, []uuid.UUID{i1.ID, i2.ID})
+	if err != nil {
+		t.Fatalf("InteractionListByIDs() wrong customer error = %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("InteractionListByIDs() wrong customer len = %d, want 0", len(res))
+	}
+}
+
+// Test_InteractionList_pagination verifies that InteractionList correctly
+// returns size+1 rows when callers pass size+1, enabling buildListResponse to
+// detect hasMore and emit a non-empty NextPageToken.
+func Test_InteractionList_pagination(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	// UUID namespace: f1b2c3d4-* (pagination tests — 'f' is valid hex, unlike 'p')
+	customerID := uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000000")
+
+	// Insert 3 interactions with the same peer so they all match.
+	rows := []struct {
+		id    uuid.UUID
+		refID uuid.UUID
+		tmC   time.Time
+	}{
+		{
+			uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000001"),
+			uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000011"),
+			time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000002"),
+			uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000012"),
+			time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC),
+		},
+		{
+			uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000003"),
+			uuid.FromStringOrNil("f1b2c3d4-0001-0001-0001-000000000013"),
+			time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, r := range rows {
+		tm := r.tmC
+		i := &interaction.Interaction{
+			ID:            r.id,
+			CustomerID:    customerID,
+			Direction:     "incoming",
+			PeerType:      "tel",
+			PeerTarget:    "+15550001111",
+			LocalType:     "tel",
+			LocalTarget:   "+15559999",
+			ReferenceType: "call",
+			ReferenceID:   r.refID,
+			TMCreate:      &tm,
+		}
+		if err := h.InteractionCreate(ctx, i); err != nil {
+			t.Fatalf("InteractionCreate error = %v", err)
+		}
+	}
+
+	// pageSize=2, pass size+1=3 → expect 3 rows returned (probe row present)
+	const pageSize uint64 = 2
+	res, err := h.InteractionList(ctx, customerID, pageSize+1, "", "tel", "+15550001111", nil)
+	if err != nil {
+		t.Fatalf("InteractionList() error = %v", err)
+	}
+	// Should get 3 rows (all 3 exist); caller uses len>pageSize to detect hasMore.
+	if uint64(len(res)) != pageSize+1 {
+		t.Fatalf("InteractionList() len = %d, want %d (probe row present)", len(res), pageSize+1)
+	}
+
+	// First page: take first pageSize rows, encode token from last.
+	page1 := res[:pageSize]
+	probe := res[pageSize]
+	_ = probe // confirms probe row exists
+
+	lastOfPage1 := page1[len(page1)-1]
+	if lastOfPage1.TMCreate == nil {
+		t.Fatal("last item TMCreate is nil; cannot build page token")
+	}
+	nextToken := EncodePageToken(lastOfPage1.TMCreate, lastOfPage1.ID)
+	if nextToken == "" {
+		t.Fatal("EncodePageToken returned empty string for non-nil TMCreate")
+	}
+
+	// Second page: pass token, expect 1 row (the remaining one).
+	res2, err := h.InteractionList(ctx, customerID, pageSize+1, nextToken, "tel", "+15550001111", nil)
+	if err != nil {
+		t.Fatalf("InteractionList page2 error = %v", err)
+	}
+	// Only 1 row should remain past the cursor; len ≤ pageSize → no more pages.
+	if len(res2) == 0 {
+		t.Error("InteractionList page2 returned 0 rows; expected 1")
+	}
+	if uint64(len(res2)) > pageSize {
+		t.Errorf("InteractionList page2 len = %d; expected ≤ %d (no more data)", len(res2), pageSize)
+	}
+}

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
@@ -13,6 +14,7 @@ import (
 
 	"monorepo/bin-contact-manager/models/contact"
 	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/models/resolution"
 	"monorepo/bin-contact-manager/pkg/cachehandler"
 )
 
@@ -51,6 +53,20 @@ type DBHandler interface {
 
 	// Interaction operations
 	InteractionCreate(ctx context.Context, i *interaction.Interaction) error
+	InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error)
+	InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, addressSet []AddressPair) ([]*interaction.Interaction, error)
+	InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error)
+	InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, error)
+
+	// Address operations
+	AddressListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]AddressPair, error)
+	AddressGetByID(ctx context.Context, customerID, id uuid.UUID) (AddressPair, error)
+
+	// Resolution operations
+	ResolutionCreate(ctx context.Context, r *resolution.Resolution) error
+	ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error
+	ResolutionListByInteraction(ctx context.Context, customerID, interactionID uuid.UUID) ([]*resolution.Resolution, error)
+	ResolutionListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]*resolution.Resolution, error)
 }
 
 // handler database handler

--- a/bin-contact-manager/pkg/dbhandler/mock_main.go
+++ b/bin-contact-manager/pkg/dbhandler/mock_main.go
@@ -13,7 +13,9 @@ import (
 	context "context"
 	contact "monorepo/bin-contact-manager/models/contact"
 	interaction "monorepo/bin-contact-manager/models/interaction"
+	resolution "monorepo/bin-contact-manager/models/resolution"
 	reflect "reflect"
+	time "time"
 
 	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -41,6 +43,36 @@ func NewMockDBHandler(ctrl *gomock.Controller) *MockDBHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDBHandler) EXPECT() *MockDBHandlerMockRecorder {
 	return m.recorder
+}
+
+// AddressGetByID mocks base method.
+func (m *MockDBHandler) AddressGetByID(ctx context.Context, customerID, id uuid.UUID) (AddressPair, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddressGetByID", ctx, customerID, id)
+	ret0, _ := ret[0].(AddressPair)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddressGetByID indicates an expected call of AddressGetByID.
+func (mr *MockDBHandlerMockRecorder) AddressGetByID(ctx, customerID, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressGetByID", reflect.TypeOf((*MockDBHandler)(nil).AddressGetByID), ctx, customerID, id)
+}
+
+// AddressListByContact mocks base method.
+func (m *MockDBHandler) AddressListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]AddressPair, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddressListByContact", ctx, customerID, contactID)
+	ret0, _ := ret[0].([]AddressPair)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddressListByContact indicates an expected call of AddressListByContact.
+func (mr *MockDBHandlerMockRecorder) AddressListByContact(ctx, customerID, contactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressListByContact", reflect.TypeOf((*MockDBHandler)(nil).AddressListByContact), ctx, customerID, contactID)
 }
 
 // ContactCreate mocks base method.
@@ -259,6 +291,66 @@ func (mr *MockDBHandlerMockRecorder) InteractionCreate(ctx, i any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionCreate", reflect.TypeOf((*MockDBHandler)(nil).InteractionCreate), ctx, i)
 }
 
+// InteractionGet mocks base method.
+func (m *MockDBHandler) InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionGet", ctx, id)
+	ret0, _ := ret[0].(*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionGet indicates an expected call of InteractionGet.
+func (mr *MockDBHandlerMockRecorder) InteractionGet(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionGet", reflect.TypeOf((*MockDBHandler)(nil).InteractionGet), ctx, id)
+}
+
+// InteractionList mocks base method.
+func (m *MockDBHandler) InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, addressSet []AddressPair) ([]*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionList", ctx, customerID, size, token, peerType, peerTarget, addressSet)
+	ret0, _ := ret[0].([]*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionList indicates an expected call of InteractionList.
+func (mr *MockDBHandlerMockRecorder) InteractionList(ctx, customerID, size, token, peerType, peerTarget, addressSet any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionList", reflect.TypeOf((*MockDBHandler)(nil).InteractionList), ctx, customerID, size, token, peerType, peerTarget, addressSet)
+}
+
+// InteractionListByIDs mocks base method.
+func (m *MockDBHandler) InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionListByIDs", ctx, customerID, ids)
+	ret0, _ := ret[0].([]*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionListByIDs indicates an expected call of InteractionListByIDs.
+func (mr *MockDBHandlerMockRecorder) InteractionListByIDs(ctx, customerID, ids any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionListByIDs", reflect.TypeOf((*MockDBHandler)(nil).InteractionListByIDs), ctx, customerID, ids)
+}
+
+// InteractionListUnresolved mocks base method.
+func (m *MockDBHandler) InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionListUnresolved", ctx, customerID, size, token, since)
+	ret0, _ := ret[0].([]*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionListUnresolved indicates an expected call of InteractionListUnresolved.
+func (mr *MockDBHandlerMockRecorder) InteractionListUnresolved(ctx, customerID, size, token, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionListUnresolved", reflect.TypeOf((*MockDBHandler)(nil).InteractionListUnresolved), ctx, customerID, size, token, since)
+}
+
 // PhoneNumberCreate mocks base method.
 func (m *MockDBHandler) PhoneNumberCreate(ctx context.Context, p *contact.PhoneNumber) error {
 	m.ctrl.T.Helper()
@@ -343,6 +435,64 @@ func (m *MockDBHandler) PhoneNumberUpdate(ctx context.Context, id uuid.UUID, fie
 func (mr *MockDBHandlerMockRecorder) PhoneNumberUpdate(ctx, id, fields any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PhoneNumberUpdate", reflect.TypeOf((*MockDBHandler)(nil).PhoneNumberUpdate), ctx, id, fields)
+}
+
+// ResolutionCreate mocks base method.
+func (m *MockDBHandler) ResolutionCreate(ctx context.Context, r *resolution.Resolution) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolutionCreate", ctx, r)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResolutionCreate indicates an expected call of ResolutionCreate.
+func (mr *MockDBHandlerMockRecorder) ResolutionCreate(ctx, r any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolutionCreate", reflect.TypeOf((*MockDBHandler)(nil).ResolutionCreate), ctx, r)
+}
+
+// ResolutionDelete mocks base method.
+func (m *MockDBHandler) ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolutionDelete", ctx, customerID, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResolutionDelete indicates an expected call of ResolutionDelete.
+func (mr *MockDBHandlerMockRecorder) ResolutionDelete(ctx, customerID, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolutionDelete", reflect.TypeOf((*MockDBHandler)(nil).ResolutionDelete), ctx, customerID, id)
+}
+
+// ResolutionListByContact mocks base method.
+func (m *MockDBHandler) ResolutionListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolutionListByContact", ctx, customerID, contactID)
+	ret0, _ := ret[0].([]*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolutionListByContact indicates an expected call of ResolutionListByContact.
+func (mr *MockDBHandlerMockRecorder) ResolutionListByContact(ctx, customerID, contactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolutionListByContact", reflect.TypeOf((*MockDBHandler)(nil).ResolutionListByContact), ctx, customerID, contactID)
+}
+
+// ResolutionListByInteraction mocks base method.
+func (m *MockDBHandler) ResolutionListByInteraction(ctx context.Context, customerID, interactionID uuid.UUID) ([]*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolutionListByInteraction", ctx, customerID, interactionID)
+	ret0, _ := ret[0].([]*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolutionListByInteraction indicates an expected call of ResolutionListByInteraction.
+func (mr *MockDBHandlerMockRecorder) ResolutionListByInteraction(ctx, customerID, interactionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolutionListByInteraction", reflect.TypeOf((*MockDBHandler)(nil).ResolutionListByInteraction), ctx, customerID, interactionID)
 }
 
 // TagAssignmentCreate mocks base method.

--- a/bin-contact-manager/pkg/dbhandler/resolution.go
+++ b/bin-contact-manager/pkg/dbhandler/resolution.go
@@ -1,0 +1,149 @@
+package dbhandler
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/gofrs/uuid"
+
+	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
+
+	"monorepo/bin-contact-manager/models/resolution"
+)
+
+const resolutionTable = "contact_resolutions"
+
+// resolutionGetFromRow scans a single row into a Resolution struct.
+func resolutionGetFromRow(rows *sql.Rows) (*resolution.Resolution, error) {
+	res := &resolution.Resolution{}
+	if err := commondatabasehandler.ScanRow(rows, res); err != nil {
+		return nil, fmt.Errorf("could not scan the row. resolutionGetFromRow. err: %v", err)
+	}
+	return res, nil
+}
+
+// ResolutionCreate inserts a new Resolution row into contact_resolutions.
+func (h *handler) ResolutionCreate(ctx context.Context, r *resolution.Resolution) error {
+	fields, err := commondatabasehandler.PrepareFields(r)
+	if err != nil {
+		return fmt.Errorf("could not prepare fields. ResolutionCreate. err: %v", err)
+	}
+
+	query, args, err := sq.Insert(resolutionTable).SetMap(fields).ToSql()
+	if err != nil {
+		return fmt.Errorf("could not build query. ResolutionCreate. err: %v", err)
+	}
+
+	_, err = h.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("could not create resolution. ResolutionCreate. err: %v", err)
+	}
+
+	return nil
+}
+
+// ResolutionDelete soft-deletes a resolution by setting tm_delete = NOW().
+// Scoped to customerID to prevent cross-tenant deletion.
+// Returns ErrNotFound if no active row matches.
+func (h *handler) ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error {
+	now := h.utilHandler.TimeNow()
+
+	query, args, err := sq.Update(resolutionTable).
+		Set("tm_delete", now).
+		Where(sq.Eq{"id": id.Bytes()}).
+		Where(sq.Eq{"customer_id": customerID.Bytes()}).
+		Where(sq.Eq{"tm_delete": nil}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("could not build query. ResolutionDelete. err: %v", err)
+	}
+
+	result, err := h.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("could not execute. ResolutionDelete. err: %v", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("could not get rows affected. ResolutionDelete. err: %v", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// ResolutionListByInteraction returns active resolutions for a given interaction,
+// scoped to customerID. Active = tm_delete IS NULL.
+func (h *handler) ResolutionListByInteraction(ctx context.Context, customerID, interactionID uuid.UUID) ([]*resolution.Resolution, error) {
+	columns := commondatabasehandler.GetDBFields(&resolution.Resolution{})
+
+	query, args, err := sq.Select(columns...).
+		From(resolutionTable).
+		Where(sq.Eq{"customer_id": customerID.Bytes()}).
+		Where(sq.Eq{"interaction_id": interactionID.Bytes()}).
+		Where(sq.Eq{"tm_delete": nil}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. ResolutionListByInteraction. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. ResolutionListByInteraction. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []*resolution.Resolution
+	for rows.Next() {
+		item, scanErr := resolutionGetFromRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. ResolutionListByInteraction. err: %v", scanErr)
+		}
+		res = append(res, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. ResolutionListByInteraction. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// ResolutionListByContact returns active resolutions for a given contact,
+// scoped to customerID. Active = tm_delete IS NULL.
+func (h *handler) ResolutionListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]*resolution.Resolution, error) {
+	columns := commondatabasehandler.GetDBFields(&resolution.Resolution{})
+
+	query, args, err := sq.Select(columns...).
+		From(resolutionTable).
+		Where(sq.Eq{"customer_id": customerID.Bytes()}).
+		Where(sq.Eq{"contact_id": contactID.Bytes()}).
+		Where(sq.Eq{"tm_delete": nil}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. ResolutionListByContact. err: %v", err)
+	}
+
+	rows, err := h.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. ResolutionListByContact. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []*resolution.Resolution
+	for rows.Next() {
+		item, scanErr := resolutionGetFromRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. ResolutionListByContact. err: %v", scanErr)
+		}
+		res = append(res, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. ResolutionListByContact. err: %v", err)
+	}
+
+	return res, nil
+}

--- a/bin-contact-manager/pkg/dbhandler/resolution_test.go
+++ b/bin-contact-manager/pkg/dbhandler/resolution_test.go
@@ -1,0 +1,310 @@
+package dbhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/models/resolution"
+	"monorepo/bin-contact-manager/pkg/cachehandler"
+)
+
+// seedResolutionParents inserts a contact + interaction for resolution tests.
+// Each caller uses a distinct namespace via the ns UUID prefix bytes.
+// Since we ignore ContactCreate errors (contact unique key on id) and
+// InteractionCreate is idempotent, repeated calls with the same ns are safe.
+func seedResolutionParents(
+	t *testing.T,
+	h handler,
+	ctx context.Context,
+	customerID, contactID, interactionID uuid.UUID,
+	mockUtil *utilhandler.MockUtilHandler,
+	mockCache *cachehandler.MockCacheHandler,
+) {
+	t.Helper()
+	ts := timePtr(time.Date(2026, 6, 28, 8, 0, 0, 0, time.UTC))
+	mockUtil.EXPECT().TimeNow().Return(ts)
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         contactID,
+			CustomerID: customerID,
+		},
+		FirstName: "Resolution",
+		LastName:  "Test",
+		Source:    "manual",
+	}
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("seedResolutionParents ContactCreate: %v", err)
+	}
+
+	iact := &interaction.Interaction{
+		ID:            interactionID,
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+15550001",
+		LocalType:     "tel",
+		LocalTarget:   "+15559990001",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("f1b2c3d4-ffff-ffff-ffff-000000000001"),
+		TMCreate:      timePtr(time.Date(2026, 6, 28, 9, 0, 0, 0, time.UTC)),
+	}
+	if err := h.InteractionCreate(ctx, iact); err != nil {
+		t.Fatalf("seedResolutionParents InteractionCreate: %v", err)
+	}
+}
+
+func Test_ResolutionCreate(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{utilHandler: mockUtil, db: dbTest, cache: mockCache}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-1001-1001-1001-000000000001")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-1001-1001-1001-000000000002")
+	interactionID := uuid.FromStringOrNil("f1b2c3d4-1001-1001-1001-000000000003")
+	seedResolutionParents(t, h, ctx, customerID, contactID, interactionID, mockUtil, mockCache)
+
+	r := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-1001-1001-1001-000000000010"),
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolution.ResolutionTypePositive,
+		ResolvedByType: resolution.ResolvedByTypeAgent,
+		ResolvedByID:   uuid.FromStringOrNil("f1b2c3d4-1001-1001-1001-000000000011"),
+		TMCreate:       timePtr(time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)),
+	}
+
+	if err := h.ResolutionCreate(ctx, r); err != nil {
+		t.Errorf("ResolutionCreate() error = %v", err)
+	}
+}
+
+func Test_ResolutionDelete(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{utilHandler: mockUtil, db: dbTest, cache: mockCache}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-2002-2002-2002-000000000001")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-2002-2002-2002-000000000002")
+	interactionID := uuid.FromStringOrNil("f1b2c3d4-2002-2002-2002-000000000003")
+	seedResolutionParents(t, h, ctx, customerID, contactID, interactionID, mockUtil, mockCache)
+
+	r := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-2002-2002-2002-000000000010"),
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolution.ResolutionTypePositive,
+		ResolvedByType: resolution.ResolvedByTypeAgent,
+		ResolvedByID:   uuid.FromStringOrNil("f1b2c3d4-2002-2002-2002-000000000011"),
+		TMCreate:       timePtr(time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC)),
+	}
+	if err := h.ResolutionCreate(ctx, r); err != nil {
+		t.Fatalf("ResolutionCreate() error = %v", err)
+	}
+
+	deleteTime := timePtr(time.Date(2026, 6, 28, 23, 0, 0, 0, time.UTC))
+
+	// soft-delete
+	mockUtil.EXPECT().TimeNow().Return(deleteTime)
+	if err := h.ResolutionDelete(ctx, r.CustomerID, r.ID); err != nil {
+		t.Errorf("ResolutionDelete() error = %v", err)
+	}
+
+	// delete again → ErrNotFound (already soft-deleted)
+	mockUtil.EXPECT().TimeNow().Return(deleteTime)
+	if err := h.ResolutionDelete(ctx, r.CustomerID, r.ID); err != ErrNotFound {
+		t.Errorf("ResolutionDelete() second delete expected ErrNotFound, got: %v", err)
+	}
+
+	// delete non-existent ID → ErrNotFound
+	mockUtil.EXPECT().TimeNow().Return(deleteTime)
+	if err := h.ResolutionDelete(ctx, r.CustomerID, uuid.FromStringOrNil("f1b2c3d4-2002-ffff-ffff-ffffffffffff")); err != ErrNotFound {
+		t.Errorf("ResolutionDelete() non-existent expected ErrNotFound, got: %v", err)
+	}
+
+	// cross-tenant: wrong customerID → ErrNotFound (regression guard for ISSUE 1 / BLOCKER fix)
+	wrongCustomerID := uuid.FromStringOrNil("f1b2c3d4-2002-dead-beef-000000000000")
+	// Insert a fresh resolution with the correct customer to delete
+	r2 := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-2002-0000-0000-000000002002"),
+		CustomerID:     r.CustomerID,
+		ContactID:      r.ContactID,
+		InteractionID:  r.InteractionID,
+		ResolutionType: resolution.ResolutionTypeNegative,
+		ResolvedByType: resolution.ResolvedByTypeAgent,
+		ResolvedByID:   uuid.FromStringOrNil("f1b2c3d4-2002-0000-0000-000000003003"),
+		TMCreate:       deleteTime,
+		TMUpdate:       deleteTime,
+	}
+	if err := h.ResolutionCreate(ctx, r2); err != nil {
+		t.Fatalf("ResolutionCreate(r2) error = %v", err)
+	}
+	mockUtil.EXPECT().TimeNow().Return(deleteTime)
+	if err := h.ResolutionDelete(ctx, wrongCustomerID, r2.ID); err != ErrNotFound {
+		t.Errorf("ResolutionDelete() cross-tenant expected ErrNotFound, got: %v", err)
+	}
+}
+
+func Test_ResolutionListByInteraction(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{utilHandler: mockUtil, db: dbTest, cache: mockCache}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-3003-3003-3003-000000000001")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-3003-3003-3003-000000000002")
+	interactionID := uuid.FromStringOrNil("f1b2c3d4-3003-3003-3003-000000000003")
+	seedResolutionParents(t, h, ctx, customerID, contactID, interactionID, mockUtil, mockCache)
+
+	r1 := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-3003-3003-3003-000000000010"),
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolution.ResolutionTypePositive,
+		ResolvedByType: resolution.ResolvedByTypeAgent,
+		ResolvedByID:   uuid.FromStringOrNil("f1b2c3d4-3003-3003-3003-000000000011"),
+		TMCreate:       timePtr(time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)),
+	}
+	r2 := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-3003-3003-3003-000000000020"),
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolution.ResolutionTypeNegative,
+		ResolvedByType: resolution.ResolvedByTypeSystem,
+		ResolvedByID:   resolution.ResolvedByIDSystem,
+		TMCreate:       timePtr(time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC)),
+	}
+	if err := h.ResolutionCreate(ctx, r1); err != nil {
+		t.Fatalf("ResolutionCreate(r1) error = %v", err)
+	}
+	if err := h.ResolutionCreate(ctx, r2); err != nil {
+		t.Fatalf("ResolutionCreate(r2) error = %v", err)
+	}
+
+	// Soft-delete r2; active only list should not include it
+	mockUtil.EXPECT().TimeNow().Return(timePtr(time.Date(2026, 6, 28, 23, 0, 0, 0, time.UTC)))
+	if err := h.ResolutionDelete(ctx, r2.CustomerID, r2.ID); err != nil {
+		t.Fatalf("ResolutionDelete(r2) error = %v", err)
+	}
+
+	res, err := h.ResolutionListByInteraction(ctx, customerID, interactionID)
+	if err != nil {
+		t.Fatalf("ResolutionListByInteraction() error = %v", err)
+	}
+
+	// No soft-deleted rows
+	for _, item := range res {
+		if item.TMDelete != nil {
+			t.Errorf("ResolutionListByInteraction() returned soft-deleted resolution %v", item.ID)
+		}
+	}
+
+	// r1 should appear
+	found := false
+	for _, item := range res {
+		if item.ID == r1.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ResolutionListByInteraction() r1 not found (len=%d)", len(res))
+	}
+}
+
+func Test_ResolutionListByContact(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{utilHandler: mockUtil, db: dbTest, cache: mockCache}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-4004-4004-4004-000000000001")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-4004-4004-4004-000000000002")
+	interactionID := uuid.FromStringOrNil("f1b2c3d4-4004-4004-4004-000000000003")
+	seedResolutionParents(t, h, ctx, customerID, contactID, interactionID, mockUtil, mockCache)
+
+	r1 := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-4004-4004-4004-000000000010"),
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolution.ResolutionTypePositive,
+		ResolvedByType: resolution.ResolvedByTypeAgent,
+		ResolvedByID:   uuid.FromStringOrNil("f1b2c3d4-4004-4004-4004-000000000011"),
+		TMCreate:       timePtr(time.Date(2026, 6, 28, 14, 0, 0, 0, time.UTC)),
+	}
+	r2 := &resolution.Resolution{
+		ID:             uuid.FromStringOrNil("f1b2c3d4-4004-4004-4004-000000000020"),
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		InteractionID:  interactionID,
+		ResolutionType: resolution.ResolutionTypeNegative,
+		ResolvedByType: resolution.ResolvedByTypeSystem,
+		ResolvedByID:   resolution.ResolvedByIDSystem,
+		TMCreate:       timePtr(time.Date(2026, 6, 28, 15, 0, 0, 0, time.UTC)),
+	}
+	if err := h.ResolutionCreate(ctx, r1); err != nil {
+		t.Fatalf("ResolutionCreate(r1) error = %v", err)
+	}
+	if err := h.ResolutionCreate(ctx, r2); err != nil {
+		t.Fatalf("ResolutionCreate(r2) error = %v", err)
+	}
+
+	// Soft-delete r2
+	mockUtil.EXPECT().TimeNow().Return(timePtr(time.Date(2026, 6, 28, 23, 0, 0, 0, time.UTC)))
+	if err := h.ResolutionDelete(ctx, r2.CustomerID, r2.ID); err != nil {
+		t.Fatalf("ResolutionDelete(r2) error = %v", err)
+	}
+
+	res, err := h.ResolutionListByContact(ctx, customerID, contactID)
+	if err != nil {
+		t.Fatalf("ResolutionListByContact() error = %v", err)
+	}
+
+	// No soft-deleted rows
+	for _, item := range res {
+		if item.TMDelete != nil {
+			t.Errorf("ResolutionListByContact() returned soft-deleted resolution %v", item.ID)
+		}
+	}
+
+	// r1 should appear
+	found := false
+	for _, item := range res {
+		if item.ID == r1.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ResolutionListByContact() r1 not found (len=%d)", len(res))
+	}
+}

--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -60,6 +60,13 @@ var (
 	// v1 contacts/{id}/tags
 	regV1ContactsTags   = regexp.MustCompile("/v1/contacts/" + regUUID + "/tags$")
 	regV1ContactsTagsID = regexp.MustCompile("/v1/contacts/" + regUUID + "/tags/" + regUUID + "$")
+
+	// v1 interactions
+	regV1InteractionsUnresolved    = regexp.MustCompile(`/v1/interactions/unresolved(\?.*)?$`)
+	regV1InteractionsGet           = regexp.MustCompile(`/v1/interactions\?(.*)$`)
+	regV1InteractionsID            = regexp.MustCompile("/v1/interactions/" + regUUID + "$")
+	regV1InteractionsResolutions   = regexp.MustCompile("/v1/interactions/" + regUUID + "/resolutions$")
+	regV1InteractionsResolutionsID = regexp.MustCompile("/v1/interactions/" + regUUID + "/resolutions/" + regUUID + "$")
 )
 
 var (
@@ -251,6 +258,35 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1ContactsTagsID.MatchString(m.URI) && m.Method == sock.RequestMethodDelete:
 		response, err = h.processV1ContactsTagsIDDelete(ctx, m)
 		requestType = "/v1/contacts/{id}/tags/{tag_id}"
+
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+	// v1 Interactions
+	/////////////////////////////////////////////////////////////////////////////////////////////////
+
+	// GET /interactions/unresolved (must be before regV1InteractionsID)
+	case regV1InteractionsUnresolved.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
+		response, err = h.processV1InteractionsUnresolvedGet(ctx, m)
+		requestType = "/v1/interactions/unresolved"
+
+	// GET /interactions?...
+	case regV1InteractionsGet.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
+		response, err = h.processV1InteractionsGet(ctx, m)
+		requestType = "/v1/interactions"
+
+	// GET /interactions/{id}
+	case regV1InteractionsID.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
+		response, err = h.processV1InteractionsIDGet(ctx, m)
+		requestType = "/v1/interactions/{id}"
+
+	// POST /interactions/{id}/resolutions
+	case regV1InteractionsResolutions.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1InteractionsResolutionsPost(ctx, m)
+		requestType = "/v1/interactions/{id}/resolutions"
+
+	// DELETE /interactions/{id}/resolutions/{rid}
+	case regV1InteractionsResolutionsID.MatchString(m.URI) && m.Method == sock.RequestMethodDelete:
+		response, err = h.processV1InteractionsResolutionsIDDelete(ctx, m)
+		requestType = "/v1/interactions/{id}/resolutions/{rid}"
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// No handler found

--- a/bin-contact-manager/pkg/listenhandler/models/request/v1_interactions.go
+++ b/bin-contact-manager/pkg/listenhandler/models/request/v1_interactions.go
@@ -1,0 +1,20 @@
+package request
+
+import "github.com/gofrs/uuid"
+
+// V1DataInteractionsResolutionsPost is the request body for
+// POST /v1/interactions/{id}/resolutions.
+type V1DataInteractionsResolutionsPost struct {
+	CustomerID     uuid.UUID `json:"customer_id"`
+	ContactID      uuid.UUID `json:"contact_id"`
+	ResolutionType string    `json:"resolution_type"`
+	ResolvedByType string    `json:"resolved_by_type"`
+	ResolvedByID   uuid.UUID `json:"resolved_by_id"`
+}
+
+// V1DataInteractionsResolutionsIDDelete is the request body for
+// DELETE /v1/interactions/{id}/resolutions/{rid}.
+// VoIPBin DELETE handlers carry customerID in the request body.
+type V1DataInteractionsResolutionsIDDelete struct {
+	CustomerID uuid.UUID `json:"customer_id"`
+}

--- a/bin-contact-manager/pkg/listenhandler/v1_interactions.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_interactions.go
@@ -1,0 +1,297 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"monorepo/bin-contact-manager/pkg/listenhandler/models/request"
+)
+
+// parseDaysDuration parses a "Nd" duration string (e.g. "7d", "30d") into time.Duration.
+// Returns an error for any other format, negative values, or values exceeding maxDays.
+func parseDaysDuration(s string, maxDays int) (time.Duration, error) {
+	if !strings.HasSuffix(s, "d") {
+		return 0, fmt.Errorf("invalid duration format %q: must be '<N>d' (e.g. '7d')", s)
+	}
+	n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration format %q: %w", s, err)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("invalid duration %q: must be a positive number of days (e.g. '7d')", s)
+	}
+	if n > maxDays {
+		return 0, fmt.Errorf("duration %q exceeds maximum of %dd", s, maxDays)
+	}
+	return time.Duration(n) * 24 * time.Hour, nil
+}
+
+// processV1InteractionsGet handles GET /v1/interactions?... request.
+// Exactly one of peer_type+peer_target, contact_id, or address_id is required.
+// customer_id is read from the JSON request body (consistent with other GET handlers).
+func (h *listenHandler) processV1InteractionsGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "processV1InteractionsGet",
+	})
+	log.WithField("request", req).Debug("Received request.")
+
+	u, err := url.Parse(req.URI)
+	if err != nil {
+		return simpleResponse(400), nil
+	}
+	q := u.Query()
+
+	// Parse pagination params from query string.
+	tmpSize, _ := strconv.Atoi(q.Get(PageSize))
+	pageSize := uint64(tmpSize)
+	pageToken := q.Get(PageToken)
+
+	// Parse filter params.
+	peerType := q.Get("peer_type")
+	peerTarget := q.Get("peer_target")
+
+	var contactID uuid.UUID
+	if s := q.Get("contact_id"); s != "" {
+		contactID = uuid.FromStringOrNil(s)
+	}
+	var addressID uuid.UUID
+	if s := q.Get("address_id"); s != "" {
+		addressID = uuid.FromStringOrNil(s)
+	}
+
+	// customer_id from JSON request body.
+	var customerID uuid.UUID
+	if len(req.Data) > 0 {
+		var bodyMap map[string]interface{}
+		if jsonErr := json.Unmarshal(req.Data, &bodyMap); jsonErr == nil {
+			if v, ok := bodyMap["customer_id"].(string); ok {
+				customerID = uuid.FromStringOrNil(v)
+			}
+		}
+	}
+	if customerID == uuid.Nil {
+		log.Error("Missing customer_id in request body.")
+		return simpleResponse(400), nil
+	}
+
+	// Validate: exactly one filter mode.
+	filterCount := 0
+	if peerType != "" || peerTarget != "" {
+		filterCount++
+	}
+	if contactID != uuid.Nil {
+		filterCount++
+	}
+	if addressID != uuid.Nil {
+		filterCount++
+	}
+	if filterCount != 1 {
+		log.Errorf("Expected exactly one filter mode, got %d.", filterCount)
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.contactHandler.InteractionList(ctx, customerID, pageSize, pageToken, peerType, peerTarget, contactID, addressID)
+	if err != nil {
+		log.Errorf("Could not list interactions. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
+// processV1InteractionsUnresolvedGet handles GET /v1/interactions/unresolved request.
+func (h *listenHandler) processV1InteractionsUnresolvedGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "processV1InteractionsUnresolvedGet",
+	})
+	log.WithField("request", req).Debug("Received request.")
+
+	u, err := url.Parse(req.URI)
+	if err != nil {
+		return simpleResponse(400), nil
+	}
+	q := u.Query()
+
+	tmpSize, _ := strconv.Atoi(q.Get(PageSize))
+	pageSize := uint64(tmpSize)
+	pageToken := q.Get(PageToken)
+
+	// Parse since (default 30d, max 180d).
+	sinceStr := q.Get("since")
+	if sinceStr == "" {
+		sinceStr = "30d"
+	}
+	sinceDuration, parseErr := parseDaysDuration(sinceStr, 180)
+	if parseErr != nil {
+		log.Errorf("Invalid since param: %v", parseErr)
+		return simpleResponse(400), nil
+	}
+	since := time.Now().Add(-sinceDuration)
+
+	// customer_id from JSON request body.
+	var customerID uuid.UUID
+	if len(req.Data) > 0 {
+		var bodyMap map[string]interface{}
+		if jsonErr := json.Unmarshal(req.Data, &bodyMap); jsonErr == nil {
+			if v, ok := bodyMap["customer_id"].(string); ok {
+				customerID = uuid.FromStringOrNil(v)
+			}
+		}
+	}
+	if customerID == uuid.Nil {
+		log.Error("Missing customer_id in request body.")
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.contactHandler.InteractionListUnresolved(ctx, customerID, pageSize, pageToken, since)
+	if err != nil {
+		log.Errorf("Could not list unresolved interactions. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
+// processV1InteractionsIDGet handles GET /v1/interactions/{id} request.
+func (h *listenHandler) processV1InteractionsIDGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "processV1InteractionsIDGet",
+	})
+	log.WithField("request", req).Debug("Received request.")
+
+	// Extract id from URI.
+	parts := strings.Split(req.URI, "/")
+	// URI pattern: /v1/interactions/<uuid>
+	if len(parts) < 4 {
+		return simpleResponse(400), nil
+	}
+	id := uuid.FromStringOrNil(parts[3])
+	if id == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	// customer_id from JSON request body.
+	var customerID uuid.UUID
+	if len(req.Data) > 0 {
+		var bodyMap map[string]interface{}
+		if jsonErr := json.Unmarshal(req.Data, &bodyMap); jsonErr == nil {
+			if v, ok := bodyMap["customer_id"].(string); ok {
+				customerID = uuid.FromStringOrNil(v)
+			}
+		}
+	}
+	if customerID == uuid.Nil {
+		log.Error("Missing customer_id in request body.")
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.contactHandler.InteractionGet(ctx, customerID, id)
+	if err != nil {
+		log.Errorf("Could not get interaction. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
+// processV1InteractionsResolutionsPost handles POST /v1/interactions/{id}/resolutions request.
+func (h *listenHandler) processV1InteractionsResolutionsPost(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "processV1InteractionsResolutionsPost",
+	})
+	log.WithField("request", req).Debug("Received request.")
+
+	// Extract interaction id from URI: /v1/interactions/<uuid>/resolutions
+	parts := strings.Split(req.URI, "/")
+	if len(parts) < 4 {
+		return simpleResponse(400), nil
+	}
+	interactionID := uuid.FromStringOrNil(parts[3])
+	if interactionID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	var body request.V1DataInteractionsResolutionsPost
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		log.Errorf("Could not unmarshal request body. err: %v", err)
+		return simpleResponse(400), nil
+	}
+
+	if body.CustomerID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.contactHandler.ResolutionCreate(ctx, body.CustomerID, body.ContactID, interactionID,
+		body.ResolutionType, body.ResolvedByType, body.ResolvedByID)
+	if err != nil {
+		log.Errorf("Could not create resolution. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
+// processV1InteractionsResolutionsIDDelete handles DELETE /v1/interactions/{id}/resolutions/{rid} request.
+func (h *listenHandler) processV1InteractionsResolutionsIDDelete(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "processV1InteractionsResolutionsIDDelete",
+	})
+	log.WithField("request", req).Debug("Received request.")
+
+	// URI: /v1/interactions/<uuid>/resolutions/<uuid>
+	parts := strings.Split(req.URI, "/")
+	if len(parts) < 6 {
+		return simpleResponse(400), nil
+	}
+	resolutionID := uuid.FromStringOrNil(parts[5])
+	if resolutionID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	var body request.V1DataInteractionsResolutionsIDDelete
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		log.Errorf("Could not unmarshal request body. err: %v", err)
+		return simpleResponse(400), nil
+	}
+
+	if body.CustomerID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	if err := h.contactHandler.ResolutionDelete(ctx, body.CustomerID, resolutionID); err != nil {
+		log.Errorf("Could not delete resolution. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	return simpleResponse(200), nil
+}

--- a/bin-contact-manager/scripts/database_scripts_test/contacts.sql
+++ b/bin-contact-manager/scripts/database_scripts_test/contacts.sql
@@ -112,3 +112,22 @@ create table contact_interactions(
 create unique index idx_contact_interactions_idem on contact_interactions(reference_type, reference_id, peer_target);
 create index idx_contact_interactions_peer on contact_interactions(customer_id, peer_type, peer_target);
 create index idx_contact_interactions_cursor on contact_interactions(customer_id, tm_create);
+
+create table contact_resolutions (
+  id                binary(16)    not null,
+  customer_id       binary(16)    not null,
+  contact_id        binary(16)    not null,
+  interaction_id    binary(16)    not null,
+  resolution_type   varchar(255)  not null default '',
+  resolved_by_type  varchar(255)  not null default '',
+  resolved_by_id    binary(16)    not null,
+  tm_create         datetime(6),
+  tm_update         datetime(6),
+  tm_delete         datetime(6),
+  primary key(id)
+);
+
+create index idx_contact_resolutions_contact_interaction
+  on contact_resolutions(customer_id, contact_id, tm_delete);
+create index idx_contact_resolutions_interaction
+  on contact_resolutions(customer_id, interaction_id, tm_delete);

--- a/docs/plans/2026-06-28-voip-1209-contact-crm-read-api-and-resolution.md
+++ b/docs/plans/2026-06-28-voip-1209-contact-crm-read-api-and-resolution.md
@@ -1,0 +1,765 @@
+# VOIP-1209: CRM Read API + Resolution
+
+- Issue: VOIP-1209
+- Parent design: docs/plans/2026-06-26-add-contact-crm-interaction-timeline-design.md (VOIP-1204)
+- Class: new read API + new DB table (contact_resolutions) + RPC client methods
+- Date: 2026-06-28
+
+## 1. Scope
+
+This document covers implementation step 4 of the VOIP-1204 CRM v1 plan:
+
+- Read API for the interaction timeline (`GET /v1/interactions`)
+- Resolution CRUD (`POST/DELETE /v1/interactions/{id}/resolutions`)
+- Unresolved queue (`GET /v1/interactions/unresolved`)
+- External RPC client additions in `bin-common-handler`
+
+Out of scope: sessionize, backfill (M2), address management, webhook events for
+resolutions.
+
+## 2. Prerequisites (all Done)
+
+- VOIP-1206: 3 new tables (contact_addresses, contact_interactions,
+  contact_resolutions) - schema landed, Alembic head ac5d4e18060c.
+- VOIP-1207: M1 address migration (phone/email -> contact_addresses), hot path
+  code rewire.
+- VOIP-1208: Projection handlers (EventCallCreated,
+  EventConversationMessageCreated).
+- VOIP-1215: Source/destination added to conversation_message webhook event
+  (unblocked VOIP-1208).
+
+## 3. New table: contact_resolutions
+
+Already in the Alembic migration (ac5d4e18060c). Test SQL fixture is NOT yet
+present; must be added.
+
+Schema (from VOIP-1204 design doc §3.3):
+
+```sql
+create table contact_resolutions (
+  id                binary(16)    not null,
+  customer_id       binary(16)    not null,
+  contact_id        binary(16)    not null,
+  interaction_id    binary(16)    not null,
+  resolution_type   varchar(255)  not null default '',
+  resolved_by_type  varchar(255)  not null default '',
+  resolved_by_id    binary(16)    not null,
+  tm_create         datetime(6),
+  tm_update         datetime(6),
+  tm_delete         datetime(6),
+  primary key(id)
+);
+
+create index idx_contact_resolutions_contact_interaction
+  on contact_resolutions(customer_id, contact_id, tm_delete);
+create index idx_contact_resolutions_interaction
+  on contact_resolutions(customer_id, interaction_id, tm_delete);
+```
+
+## 4. New model: models/resolution/
+
+New package `bin-contact-manager/models/resolution/` (parallel to
+`models/interaction/`).
+
+### resolution.go
+
+```go
+package resolution
+
+type Resolution struct {
+    ID             uuid.UUID  `json:"id"              db:"id,uuid"`
+    CustomerID     uuid.UUID  `json:"customer_id"     db:"customer_id,uuid"`
+    ContactID      uuid.UUID  `json:"contact_id"      db:"contact_id,uuid"`
+    InteractionID  uuid.UUID  `json:"interaction_id"  db:"interaction_id,uuid"`
+    ResolutionType string     `json:"resolution_type" db:"resolution_type"`
+    ResolvedByType string     `json:"resolved_by_type" db:"resolved_by_type"`
+    ResolvedByID   uuid.UUID  `json:"resolved_by_id"  db:"resolved_by_id,uuid"`
+    TMCreate       *time.Time `json:"tm_create"       db:"tm_create"`
+    TMUpdate       *time.Time `json:"tm_update"       db:"tm_update"`
+    TMDelete       *time.Time `json:"tm_delete"       db:"tm_delete"`
+}
+```
+
+Constants:
+
+```go
+const (
+    ResolutionTypePositive = "positive"
+    ResolutionTypeNegative = "negative"
+
+    ResolvedByTypeAgent  = "agent"
+    ResolvedByTypeSystem = "system"
+    ResolvedByTypeRule   = "rule"
+)
+```
+
+## 5. DB layer additions (pkg/dbhandler/)
+
+### 5.1 interaction.go additions
+
+Three new methods added to the existing file:
+
+```go
+// InteractionGet fetches a single interaction by ID.
+// Returns ErrNotFound if absent.
+InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error)
+
+// InteractionList returns a page of interactions filtered by customerID
+// and optionally by peer (peer_type + peer_target) or by a set of
+// (peer_type, peer_target) pairs (for contact_id expansion).
+// Pagination: cursor = tm_create DESC + id DESC.
+//
+// EMPTY addressSet GUARD: if peerType, peerTarget are both empty AND
+// addressSet is empty, return (nil, nil) immediately without issuing a
+// SQL query. An empty IN () is invalid SQL in both MySQL and SQLite.
+// The contactID read path calls this with an empty addressSet when the
+// contact has no registered addresses, and correctly falls back to
+// manual-resolution-only attribution.
+InteractionList(
+    ctx context.Context,
+    customerID uuid.UUID,
+    size uint64,
+    token string,
+    peerType, peerTarget string,        // direct peer filter (optional)
+    addressSet []AddressPair,           // contact_id expansion (optional)
+) ([]*interaction.Interaction, error)
+
+// InteractionListByIDs fetches interactions for a given set of IDs,
+// scoped to customerID (tenant guard — never returns another tenant's rows).
+// Used during resolution union/minus in the contact_id read path to
+// load manually attributed interactions not in the peer set.
+InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error)
+```
+
+`AddressPair` is an exported struct (capitalised so contacthandler can construct
+it without a type-assertion on the interface):
+
+```go
+// AddressPair is a (type, target) pair used for multi-column IN expansion.
+// Exported so contacthandler and tests can construct slices without
+// importing dbhandler internals.
+type AddressPair struct { Type, Target string }
+```
+
+**Pagination token encoding.** Token = `base64(json({"tm_create":"<RFC3339Nano>","id":"<uuid>"}))`.
+Page boundary: `WHERE (tm_create, id) < (cursor.tm_create, cursor.id)` (tuple
+comparison valid for DESC order: each next page returns rows strictly older than
+the cursor row). `ORDER BY tm_create DESC, id DESC LIMIT size+1` (extra row
+signals hasMore). An empty token string means "start from the newest row."
+
+**Shared encode/decode helpers.** Locate in `pkg/dbhandler/interaction.go`:
+```go
+func encodePageToken(tm *time.Time, id uuid.UUID) string  // base64+json
+func decodePageToken(token string) (time.Time, uuid.UUID, error) // inverse
+```
+These are package-internal helpers. contacthandler does not need to call them;
+it passes token strings through to dbhandler unmodified.
+
+**SQLite note.** Tests use SQLite (in-memory). Tuple comparison `(a, b) < (x, y)`
+is valid SQL and SQLite supports it since 3.15. The IN multi-column form
+`(peer_type, peer_target) IN (...)` is also supported in SQLite 3.15+; use it
+for addressSet expansion.
+
+**Squirrel limitation.** `squirrel` does not natively support multi-column IN.
+Use raw `sq.Expr("(peer_type, peer_target) IN (%s)", placeholders...)` with
+manually built `(?,?),(?,?)...` placeholder list and flattened arg slice. The
+empty-addressSet guard above ensures this branch is never reached with an empty
+list.
+
+### 5.2 resolution.go (new file)
+
+```go
+// ResolutionCreate inserts a resolution row.
+// No idempotency key: the grain is (contact_id, interaction_id, resolution_type);
+// duplicates are caller-prevented (listenhandler checks existing before insert).
+ResolutionCreate(ctx context.Context, r *resolution.Resolution) error
+
+// ResolutionDelete soft-deletes a resolution (sets tm_delete = now).
+ResolutionDelete(ctx context.Context, id uuid.UUID) error
+
+// ResolutionListByInteraction returns all ACTIVE resolutions for an interaction
+// (tm_delete IS NULL), scoped to customer_id.
+ResolutionListByInteraction(
+    ctx context.Context,
+    customerID uuid.UUID,
+    interactionID uuid.UUID,
+) ([]*resolution.Resolution, error)
+
+// ResolutionListByContact returns all ACTIVE resolutions for a contact,
+// used during contact_id read-path set-MINUS combination.
+ResolutionListByContact(
+    ctx context.Context,
+    customerID uuid.UUID,
+    contactID uuid.UUID,
+) ([]*resolution.Resolution, error)
+```
+
+## 6. DBHandler interface additions
+
+Add to `pkg/dbhandler/main.go` DBHandler interface:
+
+```go
+// Interaction read operations
+InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error)
+InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string,
+    peerType, peerTarget string, addressSet []AddressPair) ([]*interaction.Interaction, error)
+InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error)
+
+// Address read operations (used by contact_id and address_id read paths)
+AddressListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]AddressPair, error)
+AddressGetByID(ctx context.Context, id uuid.UUID) (AddressPair, error)
+
+// Resolution operations
+ResolutionCreate(ctx context.Context, r *resolution.Resolution) error
+ResolutionDelete(ctx context.Context, id uuid.UUID) error
+ResolutionListByInteraction(ctx context.Context, customerID uuid.UUID, interactionID uuid.UUID) ([]*resolution.Resolution, error)
+ResolutionListByContact(ctx context.Context, customerID uuid.UUID, contactID uuid.UUID) ([]*resolution.Resolution, error)
+```
+
+Note: `AddressGet` returns enough information for the `address_id` read path
+to extract `(type, target)`. Expose a small public struct
+`AddressRecord { Type, Target string }` or reuse `AddressPair`. Keep internal
+`addressRow` unexported; `AddressGet` returns `AddressPair` directly.
+
+## 7. Business logic layer (pkg/contacthandler/)
+
+### 7.1 interaction_read.go (new file)
+
+```go
+// InteractionGet returns a single interaction, scoped to customerID.
+InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error)
+
+// InteractionList is the main timeline read path.
+// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero.
+// Returns a response envelope with items and next_page_token.
+InteractionList(
+    ctx context.Context,
+    customerID uuid.UUID,
+    size uint64,
+    token string,
+    peerType, peerTarget string,  // ?peer_type=&peer_target= path
+    contactID uuid.UUID,          // ?contact_id= path
+    addressID uuid.UUID,          // ?address_id= path
+) (*InteractionListResponse, error)
+
+// InteractionListUnresolved returns interactions with zero-contact attribution
+// (no peer match to any active address, no active positive resolution) AND
+// peer_type != web_session. Supports pagination (size + token).
+InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) (*InteractionListResponse, error)
+```
+
+Response envelope:
+
+```go
+// InteractionListResponse is the response shape for all interaction list endpoints.
+// Defined in models/interaction/ (not in pkg/contacthandler) to avoid circular imports:
+// bin-common-handler/pkg/requesthandler imports bin-contact-manager/models/interaction,
+// and bin-contact-manager/pkg/contacthandler imports bin-common-handler/pkg/requesthandler.
+// Placing this type in pkg/contacthandler would create a confirmed cycle.
+//
+// next_page_token is empty if no more pages exist.
+type InteractionListResponse struct {
+    Items         []*Interaction `json:"items"`
+    NextPageToken string         `json:"next_page_token"`
+}
+```
+
+File location: `bin-contact-manager/models/interaction/list_response.go`
+
+This envelope is returned by the listen handler serialised as JSON. All three
+consumer services (ai-manager, flow-manager, api-manager) receive an opaque
+`next_page_token` string and forward it back verbatim on subsequent requests.
+No client-side token encoding is needed.
+
+**contact_id resolution algorithm** (VOIP-1204 §5.1):
+
+```
+STEP 0: Existence + tenant check.
+   c, err := h.db.ContactGet(ctx, contactID)
+   if err != nil (ErrNotFound) OR c.CustomerID != customerID:
+     return nil, ErrNotFound   // cross-tenant guard: never leak row existence
+   (contactHandler.Get also checks soft-delete; the above uses dbhandler.ContactGet
+    directly and must also verify c.TMDelete == nil for a soft-deleted contact.)
+
+STEP 1: Expand address set.
+   h.db.AddressListByContact(ctx, customerID, contactID)
+   -> addressPairs []AddressPair{(type, target), ...}  // may be empty
+
+STEP 2: Fetch ALL automatic peer matches (internal cap, NOT caller page size).
+   If addressPairs is non-empty:
+     h.db.InteractionList(ctx, customerID, internalCap, "" /*token*/, "", "", addressPairs)
+     -> automatic []Interaction  // up to internalCap rows; cap = max(5000, size*100)
+   Else:
+     automatic = []  // short-circuit; do NOT call with empty addressPairs
+
+   Note: token is "" here (unconditional scan from newest). The caller-supplied
+   token is applied in STEP 6 AFTER set-MINUS, so no candidate is missed by
+   premature cursor truncation. The internal cap (5000) is the known v1 limitation:
+   contacts with >5000 automatic interactions may see incomplete results on this
+   path; a cursor-walk implementation is the M2 solution.
+
+STEP 3: Fetch active resolutions.
+   h.db.ResolutionListByContact(ctx, customerID, contactID)
+   -> []Resolution (tm_delete IS NULL)
+
+STEP 4: Set-MINUS combination.
+   positiveIDs  := {r.InteractionID | r.ResolutionType == "positive"}
+   negativeIDs  := {r.InteractionID | r.ResolutionType == "negative"}
+   automaticIDs := {i.ID | i in automatic}
+
+   include = (automaticIDs | positiveIDs) - negativeIDs
+   de-dup by ID
+
+   PRECEDENCE: negative always wins, regardless of tm_create ordering.
+   Do NOT use latest-polarity (LWW). This is a set-MINUS, not a timestamp race.
+
+STEP 5: Load positive-only interactions not in automatic set.
+   missing = positiveIDs - automaticIDs
+   If missing is non-empty:
+     h.db.InteractionListByIDs(ctx, customerID, missing)  // customerID-scoped!
+     -> extra []Interaction
+     Merge extra into result, de-dup by ID.
+
+STEP 6: Apply include filter, sort, then apply caller cursor + size slice.
+   1. Filter merged set to include IDs only.
+   2. Sort by (tm_create DESC, id DESC).
+   3. Apply caller token cursor: skip rows until (tm_create, id) < cursor.
+   4. Take first `size` rows.
+   5. Build InteractionListResponse{Items: taken, NextPageToken: encodePageToken(taken[size].TMCreate, taken[size].ID) if hasMore else ""}.
+```
+
+**InteractionListUnresolved algorithm:**
+
+Supports pagination: `size uint64` + `token string` (same cursor format as
+InteractionList). `since time.Time` is a lower bound (only interactions created
+after `since` are considered). Hard cap: if `size == 0`, use default 100;
+maximum allowed size is 500 (return 400 if exceeded). See §7.3 for the SQL shape.
+
+### 7.2 resolution.go (new file in contacthandler/)
+
+```go
+// ResolutionCreate creates a new resolution.
+// Validates: interaction must exist and belong to customerID.
+// Validates: no existing active resolution of IDENTICAL type for (contact_id,
+//   interaction_id) — prevents duplicate positive or duplicate negative rows.
+//   A positive + negative coexisting is allowed (competing attributions;
+//   negative wins by set-MINUS precedence). Two positives or two negatives for
+//   the same pair are rejected (application-level check; see §3 note below).
+ResolutionCreate(
+    ctx context.Context,
+    customerID, contactID, interactionID uuid.UUID,
+    resolutionType, resolvedByType string,
+    resolvedByID uuid.UUID,
+) (*resolution.Resolution, error)
+
+// ResolutionDelete soft-deletes a resolution (sets tm_delete = now).
+// Validates: resolution must exist and belong to customerID.
+// customerID is passed to ResolutionDelete in the request body (DELETE handlers
+// in this service use a JSON body for customerID, consistent with all other
+// contact-manager DELETE endpoints). The contacthandler checks ownership via
+// the stored customer_id column before soft-deleting.
+ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error
+```
+
+**§3 note — duplicate-resolution application check vs DB constraint.**
+The production schema (§3) does NOT have a UNIQUE constraint on
+`(customer_id, contact_id, interaction_id, resolution_type)` because MySQL
+treats NULL as distinct in UNIQUE and tm_delete makes soft-deleted rows nullable;
+a generated-column workaround (like the `primary_contact_uk` pattern) would be
+needed to cover only active rows. The risk is a concurrent-create TOCTOU: two
+simultaneous `POST /v1/interactions/{id}/resolutions` for the same grain both
+pass the \"no active duplicate\" check and both insert. In a GKE multi-instance
+deployment this window exists.
+
+Decision for v1: accept application-level-only dedup. The consequence is at most
+two active positive (or two active negative) rows for the same pair. Two positives
+are harmless to the set-MINUS logic (the interaction is still included once, after
+de-dup). Two negatives are also harmless (the interaction is still excluded). The
+visible artifact is that `ResolutionListByInteraction` returns 2 rows instead of 1,
+and deleting one still leaves the other active — operator would need to delete twice.
+This is a UX nuisance, not a data-loss or mis-attribution bug. Track as a known
+limitation; add a DB UNIQUE constraint in a follow-up if dogfood surfaces the
+concurrent-create pattern.
+
+### 7.3 Unresolved queue SQL
+
+Efficient query shape for large interaction tables:
+
+```sql
+SELECT i.*
+FROM contact_interactions i
+WHERE i.customer_id = ?
+  AND i.peer_type != 'web_session'
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_addresses a
+      WHERE a.customer_id = i.customer_id
+        AND a.type = i.peer_type
+        AND a.target = i.peer_target
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_resolutions r
+      WHERE r.customer_id = i.customer_id
+        AND r.interaction_id = i.id
+        AND r.resolution_type = 'positive'
+        AND r.tm_delete IS NULL
+  )
+  AND (i.tm_create, i.id) < (?, ?)   -- pagination cursor
+ORDER BY i.tm_create DESC, i.id DESC
+LIMIT ?
+```
+
+This query lands on indexes: `idx_contact_interactions_cursor` (customer_id,
+tm_create) for the outer scan; `idx_contact_addresses_lookup` (customer_id,
+type, target) for the NOT EXISTS address check;
+`idx_contact_resolutions_interaction` (customer_id, interaction_id, tm_delete)
+for the NOT EXISTS resolution check.
+
+## 8. ContactHandler interface additions
+
+Add to `pkg/contacthandler/main.go`:
+
+```go
+// Interaction read operations
+InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error)
+InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string,
+    peerType, peerTarget string, contactID uuid.UUID, addressID uuid.UUID) (*interaction.InteractionListResponse, error)
+InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) (*interaction.InteractionListResponse, error)
+
+// Resolution operations
+ResolutionCreate(ctx context.Context, customerID, contactID, interactionID uuid.UUID,
+    resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error)
+ResolutionDelete(ctx context.Context, customerID, id uuid.UUID) error
+```
+
+`InteractionListResponse` is defined in `models/interaction/list_response.go`, NOT in
+this package, to avoid the confirmed circular import
+(`pkg/contacthandler` imports `bin-common-handler/pkg/requesthandler`, and
+`bin-common-handler/pkg/requesthandler` would need to import `InteractionListResponse`
+back — confirmed cycle from existing imports in contacthandler/main.go).
+
+Note: after this PR the ContactHandler interface has approximately 23 methods.
+This is large but acceptable for v1; consider splitting into a sub-interface
+(e.g. `InteractionHandler`) in a follow-up if the mock becomes unwieldy.
+
+## 9. Listen handler additions (pkg/listenhandler/)
+
+### 9.1 URL patterns (new in main.go)
+
+```go
+regV1Interactions          = /v1/interactions$
+regV1InteractionsGet       = /v1/interactions\?(.*)$
+regV1InteractionsUnresolved = /v1/interactions/unresolved(\?.*)?$
+regV1InteractionsID        = /v1/interactions/<uuid>$
+regV1InteractionsResolutions = /v1/interactions/<uuid>/resolutions$
+regV1InteractionsResolutionsID = /v1/interactions/<uuid>/resolutions/<uuid>$
+```
+
+**Match order is critical.** `regV1InteractionsUnresolved` must be matched BEFORE
+`regV1InteractionsID` in the switch, because `/v1/interactions/unresolved` would
+otherwise match the UUID pattern (if "unresolved" were misread as a UUID, which it
+won't be — regex requires `[0-9a-f]{8}-...` — but ordering still matters for
+clarity and future safety).
+
+### 9.2 v1_interactions.go (new file)
+
+Handlers:
+
+```
+GET  /v1/interactions?...               -> processV1InteractionsGet
+GET  /v1/interactions/unresolved        -> processV1InteractionsUnresolvedGet
+GET  /v1/interactions/{id}              -> processV1InteractionsIDGet
+POST /v1/interactions/{id}/resolutions  -> processV1InteractionsResolutionsPost
+DELETE /v1/interactions/{id}/resolutions/{rid} -> processV1InteractionsResolutionsIDDelete
+```
+
+**customerID source for GET handlers.** All GET handlers extract `customer_id`
+from the JSON request body, consistent with the existing `processV1ContactsGet`
+pattern (`utilhandler.ParseFiltersFromRequestBody` + typed filter conversion).
+The `customer_id` key is required in the request body; return 400 if absent.
+
+Query parameter parsing for `GET /v1/interactions`:
+
+```
+?peer_type=<str>&peer_target=<str>   -> peerType + peerTarget path
+?contact_id=<uuid>                   -> contactID path
+?address_id=<uuid>                   -> addressID path
+?page_size=<int>&page_token=<str>    -> pagination
+```
+
+`customer_id` is read from the JSON request body (not from query params).
+
+Exactly one of the three filter modes must be present; return 400 if zero or
+more than one is given.
+
+**`since` parameter parsing** for `GET /v1/interactions/unresolved`:
+```
+?since=<Nd>   e.g. since=7d, since=30d (default: 30d if absent)
+```
+Parse `since` with a local helper `parseDaysDuration(s string) (time.Duration, error)`:
+strip trailing `d`, parse integer with `strconv.Atoi`, multiply by `24*time.Hour`.
+Return 400 for any other format (e.g. `7h`, `foo`, `-1d`). Cap: max `since=180d`;
+return 400 if exceeded. `time.ParseDuration` is NOT used (it doesn't support `d`).
+
+### 9.3 listenhandler/models/request/ additions
+
+New file `v1_interactions.go`:
+
+```go
+type V1DataInteractionsResolutionsPost struct {
+    CustomerID     uuid.UUID `json:"customer_id"`
+    ContactID      uuid.UUID `json:"contact_id"`
+    ResolutionType string    `json:"resolution_type"`
+    ResolvedByType string    `json:"resolved_by_type"`
+    ResolvedByID   uuid.UUID `json:"resolved_by_id"`
+}
+```
+
+## 10. bin-common-handler RPC client additions
+
+New file `bin-common-handler/pkg/requesthandler/contact_interactions.go`:
+
+```go
+// ContactV1InteractionGet fetches a single interaction.
+ContactV1InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error)
+
+// ContactV1InteractionList lists interactions (one filter mode at a time).
+// Returns *contacthandler.InteractionListResponse (imported from bin-contact-manager).
+ContactV1InteractionList(
+    ctx context.Context,
+    size uint64,
+    token string,
+    customerID uuid.UUID,
+    peerType, peerTarget string,
+    contactID uuid.UUID,
+    addressID uuid.UUID,
+) (*contacthandler.InteractionListResponse, error)
+
+// ContactV1InteractionListUnresolved lists unresolved interactions.
+// since is encoded as "Nd" (e.g. "7d") in the query param.
+ContactV1InteractionListUnresolved(
+    ctx context.Context,
+    customerID uuid.UUID,
+    size uint64,
+    token string,
+    sinceDays int,  // e.g. 7 -> ?since=7d
+) (*contacthandler.InteractionListResponse, error)
+
+// ContactV1ResolutionCreate creates a resolution.
+ContactV1ResolutionCreate(
+    ctx context.Context,
+    interactionID uuid.UUID,
+    customerID, contactID uuid.UUID,
+    resolutionType, resolvedByType string,
+    resolvedByID uuid.UUID,
+) (*resolution.Resolution, error)
+
+// ContactV1ResolutionDelete soft-deletes a resolution.
+// customerID is sent in the request body (DELETE body pattern, consistent
+// with all other contact-manager DELETE methods).
+ContactV1ResolutionDelete(ctx context.Context, customerID uuid.UUID, interactionID, resolutionID uuid.UUID) error
+```
+
+These are wrappers over `r.sendRequestContact(...)`, using queue constant from
+`models/outline` (same contact-manager queue as all other `ContactV1*` methods).
+
+Return type: `*interaction.InteractionListResponse` imported from
+`monorepo/bin-contact-manager/models/interaction` — same established pattern as
+`cmcontact "monorepo/bin-contact-manager/models/contact"` in `contact_contacts.go`.
+No circular import: models packages are the cross-module boundary; neither
+`models/interaction` nor `models/resolution` imports `bin-common-handler`.
+
+## 11. DB helper: AddressListByContact and AddressGet
+
+Both methods are required for the contactID and addressID read paths respectively.
+Add to `pkg/dbhandler/address.go`:
+
+```go
+// AddressListByContact returns all (type, target) pairs for a contact.
+// contact_addresses has no soft-delete, so no tm_delete filter needed.
+AddressListByContact(ctx context.Context, customerID, contactID uuid.UUID) ([]AddressPair, error)
+
+// AddressGetByID returns the (type, target) for a single address row by id,
+// used by the address_id filter path in InteractionList.
+// Returns ErrNotFound if absent.
+AddressGetByID(ctx context.Context, id uuid.UUID) (AddressPair, error)
+```
+
+Both methods must be added to the DBHandler interface (§6).
+
+## 12. Test fixtures
+
+### 12.1 SQLite fixture addition (contacts.sql)
+
+Append to `bin-contact-manager/scripts/database_scripts_test/contacts.sql`:
+
+```sql
+create table contact_resolutions (
+  id                binary(16)    not null,
+  customer_id       binary(16)    not null,
+  contact_id        binary(16)    not null,
+  interaction_id    binary(16)    not null,
+  resolution_type   varchar(255)  not null default '',
+  resolved_by_type  varchar(255)  not null default '',
+  resolved_by_id    binary(16)    not null,
+  tm_create         datetime(6),
+  tm_update         datetime(6),
+  tm_delete         datetime(6),
+  primary key(id)
+);
+
+create index idx_contact_resolutions_contact_interaction
+  on contact_resolutions(customer_id, contact_id, tm_delete);
+create index idx_contact_resolutions_interaction
+  on contact_resolutions(customer_id, interaction_id, tm_delete);
+```
+
+### 12.2 Test coverage targets
+
+New tests required:
+
+**dbhandler:**
+- `Test_InteractionGet` (found, not found)
+- `Test_InteractionList_byPeer` (direct peer path)
+- `Test_InteractionList_byAddressSet` (contact_id expansion with multi-column IN)
+- `Test_InteractionList_pagination` (cursor page boundary)
+- `Test_InteractionListByIDs` (customerID-scoped)
+- `Test_AddressListByContact`
+- `Test_AddressGetByID` (found, not found)
+- `Test_ResolutionCreate`
+- `Test_ResolutionDelete` (soft-delete sets tm_delete)
+- `Test_ResolutionListByInteraction` (active only, ignores tm_delete!=NULL rows)
+- `Test_ResolutionListByContact` (active only)
+
+**UUID namespace allocation for dbhandler tests** (all in shared SQLite DB).
+Existing interaction tests use `a1b2c3d4-*`, `b1b2c3d4-*`, `c1b2c3d4-*`.
+New resolution/interaction-read tests MUST use distinct namespaces to avoid
+inter-test coupling on the shared in-memory DB:
+- Resolution tests: `r1b2c3d4-*`
+- InteractionList read tests: `l1b2c3d4-*`
+- AddressListByContact tests: `al1b2c3d-*`
+New tests insert all required rows (contacts, interactions, addresses) in the
+test function body, never relying on side effects from other test functions.
+
+**contacthandler (mock-based):**
+- `Test_InteractionList_peerPath`
+- `Test_InteractionList_contactIDPath` (verifies set-MINUS: negative wins)
+- `Test_InteractionList_contactIDPath_noAddresses` (empty address set falls back to positive-only)
+- `Test_InteractionList_contactIDPath_positiveWinsAutoMatch` (positive adds non-auto)
+- `Test_InteractionList_contactIDPath_notFound` (step 0: contact not found -> error)
+- `Test_InteractionList_unresolved` (web_session excluded, auto-matched excluded)
+- `Test_ResolutionCreate_validate` (interaction not found -> error)
+- `Test_ResolutionCreate_duplicateType` (dup positive -> error)
+
+**listenhandler (mock-based):**
+- `Test_V1InteractionsGet_peerPath`
+- `Test_V1InteractionsGet_contactIDPath`
+- `Test_V1InteractionsGet_badParams` (zero filter, multiple filters -> 400)
+- `Test_V1InteractionsUnresolvedGet`
+- `Test_V1InteractionsUnresolvedGet_badSince` (malformed / exceeds 180d -> 400)
+- `Test_V1InteractionsIDGet`
+- `Test_V1InteractionsResolutionsPost`
+- `Test_V1InteractionsResolutionsIDDelete`
+
+## 13. Mock regeneration
+
+After modifying DBHandler or ContactHandler interfaces:
+
+```bash
+cd bin-contact-manager
+go generate ./pkg/dbhandler/...
+go generate ./pkg/contacthandler/...
+go generate ./pkg/listenhandler/...
+```
+
+After modifying RequestHandler (in bin-common-handler):
+
+```bash
+cd bin-common-handler
+go generate ./pkg/requesthandler/...
+```
+
+## 14. File change summary
+
+### bin-contact-manager
+
+| File | Change |
+|------|--------|
+| `models/resolution/resolution.go` | NEW |
+| `models/interaction/list_response.go` | NEW: `InteractionListResponse{Items, NextPageToken}` |
+| `scripts/database_scripts_test/contacts.sql` | APPEND contact_resolutions |
+| `pkg/dbhandler/main.go` | ADD interface methods (InteractionGet/List/ListByIDs, AddressListByContact, AddressGetByID, ResolutionCreate/Delete/List*) |
+| `pkg/dbhandler/interaction.go` | ADD InteractionGet, InteractionList, InteractionListByIDs + encodePageToken/decodePageToken helpers |
+| `pkg/dbhandler/address.go` | ADD AddressListByContact, AddressGetByID |
+| `pkg/dbhandler/resolution.go` | NEW |
+| `pkg/dbhandler/interaction_test.go` | ADD read tests (namespace: l1b2c3d4-*) |
+| `pkg/dbhandler/resolution_test.go` | NEW (namespace: r1b2c3d4-*) |
+| `pkg/dbhandler/address_test.go` | ADD AddressListByContact, AddressGetByID tests (namespace: al1b2c3d-*) |
+| `pkg/dbhandler/mock_main.go` | REGEN |
+| `pkg/contacthandler/main.go` | ADD interface methods |
+| `pkg/contacthandler/interaction_read.go` | NEW |
+| `pkg/contacthandler/resolution.go` | NEW (contacthandler) |
+| `pkg/contacthandler/interaction_read_test.go` | NEW |
+| `pkg/contacthandler/resolution_test.go` | NEW |
+| `pkg/contacthandler/mock_main.go` | REGEN |
+| `pkg/listenhandler/main.go` | ADD URL patterns + switch cases |
+| `pkg/listenhandler/v1_interactions.go` | NEW |
+| `pkg/listenhandler/v1_interactions_test.go` | NEW |
+| `pkg/listenhandler/models/request/v1_interactions.go` | NEW |
+| `pkg/listenhandler/mock_main.go` | REGEN |
+
+### bin-common-handler
+
+| File | Change |
+|------|--------|
+| `pkg/requesthandler/contact_interactions.go` | NEW |
+| `pkg/requesthandler/main.go` | ADD interface methods |
+| `pkg/requesthandler/mock_main.go` | REGEN |
+
+**bin-common-handler admission rule:** `contact_interactions` read API will be consumed by
+`bin-ai-manager` (AIcall attribution), `bin-flow-manager` (Flow CRM actions),
+and `bin-api-manager` (external REST proxy). That is 3+ consumers, satisfying
+the admission rule (minimum 3 consumers for common-handler promotion).
+
+## 15. Open items
+
+1. **`since` parameter parsing.** RESOLVED: use `parseDaysDuration` helper (see §9.2).
+   Default 30d if absent. Max 180d; return 400 if exceeded. `time.ParseDuration`
+   is NOT used.
+
+2. **`addressID` filter.** RESOLVED: `AddressGetByID` is added to dbhandler (§11)
+   and DBHandler interface (§6). The listen handler reads `?address_id=`, calls
+   `AddressGetByID` to get `(type, target)`, then calls `InteractionList` with a
+   single-element `addressSet`.
+
+3. **`since` default.** RESOLVED (in §9.2): if `since` is absent, use 30d default.
+
+4. **RPC timeout.** Resolution Create/Delete use `requestTimeoutDefault` (same as
+   all other contact-manager RPCs). No special timeout needed.
+
+5. **bin-api-manager REST proxy.** Exposing the new endpoints through
+   bin-api-manager is a separate ticket. The RPC client methods added here are
+   sufficient for internal consumers (ai-manager, flow-manager).
+
+6. **`InteractionListResponse` placement.** RESOLVED: placed in `models/interaction/list_response.go`
+   (not in pkg/contacthandler). The circular import `pkg/contacthandler -> bin-common-handler/pkg/requesthandler -> pkg/contacthandler` is confirmed by existing imports; models packages are the established cross-module boundary.
+
+7. **`resolved_by_id` system sentinel.** For system/rule-originated resolutions
+   where no agent is involved, store `uuid.Nil` as `resolved_by_id`. Document this
+   in the `models/resolution/resolution.go` constants block:
+   `var ResolvedByIDSystem = uuid.Nil`.
+
+8. **v1 limitation: contactID path with >5000 automatic interactions.** The internal
+   cap of 5000 means contacts with more than 5000 peer-matching interactions may see
+   incomplete results on the `?contact_id=` path. This is accepted for v1 expected
+   volume. A cursor-walk implementation (multiple DB pages within the algorithm) is
+   the M2 solution if dogfood surfaces the limit.
+
+## 16. Invariants (do not regress)
+
+- Negative resolution always wins over positive for the same (contact_id,
+  interaction_id). LWW is forbidden.
+- web_session peer_type is always excluded from the unresolved queue.
+- contact_resolutions is soft-delete only (tm_delete); never physically deleted.
+- contact_interactions is append-only; no UPDATE or DELETE on this table.
+- Resolution does not affect interaction sort order (tm_create DESC is stable).
+- Pagination cursor uses (tm_create, id), not tm_interaction.


### PR DESCRIPTION
Add CRM v1 read API (interaction timeline + resolution) to bin-contact-manager, with RPC client methods in bin-common-handler.

- bin-contact-manager: Add models/resolution/resolution.go (Resolution struct, type constants, ResolvedByIDSystem sentinel)
- bin-contact-manager: Add models/interaction/list_response.go (InteractionListResponse envelope — placed in models to avoid circular import with bin-common-handler)
- bin-contact-manager: Append contact_resolutions table to SQLite test fixture
- bin-contact-manager: Add InteractionGet, InteractionList, InteractionListByIDs, InteractionListUnresolved to dbhandler (EncodePageToken/DecodePageToken exported helpers; empty-addressSet guard; OR-expansion for SQLite multi-column IN compat; NOT EXISTS unresolved SQL with pagination; nil-safe encodePageToken guard)
- bin-contact-manager: Add AddressListByContact, AddressGetByID to dbhandler/address.go and DBHandler interface
- bin-contact-manager: Add ResolutionCreate, ResolutionDelete, ResolutionListByInteraction, ResolutionListByContact to dbhandler/resolution.go and DBHandler interface
- bin-contact-manager: Add contacthandler/interaction_read.go (InteractionGet/List/ListUnresolved with 6-step set-MINUS algorithm, 5000-row internal cap, STEP 0 tenant+soft-delete guard, cursor applied post-merge in contactID path, pagination probe-row pattern)
- bin-contact-manager: Add contacthandler/resolution.go (ResolutionCreate with interaction existence+duplicate checks; ResolutionDelete)
- bin-contact-manager: Extend ContactHandler interface and regenerate mocks
- bin-contact-manager: Add listenhandler/models/request/v1_interactions.go (POST/DELETE request body structs)
- bin-contact-manager: Add listenhandler/v1_interactions.go (5 handlers: GET list, GET unresolved, GET by ID, POST resolution, DELETE resolution; parseDaysDuration helper; customer_id from JSON body pattern)
- bin-contact-manager: Register interaction URL patterns in listenhandler/main.go (unresolved before ID pattern to avoid false match)
- bin-contact-manager: Add Test_InteractionList_pagination covering hasMore probe row + two-page cursor walk
- bin-common-handler: Add requesthandler/contact_interactions.go (5 RPC client methods: InteractionGet, InteractionList, InteractionListUnresolved, ResolutionCreate, ResolutionDelete)
- bin-common-handler: Extend RequestHandler interface and regenerate mock