### PR TITLE
NOJIRA-Add-name-detail-to-contact-addresses

### DIFF
--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -2598,7 +2598,7 @@ type ContactManagerAddress struct {
 	// CustomerId Unique identifier of the customer this address belongs to.
 	CustomerId *openapi_types.UUID `json:"customer_id,omitempty"`
 
-	// Detail Optional free-form notes about this address.
+	// Detail Additional notes about this address.
 	Detail *string `json:"detail,omitempty"`
 
 	// Id Unique identifier for the address.
@@ -2607,7 +2607,7 @@ type ContactManagerAddress struct {
 	// IsPrimary Indicates if this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
 
-	// Name Optional human-readable label for this address.
+	// Name Optional label for this address.
 	Name *string `json:"name,omitempty"`
 
 	// Target The address endpoint. Format depends on type: phone number for tel (e.g. +14155551234), UUID for agent/conference/extension, email for email, SIP URI for sip.

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -2598,7 +2598,7 @@ type ContactManagerAddress struct {
 	// CustomerId Unique identifier of the customer this address belongs to.
 	CustomerId *openapi_types.UUID `json:"customer_id,omitempty"`
 
-	// Detail Additional notes about this address.
+	// Detail Optional free-form notes about this address.
 	Detail *string `json:"detail,omitempty"`
 
 	// Id Unique identifier for the address.
@@ -2607,7 +2607,7 @@ type ContactManagerAddress struct {
 	// IsPrimary Indicates if this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
 
-	// Name Optional label for this address.
+	// Name Optional human-readable label for this address.
 	Name *string `json:"name,omitempty"`
 
 	// Target The address endpoint. Format depends on type: phone number for tel (e.g. +14155551234), UUID for agent/conference/extension, email for email, SIP URI for sip.
@@ -5693,8 +5693,14 @@ type PostContactAddressesJSONBody struct {
 	// ContactId The ID of the contact to add the address to.
 	ContactId openapi_types.UUID `json:"contact_id"`
 
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -5708,8 +5714,14 @@ type PostContactAddressesJSONBodyType string
 
 // PutContactAddressesIdJSONBody defines parameters for PutContactAddressesId.
 type PutContactAddressesIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value. E.164 format for tel, email address for email.
 	Target *string `json:"target,omitempty"`
@@ -5785,8 +5797,14 @@ type PutContactsIdJSONBody struct {
 
 // PostContactsIdAddressesJSONBody defines parameters for PostContactsIdAddresses.
 type PostContactsIdAddressesJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -5800,8 +5818,14 @@ type PostContactsIdAddressesJSONBodyType string
 
 // PutContactsIdAddressesAddressIdJSONBody defines parameters for PutContactsIdAddressesAddressId.
 type PutContactsIdAddressesAddressIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value. E.164 format for tel, email address for email.
 	Target *string `json:"target,omitempty"`
@@ -6666,8 +6690,14 @@ type PostServiceAgentsContactAddressesJSONBody struct {
 	// ContactId The ID of the contact to add the address to.
 	ContactId openapi_types.UUID `json:"contact_id"`
 
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -6681,8 +6711,14 @@ type PostServiceAgentsContactAddressesJSONBodyType string
 
 // PutServiceAgentsContactAddressesIdJSONBody defines parameters for PutServiceAgentsContactAddressesId.
 type PutServiceAgentsContactAddressesIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value. E.164 format for tel, email address for email.
 	Target *string `json:"target,omitempty"`
@@ -6758,8 +6794,14 @@ type PutServiceAgentsContactsIdJSONBody struct {
 
 // PostServiceAgentsContactsIdAddressesJSONBody defines parameters for PostServiceAgentsContactsIdAddresses.
 type PostServiceAgentsContactsIdAddressesJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -6773,8 +6815,14 @@ type PostServiceAgentsContactsIdAddressesJSONBodyType string
 
 // PutServiceAgentsContactsIdAddressesAddressIdJSONBody defines parameters for PutServiceAgentsContactsIdAddressesAddressId.
 type PutServiceAgentsContactsIdAddressesAddressIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value.
 	Target *string `json:"target,omitempty"`

--- a/bin-api-manager/pkg/servicehandler/contact.go
+++ b/bin-api-manager/pkg/servicehandler/contact.go
@@ -314,6 +314,8 @@ func (h *serviceHandler) ContactAddressCreate(
 	addrType string,
 	target string,
 	isPrimary bool,
+	name string,
+	detail string,
 ) (*cmcontact.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ContactAddressCreate",
@@ -335,7 +337,7 @@ func (h *serviceHandler) ContactAddressCreate(
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
-	if _, err := h.reqHandler.ContactV1AddressCreate(ctx, contactID, addrType, target, isPrimary); err != nil {
+	if _, err := h.reqHandler.ContactV1AddressCreate(ctx, contactID, addrType, target, isPrimary, name, detail); err != nil {
 		log.Infof("Could not add address to contact. err: %v", err)
 		return nil, err
 	}

--- a/bin-api-manager/pkg/servicehandler/contact_address.go
+++ b/bin-api-manager/pkg/servicehandler/contact_address.go
@@ -87,6 +87,8 @@ func (h *serviceHandler) ContactAddressCreateIndependent(
 	addrType string,
 	target string,
 	isPrimary bool,
+	name string,
+	detail string,
 ) (*cmcontact.Address, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "ContactAddressCreateIndependent",
@@ -109,7 +111,7 @@ func (h *serviceHandler) ContactAddressCreateIndependent(
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
-	res, err := h.reqHandler.ContactV1ContactAddressCreate(ctx, contactID, addrType, target, isPrimary)
+	res, err := h.reqHandler.ContactV1ContactAddressCreate(ctx, contactID, addrType, target, isPrimary, name, detail)
 	if err != nil {
 		log.Infof("Could not create contact address. err: %v", err)
 		return nil, err
@@ -261,6 +263,8 @@ func (h *serviceHandler) ServiceAgentContactAddressCreateIndependent(
 	addrType string,
 	target string,
 	isPrimary bool,
+	name string,
+	detail string,
 ) (*cmcontact.Address, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "ServiceAgentContactAddressCreateIndependent",
@@ -283,7 +287,7 @@ func (h *serviceHandler) ServiceAgentContactAddressCreateIndependent(
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
-	res, err := h.reqHandler.ContactV1ContactAddressCreate(ctx, contactID, addrType, target, isPrimary)
+	res, err := h.reqHandler.ContactV1ContactAddressCreate(ctx, contactID, addrType, target, isPrimary, name, detail)
 	if err != nil {
 		log.Infof("Could not create contact address. err: %v", err)
 		return nil, err

--- a/bin-api-manager/pkg/servicehandler/contact_test.go
+++ b/bin-api-manager/pkg/servicehandler/contact_test.go
@@ -667,10 +667,10 @@ func Test_ContactAddressCreate(t *testing.T) {
 			ctx := context.Background()
 
 			mockReq.EXPECT().ContactV1ContactGet(ctx, tt.contactID).Return(tt.responseContactGet, nil)
-			mockReq.EXPECT().ContactV1AddressCreate(ctx, tt.contactID, tt.addrType, tt.target, tt.isPrimary).Return(&cmcontact.Address{}, nil)
+			mockReq.EXPECT().ContactV1AddressCreate(ctx, tt.contactID, tt.addrType, tt.target, tt.isPrimary, "", "").Return(&cmcontact.Address{}, nil)
 			mockReq.EXPECT().ContactV1ContactGet(ctx, tt.contactID).Return(tt.responseContact, nil)
 
-			res, err := h.ContactAddressCreate(ctx, tt.agent, tt.contactID, tt.addrType, tt.target, tt.isPrimary)
+			res, err := h.ContactAddressCreate(ctx, tt.agent, tt.contactID, tt.addrType, tt.target, tt.isPrimary, "", "")
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -451,6 +451,8 @@ type ServiceHandler interface {
 		addrType string,
 		target string,
 		isPrimary bool,
+		name string,
+		detail string,
 	) (*cmcontact.WebhookMessage, error)
 	ContactAddressUpdate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID, fields map[string]any) (*cmcontact.WebhookMessage, error)
 	ContactAddressDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID) (*cmcontact.WebhookMessage, error)
@@ -458,7 +460,7 @@ type ServiceHandler interface {
 	// contact_addresses (independent resource)
 	ContactAddressList(ctx context.Context, a *auth.AuthIdentity, filters map[string]any, pageToken string, pageSize uint64) ([]cmcontact.Address, error)
 	ContactAddressGet(ctx context.Context, a *auth.AuthIdentity, addressID uuid.UUID) (*cmcontact.Address, error)
-	ContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool) (*cmcontact.Address, error)
+	ContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool, name string, detail string) (*cmcontact.Address, error)
 	ContactAddressUpdateIndependent(ctx context.Context, a *auth.AuthIdentity, addressID uuid.UUID, fields map[string]any) (*cmcontact.Address, error)
 	ContactAddressDeleteIndependent(ctx context.Context, a *auth.AuthIdentity, addressID uuid.UUID) (*cmcontact.Address, error)
 
@@ -914,14 +916,14 @@ type ServiceHandler interface {
 	) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactLookup(ctx context.Context, a *auth.AuthIdentity, phoneE164 string, email string) (*cmcontact.WebhookMessage, error)
-	ServiceAgentContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool) (*cmcontact.WebhookMessage, error)
+	ServiceAgentContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool, name string, detail string) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactAddressUpdate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID, fields map[string]any) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactAddressDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID) (*cmcontact.WebhookMessage, error)
 
 	// service_agents/contact_addresses (independent resource)
 	ServiceAgentContactAddressList(ctx context.Context, a *auth.AuthIdentity, filters map[string]any, pageToken string, pageSize uint64) ([]cmcontact.Address, error)
 	ServiceAgentContactAddressGet(ctx context.Context, a *auth.AuthIdentity, addressID uuid.UUID) (*cmcontact.Address, error)
-	ServiceAgentContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool) (*cmcontact.Address, error)
+	ServiceAgentContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool, name string, detail string) (*cmcontact.Address, error)
 	ServiceAgentContactAddressUpdateIndependent(ctx context.Context, a *auth.AuthIdentity, addressID uuid.UUID, fields map[string]any) (*cmcontact.Address, error)
 	ServiceAgentContactAddressDeleteIndependent(ctx context.Context, a *auth.AuthIdentity, addressID uuid.UUID) (*cmcontact.Address, error)
 

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -1914,33 +1914,33 @@ func (mr *MockServiceHandlerMockRecorder) ConferencecallList(ctx, a, size, token
 }
 
 // ContactAddressCreate mocks base method.
-func (m *MockServiceHandler) ContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool) (*contact.WebhookMessage, error) {
+func (m *MockServiceHandler) ContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool, name, detail string) (*contact.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContactAddressCreate", ctx, a, contactID, addrType, target, isPrimary)
+	ret := m.ctrl.Call(m, "ContactAddressCreate", ctx, a, contactID, addrType, target, isPrimary, name, detail)
 	ret0, _ := ret[0].(*contact.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContactAddressCreate indicates an expected call of ContactAddressCreate.
-func (mr *MockServiceHandlerMockRecorder) ContactAddressCreate(ctx, a, contactID, addrType, target, isPrimary any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ContactAddressCreate(ctx, a, contactID, addrType, target, isPrimary, name, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactAddressCreate", reflect.TypeOf((*MockServiceHandler)(nil).ContactAddressCreate), ctx, a, contactID, addrType, target, isPrimary)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactAddressCreate", reflect.TypeOf((*MockServiceHandler)(nil).ContactAddressCreate), ctx, a, contactID, addrType, target, isPrimary, name, detail)
 }
 
 // ContactAddressCreateIndependent mocks base method.
-func (m *MockServiceHandler) ContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool) (*contact.Address, error) {
+func (m *MockServiceHandler) ContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool, name, detail string) (*contact.Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContactAddressCreateIndependent", ctx, a, contactID, addrType, target, isPrimary)
+	ret := m.ctrl.Call(m, "ContactAddressCreateIndependent", ctx, a, contactID, addrType, target, isPrimary, name, detail)
 	ret0, _ := ret[0].(*contact.Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContactAddressCreateIndependent indicates an expected call of ContactAddressCreateIndependent.
-func (mr *MockServiceHandlerMockRecorder) ContactAddressCreateIndependent(ctx, a, contactID, addrType, target, isPrimary any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ContactAddressCreateIndependent(ctx, a, contactID, addrType, target, isPrimary, name, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactAddressCreateIndependent", reflect.TypeOf((*MockServiceHandler)(nil).ContactAddressCreateIndependent), ctx, a, contactID, addrType, target, isPrimary)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactAddressCreateIndependent", reflect.TypeOf((*MockServiceHandler)(nil).ContactAddressCreateIndependent), ctx, a, contactID, addrType, target, isPrimary, name, detail)
 }
 
 // ContactAddressDelete mocks base method.
@@ -4195,33 +4195,33 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentCallList(ctx, a, size, tok
 }
 
 // ServiceAgentContactAddressCreate mocks base method.
-func (m *MockServiceHandler) ServiceAgentContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool) (*contact.WebhookMessage, error) {
+func (m *MockServiceHandler) ServiceAgentContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool, name, detail string) (*contact.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceAgentContactAddressCreate", ctx, a, contactID, addrType, target, isPrimary)
+	ret := m.ctrl.Call(m, "ServiceAgentContactAddressCreate", ctx, a, contactID, addrType, target, isPrimary, name, detail)
 	ret0, _ := ret[0].(*contact.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ServiceAgentContactAddressCreate indicates an expected call of ServiceAgentContactAddressCreate.
-func (mr *MockServiceHandlerMockRecorder) ServiceAgentContactAddressCreate(ctx, a, contactID, addrType, target, isPrimary any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentContactAddressCreate(ctx, a, contactID, addrType, target, isPrimary, name, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentContactAddressCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentContactAddressCreate), ctx, a, contactID, addrType, target, isPrimary)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentContactAddressCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentContactAddressCreate), ctx, a, contactID, addrType, target, isPrimary, name, detail)
 }
 
 // ServiceAgentContactAddressCreateIndependent mocks base method.
-func (m *MockServiceHandler) ServiceAgentContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool) (*contact.Address, error) {
+func (m *MockServiceHandler) ServiceAgentContactAddressCreateIndependent(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType, target string, isPrimary bool, name, detail string) (*contact.Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceAgentContactAddressCreateIndependent", ctx, a, contactID, addrType, target, isPrimary)
+	ret := m.ctrl.Call(m, "ServiceAgentContactAddressCreateIndependent", ctx, a, contactID, addrType, target, isPrimary, name, detail)
 	ret0, _ := ret[0].(*contact.Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ServiceAgentContactAddressCreateIndependent indicates an expected call of ServiceAgentContactAddressCreateIndependent.
-func (mr *MockServiceHandlerMockRecorder) ServiceAgentContactAddressCreateIndependent(ctx, a, contactID, addrType, target, isPrimary any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentContactAddressCreateIndependent(ctx, a, contactID, addrType, target, isPrimary, name, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentContactAddressCreateIndependent", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentContactAddressCreateIndependent), ctx, a, contactID, addrType, target, isPrimary)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentContactAddressCreateIndependent", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentContactAddressCreateIndependent), ctx, a, contactID, addrType, target, isPrimary, name, detail)
 }
 
 // ServiceAgentContactAddressDelete mocks base method.

--- a/bin-api-manager/pkg/servicehandler/serviceagent_contact.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_contact.go
@@ -267,6 +267,8 @@ func (h *serviceHandler) ServiceAgentContactAddressCreate(
 	addrType string,
 	target string,
 	isPrimary bool,
+	name string,
+	detail string,
 ) (*cmcontact.WebhookMessage, error) {
 	if !a.IsAgent() {
 		return nil, serviceerrors.ErrAuthenticationRequired
@@ -289,7 +291,7 @@ func (h *serviceHandler) ServiceAgentContactAddressCreate(
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
-	if _, err := h.reqHandler.ContactV1AddressCreate(ctx, contactID, addrType, target, isPrimary); err != nil {
+	if _, err := h.reqHandler.ContactV1AddressCreate(ctx, contactID, addrType, target, isPrimary, name, detail); err != nil {
 		log.Infof("Could not add address to contact. err: %v", err)
 		return nil, err
 	}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_contact_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_contact_test.go
@@ -698,10 +698,10 @@ func Test_ServiceAgentContactAddressCreate(t *testing.T) {
 			ctx := context.Background()
 
 			mockReq.EXPECT().ContactV1ContactGet(ctx, tt.contactID).Return(tt.responseContactGet, nil)
-			mockReq.EXPECT().ContactV1AddressCreate(ctx, tt.contactID, tt.addrType, tt.target, tt.isPrimary).Return(&cmcontact.Address{}, nil)
+			mockReq.EXPECT().ContactV1AddressCreate(ctx, tt.contactID, tt.addrType, tt.target, tt.isPrimary, "", "").Return(&cmcontact.Address{}, nil)
 			mockReq.EXPECT().ContactV1ContactGet(ctx, tt.contactID).Return(tt.responseContact, nil)
 
-			res, err := h.ServiceAgentContactAddressCreate(ctx, tt.agent, tt.contactID, tt.addrType, tt.target, tt.isPrimary)
+			res, err := h.ServiceAgentContactAddressCreate(ctx, tt.agent, tt.contactID, tt.addrType, tt.target, tt.isPrimary, "", "")
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-api-manager/server/contact_addresses.go
+++ b/bin-api-manager/server/contact_addresses.go
@@ -87,7 +87,16 @@ func (h *server) PostContactAddresses(c *gin.Context) {
 		isPrimary = *req.IsPrimary
 	}
 
-	res, err := h.serviceHandler.ContactAddressCreateIndependent(c.Request.Context(), a, contactID, string(req.Type), req.Target, isPrimary)
+	name := ""
+	if req.Name != nil {
+		name = *req.Name
+	}
+	detail := ""
+	if req.Detail != nil {
+		detail = *req.Detail
+	}
+
+	res, err := h.serviceHandler.ContactAddressCreateIndependent(c.Request.Context(), a, contactID, string(req.Type), req.Target, isPrimary, name, detail)
 	if err != nil {
 		log.Errorf("Could not create contact address. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/contact_addresses.go
+++ b/bin-api-manager/server/contact_addresses.go
@@ -170,6 +170,12 @@ func (h *server) PutContactAddressesId(c *gin.Context, id openapi_types.UUID) {
 	if req.IsPrimary != nil {
 		fields["is_primary"] = *req.IsPrimary
 	}
+	if req.Name != nil {
+		fields["name"] = *req.Name
+	}
+	if req.Detail != nil {
+		fields["detail"] = *req.Detail
+	}
 
 	res, err := h.serviceHandler.ContactAddressUpdateIndependent(c.Request.Context(), a, addressID, fields)
 	if err != nil {

--- a/bin-api-manager/server/contact_addresses_test.go
+++ b/bin-api-manager/server/contact_addresses_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	openapi_server "monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	cmcontact "monorepo/bin-contact-manager/models/contact"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+)
+
+func Test_PutContactAddressesId(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+		reqBody  []byte
+
+		responseAddress *cmcontact.Address
+
+		expectAddressID uuid.UUID
+		expectFields    map[string]any
+		expectRes       string
+	}{
+		{
+			name: "update target",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+
+			reqQuery: "/contact_addresses/a1b2c3d4-5066-11ec-ab34-23643cfdc1c5",
+			reqBody:  []byte(`{"target":"+121****9999"}`),
+
+			responseAddress: &cmcontact.Address{
+				ID:        uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+				ContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
+				Type:      "tel",
+				Target:    "+121****9999",
+			},
+
+			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+			expectFields:    map[string]any{"target": "+121****9999"},
+			expectRes:       `{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"3147612c-5066-11ec-ab34-23643cfdc1c5","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}`,
+		},
+		{
+			name: "update name and detail",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+
+			reqQuery: "/contact_addresses/a1b2c3d4-5066-11ec-ab34-23643cfdc1c5",
+			reqBody:  []byte(`{"name":"Main Office","detail":"Primary contact number"}`),
+
+			responseAddress: &cmcontact.Address{
+				ID:        uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+				ContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
+				Type:      "tel",
+				Target:    "+121****9999",
+				Name:      "Main Office",
+				Detail:    "Primary contact number",
+			},
+
+			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
+			expectRes:       `{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"3147612c-5066-11ec-ab34-23643cfdc1c5","type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","is_primary":false,"tm_create":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("PUT", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ContactAddressUpdateIndependent(req.Context(), tt.agent, tt.expectAddressID, tt.expectFields).Return(tt.responseAddress, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			}
+
+			if w.Body.String() != tt.expectRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
+			}
+		})
+	}
+}

--- a/bin-api-manager/server/contacts.go
+++ b/bin-api-manager/server/contacts.go
@@ -155,6 +155,12 @@ func (h *server) PostContacts(c *gin.Context) {
 			if v.IsPrimary != nil {
 				addr.IsPrimary = *v.IsPrimary
 			}
+			if v.Name != nil {
+				addr.Name = *v.Name
+			}
+			if v.Detail != nil {
+				addr.Detail = *v.Detail
+			}
 			addresses = append(addresses, addr)
 		}
 	}
@@ -387,7 +393,16 @@ func (h *server) PostContactsIdAddresses(c *gin.Context, id openapi_types.UUID) 
 		isPrimary = *req.IsPrimary
 	}
 
-	res, err := h.serviceHandler.ContactAddressCreate(c.Request.Context(), a, target, string(req.Type), req.Target, isPrimary)
+	name := ""
+	if req.Name != nil {
+		name = *req.Name
+	}
+	detail := ""
+	if req.Detail != nil {
+		detail = *req.Detail
+	}
+
+	res, err := h.serviceHandler.ContactAddressCreate(c.Request.Context(), a, target, string(req.Type), req.Target, isPrimary, name, detail)
 	if err != nil {
 		log.Errorf("Could not add address to contact. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/contacts.go
+++ b/bin-api-manager/server/contacts.go
@@ -457,6 +457,12 @@ func (h *server) PutContactsIdAddressesAddressId(c *gin.Context, id openapi_type
 	if req.IsPrimary != nil {
 		fields["is_primary"] = *req.IsPrimary
 	}
+	if req.Name != nil {
+		fields["name"] = *req.Name
+	}
+	if req.Detail != nil {
+		fields["detail"] = *req.Detail
+	}
 
 	res, err := h.serviceHandler.ContactAddressUpdate(c.Request.Context(), a, contactID, addrID, fields)
 	if err != nil {

--- a/bin-api-manager/server/contacts_test.go
+++ b/bin-api-manager/server/contacts_test.go
@@ -516,7 +516,7 @@ func Test_PostContactsIdAddresses(t *testing.T) {
 			expectAddrType:  "tel",
 			expectTarget:    "+121****1234",
 			expectIsPrimary: false,
-			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****1234","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****1234","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -541,7 +541,7 @@ func Test_PostContactsIdAddresses(t *testing.T) {
 			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().ContactAddressCreate(req.Context(), tt.agent, tt.expectContactID, tt.expectAddrType, tt.expectTarget, tt.expectIsPrimary).Return(tt.responseContact, nil)
+			mockSvc.EXPECT().ContactAddressCreate(req.Context(), tt.agent, tt.expectContactID, tt.expectAddrType, tt.expectTarget, tt.expectIsPrimary, "", "").Return(tt.responseContact, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusCreated {
@@ -598,7 +598,7 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 
 			expectContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****9999","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 

--- a/bin-api-manager/server/contacts_test.go
+++ b/bin-api-manager/server/contacts_test.go
@@ -568,6 +568,7 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 
 		expectContactID uuid.UUID
 		expectAddressID uuid.UUID
+		expectFields    map[string]any
 		expectRes       string
 	}{
 		{
@@ -598,7 +599,41 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 
 			expectContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+			expectFields:    map[string]any{"target": "+121****9999"},
 			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			name: "update name and detail",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+			}),
+
+			reqQuery: "/contacts/3147612c-5066-11ec-ab34-23643cfdc1c5/addresses/a1b2c3d4-5066-11ec-ab34-23643cfdc1c5",
+			reqBody:  []byte(`{"name":"Main Office","detail":"Primary contact number"}`),
+
+			responseContact: &cmcontact.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Addresses: []cmcontact.Address{
+					{
+						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Type:   "tel",
+						Target: "+121****9999",
+						Name:   "Main Office",
+						Detail: "Primary contact number",
+					},
+				},
+			},
+
+			expectContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
+			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
+			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -623,7 +658,7 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 			req, _ := http.NewRequest("PUT", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().ContactAddressUpdate(req.Context(), tt.agent, tt.expectContactID, tt.expectAddressID, gomock.Any()).Return(tt.responseContact, nil)
+			mockSvc.EXPECT().ContactAddressUpdate(req.Context(), tt.agent, tt.expectContactID, tt.expectAddressID, tt.expectFields).Return(tt.responseContact, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {

--- a/bin-api-manager/server/service_agents_contact_addresses.go
+++ b/bin-api-manager/server/service_agents_contact_addresses.go
@@ -87,7 +87,16 @@ func (h *server) PostServiceAgentsContactAddresses(c *gin.Context) {
 		isPrimary = *req.IsPrimary
 	}
 
-	res, err := h.serviceHandler.ServiceAgentContactAddressCreateIndependent(c.Request.Context(), a, contactID, string(req.Type), req.Target, isPrimary)
+	name := ""
+	if req.Name != nil {
+		name = *req.Name
+	}
+	detail := ""
+	if req.Detail != nil {
+		detail = *req.Detail
+	}
+
+	res, err := h.serviceHandler.ServiceAgentContactAddressCreateIndependent(c.Request.Context(), a, contactID, string(req.Type), req.Target, isPrimary, name, detail)
 	if err != nil {
 		log.Errorf("Could not create contact address. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/service_agents_contact_addresses.go
+++ b/bin-api-manager/server/service_agents_contact_addresses.go
@@ -170,6 +170,12 @@ func (h *server) PutServiceAgentsContactAddressesId(c *gin.Context, id openapi_t
 	if req.IsPrimary != nil {
 		fields["is_primary"] = *req.IsPrimary
 	}
+	if req.Name != nil {
+		fields["name"] = *req.Name
+	}
+	if req.Detail != nil {
+		fields["detail"] = *req.Detail
+	}
 
 	res, err := h.serviceHandler.ServiceAgentContactAddressUpdateIndependent(c.Request.Context(), a, addressID, fields)
 	if err != nil {

--- a/bin-api-manager/server/service_agents_contact_addresses_test.go
+++ b/bin-api-manager/server/service_agents_contact_addresses_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	openapi_server "monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	cmcontact "monorepo/bin-contact-manager/models/contact"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+)
+
+func Test_PutServiceAgentsContactAddressesId(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+		reqBody  []byte
+
+		responseAddress *cmcontact.Address
+
+		expectAddressID uuid.UUID
+		expectFields    map[string]any
+		expectRes       string
+	}{
+		{
+			name: "update target",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("58b5afa0-8004-11ec-aea5-5f3d4e3c86d1"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8004-11ec-aea5-d3a320e3b3c0"),
+				},
+				Permission: amagent.PermissionAll,
+			}),
+
+			reqQuery: "/service_agents/contact_addresses/a1b2c3d4-0001-11ec-0001-000000000001",
+			reqBody:  []byte(`{"target":"+121****9999"}`),
+
+			responseAddress: &cmcontact.Address{
+				ID:        uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
+				ContactID: uuid.FromStringOrNil("c07ff34e-500d-11ec-8393-2bc7870b7eff"),
+				Type:      "tel",
+				Target:    "+121****9999",
+			},
+
+			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
+			expectFields:    map[string]any{"target": "+121****9999"},
+			expectRes:       `{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}`,
+		},
+		{
+			name: "update name and detail",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("58b5afa0-8004-11ec-aea5-5f3d4e3c86d1"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8004-11ec-aea5-d3a320e3b3c0"),
+				},
+				Permission: amagent.PermissionAll,
+			}),
+
+			reqQuery: "/service_agents/contact_addresses/a1b2c3d4-0001-11ec-0001-000000000001",
+			reqBody:  []byte(`{"name":"Main Office","detail":"Primary contact number"}`),
+
+			responseAddress: &cmcontact.Address{
+				ID:        uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
+				ContactID: uuid.FromStringOrNil("c07ff34e-500d-11ec-8393-2bc7870b7eff"),
+				Type:      "tel",
+				Target:    "+121****9999",
+				Name:      "Main Office",
+				Detail:    "Primary contact number",
+			},
+
+			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
+			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
+			expectRes:       `{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","is_primary":false,"tm_create":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("PUT", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ServiceAgentContactAddressUpdateIndependent(req.Context(), tt.agent, tt.expectAddressID, tt.expectFields).Return(tt.responseAddress, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			}
+
+			if w.Body.String() != tt.expectRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
+			}
+		})
+	}
+}

--- a/bin-api-manager/server/service_agents_contacts.go
+++ b/bin-api-manager/server/service_agents_contacts.go
@@ -380,7 +380,16 @@ func (h *server) PostServiceAgentsContactsIdAddresses(c *gin.Context, id openapi
 		isPrimary = *req.IsPrimary
 	}
 
-	res, err := h.serviceHandler.ServiceAgentContactAddressCreate(c.Request.Context(), a, contactID, string(req.Type), req.Target, isPrimary)
+	name := ""
+	if req.Name != nil {
+		name = *req.Name
+	}
+	detail := ""
+	if req.Detail != nil {
+		detail = *req.Detail
+	}
+
+	res, err := h.serviceHandler.ServiceAgentContactAddressCreate(c.Request.Context(), a, contactID, string(req.Type), req.Target, isPrimary, name, detail)
 	if err != nil {
 		log.Errorf("Could not add address to contact. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/service_agents_contacts.go
+++ b/bin-api-manager/server/service_agents_contacts.go
@@ -432,6 +432,12 @@ func (h *server) PutServiceAgentsContactsIdAddressesAddressId(c *gin.Context, id
 	if req.IsPrimary != nil {
 		fields["is_primary"] = *req.IsPrimary
 	}
+	if req.Name != nil {
+		fields["name"] = *req.Name
+	}
+	if req.Detail != nil {
+		fields["detail"] = *req.Detail
+	}
 
 	res, err := h.serviceHandler.ServiceAgentContactAddressUpdate(c.Request.Context(), a, contactID, addrID, fields)
 	if err != nil {

--- a/bin-api-manager/server/service_agents_contacts_test.go
+++ b/bin-api-manager/server/service_agents_contacts_test.go
@@ -651,7 +651,7 @@ func Test_PostServiceAgentsContactsIdAddresses(t *testing.T) {
 			expectAddrType:  "tel",
 			expectTarget:    "+121****1234",
 			expectIsPrimary: false,
-			expectRes:       `{"id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","customer_id":"5f621078-8004-11ec-aea5-d3a320e3b3c0","first_name":"John","last_name":"Doe","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****1234","is_primary":false,"tm_create":null}],"tm_create":"2020-09-20T03:23:21.995Z","tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","customer_id":"5f621078-8004-11ec-aea5-d3a320e3b3c0","first_name":"John","last_name":"Doe","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****1234","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":"2020-09-20T03:23:21.995Z","tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -676,7 +676,7 @@ func Test_PostServiceAgentsContactsIdAddresses(t *testing.T) {
 			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().ServiceAgentContactAddressCreate(req.Context(), tt.agent, tt.expectContactID, tt.expectAddrType, tt.expectTarget, tt.expectIsPrimary).Return(tt.responseContact, nil)
+			mockSvc.EXPECT().ServiceAgentContactAddressCreate(req.Context(), tt.agent, tt.expectContactID, tt.expectAddrType, tt.expectTarget, tt.expectIsPrimary, "", "").Return(tt.responseContact, nil)
 
 			r.ServeHTTP(w, req)
 			if w.Code != http.StatusOK {

--- a/bin-api-manager/server/service_agents_contacts_test.go
+++ b/bin-api-manager/server/service_agents_contacts_test.go
@@ -734,6 +734,34 @@ func Test_PutServiceAgentsContactsIdAddressesAddressId(t *testing.T) {
 			expectFields:    map[string]any{"target": "+121****9999"},
 			expectRes:       `{"id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","customer_id":"5f621078-8004-11ec-aea5-d3a320e3b3c0","first_name":"John","last_name":"Doe","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","tm_create":"2020-09-20T03:23:21.995Z","tm_update":null,"tm_delete":null}`,
 		},
+		{
+			name: "update name and detail",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("58b5afa0-8004-11ec-aea5-5f3d4e3c86d1"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8004-11ec-aea5-d3a320e3b3c0"),
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+
+			reqQuery: "/service_agents/contacts/c07ff34e-500d-11ec-8393-2bc7870b7eff/addresses/a1b2c3d4-0001-11ec-0001-000000000001",
+			reqBody:  []byte(`{"name":"Main Office","detail":"Primary contact number"}`),
+
+			responseContact: &cmcontact.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c07ff34e-500d-11ec-8393-2bc7870b7eff"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8004-11ec-aea5-d3a320e3b3c0"),
+				},
+				FirstName: "John",
+				LastName:  "Doe",
+				TMCreate:  timePtr("2020-09-20T03:23:21.995Z"),
+			},
+
+			expectContactID: uuid.FromStringOrNil("c07ff34e-500d-11ec-8393-2bc7870b7eff"),
+			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
+			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
+			expectRes:       `{"id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","customer_id":"5f621078-8004-11ec-aea5-d3a320e3b3c0","first_name":"John","last_name":"Doe","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","tm_create":"2020-09-20T03:23:21.995Z","tm_update":null,"tm_delete":null}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-common-handler/pkg/requesthandler/contact_addresses.go
+++ b/bin-common-handler/pkg/requesthandler/contact_addresses.go
@@ -20,6 +20,8 @@ func (r *requestHandler) ContactV1AddressCreate(
 	addrType string,
 	target string,
 	isPrimary bool,
+	name string,
+	detail string,
 ) (*cmcontact.Address, error) {
 	uri := fmt.Sprintf("/v1/contacts/%s/addresses", contactID)
 
@@ -27,6 +29,8 @@ func (r *requestHandler) ContactV1AddressCreate(
 		Type:      addrType,
 		Target:    target,
 		IsPrimary: isPrimary,
+		Name:      name,
+		Detail:    detail,
 	}
 
 	m, err := json.Marshal(data)

--- a/bin-common-handler/pkg/requesthandler/contact_contact_addresses.go
+++ b/bin-common-handler/pkg/requesthandler/contact_contact_addresses.go
@@ -63,6 +63,8 @@ func (r *requestHandler) ContactV1ContactAddressCreate(
 	addrType string,
 	target string,
 	isPrimary bool,
+	name string,
+	detail string,
 ) (*cmcontact.Address, error) {
 	uri := "/v1/contact_addresses"
 
@@ -71,6 +73,8 @@ func (r *requestHandler) ContactV1ContactAddressCreate(
 		Type:      addrType,
 		Target:    target,
 		IsPrimary: isPrimary,
+		Name:      name,
+		Detail:    detail,
 	}
 
 	m, err := json.Marshal(data)

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -893,6 +893,8 @@ type RequestHandler interface {
 		addrType string,
 		target string,
 		isPrimary bool,
+		name string,
+		detail string,
 	) (*cmcontact.Address, error)
 	ContactV1AddressGet(ctx context.Context, contactID uuid.UUID) ([]cmcontact.Address, error)
 	ContactV1AddressUpdate(ctx context.Context, contactID uuid.UUID, addressID uuid.UUID, fields map[string]any) (*cmcontact.Contact, error)
@@ -900,7 +902,7 @@ type RequestHandler interface {
 
 	// contact-manager contact_addresses (independent resource)
 	ContactV1ContactAddressList(ctx context.Context, customerID uuid.UUID, filters map[string]any, pageToken string, pageSize uint64) ([]cmcontact.Address, error)
-	ContactV1ContactAddressCreate(ctx context.Context, contactID uuid.UUID, addrType string, target string, isPrimary bool) (*cmcontact.Address, error)
+	ContactV1ContactAddressCreate(ctx context.Context, contactID uuid.UUID, addrType string, target string, isPrimary bool, name string, detail string) (*cmcontact.Address, error)
 	ContactV1ContactAddressGet(ctx context.Context, customerID uuid.UUID, addressID uuid.UUID) (*cmcontact.Address, error)
 	ContactV1ContactAddressUpdate(ctx context.Context, customerID uuid.UUID, contactID uuid.UUID, addressID uuid.UUID, fields map[string]any) (*cmcontact.Address, error)
 	ContactV1ContactAddressDelete(ctx context.Context, customerID uuid.UUID, contactID uuid.UUID, addressID uuid.UUID) (*cmcontact.Address, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -3413,18 +3413,18 @@ func (mr *MockRequestHandlerMockRecorder) ConferenceV1ServiceTypeConferencecallS
 }
 
 // ContactV1AddressCreate mocks base method.
-func (m *MockRequestHandler) ContactV1AddressCreate(ctx context.Context, contactID uuid.UUID, addrType, target string, isPrimary bool) (*contact.Address, error) {
+func (m *MockRequestHandler) ContactV1AddressCreate(ctx context.Context, contactID uuid.UUID, addrType, target string, isPrimary bool, name, detail string) (*contact.Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContactV1AddressCreate", ctx, contactID, addrType, target, isPrimary)
+	ret := m.ctrl.Call(m, "ContactV1AddressCreate", ctx, contactID, addrType, target, isPrimary, name, detail)
 	ret0, _ := ret[0].(*contact.Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContactV1AddressCreate indicates an expected call of ContactV1AddressCreate.
-func (mr *MockRequestHandlerMockRecorder) ContactV1AddressCreate(ctx, contactID, addrType, target, isPrimary any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) ContactV1AddressCreate(ctx, contactID, addrType, target, isPrimary, name, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1AddressCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1AddressCreate), ctx, contactID, addrType, target, isPrimary)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1AddressCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1AddressCreate), ctx, contactID, addrType, target, isPrimary, name, detail)
 }
 
 // ContactV1AddressDelete mocks base method.
@@ -3473,18 +3473,18 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1AddressUpdate(ctx, contactID,
 }
 
 // ContactV1ContactAddressCreate mocks base method.
-func (m *MockRequestHandler) ContactV1ContactAddressCreate(ctx context.Context, contactID uuid.UUID, addrType, target string, isPrimary bool) (*contact.Address, error) {
+func (m *MockRequestHandler) ContactV1ContactAddressCreate(ctx context.Context, contactID uuid.UUID, addrType, target string, isPrimary bool, name, detail string) (*contact.Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContactV1ContactAddressCreate", ctx, contactID, addrType, target, isPrimary)
+	ret := m.ctrl.Call(m, "ContactV1ContactAddressCreate", ctx, contactID, addrType, target, isPrimary, name, detail)
 	ret0, _ := ret[0].(*contact.Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContactV1ContactAddressCreate indicates an expected call of ContactV1ContactAddressCreate.
-func (mr *MockRequestHandlerMockRecorder) ContactV1ContactAddressCreate(ctx, contactID, addrType, target, isPrimary any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) ContactV1ContactAddressCreate(ctx, contactID, addrType, target, isPrimary, name, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1ContactAddressCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1ContactAddressCreate), ctx, contactID, addrType, target, isPrimary)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1ContactAddressCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1ContactAddressCreate), ctx, contactID, addrType, target, isPrimary, name, detail)
 }
 
 // ContactV1ContactAddressDelete mocks base method.

--- a/bin-contact-manager/models/contact/address.go
+++ b/bin-contact-manager/models/contact/address.go
@@ -13,8 +13,10 @@ type Address struct {
 	ID         uuid.UUID  `json:"id"`
 	CustomerID uuid.UUID  `json:"customer_id"`
 	ContactID  uuid.UUID  `json:"contact_id"`
-	Type       string     `json:"type"`      // "tel" | "email"
-	Target     string     `json:"target"`    // E.164 or email
+	Type       string     `json:"type"`       // "tel" | "email"
+	Target     string     `json:"target"`     // E.164 or email
+	Name       string     `json:"name"`       // optional human-readable label
+	Detail     string     `json:"detail"`     // optional free-form notes
 	IsPrimary  bool       `json:"is_primary"`
 	TMCreate   *time.Time `json:"tm_create"`
 }
@@ -32,5 +34,7 @@ type AddressField string
 // Note: key names match the DB column names directly (no remapping needed).
 const (
 	AddressFieldTarget    AddressField = "target"     // maps to DB column target
+	AddressFieldName      AddressField = "name"       // maps to DB column name
+	AddressFieldDetail    AddressField = "detail"     // maps to DB column detail
 	AddressFieldIsPrimary AddressField = "is_primary" // maps to DB column is_primary
 )

--- a/bin-contact-manager/pkg/dbhandler/address.go
+++ b/bin-contact-manager/pkg/dbhandler/address.go
@@ -33,6 +33,8 @@ type addressRow struct {
 	ContactID  uuid.UUID  `db:"contact_id,uuid"`
 	Type       string     `db:"type"`
 	Target     string     `db:"target"`
+	Name       string     `db:"name"`
+	Detail     string     `db:"detail"`
 	IsPrimary  bool       `db:"is_primary"`
 	TMCreate   *time.Time `db:"tm_create"`
 }
@@ -54,6 +56,8 @@ func scanFullAddressRow(rows *sql.Rows) (*contact.Address, error) {
 		ContactID:  r.ContactID,
 		Type:       r.Type,
 		Target:     r.Target,
+		Name:       r.Name,
+		Detail:     r.Detail,
 		IsPrimary:  r.IsPrimary,
 		TMCreate:   r.TMCreate,
 	}, nil
@@ -111,6 +115,8 @@ func (h *handler) AddressCreate(ctx context.Context, a *contact.Address) error {
 			"type":        a.Type,
 			"target":      a.Target,
 			"target_name": "",
+			"name":        a.Name,
+			"detail":      a.Detail,
 			"is_primary":  a.IsPrimary,
 			"tm_create":   a.TMCreate,
 		}).
@@ -258,6 +264,10 @@ func (h *handler) AddressUpdate(ctx context.Context, id uuid.UUID, fields map[st
 		switch k {
 		case "target":
 			q = q.Set("target", v)
+		case "name":
+			q = q.Set("name", v)
+		case "detail":
+			q = q.Set("detail", v)
 		case "is_primary":
 			q = q.Set("is_primary", v)
 		default:

--- a/bin-contact-manager/pkg/listenhandler/models/request/contacts.go
+++ b/bin-contact-manager/pkg/listenhandler/models/request/contacts.go
@@ -35,6 +35,8 @@ type ContactUpdate struct {
 type AddressCreate struct {
 	Type      string `json:"type"`       // "tel" | "email" — required
 	Target    string `json:"target"`     // E.164 or email   — required
+	Name      string `json:"name"`       // optional label
+	Detail    string `json:"detail"`     // optional notes
 	IsPrimary bool   `json:"is_primary"`
 }
 
@@ -43,12 +45,17 @@ type ContactAddressCreate struct {
 	ContactID uuid.UUID `json:"contact_id"` // required
 	Type      string    `json:"type"`        // "tel" | "email" — required
 	Target    string    `json:"target"`      // E.164 or email   — required
+	Name      string    `json:"name"`        // optional label
+	Detail    string    `json:"detail"`      // optional notes
 	IsPrimary bool      `json:"is_primary"`
 }
 
 // AddressUpdate is the body for PUT /v1/contacts/{id}/addresses/{address_id}
+// and PUT /v1/contact_addresses/{id}
 type AddressUpdate struct {
 	Target    *string `json:"target,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Detail    *string `json:"detail,omitempty"`
 	IsPrimary *bool   `json:"is_primary,omitempty"`
 }
 

--- a/bin-contact-manager/pkg/listenhandler/v1_contact_addresses.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contact_addresses.go
@@ -92,6 +92,8 @@ func (h *listenHandler) processV1ContactAddressesPost(ctx context.Context, m *so
 	tmp, err := h.contactHandler.AddAddress(ctx, reqData.ContactID, &contact.Address{
 		Type:      reqData.Type,
 		Target:    reqData.Target,
+		Name:      reqData.Name,
+		Detail:    reqData.Detail,
 		IsPrimary: reqData.IsPrimary,
 	})
 	if err != nil {
@@ -181,6 +183,12 @@ func (h *listenHandler) processV1ContactAddressesIDPut(ctx context.Context, m *s
 	fields := map[string]any{}
 	if reqData.Target != nil {
 		fields["target"] = *reqData.Target
+	}
+	if reqData.Name != nil {
+		fields["name"] = *reqData.Name
+	}
+	if reqData.Detail != nil {
+		fields["detail"] = *reqData.Detail
 	}
 	if reqData.IsPrimary != nil {
 		fields["is_primary"] = *reqData.IsPrimary

--- a/bin-contact-manager/pkg/listenhandler/v1_contacts.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contacts.go
@@ -110,6 +110,8 @@ func (h *listenHandler) processV1ContactsPost(ctx context.Context, m *sock.Reque
 		c.Addresses = append(c.Addresses, contact.Address{
 			Type:      a.Type,
 			Target:    a.Target,
+			Name:      a.Name,
+			Detail:    a.Detail,
 			IsPrimary: a.IsPrimary,
 		})
 	}

--- a/bin-contact-manager/pkg/listenhandler/v1_contacts_addresses.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contacts_addresses.go
@@ -85,6 +85,8 @@ func (h *listenHandler) processV1ContactsAddressesPost(ctx context.Context, m *s
 	address := &contact.Address{
 		Type:      reqData.Type,
 		Target:    reqData.Target,
+		Name:      reqData.Name,
+		Detail:    reqData.Detail,
 		IsPrimary: reqData.IsPrimary,
 	}
 
@@ -138,6 +140,12 @@ func (h *listenHandler) processV1ContactsAddressesIDPut(ctx context.Context, m *
 	fields := make(map[string]any)
 	if reqData.Target != nil {
 		fields["target"] = *reqData.Target
+	}
+	if reqData.Name != nil {
+		fields["name"] = *reqData.Name
+	}
+	if reqData.Detail != nil {
+		fields["detail"] = *reqData.Detail
 	}
 	if reqData.IsPrimary != nil {
 		fields["is_primary"] = *reqData.IsPrimary

--- a/bin-contact-manager/scripts/database_scripts_test/contacts.sql
+++ b/bin-contact-manager/scripts/database_scripts_test/contacts.sql
@@ -68,6 +68,8 @@ create table contact_addresses(
   type          varchar(255),
   target        varchar(255),
   target_name   varchar(255),
+  name          varchar(255),
+  detail        varchar(255),
   is_primary    boolean,
 
   -- STORED generated column mirroring production: one-primary-per-contact.

--- a/bin-dbscheme-manager/bin-manager/main/versions/7e981e3aa8e9_contact_addresses_add_name_detail.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/7e981e3aa8e9_contact_addresses_add_name_detail.py
@@ -1,0 +1,32 @@
+"""contact_addresses_add_name_detail
+
+Add name and detail columns to contact_addresses table.
+- name: optional human-readable label for the address (e.g. "Main Office")
+- detail: optional free-form notes about the address (e.g. "Primary contact number")
+
+Revises: adb8daac2bb0
+Revision ID: 7e981e3aa8e9
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '7e981e3aa8e9'
+down_revision = 'adb8daac2bb0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE contact_addresses
+            ADD COLUMN name   VARCHAR(255) NOT NULL DEFAULT '' AFTER target_name,
+            ADD COLUMN detail VARCHAR(255) NOT NULL DEFAULT '' AFTER name
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE contact_addresses
+            DROP COLUMN detail,
+            DROP COLUMN name
+    """)

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -4803,7 +4803,7 @@ type ContactManagerAddress struct {
 	// CustomerId Unique identifier of the customer this address belongs to.
 	CustomerId *openapi_types.UUID `json:"customer_id,omitempty"`
 
-	// Detail Optional free-form notes about this address.
+	// Detail Additional notes about this address.
 	Detail *string `json:"detail,omitempty"`
 
 	// Id Unique identifier for the address.
@@ -4812,7 +4812,7 @@ type ContactManagerAddress struct {
 	// IsPrimary Indicates if this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
 
-	// Name Optional human-readable label for this address.
+	// Name Optional label for this address.
 	Name *string `json:"name,omitempty"`
 
 	// Target The address endpoint. Format depends on type: phone number for tel (e.g. +14155551234), UUID for agent/conference/extension, email for email, SIP URI for sip.

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -4803,7 +4803,7 @@ type ContactManagerAddress struct {
 	// CustomerId Unique identifier of the customer this address belongs to.
 	CustomerId *openapi_types.UUID `json:"customer_id,omitempty"`
 
-	// Detail Additional notes about this address.
+	// Detail Optional free-form notes about this address.
 	Detail *string `json:"detail,omitempty"`
 
 	// Id Unique identifier for the address.
@@ -4812,7 +4812,7 @@ type ContactManagerAddress struct {
 	// IsPrimary Indicates if this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
 
-	// Name Optional label for this address.
+	// Name Optional human-readable label for this address.
 	Name *string `json:"name,omitempty"`
 
 	// Target The address endpoint. Format depends on type: phone number for tel (e.g. +14155551234), UUID for agent/conference/extension, email for email, SIP URI for sip.
@@ -7898,8 +7898,14 @@ type PostContactAddressesJSONBody struct {
 	// ContactId The ID of the contact to add the address to.
 	ContactId openapi_types.UUID `json:"contact_id"`
 
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -7913,8 +7919,14 @@ type PostContactAddressesJSONBodyType string
 
 // PutContactAddressesIdJSONBody defines parameters for PutContactAddressesId.
 type PutContactAddressesIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value. E.164 format for tel, email address for email.
 	Target *string `json:"target,omitempty"`
@@ -7990,8 +8002,14 @@ type PutContactsIdJSONBody struct {
 
 // PostContactsIdAddressesJSONBody defines parameters for PostContactsIdAddresses.
 type PostContactsIdAddressesJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -8005,8 +8023,14 @@ type PostContactsIdAddressesJSONBodyType string
 
 // PutContactsIdAddressesAddressIdJSONBody defines parameters for PutContactsIdAddressesAddressId.
 type PutContactsIdAddressesAddressIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value. E.164 format for tel, email address for email.
 	Target *string `json:"target,omitempty"`
@@ -8871,8 +8895,14 @@ type PostServiceAgentsContactAddressesJSONBody struct {
 	// ContactId The ID of the contact to add the address to.
 	ContactId openapi_types.UUID `json:"contact_id"`
 
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -8886,8 +8916,14 @@ type PostServiceAgentsContactAddressesJSONBodyType string
 
 // PutServiceAgentsContactAddressesIdJSONBody defines parameters for PutServiceAgentsContactAddressesId.
 type PutServiceAgentsContactAddressesIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the contact.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value. E.164 format for tel, email address for email.
 	Target *string `json:"target,omitempty"`
@@ -8963,8 +8999,14 @@ type PutServiceAgentsContactsIdJSONBody struct {
 
 // PostServiceAgentsContactsIdAddressesJSONBody defines parameters for PostServiceAgentsContactsIdAddresses.
 type PostServiceAgentsContactsIdAddressesJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The address value. E.164 format for tel, email address for email.
 	Target string `json:"target"`
@@ -8978,8 +9020,14 @@ type PostServiceAgentsContactsIdAddressesJSONBodyType string
 
 // PutServiceAgentsContactsIdAddressesAddressIdJSONBody defines parameters for PutServiceAgentsContactsIdAddressesAddressId.
 type PutServiceAgentsContactsIdAddressesAddressIdJSONBody struct {
+	// Detail Optional free-form notes about this address.
+	Detail *string `json:"detail,omitempty"`
+
 	// IsPrimary Whether this is the primary address for the given type.
 	IsPrimary *bool `json:"is_primary,omitempty"`
+
+	// Name Optional human-readable label for this address.
+	Name *string `json:"name,omitempty"`
 
 	// Target The updated address value.
 	Target *string `json:"target,omitempty"`

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -3539,6 +3539,14 @@ components:
               format: uuid
               description: Unique identifier of the customer this address belongs to.
               example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Indicates if this is the primary address for the given type.

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -3539,14 +3539,6 @@ components:
               format: uuid
               description: Unique identifier of the customer this address belongs to.
               example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-            name:
-              type: string
-              description: Optional human-readable label for this address.
-              example: "Main Office"
-            detail:
-              type: string
-              description: Optional free-form notes about this address.
-              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Indicates if this is the primary address for the given type.

--- a/bin-openapi-manager/openapi/paths/contact_addresses/id.yaml
+++ b/bin-openapi-manager/openapi/paths/contact_addresses/id.yaml
@@ -54,7 +54,15 @@ put:
             target:
               type: string
               description: The updated address value. E.164 format for tel, email address for email.
-              example: "+15559999999"
+              example: "+155****9999"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the contact.

--- a/bin-openapi-manager/openapi/paths/contact_addresses/main.yaml
+++ b/bin-openapi-manager/openapi/paths/contact_addresses/main.yaml
@@ -70,7 +70,15 @@ post:
             target:
               type: string
               description: The address value. E.164 format for tel, email address for email.
-              example: "+15551234567"
+              example: "+155****4567"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the contact.

--- a/bin-openapi-manager/openapi/paths/contacts/id_addresses.yaml
+++ b/bin-openapi-manager/openapi/paths/contacts/id_addresses.yaml
@@ -30,7 +30,15 @@ post:
             target:
               type: string
               description: The address value. E.164 format for tel, email address for email.
-              example: "+15551234567"
+              example: "+155****4567"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the given type.

--- a/bin-openapi-manager/openapi/paths/contacts/id_addresses_id.yaml
+++ b/bin-openapi-manager/openapi/paths/contacts/id_addresses_id.yaml
@@ -31,6 +31,14 @@ put:
               type: string
               description: The updated address value. E.164 format for tel, email address for email.
               example: "+155****9999"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the given type.

--- a/bin-openapi-manager/openapi/paths/service_agents/contact_addresses.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/contact_addresses.yaml
@@ -71,6 +71,14 @@ post:
               type: string
               description: The address value. E.164 format for tel, email address for email.
               example: "+155****4567"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the contact.

--- a/bin-openapi-manager/openapi/paths/service_agents/contact_addresses_id.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/contact_addresses_id.yaml
@@ -55,6 +55,14 @@ put:
               type: string
               description: The updated address value. E.164 format for tel, email address for email.
               example: "+155****9999"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the contact.

--- a/bin-openapi-manager/openapi/paths/service_agents/contacts_id_addresses.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/contacts_id_addresses.yaml
@@ -31,6 +31,14 @@ post:
               type: string
               description: The address value. E.164 format for tel, email address for email.
               example: "+155****4567"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the given type.

--- a/bin-openapi-manager/openapi/paths/service_agents/contacts_id_addresses_id.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/contacts_id_addresses_id.yaml
@@ -31,6 +31,14 @@ put:
               type: string
               description: The updated address value.
               example: "+155****9999"
+            name:
+              type: string
+              description: Optional human-readable label for this address.
+              example: "Main Office"
+            detail:
+              type: string
+              description: Optional free-form notes about this address.
+              example: "Primary contact number"
             is_primary:
               type: boolean
               description: Whether this is the primary address for the given type.


### PR DESCRIPTION
Add name and detail fields to contact_addresses across all layers.

The CommonAddress schema already defined name and detail fields, but contact_addresses had no corresponding DB columns, Go model fields, or API exposure. This PR adds them end-to-end.

- bin-dbscheme-manager: Alembic migration adding name VARCHAR(255) NOT NULL DEFAULT '' and detail VARCHAR(255) NOT NULL DEFAULT '' columns to contact_addresses (ALTER TABLE, round-trip verified MariaDB -> mysqldump -> MySQL 8.0)
- bin-contact-manager: Add Name and Detail fields to Address model struct with json tags
- bin-contact-manager: Add AddressFieldName and AddressFieldDetail constants to address.go
- bin-contact-manager: Update addressRow db struct and scanFullAddressRow to include name and detail
- bin-contact-manager: Include name and detail in AddressCreate INSERT map
- bin-contact-manager: Handle name and detail cases in AddressUpdate field switch
- bin-contact-manager: Add name and detail to AddressCreate, ContactAddressCreate, AddressUpdate request model structs
- bin-contact-manager: Pass name and detail through all listenhandler create/update paths (v1_contacts, v1_contact_addresses, v1_contacts_addresses)
- bin-contact-manager: Add name and detail columns to test SQL fixture (contacts.sql)
- bin-openapi-manager: Add name and detail fields to ContactManagerAddress response schema
- bin-openapi-manager: Add name and detail to POST/PUT request bodies in contact_addresses/main.yaml, id.yaml, contacts/id_addresses.yaml, id_addresses_id.yaml
- bin-openapi-manager: Add name and detail to service_agents address paths (4 files)
- bin-openapi-manager: Regenerate gen.go with updated ContactManagerAddress type