### PR TITLE
NOJIRA-Fix-contact-addresses-id-route

### DIFF
--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -54,7 +54,7 @@ var (
 	// v1 contact_addresses (independent resource)
 	regV1ContactAddresses        = regexp.MustCompile("/v1/contact_addresses$")
 	regV1ContactAddressesGet     = regexp.MustCompile(`/v1/contact_addresses\?(.*)$`)
-	regV1ContactAddressesID      = regexp.MustCompile("/v1/contact_addresses/" + regUUID + "$")
+	regV1ContactAddressesID      = regexp.MustCompile("/v1/contact_addresses/" + regUUID + `(\?.*)?$`)
 	regV1ContactAddressesIDClaim = regexp.MustCompile("/v1/contact_addresses/" + regUUID + "/claim$")
 
 	// v1 contacts/{id}/addresses

--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -55,7 +55,7 @@ var (
 	regV1ContactAddresses        = regexp.MustCompile("/v1/contact_addresses$")
 	regV1ContactAddressesGet     = regexp.MustCompile(`/v1/contact_addresses\?(.*)$`)
 	regV1ContactAddressesID      = regexp.MustCompile("/v1/contact_addresses/" + regUUID + `(\?.*)?$`)
-	regV1ContactAddressesIDClaim = regexp.MustCompile("/v1/contact_addresses/" + regUUID + "/claim$")
+	regV1ContactAddressesIDClaim = regexp.MustCompile("/v1/contact_addresses/" + regUUID + `/claim(\?.*)?$`)
 
 	// v1 contacts/{id}/addresses
 	regV1ContactsAddresses   = regexp.MustCompile("/v1/contacts/" + regUUID + "/addresses$")

--- a/bin-contact-manager/pkg/listenhandler/v1_contact_addresses.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contact_addresses.go
@@ -149,7 +149,12 @@ func (h *listenHandler) processV1ContactAddressesPost(ctx context.Context, m *so
 
 // processV1ContactAddressesIDGet handles GET /v1/contact_addresses/{id} request
 func (h *listenHandler) processV1ContactAddressesIDGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
-	uriItems := strings.Split(m.URI, "/")
+	u, err := url.Parse(m.URI)
+	if err != nil {
+		return simpleResponse(400), nil
+	}
+
+	uriItems := strings.Split(u.Path, "/")
 	if len(uriItems) < 4 {
 		return simpleResponse(400), nil
 	}
@@ -162,7 +167,6 @@ func (h *listenHandler) processV1ContactAddressesIDGet(ctx context.Context, m *s
 	log.WithField("request", m).Debug("Received request.")
 
 	// customer_id is passed via query param for tenant scoping
-	u, _ := url.Parse(m.URI)
 	customerID := uuid.FromStringOrNil(u.Query().Get("customer_id"))
 	if customerID == uuid.Nil {
 		log.Error("Missing or invalid customer_id.")
@@ -191,7 +195,12 @@ func (h *listenHandler) processV1ContactAddressesIDGet(ctx context.Context, m *s
 // processV1ContactAddressesIDPut handles PUT /v1/contact_addresses/{id} request
 // Body: {target?, is_primary?}
 func (h *listenHandler) processV1ContactAddressesIDPut(ctx context.Context, m *sock.Request) (*sock.Response, error) {
-	uriItems := strings.Split(m.URI, "/")
+	u, err := url.Parse(m.URI)
+	if err != nil {
+		return simpleResponse(400), nil
+	}
+
+	uriItems := strings.Split(u.Path, "/")
 	if len(uriItems) < 4 {
 		return simpleResponse(400), nil
 	}
@@ -210,7 +219,6 @@ func (h *listenHandler) processV1ContactAddressesIDPut(ctx context.Context, m *s
 	}
 
 	// Build contact_id from URI query (needed for UpdateAddress)
-	u, _ := url.Parse(m.URI)
 	contactID := uuid.FromStringOrNil(u.Query().Get("contact_id"))
 
 	fields := map[string]any{}
@@ -325,7 +333,12 @@ func (h *listenHandler) processV1ContactAddressesIDClaim(ctx context.Context, m 
 
 // processV1ContactAddressesIDDelete handles DELETE /v1/contact_addresses/{id} request
 func (h *listenHandler) processV1ContactAddressesIDDelete(ctx context.Context, m *sock.Request) (*sock.Response, error) {
-	uriItems := strings.Split(m.URI, "/")
+	u, err := url.Parse(m.URI)
+	if err != nil {
+		return simpleResponse(400), nil
+	}
+
+	uriItems := strings.Split(u.Path, "/")
 	if len(uriItems) < 4 {
 		return simpleResponse(400), nil
 	}
@@ -337,7 +350,6 @@ func (h *listenHandler) processV1ContactAddressesIDDelete(ctx context.Context, m
 	})
 	log.WithField("request", m).Debug("Received request.")
 
-	u, _ := url.Parse(m.URI)
 	contactID := uuid.FromStringOrNil(u.Query().Get("contact_id"))
 
 	tmp, err := h.contactHandler.RemoveAddress(ctx, contactID, id)

--- a/bin-contact-manager/pkg/listenhandler/v1_contact_addresses_routing_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contact_addresses_routing_test.go
@@ -1,0 +1,110 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/pkg/addresshandler"
+	"monorepo/bin-contact-manager/pkg/contacthandler"
+)
+
+// Test_processRequest_ContactAddressesID_Routing is a regression test for
+// https://github.com/voipbin/monorepo/issues/1042: GET/PUT/DELETE
+// /v1/contact_addresses/{id} requests always carry a trailing
+// "?customer_id=..." (or "?contact_id=...") query string, appended by every
+// caller in bin-common-handler/pkg/requesthandler/contact_contact_addresses.go.
+// regV1ContactAddressesID previously ended in a bare "$" anchor, so it never
+// matched these URIs and the request fell through processRequest's switch
+// with no matching case, silently returning a 404-equivalent response.
+//
+// This test dispatches through processRequest (not the handler function
+// directly) so the URI-matching routing layer itself is exercised, matching
+// the class of bug that unit-testing the handler function alone missed.
+func Test_processRequest_ContactAddressesID_Routing(t *testing.T) {
+	customerID := uuid.FromStringOrNil("11111111-0002-0002-0002-000000000001")
+	contactID := uuid.FromStringOrNil("11111111-0002-0002-0002-000000000002")
+	addressID := uuid.FromStringOrNil("11111111-0002-0002-0002-000000000003")
+
+	tests := []struct {
+		name    string
+		request *sock.Request
+
+		setupMock func(mockAddress *addresshandler.MockAddressHandler, mockContact *contacthandler.MockContactHandler)
+
+		expectCode int
+	}{
+		{
+			name: "GET /contact_addresses/{id}?customer_id=... routes correctly",
+			request: &sock.Request{
+				URI:    "/v1/contact_addresses/" + addressID.String() + "?customer_id=" + customerID.String(),
+				Method: sock.RequestMethodGet,
+			},
+			setupMock: func(mockAddress *addresshandler.MockAddressHandler, _ *contacthandler.MockContactHandler) {
+				mockAddress.EXPECT().GetAddress(gomock.Any(), customerID, addressID).Return(&contact.Address{
+					ID:         addressID,
+					CustomerID: customerID,
+				}, nil)
+			},
+			expectCode: 200,
+		},
+		{
+			name: "PUT /contact_addresses/{id}?contact_id=... routes correctly",
+			request: &sock.Request{
+				URI:    "/v1/contact_addresses/" + addressID.String() + "?contact_id=" + contactID.String(),
+				Method: sock.RequestMethodPut,
+				Data:   []byte(`{"target":"+15551234567"}`),
+			},
+			setupMock: func(_ *addresshandler.MockAddressHandler, mockContact *contacthandler.MockContactHandler) {
+				mockContact.EXPECT().UpdateAddress(gomock.Any(), contactID, addressID, gomock.Any()).Return(&contact.Contact{
+					Addresses: []contact.Address{
+						{ID: addressID, CustomerID: customerID, Target: "+15551234567"},
+					},
+				}, nil)
+			},
+			expectCode: 200,
+		},
+		{
+			name: "DELETE /contact_addresses/{id}?contact_id=... routes correctly",
+			request: &sock.Request{
+				URI:    "/v1/contact_addresses/" + addressID.String() + "?contact_id=" + contactID.String(),
+				Method: sock.RequestMethodDelete,
+			},
+			setupMock: func(_ *addresshandler.MockAddressHandler, mockContact *contacthandler.MockContactHandler) {
+				mockContact.EXPECT().RemoveAddress(gomock.Any(), contactID, addressID).Return(&contact.Contact{}, nil)
+			},
+			expectCode: 200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockAddress := addresshandler.NewMockAddressHandler(mc)
+			mockContact := contacthandler.NewMockContactHandler(mc)
+			tt.setupMock(mockAddress, mockContact)
+
+			h := &listenHandler{
+				addressHandler: mockAddress,
+				contactHandler: mockContact,
+			}
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Fatalf("processRequest() error = %v", err)
+			}
+			if res == nil {
+				t.Fatalf("processRequest() returned nil response; request did not match any route (regression of #1042)")
+			}
+			if res.StatusCode != tt.expectCode {
+				t.Errorf("processRequest() StatusCode = %d, want %d", res.StatusCode, tt.expectCode)
+			}
+		})
+	}
+}

--- a/bin-contact-manager/pkg/listenhandler/v1_contact_addresses_routing_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contact_addresses_routing_test.go
@@ -79,6 +79,25 @@ func Test_processRequest_ContactAddressesID_Routing(t *testing.T) {
 			},
 			expectCode: 200,
 		},
+		{
+			// Same bug class as #1042, found in review: the /claim sub-route
+			// regex (regV1ContactAddressesIDClaim) also ended in a bare "$"
+			// anchor while ContactV1ContactAddressClaim appends
+			// "?customer_id=..." to every call, so claim requests 404'd too.
+			name: "POST /contact_addresses/{id}/claim?customer_id=... routes correctly",
+			request: &sock.Request{
+				URI:    "/v1/contact_addresses/" + addressID.String() + "/claim?customer_id=" + customerID.String(),
+				Method: sock.RequestMethodPost,
+				Data:   []byte(`{"contact_id":"` + contactID.String() + `"}`),
+			},
+			setupMock: func(_ *addresshandler.MockAddressHandler, mockContact *contacthandler.MockContactHandler) {
+				mockContact.EXPECT().ClaimAddress(gomock.Any(), customerID, addressID, contactID).Return(&contact.Address{
+					ID:         addressID,
+					CustomerID: customerID,
+				}, nil)
+			},
+			expectCode: 200,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #1042. GET/PUT/DELETE /v1/contact_addresses/{id} always fell through the routing switch with no matching case (surfaced as 404), because every caller in bin-common-handler builds the URI with a trailing ?customer_id=... or ?contact_id=... query string, but regV1ContactAddressesID ended in a bare $ anchor that required nothing after the UUID.

- bin-contact-manager: Loosen regV1ContactAddressesID to tolerate an optional trailing query string, consistent with the sibling GET-list regex
- bin-contact-manager: Fix processV1ContactAddressesIDGet/Put/Delete to parse the ID from url.Parse(m.URI).Path rather than the raw URI string; splitting the raw URI on "/" glued the query string onto the last path segment, which would have made uuid.FromStringOrNil silently return uuid.Nil once the routing regex was loosened (a second bug the issue description did not call out)
- bin-contact-manager: Found in review (independent adversarial pass) that regV1ContactAddressesIDClaim had the identical bare-$-anchor bug: ContactV1ContactAddressClaim also appends ?customer_id=... to its URI, so POST /contact_addresses/{id}/claim was equally broken in production. Loosened that regex the same way.
- bin-contact-manager: Add a routing-layer regression test (Test_processRequest_ContactAddressesID_Routing) covering GET/PUT/DELETE/claim, dispatching through processRequest per the issue's ask for a test at the URI-matching layer rather than the handler function directly. Verified each sub-case fails against its pre-fix regex and passes with the fix.
