### PR TITLE
NOJIRA-Contact-manager-duplicate-address-conflict

### DIFF
--- a/bin-contact-manager/docs/plans/2026-07-02-duplicate-address-conflict.md
+++ b/bin-contact-manager/docs/plans/2026-07-02-duplicate-address-conflict.md
@@ -1,0 +1,172 @@
+# Design: distinguishable conflict status on duplicate contact address (#1044)
+
+## Problem
+
+`AddAddress` (pkg/contacthandler/contact.go) does not classify the DB error
+it receives from `db.AddressCreate`. `contact_addresses` enforces a unique
+index on `(customer_id, type, target)`, so adding an address that already
+exists for the customer always fails at the DB layer with a duplicate-key
+error. Both listenhandler call sites that reach `AddAddress` collapse every
+error into a bare 500:
+
+- `processV1ContactsAddressesPost` (pkg/listenhandler/v1_contacts_addresses.go,
+  the endpoint named in the issue: `POST /v1/contacts/{id}/addresses`)
+- `processV1ContactAddressesPost` (pkg/listenhandler/v1_contact_addresses.go,
+  the sibling independent-resource endpoint: `POST /v1/contact_addresses`
+  with `contact_id` in the body). This one calls the identical
+  `contactHandler.AddAddress` for the resolved-contact branch and has the
+  exact same bug, just not named in the issue text.
+
+Both must be fixed together or the platform ships an inconsistency where one
+endpoint returns 409 and the sibling still returns bare 500 for the same
+underlying DB conflict.
+
+## Reference pattern already in the codebase
+
+`ClaimAddress` / `dbhandler.AddressClaim` already established the intended
+shape for this class of bug:
+
+- dbhandler owns a sentinel error (`ErrConflict`) and returns it on the
+  specific DB condition it detects.
+- contacthandler classifies with `stderrors.Is(err, dbhandler.ErrConflict)`
+  and maps it to a typed `cerrors.AlreadyExists(...)`.
+- listenhandler routes the typed error through `errorResponse(err)`, which
+  already knows how to turn a `*cerrors.VoipbinError` into the correct
+  `sock.Response` (see `errorResponse` in pkg/listenhandler/main.go, and
+  `cerrors.AlreadyExists` doc comment confirming it maps to 409).
+
+`InteractionCreate` (pkg/dbhandler/interaction.go) already has the exact
+MySQL-errno-1062 / SQLite-"UNIQUE constraint failed" detection idiom this
+fix needs, just used for a different purpose (idempotent silent-ignore
+instead of surfacing a conflict).
+
+## Plan
+
+### 1. dbhandler: detect the unique-constraint violation on `AddressCreate`
+
+New sentinel error, distinct from `ErrConflict` (whose existing message
+"address already claimed" is specific to the claim flow and would be
+misleading in AddAddress logs/tests; `ErrConflict` is also load-bearing
+elsewhere, e.g. `Test_ClaimAddress_Conflict`, so reusing it for a different
+condition risks confusing that test's intent).
+
+`pkg/dbhandler/address.go` currently imports neither `strings` nor
+`mysql_driver "github.com/go-sql-driver/mysql"` — both must be added,
+mirroring the exact imports already present in `pkg/dbhandler/interaction.go`.
+
+```go
+// pkg/dbhandler/main.go
+ErrDuplicateTarget = fmt.Errorf("address already exists for this customer")
+```
+
+In `AddressCreate` (pkg/dbhandler/address.go), wrap the `h.db.Exec` error
+check with the same MySQL 1062 / SQLite UNIQUE-constraint detection used in
+`InteractionCreate`, returning `ErrDuplicateTarget` instead of the generic
+wrapped error.
+
+### 2. contacthandler: classify and map to a typed conflict
+
+In `AddAddress` (pkg/contacthandler/contact.go), after
+`h.db.AddressCreate(ctx, a)`:
+
+```go
+if err := h.db.AddressCreate(ctx, a); err != nil {
+    if stderrors.Is(err, dbhandler.ErrDuplicateTarget) {
+        return nil, cerrors.AlreadyExists(
+            commonoutline.ServiceNameContactManager,
+            "ADDRESS_ALREADY_EXISTS",
+            "An address with this type and target already exists for this customer.",
+        ).Wrap(err)
+    }
+    return nil, fmt.Errorf("could not create address: %w", err)
+}
+```
+
+Reason code `ADDRESS_ALREADY_EXISTS` is new and distinct from the existing
+`ADDRESS_ALREADY_CLAIMED` (claim flow) so callers can tell the two conflict
+classes apart if they ever need to.
+
+### 3. listenhandler: route through `errorResponse` instead of a bare 500
+
+Both call sites change from:
+
+```go
+tmp, err := h.contactHandler.AddAddress(ctx, contactID, address)
+if err != nil {
+    log.Errorf("Could not add address. err: %v", err)
+    return simpleResponse(500), nil
+}
+```
+
+to:
+
+```go
+tmp, err := h.contactHandler.AddAddress(ctx, contactID, address)
+if err != nil {
+    log.Errorf("Could not add address. err: %v", err)
+    return errorResponse(err), nil
+}
+```
+
+Files: `pkg/listenhandler/v1_contacts_addresses.go` (`processV1ContactsAddressesPost`)
+and `pkg/listenhandler/v1_contact_addresses.go` (`processV1ContactAddressesPost`,
+resolved-contact branch only, i.e. the branch that calls
+`contactHandler.AddAddress`).
+
+**Decided scope (not deferred to implementation):** the unresolved-address
+branch of `processV1ContactAddressesPost` (calls `CreateUnresolvedAddress`,
+lines ~100-110 of v1_contact_addresses.go) is explicitly OUT OF SCOPE for
+this PR and keeps its current `simpleResponse(500)`. `CreateUnresolvedAddress`
+also calls `h.db.AddressCreate` and will transitively receive the same new
+`dbhandler.ErrDuplicateTarget` sentinel, but since it does not classify it,
+the error still falls through to `fmt.Errorf(...): %w` and 500 unchanged.
+This is NOT a regression (behavior is identical to today), just a known,
+explicitly-tracked follow-up: classifying `CreateUnresolvedAddress` the same
+way is a candidate for a dedicated follow-up issue/PR, not bundled here,
+since the original issue #1044 scopes only to the resolved `AddAddress`
+path.
+
+**Documented side effect (intentional, in-scope):** `AddAddress`
+(contact.go:261-264) calls `h.db.ContactGet(ctx, contactID)` first and
+returns that error unwrapped if the contact does not exist. Today this is
+masked as bare 500 by both call sites. After switching to
+`errorResponse(err)`, a nonexistent `contactID` will now correctly surface
+as **404** (via `errorResponse`'s `dbhandler.ErrNotFound` fallback) instead
+of 500. This is a second, small, correct behavior change riding along with
+the primary fix — called out explicitly here so it is not mistaken for an
+unreviewed regression. The new listenhandler-routing tests (section 4)
+must include a case asserting this 404 path in addition to the new 409
+path.
+
+### 4. Regression tests
+
+- `pkg/dbhandler/address_test.go`: `Test_AddressCreate_Duplicate` — create
+  once, attempt a second create with same `(customer_id, type, target)`,
+  assert `errors.Is(err, ErrDuplicateTarget)`.
+- `pkg/contacthandler/contact_test.go`: extend/add a case asserting
+  `AddAddress` maps a duplicate-target dbhandler error to a
+  `cerrors.VoipbinError` with `Status == cerrors.StatusAlreadyExists` and
+  `Reason == "ADDRESS_ALREADY_EXISTS"`.
+- `pkg/listenhandler/v1_contacts_addresses_test.go` (new or existing file):
+  routing-level tests for `processV1ContactsAddressesPost` asserting:
+  (a) 409 (not 500) when `contactHandler.AddAddress` returns the typed
+  conflict, following the pattern used for issue #1042's regression test;
+  (b) 404 (not 500) when `contactHandler.AddAddress` returns
+  `dbhandler.ErrNotFound` (documented side effect above).
+- Same two routing-level assertions (409 and 404) for
+  `processV1ContactAddressesPost`'s resolved-contact branch.
+- Confirm the existing `IsPrimary`-reset-then-create path (contact.go:279-283)
+  is unaffected: `AddAddress`'s test coverage should include a case where
+  `IsPrimary=true` and `AddressCreate` fails with the duplicate-target
+  conflict, asserting the typed error is still returned correctly (primaries
+  having already been reset with no rollback is pre-existing behavior, not
+  newly introduced or worsened by this fix — note this in the test comment
+  so a future reviewer does not mistake it for a new bug).
+
+## Not in scope
+
+- `CreateUnresolvedAddress` duplicate handling — explicitly deferred to a
+  follow-up PR/issue, per the decided-scope note in section 3 (firm
+  decision, not an open question). Not a blocker for the primary fix.
+- Square-admin frontend changes (separate PR, referenced in the issue as
+  the downstream consumer of this fix).

--- a/bin-contact-manager/pkg/contacthandler/contact.go
+++ b/bin-contact-manager/pkg/contacthandler/contact.go
@@ -283,6 +283,13 @@ func (h *contactHandler) AddAddress(ctx context.Context, contactID uuid.UUID, a 
 	}
 
 	if err := h.db.AddressCreate(ctx, a); err != nil {
+		if stderrors.Is(err, dbhandler.ErrDuplicateTarget) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameContactManager,
+				"ADDRESS_ALREADY_EXISTS",
+				"An address with this type and target already exists for this customer.",
+			).Wrap(err)
+		}
 		return nil, fmt.Errorf("could not create address: %w", err)
 	}
 

--- a/bin-contact-manager/pkg/contacthandler/contact.go
+++ b/bin-contact-manager/pkg/contacthandler/contact.go
@@ -275,7 +275,18 @@ func (h *contactHandler) AddAddress(ctx context.Context, contactID uuid.UUID, a 
 		a.Target, _ = commonaddress.NormalizeTarget(commonaddress.TypeEmail, a.Target)
 	}
 
-	// Enforce single primary: reset existing primaries before setting new one
+	// Enforce single primary: reset existing primaries before setting new one.
+	// NOTE: AddressResetPrimary and AddressCreate are two separate,
+	// unguarded statements (no transaction wrapping them). Under
+	// concurrent AddAddress(IsPrimary=true) calls for the same contact,
+	// the reset/insert pair can interleave and the losing request's
+	// insert can then collide on idx_contact_addresses_cust_primary
+	// (the one-primary-per-contact invariant), which AddressCreate now
+	// correctly classifies as a non-ErrDuplicateTarget error (see the
+	// index-name check in AddressCreate) rather than misreporting it as
+	// ADDRESS_ALREADY_EXISTS. This ordering/non-atomicity predates this
+	// fix and is not addressed here; flagged for a future transactional
+	// follow-up if the race is ever observed in production.
 	if a.IsPrimary {
 		if err := h.db.AddressResetPrimary(ctx, contactID); err != nil {
 			return nil, fmt.Errorf("could not reset primary address: %w", err)

--- a/bin-contact-manager/pkg/contacthandler/contact_test.go
+++ b/bin-contact-manager/pkg/contacthandler/contact_test.go
@@ -2,6 +2,7 @@ package contacthandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	cmcustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
@@ -985,6 +987,100 @@ func Test_AddAddress_Error(t *testing.T) {
 	_, err := h.AddAddress(ctx, contactID, addr)
 	if err == nil {
 		t.Error("AddAddress() expected error")
+	}
+}
+
+// Test_AddAddress_DuplicateTarget covers the classification path added for
+// issue #1044: a dbhandler.ErrDuplicateTarget from AddressCreate must be
+// mapped to a typed cerrors.AlreadyExists conflict (reason
+// ADDRESS_ALREADY_EXISTS), not a bare generic error, so the listenhandler
+// can route it to 409 via errorResponse instead of a bare 500.
+func Test_AddAddress_DuplicateTarget(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := contactHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	contactID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
+	addr := &contact.Address{Type: contact.AddressTypeTel, Target: "+1-555-123-4567"}
+
+	responseContact := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         contactID,
+			CustomerID: uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222"),
+		},
+	}
+
+	mockDB.EXPECT().ContactGet(ctx, contactID).Return(responseContact, nil)
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333"))
+	mockDB.EXPECT().AddressCreate(ctx, gomock.Any()).Return(dbhandler.ErrDuplicateTarget)
+
+	_, err := h.AddAddress(ctx, contactID, addr)
+
+	var ve *cerrors.VoipbinError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("AddAddress() expected a typed *cerrors.VoipbinError, got: %v (%T)", err, err)
+	}
+	if ve.Status != cerrors.StatusAlreadyExists {
+		t.Errorf("AddAddress() Status = %v, want %v", ve.Status, cerrors.StatusAlreadyExists)
+	}
+	if ve.Reason != "ADDRESS_ALREADY_EXISTS" {
+		t.Errorf("AddAddress() Reason = %q, want %q", ve.Reason, "ADDRESS_ALREADY_EXISTS")
+	}
+}
+
+// Test_AddAddress_DuplicateTarget_PrimaryReset confirms the existing
+// IsPrimary-reset-then-create ordering (AddressResetPrimary runs BEFORE
+// AddressCreate) is unaffected by the new classification: even when the
+// address being added is IsPrimary=true and AddressCreate then fails with
+// ErrDuplicateTarget, the typed conflict is still returned correctly. Note:
+// the reset having already run with no compensating rollback is pre-existing
+// behavior, not newly introduced or worsened by this fix.
+func Test_AddAddress_DuplicateTarget_PrimaryReset(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := contactHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	contactID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111112")
+	addr := &contact.Address{Type: contact.AddressTypeTel, Target: "+1-555-123-4568", IsPrimary: true}
+
+	responseContact := &contact.Contact{
+		Identity: commonidentity.Identity{
+			ID:         contactID,
+			CustomerID: uuid.FromStringOrNil("22222222-2222-2222-2222-222222222223"),
+		},
+	}
+
+	mockDB.EXPECT().ContactGet(ctx, contactID).Return(responseContact, nil)
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.FromStringOrNil("33333333-3333-3333-3333-333333333334"))
+	mockDB.EXPECT().AddressResetPrimary(ctx, contactID).Return(nil)
+	mockDB.EXPECT().AddressCreate(ctx, gomock.Any()).Return(dbhandler.ErrDuplicateTarget)
+
+	_, err := h.AddAddress(ctx, contactID, addr)
+
+	var ve *cerrors.VoipbinError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("AddAddress() expected a typed *cerrors.VoipbinError, got: %v (%T)", err, err)
+	}
+	if ve.Reason != "ADDRESS_ALREADY_EXISTS" {
+		t.Errorf("AddAddress() Reason = %q, want %q", ve.Reason, "ADDRESS_ALREADY_EXISTS")
 	}
 }
 

--- a/bin-contact-manager/pkg/dbhandler/address.go
+++ b/bin-contact-manager/pkg/dbhandler/address.go
@@ -135,16 +135,33 @@ func (h *handler) AddressCreate(ctx context.Context, a *contact.Address) error {
 	}
 
 	if _, err := h.db.Exec(query, args...); err != nil {
-		// Detect a unique-constraint violation on
+		// Detect a unique-constraint violation SPECIFICALLY on
 		// idx_contact_addresses_cust_type_target(customer_id, type, target)
 		// and surface it as a typed sentinel so callers can distinguish
 		// "duplicate address" from a genuine infrastructure failure.
-		// MySQL errno 1062 in production; SQLite "UNIQUE constraint failed"
-		// in tests. Same detection idiom as InteractionCreate.
+		//
+		// contact_addresses has a SECOND unique index,
+		// idx_contact_addresses_cust_primary(customer_id, primary_contact_uk),
+		// enforcing the one-primary-per-contact invariant via a generated
+		// column. Both indexes can raise MySQL errno 1062 / SQLite "UNIQUE
+		// constraint failed", so the violated index/key name MUST be
+		// inspected — checking only the errno/substring would misclassify
+		// a primary-invariant violation as a duplicate-target conflict.
+		// MySQL's error message names the violated key (e.g. "Duplicate
+		// entry '...' for key 'idx_contact_addresses_cust_type_target'");
+		// SQLite's names the violated columns (e.g. "UNIQUE constraint
+		// failed: contact_addresses.customer_id, contact_addresses.type,
+		// contact_addresses.target"). Same detection idiom as
+		// InteractionCreate, narrowed to the specific index.
 		if me, ok := err.(*mysql_driver.MySQLError); ok && me.Number == 1062 {
-			return ErrDuplicateTarget
+			if strings.Contains(me.Message, "idx_contact_addresses_cust_type_target") {
+				return ErrDuplicateTarget
+			}
+			return fmt.Errorf("could not execute. AddressCreate. err: %v", err)
 		}
-		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") &&
+			strings.Contains(err.Error(), "contact_addresses.type") &&
+			strings.Contains(err.Error(), "contact_addresses.target") {
 			return ErrDuplicateTarget
 		}
 		return fmt.Errorf("could not execute. AddressCreate. err: %v", err)

--- a/bin-contact-manager/pkg/dbhandler/address.go
+++ b/bin-contact-manager/pkg/dbhandler/address.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
+	mysql_driver "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/uuid"
 
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
@@ -133,6 +135,18 @@ func (h *handler) AddressCreate(ctx context.Context, a *contact.Address) error {
 	}
 
 	if _, err := h.db.Exec(query, args...); err != nil {
+		// Detect a unique-constraint violation on
+		// idx_contact_addresses_cust_type_target(customer_id, type, target)
+		// and surface it as a typed sentinel so callers can distinguish
+		// "duplicate address" from a genuine infrastructure failure.
+		// MySQL errno 1062 in production; SQLite "UNIQUE constraint failed"
+		// in tests. Same detection idiom as InteractionCreate.
+		if me, ok := err.(*mysql_driver.MySQLError); ok && me.Number == 1062 {
+			return ErrDuplicateTarget
+		}
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			return ErrDuplicateTarget
+		}
 		return fmt.Errorf("could not execute. AddressCreate. err: %v", err)
 	}
 

--- a/bin-contact-manager/pkg/dbhandler/address_test.go
+++ b/bin-contact-manager/pkg/dbhandler/address_test.go
@@ -3,6 +3,7 @@ package dbhandler
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"testing"
 	"time"
 
@@ -216,6 +217,84 @@ func Test_AddressCreate(t *testing.T) {
 	}
 	if !got.IsPrimary {
 		t.Errorf("AddressCreate() IsPrimary = false, want true")
+	}
+}
+
+// Test_AddressCreate_Duplicate covers the unique-constraint guard on
+// idx_contact_addresses_cust_type_target(customer_id, type, target):
+// inserting a second address with the same (customer_id, type, target)
+// tuple must surface ErrDuplicateTarget, not a generic wrapped error, per
+// issue #1044 (POST /v1/contacts/{id}/addresses returned bare 500 on
+// duplicate address instead of a distinguishable conflict status).
+func Test_AddressCreate_Duplicate(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("ab1b2c3d-0010-0010-0010-000000000001")
+	contactID1 := uuid.FromStringOrNil("ab1b2c3d-0010-0010-0010-000000000002")
+	contactID2 := uuid.FromStringOrNil("ab1b2c3d-0010-0010-0010-000000000003")
+	curTime := timePtr(time.Date(2026, 6, 28, 9, 0, 0, 0, time.UTC))
+
+	// Create two parent contacts for the same customer
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	c1 := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID1, CustomerID: customerID},
+		Source:   "manual",
+	}
+	if err := h.ContactCreate(ctx, c1); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	c2 := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID2, CustomerID: customerID},
+		Source:   "manual",
+	}
+	if err := h.ContactCreate(ctx, c2); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	target := "+155****9001"
+
+	// first insert for contact1 succeeds
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	a1 := &contact.Address{
+		ID:         uuid.FromStringOrNil("ab1b2c3d-0010-0010-0010-000000000004"),
+		CustomerID: customerID,
+		ContactID:  contactID1,
+		Type:       contact.AddressTypeTel,
+		Target:     target,
+	}
+	if err := h.AddressCreate(ctx, a1); err != nil {
+		t.Fatalf("first AddressCreate() error = %v", err)
+	}
+
+	// second insert with the same (customer_id, type, target), even under a
+	// DIFFERENT contact, must be rejected as a duplicate — the unique index
+	// is scoped to customer_id, not contact_id.
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	a2 := &contact.Address{
+		ID:         uuid.FromStringOrNil("ab1b2c3d-0010-0010-0010-000000000005"),
+		CustomerID: customerID,
+		ContactID:  contactID2,
+		Type:       contact.AddressTypeTel,
+		Target:     target,
+	}
+	err := h.AddressCreate(ctx, a2)
+	if !stderrors.Is(err, ErrDuplicateTarget) {
+		t.Errorf("AddressCreate() duplicate target: expected ErrDuplicateTarget, got: %v", err)
 	}
 }
 

--- a/bin-contact-manager/pkg/dbhandler/address_test.go
+++ b/bin-contact-manager/pkg/dbhandler/address_test.go
@@ -298,6 +298,82 @@ func Test_AddressCreate_Duplicate(t *testing.T) {
 	}
 }
 
+// Test_AddressCreate_PrimaryIndexCollision_NotMisclassified is a regression
+// test for a round-2 PR-review finding on issue #1044's fix:
+// contact_addresses has a SECOND unique index,
+// idx_contact_addresses_cust_primary(customer_id, primary_contact_uk), which
+// enforces the one-primary-per-contact invariant via a generated column.
+// Both this index and idx_contact_addresses_cust_type_target can raise
+// MySQL errno 1062 / SQLite "UNIQUE constraint failed", so AddressCreate's
+// duplicate-target detection must inspect WHICH index/key fired, not just
+// the errno/substring — otherwise a primary-invariant violation (two
+// addresses with DIFFERENT type/target, both IsPrimary=true, for the same
+// contact) gets misclassified as ErrDuplicateTarget / ADDRESS_ALREADY_EXISTS
+// (409), which is materially wrong for what is actually a different
+// constraint being violated.
+func Test_AddressCreate_PrimaryIndexCollision_NotMisclassified(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("ab1b2c3d-0011-0011-0011-000000000001")
+	contactID := uuid.FromStringOrNil("ab1b2c3d-0011-0011-0011-000000000002")
+	curTime := timePtr(time.Date(2026, 6, 28, 9, 0, 0, 0, time.UTC))
+
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID, CustomerID: customerID},
+		Source:   "manual",
+	}
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	// first primary address: tel
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	mockCache.EXPECT().ContactSet(ctx, gomock.Any())
+	a1 := &contact.Address{
+		ID:         uuid.FromStringOrNil("ab1b2c3d-0011-0011-0011-000000000003"),
+		CustomerID: customerID,
+		ContactID:  contactID,
+		Type:       contact.AddressTypeTel,
+		Target:     "+155****9101",
+		IsPrimary:  true,
+	}
+	if err := h.AddressCreate(ctx, a1); err != nil {
+		t.Fatalf("first AddressCreate() error = %v", err)
+	}
+
+	// second primary address: DIFFERENT type/target, same contact, also
+	// primary — collides on idx_contact_addresses_cust_primary, NOT on
+	// idx_contact_addresses_cust_type_target. Must NOT be ErrDuplicateTarget.
+	mockUtil.EXPECT().TimeNow().Return(curTime)
+	a2 := &contact.Address{
+		ID:         uuid.FromStringOrNil("ab1b2c3d-0011-0011-0011-000000000004"),
+		CustomerID: customerID,
+		ContactID:  contactID,
+		Type:       contact.AddressTypeEmail,
+		Target:     "second-primary@example.com",
+		IsPrimary:  true,
+	}
+	err := h.AddressCreate(ctx, a2)
+	if err == nil {
+		t.Fatal("AddressCreate() expected an error for the primary-index collision, got nil")
+	}
+	if stderrors.Is(err, ErrDuplicateTarget) {
+		t.Errorf("AddressCreate() primary-index collision must NOT be classified as ErrDuplicateTarget (that index/key is idx_contact_addresses_cust_primary, not idx_contact_addresses_cust_type_target), got: %v", err)
+	}
+}
+
 func Test_AddressUpdate(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -70,6 +70,12 @@ type handler struct {
 var (
 	ErrNotFound = fmt.Errorf("record not found")
 	ErrConflict = fmt.Errorf("address already claimed")
+
+	// ErrDuplicateTarget is returned by AddressCreate when the insert
+	// violates the unique index on contact_addresses(customer_id, type,
+	// target). Distinct from ErrConflict, whose message ("address already
+	// claimed") is specific to the ClaimAddress flow.
+	ErrDuplicateTarget = fmt.Errorf("address already exists for this customer")
 )
 
 // NewHandler creates DBHandler

--- a/bin-contact-manager/pkg/listenhandler/v1_contact_addresses.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contact_addresses.go
@@ -131,7 +131,7 @@ func (h *listenHandler) processV1ContactAddressesPost(ctx context.Context, m *so
 	})
 	if err != nil {
 		log.Errorf("Could not add address. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-contact-manager/pkg/listenhandler/v1_contacts_addresses.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contacts_addresses.go
@@ -93,7 +93,7 @@ func (h *listenHandler) processV1ContactsAddressesPost(ctx context.Context, m *s
 	tmp, err := h.contactHandler.AddAddress(ctx, contactID, address)
 	if err != nil {
 		log.Errorf("Could not add address. err: %v", err)
-		return simpleResponse(500), nil
+		return errorResponse(err), nil
 	}
 
 	data, err := json.Marshal(tmp)

--- a/bin-contact-manager/pkg/listenhandler/v1_contacts_addresses_post_error_routing_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_contacts_addresses_post_error_routing_test.go
@@ -1,0 +1,150 @@
+package listenhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/pkg/contacthandler"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// Test_processV1ContactsAddressesPost_ErrorRouting is a regression test for
+// https://github.com/voipbin/monorepo/issues/1044: POST
+// /v1/contacts/{id}/addresses collapsed every AddAddress error into a bare
+// 500, giving callers no way to distinguish "this address already exists
+// on this contact" (a typed conflict) from a genuine infrastructure
+// failure or a not-found contact. processV1ContactsAddressesPost now
+// routes AddAddress errors through errorResponse instead of an
+// unconditional simpleResponse(500).
+func Test_processV1ContactsAddressesPost_ErrorRouting(t *testing.T) {
+	contactID := uuid.FromStringOrNil("11111111-0004-0004-0004-000000000001")
+
+	tests := []struct {
+		name string
+
+		addAddressErr error
+		expectCode    int
+	}{
+		{
+			name: "duplicate address -> 409, not 500",
+			addAddressErr: cerrors.AlreadyExists(
+				commonoutline.ServiceNameContactManager,
+				"ADDRESS_ALREADY_EXISTS",
+				"An address with this type and target already exists for this customer.",
+			),
+			expectCode: 409,
+		},
+		{
+			name:          "nonexistent contact -> 404, not 500",
+			addAddressErr: dbhandler.ErrNotFound,
+			expectCode:    404,
+		},
+		{
+			name:          "genuine infrastructure failure -> 500",
+			addAddressErr: cerrors.Internal(commonoutline.ServiceNameContactManager, "DB_ERROR", "database is unavailable"),
+			expectCode:    500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockContact := contacthandler.NewMockContactHandler(mc)
+			h := &listenHandler{
+				contactHandler: mockContact,
+			}
+
+			mockContact.EXPECT().AddAddress(gomock.Any(), contactID, gomock.Any()).Return(nil, tt.addAddressErr)
+
+			request := &sock.Request{
+				URI:      "/v1/contacts/" + contactID.String() + "/addresses",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"type":"tel","target":"+1-555-000-0000"}`),
+			}
+
+			res, err := h.processRequest(request)
+			if err != nil {
+				t.Fatalf("processRequest() error = %v", err)
+			}
+			if res == nil {
+				t.Fatalf("processRequest() returned nil response; request did not match any route")
+			}
+			if res.StatusCode != tt.expectCode {
+				t.Errorf("processRequest() StatusCode = %d, want %d", res.StatusCode, tt.expectCode)
+			}
+		})
+	}
+}
+
+// Test_processV1ContactAddressesPost_ErrorRouting covers the sibling
+// independent-resource endpoint (POST /v1/contact_addresses with
+// contact_id in the body), which shares the exact same AddAddress call and
+// the exact same bug for issue #1044, even though only the
+// /contacts/{id}/addresses endpoint was named in the issue text.
+func Test_processV1ContactAddressesPost_ErrorRouting(t *testing.T) {
+	contactID := uuid.FromStringOrNil("11111111-0004-0004-0004-000000000002")
+
+	tests := []struct {
+		name string
+
+		addAddressErr error
+		expectCode    int
+	}{
+		{
+			name: "duplicate address -> 409, not 500",
+			addAddressErr: cerrors.AlreadyExists(
+				commonoutline.ServiceNameContactManager,
+				"ADDRESS_ALREADY_EXISTS",
+				"An address with this type and target already exists for this customer.",
+			),
+			expectCode: 409,
+		},
+		{
+			name:          "nonexistent contact -> 404, not 500",
+			addAddressErr: dbhandler.ErrNotFound,
+			expectCode:    404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockContact := contacthandler.NewMockContactHandler(mc)
+			h := &listenHandler{
+				contactHandler: mockContact,
+			}
+
+			mockContact.EXPECT().AddAddress(gomock.Any(), contactID, gomock.Any()).Return(nil, tt.addAddressErr)
+
+			request := &sock.Request{
+				URI:      "/v1/contact_addresses",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"contact_id":"` + contactID.String() + `","type":"tel","target":"+1-555-000-0000"}`),
+			}
+
+			res, err := h.processRequest(request)
+			if err != nil {
+				t.Fatalf("processRequest() error = %v", err)
+			}
+			if res == nil {
+				t.Fatalf("processRequest() returned nil response; request did not match any route")
+			}
+			if res.StatusCode != tt.expectCode {
+				t.Errorf("processRequest() StatusCode = %d, want %d", res.StatusCode, tt.expectCode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Give POST /v1/contacts/{id}/addresses (and its sibling POST /v1/contact_addresses) a distinguishable conflict status instead of a bare 500 when the address already exists for the customer.

- bin-contact-manager: Add dbhandler.ErrDuplicateTarget sentinel, detected in AddressCreate via MySQL errno 1062 / SQLite UNIQUE constraint failed, mirroring the existing InteractionCreate idiom
- bin-contact-manager: Classify ErrDuplicateTarget in contacthandler.AddAddress into a typed cerrors.AlreadyExists with reason ADDRESS_ALREADY_EXISTS, mirroring the existing ClaimAddress/ErrConflict pattern
- bin-contact-manager: Route processV1ContactsAddressesPost and processV1ContactAddressesPost errors through errorResponse instead of an unconditional simpleResponse(500), so the typed conflict maps to 409 and a nonexistent contact now correctly maps to 404
- bin-contact-manager: Add regression tests at the dbhandler, contacthandler, and listenhandler-routing layers, plus a design doc under docs/plans/ recording the scope decisions from the design review loop (CreateUnresolvedAddress duplicate handling explicitly deferred to a follow-up; the ContactGet-not-found now surfacing as 404 documented as an intentional side effect)

Closes #1044