### PR TITLE
NOJIRA-Contact-Interaction-Exclude-Internal-Peer-Types

### DIFF
--- a/bin-contact-manager/pkg/contacthandler/interaction.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction.go
@@ -31,6 +31,40 @@ func deriveEndpoints(direction string, source, dest commonaddress.Address) (peer
 	}
 }
 
+// crmIneligiblePeerTypes lists address types that never represent a
+// re-identifiable external contact (customer). Interactions whose peer
+// resolves to one of these types are internal-resource noise (agent
+// extensions, conference legs, AI resources, PSTN trunk direct-SIP legs,
+// etc.) and must not be projected into the CRM interaction timeline: they
+// can never be matched to a contact_address, so they would otherwise sit in
+// the unresolved queue forever.
+//
+// Note: PSTN trunk partner calls are NOT affected by excluding TypeSIP here.
+// bin-call-manager normalizes trunk-domain and SIP-domain incoming/outgoing
+// call endpoints to TypeTel before publishing the webhook event (see
+// AddressGetSource/AddressGetDestination call sites in
+// bin-call-manager/pkg/callhandler), so a real external SIP trunk partner is
+// always observed here as peer_type=tel, never peer_type=sip.
+var crmIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeAgent:      {},
+	commonaddress.TypeAI:         {},
+	commonaddress.TypeAITeam:     {},
+	commonaddress.TypeConference: {},
+	commonaddress.TypeExtension:  {},
+	commonaddress.TypeSIP:        {},
+	"web_session":                {}, // synthetic type; not in commonaddress.Type enum
+}
+
+// isCRMEligiblePeer reports whether the given peer address type can ever
+// represent an external, re-identifiable contact. Interactions with an
+// ineligible peer type are dropped at projection time (never persisted),
+// not merely filtered out of the unresolved queue at read time, since they
+// can never legitimately resolve to a contact.
+func isCRMEligiblePeer(peerType commonaddress.Type) bool {
+	_, ineligible := crmIneligiblePeerTypes[peerType]
+	return !ineligible
+}
+
 // EventCallCreated projects a call-created webhook event into the CRM
 // interaction timeline.
 func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMessage) error {
@@ -41,6 +75,11 @@ func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMe
 	})
 
 	peer, local := deriveEndpoints(string(m.Direction), m.Source, m.Destination)
+
+	if !isCRMEligiblePeer(peer.Type) {
+		log.Debugf("Peer type is not CRM-eligible; skipping interaction projection. peer_type: %s", peer.Type)
+		return nil
+	}
 
 	peerTarget, err := commonaddress.NormalizeTarget(peer.Type, peer.Target)
 	if err != nil {
@@ -84,6 +123,11 @@ func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m 
 	})
 
 	peer, local := deriveEndpoints(string(m.Direction), m.Source, m.Destination)
+
+	if !isCRMEligiblePeer(peer.Type) {
+		log.Debugf("Peer type is not CRM-eligible; skipping interaction projection. peer_type: %s", peer.Type)
+		return nil
+	}
 
 	peerTarget, err := commonaddress.NormalizeTarget(peer.Type, peer.Target)
 	if err != nil {

--- a/bin-contact-manager/pkg/contacthandler/interaction_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_test.go
@@ -136,6 +136,48 @@ func Test_EventCallCreated(t *testing.T) {
 				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC); return &t }(),
 			},
 		},
+		{
+			name: "incoming call - peer is agent extension - projection skipped",
+
+			message: &callmodel.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aa000004-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("aa000004-0000-0000-0000-000000000002"),
+				},
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeExtension,
+					Target: "extensionSrc",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "localTelIncoming",
+				},
+				Direction: callmodel.DirectionIncoming,
+			},
+
+			expectInteraction: nil,
+		},
+		{
+			name: "outgoing call - peer is direct-SIP leg - projection skipped",
+
+			message: &callmodel.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("aa000005-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("aa000005-0000-0000-0000-000000000002"),
+				},
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeTel,
+					Target: "localTelOutgoing",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeSIP,
+					Target: "sip:peer@example.com",
+				},
+				Direction: callmodel.DirectionOutgoing,
+			},
+
+			expectInteraction: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,9 +197,11 @@ func Test_EventCallCreated(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
-			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
-			mockDB.EXPECT().InteractionCreate(ctx, tt.expectInteraction).Return(nil)
+			if tt.expectInteraction != nil {
+				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+				mockDB.EXPECT().InteractionCreate(ctx, tt.expectInteraction).Return(nil)
+			}
 
 			if err := h.EventCallCreated(ctx, tt.message); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
@@ -212,6 +256,27 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 				TMCreate:      func() *time.Time { t := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC); return &t }(),
 			},
 		},
+		{
+			name: "outgoing web_session message - peer is synthetic web session type - projection skipped",
+
+			message: &convmsg.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("cc000002-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("cc000002-0000-0000-0000-000000000002"),
+				},
+				Direction: convmsg.DirectionIncoming,
+				Source: commonaddress.Address{
+					Type:   "web_session",
+					Target: "web_session:xyz",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeAI,
+					Target: "",
+				},
+			},
+
+			expectInteraction: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -231,9 +296,11 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
-			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
-			mockDB.EXPECT().InteractionCreate(ctx, tt.expectInteraction).Return(nil)
+			if tt.expectInteraction != nil {
+				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+				mockDB.EXPECT().InteractionCreate(ctx, tt.expectInteraction).Return(nil)
+			}
 
 			if err := h.EventConversationMessageCreated(ctx, tt.message); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)


### PR DESCRIPTION
Skip CRM interaction projection at write time when the resolved peer address type can never represent an external, re-identifiable contact.

- bin-contact-manager: Skip CRM interaction projection when the resolved peer address type can never represent an external, re-identifiable contact (agent, extension, sip, conference, ai, ai_team, web_session). These interactions previously piled up permanently in the unresolved queue since they can never match a contact_address or receive a positive resolution. PSTN trunk partner calls are unaffected: bin-call-manager already normalizes trunk/SIP-domain call endpoints to TypeTel before publishing the webhook, so real external SIP trunk partners are always observed as peer_type=tel, never peer_type=sip.
- bin-contact-manager: Add isCRMEligiblePeer helper shared by EventCallCreated and EventConversationMessageCreated, plus test coverage for the skip path in both handlers.