### PR TITLE
NOJIRA-Add-service-agent-transcribes-api

### DIFF
--- a/bin-api-manager/docs/auth.md
+++ b/bin-api-manager/docs/auth.md
@@ -112,7 +112,14 @@ This means agents can only access resources belonging to their own customer, unl
 
 ### Service Agent Auth (scoped tokens)
 
-`/service_agents/*` endpoints use the same JWT validation but with a narrower scope. The agent identity is the authenticated agent; resources are automatically scoped to `agent.CustomerID`. These endpoints are intended for the agent-facing UI (talk.voipbin.net).
+`/service_agents/*` endpoints use the same JWT validation but with a narrower scope. The agent identity is the authenticated agent; resources are automatically scoped to `agent.CustomerID`. These endpoints are intended for the agent-facing UI (talk.voipbin.net, square-talk).
+
+**CRITICAL: `square-talk` (and any other Agent-facing frontend) MUST call ONLY `/service_agents/*` paths — never the top-level `/<resource>` path directly, even if the top-level path's permission bitmask happens to allow Agent-level access.** This is a deliberate API-surface separation, not an accident of history:
+
+- **Top-level `/<resource>` endpoints** (e.g. `/transcribes`, `/contacts`) are the Admin/Manager-facing surface (`square-admin`). Their `hasPermission(...)` checks commonly hardcode `PermissionCustomerAdmin|PermissionCustomerManager` and are free to change that bitmask over time to fit admin-console needs.
+- **`/service_agents/<resource>` endpoints** are the dedicated Agent-facing surface. They exist as their own path + servicehandler function (e.g. `ServiceAgentContactList`, `ServiceAgentTranscribeList`) specifically so their permission model (`amagent.PermissionAll`, i.e. "any authenticated agent of this customer") can evolve independently of the Admin/Manager surface's needs.
+
+**Do NOT "fix" a missing Agent-facing capability by relaxing the top-level endpoint's permission bitmask instead of adding the missing `/service_agents/<resource>` endpoint.** That shortcut collapses the two intentionally-separate surfaces into one, makes future permission changes on the Admin surface risk silently breaking the Agent-facing app (and vice versa), and violates the frontend's own architectural contract (square-talk's CLAUDE.md/skill states it uses `service_agents/*` only). If a `service_agents/<resource>` endpoint doesn't exist yet for a capability an Agent-facing app needs, add it as a new resource (new OpenAPI path file, new `ServiceAgent*` servicehandler function reusing the existing private `resourceGet`/`resourceList` helpers, new `server/service_agents_<resource>.go` handler) — do not touch the top-level endpoint's permission check. See `bin-openapi-manager/CLAUDE.md`'s "Adding a Service Agent (Agent-facing) resource" section for the concrete checklist, and `pkg/servicehandler/serviceagent_transcribe.go` for a worked example (adds `ServiceAgentTranscribeList`/`ServiceAgentTranscribeStart` alongside the pre-existing Admin/Manager-gated `TranscribeList`/`TranscribeStart`, without changing the latter).
 
 ### Direct Token Auth
 

--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -18888,6 +18888,154 @@
         }
       }
     },
+    "/service_agents/transcribes": {
+      "get": {
+        "summary": "List transcribes",
+        "description": "Retrieves a paginated list of transcriptions for the service agent's customer. Optionally filter by the origin resource (reference_type + reference_id) to find all transcribes tied to a specific call, conference, or recording. Note a single reference can have multiple transcribes (e.g. one per language, or multiple start/stop sessions), so this always returns a list, not a single item.",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageToken"
+          },
+          {
+            "name": "reference_type",
+            "in": "query",
+            "required": false,
+            "description": "Filter by the reference type of the origin resource. Must be supplied together with reference_id; supplying only one of the two returns a 400 error.",
+            "schema": {
+              "$ref": "#/components/schemas/TranscribeManagerTranscribeReferenceType"
+            },
+            "example": "call"
+          },
+          {
+            "name": "reference_id",
+            "in": "query",
+            "required": false,
+            "description": "Filter by the ID of the origin resource (e.g. a call ID returned from `GET /service_agents/calls`). Must be supplied together with reference_type; supplying only one of the two returns a 400 error.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "5e4a0680-804e-11ec-8477-2fea5968d85b"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of transcriptions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonPagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "result": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/TranscribeManagerTranscribe"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Start a transcribe",
+        "description": "Starts a transcription of the given reference (call, conference, or recording) for the service agent's customer and returns the result.",
+        "tags": [
+          "Service Agent"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reference_type": {
+                    "$ref": "#/components/schemas/TranscribeManagerTranscribeReferenceType"
+                  },
+                  "reference_id": {
+                    "type": "string",
+                    "description": "The ID of the reference for the transcription."
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "The language of the transcription."
+                  },
+                  "direction": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/TranscribeManagerTranscribeDirection"
+                      }
+                    ],
+                    "description": "Which audio legs to transcribe. If omitted, defaults to \"both\"."
+                  },
+                  "provider": {
+                    "$ref": "#/components/schemas/TranscribeManagerTranscribeProvider"
+                  },
+                  "on_end_flow_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "x-go-type": "string",
+                    "description": "The flow to execute when the transcription ends. The flow ID returned from the POST /flows or GET /flows response. If omitted, no follow-up flow is executed.",
+                    "example": "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+                  }
+                },
+                "required": [
+                  "reference_type",
+                  "reference_id",
+                  "language"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created transcribe details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranscribeManagerTranscribe"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/speakings": {
       "get": {
         "summary": "List speaking sessions",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -7039,6 +7039,38 @@ type PostServiceAgentsTalkMessagesIdReactionsJSONBody struct {
 	Emoji string `json:"emoji"`
 }
 
+// GetServiceAgentsTranscribesParams defines parameters for GetServiceAgentsTranscribes.
+type GetServiceAgentsTranscribesParams struct {
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// ReferenceType Filter by the reference type of the origin resource. Must be supplied together with reference_id; supplying only one of the two returns a 400 error.
+	ReferenceType *TranscribeManagerTranscribeReferenceType `form:"reference_type,omitempty" json:"reference_type,omitempty"`
+
+	// ReferenceId Filter by the ID of the origin resource (e.g. a call ID returned from `GET /service_agents/calls`). Must be supplied together with reference_type; supplying only one of the two returns a 400 error.
+	ReferenceId *openapi_types.UUID `form:"reference_id,omitempty" json:"reference_id,omitempty"`
+}
+
+// PostServiceAgentsTranscribesJSONBody defines parameters for PostServiceAgentsTranscribes.
+type PostServiceAgentsTranscribesJSONBody struct {
+	// Direction Which audio legs to transcribe. If omitted, defaults to "both".
+	Direction *TranscribeManagerTranscribeDirection `json:"direction,omitempty"`
+
+	// Language The language of the transcription.
+	Language string `json:"language"`
+
+	// OnEndFlowId The flow to execute when the transcription ends. The flow ID returned from the POST /flows or GET /flows response. If omitted, no follow-up flow is executed.
+	OnEndFlowId *string                              `json:"on_end_flow_id,omitempty"`
+	Provider    *TranscribeManagerTranscribeProvider `json:"provider,omitempty"`
+
+	// ReferenceId The ID of the reference for the transcription.
+	ReferenceId   string                                   `json:"reference_id"`
+	ReferenceType TranscribeManagerTranscribeReferenceType `json:"reference_type"`
+}
+
 // GetSpeakingsParams defines parameters for GetSpeakings.
 type GetSpeakingsParams struct {
 	PageSize  *int    `form:"page_size,omitempty" json:"page_size,omitempty"`
@@ -7656,6 +7688,9 @@ type PostServiceAgentsTalkMessagesJSONRequestBody PostServiceAgentsTalkMessagesJ
 
 // PostServiceAgentsTalkMessagesIdReactionsJSONRequestBody defines body for PostServiceAgentsTalkMessagesIdReactions for application/json ContentType.
 type PostServiceAgentsTalkMessagesIdReactionsJSONRequestBody PostServiceAgentsTalkMessagesIdReactionsJSONBody
+
+// PostServiceAgentsTranscribesJSONRequestBody defines body for PostServiceAgentsTranscribes for application/json ContentType.
+type PostServiceAgentsTranscribesJSONRequestBody PostServiceAgentsTranscribesJSONBody
 
 // PostSpeakingsJSONRequestBody defines body for PostSpeakings for application/json ContentType.
 type PostSpeakingsJSONRequestBody PostSpeakingsJSONBody
@@ -8661,6 +8696,12 @@ type ServerInterface interface {
 	// Add a reaction to a talk message
 	// (POST /service_agents/talk_messages/{id}/reactions)
 	PostServiceAgentsTalkMessagesIdReactions(c *gin.Context, id string)
+	// List transcribes
+	// (GET /service_agents/transcribes)
+	GetServiceAgentsTranscribes(c *gin.Context, params GetServiceAgentsTranscribesParams)
+	// Start a transcribe
+	// (POST /service_agents/transcribes)
+	PostServiceAgentsTranscribes(c *gin.Context)
 	// Establish a WebSocket connection
 	// (GET /service_agents/ws)
 	GetServiceAgentsWs(c *gin.Context)
@@ -16919,6 +16960,69 @@ func (siw *ServerInterfaceWrapper) PostServiceAgentsTalkMessagesIdReactions(c *g
 	siw.Handler.PostServiceAgentsTalkMessagesIdReactions(c, id)
 }
 
+// GetServiceAgentsTranscribes operation middleware
+func (siw *ServerInterfaceWrapper) GetServiceAgentsTranscribes(c *gin.Context) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetServiceAgentsTranscribesParams
+
+	// ------------- Optional query parameter "page_size" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_size", c.Request.URL.Query(), &params.PageSize)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_size: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_token" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_token", c.Request.URL.Query(), &params.PageToken)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_token: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "reference_type" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "reference_type", c.Request.URL.Query(), &params.ReferenceType)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter reference_type: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "reference_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "reference_id", c.Request.URL.Query(), &params.ReferenceId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter reference_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetServiceAgentsTranscribes(c, params)
+}
+
+// PostServiceAgentsTranscribes operation middleware
+func (siw *ServerInterfaceWrapper) PostServiceAgentsTranscribes(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.PostServiceAgentsTranscribes(c)
+}
+
 // GetServiceAgentsWs operation middleware
 func (siw *ServerInterfaceWrapper) GetServiceAgentsWs(c *gin.Context) {
 
@@ -18476,6 +18580,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.DELETE(options.BaseURL+"/service_agents/talk_messages/:id", wrapper.DeleteServiceAgentsTalkMessagesId)
 	router.GET(options.BaseURL+"/service_agents/talk_messages/:id", wrapper.GetServiceAgentsTalkMessagesId)
 	router.POST(options.BaseURL+"/service_agents/talk_messages/:id/reactions", wrapper.PostServiceAgentsTalkMessagesIdReactions)
+	router.GET(options.BaseURL+"/service_agents/transcribes", wrapper.GetServiceAgentsTranscribes)
+	router.POST(options.BaseURL+"/service_agents/transcribes", wrapper.PostServiceAgentsTranscribes)
 	router.GET(options.BaseURL+"/service_agents/ws", wrapper.GetServiceAgentsWs)
 	router.GET(options.BaseURL+"/speakings", wrapper.GetSpeakings)
 	router.POST(options.BaseURL+"/speakings", wrapper.PostSpeakings)
@@ -36678,6 +36784,98 @@ func (response PostServiceAgentsTalkMessagesIdReactions500JSONResponse) VisitPos
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetServiceAgentsTranscribesRequestObject struct {
+	Params GetServiceAgentsTranscribesParams
+}
+
+type GetServiceAgentsTranscribesResponseObject interface {
+	VisitGetServiceAgentsTranscribesResponse(w http.ResponseWriter) error
+}
+
+type GetServiceAgentsTranscribes200JSONResponse struct {
+	// NextPageToken Cursor token for the next page of results. Pass this value as the page_token parameter in the next request.
+	NextPageToken *string                        `json:"next_page_token,omitempty"`
+	Result        *[]TranscribeManagerTranscribe `json:"result,omitempty"`
+}
+
+func (response GetServiceAgentsTranscribes200JSONResponse) VisitGetServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscribes400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetServiceAgentsTranscribes400JSONResponse) VisitGetServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscribes401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response GetServiceAgentsTranscribes401JSONResponse) VisitGetServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscribes500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetServiceAgentsTranscribes500JSONResponse) VisitGetServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsTranscribesRequestObject struct {
+	Body *PostServiceAgentsTranscribesJSONRequestBody
+}
+
+type PostServiceAgentsTranscribesResponseObject interface {
+	VisitPostServiceAgentsTranscribesResponse(w http.ResponseWriter) error
+}
+
+type PostServiceAgentsTranscribes200JSONResponse TranscribeManagerTranscribe
+
+func (response PostServiceAgentsTranscribes200JSONResponse) VisitPostServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsTranscribes400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PostServiceAgentsTranscribes400JSONResponse) VisitPostServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsTranscribes401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response PostServiceAgentsTranscribes401JSONResponse) VisitPostServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsTranscribes500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response PostServiceAgentsTranscribes500JSONResponse) VisitPostServiceAgentsTranscribesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetServiceAgentsWsRequestObject struct {
 }
 
@@ -40393,6 +40591,12 @@ type StrictServerInterface interface {
 	// Add a reaction to a talk message
 	// (POST /service_agents/talk_messages/{id}/reactions)
 	PostServiceAgentsTalkMessagesIdReactions(ctx context.Context, request PostServiceAgentsTalkMessagesIdReactionsRequestObject) (PostServiceAgentsTalkMessagesIdReactionsResponseObject, error)
+	// List transcribes
+	// (GET /service_agents/transcribes)
+	GetServiceAgentsTranscribes(ctx context.Context, request GetServiceAgentsTranscribesRequestObject) (GetServiceAgentsTranscribesResponseObject, error)
+	// Start a transcribe
+	// (POST /service_agents/transcribes)
+	PostServiceAgentsTranscribes(ctx context.Context, request PostServiceAgentsTranscribesRequestObject) (PostServiceAgentsTranscribesResponseObject, error)
 	// Establish a WebSocket connection
 	// (GET /service_agents/ws)
 	GetServiceAgentsWs(ctx context.Context, request GetServiceAgentsWsRequestObject) (GetServiceAgentsWsResponseObject, error)
@@ -50092,6 +50296,66 @@ func (sh *strictHandler) PostServiceAgentsTalkMessagesIdReactions(ctx *gin.Conte
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(PostServiceAgentsTalkMessagesIdReactionsResponseObject); ok {
 		if err := validResponse.VisitPostServiceAgentsTalkMessagesIdReactionsResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetServiceAgentsTranscribes operation middleware
+func (sh *strictHandler) GetServiceAgentsTranscribes(ctx *gin.Context, params GetServiceAgentsTranscribesParams) {
+	var request GetServiceAgentsTranscribesRequestObject
+
+	request.Params = params
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetServiceAgentsTranscribes(ctx, request.(GetServiceAgentsTranscribesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetServiceAgentsTranscribes")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetServiceAgentsTranscribesResponseObject); ok {
+		if err := validResponse.VisitGetServiceAgentsTranscribesResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PostServiceAgentsTranscribes operation middleware
+func (sh *strictHandler) PostServiceAgentsTranscribes(ctx *gin.Context) {
+	var request PostServiceAgentsTranscribesRequestObject
+
+	var body PostServiceAgentsTranscribesJSONRequestBody
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
+		ctx.Error(err)
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostServiceAgentsTranscribes(ctx, request.(PostServiceAgentsTranscribesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostServiceAgentsTranscribes")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(PostServiceAgentsTranscribesResponseObject); ok {
+		if err := validResponse.VisitPostServiceAgentsTranscribesResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -917,6 +917,19 @@ type ServiceHandler interface {
 	) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactLookup(ctx context.Context, a *auth.AuthIdentity, phoneE164 string, email string) (*cmcontact.WebhookMessage, error)
+
+	// service agent transcribe handlers
+	ServiceAgentTranscribeList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, referenceType string, referenceID uuid.UUID) ([]*tmtranscribe.WebhookMessage, error)
+	ServiceAgentTranscribeStart(
+		ctx context.Context,
+		a *auth.AuthIdentity,
+		referenceType string,
+		referenceID uuid.UUID,
+		language string,
+		direction tmtranscribe.Direction,
+		onEndFlowID uuid.UUID,
+		provider tmtranscribe.Provider,
+	) (*tmtranscribe.WebhookMessage, error)
 	ServiceAgentContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool, name string, detail string) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactAddressUpdate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID, fields map[string]any) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactAddressDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID) (*cmcontact.WebhookMessage, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -5004,6 +5004,36 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentTalkParticipantList(ctx, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTalkParticipantList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTalkParticipantList), ctx, a, chatID)
 }
 
+// ServiceAgentTranscribeList mocks base method.
+func (m *MockServiceHandler) ServiceAgentTranscribeList(ctx context.Context, a *auth.AuthIdentity, size uint64, token, referenceType string, referenceID uuid.UUID) ([]*transcribe.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentTranscribeList", ctx, a, size, token, referenceType, referenceID)
+	ret0, _ := ret[0].([]*transcribe.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentTranscribeList indicates an expected call of ServiceAgentTranscribeList.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentTranscribeList(ctx, a, size, token, referenceType, referenceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTranscribeList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTranscribeList), ctx, a, size, token, referenceType, referenceID)
+}
+
+// ServiceAgentTranscribeStart mocks base method.
+func (m *MockServiceHandler) ServiceAgentTranscribeStart(ctx context.Context, a *auth.AuthIdentity, referenceType string, referenceID uuid.UUID, language string, direction transcribe.Direction, onEndFlowID uuid.UUID, provider transcribe.Provider) (*transcribe.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentTranscribeStart", ctx, a, referenceType, referenceID, language, direction, onEndFlowID, provider)
+	ret0, _ := ret[0].(*transcribe.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentTranscribeStart indicates an expected call of ServiceAgentTranscribeStart.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentTranscribeStart(ctx, a, referenceType, referenceID, language, direction, onEndFlowID, provider any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTranscribeStart", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTranscribeStart), ctx, a, referenceType, referenceID, language, direction, onEndFlowID, provider)
+}
+
 // SpeakingCreate mocks base method.
 func (m *MockServiceHandler) SpeakingCreate(ctx context.Context, a *auth.AuthIdentity, referenceType streaming.ReferenceType, referenceID uuid.UUID, language, provider, voiceID string, direction streaming.Direction) (*speaking.WebhookMessage, error) {
 	m.ctrl.T.Helper()

--- a/bin-api-manager/pkg/servicehandler/serviceagent_transcribe.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_transcribe.go
@@ -1,0 +1,208 @@
+package servicehandler
+
+import (
+	"context"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// ServiceAgentTranscribeList sends a request to transcribe-manager
+// to get a list of transcribes for the service agent's customer.
+// it returns list of transcribe info if it succeed.
+// If referenceType/referenceID are both provided, results are additionally
+// filtered to transcribes originating from that specific resource (e.g. a
+// call). Note a single reference can have multiple transcribes (different
+// languages, or multiple start/stop sessions), so this can return more than
+// one item even when scoped to a single reference.
+// The caller (server/service_agents_transcribes.go) is expected to reject a
+// partial pair (only one of referenceType/referenceID non-zero) before
+// calling this; this function does not itself validate pairing.
+func (h *serviceHandler) ServiceAgentTranscribeList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, referenceType string, referenceID uuid.UUID) ([]*tmtranscribe.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":           "ServiceAgentTranscribeList",
+		"customer_id":    a.CustomerID,
+		"username":       a.DisplayName(),
+		"size":           size,
+		"token":          token,
+		"reference_type": referenceType,
+		"reference_id":   referenceID,
+	})
+
+	if token == "" {
+		token = h.utilHandler.TimeGetCurTime()
+	}
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	filters := map[string]string{
+		"customer_id": a.CustomerID.String(),
+		"deleted":     "false",
+	}
+	if referenceType != "" {
+		filters["reference_type"] = referenceType
+	}
+	if referenceID != uuid.Nil {
+		filters["reference_id"] = referenceID.String()
+	}
+
+	typedFilters, err := h.convertTranscribeFilters(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	tmps, err := h.reqHandler.TranscribeV1TranscribeList(ctx, token, size, typedFilters)
+	if err != nil {
+		log.Errorf("Could not get transcribes. err: %v", err)
+		return nil, err
+	}
+
+	res := []*tmtranscribe.WebhookMessage{}
+	for _, tmp := range tmps {
+		e := tmp.ConvertWebhookMessage()
+		res = append(res, e)
+	}
+
+	return res, nil
+}
+
+// ServiceAgentTranscribeStart sends a request to transcribe-manager
+// to start a transcribe for the service agent's customer.
+// it returns transcribe if it succeed.
+func (h *serviceHandler) ServiceAgentTranscribeStart(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	referenceType string,
+	referenceID uuid.UUID,
+	language string,
+	direction tmtranscribe.Direction,
+	onEndFlowID uuid.UUID,
+	provider tmtranscribe.Provider,
+) (*tmtranscribe.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":           "ServiceAgentTranscribeStart",
+		"customer_id":    a.CustomerID,
+		"reference_type": referenceType,
+		"reference_id":   referenceID,
+		"language":       language,
+		"direction":      direction,
+		"on_end_flow_id": onEndFlowID,
+		"provider":       provider,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	// get transcribe resource info. this validates ownership of the
+	// reference resource against the agent's own customer.
+	tmpReferenceType, tmpReferenceID, err := h.transcribeGetResourceInfoForAgent(ctx, a, referenceType, referenceID)
+	if err != nil {
+		log.Errorf("Could not get transcribe resource info. err: %v", err)
+		return nil, err
+	}
+
+	tmp, err := h.reqHandler.TranscribeV1TranscribeStart(
+		ctx,
+		a.CustomerID,
+		uuid.Nil,
+		onEndFlowID,
+		tmpReferenceType,
+		tmpReferenceID,
+		language,
+		direction,
+		provider,
+		60000,
+	)
+	if err != nil {
+		log.Errorf("Could not start the transcribe. err: %v", err)
+		return nil, err
+	}
+
+	res := tmp.ConvertWebhookMessage()
+	return res, nil
+}
+
+// transcribeGetResourceInfoForAgent returns corresponding transcribe resource
+// info of the given reference, scoped to Agent-level permission (customer
+// tenant boundary only, no Admin/Manager requirement). This mirrors
+// transcribeGetResourceInfo (used by the Admin/Manager-gated TranscribeStart)
+// but checks amagent.PermissionAll instead of
+// PermissionCustomerAdmin|PermissionCustomerManager, matching the
+// service_agents/* API surface's Agent-level access model.
+// Returns error if the reference is not transcribe-able or the agent has no
+// permission on the resolved resource's customer.
+func (h *serviceHandler) transcribeGetResourceInfoForAgent(ctx context.Context, a *auth.AuthIdentity, referenceType string, referenceID uuid.UUID) (tmtranscribe.ReferenceType, uuid.UUID, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":           "transcribeGetResourceInfoForAgent",
+		"agent":          a,
+		"reference_type": referenceType,
+		"reference_id":   referenceID,
+	})
+
+	var err error
+	var tmpCustomerID uuid.UUID
+	var resReferenceType tmtranscribe.ReferenceType
+	var resReferenceID uuid.UUID
+
+	switch referenceType {
+	case "call":
+		tmpResource, tmpErr := h.callGet(ctx, referenceID)
+		if tmpErr != nil {
+			err = tmpErr
+			break
+		}
+		tmpCustomerID = tmpResource.CustomerID
+		resReferenceType = tmtranscribe.ReferenceTypeCall
+		resReferenceID = tmpResource.ID
+
+	case "conference":
+		tmpResource, tmpErr := h.conferenceGet(ctx, referenceID)
+		if tmpErr != nil {
+			err = tmpErr
+		}
+		tmpCustomerID = tmpResource.CustomerID
+		resReferenceType = tmtranscribe.ReferenceTypeConfbridge
+		resReferenceID = tmpResource.ConfbridgeID
+
+	case "recording":
+		tmpResource, tmpErr := h.recordingGet(ctx, referenceID)
+		if tmpErr != nil {
+			err = tmpErr
+		}
+		tmpCustomerID = tmpResource.CustomerID
+		resReferenceType = tmtranscribe.ReferenceTypeRecording
+		resReferenceID = tmpResource.ID
+
+	default:
+		err = serviceerrors.ErrInvalidArgument
+	}
+	if err != nil {
+		log.Errorf("Could not pass the reference validation. err: %v", err)
+		return "", uuid.Nil, err
+	}
+
+	if !h.hasPermission(ctx, a, tmpCustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return "", uuid.Nil, serviceerrors.ErrPermissionDenied
+	}
+
+	return resReferenceType, resReferenceID, nil
+}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_transcribe_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_transcribe_test.go
@@ -1,0 +1,254 @@
+package servicehandler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	cmcall "monorepo/bin-call-manager/models/call"
+	cmrecording "monorepo/bin-call-manager/models/recording"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/dbhandler"
+)
+
+func Test_ServiceAgentTranscribeList(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		agent         *auth.AuthIdentity
+		pageToken     string
+		pageSize      uint64
+		referenceType string
+		referenceID   uuid.UUID
+
+		response []tmtranscribe.Transcribe
+
+		expectFilters map[tmtranscribe.Field]any
+		expectRes     []*tmtranscribe.WebhookMessage
+	}{
+		{
+			// Plain Agent permission (not Admin/Manager) must be able to list
+			// its own customer's transcribes via the service_agents surface.
+			// This is the whole point of the new endpoint.
+			"agent permission, no reference filter",
+			auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			"2020-10-20T01:00:00.995000Z",
+			10,
+			"",
+			uuid.Nil,
+
+			[]tmtranscribe.Transcribe{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+					},
+				},
+			},
+
+			map[tmtranscribe.Field]any{
+				tmtranscribe.FieldCustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				tmtranscribe.FieldDeleted:    false,
+			},
+			[]*tmtranscribe.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+					},
+				},
+			},
+		},
+		{
+			"agent permission, filtered by reference_type and reference_id",
+			auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			"2020-10-20T01:00:00.995000Z",
+			10,
+			"call",
+			uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+
+			[]tmtranscribe.Transcribe{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+					},
+				},
+			},
+
+			map[tmtranscribe.Field]any{
+				tmtranscribe.FieldCustomerID:    uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				tmtranscribe.FieldDeleted:       false,
+				tmtranscribe.FieldReferenceType: "call",
+				tmtranscribe.FieldReferenceID:   uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			},
+			[]*tmtranscribe.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().TranscribeV1TranscribeList(ctx, tt.pageToken, tt.pageSize, tt.expectFilters).Return(tt.response, nil)
+			res, err := h.ServiceAgentTranscribeList(ctx, tt.agent, tt.pageSize, tt.pageToken, tt.referenceType, tt.referenceID)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %v\n, got: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_ServiceAgentTranscribeStart(t *testing.T) {
+
+	type test struct {
+		name string
+
+		agent         *auth.AuthIdentity
+		referenceType string
+		referenceID   uuid.UUID
+		language      string
+		direction     tmtranscribe.Direction
+		onEndFlowID   uuid.UUID
+		provider      tmtranscribe.Provider
+
+		responseCall       *cmcall.Call
+		responseRecording  *cmrecording.Recording
+		responseTranscribe *tmtranscribe.Transcribe
+
+		expectReferenceType tmtranscribe.ReferenceType
+		expectRes           *tmtranscribe.WebhookMessage
+	}
+
+	tests := []test{
+		{
+			// Plain Agent permission must be able to start a transcribe on a
+			// call belonging to its own customer via the service_agents
+			// surface.
+			name: "agent permission, call reference",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			referenceType: "call",
+			referenceID:   uuid.FromStringOrNil("cafe48aa-8281-11ed-ae72-b7dd7e37dc39"),
+			language:      "en-US",
+			direction:     tmtranscribe.DirectionBoth,
+			onEndFlowID:   uuid.FromStringOrNil("9772a0da-0943-11f0-879f-47ce2d322564"),
+			provider:      tmtranscribe.ProviderGCP,
+
+			responseCall: &cmcall.Call{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("cafe48aa-8281-11ed-ae72-b7dd7e37dc39"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Status:   cmcall.StatusProgressing,
+				TMDelete: nil,
+			},
+			responseTranscribe: &tmtranscribe.Transcribe{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2b76bad2-8282-11ed-9cde-fb9aba5fd1d7"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+			},
+
+			expectReferenceType: tmtranscribe.ReferenceTypeCall,
+			expectRes: &tmtranscribe.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("2b76bad2-8282-11ed-9cde-fb9aba5fd1d7"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+			ctx := context.Background()
+
+			switch tt.referenceType {
+			case "call":
+				mockReq.EXPECT().CallV1CallGet(ctx, tt.referenceID).Return(tt.responseCall, nil)
+
+			case "recording":
+				mockReq.EXPECT().CallV1RecordingGet(ctx, tt.referenceID).Return(tt.responseRecording, nil)
+			}
+			mockReq.EXPECT().TranscribeV1TranscribeStart(
+				ctx,
+				tt.agent.CustomerID,
+				uuid.Nil,
+				tt.onEndFlowID,
+				tt.expectReferenceType,
+				tt.referenceID,
+				tt.language,
+				tt.direction,
+				tt.provider,
+				60000,
+			).Return(tt.responseTranscribe, nil)
+
+			res, err := h.ServiceAgentTranscribeStart(ctx, tt.agent, tt.referenceType, tt.referenceID, tt.language, tt.direction, tt.onEndFlowID, tt.provider)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}

--- a/bin-api-manager/server/service_agents_transcribes.go
+++ b/bin-api-manager/server/service_agents_transcribes.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"monorepo/bin-api-manager/gens/openapi_server"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// GetServiceAgentsTranscribes handles GET /service_agents/transcribes
+func (h *server) GetServiceAgentsTranscribes(c *gin.Context, params openapi_server.GetServiceAgentsTranscribesParams) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "GetServiceAgentsTranscribes",
+		"request_address": c.ClientIP,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithFields(logrus.Fields{
+		"agent": a,
+	})
+
+	pageSize := uint64(100)
+	if params.PageSize != nil {
+		pageSize = uint64(*params.PageSize)
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 100
+		log.Debugf("Invalid requested page size. Set to default. page_size: %d", pageSize)
+	}
+
+	pageToken := ""
+	if params.PageToken != nil {
+		pageToken = *params.PageToken
+	}
+
+	referenceType := ""
+	if params.ReferenceType != nil {
+		referenceType = string(*params.ReferenceType)
+	}
+
+	referenceID := uuid.Nil
+	if params.ReferenceId != nil {
+		referenceID = uuid.UUID(*params.ReferenceId)
+	}
+
+	// reference_type and reference_id are documented as a pair (see the
+	// OpenAPI description); reject a partial filter explicitly instead of
+	// silently applying only one half of the intended filter.
+	if (referenceType == "") != (referenceID == uuid.Nil) {
+		log.Errorf("reference_type and reference_id must be supplied together. reference_type: %s, reference_id: %s", referenceType, referenceID)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_REFERENCE_FILTER", "reference_type and reference_id must be supplied together."))
+		return
+	}
+
+	tmps, err := h.serviceHandler.ServiceAgentTranscribeList(c.Request.Context(), a, pageSize, pageToken, referenceType, referenceID)
+	if err != nil {
+		logrus.Errorf("Could not get transcribes info. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	nextToken := ""
+	if len(tmps) > 0 {
+		if tmps[len(tmps)-1].TMCreate != nil {
+			nextToken = tmps[len(tmps)-1].TMCreate.UTC().Format("2006-01-02T15:04:05.000000Z")
+		}
+	}
+
+	res := GenerateListResponse(tmps, nextToken)
+	c.JSON(200, res)
+}
+
+// PostServiceAgentsTranscribes handles POST /service_agents/transcribes
+func (h *server) PostServiceAgentsTranscribes(c *gin.Context) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "PostServiceAgentsTranscribes",
+		"request_address": c.ClientIP,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithFields(logrus.Fields{
+		"agent": a,
+	})
+
+	var req openapi_server.PostServiceAgentsTranscribesJSONBody
+	if err := c.BindJSON(&req); err != nil {
+		log.Errorf("Could not parse the request. err: %v", err)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_JSON_BODY", "The request body is not valid JSON.").Wrap(err))
+		return
+	}
+
+	referenceID := uuid.FromStringOrNil(req.ReferenceId)
+	onEndFlowID := uuid.Nil
+	if req.OnEndFlowId != nil {
+		onEndFlowID = uuid.FromStringOrNil(*req.OnEndFlowId)
+	}
+
+	var provider tmtranscribe.Provider
+	if req.Provider != nil {
+		provider = tmtranscribe.Provider(*req.Provider)
+	}
+
+	// Default to "both" when direction is omitted or empty, and fall back to
+	// "both" for a non-empty but invalid value. See server/transcribes.go's
+	// PostTranscribes for the identical, previously-established reasoning.
+	direction := tmtranscribe.DirectionBoth
+	if req.Direction != nil && *req.Direction != "" {
+		direction = tmtranscribe.Direction(*req.Direction)
+		if normalized := direction.Normalize(); normalized != direction {
+			log.Warnf("Invalid direction. Falling back to both. direction: %s", direction)
+			direction = normalized
+		}
+	}
+
+	res, err := h.serviceHandler.ServiceAgentTranscribeStart(
+		c.Request.Context(),
+		a,
+		string(req.ReferenceType),
+		referenceID,
+		req.Language,
+		direction,
+		onEndFlowID,
+		provider,
+	)
+	if err != nil {
+		log.Errorf("Could not create a transcribe. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, res)
+}

--- a/bin-api-manager/server/service_agents_transcribes_test.go
+++ b/bin-api-manager/server/service_agents_transcribes_test.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/lib/middleware"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_GetServiceAgentsTranscribes(t *testing.T) {
+
+	type test struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+
+		responseTranscribes []*tmtranscribe.WebhookMessage
+
+		expectedPageSize      uint64
+		expectedPageToken     string
+		expectedReferenceType string
+		expectedReferenceID   uuid.UUID
+		expectedRes           string
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/transcribes?page_size=10&page_token=2020-09-20T03:23:20.995000Z",
+
+			responseTranscribes: []*tmtranscribe.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("6e812ad0-828a-11ed-bfe8-9f9b344a834b"),
+					},
+				},
+			},
+
+			expectedPageSize:  10,
+			expectedPageToken: "2020-09-20T03:23:20.995000Z",
+			expectedRes:       `{"result":[{"id":"6e812ad0-828a-11ed-bfe8-9f9b344a834b","customer_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","on_end_flow_id":"00000000-0000-0000-0000-000000000000","reference_type":"","reference_id":"00000000-0000-0000-0000-000000000000","status":"","language":"","direction":"","provider":"","tm_create":null,"tm_update":null,"tm_delete":null}],"next_page_token":""}`,
+		},
+		{
+			name: "filtered by reference_type and reference_id",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/transcribes?reference_type=call&reference_id=5e4a0680-804e-11ec-8477-2fea5968d85b",
+
+			responseTranscribes: []*tmtranscribe.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("6e812ad0-828a-11ed-bfe8-9f9b344a834b"),
+					},
+				},
+			},
+
+			expectedPageSize:      100,
+			expectedPageToken:     "",
+			expectedReferenceType: "call",
+			expectedReferenceID:   uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			expectedRes:           `{"result":[{"id":"6e812ad0-828a-11ed-bfe8-9f9b344a834b","customer_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","on_end_flow_id":"00000000-0000-0000-0000-000000000000","reference_type":"","reference_id":"00000000-0000-0000-0000-000000000000","status":"","language":"","direction":"","provider":"","tm_create":null,"tm_update":null,"tm_delete":null}],"next_page_token":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ServiceAgentTranscribeList(req.Context(), tt.agent, tt.expectedPageSize, tt.expectedPageToken, tt.expectedReferenceType, tt.expectedReferenceID).Return(tt.responseTranscribes, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			}
+
+			if w.Body.String() != tt.expectedRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectedRes, w.Body)
+			}
+		})
+	}
+}
+
+// Test_GetServiceAgentsTranscribes_PartialReferenceFilter verifies
+// GetServiceAgentsTranscribes rejects a partial reference_type/reference_id
+// filter (only one of the two supplied) with INVALID_ARGUMENT /
+// INVALID_REFERENCE_FILTER before the servicehandler is consulted, instead
+// of silently applying only one half of the intended filter. Mirrors
+// Test_transcribesGET_PartialReferenceFilter in transcribes_test.go.
+func Test_GetServiceAgentsTranscribes_PartialReferenceFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	type test struct {
+		name     string
+		reqQuery string
+	}
+
+	tests := []test{
+		{
+			name:     "reference_type without reference_id",
+			reqQuery: "/service_agents/transcribes?reference_type=call",
+		},
+		{
+			name:     "reference_id without reference_type",
+			reqQuery: "/service_agents/transcribes?reference_id=5e4a0680-804e-11ec-8477-2fea5968d85b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			})
+
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{serviceHandler: mockSvc}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+			r.Use(middleware.RequestID())
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest(http.MethodGet, tt.reqQuery, nil)
+			r.ServeHTTP(w, req)
+
+			assertErrorResponse(t, w, cerrors.StatusInvalidArgument, "INVALID_REFERENCE_FILTER")
+		})
+	}
+}
+
+func Test_PostServiceAgentsTranscribes(t *testing.T) {
+
+	type test struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+		reqBody  []byte
+
+		responseTranscribe *tmtranscribe.WebhookMessage
+
+		expectReferenceType string
+		expectReferenceID   uuid.UUID
+		expectLanguage      string
+		expectDirection     tmtranscribe.Direction
+		expectOnEndFlowID   uuid.UUID
+		expectProvider      tmtranscribe.Provider
+		expectRes           string
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/transcribes",
+			reqBody:  []byte(`{"reference_type":"call","reference_id":"4ecc56ec-8285-11ed-9958-8b0a60b665bf","language":"en-US","direction":"both","on_end_flow_id":"199a8a78-0944-11f0-b57c-dbf18b86df64"}`),
+
+			responseTranscribe: &tmtranscribe.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("72e68b78-8286-11ed-8875-378ced61c021"),
+				},
+			},
+
+			expectReferenceType: "call",
+			expectReferenceID:   uuid.FromStringOrNil("4ecc56ec-8285-11ed-9958-8b0a60b665bf"),
+			expectLanguage:      "en-US",
+			expectDirection:     tmtranscribe.DirectionBoth,
+			expectOnEndFlowID:   uuid.FromStringOrNil("199a8a78-0944-11f0-b57c-dbf18b86df64"),
+			expectProvider:      tmtranscribe.ProviderEmpty,
+			expectRes:           `{"id":"72e68b78-8286-11ed-8875-378ced61c021","customer_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","on_end_flow_id":"00000000-0000-0000-0000-000000000000","reference_type":"","reference_id":"00000000-0000-0000-0000-000000000000","status":"","language":"","direction":"","provider":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			name: "direction omitted defaults to both",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/transcribes",
+			reqBody:  []byte(`{"reference_type":"call","reference_id":"4ecc56ec-8285-11ed-9958-8b0a60b665bf","language":"en-US","on_end_flow_id":"199a8a78-0944-11f0-b57c-dbf18b86df64"}`),
+
+			responseTranscribe: &tmtranscribe.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("72e68b78-8286-11ed-8875-378ced61c021"),
+				},
+			},
+
+			expectReferenceType: "call",
+			expectReferenceID:   uuid.FromStringOrNil("4ecc56ec-8285-11ed-9958-8b0a60b665bf"),
+			expectLanguage:      "en-US",
+			expectDirection:     tmtranscribe.DirectionBoth,
+			expectOnEndFlowID:   uuid.FromStringOrNil("199a8a78-0944-11f0-b57c-dbf18b86df64"),
+			expectProvider:      tmtranscribe.ProviderEmpty,
+			expectRes:           `{"id":"72e68b78-8286-11ed-8875-378ced61c021","customer_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","on_end_flow_id":"00000000-0000-0000-0000-000000000000","reference_type":"","reference_id":"00000000-0000-0000-0000-000000000000","status":"","language":"","direction":"","provider":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ServiceAgentTranscribeStart(
+				req.Context(),
+				tt.agent,
+				tt.expectReferenceType,
+				tt.expectReferenceID,
+				tt.expectLanguage,
+				tt.expectDirection,
+				tt.expectOnEndFlowID,
+				tt.expectProvider,
+			).Return(tt.responseTranscribe, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			}
+
+			if w.Body.String() != tt.expectRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
+			}
+		})
+	}
+}

--- a/bin-openapi-manager/CLAUDE.md
+++ b/bin-openapi-manager/CLAUDE.md
@@ -55,7 +55,23 @@ OpenAPI schemas must match the `WebhookMessage` struct in each service (`models/
 4. Run `go generate ./...`.
 5. Commit `gens/models/gen.go` with spec changes.
 
+## CRITICAL: Adding a Service Agent (Agent-facing) resource — never widen the Admin/Manager endpoint instead
+
+**`/service_agents/<resource>` and top-level `/<resource>` are two intentionally separate API surfaces, not two routes to the same permission check.** Top-level `/<resource>` is the Admin/Manager surface (square-admin); `/service_agents/<resource>` is the Agent surface (square-talk and any other Agent-facing frontend). Agent-facing frontends are architecturally required to call ONLY `service_agents/*` paths (see `bin-api-manager/docs/auth.md`'s "Service Agent Auth" section).
+
+**If an Agent-facing app needs a capability that only exists as a top-level `/<resource>` endpoint today (e.g. it discovers `/transcribes` is Admin/Manager-gated and it needs list/start access), the fix is to add the missing `service_agents/<resource>` endpoint — never to relax the top-level endpoint's `hasPermission(...)` bitmask.** Relaxing the top-level endpoint's permission is a shortcut that (a) breaks the surface separation the two paths exist to preserve, (b) risks silently opening Admin/Manager-only data to Agents on a path square-admin also depends on, and (c) violates the Agent-facing frontend's own convention of using only `service_agents/*`.
+
+Checklist for adding a new `service_agents/<resource>` endpoint (worked example: `bin-api-manager/pkg/servicehandler/serviceagent_transcribe.go`, added alongside the pre-existing `TranscribeList`/`TranscribeStart` without touching them):
+
+1. **OpenAPI**: create `openapi/paths/service_agents/<resource>.yaml` (a NEW file — do not edit the top-level `openapi/paths/<resource>/main.yaml`), register it under `paths: /service_agents/<resource>:` in `openapi.yaml`. Reuse the same request/response schemas as the top-level endpoint; only the path and `tags: [Service Agent]` differ.
+2. **servicehandler**: add new `ServiceAgent<Resource><Action>` functions (e.g. `ServiceAgentTranscribeList`) in a new `pkg/servicehandler/serviceagent_<resource>.go` file. These call the SAME private, no-permission-check helpers the Admin/Manager functions already use (e.g. `h.transcribeGet`, `h.reqHandler.TranscribeV1TranscribeList`) — do not duplicate the RPC call, only the permission check and the public wrapper. Gate with `amagent.PermissionAll` (the "any authenticated agent of this customer" sentinel used throughout `ServiceAgentContact*`), not `PermissionCustomerAdmin|PermissionCustomerManager`.
+3. **Interface + mock**: add the new method signatures to the `ServiceHandler` interface in `pkg/servicehandler/main.go`, then regenerate the mock (`mockgen -package servicehandler -destination ./mock_main.go -source main.go -build_flags=-mod=mod`, run from `pkg/servicehandler/`).
+4. **server**: add a new `server/service_agents_<resource>.go` file with `Get/PostServiceAgents<Resource>` handlers, mirroring the existing top-level handler's request parsing (`server/<resource>.go`) but calling the new `ServiceAgent*` servicehandler methods.
+5. **Tests**: add both a servicehandler-level test (asserting the new function accepts a plain-Agent-permission identity, not just Admin/Manager) and a server-level HTTP test hitting the new `/service_agents/<resource>` path.
+6. Run the full verification workflow in `bin-api-manager` (`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`) — codegen touches both `bin-openapi-manager` and `bin-api-manager`, run `go generate ./...` in `bin-openapi-manager` FIRST, then in `bin-api-manager`.
+
 ## Further reading
 
 - [docs/architecture.md](docs/architecture.md)
 - [docs/usage.md](docs/usage.md)
+

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -9244,6 +9244,38 @@ type PostServiceAgentsTalkMessagesIdReactionsJSONBody struct {
 	Emoji string `json:"emoji"`
 }
 
+// GetServiceAgentsTranscribesParams defines parameters for GetServiceAgentsTranscribes.
+type GetServiceAgentsTranscribesParams struct {
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// ReferenceType Filter by the reference type of the origin resource. Must be supplied together with reference_id; supplying only one of the two returns a 400 error.
+	ReferenceType *TranscribeManagerTranscribeReferenceType `form:"reference_type,omitempty" json:"reference_type,omitempty"`
+
+	// ReferenceId Filter by the ID of the origin resource (e.g. a call ID returned from `GET /service_agents/calls`). Must be supplied together with reference_type; supplying only one of the two returns a 400 error.
+	ReferenceId *openapi_types.UUID `form:"reference_id,omitempty" json:"reference_id,omitempty"`
+}
+
+// PostServiceAgentsTranscribesJSONBody defines parameters for PostServiceAgentsTranscribes.
+type PostServiceAgentsTranscribesJSONBody struct {
+	// Direction Which audio legs to transcribe. If omitted, defaults to "both".
+	Direction *TranscribeManagerTranscribeDirection `json:"direction,omitempty"`
+
+	// Language The language of the transcription.
+	Language string `json:"language"`
+
+	// OnEndFlowId The flow to execute when the transcription ends. The flow ID returned from the POST /flows or GET /flows response. If omitted, no follow-up flow is executed.
+	OnEndFlowId *string                              `json:"on_end_flow_id,omitempty"`
+	Provider    *TranscribeManagerTranscribeProvider `json:"provider,omitempty"`
+
+	// ReferenceId The ID of the reference for the transcription.
+	ReferenceId   string                                   `json:"reference_id"`
+	ReferenceType TranscribeManagerTranscribeReferenceType `json:"reference_type"`
+}
+
 // GetSpeakingsParams defines parameters for GetSpeakings.
 type GetSpeakingsParams struct {
 	PageSize  *int    `form:"page_size,omitempty" json:"page_size,omitempty"`
@@ -9861,6 +9893,9 @@ type PostServiceAgentsTalkMessagesJSONRequestBody PostServiceAgentsTalkMessagesJ
 
 // PostServiceAgentsTalkMessagesIdReactionsJSONRequestBody defines body for PostServiceAgentsTalkMessagesIdReactions for application/json ContentType.
 type PostServiceAgentsTalkMessagesIdReactionsJSONRequestBody PostServiceAgentsTalkMessagesIdReactionsJSONBody
+
+// PostServiceAgentsTranscribesJSONRequestBody defines body for PostServiceAgentsTranscribes for application/json ContentType.
+type PostServiceAgentsTranscribesJSONRequestBody PostServiceAgentsTranscribesJSONBody
 
 // PostSpeakingsJSONRequestBody defines body for PostSpeakings for application/json ContentType.
 type PostSpeakingsJSONRequestBody PostSpeakingsJSONBody

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -8195,6 +8195,9 @@ paths:
   /service_agents/tags:
     $ref: './paths/service_agents/tags.yaml'
 
+  /service_agents/transcribes:
+    $ref: './paths/service_agents/transcribes.yaml'
+
   /speakings:
     $ref: './paths/speakings/main.yaml'
   /speakings/{id}:

--- a/bin-openapi-manager/openapi/paths/service_agents/transcribes.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/transcribes.yaml
@@ -1,0 +1,111 @@
+get:
+  summary: List transcribes
+  description: >-
+    Retrieves a paginated list of transcriptions for the service agent's
+    customer. Optionally filter by the origin resource (reference_type +
+    reference_id) to find all transcribes tied to a specific call,
+    conference, or recording. Note a single reference can have multiple
+    transcribes (e.g. one per language, or multiple start/stop sessions),
+    so this always returns a list, not a single item.
+  tags:
+    - Service Agent
+  parameters:
+    - $ref: '#/components/parameters/PageSize'
+    - $ref: '#/components/parameters/PageToken'
+    - name: reference_type
+      in: query
+      required: false
+      description: >-
+        Filter by the reference type of the origin resource. Must be supplied
+        together with reference_id; supplying only one of the two returns a
+        400 error.
+      schema:
+        $ref: '#/components/schemas/TranscribeManagerTranscribeReferenceType'
+      example: "call"
+    - name: reference_id
+      in: query
+      required: false
+      description: >-
+        Filter by the ID of the origin resource (e.g. a call ID returned from
+        `GET /service_agents/calls`). Must be supplied together with
+        reference_type; supplying only one of the two returns a 400 error.
+      schema:
+        type: string
+        format: uuid
+      example: "5e4a0680-804e-11ec-8477-2fea5968d85b"
+  responses:
+    '200':
+      description: A list of transcriptions.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/CommonPagination'
+              - type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TranscribeManagerTranscribe'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '500':
+      $ref: '#/components/responses/InternalError'
+
+post:
+  summary: Start a transcribe
+  description: >-
+    Starts a transcription of the given reference (call, conference, or
+    recording) for the service agent's customer and returns the result.
+  tags:
+    - Service Agent
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            reference_type:
+              $ref: '#/components/schemas/TranscribeManagerTranscribeReferenceType'
+            reference_id:
+              type: string
+              description: The ID of the reference for the transcription.
+            language:
+              type: string
+              description: The language of the transcription.
+            direction:
+              allOf:
+                - $ref: '#/components/schemas/TranscribeManagerTranscribeDirection'
+              description: >-
+                Which audio legs to transcribe. If omitted, defaults to "both".
+            provider:
+              $ref: '#/components/schemas/TranscribeManagerTranscribeProvider'
+            on_end_flow_id:
+              type: string
+              format: uuid
+              x-go-type: string
+              description: >-
+                The flow to execute when the transcription ends. The flow ID
+                returned from the POST /flows or GET /flows response. If
+                omitted, no follow-up flow is executed.
+              example: "d4e5f6a7-b8c9-0123-4567-890abcdef012"
+          required:
+            - reference_type
+            - reference_id
+            - language
+  responses:
+    '200':
+      description: The created transcribe details.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TranscribeManagerTranscribe'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '500':
+      $ref: '#/components/responses/InternalError'


### PR DESCRIPTION
Add a new Agent-facing service_agents/transcribes API endpoint so square-talk (which is architecturally restricted to calling only service_agents/* paths) can list and start transcribes, without weakening the existing Admin/Manager-gated top-level /transcribes endpoint.

- bin-openapi-manager: Add openapi/paths/service_agents/transcribes.yaml (GET list + POST start), register in openapi.yaml
- bin-openapi-manager: Add CRITICAL checklist to CLAUDE.md for adding a new Service Agent (Agent-facing) resource, and the rule to never widen the Admin/Manager top-level endpoint's permission instead
- bin-api-manager: Add ServiceAgentTranscribeList/ServiceAgentTranscribeStart in pkg/servicehandler/serviceagent_transcribe.go, gated with amagent.PermissionAll (Agent-level), reusing existing transcribe-manager RPC calls via the same private helpers the Admin/Manager path already uses
- bin-api-manager: Add GetServiceAgentsTranscribes/PostServiceAgentsTranscribes handlers in server/service_agents_transcribes.go
- bin-api-manager: Add unit tests for both new servicehandler functions and server handlers, confirming plain Agent permission (not Admin/Manager) can list/start transcribes via the new surface
- bin-api-manager: Document the Admin-vs-Agent API surface separation rule in docs/auth.md's Service Agent Auth section, with an explicit instruction to add a missing service_agents/<resource> endpoint rather than relaxing the top-level endpoint's permission bitmask