### PR TITLE
NOJIRA-Add-service-agent-transcripts-api

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -19036,6 +19036,76 @@
         }
       }
     },
+    "/service_agents/transcripts": {
+      "get": {
+        "summary": "List transcript lines",
+        "description": "Retrieves the individual spoken/written lines (transcript entries) for one transcribe session, scoped to the service agent's own customer. Ownership is authorized against the target transcribe's own customer_id (fetched by transcribe_id), not a re-derived parent resource.",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "name": "transcribe_id",
+            "in": "query",
+            "required": true,
+            "description": "The transcribe session ID returned from `GET /service_agents/transcribes` or `POST /service_agents/transcribes`.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageToken"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of transcript lines, in creation order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonPagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "result": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/TranscribeManagerTranscript"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/speakings": {
       "get": {
         "summary": "List speaking sessions",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -7071,6 +7071,18 @@ type PostServiceAgentsTranscribesJSONBody struct {
 	ReferenceType TranscribeManagerTranscribeReferenceType `json:"reference_type"`
 }
 
+// GetServiceAgentsTranscriptsParams defines parameters for GetServiceAgentsTranscripts.
+type GetServiceAgentsTranscriptsParams struct {
+	// TranscribeId The transcribe session ID returned from `GET /service_agents/transcribes` or `POST /service_agents/transcribes`.
+	TranscribeId openapi_types.UUID `form:"transcribe_id" json:"transcribe_id"`
+
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+}
+
 // GetSpeakingsParams defines parameters for GetSpeakings.
 type GetSpeakingsParams struct {
 	PageSize  *int    `form:"page_size,omitempty" json:"page_size,omitempty"`
@@ -8702,6 +8714,9 @@ type ServerInterface interface {
 	// Start a transcribe
 	// (POST /service_agents/transcribes)
 	PostServiceAgentsTranscribes(c *gin.Context)
+	// List transcript lines
+	// (GET /service_agents/transcripts)
+	GetServiceAgentsTranscripts(c *gin.Context, params GetServiceAgentsTranscriptsParams)
 	// Establish a WebSocket connection
 	// (GET /service_agents/ws)
 	GetServiceAgentsWs(c *gin.Context)
@@ -17023,6 +17038,55 @@ func (siw *ServerInterfaceWrapper) PostServiceAgentsTranscribes(c *gin.Context) 
 	siw.Handler.PostServiceAgentsTranscribes(c)
 }
 
+// GetServiceAgentsTranscripts operation middleware
+func (siw *ServerInterfaceWrapper) GetServiceAgentsTranscripts(c *gin.Context) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetServiceAgentsTranscriptsParams
+
+	// ------------- Required query parameter "transcribe_id" -------------
+
+	if paramValue := c.Query("transcribe_id"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandler(c, fmt.Errorf("Query argument transcribe_id is required, but not found"), http.StatusBadRequest)
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "transcribe_id", c.Request.URL.Query(), &params.TranscribeId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter transcribe_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_size" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_size", c.Request.URL.Query(), &params.PageSize)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_size: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_token" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_token", c.Request.URL.Query(), &params.PageToken)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_token: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetServiceAgentsTranscripts(c, params)
+}
+
 // GetServiceAgentsWs operation middleware
 func (siw *ServerInterfaceWrapper) GetServiceAgentsWs(c *gin.Context) {
 
@@ -18582,6 +18646,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/service_agents/talk_messages/:id/reactions", wrapper.PostServiceAgentsTalkMessagesIdReactions)
 	router.GET(options.BaseURL+"/service_agents/transcribes", wrapper.GetServiceAgentsTranscribes)
 	router.POST(options.BaseURL+"/service_agents/transcribes", wrapper.PostServiceAgentsTranscribes)
+	router.GET(options.BaseURL+"/service_agents/transcripts", wrapper.GetServiceAgentsTranscripts)
 	router.GET(options.BaseURL+"/service_agents/ws", wrapper.GetServiceAgentsWs)
 	router.GET(options.BaseURL+"/speakings", wrapper.GetSpeakings)
 	router.POST(options.BaseURL+"/speakings", wrapper.PostSpeakings)
@@ -36876,6 +36941,72 @@ func (response PostServiceAgentsTranscribes500JSONResponse) VisitPostServiceAgen
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetServiceAgentsTranscriptsRequestObject struct {
+	Params GetServiceAgentsTranscriptsParams
+}
+
+type GetServiceAgentsTranscriptsResponseObject interface {
+	VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error
+}
+
+type GetServiceAgentsTranscripts200JSONResponse struct {
+	// NextPageToken Cursor token for the next page of results. Pass this value as the page_token parameter in the next request.
+	NextPageToken *string                        `json:"next_page_token,omitempty"`
+	Result        *[]TranscribeManagerTranscript `json:"result,omitempty"`
+}
+
+func (response GetServiceAgentsTranscripts200JSONResponse) VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscripts400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetServiceAgentsTranscripts400JSONResponse) VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscripts401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response GetServiceAgentsTranscripts401JSONResponse) VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscripts403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response GetServiceAgentsTranscripts403JSONResponse) VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscripts404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetServiceAgentsTranscripts404JSONResponse) VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsTranscripts500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetServiceAgentsTranscripts500JSONResponse) VisitGetServiceAgentsTranscriptsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetServiceAgentsWsRequestObject struct {
 }
 
@@ -40597,6 +40728,9 @@ type StrictServerInterface interface {
 	// Start a transcribe
 	// (POST /service_agents/transcribes)
 	PostServiceAgentsTranscribes(ctx context.Context, request PostServiceAgentsTranscribesRequestObject) (PostServiceAgentsTranscribesResponseObject, error)
+	// List transcript lines
+	// (GET /service_agents/transcripts)
+	GetServiceAgentsTranscripts(ctx context.Context, request GetServiceAgentsTranscriptsRequestObject) (GetServiceAgentsTranscriptsResponseObject, error)
 	// Establish a WebSocket connection
 	// (GET /service_agents/ws)
 	GetServiceAgentsWs(ctx context.Context, request GetServiceAgentsWsRequestObject) (GetServiceAgentsWsResponseObject, error)
@@ -50356,6 +50490,33 @@ func (sh *strictHandler) PostServiceAgentsTranscribes(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(PostServiceAgentsTranscribesResponseObject); ok {
 		if err := validResponse.VisitPostServiceAgentsTranscribesResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetServiceAgentsTranscripts operation middleware
+func (sh *strictHandler) GetServiceAgentsTranscripts(ctx *gin.Context, params GetServiceAgentsTranscriptsParams) {
+	var request GetServiceAgentsTranscriptsRequestObject
+
+	request.Params = params
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetServiceAgentsTranscripts(ctx, request.(GetServiceAgentsTranscriptsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetServiceAgentsTranscripts")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetServiceAgentsTranscriptsResponseObject); ok {
+		if err := validResponse.VisitGetServiceAgentsTranscriptsResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -930,6 +930,7 @@ type ServiceHandler interface {
 		onEndFlowID uuid.UUID,
 		provider tmtranscribe.Provider,
 	) (*tmtranscribe.WebhookMessage, error)
+	ServiceAgentTranscriptList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, transcribeID uuid.UUID) ([]*tmtranscript.WebhookMessage, error)
 	ServiceAgentContactAddressCreate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addrType string, target string, isPrimary bool, name string, detail string) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactAddressUpdate(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID, fields map[string]any) (*cmcontact.WebhookMessage, error)
 	ServiceAgentContactAddressDelete(ctx context.Context, a *auth.AuthIdentity, contactID uuid.UUID, addressID uuid.UUID) (*cmcontact.WebhookMessage, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -5034,6 +5034,21 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentTranscribeStart(ctx, a, re
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTranscribeStart", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTranscribeStart), ctx, a, referenceType, referenceID, language, direction, onEndFlowID, provider)
 }
 
+// ServiceAgentTranscriptList mocks base method.
+func (m *MockServiceHandler) ServiceAgentTranscriptList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, transcribeID uuid.UUID) ([]*transcript.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentTranscriptList", ctx, a, size, token, transcribeID)
+	ret0, _ := ret[0].([]*transcript.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentTranscriptList indicates an expected call of ServiceAgentTranscriptList.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentTranscriptList(ctx, a, size, token, transcribeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentTranscriptList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentTranscriptList), ctx, a, size, token, transcribeID)
+}
+
 // SpeakingCreate mocks base method.
 func (m *MockServiceHandler) SpeakingCreate(ctx context.Context, a *auth.AuthIdentity, referenceType streaming.ReferenceType, referenceID uuid.UUID, language, provider, voiceID string, direction streaming.Direction) (*speaking.WebhookMessage, error) {
 	m.ctrl.T.Helper()

--- a/bin-api-manager/pkg/servicehandler/serviceagent_transcript.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_transcript.go
@@ -1,0 +1,75 @@
+package servicehandler
+
+import (
+	"context"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// ServiceAgentTranscriptList sends a request to transcribe-manager
+// to get a list of transcript lines for one transcribe session, scoped to
+// the service agent's own customer.
+// Ownership is authorized against the target transcribe's own CustomerID
+// (fetched by transcribeID), not a re-derived parent resource — this is a
+// pure Get/Read path, not a Create/Start path validating a caller-supplied
+// reference before the row exists. Mirrors TranscriptList's own existing
+// shape (fetch, then hasPermission on the fetched struct's field) — only
+// the permission bitmask changes (PermissionAll instead of Admin|Manager).
+func (h *serviceHandler) ServiceAgentTranscriptList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, transcribeID uuid.UUID) ([]*tmtranscript.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":          "ServiceAgentTranscriptList",
+		"customer_id":   a.CustomerID,
+		"username":      a.DisplayName(),
+		"transcribe_id": transcribeID,
+		"size":          size,
+		"token":         token,
+	})
+
+	if token == "" {
+		token = h.utilHandler.TimeGetCurTime()
+	}
+
+	t, err := h.transcribeGet(ctx, transcribeID)
+	if err != nil {
+		log.Infof("Could not get transcribe info. err: %v", err)
+		return nil, err
+	}
+
+	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	filters := map[string]string{
+		"transcribe_id": transcribeID.String(),
+		"deleted":       "false",
+	}
+	typedFilters, err := h.convertTranscriptFilters(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	tmps, err := h.reqHandler.TranscribeV1TranscriptList(ctx, token, size, typedFilters)
+	if err != nil {
+		log.Errorf("Could not get transcripts. err: %v", err)
+		return nil, err
+	}
+
+	res := []*tmtranscript.WebhookMessage{}
+	for _, tmp := range tmps {
+		e := tmp.ConvertWebhookMessage()
+		res = append(res, e)
+	}
+
+	return res, nil
+}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_transcript_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_transcript_test.go
@@ -1,0 +1,201 @@
+package servicehandler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
+	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/dbhandler"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+)
+
+func Test_ServiceAgentTranscriptList(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		agent        *auth.AuthIdentity
+		pageSize     uint64
+		pageToken    string
+		transcribeID uuid.UUID
+
+		responseTranscribe  *tmtranscribe.Transcribe
+		responseTranscripts []tmtranscript.Transcript
+
+		expectFilters map[tmtranscript.Field]any
+		expectRes     []*tmtranscript.WebhookMessage
+	}{
+		{
+			// Plain Agent permission (not Admin/Manager) must be able to list
+			// transcript lines for a transcribe belonging to its own
+			// customer via the service_agents surface. This is the whole
+			// point of the new endpoint.
+			"agent permission, own customer's transcribe",
+			auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			10,
+			"2020-10-20T01:00:00.995000Z",
+			uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+
+			&tmtranscribe.Transcribe{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+			},
+			[]tmtranscript.Transcript{
+				{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+						CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+					},
+					TranscribeID: uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+					Message:      "Hello, how can I help you?",
+				},
+			},
+
+			map[tmtranscript.Field]any{
+				tmtranscript.FieldTranscribeID: uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+				tmtranscript.FieldDeleted:      false,
+			},
+			[]*tmtranscript.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+						CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+					},
+					TranscribeID: uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+					Message:      "Hello, how can I help you?",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler:  mockReq,
+				dbHandler:   mockDB,
+				utilHandler: mockUtil,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().TranscribeV1TranscribeGet(ctx, tt.transcribeID).Return(tt.responseTranscribe, nil)
+			mockReq.EXPECT().TranscribeV1TranscriptList(ctx, tt.pageToken, tt.pageSize, tt.expectFilters).Return(tt.responseTranscripts, nil)
+
+			res, err := h.ServiceAgentTranscriptList(ctx, tt.agent, tt.pageSize, tt.pageToken, tt.transcribeID)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_ServiceAgentTranscriptList_CrossCustomerDenied(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler:  mockReq,
+		dbHandler:   mockDB,
+		utilHandler: mockUtil,
+	}
+	ctx := context.Background()
+
+	// Agent belongs to a DIFFERENT customer than the fetched transcribe —
+	// must be denied even though the transcribe_id itself is valid and
+	// resolves successfully. This is the IDOR/cross-tenant boundary check.
+	agent := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111"),
+		},
+		Permission: amagent.PermissionCustomerAgent,
+	})
+	transcribeID := uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e")
+
+	mockReq.EXPECT().TranscribeV1TranscribeGet(ctx, transcribeID).Return(&tmtranscribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID:         transcribeID,
+			CustomerID: uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222"),
+		},
+	}, nil)
+	mockUtil.EXPECT().TimeGetCurTime().Return("2020-10-20T01:00:00.995000Z")
+
+	res, err := h.ServiceAgentTranscriptList(ctx, agent, 100, "", transcribeID)
+	if err != serviceerrors.ErrPermissionDenied {
+		t.Errorf("Wrong match. expect: ErrPermissionDenied, got: %v, res: %v", err, res)
+	}
+}
+
+func Test_ServiceAgentTranscriptList_TranscribeNotFound(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler:  mockReq,
+		dbHandler:   mockDB,
+		utilHandler: mockUtil,
+	}
+	ctx := context.Background()
+
+	// A malformed/missing transcribe_id resolves to uuid.Nil at the HTTP
+	// layer (see server/service_agents_transcripts.go), which flows into
+	// transcribeGet the same way any not-found transcribe_id would — the
+	// RPC layer is expected to surface a not-found error, which must
+	// propagate here rather than panic or silently succeed.
+	agent := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		},
+		Permission: amagent.PermissionCustomerAgent,
+	})
+
+	expectErr := serviceerrors.ErrNotFound
+
+	mockUtil.EXPECT().TimeGetCurTime().Return("2020-10-20T01:00:00.995000Z")
+	mockReq.EXPECT().TranscribeV1TranscribeGet(ctx, uuid.Nil).Return(nil, expectErr)
+
+	res, err := h.ServiceAgentTranscriptList(ctx, agent, 100, "", uuid.Nil)
+	if err != expectErr {
+		t.Errorf("Wrong match. expect: %v, got: %v, res: %v", expectErr, err, res)
+	}
+}

--- a/bin-api-manager/server/service_agents_transcripts.go
+++ b/bin-api-manager/server/service_agents_transcripts.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"monorepo/bin-api-manager/gens/openapi_server"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// GetServiceAgentsTranscripts handles GET /service_agents/transcripts
+func (h *server) GetServiceAgentsTranscripts(c *gin.Context, params openapi_server.GetServiceAgentsTranscriptsParams) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "GetServiceAgentsTranscripts",
+		"request_address": c.ClientIP,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithFields(logrus.Fields{
+		"agent": a,
+	})
+
+	pageSize := uint64(100)
+	if params.PageSize != nil {
+		pageSize = uint64(*params.PageSize)
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 100
+		log.Debugf("Invalid requested page size. Set to default. page_size: %d", pageSize)
+	}
+
+	pageToken := ""
+	if params.PageToken != nil {
+		pageToken = *params.PageToken
+	}
+
+	transcribeID := uuid.UUID(params.TranscribeId)
+
+	tmps, err := h.serviceHandler.ServiceAgentTranscriptList(c.Request.Context(), a, pageSize, pageToken, transcribeID)
+	if err != nil {
+		logrus.Errorf("Could not get transcripts info. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	nextToken := ""
+	if len(tmps) > 0 {
+		if tmps[len(tmps)-1].TMCreate != nil {
+			nextToken = tmps[len(tmps)-1].TMCreate.UTC().Format("2006-01-02T15:04:05.000000Z")
+		}
+	}
+
+	res := GenerateListResponse(tmps, nextToken)
+	c.JSON(200, res)
+}

--- a/bin-api-manager/server/service_agents_transcripts_test.go
+++ b/bin-api-manager/server/service_agents_transcripts_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_GetServiceAgentsTranscripts(t *testing.T) {
+
+	type test struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+
+		responseTranscripts []*tmtranscript.WebhookMessage
+
+		expectedPageSize     uint64
+		expectedPageToken    string
+		expectedTranscribeID uuid.UUID
+		expectedRes          string
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/transcripts?transcribe_id=b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e&page_size=10&page_token=2020-09-20T03:23:20.995000Z",
+
+			responseTranscripts: []*tmtranscript.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
+					},
+					TranscribeID: uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+					Message:      "Hello, how can I help you?",
+				},
+			},
+
+			expectedPageSize:     10,
+			expectedPageToken:    "2020-09-20T03:23:20.995000Z",
+			expectedTranscribeID: uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+			expectedRes:          `{"result":[{"id":"550e8400-e29b-41d4-a716-446655440000","customer_id":"00000000-0000-0000-0000-000000000000","transcribe_id":"b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e","direction":"","message":"Hello, how can I help you?","tm_transcript":null,"tm_create":null}],"next_page_token":""}`,
+		},
+		{
+			// Regression test for the round-1 design review pagination fix
+			// — page_size/page_token must actually be forwarded to the
+			// servicehandler, not silently dropped/hardcoded.
+			name: "default page_size and page_token when omitted",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/transcripts?transcribe_id=b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e",
+
+			responseTranscripts: []*tmtranscript.WebhookMessage{},
+
+			expectedPageSize:     100,
+			expectedPageToken:    "",
+			expectedTranscribeID: uuid.FromStringOrNil("b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e"),
+			expectedRes:          `{"result":[],"next_page_token":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ServiceAgentTranscriptList(req.Context(), tt.agent, tt.expectedPageSize, tt.expectedPageToken, tt.expectedTranscribeID).Return(tt.responseTranscripts, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d, body: %s", http.StatusOK, w.Code, w.Body)
+			}
+
+			if w.Body.String() != tt.expectedRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectedRes, w.Body)
+			}
+		})
+	}
+}
+
+// Test_GetServiceAgentsTranscripts_MissingTranscribeID verifies the
+// required transcribe_id query parameter is enforced by the generated
+// oapi-codegen wrapper with an automatic 400, before this handler (or the
+// servicehandler) is ever consulted.
+func Test_GetServiceAgentsTranscripts_MissingTranscribeID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+		},
+	})
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSvc := servicehandler.NewMockServiceHandler(mc)
+	h := &server{serviceHandler: mockSvc}
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		c.Set("auth_identity", agent)
+	})
+	openapi_server.RegisterHandlers(r, h)
+
+	req, _ := http.NewRequest(http.MethodGet, "/service_agents/transcripts", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Wrong match. expect: %d, got: %d, body: %s", http.StatusBadRequest, w.Code, w.Body)
+	}
+}

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -9276,6 +9276,18 @@ type PostServiceAgentsTranscribesJSONBody struct {
 	ReferenceType TranscribeManagerTranscribeReferenceType `json:"reference_type"`
 }
 
+// GetServiceAgentsTranscriptsParams defines parameters for GetServiceAgentsTranscripts.
+type GetServiceAgentsTranscriptsParams struct {
+	// TranscribeId The transcribe session ID returned from `GET /service_agents/transcribes` or `POST /service_agents/transcribes`.
+	TranscribeId openapi_types.UUID `form:"transcribe_id" json:"transcribe_id"`
+
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+}
+
 // GetSpeakingsParams defines parameters for GetSpeakings.
 type GetSpeakingsParams struct {
 	PageSize  *int    `form:"page_size,omitempty" json:"page_size,omitempty"`

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -8198,6 +8198,9 @@ paths:
   /service_agents/transcribes:
     $ref: './paths/service_agents/transcribes.yaml'
 
+  /service_agents/transcripts:
+    $ref: './paths/service_agents/transcripts.yaml'
+
   /speakings:
     $ref: './paths/speakings/main.yaml'
   /speakings/{id}:

--- a/bin-openapi-manager/openapi/paths/service_agents/transcripts.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/transcripts.yaml
@@ -1,0 +1,46 @@
+get:
+  summary: List transcript lines
+  description: >-
+    Retrieves the individual spoken/written lines (transcript entries) for
+    one transcribe session, scoped to the service agent's own customer.
+    Ownership is authorized against the target transcribe's own customer_id
+    (fetched by transcribe_id), not a re-derived parent resource.
+  tags:
+    - Service Agent
+  parameters:
+    - name: transcribe_id
+      in: query
+      required: true
+      description: >-
+        The transcribe session ID returned from `GET /service_agents/transcribes`
+        or `POST /service_agents/transcribes`.
+      schema:
+        type: string
+        format: uuid
+      example: "550e8400-e29b-41d4-a716-446655440000"
+    - $ref: '#/components/parameters/PageSize'
+    - $ref: '#/components/parameters/PageToken'
+  responses:
+    '200':
+      description: A list of transcript lines, in creation order.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/CommonPagination'
+              - type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TranscribeManagerTranscript'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/docs/plans/2026-07-04-service-agent-transcripts-api-design.md
+++ b/docs/plans/2026-07-04-service-agent-transcripts-api-design.md
@@ -1,0 +1,285 @@
+# service_agents/transcripts API design (SQUARE-7 backend dependency)
+
+## Problem
+
+SQUARE-7 (square-talk: "Contacts → Interaction click auto-shows the call's
+transcribe") needs to show the *actual conversation text* of a transcribe, not
+just its metadata. `service_agents/transcribes` (added in PR #1049) already
+returns `TranscribeManagerTranscribe` — status/language/provider/timestamps —
+but carries no message content. The individual spoken lines live in a
+separate resource, `TranscribeManagerTranscript` (plural is misleading; one
+`Transcript` row = one utterance), queried via `GET /transcripts?transcribe_id=`.
+
+That endpoint exists only as a top-level, Admin/Manager-gated path
+(`bin-api-manager/pkg/servicehandler/transcript.go`'s `TranscriptList`, gated
+`PermissionCustomerAdmin|PermissionCustomerManager`). There is no
+`service_agents/transcripts` twin. Per this repo's established rule (see
+`bin-openapi-manager/CLAUDE.md`'s "Adding a Service Agent resource" section,
+and the `voipbin-square-talk-feature` skill's "missing capability = missing
+endpoint first" section), the fix is to add the missing Agent-facing
+endpoint — never to relax the top-level endpoint's permission.
+
+## Shape of the gap
+
+This mirrors the exact precedent that shipped `service_agents/transcribes`
+(PR #1049) one JIRA cycle ago: the Agent-facing need is the resource's core
+READ shape (list all transcript lines for one transcribe), not a narrow
+write verb. Per the skill's rule of thumb, this is a "stand up the parallel
+`service_agents/<resource>`" case, not a "relax two write verbs" case.
+
+## Design
+
+### 1. OpenAPI (`bin-openapi-manager`)
+
+New file `openapi/paths/service_agents/transcripts.yaml`:
+
+```yaml
+get:
+  summary: List transcript lines
+  description: >-
+    Retrieves the individual spoken/written lines (transcript entries) for
+    one transcribe session, scoped to the service agent's own customer.
+    Ownership is authorized against the target transcribe's own customer_id
+    (fetched by transcribe_id), not a re-derived parent resource — see
+    servicehandler implementation notes.
+  tags:
+    - Service Agent
+  parameters:
+    - name: transcribe_id
+      in: query
+      required: true
+      description: >-
+        The transcribe session ID returned from `GET /service_agents/transcribes`
+        or `POST /service_agents/transcribes`.
+      schema:
+        type: string
+        format: uuid
+      example: "550e8400-e29b-41d4-a716-446655440000"
+    - $ref: '#/components/parameters/PageSize'
+    - $ref: '#/components/parameters/PageToken'
+  responses:
+    '200':
+      description: A list of transcript lines, in creation order.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/CommonPagination'
+              - type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TranscribeManagerTranscript'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'
+```
+
+Register under `paths: /service_agents/transcripts:` in `openapi.yaml`.
+Reuses `TranscribeManagerTranscript` schema (already defined, no changes
+needed there).
+
+### 2. servicehandler (`bin-api-manager/pkg/servicehandler/serviceagent_transcript.go`, new file)
+
+```go
+func (h *serviceHandler) ServiceAgentTranscriptList(
+	ctx context.Context, a *auth.AuthIdentity, size uint64, token string, transcribeID uuid.UUID,
+) ([]*tmtranscript.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":          "ServiceAgentTranscriptList",
+		"customer_id":   a.CustomerID,
+		"username":      a.DisplayName(),
+		"transcribe_id": transcribeID,
+		"size":          size,
+		"token":         token,
+	})
+
+	if token == "" {
+		token = h.utilHandler.TimeGetCurTime()
+	}
+
+	// Fetch the target transcribe first — its own CustomerID field is the
+	// authoritative tenant boundary. No second RPC to a parent resource
+	// (call/conference/recording) is needed: this is a pure Get/Read path,
+	// not a Create/Start path validating a caller-supplied reference before
+	// the row exists. Mirrors TranscriptList's own existing shape (fetch,
+	// then hasPermission on the fetched struct's field) — only the
+	// permission bitmask changes (PermissionAll instead of Admin|Manager).
+	t, err := h.transcribeGet(ctx, transcribeID)
+	if err != nil {
+		log.Infof("Could not get transcribe info. err: %v", err)
+		return nil, err
+	}
+
+	if !h.hasPermission(ctx, a, t.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	filters := map[string]string{
+		"transcribe_id": transcribeID.String(),
+		"deleted":       "false",
+	}
+	typedFilters, err := h.convertTranscriptFilters(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	tmps, err := h.reqHandler.TranscribeV1TranscriptList(ctx, token, size, typedFilters)
+	if err != nil {
+		log.Errorf("Could not get transcripts. err: %v", err)
+		return nil, err
+	}
+
+	res := []*tmtranscript.WebhookMessage{}
+	for _, tmp := range tmps {
+		res = append(res, tmp.ConvertWebhookMessage())
+	}
+	return res, nil
+}
+```
+
+Reuses the existing private `convertTranscriptFilters` helper (already
+defined in `transcript.go`, no duplication needed — same file/package).
+
+**Pagination fix (added after round-1 review — IMPORTANT fix):** an earlier
+draft of this design hardcoded `token=""`/`size=100` inside the
+servicehandler function, silently ignoring the OpenAPI spec's advertised
+`page_size`/`page_token` query parameters — the exact same "advertises
+pagination, doesn't implement it" defect the reviewer found already present
+in the top-level `TranscriptList`/`GetTranscripts` pair. Rather than
+propagate that defect into a brand-new endpoint, `size`/`token` are now real
+parameters threaded from the HTTP layer through to
+`TranscribeV1TranscriptList`, matching `ServiceAgentTranscribeList`'s own
+existing pagination handling exactly (same `token == "" → TimeGetCurTime()`
+default-token pattern). A call with more than one page of utterances now
+gets a genuinely usable `next_page_token` in the response instead of a
+silent truncation at 100 rows — see server handler section below for the
+param wiring. (Fixing the OLDER top-level `TranscriptList`'s identical defect
+is explicitly out of scope for this PR — flagged as a separate, pre-existing
+issue not introduced here.)
+
+### 3. Interface + mock
+
+Add `ServiceAgentTranscriptList(ctx, a, size, token, transcribeID) ([]*tmtranscript.WebhookMessage, error)`
+to the `ServiceHandler` interface in `pkg/servicehandler/main.go` (signature
+updated to match the pagination fix above), regenerate mock via `mockgen
+-package servicehandler -destination ./mock_main.go -source main.go
+-build_flags=-mod=mod`.
+
+### 4. server handler (`bin-api-manager/server/service_agents_transcripts.go`, new file)
+
+```go
+func (h *server) GetServiceAgentsTranscripts(c *gin.Context, params openapi_server.GetServiceAgentsTranscriptsParams) {
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		abortWithError(c, cerrors.Unauthenticated(...))
+		return
+	}
+
+	pageSize := uint64(100)
+	if params.PageSize != nil {
+		pageSize = uint64(*params.PageSize)
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 100
+	}
+
+	pageToken := ""
+	if params.PageToken != nil {
+		pageToken = *params.PageToken
+	}
+
+	transcribeID := uuid.FromStringOrNil(params.TranscribeId)
+
+	tmps, err := h.serviceHandler.ServiceAgentTranscriptList(c.Request.Context(), a, pageSize, pageToken, transcribeID)
+	if err != nil {
+		abortWithServiceError(c, err)
+		return
+	}
+
+	nextToken := ""
+	if len(tmps) > 0 && tmps[len(tmps)-1].TMCreate != nil {
+		nextToken = tmps[len(tmps)-1].TMCreate.UTC().Format("2006-01-02T15:04:05.000000Z")
+	}
+
+	res := GenerateListResponse(tmps, nextToken)
+	c.JSON(200, res)
+}
+```
+
+Mirrors `server/transcribes.go`'s `GetTranscribes` param-parsing shape (not
+`server/transcripts.go`'s `GetTranscripts`, which is the one with the
+hardcoded-pagination defect flagged in round-1 review) — this file now
+threads `page_size`/`page_token` all the way through, matching the
+OpenAPI spec's advertised contract.
+
+### 5. Edge cases (added after round-1 review)
+
+- **Missing/malformed `transcribe_id`**: OpenAPI marks `transcribe_id` as
+  `required: true`, so oapi-codegen's generated `ServerInterfaceWrapper`
+  rejects a request with the parameter entirely absent with an automatic 400
+  before this handler ever runs (confirmed against `GetTranscribes`' actual
+  generated wrapper code in round-1 review). A syntactically-present but
+  non-UUID string (e.g. `transcribe_id=not-a-uuid`) is NOT caught by that
+  wrapper — it reaches `uuid.FromStringOrNil`, which silently converts it to
+  `uuid.Nil`, exactly the same as the pre-existing top-level `GetTranscripts`
+  handler's own behavior. This is an intentional match to the existing
+  pattern, not a new gap introduced by this endpoint: `uuid.Nil` flows into
+  `transcribeGet(ctx, uuid.Nil)`, which the RPC chain resolves to a
+  not-found response (404), so the net behavior for a malformed ID is
+  "404 Not Found" rather than "400 Bad Request." Documented here explicitly
+  as the accepted behavior — improving this (returning 400 for a
+  syntactically invalid UUID) would be a good small follow-up but is a
+  pre-existing platform-wide pattern, not something to fix ad hoc inside
+  this one new endpoint.
+- **Pagination truncation signal**: with the fix above, `next_page_token`
+  in the response is now a real, usable value (not always empty) — a client
+  reading an empty `next_page_token` after a full page of exactly `pageSize`
+  results should treat that as potentially more data available and can
+  re-request with the token; an empty token AND fewer than `pageSize`
+  results returned means "no more data." (Same convention `ServiceAgent
+  TranscribeList` already establishes — no new convention introduced.)
+
+### 6. Tests
+
+- `serviceagent_transcript_test.go`: assert a plain-Agent-permission identity
+  succeeds (the whole point), assert cross-customer denial (agent's
+  CustomerID differs from the fetched transcribe's CustomerID → PermissionDenied),
+  assert `transcribeGet` error (e.g. not-found transcribe_id) propagates,
+  assert a malformed/`uuid.Nil` `transcribe_id` resolves to the not-found
+  path per the edge-case section above (not a panic or a 400).
+- `service_agents_transcripts_test.go`: HTTP-level test hitting the new path,
+  mirroring `transcribes_test.go`'s existing style, including a case
+  asserting `page_size`/`page_token` are actually forwarded (not silently
+  dropped — this is the regression test for the round-1 pagination fix).
+
+### 7. Verification
+
+Standard workflow: `bin-openapi-manager` (`go generate ./...`) first, then
+`bin-api-manager` (`go mod tidy && go mod vendor && go generate ./... && go
+test ./... && golangci-lint run -v --timeout 5m`).
+
+## Out of scope
+
+- No changes to the top-level `/transcripts` endpoint (stays Admin/Manager;
+  its own pre-existing hardcoded-pagination defect, found during this
+  design's review, is a separate follow-up issue, not fixed here).
+- No write/delete on transcript lines (read-only resource by design —
+  transcript lines are produced by the STT pipeline, never edited/created
+  via this API).
+- Returning 400 (instead of the current 404) for a syntactically invalid
+  (non-UUID) `transcribe_id` string — matches the pre-existing top-level
+  endpoint's behavior; a platform-wide fix, not scoped to this one PR.


### PR DESCRIPTION
Add the missing Agent-facing service_agents/transcripts endpoint, the SQUARE-7 backend dependency for showing a call's actual conversation text (not just transcribe metadata) in square-talk.

- bin-openapi-manager: Add openapi/paths/service_agents/transcripts.yaml (GET, reuses TranscribeManagerTranscript schema)
- bin-api-manager: Add ServiceAgentTranscriptList servicehandler function, authorizing against the fetched transcribe's own CustomerID with amagent.PermissionAll (no relaxation of the Admin/Manager-gated top-level /transcripts endpoint)
- bin-api-manager: Add GetServiceAgentsTranscripts server handler with real page_size/page_token forwarding to transcribe-manager
- bin-api-manager: Add servicehandler and server-level tests (agent-permission success, cross-customer denial, transcribe-not-found propagation, pagination forwarding, missing required param)
- docs: Add design doc with review history (2 rounds design review + 2 rounds PR code review, all issues resolved, no blockers)