### PR TITLE
NOJIRA-Revert-interaction-permission-relax-add-service-agents-endpoint

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -18888,6 +18888,335 @@
         }
       }
     },
+    "/service_agents/interactions": {
+      "get": {
+        "summary": "List interactions",
+        "description": "List CRM interactions for the service agent's customer. Exactly one filter is required:\npeer_type + peer_target (remote endpoint), contact_id, or address_id.\n",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "name": "peer_type",
+            "in": "query",
+            "description": "Remote endpoint type (e.g. \"tel\", \"email\"). Required with peer_target.",
+            "schema": {
+              "type": "string",
+              "example": "tel"
+            }
+          },
+          {
+            "name": "peer_target",
+            "in": "query",
+            "description": "Remote endpoint target (e.g. \"+155****4567\"). Required with peer_type.",
+            "schema": {
+              "type": "string",
+              "example": "+155****4567"
+            }
+          },
+          {
+            "name": "contact_id",
+            "in": "query",
+            "description": "Filter by resolved contact ID.",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          },
+          {
+            "name": "address_id",
+            "in": "query",
+            "description": "Filter by contact address ID.",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "7c4d2f3a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageToken"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactManagerInteractionListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/service_agents/interactions/unresolved": {
+      "get": {
+        "summary": "List unresolved interactions",
+        "description": "List interactions that have no active resolution within the given time window,\nfor the service agent's customer.\nThe \"since\" parameter defines the lookback window (e.g. \"7d\" = last 7 days).\nDefault is \"30d\"; maximum is \"180d\".\n",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Lookback window in days (e.g. \"7d\", \"30d\"). Default \"30d\", max \"180d\".\n",
+            "schema": {
+              "type": "string",
+              "example": "30d"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageToken"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactManagerInteractionListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/service_agents/interactions/{id}": {
+      "get": {
+        "summary": "Get an interaction",
+        "description": "Get the interaction of the given ID, for the service agent's customer.",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the interaction. The ID is returned from GET /service_agents/interactions response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactManagerInteraction"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/service_agents/interactions/{id}/resolutions": {
+      "post": {
+        "summary": "Create a resolution for an interaction",
+        "description": "Manually attribute (positive) or suppress (negative) an interaction for a contact,\nfor the service agent's customer.\nA positive resolution attaches the interaction to the contact.\nA negative resolution suppresses an incorrect automatic match.\n",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the interaction. The ID is returned from GET /service_agents/interactions response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "contact_id",
+                  "resolution_type",
+                  "resolved_by_type",
+                  "resolved_by_id"
+                ],
+                "properties": {
+                  "contact_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The contact to attach or suppress this interaction for.",
+                    "example": "7c4d2f3a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
+                  },
+                  "resolution_type": {
+                    "type": "string",
+                    "description": "Type of resolution.",
+                    "enum": [
+                      "positive",
+                      "negative"
+                    ],
+                    "example": "positive"
+                  },
+                  "resolved_by_type": {
+                    "type": "string",
+                    "description": "Who resolved this interaction.",
+                    "enum": [
+                      "agent",
+                      "system",
+                      "rule"
+                    ],
+                    "example": "agent"
+                  },
+                  "resolved_by_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "ID of the agent, system, or rule that resolved the interaction.",
+                    "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Resolution created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactManagerResolution"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/service_agents/interactions/{id}/resolutions/{rid}": {
+      "delete": {
+        "summary": "Delete a resolution",
+        "description": "Soft-delete a resolution, for the service agent's customer.\nUse this to retract a wrong positive or negative resolution.\nRe-attribute by creating a new resolution after deletion.\n",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the interaction. The ID is returned from GET /service_agents/interactions response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          },
+          {
+            "name": "rid",
+            "in": "path",
+            "description": "The ID of the resolution. The ID is returned from POST /service_agents/interactions/{id}/resolutions response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resolution deleted successfully."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/service_agents/transcribes": {
       "get": {
         "summary": "List transcribes",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -1112,6 +1112,19 @@ const (
 	Talk PostServiceAgentsFilesMultipartBodyType = "talk"
 )
 
+// Defines values for PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType.
+const (
+	Negative PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType = "negative"
+	Positive PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType = "positive"
+)
+
+// Defines values for PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType.
+const (
+	Agent  PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType = "agent"
+	Rule   PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType = "rule"
+	System PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType = "system"
+)
+
 // Defines values for PostStorageFilesMultipartBodyType.
 const (
 	Rag PostStorageFilesMultipartBodyType = "rag"
@@ -6913,6 +6926,60 @@ type PostServiceAgentsFilesMultipartBody struct {
 // PostServiceAgentsFilesMultipartBodyType defines parameters for PostServiceAgentsFiles.
 type PostServiceAgentsFilesMultipartBodyType string
 
+// GetServiceAgentsInteractionsParams defines parameters for GetServiceAgentsInteractions.
+type GetServiceAgentsInteractionsParams struct {
+	// PeerType Remote endpoint type (e.g. "tel", "email"). Required with peer_target.
+	PeerType *string `form:"peer_type,omitempty" json:"peer_type,omitempty"`
+
+	// PeerTarget Remote endpoint target (e.g. "+155****4567"). Required with peer_type.
+	PeerTarget *string `form:"peer_target,omitempty" json:"peer_target,omitempty"`
+
+	// ContactId Filter by resolved contact ID.
+	ContactId *openapi_types.UUID `form:"contact_id,omitempty" json:"contact_id,omitempty"`
+
+	// AddressId Filter by contact address ID.
+	AddressId *openapi_types.UUID `form:"address_id,omitempty" json:"address_id,omitempty"`
+
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+}
+
+// GetServiceAgentsInteractionsUnresolvedParams defines parameters for GetServiceAgentsInteractionsUnresolved.
+type GetServiceAgentsInteractionsUnresolvedParams struct {
+	// Since Lookback window in days (e.g. "7d", "30d"). Default "30d", max "180d".
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
+
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+}
+
+// PostServiceAgentsInteractionsIdResolutionsJSONBody defines parameters for PostServiceAgentsInteractionsIdResolutions.
+type PostServiceAgentsInteractionsIdResolutionsJSONBody struct {
+	// ContactId The contact to attach or suppress this interaction for.
+	ContactId openapi_types.UUID `json:"contact_id"`
+
+	// ResolutionType Type of resolution.
+	ResolutionType PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType `json:"resolution_type"`
+
+	// ResolvedById ID of the agent, system, or rule that resolved the interaction.
+	ResolvedById openapi_types.UUID `json:"resolved_by_id"`
+
+	// ResolvedByType Who resolved this interaction.
+	ResolvedByType PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType `json:"resolved_by_type"`
+}
+
+// PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType defines parameters for PostServiceAgentsInteractionsIdResolutions.
+type PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType string
+
+// PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType defines parameters for PostServiceAgentsInteractionsIdResolutions.
+type PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType string
+
 // PutServiceAgentsMeJSONBody defines parameters for PutServiceAgentsMe.
 type PutServiceAgentsMeJSONBody struct {
 	// Detail Additional details about the agent.
@@ -7673,6 +7740,9 @@ type PostServiceAgentsConversationsIdMessagesJSONRequestBody PostServiceAgentsCo
 
 // PostServiceAgentsFilesMultipartRequestBody defines body for PostServiceAgentsFiles for multipart/form-data ContentType.
 type PostServiceAgentsFilesMultipartRequestBody PostServiceAgentsFilesMultipartBody
+
+// PostServiceAgentsInteractionsIdResolutionsJSONRequestBody defines body for PostServiceAgentsInteractionsIdResolutions for application/json ContentType.
+type PostServiceAgentsInteractionsIdResolutionsJSONRequestBody PostServiceAgentsInteractionsIdResolutionsJSONBody
 
 // PutServiceAgentsMeJSONRequestBody defines body for PutServiceAgentsMe for application/json ContentType.
 type PutServiceAgentsMeJSONRequestBody PutServiceAgentsMeJSONBody
@@ -8642,6 +8712,21 @@ type ServerInterface interface {
 	// Download the service agent file
 	// (GET /service_agents/files/{id}/file)
 	GetServiceAgentsFilesIdFile(c *gin.Context, id openapi_types.UUID)
+	// List interactions
+	// (GET /service_agents/interactions)
+	GetServiceAgentsInteractions(c *gin.Context, params GetServiceAgentsInteractionsParams)
+	// List unresolved interactions
+	// (GET /service_agents/interactions/unresolved)
+	GetServiceAgentsInteractionsUnresolved(c *gin.Context, params GetServiceAgentsInteractionsUnresolvedParams)
+	// Get an interaction
+	// (GET /service_agents/interactions/{id})
+	GetServiceAgentsInteractionsId(c *gin.Context, id openapi_types.UUID)
+	// Create a resolution for an interaction
+	// (POST /service_agents/interactions/{id}/resolutions)
+	PostServiceAgentsInteractionsIdResolutions(c *gin.Context, id openapi_types.UUID)
+	// Delete a resolution
+	// (DELETE /service_agents/interactions/{id}/resolutions/{rid})
+	DeleteServiceAgentsInteractionsIdResolutionsRid(c *gin.Context, id openapi_types.UUID, rid openapi_types.UUID)
 	// Get authenticated agent's details
 	// (GET /service_agents/me)
 	GetServiceAgentsMe(c *gin.Context)
@@ -16460,6 +16545,195 @@ func (siw *ServerInterfaceWrapper) GetServiceAgentsFilesIdFile(c *gin.Context) {
 	siw.Handler.GetServiceAgentsFilesIdFile(c, id)
 }
 
+// GetServiceAgentsInteractions operation middleware
+func (siw *ServerInterfaceWrapper) GetServiceAgentsInteractions(c *gin.Context) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetServiceAgentsInteractionsParams
+
+	// ------------- Optional query parameter "peer_type" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "peer_type", c.Request.URL.Query(), &params.PeerType)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter peer_type: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "peer_target" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "peer_target", c.Request.URL.Query(), &params.PeerTarget)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter peer_target: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "contact_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "contact_id", c.Request.URL.Query(), &params.ContactId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter contact_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "address_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "address_id", c.Request.URL.Query(), &params.AddressId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter address_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_size" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_size", c.Request.URL.Query(), &params.PageSize)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_size: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_token" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_token", c.Request.URL.Query(), &params.PageToken)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_token: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetServiceAgentsInteractions(c, params)
+}
+
+// GetServiceAgentsInteractionsUnresolved operation middleware
+func (siw *ServerInterfaceWrapper) GetServiceAgentsInteractionsUnresolved(c *gin.Context) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetServiceAgentsInteractionsUnresolvedParams
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "since", c.Request.URL.Query(), &params.Since)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter since: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_size" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_size", c.Request.URL.Query(), &params.PageSize)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_size: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_token" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_token", c.Request.URL.Query(), &params.PageToken)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_token: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetServiceAgentsInteractionsUnresolved(c, params)
+}
+
+// GetServiceAgentsInteractionsId operation middleware
+func (siw *ServerInterfaceWrapper) GetServiceAgentsInteractionsId(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetServiceAgentsInteractionsId(c, id)
+}
+
+// PostServiceAgentsInteractionsIdResolutions operation middleware
+func (siw *ServerInterfaceWrapper) PostServiceAgentsInteractionsIdResolutions(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.PostServiceAgentsInteractionsIdResolutions(c, id)
+}
+
+// DeleteServiceAgentsInteractionsIdResolutionsRid operation middleware
+func (siw *ServerInterfaceWrapper) DeleteServiceAgentsInteractionsIdResolutionsRid(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Path parameter "rid" -------------
+	var rid openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "rid", c.Param("rid"), &rid, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter rid: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.DeleteServiceAgentsInteractionsIdResolutionsRid(c, id, rid)
+}
+
 // GetServiceAgentsMe operation middleware
 func (siw *ServerInterfaceWrapper) GetServiceAgentsMe(c *gin.Context) {
 
@@ -18622,6 +18896,11 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.DELETE(options.BaseURL+"/service_agents/files/:id", wrapper.DeleteServiceAgentsFilesId)
 	router.GET(options.BaseURL+"/service_agents/files/:id", wrapper.GetServiceAgentsFilesId)
 	router.GET(options.BaseURL+"/service_agents/files/:id/file", wrapper.GetServiceAgentsFilesIdFile)
+	router.GET(options.BaseURL+"/service_agents/interactions", wrapper.GetServiceAgentsInteractions)
+	router.GET(options.BaseURL+"/service_agents/interactions/unresolved", wrapper.GetServiceAgentsInteractionsUnresolved)
+	router.GET(options.BaseURL+"/service_agents/interactions/:id", wrapper.GetServiceAgentsInteractionsId)
+	router.POST(options.BaseURL+"/service_agents/interactions/:id/resolutions", wrapper.PostServiceAgentsInteractionsIdResolutions)
+	router.DELETE(options.BaseURL+"/service_agents/interactions/:id/resolutions/:rid", wrapper.DeleteServiceAgentsInteractionsIdResolutionsRid)
 	router.GET(options.BaseURL+"/service_agents/me", wrapper.GetServiceAgentsMe)
 	router.PUT(options.BaseURL+"/service_agents/me", wrapper.PutServiceAgentsMe)
 	router.PUT(options.BaseURL+"/service_agents/me/addresses", wrapper.PutServiceAgentsMeAddresses)
@@ -35709,6 +35988,299 @@ func (response GetServiceAgentsFilesIdFile500JSONResponse) VisitGetServiceAgents
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetServiceAgentsInteractionsRequestObject struct {
+	Params GetServiceAgentsInteractionsParams
+}
+
+type GetServiceAgentsInteractionsResponseObject interface {
+	VisitGetServiceAgentsInteractionsResponse(w http.ResponseWriter) error
+}
+
+type GetServiceAgentsInteractions200JSONResponse ContactManagerInteractionListResponse
+
+func (response GetServiceAgentsInteractions200JSONResponse) VisitGetServiceAgentsInteractionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractions400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetServiceAgentsInteractions400JSONResponse) VisitGetServiceAgentsInteractionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractions401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response GetServiceAgentsInteractions401JSONResponse) VisitGetServiceAgentsInteractionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractions403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response GetServiceAgentsInteractions403JSONResponse) VisitGetServiceAgentsInteractionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractions500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetServiceAgentsInteractions500JSONResponse) VisitGetServiceAgentsInteractionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsUnresolvedRequestObject struct {
+	Params GetServiceAgentsInteractionsUnresolvedParams
+}
+
+type GetServiceAgentsInteractionsUnresolvedResponseObject interface {
+	VisitGetServiceAgentsInteractionsUnresolvedResponse(w http.ResponseWriter) error
+}
+
+type GetServiceAgentsInteractionsUnresolved200JSONResponse ContactManagerInteractionListResponse
+
+func (response GetServiceAgentsInteractionsUnresolved200JSONResponse) VisitGetServiceAgentsInteractionsUnresolvedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsUnresolved400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetServiceAgentsInteractionsUnresolved400JSONResponse) VisitGetServiceAgentsInteractionsUnresolvedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsUnresolved401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response GetServiceAgentsInteractionsUnresolved401JSONResponse) VisitGetServiceAgentsInteractionsUnresolvedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsUnresolved403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response GetServiceAgentsInteractionsUnresolved403JSONResponse) VisitGetServiceAgentsInteractionsUnresolvedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsUnresolved500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetServiceAgentsInteractionsUnresolved500JSONResponse) VisitGetServiceAgentsInteractionsUnresolvedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsIdRequestObject struct {
+	Id openapi_types.UUID `json:"id"`
+}
+
+type GetServiceAgentsInteractionsIdResponseObject interface {
+	VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error
+}
+
+type GetServiceAgentsInteractionsId200JSONResponse ContactManagerInteraction
+
+func (response GetServiceAgentsInteractionsId200JSONResponse) VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsId400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetServiceAgentsInteractionsId400JSONResponse) VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsId401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response GetServiceAgentsInteractionsId401JSONResponse) VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsId403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response GetServiceAgentsInteractionsId403JSONResponse) VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsId404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetServiceAgentsInteractionsId404JSONResponse) VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsInteractionsId500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetServiceAgentsInteractionsId500JSONResponse) VisitGetServiceAgentsInteractionsIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsInteractionsIdResolutionsRequestObject struct {
+	Id   openapi_types.UUID `json:"id"`
+	Body *PostServiceAgentsInteractionsIdResolutionsJSONRequestBody
+}
+
+type PostServiceAgentsInteractionsIdResolutionsResponseObject interface {
+	VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error
+}
+
+type PostServiceAgentsInteractionsIdResolutions201JSONResponse ContactManagerResolution
+
+func (response PostServiceAgentsInteractionsIdResolutions201JSONResponse) VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsInteractionsIdResolutions400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PostServiceAgentsInteractionsIdResolutions400JSONResponse) VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsInteractionsIdResolutions401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response PostServiceAgentsInteractionsIdResolutions401JSONResponse) VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsInteractionsIdResolutions403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response PostServiceAgentsInteractionsIdResolutions403JSONResponse) VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsInteractionsIdResolutions404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response PostServiceAgentsInteractionsIdResolutions404JSONResponse) VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsInteractionsIdResolutions500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response PostServiceAgentsInteractionsIdResolutions500JSONResponse) VisitPostServiceAgentsInteractionsIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRidRequestObject struct {
+	Id  openapi_types.UUID `json:"id"`
+	Rid openapi_types.UUID `json:"rid"`
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRidResponseObject interface {
+	VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRid200Response struct {
+}
+
+func (response DeleteServiceAgentsInteractionsIdResolutionsRid200Response) VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error {
+	w.WriteHeader(200)
+	return nil
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRid400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response DeleteServiceAgentsInteractionsIdResolutionsRid400JSONResponse) VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRid401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response DeleteServiceAgentsInteractionsIdResolutionsRid401JSONResponse) VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRid403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response DeleteServiceAgentsInteractionsIdResolutionsRid403JSONResponse) VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRid404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response DeleteServiceAgentsInteractionsIdResolutionsRid404JSONResponse) VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteServiceAgentsInteractionsIdResolutionsRid500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response DeleteServiceAgentsInteractionsIdResolutionsRid500JSONResponse) VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetServiceAgentsMeRequestObject struct {
 }
 
@@ -40656,6 +41228,21 @@ type StrictServerInterface interface {
 	// Download the service agent file
 	// (GET /service_agents/files/{id}/file)
 	GetServiceAgentsFilesIdFile(ctx context.Context, request GetServiceAgentsFilesIdFileRequestObject) (GetServiceAgentsFilesIdFileResponseObject, error)
+	// List interactions
+	// (GET /service_agents/interactions)
+	GetServiceAgentsInteractions(ctx context.Context, request GetServiceAgentsInteractionsRequestObject) (GetServiceAgentsInteractionsResponseObject, error)
+	// List unresolved interactions
+	// (GET /service_agents/interactions/unresolved)
+	GetServiceAgentsInteractionsUnresolved(ctx context.Context, request GetServiceAgentsInteractionsUnresolvedRequestObject) (GetServiceAgentsInteractionsUnresolvedResponseObject, error)
+	// Get an interaction
+	// (GET /service_agents/interactions/{id})
+	GetServiceAgentsInteractionsId(ctx context.Context, request GetServiceAgentsInteractionsIdRequestObject) (GetServiceAgentsInteractionsIdResponseObject, error)
+	// Create a resolution for an interaction
+	// (POST /service_agents/interactions/{id}/resolutions)
+	PostServiceAgentsInteractionsIdResolutions(ctx context.Context, request PostServiceAgentsInteractionsIdResolutionsRequestObject) (PostServiceAgentsInteractionsIdResolutionsResponseObject, error)
+	// Delete a resolution
+	// (DELETE /service_agents/interactions/{id}/resolutions/{rid})
+	DeleteServiceAgentsInteractionsIdResolutionsRid(ctx context.Context, request DeleteServiceAgentsInteractionsIdResolutionsRidRequestObject) (DeleteServiceAgentsInteractionsIdResolutionsRidResponseObject, error)
 	// Get authenticated agent's details
 	// (GET /service_agents/me)
 	GetServiceAgentsMe(ctx context.Context, request GetServiceAgentsMeRequestObject) (GetServiceAgentsMeResponseObject, error)
@@ -49777,6 +50364,150 @@ func (sh *strictHandler) GetServiceAgentsFilesIdFile(ctx *gin.Context, id openap
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(GetServiceAgentsFilesIdFileResponseObject); ok {
 		if err := validResponse.VisitGetServiceAgentsFilesIdFileResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetServiceAgentsInteractions operation middleware
+func (sh *strictHandler) GetServiceAgentsInteractions(ctx *gin.Context, params GetServiceAgentsInteractionsParams) {
+	var request GetServiceAgentsInteractionsRequestObject
+
+	request.Params = params
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetServiceAgentsInteractions(ctx, request.(GetServiceAgentsInteractionsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetServiceAgentsInteractions")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetServiceAgentsInteractionsResponseObject); ok {
+		if err := validResponse.VisitGetServiceAgentsInteractionsResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetServiceAgentsInteractionsUnresolved operation middleware
+func (sh *strictHandler) GetServiceAgentsInteractionsUnresolved(ctx *gin.Context, params GetServiceAgentsInteractionsUnresolvedParams) {
+	var request GetServiceAgentsInteractionsUnresolvedRequestObject
+
+	request.Params = params
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetServiceAgentsInteractionsUnresolved(ctx, request.(GetServiceAgentsInteractionsUnresolvedRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetServiceAgentsInteractionsUnresolved")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetServiceAgentsInteractionsUnresolvedResponseObject); ok {
+		if err := validResponse.VisitGetServiceAgentsInteractionsUnresolvedResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetServiceAgentsInteractionsId operation middleware
+func (sh *strictHandler) GetServiceAgentsInteractionsId(ctx *gin.Context, id openapi_types.UUID) {
+	var request GetServiceAgentsInteractionsIdRequestObject
+
+	request.Id = id
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetServiceAgentsInteractionsId(ctx, request.(GetServiceAgentsInteractionsIdRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetServiceAgentsInteractionsId")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetServiceAgentsInteractionsIdResponseObject); ok {
+		if err := validResponse.VisitGetServiceAgentsInteractionsIdResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PostServiceAgentsInteractionsIdResolutions operation middleware
+func (sh *strictHandler) PostServiceAgentsInteractionsIdResolutions(ctx *gin.Context, id openapi_types.UUID) {
+	var request PostServiceAgentsInteractionsIdResolutionsRequestObject
+
+	request.Id = id
+
+	var body PostServiceAgentsInteractionsIdResolutionsJSONRequestBody
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
+		ctx.Error(err)
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostServiceAgentsInteractionsIdResolutions(ctx, request.(PostServiceAgentsInteractionsIdResolutionsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostServiceAgentsInteractionsIdResolutions")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(PostServiceAgentsInteractionsIdResolutionsResponseObject); ok {
+		if err := validResponse.VisitPostServiceAgentsInteractionsIdResolutionsResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteServiceAgentsInteractionsIdResolutionsRid operation middleware
+func (sh *strictHandler) DeleteServiceAgentsInteractionsIdResolutionsRid(ctx *gin.Context, id openapi_types.UUID, rid openapi_types.UUID) {
+	var request DeleteServiceAgentsInteractionsIdResolutionsRidRequestObject
+
+	request.Id = id
+	request.Rid = rid
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteServiceAgentsInteractionsIdResolutionsRid(ctx, request.(DeleteServiceAgentsInteractionsIdResolutionsRidRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteServiceAgentsInteractionsIdResolutionsRid")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(DeleteServiceAgentsInteractionsIdResolutionsRidResponseObject); ok {
+		if err := validResponse.VisitDeleteServiceAgentsInteractionsIdResolutionsRidResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/bin-api-manager/pkg/servicehandler/interaction.go
+++ b/bin-api-manager/pkg/servicehandler/interaction.go
@@ -66,7 +66,7 @@ func (h *serviceHandler) InteractionList(
 		return nil, "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
-	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAgent|amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		return nil, "", serviceerrors.ErrPermissionDenied
 	}
 
@@ -99,7 +99,7 @@ func (h *serviceHandler) InteractionListUnresolved(
 		return nil, "", serviceerrors.ErrDirectAccessNotSupported
 	}
 
-	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAgent|amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		return nil, "", serviceerrors.ErrPermissionDenied
 	}
 
@@ -132,7 +132,7 @@ func (h *serviceHandler) InteractionGet(ctx context.Context, a *auth.AuthIdentit
 		return nil, err
 	}
 
-	if !h.hasPermission(ctx, a, res.CustomerID, amagent.PermissionCustomerAgent|amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+	if !h.hasPermission(ctx, a, res.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
@@ -170,7 +170,7 @@ func (h *serviceHandler) ResolutionCreate(
 		return nil, err
 	}
 
-	if !h.hasPermission(ctx, a, ia.CustomerID, amagent.PermissionCustomerAgent|amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+	if !h.hasPermission(ctx, a, ia.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
@@ -199,7 +199,7 @@ func (h *serviceHandler) ResolutionDelete(ctx context.Context, a *auth.AuthIdent
 		return serviceerrors.ErrDirectAccessNotSupported
 	}
 
-	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAgent|amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
 		return serviceerrors.ErrPermissionDenied
 	}
 

--- a/bin-api-manager/pkg/servicehandler/interaction_test.go
+++ b/bin-api-manager/pkg/servicehandler/interaction_test.go
@@ -59,7 +59,7 @@ func Test_InteractionList(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name: "agent permission is sufficient",
+			name: "agent permission is insufficient",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID:         agentID,
@@ -74,9 +74,7 @@ func Test_InteractionList(t *testing.T) {
 			contactID:  uuid.Nil,
 			addressID:  uuid.Nil,
 
-			responseItems: []*cminteraction.Interaction{},
-			responseToken: "",
-			expectErr:     false,
+			expectErr: true,
 		},
 		{
 			name: "permission denied",
@@ -178,7 +176,7 @@ func Test_InteractionGet(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "agent permission is sufficient",
+			name: "agent permission is insufficient",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID:         agentID,
@@ -195,14 +193,7 @@ func Test_InteractionGet(t *testing.T) {
 				PeerType:   "tel",
 				PeerTarget: "+155****1111",
 			},
-			expectRes: &cminteraction.Interaction{
-				ID:         interactionID,
-				CustomerID: customerID,
-				Direction:  "incoming",
-				PeerType:   "tel",
-				PeerTarget: "+155****1111",
-			},
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name: "permission denied",
@@ -315,7 +306,7 @@ func Test_ResolutionCreate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "agent permission is sufficient",
+			name: "agent permission is insufficient",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID:         agentID,
@@ -333,16 +324,7 @@ func Test_ResolutionCreate(t *testing.T) {
 				ID:         interactionID,
 				CustomerID: customerID,
 			},
-			responseResolution: &cmresolution.Resolution{
-				ID:             uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004"),
-				CustomerID:     customerID,
-				InteractionID:  interactionID,
-				ContactID:      contactID,
-				ResolutionType: "positive",
-				ResolvedByType: "agent",
-				ResolvedByID:   resolvedByID,
-			},
-			expectErr: false,
+			expectErr: true,
 		},
 		{
 			name: "no permission",
@@ -443,7 +425,7 @@ func Test_ResolutionDelete(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name: "agent permission is sufficient",
+			name: "agent permission is insufficient",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID:         agentID,
@@ -453,7 +435,8 @@ func Test_ResolutionDelete(t *testing.T) {
 			}),
 			interactionID: interactionID,
 			resolutionID:  resolutionID,
-			expectErr:     false,
+			expectErr:     true,
+			expectErrVal:  serviceerrors.ErrPermissionDenied,
 		},
 		{
 			name: "permission denied",
@@ -555,7 +538,7 @@ func Test_InteractionListUnresolved(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name: "agent permission is sufficient",
+			name: "agent permission is insufficient",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID:         agentID,
@@ -563,12 +546,10 @@ func Test_InteractionListUnresolved(t *testing.T) {
 				},
 				Permission: amagent.PermissionCustomerAgent,
 			}),
-			size:          20,
-			token:         "",
-			since:         "",
-			responseItems: []*cminteraction.Interaction{},
-			responseToken: "",
-			expectErr:     false,
+			size:      20,
+			token:     "",
+			since:     "",
+			expectErr: true,
 		},
 		{
 			name: "permission denied",

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -496,6 +496,34 @@ type ServiceHandler interface {
 	) (*cmresolution.Resolution, error)
 	ResolutionDelete(ctx context.Context, a *auth.AuthIdentity, interactionID, resolutionID uuid.UUID) error
 
+	// service agent interaction handlers
+	ServiceAgentInteractionList(
+		ctx context.Context,
+		a *auth.AuthIdentity,
+		size uint64,
+		token string,
+		peerType, peerTarget string,
+		contactID, addressID uuid.UUID,
+	) ([]*cminteraction.Interaction, string, error)
+	ServiceAgentInteractionListUnresolved(
+		ctx context.Context,
+		a *auth.AuthIdentity,
+		size uint64,
+		token string,
+		since string,
+	) ([]*cminteraction.Interaction, string, error)
+	ServiceAgentInteractionGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*cminteraction.Interaction, error)
+	ServiceAgentResolutionCreate(
+		ctx context.Context,
+		a *auth.AuthIdentity,
+		interactionID uuid.UUID,
+		contactID uuid.UUID,
+		resolutionType string,
+		resolvedByType string,
+		resolvedByID uuid.UUID,
+	) (*cmresolution.Resolution, error)
+	ServiceAgentResolutionDelete(ctx context.Context, a *auth.AuthIdentity, interactionID, resolutionID uuid.UUID) error
+
 	// conversation handlers
 	ConversationGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*cvconversation.WebhookMessage, error)
 	ConversationGetsByCustomerID(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, ownerID uuid.UUID) ([]*cvconversation.WebhookMessage, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -4674,6 +4674,53 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentFileList(ctx, a, size, tok
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentFileList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentFileList), ctx, a, size, token)
 }
 
+// ServiceAgentInteractionGet mocks base method.
+func (m *MockServiceHandler) ServiceAgentInteractionGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentInteractionGet", ctx, a, id)
+	ret0, _ := ret[0].(*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentInteractionGet indicates an expected call of ServiceAgentInteractionGet.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentInteractionGet(ctx, a, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentInteractionGet", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentInteractionGet), ctx, a, id)
+}
+
+// ServiceAgentInteractionList mocks base method.
+func (m *MockServiceHandler) ServiceAgentInteractionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID) ([]*interaction.Interaction, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentInteractionList", ctx, a, size, token, peerType, peerTarget, contactID, addressID)
+	ret0, _ := ret[0].([]*interaction.Interaction)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ServiceAgentInteractionList indicates an expected call of ServiceAgentInteractionList.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentInteractionList(ctx, a, size, token, peerType, peerTarget, contactID, addressID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentInteractionList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentInteractionList), ctx, a, size, token, peerType, peerTarget, contactID, addressID)
+}
+
+// ServiceAgentInteractionListUnresolved mocks base method.
+func (m *MockServiceHandler) ServiceAgentInteractionListUnresolved(ctx context.Context, a *auth.AuthIdentity, size uint64, token, since string) ([]*interaction.Interaction, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentInteractionListUnresolved", ctx, a, size, token, since)
+	ret0, _ := ret[0].([]*interaction.Interaction)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ServiceAgentInteractionListUnresolved indicates an expected call of ServiceAgentInteractionListUnresolved.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentInteractionListUnresolved(ctx, a, size, token, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentInteractionListUnresolved", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentInteractionListUnresolved), ctx, a, size, token, since)
+}
+
 // ServiceAgentMeGet mocks base method.
 func (m *MockServiceHandler) ServiceAgentMeGet(ctx context.Context, a *auth.AuthIdentity) (*agent.WebhookMessage, error) {
 	m.ctrl.T.Helper()
@@ -4747,6 +4794,35 @@ func (m *MockServiceHandler) ServiceAgentMeUpdateStatus(ctx context.Context, a *
 func (mr *MockServiceHandlerMockRecorder) ServiceAgentMeUpdateStatus(ctx, a, status any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentMeUpdateStatus", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentMeUpdateStatus), ctx, a, status)
+}
+
+// ServiceAgentResolutionCreate mocks base method.
+func (m *MockServiceHandler) ServiceAgentResolutionCreate(ctx context.Context, a *auth.AuthIdentity, interactionID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentResolutionCreate", ctx, a, interactionID, contactID, resolutionType, resolvedByType, resolvedByID)
+	ret0, _ := ret[0].(*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentResolutionCreate indicates an expected call of ServiceAgentResolutionCreate.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentResolutionCreate(ctx, a, interactionID, contactID, resolutionType, resolvedByType, resolvedByID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentResolutionCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentResolutionCreate), ctx, a, interactionID, contactID, resolutionType, resolvedByType, resolvedByID)
+}
+
+// ServiceAgentResolutionDelete mocks base method.
+func (m *MockServiceHandler) ServiceAgentResolutionDelete(ctx context.Context, a *auth.AuthIdentity, interactionID, resolutionID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentResolutionDelete", ctx, a, interactionID, resolutionID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ServiceAgentResolutionDelete indicates an expected call of ServiceAgentResolutionDelete.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentResolutionDelete(ctx, a, interactionID, resolutionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentResolutionDelete", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentResolutionDelete), ctx, a, interactionID, resolutionID)
 }
 
 // ServiceAgentTagGet mocks base method.

--- a/bin-api-manager/pkg/servicehandler/serviceagent_interaction.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_interaction.go
@@ -1,0 +1,208 @@
+package servicehandler
+
+import (
+	"context"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+)
+
+// ServiceAgentInteractionList sends a request to contact-manager
+// to list interactions matching the given filter, for the service agent's customer.
+// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero
+// (same requirement as the top-level Admin/Manager InteractionList).
+func (h *serviceHandler) ServiceAgentInteractionList(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	size uint64,
+	token string,
+	peerType, peerTarget string,
+	contactID, addressID uuid.UUID,
+) ([]*cminteraction.Interaction, string, error) {
+	if !a.IsAgent() {
+		return nil, "", serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":         "ServiceAgentInteractionList",
+		"customer_id":  a.CustomerID,
+		"peer_type":    peerType,
+		"peer_target":  peerTarget,
+		"contact_id":   contactID,
+		"address_id":   addressID,
+	})
+
+	if a.IsDirect() {
+		return nil, "", serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, "", serviceerrors.ErrPermissionDenied
+	}
+
+	items, nextToken, err := h.reqHandler.ContactV1InteractionList(ctx, a.CustomerID, size, token, peerType, peerTarget, contactID, addressID)
+	if err != nil {
+		log.Errorf("Could not list interactions. err: %v", err)
+		return nil, "", err
+	}
+
+	return items, nextToken, nil
+}
+
+// ServiceAgentInteractionListUnresolved sends a request to contact-manager
+// to list interactions with no active resolution within the given lookback window,
+// for the service agent's customer.
+func (h *serviceHandler) ServiceAgentInteractionListUnresolved(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	size uint64,
+	token string,
+	since string,
+) ([]*cminteraction.Interaction, string, error) {
+	if !a.IsAgent() {
+		return nil, "", serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "ServiceAgentInteractionListUnresolved",
+		"customer_id": a.CustomerID,
+		"since":       since,
+	})
+
+	if a.IsDirect() {
+		return nil, "", serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, "", serviceerrors.ErrPermissionDenied
+	}
+
+	items, nextToken, err := h.reqHandler.ContactV1InteractionListUnresolved(ctx, a.CustomerID, size, token, since)
+	if err != nil {
+		log.Errorf("Could not list unresolved interactions. err: %v", err)
+		return nil, "", err
+	}
+
+	return items, nextToken, nil
+}
+
+// ServiceAgentInteractionGet sends a request to contact-manager
+// to get a single interaction by ID, for the service agent's customer.
+func (h *serviceHandler) ServiceAgentInteractionGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*cminteraction.Interaction, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "ServiceAgentInteractionGet",
+		"customer_id":     a.CustomerID,
+		"interaction_id":  id,
+	})
+
+	if a.IsDirect() {
+		return nil, serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	// Fetch first to validate ownership (interaction.CustomerID must match a.CustomerID).
+	res, err := h.interactionGet(ctx, a.CustomerID, id)
+	if err != nil {
+		log.Errorf("Could not get the interaction. err: %v", err)
+		return nil, err
+	}
+
+	if !h.hasPermission(ctx, a, res.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	return res, nil
+}
+
+// ServiceAgentResolutionCreate sends a request to contact-manager
+// to create a resolution for an interaction, for the service agent's customer.
+func (h *serviceHandler) ServiceAgentResolutionCreate(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	interactionID uuid.UUID,
+	contactID uuid.UUID,
+	resolutionType string,
+	resolvedByType string,
+	resolvedByID uuid.UUID,
+) (*cmresolution.Resolution, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":             "ServiceAgentResolutionCreate",
+		"customer_id":      a.CustomerID,
+		"interaction_id":   interactionID,
+		"contact_id":       contactID,
+		"resolution_type":  resolutionType,
+	})
+
+	if a.IsDirect() {
+		return nil, serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	// Fetch interaction first to validate ownership before attaching a resolution.
+	ia, err := h.interactionGet(ctx, a.CustomerID, interactionID)
+	if err != nil {
+		log.Errorf("Could not get the interaction info. err: %v", err)
+		return nil, err
+	}
+
+	if !h.hasPermission(ctx, a, ia.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	res, err := h.reqHandler.ContactV1ResolutionCreate(ctx, a.CustomerID, contactID, interactionID, resolutionType, resolvedByType, resolvedByID)
+	if err != nil {
+		log.Errorf("Could not create resolution. err: %v", err)
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// ServiceAgentResolutionDelete sends a request to contact-manager
+// to soft-delete a resolution, for the service agent's customer.
+// interactionID is passed through the full chain so the DB enforces
+// WHERE customer_id=? AND interaction_id=? AND id=? — preventing cross-interaction deletion.
+func (h *serviceHandler) ServiceAgentResolutionDelete(ctx context.Context, a *auth.AuthIdentity, interactionID, resolutionID uuid.UUID) error {
+	if !a.IsAgent() {
+		return serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "ServiceAgentResolutionDelete",
+		"customer_id":     a.CustomerID,
+		"interaction_id":  interactionID,
+		"resolution_id":   resolutionID,
+	})
+
+	if a.IsDirect() {
+		return serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return serviceerrors.ErrPermissionDenied
+	}
+
+	if err := h.reqHandler.ContactV1ResolutionDelete(ctx, a.CustomerID, interactionID, resolutionID); err != nil {
+		log.Errorf("Could not delete resolution. err: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_interaction.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_interaction.go
@@ -30,12 +30,12 @@ func (h *serviceHandler) ServiceAgentInteractionList(
 	}
 
 	log := logrus.WithFields(logrus.Fields{
-		"func":         "ServiceAgentInteractionList",
-		"customer_id":  a.CustomerID,
-		"peer_type":    peerType,
-		"peer_target":  peerTarget,
-		"contact_id":   contactID,
-		"address_id":   addressID,
+		"func":        "ServiceAgentInteractionList",
+		"customer_id": a.CustomerID,
+		"peer_type":   peerType,
+		"peer_target": peerTarget,
+		"contact_id":  contactID,
+		"address_id":  addressID,
 	})
 
 	if a.IsDirect() {
@@ -102,9 +102,9 @@ func (h *serviceHandler) ServiceAgentInteractionGet(ctx context.Context, a *auth
 	}
 
 	log := logrus.WithFields(logrus.Fields{
-		"func":            "ServiceAgentInteractionGet",
-		"customer_id":     a.CustomerID,
-		"interaction_id":  id,
+		"func":           "ServiceAgentInteractionGet",
+		"customer_id":    a.CustomerID,
+		"interaction_id": id,
 	})
 
 	if a.IsDirect() {
@@ -142,11 +142,11 @@ func (h *serviceHandler) ServiceAgentResolutionCreate(
 	}
 
 	log := logrus.WithFields(logrus.Fields{
-		"func":             "ServiceAgentResolutionCreate",
-		"customer_id":      a.CustomerID,
-		"interaction_id":   interactionID,
-		"contact_id":       contactID,
-		"resolution_type":  resolutionType,
+		"func":            "ServiceAgentResolutionCreate",
+		"customer_id":     a.CustomerID,
+		"interaction_id":  interactionID,
+		"contact_id":      contactID,
+		"resolution_type": resolutionType,
 	})
 
 	if a.IsDirect() {
@@ -184,10 +184,10 @@ func (h *serviceHandler) ServiceAgentResolutionDelete(ctx context.Context, a *au
 	}
 
 	log := logrus.WithFields(logrus.Fields{
-		"func":            "ServiceAgentResolutionDelete",
-		"customer_id":     a.CustomerID,
-		"interaction_id":  interactionID,
-		"resolution_id":   resolutionID,
+		"func":           "ServiceAgentResolutionDelete",
+		"customer_id":    a.CustomerID,
+		"interaction_id": interactionID,
+		"resolution_id":  resolutionID,
 	})
 
 	if a.IsDirect() {

--- a/bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go
@@ -1,0 +1,458 @@
+package servicehandler
+
+import (
+	"context"
+	"testing"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"monorepo/bin-api-manager/pkg/dbhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_ServiceAgentInteractionList(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+
+	tests := []struct {
+		name string
+
+		agent      *auth.AuthIdentity
+		size       uint64
+		token      string
+		peerType   string
+		peerTarget string
+		contactID  uuid.UUID
+		addressID  uuid.UUID
+
+		responseItems []*cminteraction.Interaction
+		responseToken string
+		expectErr     bool
+	}{
+		{
+			name: "normal - plain agent permission is sufficient",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			size:       20,
+			token:      "",
+			peerType:   "tel",
+			peerTarget: "+155****1111",
+			contactID:  uuid.Nil,
+			addressID:  uuid.Nil,
+
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectErr:     false,
+		},
+		{
+			name:  "permission denied - direct access not supported",
+			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			size:       20,
+			token:      "",
+			peerType:   "tel",
+			peerTarget: "+155****1111",
+
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			if !tt.expectErr {
+				mockReq.EXPECT().
+					ContactV1InteractionList(ctx, tt.agent.CustomerID, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID).
+					Return(tt.responseItems, tt.responseToken, nil)
+			}
+
+			items, _, err := h.ServiceAgentInteractionList(ctx, tt.agent, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if items == nil {
+				t.Errorf("Wrong match. expect: non-nil, got: nil")
+			}
+		})
+	}
+}
+
+func Test_ServiceAgentInteractionListUnresolved(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+
+	tests := []struct {
+		name string
+
+		agent *auth.AuthIdentity
+		size  uint64
+		token string
+		since string
+
+		responseItems []*cminteraction.Interaction
+		responseToken string
+		expectErr     bool
+	}{
+		{
+			name: "normal - plain agent permission is sufficient",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			size:          20,
+			token:         "",
+			since:         "7d",
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectErr:     false,
+		},
+		{
+			name:  "permission denied - direct access not supported",
+			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			size:      20,
+			token:     "",
+			since:     "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			if !tt.expectErr {
+				mockReq.EXPECT().
+					ContactV1InteractionListUnresolved(ctx, tt.agent.CustomerID, tt.size, tt.token, tt.since).
+					Return(tt.responseItems, tt.responseToken, nil)
+			}
+
+			items, _, err := h.ServiceAgentInteractionListUnresolved(ctx, tt.agent, tt.size, tt.token, tt.since)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if items == nil {
+				t.Errorf("Wrong match. expect: non-nil, got: nil")
+			}
+		})
+	}
+}
+
+func Test_ServiceAgentInteractionGet(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	otherCustomerID := uuid.FromStringOrNil("6f621078-8e5f-11ee-97b2-cfe7337b701d")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	interactionID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+
+	tests := []struct {
+		name string
+
+		agent         *auth.AuthIdentity
+		interactionID uuid.UUID
+
+		responseInteraction *cminteraction.Interaction
+		expectErr           bool
+	}{
+		{
+			name: "normal - plain agent permission is sufficient",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			interactionID: interactionID,
+
+			responseInteraction: &cminteraction.Interaction{
+				ID:         interactionID,
+				CustomerID: customerID,
+				Direction:  "incoming",
+			},
+			expectErr: false,
+		},
+		{
+			name: "permission denied - interaction belongs to a different customer",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			interactionID: interactionID,
+
+			responseInteraction: &cminteraction.Interaction{
+				ID:         interactionID,
+				CustomerID: otherCustomerID,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().
+				ContactV1InteractionGet(ctx, tt.agent.CustomerID, tt.interactionID).
+				Return(tt.responseInteraction, nil)
+
+			res, err := h.ServiceAgentInteractionGet(ctx, tt.agent, tt.interactionID)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res == nil {
+				t.Errorf("Wrong match. expect: non-nil, got: nil")
+			}
+		})
+	}
+}
+
+func Test_ServiceAgentResolutionCreate(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	interactionID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("22222222-0000-0000-0000-000000000002")
+	resolvedByID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000003")
+
+	tests := []struct {
+		name string
+
+		agent          *auth.AuthIdentity
+		interactionID  uuid.UUID
+		contactID      uuid.UUID
+		resolutionType string
+		resolvedByType string
+		resolvedByID   uuid.UUID
+
+		responseInteraction *cminteraction.Interaction
+		responseResolution  *cmresolution.Resolution
+		expectErr           bool
+	}{
+		{
+			name: "normal - plain agent permission is sufficient",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			interactionID:  interactionID,
+			contactID:      contactID,
+			resolutionType: "positive",
+			resolvedByType: "agent",
+			resolvedByID:   resolvedByID,
+
+			responseInteraction: &cminteraction.Interaction{
+				ID:         interactionID,
+				CustomerID: customerID,
+			},
+			responseResolution: &cmresolution.Resolution{
+				ID:             uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004"),
+				CustomerID:     customerID,
+				InteractionID:  interactionID,
+				ContactID:      contactID,
+				ResolutionType: "positive",
+				ResolvedByType: "agent",
+				ResolvedByID:   resolvedByID,
+			},
+			expectErr: false,
+		},
+		{
+			name:  "permission denied - direct access not supported",
+			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			interactionID:  interactionID,
+			contactID:      contactID,
+			resolutionType: "positive",
+			resolvedByType: "agent",
+			resolvedByID:   resolvedByID,
+
+			responseInteraction: nil,
+			expectErr:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			if tt.agent.IsAgent() {
+				mockReq.EXPECT().
+					ContactV1InteractionGet(ctx, tt.agent.CustomerID, tt.interactionID).
+					Return(tt.responseInteraction, nil)
+			}
+
+			if !tt.expectErr {
+				mockReq.EXPECT().
+					ContactV1ResolutionCreate(ctx, tt.agent.CustomerID, tt.contactID, tt.interactionID, tt.resolutionType, tt.resolvedByType, tt.resolvedByID).
+					Return(tt.responseResolution, nil)
+			}
+
+			res, err := h.ServiceAgentResolutionCreate(ctx, tt.agent, tt.interactionID, tt.contactID, tt.resolutionType, tt.resolvedByType, tt.resolvedByID)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res == nil {
+				t.Errorf("Wrong match. expect: non-nil, got: nil")
+			}
+		})
+	}
+}
+
+func Test_ServiceAgentResolutionDelete(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	interactionID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	resolutionID := uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004")
+
+	tests := []struct {
+		name string
+
+		agent         *auth.AuthIdentity
+		interactionID uuid.UUID
+		resolutionID  uuid.UUID
+
+		expectErr    bool
+		expectErrVal error
+	}{
+		{
+			name: "normal - plain agent permission is sufficient",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			interactionID: interactionID,
+			resolutionID:  resolutionID,
+			expectErr:     false,
+		},
+		{
+			name:  "permission denied - direct access not supported",
+			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			interactionID: interactionID,
+			resolutionID:  resolutionID,
+			expectErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			if !tt.expectErr {
+				mockReq.EXPECT().
+					ContactV1ResolutionDelete(ctx, tt.agent.CustomerID, tt.interactionID, tt.resolutionID).
+					Return(nil)
+			}
+
+			err := h.ServiceAgentResolutionDelete(ctx, tt.agent, tt.interactionID, tt.resolutionID)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go
@@ -58,8 +58,8 @@ func Test_ServiceAgentInteractionList(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name:  "permission denied - direct access not supported",
-			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			name:       "permission denied - direct access not supported",
+			agent:      auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
 			size:       20,
 			token:      "",
 			peerType:   "tel",
@@ -140,8 +140,8 @@ func Test_ServiceAgentInteractionListUnresolved(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name:  "permission denied - direct access not supported",
-			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			name:      "permission denied - direct access not supported",
+			agent:     auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
 			size:      20,
 			token:     "",
 			since:     "",
@@ -327,8 +327,8 @@ func Test_ServiceAgentResolutionCreate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:  "permission denied - direct access not supported",
-			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			name:           "permission denied - direct access not supported",
+			agent:          auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
 			interactionID:  interactionID,
 			contactID:      contactID,
 			resolutionType: "positive",
@@ -414,8 +414,8 @@ func Test_ServiceAgentResolutionDelete(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name:  "permission denied - direct access not supported",
-			agent: auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
+			name:          "permission denied - direct access not supported",
+			agent:         auth.NewDirectIdentity(&auth.DirectScope{CustomerID: customerID}),
 			interactionID: interactionID,
 			resolutionID:  resolutionID,
 			expectErr:     true,

--- a/bin-api-manager/server/service_agents_interactions.go
+++ b/bin-api-manager/server/service_agents_interactions.go
@@ -1,0 +1,248 @@
+package server
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-api-manager/gens/openapi_server"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// GetServiceAgentsInteractions handles GET /service_agents/interactions
+func (h *server) GetServiceAgentsInteractions(c *gin.Context, params openapi_server.GetServiceAgentsInteractionsParams) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "GetServiceAgentsInteractions",
+		"request_address": c.ClientIP(),
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	pageSize := uint64(100)
+	if params.PageSize != nil {
+		pageSize = uint64(*params.PageSize)
+	}
+	if pageSize == 0 || pageSize > 100 {
+		pageSize = 100
+	}
+
+	pageToken := ""
+	if params.PageToken != nil {
+		pageToken = string(*params.PageToken)
+	}
+
+	peerType := ""
+	if params.PeerType != nil {
+		peerType = *params.PeerType
+	}
+
+	peerTarget := ""
+	if params.PeerTarget != nil {
+		peerTarget = *params.PeerTarget
+	}
+
+	contactID := uuid.Nil
+	if params.ContactId != nil {
+		contactID = uuid.UUID(*params.ContactId)
+	}
+
+	addressID := uuid.Nil
+	if params.AddressId != nil {
+		addressID = uuid.UUID(*params.AddressId)
+	}
+
+	// Validate: exactly one filter mode must be provided (same as top-level GetInteractions).
+	filterCount := 0
+	if peerType != "" || peerTarget != "" {
+		filterCount++
+	}
+	if contactID != uuid.Nil {
+		filterCount++
+	}
+	if addressID != uuid.Nil {
+		filterCount++
+	}
+	if filterCount != 1 {
+		log.Errorf("Expected exactly one filter mode, got %d.", filterCount)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_FILTER", "Exactly one filter is required: peer_type+peer_target, contact_id, or address_id."))
+		return
+	}
+
+	items, nextToken, err := h.serviceHandler.ServiceAgentInteractionList(c.Request.Context(), a, pageSize, pageToken, peerType, peerTarget, contactID, addressID)
+	if err != nil {
+		log.Errorf("Could not list interactions. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, GenerateListResponse(items, nextToken))
+}
+
+// GetServiceAgentsInteractionsUnresolved handles GET /service_agents/interactions/unresolved
+func (h *server) GetServiceAgentsInteractionsUnresolved(c *gin.Context, params openapi_server.GetServiceAgentsInteractionsUnresolvedParams) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "GetServiceAgentsInteractionsUnresolved",
+		"request_address": c.ClientIP(),
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	pageSize := uint64(100)
+	if params.PageSize != nil {
+		pageSize = uint64(*params.PageSize)
+	}
+	if pageSize == 0 || pageSize > 100 {
+		pageSize = 100
+	}
+
+	pageToken := ""
+	if params.PageToken != nil {
+		pageToken = string(*params.PageToken)
+	}
+
+	since := ""
+	if params.Since != nil && *params.Since != "" {
+		s := *params.Since
+		if !strings.HasSuffix(s, "d") {
+			log.Errorf("Invalid since param format: %q", s)
+			abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_SINCE", "The 'since' parameter must be in the format '<N>d' (e.g. '7d', '30d')."))
+			return
+		}
+		n, parseErr := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if parseErr != nil || n <= 0 {
+			log.Errorf("Invalid since param value: %q", s)
+			abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_SINCE", "The 'since' parameter must be a positive number of days (e.g. '7d')."))
+			return
+		}
+		since = s
+	}
+
+	items, nextToken, err := h.serviceHandler.ServiceAgentInteractionListUnresolved(c.Request.Context(), a, pageSize, pageToken, since)
+	if err != nil {
+		log.Errorf("Could not list unresolved interactions. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, GenerateListResponse(items, nextToken))
+}
+
+// GetServiceAgentsInteractionsId handles GET /service_agents/interactions/{id}
+func (h *server) GetServiceAgentsInteractionsId(c *gin.Context, id openapi_types.UUID) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "GetServiceAgentsInteractionsId",
+		"request_address": c.ClientIP(),
+		"id":              id,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	interactionID := uuid.UUID(id)
+
+	res, err := h.serviceHandler.ServiceAgentInteractionGet(c.Request.Context(), a, interactionID)
+	if err != nil {
+		log.Errorf("Could not get interaction. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, res)
+}
+
+// PostServiceAgentsInteractionsIdResolutions handles POST /service_agents/interactions/{id}/resolutions
+func (h *server) PostServiceAgentsInteractionsIdResolutions(c *gin.Context, id openapi_types.UUID) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "PostServiceAgentsInteractionsIdResolutions",
+		"request_address": c.ClientIP(),
+		"id":              id,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	var req openapi_server.PostServiceAgentsInteractionsIdResolutionsJSONRequestBody
+	if err := c.BindJSON(&req); err != nil {
+		log.Errorf("Could not parse the request. err: %v", err)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_JSON_BODY", "The request body is not valid JSON.").Wrap(err))
+		return
+	}
+
+	interactionID := uuid.UUID(id)
+	contactID := uuid.UUID(req.ContactId)
+	resolvedByID := uuid.UUID(req.ResolvedById)
+
+	res, err := h.serviceHandler.ServiceAgentResolutionCreate(
+		c.Request.Context(),
+		a,
+		interactionID,
+		contactID,
+		string(req.ResolutionType),
+		string(req.ResolvedByType),
+		resolvedByID,
+	)
+	if err != nil {
+		log.Errorf("Could not create resolution. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(201, res)
+}
+
+// DeleteServiceAgentsInteractionsIdResolutionsRid handles DELETE /service_agents/interactions/{id}/resolutions/{rid}
+func (h *server) DeleteServiceAgentsInteractionsIdResolutionsRid(c *gin.Context, id openapi_types.UUID, rid openapi_types.UUID) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "DeleteServiceAgentsInteractionsIdResolutionsRid",
+		"request_address": c.ClientIP(),
+		"id":              id,
+		"rid":             rid,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	interactionID := uuid.UUID(id)
+	resolutionID := uuid.UUID(rid)
+
+	if err := h.serviceHandler.ServiceAgentResolutionDelete(c.Request.Context(), a, interactionID, resolutionID); err != nil {
+		log.Errorf("Could not delete resolution. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, gin.H{})
+}

--- a/bin-api-manager/server/service_agents_interactions_test.go
+++ b/bin-api-manager/server/service_agents_interactions_test.go
@@ -1,0 +1,423 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_GetServiceAgentsInteractions(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+
+		responseItems []*cminteraction.Interaction
+		responseToken string
+		expectStatus  int
+	}{
+		{
+			name: "normal - filter by contact_id, plain agent permission",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:      "/service_agents/interactions?contact_id=11111111-0000-0000-0000-000000000001",
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectStatus:  http.StatusOK,
+		},
+		{
+			name: "normal - admin permission also passes",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAdmin,
+			}),
+			reqQuery:      "/service_agents/interactions?contact_id=11111111-0000-0000-0000-000000000001",
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectStatus:  http.StatusOK,
+		},
+		{
+			name: "bad request - no filter",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:     "/service_agents/interactions",
+			expectStatus: http.StatusBadRequest,
+		},
+		{
+			name:         "unauthenticated",
+			agent:        nil,
+			reqQuery:     "/service_agents/interactions?contact_id=11111111-0000-0000-0000-000000000001",
+			expectStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{serviceHandler: mockSvc}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				if tt.agent != nil {
+					c.Set("auth_identity", tt.agent)
+				}
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
+
+			if tt.responseItems != nil && tt.agent != nil {
+				mockSvc.EXPECT().
+					ServiceAgentInteractionList(req.Context(), tt.agent, uint64(100), "", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(tt.responseItems, tt.responseToken, nil)
+			}
+
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func Test_GetServiceAgentsInteractionsUnresolved(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery      string
+		responseItems []*cminteraction.Interaction
+		responseToken string
+		expectStatus  int
+	}{
+		{
+			name: "normal - default since",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:      "/service_agents/interactions/unresolved",
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectStatus:  http.StatusOK,
+		},
+		{
+			name: "bad request - invalid since format",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:     "/service_agents/interactions/unresolved?since=30",
+			expectStatus: http.StatusBadRequest,
+		},
+		{
+			name:         "unauthenticated",
+			agent:        nil,
+			reqQuery:     "/service_agents/interactions/unresolved",
+			expectStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{serviceHandler: mockSvc}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				if tt.agent != nil {
+					c.Set("auth_identity", tt.agent)
+				}
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
+
+			if tt.responseItems != nil && tt.agent != nil {
+				mockSvc.EXPECT().
+					ServiceAgentInteractionListUnresolved(req.Context(), tt.agent, uint64(100), "", gomock.Any()).
+					Return(tt.responseItems, tt.responseToken, nil)
+			}
+
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func Test_GetServiceAgentsInteractionsId(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	interactionID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery            string
+		responseInteraction *cminteraction.Interaction
+		expectStatus        int
+	}{
+		{
+			name: "normal - plain agent permission",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery: "/service_agents/interactions/11111111-0000-0000-0000-000000000001",
+			responseInteraction: &cminteraction.Interaction{
+				ID:         interactionID,
+				CustomerID: customerID,
+				Direction:  "incoming",
+			},
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "unauthenticated",
+			agent:        nil,
+			reqQuery:     "/service_agents/interactions/11111111-0000-0000-0000-000000000001",
+			expectStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{serviceHandler: mockSvc}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				if tt.agent != nil {
+					c.Set("auth_identity", tt.agent)
+				}
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
+
+			if tt.responseInteraction != nil && tt.agent != nil {
+				mockSvc.EXPECT().
+					ServiceAgentInteractionGet(req.Context(), tt.agent, interactionID).
+					Return(tt.responseInteraction, nil)
+			}
+
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func Test_PostServiceAgentsInteractionsIdResolutions(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	interactionID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("22222222-0000-0000-0000-000000000002")
+	resolvedByID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000003")
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery     string
+		reqBody      map[string]string
+		responseRes  *cmresolution.Resolution
+		expectStatus int
+	}{
+		{
+			name: "normal - plain agent permission",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery: "/service_agents/interactions/11111111-0000-0000-0000-000000000001/resolutions",
+			reqBody: map[string]string{
+				"contact_id":       contactID.String(),
+				"resolution_type":  "positive",
+				"resolved_by_type": "agent",
+				"resolved_by_id":   resolvedByID.String(),
+			},
+			responseRes: &cmresolution.Resolution{
+				ID:            uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004"),
+				CustomerID:    customerID,
+				InteractionID: interactionID,
+				ContactID:     contactID,
+			},
+			expectStatus: http.StatusCreated,
+		},
+		{
+			name:         "unauthenticated",
+			agent:        nil,
+			reqQuery:     "/service_agents/interactions/11111111-0000-0000-0000-000000000001/resolutions",
+			reqBody:      map[string]string{},
+			expectStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{serviceHandler: mockSvc}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				if tt.agent != nil {
+					c.Set("auth_identity", tt.agent)
+				}
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			bodyBytes, _ := json.Marshal(tt.reqBody)
+			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBuffer(bodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tt.responseRes != nil && tt.agent != nil {
+				mockSvc.EXPECT().
+					ServiceAgentResolutionCreate(req.Context(), tt.agent, interactionID, contactID, "positive", "agent", resolvedByID).
+					Return(tt.responseRes, nil)
+			}
+
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func Test_DeleteServiceAgentsInteractionsIdResolutionsRid(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	interactionID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	resolutionID := uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004")
+
+	tests := []struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery     string
+		expectStatus int
+	}{
+		{
+			name: "normal - plain agent permission",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:     "/service_agents/interactions/11111111-0000-0000-0000-000000000001/resolutions/44444444-0000-0000-0000-000000000004",
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "unauthenticated",
+			agent:        nil,
+			reqQuery:     "/service_agents/interactions/11111111-0000-0000-0000-000000000001/resolutions/44444444-0000-0000-0000-000000000004",
+			expectStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{serviceHandler: mockSvc}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				if tt.agent != nil {
+					c.Set("auth_identity", tt.agent)
+				}
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("DELETE", tt.reqQuery, nil)
+
+			if tt.agent != nil {
+				mockSvc.EXPECT().
+					ServiceAgentResolutionDelete(req.Context(), tt.agent, interactionID, resolutionID).
+					Return(nil)
+			}
+
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -3291,6 +3291,45 @@ func (e PostServiceAgentsFilesMultipartBodyType) Valid() bool {
 	}
 }
 
+// Defines values for PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType.
+const (
+	Negative PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType = "negative"
+	Positive PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType = "positive"
+)
+
+// Valid indicates whether the value is a known member of the PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType enum.
+func (e PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType) Valid() bool {
+	switch e {
+	case Negative:
+		return true
+	case Positive:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType.
+const (
+	Agent  PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType = "agent"
+	Rule   PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType = "rule"
+	System PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType = "system"
+)
+
+// Valid indicates whether the value is a known member of the PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType enum.
+func (e PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType) Valid() bool {
+	switch e {
+	case Agent:
+		return true
+	case Rule:
+		return true
+	case System:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PostStorageFilesMultipartBodyType.
 const (
 	Rag PostStorageFilesMultipartBodyType = "rag"
@@ -9118,6 +9157,60 @@ type PostServiceAgentsFilesMultipartBody struct {
 // PostServiceAgentsFilesMultipartBodyType defines parameters for PostServiceAgentsFiles.
 type PostServiceAgentsFilesMultipartBodyType string
 
+// GetServiceAgentsInteractionsParams defines parameters for GetServiceAgentsInteractions.
+type GetServiceAgentsInteractionsParams struct {
+	// PeerType Remote endpoint type (e.g. "tel", "email"). Required with peer_target.
+	PeerType *string `form:"peer_type,omitempty" json:"peer_type,omitempty"`
+
+	// PeerTarget Remote endpoint target (e.g. "+155****4567"). Required with peer_type.
+	PeerTarget *string `form:"peer_target,omitempty" json:"peer_target,omitempty"`
+
+	// ContactId Filter by resolved contact ID.
+	ContactId *openapi_types.UUID `form:"contact_id,omitempty" json:"contact_id,omitempty"`
+
+	// AddressId Filter by contact address ID.
+	AddressId *openapi_types.UUID `form:"address_id,omitempty" json:"address_id,omitempty"`
+
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+}
+
+// GetServiceAgentsInteractionsUnresolvedParams defines parameters for GetServiceAgentsInteractionsUnresolved.
+type GetServiceAgentsInteractionsUnresolvedParams struct {
+	// Since Lookback window in days (e.g. "7d", "30d"). Default "30d", max "180d".
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
+
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+}
+
+// PostServiceAgentsInteractionsIdResolutionsJSONBody defines parameters for PostServiceAgentsInteractionsIdResolutions.
+type PostServiceAgentsInteractionsIdResolutionsJSONBody struct {
+	// ContactId The contact to attach or suppress this interaction for.
+	ContactId openapi_types.UUID `json:"contact_id"`
+
+	// ResolutionType Type of resolution.
+	ResolutionType PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType `json:"resolution_type"`
+
+	// ResolvedById ID of the agent, system, or rule that resolved the interaction.
+	ResolvedById openapi_types.UUID `json:"resolved_by_id"`
+
+	// ResolvedByType Who resolved this interaction.
+	ResolvedByType PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType `json:"resolved_by_type"`
+}
+
+// PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType defines parameters for PostServiceAgentsInteractionsIdResolutions.
+type PostServiceAgentsInteractionsIdResolutionsJSONBodyResolutionType string
+
+// PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType defines parameters for PostServiceAgentsInteractionsIdResolutions.
+type PostServiceAgentsInteractionsIdResolutionsJSONBodyResolvedByType string
+
 // PutServiceAgentsMeJSONBody defines parameters for PutServiceAgentsMe.
 type PutServiceAgentsMeJSONBody struct {
 	// Detail Additional details about the agent.
@@ -9878,6 +9971,9 @@ type PostServiceAgentsConversationsIdMessagesJSONRequestBody PostServiceAgentsCo
 
 // PostServiceAgentsFilesMultipartRequestBody defines body for PostServiceAgentsFiles for multipart/form-data ContentType.
 type PostServiceAgentsFilesMultipartRequestBody PostServiceAgentsFilesMultipartBody
+
+// PostServiceAgentsInteractionsIdResolutionsJSONRequestBody defines body for PostServiceAgentsInteractionsIdResolutions for application/json ContentType.
+type PostServiceAgentsInteractionsIdResolutionsJSONRequestBody PostServiceAgentsInteractionsIdResolutionsJSONBody
 
 // PutServiceAgentsMeJSONRequestBody defines body for PutServiceAgentsMe for application/json ContentType.
 type PutServiceAgentsMeJSONRequestBody PutServiceAgentsMeJSONBody

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -8192,8 +8192,20 @@ paths:
 
   /service_agents/tags/{id}:
     $ref: './paths/service_agents/tags_id.yaml'
+
   /service_agents/tags:
     $ref: './paths/service_agents/tags.yaml'
+
+  /service_agents/interactions:
+    $ref: './paths/service_agents/interactions.yaml'
+  /service_agents/interactions/unresolved:
+    $ref: './paths/service_agents/interactions_unresolved.yaml'
+  /service_agents/interactions/{id}:
+    $ref: './paths/service_agents/interactions_id.yaml'
+  /service_agents/interactions/{id}/resolutions:
+    $ref: './paths/service_agents/interactions_id_resolutions.yaml'
+  /service_agents/interactions/{id}/resolutions/{rid}:
+    $ref: './paths/service_agents/interactions_id_resolutions_id.yaml'
 
   /service_agents/transcribes:
     $ref: './paths/service_agents/transcribes.yaml'

--- a/bin-openapi-manager/openapi/paths/service_agents/interactions.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/interactions.yaml
@@ -1,0 +1,51 @@
+get:
+  summary: List interactions
+  description: |
+    List CRM interactions for the service agent's customer. Exactly one filter is required:
+    peer_type + peer_target (remote endpoint), contact_id, or address_id.
+  tags:
+    - Service Agent
+  parameters:
+    - name: peer_type
+      in: query
+      description: Remote endpoint type (e.g. "tel", "email"). Required with peer_target.
+      schema:
+        type: string
+        example: "tel"
+    - name: peer_target
+      in: query
+      description: Remote endpoint target (e.g. "+155****4567"). Required with peer_type.
+      schema:
+        type: string
+        example: "+155****4567"
+    - name: contact_id
+      in: query
+      description: Filter by resolved contact ID.
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+    - name: address_id
+      in: query
+      description: Filter by contact address ID.
+      schema:
+        type: string
+        format: uuid
+        example: "7c4d2f3a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
+    - $ref: '#/components/parameters/PageSize'
+    - $ref: '#/components/parameters/PageToken'
+  responses:
+    '200':
+      description: Successful response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ContactManagerInteractionListResponse'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/service_agents/interactions_id.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/interactions_id.yaml
@@ -1,0 +1,31 @@
+get:
+  summary: Get an interaction
+  description: Get the interaction of the given ID, for the service agent's customer.
+  tags:
+    - Service Agent
+  parameters:
+    - name: id
+      in: path
+      description: The ID of the interaction. The ID is returned from GET /service_agents/interactions response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+  responses:
+    '200':
+      description: Successful response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ContactManagerInteraction'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/service_agents/interactions_id_resolutions.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/interactions_id_resolutions.yaml
@@ -1,0 +1,72 @@
+post:
+  summary: Create a resolution for an interaction
+  description: |
+    Manually attribute (positive) or suppress (negative) an interaction for a contact,
+    for the service agent's customer.
+    A positive resolution attaches the interaction to the contact.
+    A negative resolution suppresses an incorrect automatic match.
+  tags:
+    - Service Agent
+  parameters:
+    - name: id
+      in: path
+      description: The ID of the interaction. The ID is returned from GET /service_agents/interactions response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - contact_id
+            - resolution_type
+            - resolved_by_type
+            - resolved_by_id
+          properties:
+            contact_id:
+              type: string
+              format: uuid
+              description: The contact to attach or suppress this interaction for.
+              example: "7c4d2f3a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
+            resolution_type:
+              type: string
+              description: Type of resolution.
+              enum:
+                - positive
+                - negative
+              example: "positive"
+            resolved_by_type:
+              type: string
+              description: Who resolved this interaction.
+              enum:
+                - agent
+                - system
+                - rule
+              example: "agent"
+            resolved_by_id:
+              type: string
+              format: uuid
+              description: ID of the agent, system, or rule that resolved the interaction.
+              example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  responses:
+    '201':
+      description: Resolution created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ContactManagerResolution'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/service_agents/interactions_id_resolutions_id.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/interactions_id_resolutions_id.yaml
@@ -1,0 +1,38 @@
+delete:
+  summary: Delete a resolution
+  description: |
+    Soft-delete a resolution, for the service agent's customer.
+    Use this to retract a wrong positive or negative resolution.
+    Re-attribute by creating a new resolution after deletion.
+  tags:
+    - Service Agent
+  parameters:
+    - name: id
+      in: path
+      description: The ID of the interaction. The ID is returned from GET /service_agents/interactions response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+    - name: rid
+      in: path
+      description: The ID of the resolution. The ID is returned from POST /service_agents/interactions/{id}/resolutions response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  responses:
+    '200':
+      description: Resolution deleted successfully.
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/service_agents/interactions_unresolved.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/interactions_unresolved.yaml
@@ -1,0 +1,34 @@
+get:
+  summary: List unresolved interactions
+  description: |
+    List interactions that have no active resolution within the given time window,
+    for the service agent's customer.
+    The "since" parameter defines the lookback window (e.g. "7d" = last 7 days).
+    Default is "30d"; maximum is "180d".
+  tags:
+    - Service Agent
+  parameters:
+    - name: since
+      in: query
+      description: |
+        Lookback window in days (e.g. "7d", "30d"). Default "30d", max "180d".
+      schema:
+        type: string
+        example: "30d"
+    - $ref: '#/components/parameters/PageSize'
+    - $ref: '#/components/parameters/PageToken'
+  responses:
+    '200':
+      description: Successful response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ContactManagerInteractionListResponse'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/docs/plans/2026-07-04-revert-interaction-permission-relax-add-service-agents-endpoint-design.md
+++ b/docs/plans/2026-07-04-revert-interaction-permission-relax-add-service-agents-endpoint-design.md
@@ -1,0 +1,177 @@
+# NOJIRA: Revert interaction permission relax, add service_agents/interactions & service_agents/resolutions
+
+**Status:** Draft (Round 2, revised after Round 1 review)
+**Ticket:** #1052
+**Author:** Hermes (CPO)
+**Date:** 2026-07-04
+**Corrects:** PR #1047 (`NOJIRA-Relax-interaction-agent-permission`, merged, commit `1608cfa5f`)
+
+---
+
+## 1. Context
+
+PR #1047은 square-talk(Agent 전용 프론트엔드)가 CRM interaction/resolution 기능을 쓸 수 있도록, top-level `/interactions/*`, `/interactions/{id}/resolutions*` 5개 엔드포인트의 권한 비트마스크에 `PermissionCustomerAgent`를 직접 추가했다.
+
+이는 `bin-openapi-manager/CLAUDE.md`의 "Adding a Service Agent (Agent-facing) resource" 원칙 위반이다:
+
+> Agent-facing frontend가 Admin/Manager-gated 리소스에 새 capability가 필요할 때는, top-level 엔드포인트의 `hasPermission(...)` 비트마스크를 완화하는 게 아니라 신규 `service_agents/<resource>` 엔드포인트를 추가해야 한다.
+
+top-level `/interactions/*`는 square-admin(Admin/Manager 전용 화면)도 계속 호출하는 표면이다. 비트마스크 완화로 인해, 원칙이 막고자 했던 "Admin/Manager 전용 표면을 Agent에게까지 조용히 열어버리는" 상황이 실제로 발생했다.
+
+**구분 기준 (스킬 `voipbin-square-talk-feature`에 이미 명문화된 판단 기준):** Agent-facing 앱이 필요로 하는 게 리소스의 좁은 WRITE 액션 1~2개뿐이면 top-level 비트마스크를 완화하는 선택지도 있다. 그러나 이번 케이스는 GET List/Unresolved/Get을 포함한 리소스 표면 대부분이 필요하므로, 신규 `service_agents/interactions`, `service_agents/resolutions` 표면을 만드는 게 맞는 선택이다.
+
+---
+
+## 2. Scope
+
+### 2.1 되돌리기 (top-level, 원상복구)
+
+`bin-api-manager/pkg/servicehandler/interaction.go`의 5개 메서드에서 `amagent.PermissionCustomerAgent` 비트 제거:
+
+| 메서드 | 현재 (PR #1047) | 되돌린 후 |
+|--------|-----------------|-----------|
+| `InteractionList` | `PermissionCustomerAgent\|Admin\|Manager` | `PermissionCustomerAdmin\|PermissionCustomerManager` |
+| `InteractionListUnresolved` | 〃 | 〃 |
+| `InteractionGet` | 〃 | 〃 |
+| `ResolutionCreate` | 〃 | 〃 |
+| `ResolutionDelete` | 〃 | 〃 |
+
+OpenAPI 스펙(`openapi/paths/interactions/*.yaml`)은 요청/응답 계약이 바뀌지 않으므로 **수정하지 않는다**. 순수하게 Go 코드의 권한 게이트만 되돌린다.
+
+### 2.2 신규 추가 (Agent 전용 표면)
+
+**OpenAPI (신규 파일, top-level 미수정):**
+```
+openapi/paths/service_agents/interactions.yaml
+openapi/paths/service_agents/interactions_unresolved.yaml
+openapi/paths/service_agents/interactions_id.yaml
+openapi/paths/service_agents/interactions_id_resolutions.yaml
+openapi/paths/service_agents/interactions_id_resolutions_id.yaml
+```
+
+**servicehandler (신규 파일 `pkg/servicehandler/serviceagent_interaction.go`):**
+```go
+ServiceAgentInteractionList(ctx, a, size, token, peerType, peerTarget, contactID, addressID) ([]*cminteraction.Interaction, string, error)
+ServiceAgentInteractionListUnresolved(ctx, a, size, token, since) ([]*cminteraction.Interaction, string, error)
+ServiceAgentInteractionGet(ctx, a, id) (*cminteraction.Interaction, error)
+ServiceAgentResolutionCreate(ctx, a, interactionID, contactID, resolutionType, resolvedByType, resolvedByID) (*cmresolution.Resolution, error)
+ServiceAgentResolutionDelete(ctx, a, interactionID, resolutionID) error
+```
+
+내부적으로 top-level과 동일한 private 헬퍼(`h.interactionGet`)와 동일한 RPC 호출(`h.reqHandler.ContactV1Interaction*`, `h.reqHandler.ContactV1Resolution*`)을 재사용한다. 권한 게이트만 `amagent.PermissionAll`(`ServiceAgentContact*`, `ServiceAgentTranscribe*`와 동일한 "이 customer의 인증된 Agent라면 누구나" 센티널)로 다르다.
+
+**필수 컨벤션 (Round 1 리뷰에서 확인, 기존 초안 누락):** `serviceagent_contact.go`, `serviceagent_transcribe.go`의 모든 `ServiceAgent*` public 함수는 예외 없이 첫 줄에 다음 가드를 둔다:
+```go
+if !a.IsAgent() {
+    return nil, serviceerrors.ErrAuthenticationRequired
+}
+```
+5개 신규 함수 전부 이 가드를 첫 줄에 포함한다.
+
+**server (신규 파일 `server/service_agents_interactions.go`):**
+```
+GetServiceAgentsInteractions
+GetServiceAgentsInteractionsUnresolved
+GetServiceAgentsInteractionsId
+PostServiceAgentsInteractionsIdResolutions
+DeleteServiceAgentsInteractionsIdResolutionsRid
+```
+top-level `server/interactions.go`의 파싱/검증 로직을 그대로 재사용하되, 호출하는 servicehandler 메서드만 `ServiceAgent*`로 교체한다.
+
+### 2.3 필터 요구사항 (신규 표면도 top-level과 동일하게 유지 — Round 1 계획에서 변경됨)
+
+top-level `GetInteractions`는 `peer_type+peer_target` / `contact_id` / `address_id` 중 **정확히 1개**를 요구한다(§7 of VOIP-1220 design). 신규 `GetServiceAgentsInteractions`도 **동일하게 정확히 1개**를 요구한다.
+
+**Round 1 리뷰에서 뒤집힌 결정:** 최초 초안은 신규 표면에서 "필터 0개(전체 조회)"도 허용하는 안이었다. 병렬 설계 리뷰에서 다음이 확인됨:
+- `ServiceAgentInteractionList`가 재사용할 예정인 `h.reqHandler.ContactV1InteractionList` RPC는 top-level과 **동일한 공유 코드 경로**(`bin-contact-manager/pkg/contacthandler/interaction_read.go`의 `InteractionList`)로 귀결된다. 이 함수는 필터가 전부 비어있으면 `default` 분기에서 `cerrors.InvalidArgument("INVALID_FILTER", ...)`를 반환한다(현재 코드 확인, 라인 90-95). `bin-contact-manager/pkg/listenhandler/v1_interactions.go`도 독립적으로 동일한 "정확히 1개" 검증을 한 번 더 강제한다.
+- 즉 `bin-api-manager` 레이어에서만 필터 개수 검증을 완화해도, 요청은 결국 `ContactV1InteractionList` RPC를 거쳐 `bin-contact-manager`의 두 계층 모두에서 400으로 막힌다. `bin-api-manager`만의 변경으로는 "필터 0개 = 전체 조회"가 동작하지 않는다.
+- 이를 실제로 동작시키려면 `bin-contact-manager`에 신규 RPC 또는 파라미터 추가(예: `allow_empty_filter` 플래그를 listenhandler→contacthandler→dbhandler까지 관통시키는 변경)가 필요하다. 이는 **크로스 서비스 백엔드 변경**이며, 이번 티켓(#1052, 권한 되돌리기 + 표면 분리)의 스코프를 넘어선다.
+
+**결정:** 이번 라운드에서는 "필터 0개(전체 조회)" 기능을 **드롭**한다. `GetServiceAgentsInteractions`는 top-level과 동일하게 "정확히 1개 필터" 요구사항을 그대로 적용한다. "customer 전체 interaction 목록(필터 없이 조회)" 기능은 `bin-contact-manager` 변경을 포함하는 **별도 후속 티켓**으로 분리한다(§9 Follow-up 참조). 이렇게 하면 신규 표면이 정말로 기존 patterns(`serviceagent_contact.go`, `serviceagent_transcribe.go`)와 완전히 동일한 "권한 게이트만 다르고 로직은 순수 재사용" 원칙을 지킨다 — 새 필터 검증 로직도, 백엔드 변경도 없다.
+
+```go
+// server/service_agents_interactions.go — GetServiceAgentsInteractions
+// top-level GetInteractions(server/interactions.go)와 완전히 동일한 검증 로직 재사용.
+filterCount := 0
+if peerType != "" || peerTarget != "" { filterCount++ }
+if contactID != uuid.Nil               { filterCount++ }
+if addressID != uuid.Nil               { filterCount++ }
+if filterCount != 1 {
+    // 400 InvalidArgument — top-level과 동일
+}
+```
+
+---
+
+## 3. Interface + Mock
+
+`pkg/servicehandler/main.go`에 5개 메서드 시그니처 추가, `mockgen -package servicehandler -destination ./mock_main.go -source main.go -build_flags=-mod=mod` 재생성 (`pkg/servicehandler/`에서 실행).
+
+---
+
+## 4. Tests
+
+### 4.1 되돌리기 대상 (기존 테스트 갱신)
+
+`pkg/servicehandler/interaction_test.go`에서 PR #1047(`git show 1608cfa5f`)이 추가한 5개 "agent permission is sufficient" 서브테스트를 확인 완료(Round 1 리뷰에서 라인 단위 확인):
+
+| 함수 | 서브테스트 위치 |
+|------|------------------|
+| `Test_InteractionList` | L61-80 `"agent permission is sufficient"` |
+| `Test_InteractionListUnresolved` | L558-572 `"agent permission is sufficient"` |
+| `Test_InteractionGet` | L181-206 `"agent permission is sufficient"` |
+| `Test_ResolutionCreate` | L318-346 `"agent permission is sufficient"` |
+| `Test_ResolutionDelete` | L446-457 `"agent permission is sufficient"` |
+
+5개 전부 `serviceerrors.ErrPermissionDenied`를 기대하는 어서션으로 되돌린다(같은 함수 내 기존 `"permission denied"`/`"no permission"` 서브테스트와 동일한 패턴). 라인 번호는 구현 시점에 재확인(브랜치 분기 이후 다른 커밋이 반영됐을 수 있음).
+
+### 4.2 신규 표면
+
+| 메서드 | 테스트 케이스 |
+|--------|--------------|
+| ServiceAgentInteractionList | 정상(필터 있음, 1개), 필터 0개 → 400 InvalidArgument(top-level과 동일 검증), 필터 2개 이상 → 400, Admin 권한도 통과(PermissionAll 포함 확인), 미인증 |
+| ServiceAgentInteractionListUnresolved | 정상, 잘못된 since 형식 → 400 |
+| ServiceAgentInteractionGet | 정상, 타 customer 소유 interaction → PermissionDenied |
+| ServiceAgentResolutionCreate | 정상 → 201, 타 customer interaction에 대한 resolution 생성 시도 → 에러 |
+| ServiceAgentResolutionDelete | 정상 → 200 |
+
+server 레벨 HTTP 테스트(`server/service_agents_interactions_test.go`)도 동일 케이스로 작성.
+
+---
+
+## 5. Verification
+
+`bin-openapi-manager`에서 `go generate ./...` 먼저, 그다음 `bin-api-manager`에서 `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`.
+
+---
+
+## 6. Not in scope
+
+- square-talk `src/api/services/interactions.js`를 `/v1.0/service_agents/interactions`로 전환하는 프론트엔드 변경 — 별도 커밋/PR (SQUARE-7 워크트리에서 진행, 이 백엔드 PR 머지 후).
+- square-talk Home 탭 UI 자체 구현 (SQUARE-7).
+- **[정정, Round 1 리뷰에서 확인]** VOIP-1220 design doc §6이 기술한 "`ResolutionDelete`가 `interaction_id`를 DB WHERE 절에 포함하지 않는다"는 한계는 **현재 코드에는 존재하지 않는다.** `bin-contact-manager/pkg/dbhandler/resolution.go:57`을 직접 확인한 결과 `Where(sq.Eq{"interaction_id": interactionID.Bytes()})`가 이미 포함되어 있다(`WHERE customer_id=? AND interaction_id=? AND id=?` 전부 강제). VOIP-1220 문서 작성 시점 이후 별도 커밋으로 수정된 것으로 보인다. 따라서 이번 티켓은 이 항목에 대해 "상속하는 기존 결함"이 없으며, 신규 `ServiceAgentResolutionDelete`도 동일하게 3중 WHERE 절이 강제된 안전한 상태로 시작한다. (VOIP-1220 문서 자체는 별도로 정정이 필요하나 이 티켓의 스코프는 아니다.)
+- "customer 전체 interaction 목록(필터 없이 조회)" 기능 — §2.3에서 설명한 대로 `bin-contact-manager` 백엔드 변경이 필요해 이번 라운드에서 드롭. 별도 후속 티켓 필요(§9).
+
+---
+
+## 7. Implementation Order
+
+1. `bin-api-manager/pkg/servicehandler/interaction.go`: 5개 메서드 권한 비트 되돌리기
+2. `pkg/servicehandler/interaction_test.go`: Agent 권한 케이스를 PermissionDenied로 되돌리기
+3. `bin-openapi-manager`: 5개 YAML 신규 파일 작성 → `openapi.yaml` 등록 → `go generate ./...`
+4. `bin-api-manager`: `go generate ./...` (gen.go 갱신)
+5. `pkg/servicehandler/main.go` 인터페이스 추가 → `serviceagent_interaction.go` 구현 → mock 재생성
+6. `server/service_agents_interactions.go` 구현
+7. 테스트 파일 작성 (servicehandler + server 레벨)
+8. 전체 검증 워크플로
+
+---
+
+## 8. Open Questions
+
+- **RST 문서 업데이트**: `bin-api-manager/CLAUDE.md`는 신규 엔드포인트 추가 시 `docsdev/source/` 업데이트를 요구. 이 PR에 포함할지 별도 티켓으로 분리할지 대표님 판단.
+
+## 9. Follow-up (별도 티켓, 이번 스코프 아님)
+
+- **customer 전체 interaction 목록(필터 없이 조회)**: `bin-contact-manager`의 `ContactV1InteractionList` RPC 체인(listenhandler → contacthandler → dbhandler)에 "필터 전부 없음 = customer_id만으로 스코핑된 전체 조회" 경로를 새로 추가하는 크로스 서비스 백엔드 변경. `dbhandler/interaction.go:116-119`는 이미 전부-빈 필터를 무해하게 처리하는 로직이 있으나(`nil, nil` 반환, 에러 아님) 그 위 두 계층(listenhandler, contacthandler)이 먼저 400을 반환해 도달 불가 상태. 이 두 계층의 얼리리턴 가드를 수정/분기하는 별도 설계 문서 + 리뷰 필요.
+- **VOIP-1220 design doc 정정**: §6의 "interaction_id가 DB WHERE에 없다"는 서술이 현재 코드와 불일치(이미 수정됨). 문서 정정 필요(코드 변경 아님, docs만).


### PR DESCRIPTION
Revert the top-level /interactions and /resolutions permission bitmask relax
from PR #1047, and add a proper service_agents/interactions Agent-facing API
surface instead, per bin-openapi-manager/CLAUDE.md's service-agent-resource
principle. Closes #1052.

- bin-api-manager: Revert PermissionCustomerAgent bitmask on 5 top-level interaction/resolution methods back to PermissionCustomerAdmin|Manager
- bin-api-manager: Revert the 5 corresponding "agent permission is sufficient" test subtests to assert PermissionDenied
- bin-api-manager: Add serviceagent_interaction.go with ServiceAgentInteractionList/ListUnresolved/Get and ServiceAgentResolutionCreate/Delete, gated with amagent.PermissionAll, reusing the existing private helpers and RPC calls
- bin-api-manager: Add ServiceHandler interface methods and regenerate mock_main.go
- bin-api-manager: Add server/service_agents_interactions.go HTTP handlers mirroring the top-level interactions.go request parsing
- bin-api-manager: Add servicehandler and server level tests for the new service_agents/interactions surface, including a plain-Agent permission success case and a cross-customer denial case
- bin-openapi-manager: Add openapi/paths/service_agents/interactions*.yaml (5 new files) mirroring the top-level interactions/*.yaml contract, register under /service_agents/interactions* in openapi.yaml
- docs: Add design doc recording the correction rationale, the 2-round design review findings (empty-filter feature dropped as out of scope, ResolutionDelete ownership gap confirmed already fixed in current code), and the follow-up items deferred to separate tickets