### PR TITLE
NOJIRA-Add-multi-filter-rejection-test-interactions

### DIFF
--- a/bin-api-manager/server/interactions_test.go
+++ b/bin-api-manager/server/interactions_test.go
@@ -60,6 +60,17 @@ func Test_GetInteractions(t *testing.T) {
 			expectStatus: http.StatusBadRequest,
 		},
 		{
+			name: "bad request - two filters provided simultaneously",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+			}),
+			reqQuery:     "/interactions?contact_id=11111111-0000-0000-0000-000000000001&peer_type=tel&peer_target=%2B155****1111",
+			expectStatus: http.StatusBadRequest,
+		},
+		{
 			name:         "unauthenticated",
 			agent:        nil,
 			reqQuery:     "/interactions?contact_id=11111111-0000-0000-0000-000000000001",

--- a/bin-api-manager/server/service_agents_interactions_test.go
+++ b/bin-api-manager/server/service_agents_interactions_test.go
@@ -76,6 +76,18 @@ func Test_GetServiceAgentsInteractions(t *testing.T) {
 			expectStatus: http.StatusBadRequest,
 		},
 		{
+			name: "bad request - two filters provided simultaneously",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:     "/service_agents/interactions?contact_id=11111111-0000-0000-0000-000000000001&peer_type=tel&peer_target=%2B155****1111",
+			expectStatus: http.StatusBadRequest,
+		},
+		{
 			name:         "unauthenticated",
 			agent:        nil,
 			reqQuery:     "/service_agents/interactions?contact_id=11111111-0000-0000-0000-000000000001",


### PR DESCRIPTION
Add missing test coverage for the multi-filter-provided-simultaneously
rejection path on both the top-level and service_agents interactions
list endpoints. No production code changes. Closes #1055.

- bin-api-manager: Add "two filters provided simultaneously" test case to Test_GetInteractions (contact_id + peer_type/peer_target together must 400, previously only the zero-filter case was tested)
- bin-api-manager: Add the same test case to Test_GetServiceAgentsInteractions for parity with the new service_agents/interactions surface