### PR TITLE
NOJIRA-Add-service-agent-interactions-unfiltered-list

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -18891,7 +18891,7 @@
     "/service_agents/interactions": {
       "get": {
         "summary": "List interactions",
-        "description": "List CRM interactions for the service agent's customer. Exactly one filter is required:\npeer_type + peer_target (remote endpoint), contact_id, or address_id.\n",
+        "description": "List CRM interactions for the service agent's customer. At most one filter may be\nprovided: peer_type + peer_target (remote endpoint), contact_id, or address_id.\nIf no filter is provided, the full customer interaction history is returned,\nscoped to the \"since\" lookback window (default \"30d\", maximum \"180d\").\n",
         "tags": [
           "Service Agent"
         ],
@@ -18932,6 +18932,15 @@
               "type": "string",
               "format": "uuid",
               "example": "7c4d2f3a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Lookback window in days (e.g. \"7d\", \"30d\"), used only when no filter\n(peer_type+peer_target, contact_id, address_id) is provided. Default \"30d\", max \"180d\".\nIgnored when a filter is provided.\n",
+            "schema": {
+              "type": "string",
+              "example": "30d"
             }
           },
           {

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -6940,6 +6940,11 @@ type GetServiceAgentsInteractionsParams struct {
 	// AddressId Filter by contact address ID.
 	AddressId *openapi_types.UUID `form:"address_id,omitempty" json:"address_id,omitempty"`
 
+	// Since Lookback window in days (e.g. "7d", "30d"), used only when no filter
+	// (peer_type+peer_target, contact_id, address_id) is provided. Default "30d", max "180d".
+	// Ignored when a filter is provided.
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
+
 	// PageSize Number of results to return per page.
 	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
 
@@ -16582,6 +16587,14 @@ func (siw *ServerInterfaceWrapper) GetServiceAgentsInteractions(c *gin.Context) 
 	err = runtime.BindQueryParameter("form", true, false, "address_id", c.Request.URL.Query(), &params.AddressId)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter address_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "since", c.Request.URL.Query(), &params.Since)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter since: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/bin-api-manager/pkg/servicehandler/interaction.go
+++ b/bin-api-manager/pkg/servicehandler/interaction.go
@@ -2,6 +2,7 @@ package servicehandler
 
 import (
 	"context"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -70,7 +71,7 @@ func (h *serviceHandler) InteractionList(
 		return nil, "", serviceerrors.ErrPermissionDenied
 	}
 
-	items, nextToken, err := h.reqHandler.ContactV1InteractionList(ctx, a.CustomerID, size, token, peerType, peerTarget, contactID, addressID)
+	items, nextToken, err := h.reqHandler.ContactV1InteractionList(ctx, a.CustomerID, size, token, peerType, peerTarget, contactID, addressID, time.Time{})
 	if err != nil {
 		log.Errorf("Could not list interactions. err: %v", err)
 		return nil, "", err

--- a/bin-api-manager/pkg/servicehandler/interaction_test.go
+++ b/bin-api-manager/pkg/servicehandler/interaction_test.go
@@ -3,6 +3,7 @@ package servicehandler
 import (
 	"context"
 	"testing"
+	"time"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -111,7 +112,7 @@ func Test_InteractionList(t *testing.T) {
 
 			if !tt.expectErr {
 				mockReq.EXPECT().
-					ContactV1InteractionList(ctx, tt.agent.CustomerID, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID).
+					ContactV1InteractionList(ctx, tt.agent.CustomerID, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID, time.Time{}).
 					Return(tt.responseItems, tt.responseToken, nil)
 			}
 

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -29,8 +29,8 @@ import (
 	cscustomer "monorepo/bin-customer-manager/models/customer"
 
 	amai "monorepo/bin-ai-manager/models/ai"
-	amaicall "monorepo/bin-ai-manager/models/aicall"
 	amaiaudit "monorepo/bin-ai-manager/models/aiaudit"
+	amaicall "monorepo/bin-ai-manager/models/aicall"
 	amaiprompthistory "monorepo/bin-ai-manager/models/aiprompthistory"
 	amaipromptproposal "monorepo/bin-ai-manager/models/aipromptproposal"
 	ammessage "monorepo/bin-ai-manager/models/message"
@@ -76,8 +76,8 @@ import (
 
 	tmtag "monorepo/bin-tag-manager/models/tag"
 
-	tmsipmessage "monorepo/bin-timeline-manager/models/sipmessage"
 	tmanalysis "monorepo/bin-timeline-manager/models/analysis"
+	tmsipmessage "monorepo/bin-timeline-manager/models/sipmessage"
 
 	tkchat "monorepo/bin-talk-manager/models/chat"
 	tkmessage "monorepo/bin-talk-manager/models/message"
@@ -504,6 +504,7 @@ type ServiceHandler interface {
 		token string,
 		peerType, peerTarget string,
 		contactID, addressID uuid.UUID,
+		since time.Time,
 	) ([]*cminteraction.Interaction, string, error)
 	ServiceAgentInteractionListUnresolved(
 		ctx context.Context,

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -80,6 +80,7 @@ import (
 	streaming "monorepo/bin-tts-manager/models/streaming"
 	http "net/http"
 	reflect "reflect"
+	time "time"
 
 	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -4690,9 +4691,9 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentInteractionGet(ctx, a, id 
 }
 
 // ServiceAgentInteractionList mocks base method.
-func (m *MockServiceHandler) ServiceAgentInteractionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID) ([]*interaction.Interaction, string, error) {
+func (m *MockServiceHandler) ServiceAgentInteractionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID, since time.Time) ([]*interaction.Interaction, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceAgentInteractionList", ctx, a, size, token, peerType, peerTarget, contactID, addressID)
+	ret := m.ctrl.Call(m, "ServiceAgentInteractionList", ctx, a, size, token, peerType, peerTarget, contactID, addressID, since)
 	ret0, _ := ret[0].([]*interaction.Interaction)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -4700,9 +4701,9 @@ func (m *MockServiceHandler) ServiceAgentInteractionList(ctx context.Context, a 
 }
 
 // ServiceAgentInteractionList indicates an expected call of ServiceAgentInteractionList.
-func (mr *MockServiceHandlerMockRecorder) ServiceAgentInteractionList(ctx, a, size, token, peerType, peerTarget, contactID, addressID any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentInteractionList(ctx, a, size, token, peerType, peerTarget, contactID, addressID, since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentInteractionList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentInteractionList), ctx, a, size, token, peerType, peerTarget, contactID, addressID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentInteractionList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentInteractionList), ctx, a, size, token, peerType, peerTarget, contactID, addressID, since)
 }
 
 // ServiceAgentInteractionListUnresolved mocks base method.

--- a/bin-api-manager/pkg/servicehandler/serviceagent_interaction.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_interaction.go
@@ -2,6 +2,7 @@ package servicehandler
 
 import (
 	"context"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -15,8 +16,9 @@ import (
 
 // ServiceAgentInteractionList sends a request to contact-manager
 // to list interactions matching the given filter, for the service agent's customer.
-// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero
-// (same requirement as the top-level Admin/Manager InteractionList).
+// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero,
+// UNLESS all three are zero, in which case the full customer history is listed,
+// scoped to the last `since` (default/max enforced by the server layer, §3.5 of the design doc).
 func (h *serviceHandler) ServiceAgentInteractionList(
 	ctx context.Context,
 	a *auth.AuthIdentity,
@@ -24,6 +26,7 @@ func (h *serviceHandler) ServiceAgentInteractionList(
 	token string,
 	peerType, peerTarget string,
 	contactID, addressID uuid.UUID,
+	since time.Time,
 ) ([]*cminteraction.Interaction, string, error) {
 	if !a.IsAgent() {
 		return nil, "", serviceerrors.ErrAuthenticationRequired
@@ -36,6 +39,7 @@ func (h *serviceHandler) ServiceAgentInteractionList(
 		"peer_target": peerTarget,
 		"contact_id":  contactID,
 		"address_id":  addressID,
+		"since":       since,
 	})
 
 	if a.IsDirect() {
@@ -47,7 +51,7 @@ func (h *serviceHandler) ServiceAgentInteractionList(
 		return nil, "", serviceerrors.ErrPermissionDenied
 	}
 
-	items, nextToken, err := h.reqHandler.ContactV1InteractionList(ctx, a.CustomerID, size, token, peerType, peerTarget, contactID, addressID)
+	items, nextToken, err := h.reqHandler.ContactV1InteractionList(ctx, a.CustomerID, size, token, peerType, peerTarget, contactID, addressID, since)
 	if err != nil {
 		log.Errorf("Could not list interactions. err: %v", err)
 		return nil, "", err

--- a/bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go
@@ -3,6 +3,7 @@ package servicehandler
 import (
 	"context"
 	"testing"
+	"time"
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
@@ -21,6 +22,7 @@ import (
 func Test_ServiceAgentInteractionList(t *testing.T) {
 	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
 	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	fixedSince := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
 		name string
@@ -32,6 +34,7 @@ func Test_ServiceAgentInteractionList(t *testing.T) {
 		peerTarget string
 		contactID  uuid.UUID
 		addressID  uuid.UUID
+		since      time.Time
 
 		responseItems []*cminteraction.Interaction
 		responseToken string
@@ -52,6 +55,28 @@ func Test_ServiceAgentInteractionList(t *testing.T) {
 			peerTarget: "+155****1111",
 			contactID:  uuid.Nil,
 			addressID:  uuid.Nil,
+			since:      time.Time{},
+
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectErr:     false,
+		},
+		{
+			name: "normal - no filter, unfiltered mode with since forwarded to RPC",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			size:       20,
+			token:      "",
+			peerType:   "",
+			peerTarget: "",
+			contactID:  uuid.Nil,
+			addressID:  uuid.Nil,
+			since:      fixedSince,
 
 			responseItems: []*cminteraction.Interaction{},
 			responseToken: "",
@@ -86,11 +111,11 @@ func Test_ServiceAgentInteractionList(t *testing.T) {
 
 			if !tt.expectErr {
 				mockReq.EXPECT().
-					ContactV1InteractionList(ctx, tt.agent.CustomerID, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID).
+					ContactV1InteractionList(ctx, tt.agent.CustomerID, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID, tt.since).
 					Return(tt.responseItems, tt.responseToken, nil)
 			}
 
-			items, _, err := h.ServiceAgentInteractionList(ctx, tt.agent, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID)
+			items, _, err := h.ServiceAgentInteractionList(ctx, tt.agent, tt.size, tt.token, tt.peerType, tt.peerTarget, tt.contactID, tt.addressID, tt.since)
 			if tt.expectErr {
 				if err == nil {
 					t.Errorf("Wrong match. expect: err, got: ok")

--- a/bin-api-manager/server/service_agents_interactions.go
+++ b/bin-api-manager/server/service_agents_interactions.go
@@ -3,6 +3,7 @@ package server
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gofrs/uuid"
@@ -63,7 +64,8 @@ func (h *server) GetServiceAgentsInteractions(c *gin.Context, params openapi_ser
 		addressID = uuid.UUID(*params.AddressId)
 	}
 
-	// Validate: exactly one filter mode must be provided (same as top-level GetInteractions).
+	// Validate: at most one filter mode. Zero filters means "unfiltered, time-scoped" mode
+	// (customer's full interaction history within the `since` window).
 	filterCount := 0
 	if peerType != "" || peerTarget != "" {
 		filterCount++
@@ -74,13 +76,38 @@ func (h *server) GetServiceAgentsInteractions(c *gin.Context, params openapi_ser
 	if addressID != uuid.Nil {
 		filterCount++
 	}
-	if filterCount != 1 {
-		log.Errorf("Expected exactly one filter mode, got %d.", filterCount)
-		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_FILTER", "Exactly one filter is required: peer_type+peer_target, contact_id, or address_id."))
+	if filterCount > 1 {
+		log.Errorf("Expected at most one filter mode, got %d.", filterCount)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_FILTER", "At most one filter is allowed: peer_type+peer_target, contact_id, or address_id."))
 		return
 	}
 
-	items, nextToken, err := h.serviceHandler.ServiceAgentInteractionList(c.Request.Context(), a, pageSize, pageToken, peerType, peerTarget, contactID, addressID)
+	var since time.Time
+	if filterCount == 0 {
+		sinceStr := "30d"
+		if params.Since != nil && *params.Since != "" {
+			sinceStr = *params.Since
+		}
+		if !strings.HasSuffix(sinceStr, "d") {
+			log.Errorf("Invalid since param format: %q", sinceStr)
+			abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_SINCE", "The 'since' parameter must be in the format '<N>d' (e.g. '7d', '30d')."))
+			return
+		}
+		n, parseErr := strconv.Atoi(strings.TrimSuffix(sinceStr, "d"))
+		if parseErr != nil || n <= 0 {
+			log.Errorf("Invalid since param value: %q", sinceStr)
+			abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_SINCE", "The 'since' parameter must be a positive number of days (e.g. '7d')."))
+			return
+		}
+		if n > 180 {
+			log.Errorf("since param exceeds maximum of 180d: %q", sinceStr)
+			abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_SINCE", "The 'since' parameter must be at most 180d."))
+			return
+		}
+		since = time.Now().Add(-time.Duration(n) * 24 * time.Hour)
+	}
+
+	items, nextToken, err := h.serviceHandler.ServiceAgentInteractionList(c.Request.Context(), a, pageSize, pageToken, peerType, peerTarget, contactID, addressID, since)
 	if err != nil {
 		log.Errorf("Could not list interactions. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/service_agents_interactions_test.go
+++ b/bin-api-manager/server/service_agents_interactions_test.go
@@ -64,7 +64,7 @@ func Test_GetServiceAgentsInteractions(t *testing.T) {
 			expectStatus:  http.StatusOK,
 		},
 		{
-			name: "bad request - no filter",
+			name: "normal - no filter, unfiltered mode with default 30d since",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID:         agentID,
@@ -72,7 +72,47 @@ func Test_GetServiceAgentsInteractions(t *testing.T) {
 				},
 				Permission: amagent.PermissionCustomerAgent,
 			}),
-			reqQuery:     "/service_agents/interactions",
+			reqQuery:      "/service_agents/interactions",
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectStatus:  http.StatusOK,
+		},
+		{
+			name: "normal - no filter, explicit since",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:      "/service_agents/interactions?since=7d",
+			responseItems: []*cminteraction.Interaction{},
+			responseToken: "",
+			expectStatus:  http.StatusOK,
+		},
+		{
+			name: "bad request - since invalid format",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:     "/service_agents/interactions?since=7days",
+			expectStatus: http.StatusBadRequest,
+		},
+		{
+			name: "bad request - since exceeds 180d max",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			reqQuery:     "/service_agents/interactions?since=181d",
 			expectStatus: http.StatusBadRequest,
 		},
 		{
@@ -117,7 +157,7 @@ func Test_GetServiceAgentsInteractions(t *testing.T) {
 
 			if tt.responseItems != nil && tt.agent != nil {
 				mockSvc.EXPECT().
-					ServiceAgentInteractionList(req.Context(), tt.agent, uint64(100), "", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					ServiceAgentInteractionList(req.Context(), tt.agent, uint64(100), "", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(tt.responseItems, tt.responseToken, nil)
 			}
 

--- a/bin-common-handler/pkg/requesthandler/contact_interactions.go
+++ b/bin-common-handler/pkg/requesthandler/contact_interactions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/gofrs/uuid"
 
@@ -38,7 +39,10 @@ func (r *requestHandler) ContactV1InteractionGet(ctx context.Context, customerID
 }
 
 // ContactV1InteractionList lists interactions from contact-manager.
-// Exactly one of (peerType+peerTarget), contactID, or addressID should be non-zero.
+// Exactly one of (peerType+peerTarget), contactID, or addressID should be non-zero,
+// UNLESS since is non-zero, in which case zero filters is allowed (unfiltered, time-scoped mode).
+// since is encoded as an absolute RFC3339Nano timestamp on the wire (not a relative "Nd" string) —
+// any "Nd" parsing/range validation happens at the bin-api-manager HTTP layer before this call.
 func (r *requestHandler) ContactV1InteractionList(
 	ctx context.Context,
 	customerID uuid.UUID,
@@ -46,6 +50,7 @@ func (r *requestHandler) ContactV1InteractionList(
 	token string,
 	peerType, peerTarget string,
 	contactID, addressID uuid.UUID,
+	since time.Time,
 ) ([]*cminteraction.Interaction, string, error) {
 	u := url.Values{}
 	if peerType != "" {
@@ -59,6 +64,9 @@ func (r *requestHandler) ContactV1InteractionList(
 	}
 	if addressID != uuid.Nil {
 		u.Set("address_id", addressID.String())
+	}
+	if !since.IsZero() {
+		u.Set("since", since.UTC().Format(time.RFC3339Nano))
 	}
 	if size > 0 {
 		u.Set("page_size", fmt.Sprintf("%d", size))

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -5,6 +5,7 @@ package requesthandler
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"monorepo/bin-common-handler/pkg/circuitbreakerhandler"
 
@@ -28,11 +29,11 @@ import (
 	cscustomer "monorepo/bin-customer-manager/models/customer"
 
 	amai "monorepo/bin-ai-manager/models/ai"
-	amaicall "monorepo/bin-ai-manager/models/aicall"
 	amaiaudit "monorepo/bin-ai-manager/models/aiaudit"
-	amanalysis "monorepo/bin-ai-manager/models/analysis"
+	amaicall "monorepo/bin-ai-manager/models/aicall"
 	amaiprompthistory "monorepo/bin-ai-manager/models/aiprompthistory"
 	amaipromptproposal "monorepo/bin-ai-manager/models/aipromptproposal"
+	amanalysis "monorepo/bin-ai-manager/models/analysis"
 	ammessage "monorepo/bin-ai-manager/models/message"
 	amparticipant "monorepo/bin-ai-manager/models/participant"
 	amsummary "monorepo/bin-ai-manager/models/summary"
@@ -95,9 +96,9 @@ import (
 	tmevent "monorepo/bin-timeline-manager/models/event"
 	tmsipmessage "monorepo/bin-timeline-manager/models/sipmessage"
 
+	tkchat "monorepo/bin-talk-manager/models/chat"
 	talkmessage "monorepo/bin-talk-manager/models/message"
 	talkparticipant "monorepo/bin-talk-manager/models/participant"
-	tkchat "monorepo/bin-talk-manager/models/chat"
 
 	tmtranscribe "monorepo/bin-transcribe-manager/models/transcribe"
 	tmtranscript "monorepo/bin-transcribe-manager/models/transcript"
@@ -914,7 +915,7 @@ type RequestHandler interface {
 
 	// contact-manager interactions (CRM v1 read API, VOIP-1209)
 	ContactV1InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*cminteraction.Interaction, error)
-	ContactV1InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, contactID, addressID uuid.UUID) ([]*cminteraction.Interaction, string, error)
+	ContactV1InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, contactID, addressID uuid.UUID, since time.Time) ([]*cminteraction.Interaction, string, error)
 	ContactV1InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since string) ([]*cminteraction.Interaction, string, error)
 	ContactV1ResolutionCreate(ctx context.Context, customerID, contactID, interactionID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*cmresolution.Resolution, error)
 	ContactV1ResolutionDelete(ctx context.Context, customerID uuid.UUID, interactionID, resolutionID uuid.UUID) error

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -99,6 +99,7 @@ import (
 	tts "monorepo/bin-tts-manager/models/tts"
 	webhook "monorepo/bin-webhook-manager/models/webhook"
 	reflect "reflect"
+	time "time"
 
 	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -3668,9 +3669,9 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1InteractionGet(ctx, customerI
 }
 
 // ContactV1InteractionList mocks base method.
-func (m *MockRequestHandler) ContactV1InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID) ([]*interaction.Interaction, string, error) {
+func (m *MockRequestHandler) ContactV1InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID, since time.Time) ([]*interaction.Interaction, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContactV1InteractionList", ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+	ret := m.ctrl.Call(m, "ContactV1InteractionList", ctx, customerID, size, token, peerType, peerTarget, contactID, addressID, since)
 	ret0, _ := ret[0].([]*interaction.Interaction)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -3678,9 +3679,9 @@ func (m *MockRequestHandler) ContactV1InteractionList(ctx context.Context, custo
 }
 
 // ContactV1InteractionList indicates an expected call of ContactV1InteractionList.
-func (mr *MockRequestHandlerMockRecorder) ContactV1InteractionList(ctx, customerID, size, token, peerType, peerTarget, contactID, addressID any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) ContactV1InteractionList(ctx, customerID, size, token, peerType, peerTarget, contactID, addressID, since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1InteractionList", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1InteractionList), ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1InteractionList", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1InteractionList), ctx, customerID, size, token, peerType, peerTarget, contactID, addressID, since)
 }
 
 // ContactV1InteractionListUnresolved mocks base method.

--- a/bin-contact-manager/pkg/contacthandler/interaction_read.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_read.go
@@ -52,7 +52,8 @@ func (h *contactHandler) InteractionGet(ctx context.Context, customerID, id uuid
 }
 
 // InteractionList is the main timeline read path.
-// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero.
+// Exactly one of (peerType+peerTarget), contactID, or addressID must be non-zero,
+// UNLESS since is non-zero, in which case zero filters is allowed (unfiltered, time-scoped mode).
 // Returns the interaction slice and a next-page token (empty when no further pages).
 func (h *contactHandler) InteractionList(
 	ctx context.Context,
@@ -62,6 +63,7 @@ func (h *contactHandler) InteractionList(
 	peerType, peerTarget string,
 	contactID uuid.UUID,
 	addressID uuid.UUID,
+	since time.Time,
 ) ([]*interaction.Interaction, string, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "InteractionList",
@@ -75,7 +77,7 @@ func (h *contactHandler) InteractionList(
 	switch {
 	case peerType != "" || peerTarget != "":
 		// Direct peer path
-		items, err := h.db.InteractionList(ctx, customerID, size+1, token, peerType, peerTarget, nil)
+		items, err := h.db.InteractionList(ctx, customerID, size+1, token, peerType, peerTarget, nil, time.Time{})
 		if err != nil {
 			return nil, "", fmt.Errorf("could not list interactions by peer. InteractionList. err: %v", err)
 		}
@@ -86,6 +88,14 @@ func (h *contactHandler) InteractionList(
 
 	case addressID != uuid.Nil:
 		return h.interactionListByAddress(ctx, customerID, addressID, size, token)
+
+	case !since.IsZero():
+		// Unfiltered mode: scope by customer_id + tm_create >= since only.
+		items, err := h.db.InteractionList(ctx, customerID, size+1, token, "", "", nil, since)
+		if err != nil {
+			return nil, "", fmt.Errorf("could not list all interactions. InteractionList. err: %v", err)
+		}
+		return buildPagedResult(items, size)
 
 	default:
 		return nil, "", cerrors.InvalidArgument(
@@ -127,7 +137,7 @@ func (h *contactHandler) interactionListByContact(
 	// STEP 2: Fetch ALL automatic peer matches (internal cap, not caller page size).
 	var automatic []*interaction.Interaction
 	if len(addressPairs) > 0 {
-		automatic, err = h.db.InteractionList(ctx, customerID, interactionInternalCap, "", "", "", addressPairs)
+		automatic, err = h.db.InteractionList(ctx, customerID, interactionInternalCap, "", "", "", addressPairs, time.Time{})
 		if err != nil {
 			return nil, "", fmt.Errorf("could not list interactions by address set. interactionListByContact. err: %v", err)
 		}
@@ -263,7 +273,7 @@ func (h *contactHandler) interactionListByAddress(
 		return nil, "", fmt.Errorf("could not get address. interactionListByAddress. err: %v", err)
 	}
 
-	items, err := h.db.InteractionList(ctx, customerID, size+1, token, "", "", []dbhandler.AddressPair{{Type: ap.Type, Target: ap.Target}})
+	items, err := h.db.InteractionList(ctx, customerID, size+1, token, "", "", []dbhandler.AddressPair{{Type: ap.Type, Target: ap.Target}}, time.Time{})
 	if err != nil {
 		return nil, "", fmt.Errorf("could not list interactions by address. interactionListByAddress. err: %v", err)
 	}

--- a/bin-contact-manager/pkg/contacthandler/interaction_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_test.go
@@ -26,7 +26,7 @@ func Test_EventCallCreated(t *testing.T) {
 
 		message *callmodel.WebhookMessage
 
-		responseUUID uuid.UUID
+		responseUUID    uuid.UUID
 		responseCurTime *time.Time
 
 		expectInteraction *interaction.Interaction
@@ -304,6 +304,86 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 
 			if err := h.EventConversationMessageCreated(ctx, tt.message); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+// Test_InteractionList_unfiltered covers the new since-based unfiltered branch
+// added alongside PR #1054/§3.2 of the design doc: when peerType/peerTarget/
+// contactID/addressID are all zero but since is non-zero, InteractionList must
+// route to h.db.InteractionList with an empty peer/addressSet and the since
+// value forwarded verbatim (not the interactionListByContact/ByAddress paths).
+func Test_InteractionList_unfiltered(t *testing.T) {
+	customerID := uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001")
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+
+		customerID uuid.UUID
+		since      time.Time
+
+		responseItems []*interaction.Interaction
+		expectErr     bool
+	}{
+		{
+			name:       "normal - since forwarded, unfiltered branch reached",
+			customerID: customerID,
+			since:      since,
+
+			responseItems: []*interaction.Interaction{
+				{
+					ID:         uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000002"),
+					CustomerID: customerID,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:       "bad request - since is zero-value, no filter provided",
+			customerID: customerID,
+			since:      time.Time{},
+
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			h := contactHandler{
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+				utilHandler:   mockUtil,
+			}
+			ctx := context.Background()
+
+			if !tt.expectErr {
+				mockDB.EXPECT().
+					InteractionList(ctx, tt.customerID, uint64(21), "", "", "", nil, tt.since).
+					Return(tt.responseItems, nil)
+			}
+
+			items, _, err := h.InteractionList(ctx, tt.customerID, 20, "", "", "", uuid.Nil, uuid.Nil, tt.since)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: err, got: ok")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if len(items) != len(tt.responseItems) {
+				t.Errorf("Wrong match. expect: %d items, got: %d", len(tt.responseItems), len(items))
 			}
 		})
 	}

--- a/bin-contact-manager/pkg/contacthandler/main.go
+++ b/bin-contact-manager/pkg/contacthandler/main.go
@@ -54,7 +54,7 @@ type ContactHandler interface {
 	// Interaction read operations (CRM v1 read API, VOIP-1209)
 	InteractionGet(ctx context.Context, customerID, id uuid.UUID) (*interaction.Interaction, error)
 	InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string,
-		peerType, peerTarget string, contactID uuid.UUID, addressID uuid.UUID) ([]*interaction.Interaction, string, error)
+		peerType, peerTarget string, contactID uuid.UUID, addressID uuid.UUID, since time.Time) ([]*interaction.Interaction, string, error)
 	InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, string, error)
 
 	// Resolution operations (CRM v1 attribution, VOIP-1209)

--- a/bin-contact-manager/pkg/contacthandler/mock_main.go
+++ b/bin-contact-manager/pkg/contacthandler/mock_main.go
@@ -211,9 +211,9 @@ func (mr *MockContactHandlerMockRecorder) InteractionGet(ctx, customerID, id any
 }
 
 // InteractionList mocks base method.
-func (m *MockContactHandler) InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID) ([]*interaction.Interaction, string, error) {
+func (m *MockContactHandler) InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, contactID, addressID uuid.UUID, since time.Time) ([]*interaction.Interaction, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InteractionList", ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+	ret := m.ctrl.Call(m, "InteractionList", ctx, customerID, size, token, peerType, peerTarget, contactID, addressID, since)
 	ret0, _ := ret[0].([]*interaction.Interaction)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -221,9 +221,9 @@ func (m *MockContactHandler) InteractionList(ctx context.Context, customerID uui
 }
 
 // InteractionList indicates an expected call of InteractionList.
-func (mr *MockContactHandlerMockRecorder) InteractionList(ctx, customerID, size, token, peerType, peerTarget, contactID, addressID any) *gomock.Call {
+func (mr *MockContactHandlerMockRecorder) InteractionList(ctx, customerID, size, token, peerType, peerTarget, contactID, addressID, since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionList", reflect.TypeOf((*MockContactHandler)(nil).InteractionList), ctx, customerID, size, token, peerType, peerTarget, contactID, addressID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionList", reflect.TypeOf((*MockContactHandler)(nil).InteractionList), ctx, customerID, size, token, peerType, peerTarget, contactID, addressID, since)
 }
 
 // InteractionListUnresolved mocks base method.

--- a/bin-contact-manager/pkg/dbhandler/interaction.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction.go
@@ -98,11 +98,11 @@ func (h *handler) InteractionGet(ctx context.Context, id uuid.UUID) (*interactio
 	return res, nil
 }
 
-
-
 // InteractionList returns a page of interactions.
-// Filter mode: either (peerType+peerTarget) OR addressSet (multi-column IN).
-// If both peerType/peerTarget are empty AND addressSet is empty → returns nil, nil immediately.
+// Filter mode: either (peerType+peerTarget) OR addressSet (multi-column IN) OR since (unfiltered, time-scoped).
+// If peerType/peerTarget/addressSet are all empty AND since is zero-value → returns nil, nil immediately
+// (preserves the original "no filter" behavior for existing callers).
+// If peerType/peerTarget/addressSet are all empty AND since is non-zero → scopes by customer_id + tm_create >= since only.
 // Pagination: cursor is a tm_create timestamp string (WHERE tm_create < token ORDER BY tm_create DESC).
 // This matches the platform-wide convention used by calls, messages, emails, etc.
 func (h *handler) InteractionList(
@@ -112,9 +112,10 @@ func (h *handler) InteractionList(
 	token string,
 	peerType, peerTarget string,
 	addressSet []AddressPair,
+	since time.Time,
 ) ([]*interaction.Interaction, error) {
-	// 1. If all filters empty → return nil, nil
-	if peerType == "" && peerTarget == "" && len(addressSet) == 0 {
+	// 1. If all filters empty and since not set → return nil, nil (unchanged legacy behavior)
+	if peerType == "" && peerTarget == "" && len(addressSet) == 0 && since.IsZero() {
 		return nil, nil
 	}
 
@@ -135,6 +136,11 @@ func (h *handler) InteractionList(
 			or = append(or, sq.Eq{"peer_type": ap.Type, "peer_target": ap.Target})
 		}
 		builder = builder.Where(or)
+	}
+
+	// 3b. Unfiltered mode: scope by tm_create lower bound (customer_id is already applied above).
+	if !since.IsZero() {
+		builder = builder.Where(sq.GtOrEq{"tm_create": since.UTC()})
 	}
 
 	// 4. Apply cursor if token != "" (simple timestamp cursor, platform standard)

--- a/bin-contact-manager/pkg/dbhandler/interaction_test.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction_test.go
@@ -215,7 +215,7 @@ func Test_InteractionList_byPeer(t *testing.T) {
 	}
 
 	// InteractionList with peerType+peerTarget → both returned
-	res, err := h.InteractionList(ctx, customerID, 10, "", peerType, peerTarget, nil)
+	res, err := h.InteractionList(ctx, customerID, 10, "", peerType, peerTarget, nil, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList() error = %v", err)
 	}
@@ -224,7 +224,7 @@ func Test_InteractionList_byPeer(t *testing.T) {
 	}
 
 	// InteractionList with wrong peer → empty
-	res, err = h.InteractionList(ctx, customerID, 10, "", peerType, "+19990000000", nil)
+	res, err = h.InteractionList(ctx, customerID, 10, "", peerType, "+19990000000", nil, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList() wrong peer error = %v", err)
 	}
@@ -285,7 +285,7 @@ func Test_InteractionList_byAddressSet(t *testing.T) {
 		{Type: "tel", Target: "+15550003001"},
 		{Type: "line", Target: "Ufake12345"},
 	}
-	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", bothPairs)
+	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", bothPairs, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList() both pairs error = %v", err)
 	}
@@ -297,7 +297,7 @@ func Test_InteractionList_byAddressSet(t *testing.T) {
 	onePair := []AddressPair{
 		{Type: "tel", Target: "+15550003001"},
 	}
-	res, err = h.InteractionList(ctx, customerID, 10, "", "", "", onePair)
+	res, err = h.InteractionList(ctx, customerID, 10, "", "", "", onePair, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList() one pair error = %v", err)
 	}
@@ -321,13 +321,92 @@ func Test_InteractionList_empty(t *testing.T) {
 
 	customerID := uuid.FromStringOrNil("e1b2c3d4-0004-0004-0004-000000000001")
 
-	// InteractionList with all-empty filters → no error, nil result
-	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", nil)
+	// InteractionList with all-empty filters and since=zero-value → no error, nil result (legacy behavior)
+	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", nil, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList() empty filters error = %v", err)
 	}
 	if res != nil {
 		t.Errorf("InteractionList() empty filters expected nil, got %v", res)
+	}
+}
+
+// Test_InteractionList_unfiltered_since verifies the new unfiltered mode: when all
+// filters are empty but since is non-zero, InteractionList scopes by customer_id +
+// tm_create >= since only, and correctly excludes both other customers' rows and
+// rows older than since.
+func Test_InteractionList_unfiltered_since(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000001")
+	otherCustomerID := uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000099")
+
+	recent := time.Date(2026, 6, 20, 10, 0, 0, 0, time.UTC)
+	old := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	since := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	iRecent := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000002"),
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+155****6001",
+		LocalType:     "tel",
+		LocalTarget:   "+155****0006",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000003"),
+		TMCreate:      &recent,
+	}
+	iOld := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000004"),
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+155****6002",
+		LocalType:     "tel",
+		LocalTarget:   "+155****0006",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000005"),
+		TMCreate:      &old,
+	}
+	iOtherCustomer := &interaction.Interaction{
+		ID:            uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000006"),
+		CustomerID:    otherCustomerID,
+		Direction:     "incoming",
+		PeerType:      "tel",
+		PeerTarget:    "+155****6003",
+		LocalType:     "tel",
+		LocalTarget:   "+155****0006",
+		ReferenceType: "call",
+		ReferenceID:   uuid.FromStringOrNil("e1b2c3d4-0006-0006-0006-000000000007"),
+		TMCreate:      &recent,
+	}
+
+	for _, i := range []*interaction.Interaction{iRecent, iOld, iOtherCustomer} {
+		if err := h.InteractionCreate(ctx, i); err != nil {
+			t.Fatalf("InteractionCreate() error = %v", err)
+		}
+	}
+
+	res, err := h.InteractionList(ctx, customerID, 10, "", "", "", nil, since)
+	if err != nil {
+		t.Fatalf("InteractionList() unfiltered since error = %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("InteractionList() unfiltered since len = %d, want 1", len(res))
+	}
+	if res[0].ID != iRecent.ID {
+		t.Errorf("InteractionList() unfiltered since returned wrong row. got ID = %v, want %v", res[0].ID, iRecent.ID)
 	}
 }
 
@@ -460,7 +539,7 @@ func Test_InteractionList_pagination(t *testing.T) {
 
 	// pageSize=2, pass size+1=3 → expect 3 rows returned (probe row present)
 	const pageSize uint64 = 2
-	res, err := h.InteractionList(ctx, customerID, pageSize+1, "", "tel", "+15550001111", nil)
+	res, err := h.InteractionList(ctx, customerID, pageSize+1, "", "tel", "+15550001111", nil, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList() error = %v", err)
 	}
@@ -484,7 +563,7 @@ func Test_InteractionList_pagination(t *testing.T) {
 	}
 
 	// Second page: pass token, expect 1 row (the remaining one).
-	res2, err := h.InteractionList(ctx, customerID, pageSize+1, nextToken, "tel", "+15550001111", nil)
+	res2, err := h.InteractionList(ctx, customerID, pageSize+1, nextToken, "tel", "+15550001111", nil, time.Time{})
 	if err != nil {
 		t.Fatalf("InteractionList page2 error = %v", err)
 	}

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -48,7 +48,7 @@ type DBHandler interface {
 	// Interaction operations
 	InteractionCreate(ctx context.Context, i *interaction.Interaction) error
 	InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error)
-	InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, addressSet []AddressPair) ([]*interaction.Interaction, error)
+	InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, addressSet []AddressPair, since time.Time) ([]*interaction.Interaction, error)
 	InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error)
 	InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, error)
 

--- a/bin-contact-manager/pkg/dbhandler/mock_main.go
+++ b/bin-contact-manager/pkg/dbhandler/mock_main.go
@@ -306,18 +306,18 @@ func (mr *MockDBHandlerMockRecorder) InteractionGet(ctx, id any) *gomock.Call {
 }
 
 // InteractionList mocks base method.
-func (m *MockDBHandler) InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, addressSet []AddressPair) ([]*interaction.Interaction, error) {
+func (m *MockDBHandler) InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, addressSet []AddressPair, since time.Time) ([]*interaction.Interaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InteractionList", ctx, customerID, size, token, peerType, peerTarget, addressSet)
+	ret := m.ctrl.Call(m, "InteractionList", ctx, customerID, size, token, peerType, peerTarget, addressSet, since)
 	ret0, _ := ret[0].([]*interaction.Interaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InteractionList indicates an expected call of InteractionList.
-func (mr *MockDBHandlerMockRecorder) InteractionList(ctx, customerID, size, token, peerType, peerTarget, addressSet any) *gomock.Call {
+func (mr *MockDBHandlerMockRecorder) InteractionList(ctx, customerID, size, token, peerType, peerTarget, addressSet, since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionList", reflect.TypeOf((*MockDBHandler)(nil).InteractionList), ctx, customerID, size, token, peerType, peerTarget, addressSet)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionList", reflect.TypeOf((*MockDBHandler)(nil).InteractionList), ctx, customerID, size, token, peerType, peerTarget, addressSet, since)
 }
 
 // InteractionListByIDs mocks base method.

--- a/bin-contact-manager/pkg/listenhandler/v1_interactions.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_interactions.go
@@ -84,7 +84,7 @@ func (h *listenHandler) processV1InteractionsGet(ctx context.Context, req *sock.
 		return simpleResponse(400), nil
 	}
 
-	// Validate: exactly one filter mode.
+	// Validate: exactly one filter mode, UNLESS since is provided with zero filters (unfiltered mode).
 	filterCount := 0
 	if peerType != "" || peerTarget != "" {
 		filterCount++
@@ -95,12 +95,35 @@ func (h *listenHandler) processV1InteractionsGet(ctx context.Context, req *sock.
 	if addressID != uuid.Nil {
 		filterCount++
 	}
-	if filterCount != 1 {
+
+	var since time.Time
+	if filterCount == 0 {
+		sinceStr := q.Get("since")
+		if sinceStr == "" {
+			since = time.Now().Add(-30 * 24 * time.Hour) // default 30d
+		} else {
+			parsed, parseErr := time.Parse(time.RFC3339Nano, sinceStr)
+			if parseErr != nil {
+				log.Errorf("Invalid since param format: %v", parseErr)
+				return simpleResponse(400), nil
+			}
+			since = parsed
+		}
+		// Re-validate the 180d max lookback here too (defense-in-depth, matches
+		// processV1InteractionsUnresolvedGet's parseDaysDuration(sinceStr, 180) precedent).
+		maxLookback := time.Now().Add(-180 * 24 * time.Hour)
+		if since.Before(maxLookback) {
+			log.Errorf("since exceeds maximum lookback of 180d: %v", since)
+			return simpleResponse(400), nil
+		}
+	}
+
+	if filterCount != 1 && filterCount != 0 {
 		log.Errorf("Expected exactly one filter mode, got %d.", filterCount)
 		return simpleResponse(400), nil
 	}
 
-	res, _, err := h.contactHandler.InteractionList(ctx, customerID, pageSize, pageToken, peerType, peerTarget, contactID, addressID)
+	res, _, err := h.contactHandler.InteractionList(ctx, customerID, pageSize, pageToken, peerType, peerTarget, contactID, addressID, since)
 	if err != nil {
 		log.Errorf("Could not list interactions. err: %v", err)
 		return errorResponse(err), nil

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -9171,6 +9171,11 @@ type GetServiceAgentsInteractionsParams struct {
 	// AddressId Filter by contact address ID.
 	AddressId *openapi_types.UUID `form:"address_id,omitempty" json:"address_id,omitempty"`
 
+	// Since Lookback window in days (e.g. "7d", "30d"), used only when no filter
+	// (peer_type+peer_target, contact_id, address_id) is provided. Default "30d", max "180d".
+	// Ignored when a filter is provided.
+	Since *string `form:"since,omitempty" json:"since,omitempty"`
+
 	// PageSize Number of results to return per page.
 	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
 

--- a/bin-openapi-manager/openapi/paths/service_agents/interactions.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/interactions.yaml
@@ -1,8 +1,10 @@
 get:
   summary: List interactions
   description: |
-    List CRM interactions for the service agent's customer. Exactly one filter is required:
-    peer_type + peer_target (remote endpoint), contact_id, or address_id.
+    List CRM interactions for the service agent's customer. At most one filter may be
+    provided: peer_type + peer_target (remote endpoint), contact_id, or address_id.
+    If no filter is provided, the full customer interaction history is returned,
+    scoped to the "since" lookback window (default "30d", maximum "180d").
   tags:
     - Service Agent
   parameters:
@@ -32,6 +34,15 @@ get:
         type: string
         format: uuid
         example: "7c4d2f3a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
+    - name: since
+      in: query
+      description: |
+        Lookback window in days (e.g. "7d", "30d"), used only when no filter
+        (peer_type+peer_target, contact_id, address_id) is provided. Default "30d", max "180d".
+        Ignored when a filter is provided.
+      schema:
+        type: string
+        example: "30d"
     - $ref: '#/components/parameters/PageSize'
     - $ref: '#/components/parameters/PageToken'
   responses:

--- a/docs/plans/2026-07-04-add-service-agent-interactions-unfiltered-list-design.md
+++ b/docs/plans/2026-07-04-add-service-agent-interactions-unfiltered-list-design.md
@@ -1,0 +1,292 @@
+# NOJIRA: Add service_agents/interactions unfiltered-list support
+
+**Status:** Ready for implementation (Round 3 fixes applied: duplicate/stale code block in §3.3 removed and merged into a single coherent version)
+**Ticket:** #1054
+**Author:** Hermes (CPO)
+**Date:** 2026-07-04
+**Depends on:** PR #1053 (merged), PR #1056 (merged)
+
+---
+
+## 1. Context
+
+PR #1053이 `service_agents/interactions` Agent 전용 엔드포인트를 신규 추가하면서, 원래 검토했던 "필터 없이 customer 전체 interaction 목록 조회" 기능은 스코프에서 드롭됐다(설계 문서 `docs/plans/2026-07-04-revert-interaction-permission-relax-add-service-agents-endpoint-design.md` §2.3 참조).
+
+드롭 사유: `GetServiceAgentsInteractions`가 재사용하는 `h.reqHandler.ContactV1InteractionList` RPC는 top-level과 동일한 공유 코드 경로로 귀결되며, 다음 두 계층 모두에서 "필터 전부 없음"을 거부한다:
+
+1. `bin-contact-manager/pkg/listenhandler/v1_interactions.go`의 `processV1InteractionsGet` — `filterCount != 1` → HTTP 400 (line 98-101)
+2. `bin-contact-manager/pkg/contacthandler/interaction_read.go`의 `InteractionList` — `switch` 문의 `default` 분기에서 `cerrors.InvalidArgument("INVALID_FILTER", ...)` 반환 (line 90-95)
+
+한편 `bin-contact-manager/pkg/dbhandler/interaction.go`의 `InteractionList`는 이미 전부-빈 필터를 무해하게 처리하는 로직이 있다(line 117-119: `if peerType == "" && peerTarget == "" && len(addressSet) == 0 { return nil, nil }`) — 이 최하위 레이어는 준비되어 있으나 위 두 계층의 얼리리턴 가드가 도달을 막고 있다.
+
+## 2. Goal
+
+`GET service_agents/interactions`를 필터 없이 호출하면, 호출한 Agent의 `customer_id` 전체 interaction 목록을 페이지네이션과 함께 반환한다. **top-level `GET /interactions`(Admin/Manager 전용)는 기존 동작(정확히 1개 필터 필수)을 그대로 유지한다** — 이번 변경은 신규 Agent 표면에만 적용되는 opt-in 확장이다.
+
+## 2.1 Round 1 리뷰에서 확인된 major 이슈와 수정 (since 상한 필수화)
+
+**리뷰 결과(2개 병렬 리뷰):** 리뷰어 1(코드 정확성/blast radius)은 APPROVE WITH MINOR FIXES. 리뷰어 2(프로덕션 스케일 안전성)는 **CHANGES REQUIRED** — 다음 두 가지 major 이슈를 지적했다:
+
+1. **인덱스는 문제없음(PASS)**: `bin-contact-manager/scripts/database_scripts_test/contacts.sql`에 `idx_contact_interactions_cursor on contact_interactions(customer_id, tm_create)` 복합 인덱스가 이미 존재하여, `WHERE customer_id=? ORDER BY tm_create DESC` 쿼리는 풀스캔이 아닌 효율적인 인덱스 레인지 스캔이다.
+
+2. **`since` 상한 부재(major, 최초 초안의 실질적 결함)**: `contact_interactions`는 `EventCallCreated`/`EventConversationMessageCreated`(`bin-contact-manager/pkg/contacthandler/interaction.go`)에서 CRM 적격 통화/대화 메시지마다 1행씩 append되는, TTL·압축·아카이빙이 전혀 없는 무제한 증가 테이블이다. 활성 고객은 수년치 트래픽으로 수십만~수백만 행에 달할 수 있다. 개별 페이지 조회는 인덱스 덕분에 저렴하지만, **`since` 하한이 없으면 Agent 클라이언트가 필터도 시간범위도 없이 고객의 전체 이력을 무한 페이지네이션으로 순회할 수 있어**, ops 입장에서 요청당 최악 스캔량을 제한할 방법이 없다. 같은 코드베이스의 가장 가까운 선례인 `InteractionListUnresolved`가 정확히 이 패턴(기본 30d, 최대 180d `since` 강제)으로 이미 이 문제를 해결해뒀는데, 최초 초안은 이를 놓쳤다.
+
+**결정: 이번 라운드에서 `allowUnfiltered=true` 경로에 `since` 파라미터를 필수로 추가한다.** `InteractionListUnresolved`와 동일한 패턴(기본 30d, 최대 180d, `"Nd"` 형식 강제)을 그대로 재사용한다. 이렇게 하면 "필터 없음"이 진짜로 "무제한"이 아니라 "필터 없이, 단 최근 N일로 시간 스코핑됨"이 되어 스캔량 상한이 보장된다.
+
+**page_size 상한(리뷰어 2의 2번째 major 이슈):** `since` 상한을 추가하면 이 우려는 상당 부분 해소된다(`InteractionListUnresolved`도 `since` 하나만으로 이 리스크를 막고 있으며 page_size는 그대로 100 유지). 별도의 더 엄격한 page_size 캡은 추가하지 않는다 — `since`가 근본 원인(무제한 이력 순회)을 막으므로 이중 방어는 과잉이라고 판단.
+
+## 3. Design decision: opt-in bool 파라미터를 전 계층에 관통
+
+가장 좁은 blast radius를 위해, 기존 시그니처를 바꾸지 않고 새 파라미터 하나 `since time.Time`을 4개 계층(dbhandler → contacthandler → listenhandler → requesthandler)에 추가한다. **`allowUnfiltered bool`을 별도로 추가하지 않는다** — `since`가 zero-value(`time.Time{}`)이면 "unfiltered 모드 아님"(top-level의 기존 동작), non-zero이면 "unfiltered 모드 + 해당 시각 이후로 스코핑"으로 겸용한다. 이렇게 하면 시그니처에 파라미터가 하나만 추가되고, "unfiltered인데 since가 없는" 상태 자체가 타입 레벨에서 존재할 수 없어 §2.1의 안전장치가 우회될 수 없다.
+
+기존 top-level 호출부는 전부 `time.Time{}`(zero-value)를 명시적으로 전달해 현재 동작을 그대로 보존한다.
+
+**왜 새 RPC 메서드를 만들지 않고 기존 `ContactV1InteractionList`에 파라미터를 추가하는가:** 이미 `ServiceAgentInteractionList`가 top-level `InteractionList`와 완전히 동일한 로직/RPC를 재사용하는 패턴이 확립되어 있다(PR #1053). 새 RPC 메서드를 만들면 이 재사용 원칙을 깨고 로직 중복(및 향후 두 메서드 간 drift 리스크)이 생긴다. 파라미터 추가가 기존 패턴과의 일관성을 지키는 최소 변경이다.
+
+### 3.1 dbhandler 계층
+
+`bin-contact-manager/pkg/dbhandler/interaction.go`:
+
+```go
+func (h *handler) InteractionList(
+    ctx context.Context,
+    customerID uuid.UUID,
+    size uint64,
+    token string,
+    peerType, peerTarget string,
+    addressSet []AddressPair,
+    since time.Time,  // 신규. zero-value = 미적용(기존 동작 그대로)
+) ([]*interaction.Interaction, error) {
+    if peerType == "" && peerTarget == "" && len(addressSet) == 0 {
+        if since.IsZero() {
+            return nil, nil
+        }
+        // since가 non-zero: 필터 없이 customer_id + tm_create >= since로 스코핑해서 계속 진행
+        // (아래 builder는 이미 WHERE customer_id=? 를 기본 적용하므로,
+        //  peer/addressSet 조건절 대신 tm_create >= since 조건절만 추가하면 됨)
+    }
+    ...
+    if !since.IsZero() {
+        builder = builder.Where(sq.GtOrEq{"tm_create": since.UTC()})
+    }
+    ...
+}
+```
+
+**주의:** `interactionListByContact`(§99-245, set-MINUS 알고리즘)와 `interactionListByAddress`(§247-271) 내부에서도 `h.db.InteractionList`를 호출하지만, 이들은 항상 `addressSet`이 비어있지 않은 상태로 호출하므로 이 변경의 영향을 받지 않는다. `since` 파라미터는 이 두 내부 호출부에서 `time.Time{}`(zero-value)로 고정.
+
+### 3.2 contacthandler 계층
+
+`bin-contact-manager/pkg/contacthandler/interaction_read.go`의 `InteractionList`:
+
+```go
+func (h *contactHandler) InteractionList(
+    ctx context.Context,
+    customerID uuid.UUID,
+    size uint64,
+    token string,
+    peerType, peerTarget string,
+    contactID uuid.UUID,
+    addressID uuid.UUID,
+    since time.Time,  // 신규
+) ([]*interaction.Interaction, string, error) {
+    ...
+    switch {
+    case peerType != "" || peerTarget != "":
+        ...
+    case contactID != uuid.Nil:
+        return h.interactionListByContact(...)
+    case addressID != uuid.Nil:
+        return h.interactionListByAddress(...)
+    case !since.IsZero():  // 신규 분기, default보다 먼저 배치
+        items, err := h.db.InteractionList(ctx, customerID, size+1, token, "", "", nil, since)
+        if err != nil {
+            return nil, "", fmt.Errorf("could not list all interactions. InteractionList. err: %v", err)
+        }
+        return buildPagedResult(items, size)
+    default:
+        return nil, "", cerrors.InvalidArgument(...)
+    }
+}
+```
+
+### 3.3 listenhandler 계층
+
+`bin-contact-manager/pkg/listenhandler/v1_interactions.go`의 `processV1InteractionsGet`:
+
+- 신규 쿼리 파라미터 `since`를 **필터가 전부 없을 때만** 파싱한다.
+- **`since`의 형식은 RFC3339Nano 절대시각 문자열이다**(`"30d"` 같은 상대값 문자열이 아니다) — 근거는 §3.4의 인코딩 결정을 참조. `parseDaysDuration`(상대 `"Nd"` 파싱 헬퍼)은 이 계층에서 재사용하지 않는다. 상대값 파싱은 `bin-api-manager`의 HTTP 파라미터 레벨(§3.5)에서만 발생하고, RPC 경계를 넘을 때는 이미 절대시각으로 정규화되어 전달된다.
+- 필터 검증 및 `since` 처리 로직:
+
+```go
+filterCount := 0
+... // 기존 3개 필터 카운트 로직 그대로
+
+var since time.Time
+if filterCount == 0 {
+    sinceStr := q.Get("since")
+    if sinceStr == "" {
+        since = time.Now().Add(-30 * 24 * time.Hour)  // 기본 30d
+    } else {
+        parsed, parseErr := time.Parse(time.RFC3339Nano, sinceStr)
+        if parseErr != nil {
+            log.Errorf("Invalid since param format: %v", parseErr)
+            return simpleResponse(400), nil
+        }
+        since = parsed
+    }
+    // 180일 상한 재검증 (근거는 아래 단락 참조)
+    maxLookback := time.Now().Add(-180 * 24 * time.Hour)
+    if since.Before(maxLookback) {
+        log.Errorf("since exceeds maximum lookback of 180d: %v", since)
+        return simpleResponse(400), nil
+    }
+}
+
+if filterCount != 1 && filterCount != 0 {
+    log.Errorf("Expected exactly one filter mode, got %d.", filterCount)
+    return simpleResponse(400), nil
+}
+```
+
+- `filterCount >= 2`는 여전히 400 (모호한 쿼리는 항상 거부).
+- **필터가 1개일 때는 `since`가 절대 적용되지 않는다** — top-level `/interactions`(필터 필수)는 이 신규 파라미터를 아예 파싱하지 않으므로 기존 동작에 영향 없음. 이 분기는 오직 `filterCount == 0`일 때만 도달.
+
+**180일 상한을 listenhandler에도 재검증하는 이유(Round 2 리뷰에서 확정):** 초기 개정판은 "bin-api-manager HTTP 레이어에서만 검증하고 RPC 레이어는 신뢰한다"고 설계했으나, 이는 실제 기존 선례와 반대임이 Round 2 리뷰에서 확인됐다:
+
+- `bin-api-manager/server/interactions.go:121-139`(`GetInteractionsUnresolved`)는 `since` 파라미터의 **형식만**(`HasSuffix "d"`, 양수) 검증하고, 상한(180d) 검증은 명시적으로 하지 않는다 — 코드 주석에 "upper-bound (180d) is enforced by the contact-manager listenhandler"라고 직접 적혀 있다(line 123).
+- `bin-contact-manager/pkg/listenhandler/v1_interactions.go:139`(`processV1InteractionsUnresolvedGet`)의 `parseDaysDuration(sinceStr, 180)`가 **실제 180일 상한을 강제하는 지점**이다.
+
+즉 기존 코드베이스의 실제 분업은 "bin-api-manager는 형식만, bin-contact-manager(RPC 경계)가 범위를 강제"다. `contact_interactions`가 무제한 증가 테이블임이 확인된 상황에서(§2.1), 범위 검증을 bin-api-manager 단일 레이어에만 두는 것은 방어 심도(defense-in-depth)를 후퇴시키는 실질적 리스크다. **결정: listenhandler에도 180일 상한 재검증을 추가한다**(위 코드 블록에 반영 완료). 새 엔드포인트는 절대시각을 받으므로 `parseDaysDuration`(상대 `"Nd"` 문자열 전용)을 그대로 호출할 수는 없지만, 위 인라인 `since.Before(maxLookback)` 체크가 동일한 포함 상한(180일째는 허용, 181일째부터 거부) 의미를 재현한다 — 이렇게 하면 실제 기존 선례(`processV1InteractionsUnresolvedGet`)와 정확히 동일한 이중 방어 구조가 된다.
+
+### 3.4 requesthandler 계층 (RPC 클라이언트)
+
+`bin-common-handler/pkg/requesthandler/contact_interactions.go`의 `ContactV1InteractionList`:
+
+```go
+func (r *requestHandler) ContactV1InteractionList(
+    ctx context.Context,
+    customerID uuid.UUID,
+    size uint64,
+    token string,
+    peerType, peerTarget string,
+    contactID, addressID uuid.UUID,
+    since time.Time,  // 신규. zero-value = 미적용
+) ([]*cminteraction.Interaction, string, error) {
+    u := url.Values{}
+    ...
+    if !since.IsZero() {
+        u.Set("since", since.UTC().Format(time.RFC3339Nano))
+    }
+    ...
+}
+```
+
+**인코딩 결정(확정):** `since`는 절대시각을 RFC3339Nano 문자열로 URL 쿼리에 실어 보낸다("Nd" 상대값 문자열이 아님). `.UTC()`를 먼저 호출하므로 포맷 결과는 항상 `Z` 서픽스로 끝나고 `+HH:MM` 형식의 타임존 오프셋(`+` 문자 포함)은 나타나지 않는다 — 따라서 PR #1056에서 확인했던 `peer_target`의 `+` URL 인코딩 이슈(`%2B` 필요)는 이 값에는 해당하지 않는다. `u.Set()`/`u.Encode()`(송신)와 `url.Parse()`+`q.Get()`(수신)는 Go 표준 라이브러리의 대칭적 percent-encode/decode 계약을 그대로 따르므로 추가 인코딩 처리가 불필요하다.
+
+**⚠️ Round 1 리뷰에서 확인된 blast radius:** 이 함수는 `bin-common-handler`에 있으므로, 시그니처 변경이 **모든 호출부**를 건드린다. 병렬 리뷰가 전체 monorepo grep으로 확인한 현재 호출부는 정확히 2곳(non-test):
+- `bin-api-manager/pkg/servicehandler/interaction.go:73`의 `InteractionList`(top-level) → `since=time.Time{}` 고정 전달
+- `bin-api-manager/pkg/servicehandler/serviceagent_interaction.go:50`의 `ServiceAgentInteractionList`(신규 표면) → `since` 파라미터를 그대로 전달(아래 §3.5)
+
+이 외에 **테스트 파일 2곳도 mock 호출 시그니처를 갱신해야 한다**(Round 1 리뷰에서 지적됨, 최초 초안 누락):
+- `bin-api-manager/pkg/servicehandler/interaction_test.go:114`의 mock `.ContactV1InteractionList(...)` 기대값
+- `bin-api-manager/pkg/servicehandler/serviceagent_interaction_test.go:89`의 mock `.ContactV1InteractionList(...)` 기대값
+
+### 3.5 bin-api-manager 계층
+
+**top-level (`interaction.go`):** `InteractionList` 시그니처는 바꾸지 않는다(top-level은 여전히 "정확히 1개 필터"만 지원, `since` 개념 자체가 없음). 내부에서 `ContactV1InteractionList(..., time.Time{})`로 고정 호출.
+
+**신규 표면 (`serviceagent_interaction.go`):** `ServiceAgentInteractionList`에 파라미터 추가:
+
+```go
+func (h *serviceHandler) ServiceAgentInteractionList(
+    ctx context.Context,
+    a *auth.AuthIdentity,
+    size uint64,
+    token string,
+    peerType, peerTarget string,
+    contactID, addressID uuid.UUID,
+    since time.Time,  // 신규. server 레이어가 계산해서 전달 (필터 0개일 때만 non-zero)
+) ([]*cminteraction.Interaction, string, error) {
+    ...
+    items, nextToken, err := h.reqHandler.ContactV1InteractionList(ctx, a.CustomerID, size, token, peerType, peerTarget, contactID, addressID, since)
+    ...
+}
+```
+
+**server (`service_agents_interactions.go`):** `GetServiceAgentsInteractions`의 필터 검증을 "정확히 1개" → "0개 또는 1개"로 완화하고, 필터 0개일 때 `since` 파싱(top-level `GetInteractionsUnresolved`의 기존 `since` 파싱 로직과 동일한 패턴 재사용):
+
+```go
+filterCount := 0
+if peerType != "" || peerTarget != "" { filterCount++ }
+if contactID != uuid.Nil               { filterCount++ }
+if addressID != uuid.Nil               { filterCount++ }
+if filterCount > 1 {
+    // 400 InvalidArgument — 여러 필터 동시 지정은 여전히 금지
+}
+
+var since time.Time
+if filterCount == 0 {
+    sinceStr := "30d"
+    if params.Since != nil && *params.Since != "" {
+        sinceStr = *params.Since
+    }
+    // 기존 GetServiceAgentsInteractionsUnresolved의 since 검증 로직(HasSuffix "d" + Atoi + 범위체크,
+    // max 180d)을 공용 헬퍼로 추출해서 재사용 — 코드 중복 방지
+    sinceDuration, err := parseSinceParam(sinceStr, 180)
+    if err != nil {
+        abortWithError(c, cerrors.InvalidArgument(..., "INVALID_SINCE", ...))
+        return
+    }
+    since = time.Now().Add(-sinceDuration)
+}
+// filterCount == 0 → since로 스코핑된 목록, 정상 허용
+```
+
+**신규 공용 헬퍼 `parseSinceParam`:** 현재 `GetInteractionsUnresolved`(top-level)와 `GetServiceAgentsInteractionsUnresolved`(신규 표면) 양쪽에 이미 거의 동일한 "Nd 형식 검증 + Atoi + 범위체크" 인라인 코드가 중복 존재한다(PR #1053에서 이미 한 번 복제됨). 이번 PR에서 세 번째 사용처가 생기므로, `server/` 패키지에 공용 헬퍼 함수로 추출하는 것을 권장(기존 2곳도 리팩터링해 통일 — 별도 커밋으로 분리 가능, 필수는 아니지만 강력 권장).
+
+## 4. Tenant boundary
+
+`h.db.InteractionList`가 `WHERE customer_id=?`를 항상 강제하므로(builder 초기화 시점에 적용, 필터/`since` 유무와 무관), `since` non-zero 경로도 다른 customer의 데이터를 노출하지 않는다. `ServiceAgentInteractionList`는 `a.CustomerID`만 전달하므로(다른 customer_id를 지정할 방법이 API 표면에 없음) 추가 검증 불필요.
+
+## 5. Pagination / 응답 형태
+
+기존 `buildPagedResult` 그대로 재사용(cursor = `tm_create` 내림차순). 전체 목록이라도 페이지네이션 동작은 필터가 있을 때와 동일 — 신규 로직 없음. `since` 하한과 cursor(`tm_create < token`) 상한이 함께 적용되어 페이지네이션 도중에도 스코핑이 일관되게 유지된다.
+
+## 6. Tests
+
+### 6.1 dbhandler (`interaction_test.go`)
+- `InteractionList` with `since`=non-zero, 전부 빈 필터 → customer 소속 + `tm_create >= since`인 row만 반환(다른 customer 제외, since 이전 row 제외 확인)
+- `InteractionList` with `since`=zero-value, 전부 빈 필터 → `nil, nil` (기존 동작 보존, 회귀 테스트)
+
+### 6.2 contacthandler (`interaction_read_test.go` — 있다면, 없으면 신규)
+- `InteractionList` with `since`=non-zero, 필터 없음 → 정상 반환
+- `InteractionList` with `since`=zero-value, 필터 없음 → 기존과 동일하게 `INVALID_FILTER` 에러 (회귀 테스트)
+
+### 6.3 listenhandler (`v1_interactions_test.go` — 있다면)
+- `since=<RFC3339Nano 절대시각>` 쿼리 파라미터 + 필터 없음 → 200
+- `since` 없음 + 필터 없음 → 200, 기본 30d 적용 확인
+- `since` 잘못된 형식 + 필터 없음 → 400
+- `since`가 180일보다 오래된 시각 + 필터 없음 → 400 (Round 2 리뷰에서 추가, listenhandler 레벨 상한 재검증 확인)
+- `since` 없음(또는 있음) + 필터 1개 → **`since`가 무시되고** 기존과 동일하게 정상 동작 (top-level 회귀 테스트, filterCount==1이면 since 분기 자체가 실행되지 않음을 확인)
+- 필터 2개 이상 → 400 (모호한 쿼리는 여전히 거부, `since` 값과 무관)
+
+### 6.4 bin-api-manager
+- `pkg/servicehandler/interaction_test.go`(top-level `InteractionList`): 기존 테스트가 여전히 `since=time.Time{}`을 mock 기대값에 포함하도록 갱신 (시그니처 변경이므로 mock 재생성 필요)
+- `pkg/servicehandler/serviceagent_interaction_test.go`: `ServiceAgentInteractionList` 필터 없음 케이스 신규 추가, RPC에 non-zero `since`가 전달되는지 검증
+- `server/service_agents_interactions_test.go`: `GetServiceAgentsInteractions` 필터 0개 → 200 케이스로 변경(기존에는 400을 테스트했음, PR #1056에서 추가한 "필터 0개→400" 테스트는 이 PR에서 "필터 0개→200, 기본 30d 적용"으로 수정 필요). `since` 형식 오류 → 400 케이스 신규 추가(top-level `GetServiceAgentsInteractionsUnresolved`의 기존 since 검증 테스트 패턴 재사용).
+- `server/interactions_test.go`(top-level): 변경 없음(여전히 필터 0개 → 400, `since` 개념 자체가 없음)
+
+## 7. Verification
+
+`bin-common-handler` 시그니처 변경이므로 CLAUDE.md 규칙에 따라: 1) `bin-common-handler` 자체 빌드 확인 2) 영향받는 모든 컨슈머(`bin-contact-manager`, `bin-api-manager`) 각각 전체 검증 워크플로 실행. Go workspace/local replace 구조상 각 서비스 디렉토리에서 개별적으로 `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run`을 순서대로(bin-common-handler → bin-contact-manager → bin-api-manager) 실행.
+
+## 8. Not in scope
+
+- square-talk 프론트엔드에서 필터 없는 목록을 실제로 노출하는 UI (SQUARE-7 계열, 별도 프론트엔드 작업)
+- `interactionListByContact`/`interactionListByAddress` 내부 로직 변경 (영향 없음, §3.1에서 확인)
+- PR #1055/#1056에서 다룬 "필터 2개 이상" 테스트 커버리지 확장 (이미 별도로 처리됨)
+
+## 9. Review requirement
+
+CLAUDE.md 규칙에 따라 설계 문서 병렬 리뷰 최소 2라운드(수렴 확인 라운드 포함), 코드 PR도 최소 3라운드 리뷰. `bin-common-handler` 공유 라이브러리 변경이므로 특히 "모든 컨슈머 빌드 확인" 항목을 리뷰에서 중점적으로 검증.


### PR DESCRIPTION
Add unfiltered (no peer_type/contact_id/address_id filter) listing support to
service_agents/interactions, scoped to a "since" lookback window (default 30d,
max 180d, enforced at both the HTTP layer and the contact-manager RPC layer).
The top-level Admin/Manager /interactions endpoint keeps its existing "exactly
one filter required" behavior unchanged. Closes #1054.

- docs: Add design doc (3 review rounds: round 1 caught missing time-bound safety on the original allowUnfiltered-bool approach; round 2 caught a mis-cited precedent that dropped the 180d cap re-validation at the listenhandler layer; round 3 caught a leftover duplicate/stale code block from the round 2 revision)
- bin-contact-manager: Add `since time.Time` parameter to dbhandler.InteractionList (WHERE tm_create >= since when set), contacthandler.InteractionList (new unfiltered branch), and listenhandler's processV1InteractionsGet (parses `since` as an absolute RFC3339Nano timestamp when no filter is provided, defaults to 30d, rejects lookbacks older than 180d)
- bin-common-handler: Add `since time.Time` parameter to requesthandler.ContactV1InteractionList; encoded as RFC3339Nano on the wire (not a relative "Nd" string) so range validation stays a bin-api-manager HTTP-layer concern
- bin-api-manager: Add `since time.Time` parameter to servicehandler.ServiceAgentInteractionList; top-level InteractionList keeps calling ContactV1InteractionList with a fixed zero-value since. GetServiceAgentsInteractions now accepts zero filters (previously required exactly one), parsing an optional `since` query param ("Nd" format, default 30d, max 180d) for the unfiltered path
- bin-openapi-manager: Add `since` query parameter to service_agents/interactions.yaml, regenerate models/server bindings
- bin-contact-manager, bin-api-manager: Add/update tests covering the new unfiltered-since branch (dbhandler tenant/time scoping, servicehandler RPC forwarding, server-layer default/explicit/invalid/over-180d since handling)