### PR TITLE
VOIP-1227-transcribe-live-duplicate-409

### DIFF
--- a/bin-openapi-manager/openapi/paths/service_agents/transcribes.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/transcribes.yaml
@@ -107,5 +107,7 @@ post:
       $ref: '#/components/responses/BadRequest'
     '401':
       $ref: '#/components/responses/Unauthenticated'
+    '409':
+      $ref: '#/components/responses/Conflict'
     '500':
       $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/service_agents/transcribes.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/transcribes.yaml
@@ -59,6 +59,12 @@ post:
   description: >-
     Starts a transcription of the given reference (call, conference, or
     recording) for the service agent's customer and returns the result.
+    Duplicate behavior differs by reference type: for a recording that
+    already has a transcribe in the requested language, the existing
+    transcribe is returned (200); for a call/confbridge that already has
+    a progressing live transcribe in the requested language, the request
+    is rejected with 409. Stop the existing transcribe first, or start
+    with a different language.
   tags:
     - Service Agent
   requestBody:

--- a/bin-openapi-manager/openapi/paths/transcribes/main.yaml
+++ b/bin-openapi-manager/openapi/paths/transcribes/main.yaml
@@ -105,5 +105,7 @@ post:
       $ref: '#/components/responses/BadRequest'
     '401':
       $ref: '#/components/responses/Unauthenticated'
+    '409':
+      $ref: '#/components/responses/Conflict'
     '500':
       $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/transcribes/main.yaml
+++ b/bin-openapi-manager/openapi/paths/transcribes/main.yaml
@@ -56,7 +56,14 @@ get:
 
 post:
   summary: Create a transcribe
-  description: Creates a transcription of a recording and returns the result.
+  description: >-
+    Starts a transcription of the given reference (call, confbridge, or
+    recording) and returns the result. Duplicate behavior differs by
+    reference type: for a recording that already has a transcribe in the
+    requested language, the existing transcribe is returned (200); for a
+    call/confbridge that already has a progressing live transcribe in the
+    requested language, the request is rejected with 409. Stop the
+    existing transcribe first, or start with a different language.
   tags:
     - Transcribe
   requestBody:

--- a/bin-transcribe-manager/pkg/transcribehandler/start.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start.go
@@ -209,7 +209,7 @@ func (h *transcribeHandler) startLive(
 		return nil, cerrors.AlreadyExists(
 			commonoutline.ServiceNameTranscribeManager,
 			"TRANSCRIBE_ALREADY_PROGRESSING",
-			"A live transcribe is already progressing for this reference and language.",
+			"A live transcribe is already progressing for this reference and language. Stop the existing transcribe first, or start with a different language.",
 		)
 	}
 

--- a/bin-transcribe-manager/pkg/transcribehandler/start.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-transcribe-manager/models/transcribe"
 	"monorepo/bin-transcribe-manager/models/transcript"
 )
@@ -166,6 +168,37 @@ func (h *transcribeHandler) startLive(
 	id := h.utilHandler.UUIDCreate()
 	log = log.WithField("transcribe_id", id)
 	log.Debugf("Starting live transcribe. transcribe_id: %s", id)
+
+	// Reject a duplicate live session: if a progressing transcribe already
+	// exists for the same reference and language, starting another one would
+	// silently create parallel streaming sessions (double-click, network
+	// retry, or two agents pressing Start simultaneously). The recording path
+	// has its own dedup (startRecording returns the existing transcribe); for
+	// live we conflict instead of returning the existing one because the
+	// caller may have requested a different direction/provider, and the
+	// existing session keeps streaming either way. Scoped per language so
+	// multi-language sessions on one call remain possible. Note this is a
+	// read-then-create check, not a DB unique constraint, so a true
+	// concurrent race can still slip through; it closes the practical
+	// double-start window.
+	dupFilters := map[transcribe.Field]any{
+		transcribe.FieldReferenceID: referenceID,
+		transcribe.FieldLanguage:    language,
+		transcribe.FieldStatus:      transcribe.StatusProgressing,
+		transcribe.FieldDeleted:     false,
+	}
+	existings, err := h.List(ctx, 1, "", dupFilters)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not check for an existing live transcribe. reference_id: %s", referenceID)
+	}
+	if len(existings) > 0 {
+		log.Infof("Found an existing progressing transcribe. Rejecting duplicate start. existing_transcribe_id: %s", existings[0].ID)
+		return nil, cerrors.AlreadyExists(
+			commonoutline.ServiceNameTranscribeManager,
+			"TRANSCRIBE_ALREADY_PROGRESSING",
+			"A live transcribe is already progressing for this reference and language.",
+		)
+	}
 
 	directions := []transcript.Direction{transcript.Direction(direction)}
 	if direction == transcribe.DirectionBoth {

--- a/bin-transcribe-manager/pkg/transcribehandler/start.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start.go
@@ -170,18 +170,31 @@ func (h *transcribeHandler) startLive(
 	log.Debugf("Starting live transcribe. transcribe_id: %s", id)
 
 	// Reject a duplicate live session: if a progressing transcribe already
-	// exists for the same reference and language, starting another one would
-	// silently create parallel streaming sessions (double-click, network
-	// retry, or two agents pressing Start simultaneously). The recording path
-	// has its own dedup (startRecording returns the existing transcribe); for
-	// live we conflict instead of returning the existing one because the
-	// caller may have requested a different direction/provider, and the
-	// existing session keeps streaming either way. Scoped per language so
-	// multi-language sessions on one call remain possible. Note this is a
-	// read-then-create check, not a DB unique constraint, so a true
-	// concurrent race can still slip through; it closes the practical
-	// double-start window.
+	// exists for the same customer, reference and language, starting another
+	// one would silently create parallel streaming sessions (double-click,
+	// network retry, or two agents pressing Start simultaneously). The
+	// recording path has its own dedup (startRecording returns the existing
+	// transcribe); for live we conflict instead of returning the existing one
+	// because the caller may have requested a different direction/provider,
+	// and the existing session keeps streaming either way.
+	//
+	// Scoped per customer_id AND language on purpose:
+	// - customer_id: bin-ai-manager starts its own summary transcribes on the
+	//   SAME call/confbridge under IDAIManager ownership (see
+	//   bin-ai-manager/pkg/summaryhandler/start.go) — those must keep
+	//   coexisting with the customer's own live transcribe, and a customer
+	//   must never be blocked by a hidden system-owned session. The
+	//   double-start scenarios this guard exists for are all same-customer.
+	// - language: multi-language sessions on one call remain possible.
+	//
+	// Note this is a read-then-create check, not a DB unique constraint, so a
+	// true concurrent race can still slip through; it closes the practical
+	// double-start window. Also, a transcribe stuck in progressing (e.g. an
+	// orphaned session after a pod restart whose hangup event was lost) keeps
+	// returning 409 for its reference until it is stopped or cleaned up —
+	// acceptable for call-scoped lifetimes, but worth knowing when debugging.
 	dupFilters := map[transcribe.Field]any{
+		transcribe.FieldCustomerID:  customerID,
 		transcribe.FieldReferenceID: referenceID,
 		transcribe.FieldLanguage:    language,
 		transcribe.FieldStatus:      transcribe.StatusProgressing,

--- a/bin-transcribe-manager/pkg/transcribehandler/start_test.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start_test.go
@@ -422,7 +422,20 @@ func Test_startLive_duplicate_rejected(t *testing.T) {
 			ctx := context.Background()
 
 			mockUtil.EXPECT().UUIDCreate().Return(uuid.FromStringOrNil("ad23290c-9877-11ed-8d54-07172f870dfb"))
-			mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", gomock.Any()).Return(tt.responseExisting, nil)
+
+			// exact-match the duplicate-check filters: if any scoping key
+			// (customer_id, language, status) is dropped from dupFilters,
+			// this test must fail — that scoping is what keeps ai-manager's
+			// IDAIManager-owned summary transcribes and other-language
+			// sessions coexisting.
+			expectFilters := map[transcribe.Field]any{
+				transcribe.FieldCustomerID:  tt.customerID,
+				transcribe.FieldReferenceID: tt.referenceID,
+				transcribe.FieldLanguage:    tt.language,
+				transcribe.FieldStatus:      transcribe.StatusProgressing,
+				transcribe.FieldDeleted:     false,
+			}
+			mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", expectFilters).Return(tt.responseExisting, nil)
 
 			res, err := h.startLive(ctx, tt.customerID, tt.activeflowID, tt.onEndFlowID, tt.referenceType, tt.referenceID, tt.language, tt.direction, tt.provider)
 			if err == nil {

--- a/bin-transcribe-manager/pkg/transcribehandler/start_test.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start_test.go
@@ -2,12 +2,14 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 	"reflect"
 	"testing"
 
 	cmcall "monorepo/bin-call-manager/models/call"
 	cmconfbridge "monorepo/bin-call-manager/models/confbridge"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
@@ -138,6 +140,9 @@ func Test_Start_referencetype_call(t *testing.T) {
 
 			// streaming start
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+
+			// duplicate check finds nothing
+			mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", gomock.Any()).Return([]*transcribe.Transcribe{}, nil)
 
 			if tt.direction == transcribe.DirectionBoth {
 				mockStreaming.EXPECT().Start(ctx, tt.customerID, tt.responseUUID, tt.referenceType, tt.referenceID, tt.language, transcript.DirectionIn, tt.provider).Return(tt.responseStreamings[0], nil)
@@ -331,6 +336,9 @@ func Test_startLive(t *testing.T) {
 
 			ctx := context.Background()
 
+			// duplicate check finds nothing
+			mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", gomock.Any()).Return([]*transcribe.Transcribe{}, nil)
+
 			// create
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
 			mockDB.EXPECT().TranscribeCreate(ctx, gomock.Any()).Return(nil)
@@ -355,6 +363,78 @@ func Test_startLive(t *testing.T) {
 			}
 
 
+		})
+	}
+}
+
+func Test_startLive_duplicate_rejected(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		customerID    uuid.UUID
+		activeflowID  uuid.UUID
+		onEndFlowID   uuid.UUID
+		referenceType transcribe.ReferenceType
+		referenceID   uuid.UUID
+		language      string
+		direction     transcribe.Direction
+		provider      transcribe.Provider
+
+		responseExisting []*transcribe.Transcribe
+	}{
+		{
+			name: "existing progressing transcribe rejects duplicate start",
+
+			customerID:    uuid.FromStringOrNil("469b200c-8786-11ec-bd4f-bb7ae5541d57"),
+			activeflowID:  uuid.FromStringOrNil("6dc457de-0924-11f0-9360-739df5241a77"),
+			onEndFlowID:   uuid.FromStringOrNil("6df2b30e-0924-11f0-9350-cf73077f53bd"),
+			referenceType: transcribe.ReferenceTypeCall,
+			referenceID:   uuid.FromStringOrNil("47b30720-8786-11ec-ac47-f37c07bbbef5"),
+			language:      "en-US",
+			direction:     transcribe.DirectionBoth,
+			provider:      transcribe.ProviderEmpty,
+
+			responseExisting: []*transcribe.Transcribe{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("49a3529c-8786-11ec-928e-bb8e9b925697"),
+					},
+					Status: transcribe.StatusProgressing,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := &transcribeHandler{
+				utilHandler: mockUtil,
+				db:          mockDB,
+			}
+
+			ctx := context.Background()
+
+			mockUtil.EXPECT().UUIDCreate().Return(uuid.FromStringOrNil("ad23290c-9877-11ed-8d54-07172f870dfb"))
+			mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", gomock.Any()).Return(tt.responseExisting, nil)
+
+			res, err := h.startLive(ctx, tt.customerID, tt.activeflowID, tt.onEndFlowID, tt.referenceType, tt.referenceID, tt.language, tt.direction, tt.provider)
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: ok. res: %v", res)
+			}
+
+			var ve *cerrors.VoipbinError
+			if !stderrors.As(err, &ve) {
+				t.Errorf("Wrong error type. expect: VoipbinError, got: %T", err)
+			} else if ve.Status != cerrors.StatusAlreadyExists {
+				t.Errorf("Wrong status. expect: %s, got: %s", cerrors.StatusAlreadyExists, ve.Status)
+			}
 		})
 	}
 }
@@ -558,6 +638,9 @@ func Test_Start_direction_normalize(t *testing.T) {
 
 			mockReq.EXPECT().CallV1CallGet(ctx, tt.referenceID).Return(tt.responseCall, nil)
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
+
+			// duplicate check finds nothing
+			mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", gomock.Any()).Return([]*transcribe.Transcribe{}, nil)
 
 			// the streamings started must match the normalized direction:
 			// "both" starts in and out, a single direction starts only that leg.

--- a/bin-transcribe-manager/pkg/transcribehandler/start_test.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/start_test.go
@@ -452,6 +452,68 @@ func Test_startLive_duplicate_rejected(t *testing.T) {
 	}
 }
 
+func Test_startLive_different_language_coexists(t *testing.T) {
+	// Positive coexistence guard: a progressing transcribe in ANOTHER
+	// language must NOT block a new start — the duplicate check is scoped
+	// per customer+reference+language. The dup-check List (exact-matched on
+	// the requested ja-JP) returns empty even though an en-US session
+	// exists, and the start proceeds normally.
+	customerID := uuid.FromStringOrNil("469b200c-8786-11ec-bd4f-bb7ae5541d57")
+	activeflowID := uuid.FromStringOrNil("6dc457de-0924-11f0-9360-739df5241a77")
+	onEndFlowID := uuid.FromStringOrNil("6df2b30e-0924-11f0-9350-cf73077f53bd")
+	referenceID := uuid.FromStringOrNil("47b30720-8786-11ec-ac47-f37c07bbbef5")
+	responseUUID := uuid.FromStringOrNil("ad23290c-9877-11ed-8d54-07172f870dfb")
+	responseTranscribe := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("49a3529c-8786-11ec-928e-bb8e9b925697"),
+		},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockStreaming := streaminghandler.NewMockStreamingHandler(mc)
+
+	h := &transcribeHandler{
+		utilHandler:      mockUtil,
+		reqHandler:       mockReq,
+		db:               mockDB,
+		notifyHandler:    mockNotify,
+		streamingHandler: mockStreaming,
+	}
+
+	ctx := context.Background()
+
+	mockUtil.EXPECT().UUIDCreate().Return(responseUUID)
+
+	expectFilters := map[transcribe.Field]any{
+		transcribe.FieldCustomerID:  customerID,
+		transcribe.FieldReferenceID: referenceID,
+		transcribe.FieldLanguage:    "ja-JP",
+		transcribe.FieldStatus:      transcribe.StatusProgressing,
+		transcribe.FieldDeleted:     false,
+	}
+	mockDB.EXPECT().TranscribeList(ctx, uint64(1), "", expectFilters).Return([]*transcribe.Transcribe{}, nil)
+
+	mockStreaming.EXPECT().Start(ctx, customerID, responseUUID, transcribe.ReferenceTypeCall, referenceID, "ja-JP", transcript.DirectionIn, transcribe.ProviderEmpty).Return(&streaming.Streaming{}, nil)
+	mockDB.EXPECT().TranscribeCreate(ctx, gomock.Any()).Return(nil)
+	mockDB.EXPECT().TranscribeGet(ctx, gomock.Any()).Return(responseTranscribe, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(nil)
+	mockNotify.EXPECT().PublishWebhookEvent(ctx, responseTranscribe.CustomerID, transcribe.EventTypeTranscribeCreated, responseTranscribe)
+
+	res, err := h.startLive(ctx, customerID, activeflowID, onEndFlowID, transcribe.ReferenceTypeCall, referenceID, "ja-JP", transcribe.DirectionIn, transcribe.ProviderEmpty)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res == nil || res.ID != responseTranscribe.ID {
+		t.Errorf("Wrong match.\nexpect: %v\ngot: %v", responseTranscribe, res)
+	}
+}
+
 func Test_Start_direction_normalize(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
Prevent duplicate live transcribe sessions for call/confbridge references. Follow-up from monorepo-javascript#344 review, JIRA VOIP-1227.

- bin-transcribe-manager: Reject a duplicate live transcribe start when a progressing transcribe already exists for the same reference and language, returning ALREADY_EXISTS (409) instead of silently creating parallel streaming sessions
- bin-transcribe-manager: Keep the recording path's existing return-existing dedup behavior unchanged; live conflicts instead because direction/provider may differ
- bin-transcribe-manager: Add Test_startLive_duplicate_rejected and update existing startLive/Start tests with the duplicate-check TranscribeList expectation