### PR TITLE
VOIP-1229-remove-storage-manager-workload-identity

### DIFF
--- a/bin-storage-manager/CLAUDE.md
+++ b/bin-storage-manager/CLAUDE.md
@@ -21,7 +21,7 @@ File and media storage service for the VoIPbin platform. Manages customer storag
 | `pkg/listenhandler` | RabbitMQ RPC router (regex dispatch) |
 | `pkg/subscribehandler` | Event consumer (customer_deleted) |
 | `pkg/storagehandler` | Core business logic |
-| `pkg/filehandler` | GCS operations and signed URL generation |
+| `pkg/filehandler` | GCS operations and signed URL generation (requires `GOOGLE_APPLICATION_CREDENTIALS` service account key file; no in-cluster metadata-server fallback) |
 | `pkg/accounthandler` | 10 GB quota enforcement |
 | `pkg/dbhandler` | MySQL reads/writes |
 | `pkg/cachehandler` | Redis cache |

--- a/bin-storage-manager/cmd/storage-control/main.go
+++ b/bin-storage-manager/cmd/storage-control/main.go
@@ -88,7 +88,7 @@ func initHandler(sqlDB *sql.DB, cache cachehandler.CacheHandler) (storagehandler
 	reqHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameStorageEvent, serviceName)
 	accountHandler := accounthandler.NewAccountHandler(notifyHandler, db)
-	fileHandler := filehandler.NewFileHandler(
+	fileHandler, errFileHandler := filehandler.NewFileHandler(
 		notifyHandler,
 		db,
 		accountHandler,
@@ -96,6 +96,9 @@ func initHandler(sqlDB *sql.DB, cache cachehandler.CacheHandler) (storagehandler
 		config.Get().GCPBucketNameMedia,
 		config.Get().GCPBucketNameTmp,
 	)
+	if errFileHandler != nil {
+		return nil, errors.Wrapf(errFileHandler, "could not create the file handler")
+	}
 
 	return storagehandler.NewStorageHandler(reqHandler, fileHandler, config.Get().GCPBucketNameMedia), nil
 }

--- a/bin-storage-manager/cmd/storage-manager/main.go
+++ b/bin-storage-manager/cmd/storage-manager/main.go
@@ -154,7 +154,11 @@ func runService(dbHandler dbhandler.DBHandler) error {
 	reqHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameStorageEvent, serviceName)
 	accountHandler := accounthandler.NewAccountHandler(notifyHandler, dbHandler)
-	fileHandler := filehandler.NewFileHandler(notifyHandler, dbHandler, accountHandler, cfg.GCPProjectID, cfg.GCPBucketNameMedia, cfg.GCPBucketNameTmp)
+	fileHandler, errFileHandler := filehandler.NewFileHandler(notifyHandler, dbHandler, accountHandler, cfg.GCPProjectID, cfg.GCPBucketNameMedia, cfg.GCPBucketNameTmp)
+	if errFileHandler != nil {
+		log.Errorf("Could not create the file handler. err: %v", errFileHandler)
+		return errFileHandler
+	}
 	storageHandler := storagehandler.NewStorageHandler(reqHandler, fileHandler, cfg.GCPBucketNameMedia)
 
 	// run listener

--- a/bin-storage-manager/docs/architecture.md
+++ b/bin-storage-manager/docs/architecture.md
@@ -25,16 +25,17 @@ models/                 — Data structures (file, account, bucketfile, compress
 | Transport | `pkg/listenhandler` | Consumes `bin-manager.storage-manager.request`; regex-routes to storagehandler |
 | Events | `pkg/subscribehandler` | Subscribes to `bin-manager.customer-manager.event`; handles cascading deletes |
 | Business logic | `pkg/storagehandler` | Coordinates file lifecycle, quota checks, recording compression |
-| GCS operations | `pkg/filehandler` | Bucket CRUD, signed URL generation (local-key or IAM Credentials API) |
+| GCS operations | `pkg/filehandler` | Bucket CRUD, signed URL generation (service account JSON key file, local signing) |
 | Account management | `pkg/accounthandler` | 10 GB quota enforcement per customer |
 | Persistence | `pkg/dbhandler` | MySQL for durable records; Redis for cache |
 | Cache | `pkg/cachehandler` | Redis lookups for files and accounts; invalidates on mutation |
 
 ### GCS Authentication
 
-Two modes supported:
-1. **Service Account JSON** — `GOOGLE_APPLICATION_CREDENTIALS` points to JSON file; private keys used for local signing.
-2. **ADC/Workload Identity** — GKE environment; uses Application Default Credentials with IAM Credentials API for signing.
+`GOOGLE_APPLICATION_CREDENTIALS` must point to a service account JSON key file. The key's
+private key is used for local GCS V4 signed-URL signing (`storage.SignedURLOptions.PrivateKey`).
+There is no in-cluster metadata-server / IAM Credentials API fallback — the env var is
+required and the handler refuses to start without it.
 
 ## Request Routing
 

--- a/bin-storage-manager/docs/dependencies.md
+++ b/bin-storage-manager/docs/dependencies.md
@@ -22,7 +22,7 @@
 | Redis | Cache for file and account lookups; invalidated on mutation |
 | GCS bucket (`gcp_bucket_name_media`) | Persistent storage for recordings and uploaded files |
 | GCS bucket (`gcp_bucket_name_tmp`) | Transient storage for on-demand zip archives |
-| Google IAM Credentials API | Signed URL generation in GKE without a local service account key |
+| Google service account JSON key (`GOOGLE_APPLICATION_CREDENTIALS`) | Local blob signing for GCS V4 signed URLs (no in-cluster metadata-server / IAM Credentials API fallback) |
 
 ## Monorepo Module Dependencies
 

--- a/bin-storage-manager/docs/operations.md
+++ b/bin-storage-manager/docs/operations.md
@@ -6,7 +6,7 @@
 |---------|-------------|-----------|
 | File upload rejected | Customer storage quota (10 GB) exceeded | Check account usage; delete old files or contact customer |
 | Signed URL expired | Default 24 h expiry passed | Call `POST /v1/files/<uuid>/download_uri_refresh` |
-| GCS signed URL generation fails | `GOOGLE_APPLICATION_CREDENTIALS` missing/invalid, or the service account JSON key lacks bucket permissions | Verify the env var points to a valid service account key file with `storage.objects.get`/`storage.signUrl` |
+| GCS signed URL generation fails | `GOOGLE_APPLICATION_CREDENTIALS` missing/invalid, or the service account JSON key lacks bucket permissions | Verify the env var points to a valid service account key file with `storage.objects.get`/`storage.signUrl`. **Known failure mode**: if the key file is missing at startup, `storage-manager`/`storage-control` fail fast and exit non-zero (`NewFileHandler` returns an error that aborts `main()`) — the process will not start with a broken signed-URL path. |
 | Cascading delete incomplete | `subscribehandler` missed `customer_deleted` event | Check RabbitMQ dead-letter queue; re-publish event manually |
 | Redis cache stale | Crash between DB write and cache invalidation | Restart pod — cache keys expire; DB is the source of truth |
 | Compressfile generation slow | Many large recordings with same `reference_id` | Expected; zip is built synchronously on first request |
@@ -52,8 +52,7 @@ go tool cover -html=cp.out -o cp.html
 | `GCP_PROJECT_ID` | Google Cloud project | required |
 | `GCP_BUCKET_NAME_MEDIA` | Persistent media GCS bucket | required |
 | `GCP_BUCKET_NAME_TMP` | Temporary zip GCS bucket | required |
-| `GOOGLE_APPLICATION_CREDENTIALS` | SA JSON path (local dev / non-GKE) | optional |
-| `GOOGLE_SERVICE_ACCOUNT_EMAIL` | SA email for IAM signing (non-GCE) | optional |
+| `GOOGLE_APPLICATION_CREDENTIALS` | SA JSON key file path | required |
 | `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
 | `PROMETHEUS_LISTEN_ADDRESS` | Metrics listen address | `:2112` |
 

--- a/bin-storage-manager/docs/operations.md
+++ b/bin-storage-manager/docs/operations.md
@@ -52,7 +52,7 @@ go tool cover -html=cp.out -o cp.html
 | `GCP_PROJECT_ID` | Google Cloud project | required |
 | `GCP_BUCKET_NAME_MEDIA` | Persistent media GCS bucket | required |
 | `GCP_BUCKET_NAME_TMP` | Temporary zip GCS bucket | required |
-| `GOOGLE_APPLICATION_CREDENTIALS` | SA JSON key file path | required |
+| `GOOGLE_APPLICATION_CREDENTIALS` | SA JSON key file path (mounted in k8s from `Secret/voipbin` key `GOOGLE_APPLICATION_CREDENTIALS_JSON` at `/var/secrets/google/service-account.json`) | required |
 | `PROMETHEUS_ENDPOINT` | Metrics path | `/metrics` |
 | `PROMETHEUS_LISTEN_ADDRESS` | Metrics listen address | `:2112` |
 

--- a/bin-storage-manager/docs/operations.md
+++ b/bin-storage-manager/docs/operations.md
@@ -6,7 +6,7 @@
 |---------|-------------|-----------|
 | File upload rejected | Customer storage quota (10 GB) exceeded | Check account usage; delete old files or contact customer |
 | Signed URL expired | Default 24 h expiry passed | Call `POST /v1/files/<uuid>/download_uri_refresh` |
-| GCS signed URL generation fails | IAM Credentials API disabled or Workload Identity misconfigured | Verify pod SA has `iam.serviceAccountTokenCreator` role |
+| GCS signed URL generation fails | `GOOGLE_APPLICATION_CREDENTIALS` missing/invalid, or the service account JSON key lacks bucket permissions | Verify the env var points to a valid service account key file with `storage.objects.get`/`storage.signUrl` |
 | Cascading delete incomplete | `subscribehandler` missed `customer_deleted` event | Check RabbitMQ dead-letter queue; re-publish event manually |
 | Redis cache stale | Crash between DB write and cache invalidation | Restart pod — cache keys expire; DB is the source of truth |
 | Compressfile generation slow | Many large recordings with same `reference_id` | Expected; zip is built synchronously on first request |

--- a/bin-storage-manager/go.mod
+++ b/bin-storage-manager/go.mod
@@ -81,8 +81,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.9.0
-	cloud.google.com/go/iam v1.5.3
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/go-redsync/redsync/v4 v4.15.0
 	github.com/go-sql-driver/mysql v1.9.3
@@ -101,6 +99,8 @@ require (
 	cloud.google.com/go v0.123.0 // indirect
 	cloud.google.com/go/auth v0.18.2 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect

--- a/bin-storage-manager/go.sum
+++ b/bin-storage-manager/go.sum
@@ -467,6 +467,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dongri/phonenumber v0.1.12 h1:rR/4VZzxqpocUdyM4dIdfY0TWd8FcW43oiyPaOUxNIk=
+github.com/dongri/phonenumber v0.1.12/go.mod h1:cuHFSstIxh6qh/Qs/SCV3Grb/JMYregBLuXELvSYmT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/bin-storage-manager/k8s/deployment.yml
+++ b/bin-storage-manager/k8s/deployment.yml
@@ -78,6 +78,12 @@ spec:
                 secretKeyRef:
                   name: voipbin
                   key: CLICKHOUSE_ADDRESS
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/service-account.json"
+          volumeMounts:
+            - name: google-application-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
           ports:
             - name: metrics
               protocol: "TCP"
@@ -89,3 +95,10 @@ spec:
             limits:
               cpu: "100m"
               memory: "100M"
+      volumes:
+        - name: google-application-credentials
+          secret:
+            secretName: voipbin
+            items:
+              - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
+                path: service-account.json

--- a/bin-storage-manager/pkg/filehandler/bucketfile.go
+++ b/bin-storage-manager/pkg/filehandler/bucketfile.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -157,23 +156,7 @@ func (h *fileHandler) bucketfileGenerateDownloadURI(bucketName string, filepath 
 	}
 
 	if opts.PrivateKey == nil {
-		if h.iamClient == nil {
-			return "", errors.New("No private key found and IAM Credentials Client is not configured. Cannot generate signed URLs.")
-		}
-
-		opts.SignBytes = func(b []byte) ([]byte, error) {
-			req := &credentialspb.SignBlobRequest{
-				Name:    "projects/-/serviceAccounts/" + h.accessID,
-				Payload: b,
-			}
-
-			resp, err := h.iamClient.SignBlob(context.Background(), req)
-			if err != nil {
-				return nil, errors.Wrapf(err, "could not sign the blob using IAM SignBlob API")
-			}
-
-			return resp.SignedBlob, nil
-		}
+		return "", errors.New("No private key found. Cannot generate signed URLs.")
 	}
 
 	// get downloadable url

--- a/bin-storage-manager/pkg/filehandler/main.go
+++ b/bin-storage-manager/pkg/filehandler/main.go
@@ -18,8 +18,6 @@ import (
 	accounthandler "monorepo/bin-storage-manager/pkg/accounthandler"
 	"monorepo/bin-storage-manager/pkg/dbhandler"
 
-	"cloud.google.com/go/compute/metadata"
-	credentials "cloud.google.com/go/iam/credentials/apiv1"
 	"cloud.google.com/go/storage"
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
@@ -71,8 +69,7 @@ type fileHandler struct {
 	db             dbhandler.DBHandler
 	accountHandler accounthandler.AccountHandler
 
-	client    *storage.Client
-	iamClient *credentials.IamCredentialsClient
+	client *storage.Client
 
 	projectID string
 
@@ -95,76 +92,33 @@ func NewFileHandler(
 ) FileHandler {
 	log := logrus.WithField("func", "NewFileHandler")
 
-	var client *storage.Client
-	var accessID string
-	var privateKey []byte
-	var errClient error
-	ctx := context.Background()
-
 	envCredPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-	if envCredPath != "" {
-		log.Infof("Found GOOGLE_APPLICATION_CREDENTIALS at: %s", envCredPath)
-
-		jsonContent, err := os.ReadFile(envCredPath)
-		if err != nil {
-			log.Errorf("Failed to read credential file: %v", err)
-			return nil
-		}
-
-		conf, err := google.JWTConfigFromJSON(jsonContent)
-		if err != nil {
-			log.Errorf("Failed to parse credential JSON: %v", err)
-			return nil
-		}
-
-		accessID = conf.Email
-		privateKey = conf.PrivateKey
-		client, errClient = storage.NewClient(ctx)
-	} else {
-		log.Info("No GOOGLE_APPLICATION_CREDENTIALS, trying ADC/Metadata")
-
-		client, errClient = storage.NewClient(ctx)
-		privateKey = nil
-		if metadata.OnGCE() {
-			log.Debugf("The service is running on the GCE")
-			email, err := metadata.EmailWithContext(ctx, "default")
-			if err != nil {
-				log.Errorf("Failed to retrieve service account email from metadata: %v", err)
-				return nil
-			} else {
-				accessID = email
-			}
-		} else {
-			if localEmail := os.Getenv("GOOGLE_SERVICE_ACCOUNT_EMAIL"); localEmail != "" {
-				log.Infof("Using explicit service account email from env: %s", localEmail)
-				accessID = localEmail
-			} else {
-				log.Errorf("Could not determine Service Account Email. Not running on GCE/GKE and GOOGLE_SERVICE_ACCOUNT_EMAIL is not set.")
-				return nil
-			}
-		}
+	if envCredPath == "" {
+		log.Error("GOOGLE_APPLICATION_CREDENTIALS is not set. A service account JSON key file is required to generate GCS signed URLs.")
+		return nil
 	}
+	log.Infof("Found GOOGLE_APPLICATION_CREDENTIALS at: %s", envCredPath)
 
-	if errClient != nil {
-		log.Errorf("Failed to create client: %v", errClient)
+	jsonContent, err := os.ReadFile(envCredPath)
+	if err != nil {
+		log.Errorf("Failed to read credential file: %v", err)
 		return nil
 	}
 
-	var iamClient *credentials.IamCredentialsClient
-	// privateKey is set when GOOGLE_APPLICATION_CREDENTIALS points to a service account
-	// JSON file and we parse it via google.JWTConfigFromJSON above. In that case we can
-	// sign blobs locally and do not need an IAM Credentials client. When no JSON file
-	// is provided (ADC/metadata scenarios), privateKey remains nil and we rely on the
-	// IAM Credentials API instead, so we create an IamCredentialsClient here.
-	if privateKey == nil {
-		log.Debugf("The private key is nil. Creating IAM Credentials Client.")
-		tmpClient, err := credentials.NewIamCredentialsClient(ctx)
-		if err != nil {
-			log.Errorf("Failed to create IAM Credentials Client: %v", err)
-			return nil
-		}
+	conf, err := google.JWTConfigFromJSON(jsonContent)
+	if err != nil {
+		log.Errorf("Failed to parse credential JSON: %v", err)
+		return nil
+	}
 
-		iamClient = tmpClient
+	accessID := conf.Email
+	privateKey := conf.PrivateKey
+
+	ctx := context.Background()
+	client, errClient := storage.NewClient(ctx)
+	if errClient != nil {
+		log.Errorf("Failed to create client: %v", errClient)
+		return nil
 	}
 
 	log.Debugf("Checking account. project_id: %s, bucket_media: %s, bucket_tmp: %s, access_id: %s", projectID, bucketMedia, bucketTmp, accessID)
@@ -175,7 +129,6 @@ func NewFileHandler(
 		accountHandler: accountHandler,
 
 		client:      client,
-		iamClient:   iamClient,
 		projectID:   projectID,
 		bucketMedia: bucketMedia,
 		bucketTmp:   bucketTmp,

--- a/bin-storage-manager/pkg/filehandler/main.go
+++ b/bin-storage-manager/pkg/filehandler/main.go
@@ -20,6 +20,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
 )
@@ -89,26 +90,23 @@ func NewFileHandler(
 	projectID string,
 	bucketMedia string,
 	bucketTmp string,
-) FileHandler {
+) (FileHandler, error) {
 	log := logrus.WithField("func", "NewFileHandler")
 
 	envCredPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	if envCredPath == "" {
-		log.Error("GOOGLE_APPLICATION_CREDENTIALS is not set. A service account JSON key file is required to generate GCS signed URLs.")
-		return nil
+		return nil, errors.New("GOOGLE_APPLICATION_CREDENTIALS is not set. A service account JSON key file is required to generate GCS signed URLs")
 	}
 	log.Infof("Found GOOGLE_APPLICATION_CREDENTIALS at: %s", envCredPath)
 
 	jsonContent, err := os.ReadFile(envCredPath)
 	if err != nil {
-		log.Errorf("Failed to read credential file: %v", err)
-		return nil
+		return nil, errors.Wrapf(err, "failed to read credential file")
 	}
 
 	conf, err := google.JWTConfigFromJSON(jsonContent)
 	if err != nil {
-		log.Errorf("Failed to parse credential JSON: %v", err)
-		return nil
+		return nil, errors.Wrapf(err, "failed to parse credential JSON")
 	}
 
 	accessID := conf.Email
@@ -117,8 +115,7 @@ func NewFileHandler(
 	ctx := context.Background()
 	client, errClient := storage.NewClient(ctx)
 	if errClient != nil {
-		log.Errorf("Failed to create client: %v", errClient)
-		return nil
+		return nil, errors.Wrapf(errClient, "failed to create client")
 	}
 
 	log.Debugf("Checking account. project_id: %s, bucket_media: %s, bucket_tmp: %s, access_id: %s", projectID, bucketMedia, bucketTmp, accessID)
@@ -136,7 +133,7 @@ func NewFileHandler(
 		privateKey:  privateKey,
 	}
 
-	return res
+	return res, nil
 }
 
 // Init initialize the bucket

--- a/bin-storage-manager/pkg/filehandler/main_test.go
+++ b/bin-storage-manager/pkg/filehandler/main_test.go
@@ -1,6 +1,7 @@
 package filehandler
 
 import (
+	"os"
 	"testing"
 )
 
@@ -36,7 +37,6 @@ func Test_getFilename(t *testing.T) {
 }
 
 func Test_filenameHash(t *testing.T) {
-
 	type test struct {
 		name string
 
@@ -66,5 +66,28 @@ func Test_filenameHash(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %s\ngot: %s", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+// Test_NewFileHandler_MissingCredentials verifies that NewFileHandler fails
+// fast with a non-nil error (not a silent nil interface) when
+// GOOGLE_APPLICATION_CREDENTIALS is unset. Callers rely on this error to
+// abort startup instead of continuing with a nil FileHandler that would
+// panic on the first request.
+func Test_NewFileHandler_MissingCredentials(t *testing.T) {
+	origCredPath, hadCredPath := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS")
+	if hadCredPath {
+		defer func() { _ = os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", origCredPath) }()
+	} else {
+		defer func() { _ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS") }()
+	}
+	_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+	res, err := NewFileHandler(nil, nil, nil, "test-project", "test-bucket-media", "test-bucket-tmp")
+	if err == nil {
+		t.Errorf("Wrong match. expect: non-nil error, got: nil error")
+	}
+	if res != nil {
+		t.Errorf("Wrong match. expect: nil FileHandler, got: %v", res)
 	}
 }


### PR DESCRIPTION
Remove GKE metadata-server workload identity fallback from bin-storage-manager's GCS signed URL signing path, fix a nil-interface panic risk found in review, and wire the k8s manifest to the new file-based credential so the service starts successfully in production. This is the first step in removing GKE-specific dependencies from the monorepo (ADC key-file auth stays; only the in-cluster metadata-server / IAM Credentials API remote-signing fallback is removed).

- bin-storage-manager: Remove GKE metadata-server workload identity fallback for GCS signed URL signing (metadata.OnGCE(), IAM Credentials API SignBlob path); always require GOOGLE_APPLICATION_CREDENTIALS service account key file for local signing
- bin-storage-manager: Remove unused cloud.google.com/go/compute/metadata and cloud.google.com/go/iam/credentials/apiv1 direct dependencies
- bin-storage-manager: Fix docs/dependencies.md stale reference to the removed Google IAM Credentials API infrastructure dependency
- bin-storage-manager: Change NewFileHandler to return (FileHandler, error) instead of a bare nil interface when GOOGLE_APPLICATION_CREDENTIALS is missing/invalid, so cmd/storage-manager and cmd/storage-control fail fast at startup instead of panicking on first request; add a unit test for the fail-fast path
- bin-storage-manager: Update CLAUDE.md, docs/architecture.md, docs/operations.md to describe the single service-account-key-file auth path and its fail-fast failure mode
- bin-storage-manager: Mount the GOOGLE_APPLICATION_CREDENTIALS_JSON key from Secret/voipbin (added in monorepo-etc PR #75, already live in production) as a file volume at /var/secrets/google/service-account.json in k8s/deployment.yml, and set GOOGLE_APPLICATION_CREDENTIALS to that path -- this is the last piece required for storage-manager to start successfully once this PR deploys