### PR TITLE
NOJIRA-wire-gcp-credentials-remaining-services

### DIFF
--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -124,6 +124,8 @@ func run(
 	sockHandler sockhandler.SockHandler,
 	db dbhandler.DBHandler,
 ) {
+	log := logrus.WithField("func", "run")
+
 	cfg := config.Get()
 	addressListenStream := getAddressListenAudiosock()
 
@@ -132,7 +134,10 @@ func run(
 	zmqPubHandler := zmqpubhandler.NewZMQPubHandler()
 	streamHandler := streamhandler.NewStreamHandler(requestHandler, addressListenStream)
 	websockHandler := websockhandler.NewWebsockHandler(requestHandler, streamHandler)
-	serviceHandler := servicehandler.NewServiceHandler(requestHandler, db, websockHandler, cfg.GCPProjectID, cfg.GCPBucketName, cfg.JWTKey)
+	serviceHandler, err := servicehandler.NewServiceHandler(requestHandler, db, websockHandler, cfg.GCPProjectID, cfg.GCPBucketName, cfg.JWTKey)
+	if err != nil {
+		log.Fatalf("Could not create service handler. err: %v", err)
+	}
 
 	go runSubscribe(sockHandler, requestHandler, zmqPubHandler)
 	go runListenHTTP(serviceHandler)

--- a/bin-api-manager/k8s/deployment.yml
+++ b/bin-api-manager/k8s/deployment.yml
@@ -18,6 +18,13 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "2112"
     spec:
+      volumes:
+        - name: google-application-credentials
+          secret:
+            secretName: voipbin
+            items:
+              - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
+                path: service-account.json
       containers:
         - name: api-manager
           image: api-manager-image
@@ -90,6 +97,12 @@ spec:
                 secretKeyRef:
                   name: voipbin
                   key: JWT_KEY
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/service-account.json"
+          volumeMounts:
+            - name: google-application-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /ping

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -5,6 +5,7 @@ package servicehandler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	multipart "mime/multipart"
 	"net/http"
 	"time"
@@ -1153,14 +1154,14 @@ func NewServiceHandler(
 	bucketName string,
 
 	jwtKey string,
-) ServiceHandler {
+) (ServiceHandler, error) {
 	log := logrus.WithField("func", "NewServiceHandler")
 
 	// Create storage client using the decoded credentials
 	storageClient, err := storage.NewClient(context.Background())
 	if err != nil {
 		log.Errorf("Could not create a new storage client. Please ensure the environment is configured for Application Default Credentials (ADC) (for example via GOOGLE_APPLICATION_CREDENTIALS, workload identity, or in-cluster metadata). error: %v", err)
-		return nil
+		return nil, fmt.Errorf("could not create a new storage client: %w", err)
 	}
 
 	return &serviceHandler{
@@ -1174,7 +1175,7 @@ func NewServiceHandler(
 		bucketName:    bucketName,
 
 		jwtKey: []byte(jwtKey),
-	}
+	}, nil
 }
 
 // Find takes a slice and looks for an element in it. If found it will

--- a/bin-rag-manager/CLAUDE.md
+++ b/bin-rag-manager/CLAUDE.md
@@ -7,7 +7,7 @@ Multi-tenant RAG (Retrieval-Augmented Generation) service. Indexes document sour
 ## Key facts
 
 - **PostgreSQL + pgvector** (not MySQL). DSN via `POSTGRESQL_DSN`.
-- **Google Gemini** (`text-embedding-004`, 768-dim vectors). Auth via GKE Workload Identity — no API keys.
+- **Google Gemini** (`text-embedding-004`, 768-dim vectors). Auth via `GOOGLE_APPLICATION_CREDENTIALS` service account key file (mounted from `Secret/voipbin` key `GOOGLE_APPLICATION_CREDENTIALS_JSON`) — no metadata-server fallback.
 - **RabbitMQ queue**: `bin-manager.rag-manager.request`
 - **No SubscribeHandler** — no event subscriptions.
 

--- a/bin-rag-manager/docs/operations.md
+++ b/bin-rag-manager/docs/operations.md
@@ -4,7 +4,7 @@
 
 | Symptom | Likely Cause | Resolution |
 |---------|-------------|-----------|
-| Embedding calls fail / timeout | Vertex AI quota exhausted or GKE Workload Identity misconfigured | Check pod IAM binding; verify `GCP_PROJECT_ID` and `GCP_REGION` |
+| Embedding calls fail / timeout | GCP credential file missing/invalid, or Vertex AI quota exhausted | Verify `GOOGLE_APPLICATION_CREDENTIALS` points to a valid service account key file; verify `GCP_PROJECT_ID` and `GCP_REGION` |
 | "missing go.sum entry" at Docker build | `go mod tidy` not run after dependency change | Run full verification workflow |
 | pgvector extension missing | PostgreSQL instance provisioned without pgvector | Run `CREATE EXTENSION IF NOT EXISTS vector` on the database |
 | Query returns 0 chunks | RAG config has no indexed sources, or embedding dimension mismatch | Verify documents were successfully ingested; check chunk count in DB |
@@ -17,8 +17,8 @@
 # Check pod logs
 kubectl logs -n voipbin -l app=rag-manager --tail=100
 
-# Verify Workload Identity is working
-kubectl exec -n voipbin <pod> -- curl -s "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" -H "Metadata-Flavor: Google"
+# Verify the mounted service account key file is present and readable
+kubectl exec -n voipbin <pod> -- cat /var/secrets/google/service-account.json | head -c 100
 
 # Check pgvector extension
 psql $POSTGRESQL_DSN -c "SELECT extname FROM pg_extension WHERE extname='vector';"

--- a/bin-rag-manager/k8s/deployment.yml
+++ b/bin-rag-manager/k8s/deployment.yml
@@ -18,6 +18,13 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "2112"
     spec:
+      volumes:
+        - name: google-application-credentials
+          secret:
+            secretName: voipbin
+            items:
+              - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
+                path: service-account.json
       containers:
         - name: rag-manager
           image: rag-manager-image
@@ -52,6 +59,12 @@ spec:
                 secretKeyRef:
                   name: voipbin
                   key: DATABASE_DSN_POSTGRES
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/service-account.json"
+          volumeMounts:
+            - name: google-application-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
           ports:
             - name: metrics
               protocol: "TCP"

--- a/bin-transcribe-manager/docs/operations.md
+++ b/bin-transcribe-manager/docs/operations.md
@@ -7,7 +7,7 @@
 | Session stuck in `progressing` | `call_hangup` event not received or not processed | Check subscribe handler queue; manually stop via `POST /v1/transcribes/{id}/stop` |
 | STT RPC routed to wrong pod | Stale `host_id` after pod restart (Calico POD_IP recycle) | See [per-pod-queues.md](../../docs/patterns/per-pod-queues.md) for known limitation; session must be recreated |
 | No transcripts appearing | WebSocket to Asterisk not established | Check `streaming_handler` logs for dial errors; verify `MediaURI` from `ExternalMediaStart` |
-| GCP auth failure | ADC not configured | Check `GOOGLE_APPLICATION_CREDENTIALS` or GKE workload identity |
+| GCP auth failure | ADC not configured | Check `GOOGLE_APPLICATION_CREDENTIALS` points to a valid mounted service account key file |
 | AWS auth failure | Missing credentials | Verify `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` env vars |
 | Session health-check failing | Pod hosting session is down | Session is lost; streaming cannot be resumed — client must recreate |
 | `customer_deleted` cascade not running | Subscribe handler not consuming customer-manager events | Check queue binding: `bin-manager.customer-manager.event` |

--- a/bin-transcribe-manager/k8s/deployment.yml
+++ b/bin-transcribe-manager/k8s/deployment.yml
@@ -18,6 +18,13 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "2112"
     spec:
+      volumes:
+        - name: google-application-credentials
+          secret:
+            secretName: voipbin
+            items:
+              - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
+                path: service-account.json
       containers:
         - name: transcribe-manager
           image: transcribe-manager-image
@@ -80,6 +87,12 @@ spec:
                 secretKeyRef:
                   name: voipbin
                   key: CLICKHOUSE_ADDRESS
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/service-account.json"
+          volumeMounts:
+            - name: google-application-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
           resources:
             requests:
               cpu: "6m"

--- a/bin-tts-manager/docs/operations.md
+++ b/bin-tts-manager/docs/operations.md
@@ -4,7 +4,7 @@
 
 | Symptom | Likely Cause | Resolution |
 |---------|-------------|------------|
-| Batch TTS returns no audio URL | GCP ADC credentials not available | Check `GOOGLE_APPLICATION_CREDENTIALS` or GKE workload identity; check `speech_fallback_total` metric |
+| Batch TTS returns no audio URL | GCP ADC credentials not available | Check `GOOGLE_APPLICATION_CREDENTIALS` points to a valid mounted service account key file; check `speech_fallback_total` metric |
 | AWS Polly fallback failing | Missing `aws_access_key` / `aws_secret_key` | Verify credentials in environment; check AWS Polly quotas |
 | Streaming session RPC timeout | RPC routed to wrong pod (wrong per-pod queue) | Verify `host_id` matches `HOSTNAME` of target pod; check per-pod queue binding |
 | AudioSocket connection refused | Go service port 8080 not listening | Check pod readiness; verify no port conflict with Python sidecar |
@@ -63,7 +63,7 @@ kubectl logs -n voipbin -l app=tts-manager -c tts-manager --tail=200 | grep -E "
 | `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics HTTP path | `/metrics` |
 | `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics listen address | `:2112` |
 
-GCP authentication uses Application Default Credentials — typically via `GOOGLE_APPLICATION_CREDENTIALS` or GKE workload identity.
+GCP authentication uses Application Default Credentials via `GOOGLE_APPLICATION_CREDENTIALS` (mounted service account key file from `Secret/voipbin` key `GOOGLE_APPLICATION_CREDENTIALS_JSON`).
 
 ## Prometheus Metrics
 

--- a/bin-tts-manager/k8s/deployment.yml
+++ b/bin-tts-manager/k8s/deployment.yml
@@ -21,6 +21,12 @@ spec:
       volumes:
         - name: shared-data
           emptyDir: {}
+        - name: google-application-credentials
+          secret:
+            secretName: voipbin
+            items:
+              - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
+                path: service-account.json
       containers:
         - name: tts-manager
           image: tts-manager-image
@@ -86,9 +92,14 @@ spec:
                 secretKeyRef:
                   name: voipbin
                   key: CLICKHOUSE_ADDRESS
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/secrets/google/service-account.json"
           volumeMounts:
             - name: shared-data
               mountPath: /shared-data
+            - name: google-application-credentials
+              mountPath: /var/secrets/google
+              readOnly: true
           command:
             - './tts-manager'
           ports:


### PR DESCRIPTION
Wire the GOOGLE_APPLICATION_CREDENTIALS_JSON key (already live in production Secret/voipbin, added in monorepo-etc PR #75) as a mounted file volume for the four remaining services that implicitly rely on the GKE metadata server for GCP authentication: bin-tts-manager, bin-rag-manager, bin-api-manager, bin-transcribe-manager. Also fixes a nil-interface fail-fast gap in bin-api-manager found during review, mirroring VOIP-1229's fix for bin-storage-manager.

All four already use the standard Google Cloud client library ADC path (texttospeech.NewClient, speech.NewClient, storage.NewClient) with no explicit metadata-server fallback code in Go -- the client library itself checks GOOGLE_APPLICATION_CREDENTIALS first, falling back to the metadata server only if unset. So the manifest wiring itself required no Go code changes for tts-manager, rag-manager, or transcribe-manager, following the exact volume mount pattern already verified working in production for bin-storage-manager (VOIP-1229).

- bin-tts-manager: Mount GOOGLE_APPLICATION_CREDENTIALS_JSON as a file volume in k8s/deployment.yml (tts-manager container only, not the http-server sidecar), set GOOGLE_APPLICATION_CREDENTIALS; update docs/operations.md to drop GKE workload-identity references
- bin-rag-manager: Mount GOOGLE_APPLICATION_CREDENTIALS_JSON as a file volume, set GOOGLE_APPLICATION_CREDENTIALS; update CLAUDE.md and docs/operations.md to describe the service-account-key-file auth path
- bin-transcribe-manager: Mount GOOGLE_APPLICATION_CREDENTIALS_JSON as a file volume, set GOOGLE_APPLICATION_CREDENTIALS; update docs/operations.md to drop GKE workload-identity reference
- bin-api-manager: Mount GOOGLE_APPLICATION_CREDENTIALS_JSON as a file volume, set GOOGLE_APPLICATION_CREDENTIALS (unblocks its cloud.google.com/go/storage client)
- bin-api-manager: Change NewServiceHandler to return (ServiceHandler, error) instead of a bare nil interface when storage.NewClient fails, and make cmd/api-manager's run() fail-fast (log.Fatalf) on that error. Previously a broken GCP credential mount would leave the sole HTTP gateway reporting Ready (its /ping readinessProbe never touches ServiceHandler) while every real request panicked into a 500 via gin.Recovery(), with no auto-heal -- the same fail-fast defect class fixed for bin-storage-manager in VOIP-1229, caught in review before this PR's manifest change activates the file-based credential path for api-manager for the first time

This does not remove any code path or change fail-fast behavior in tts-manager, rag-manager, or transcribe-manager (unlike VOIP-1229's storage-manager change) -- it only stops them from silently depending on the GKE metadata server, one more step toward removing GKE-specific dependencies from the monorepo.