### PR TITLE
VOIP-1231-fix-contact-manager-case-timeout-flag

### DIFF
--- a/bin-contact-manager/cmd/contact-manager/main.go
+++ b/bin-contact-manager/cmd/contact-manager/main.go
@@ -55,6 +55,7 @@ func init() {
 	rootCmd.Flags().String("redis_address", "127.0.0.1:6379", "Address of the Redis server (e.g., localhost:6379)")
 	rootCmd.Flags().Int("redis_database", 1, "Redis database index to use (default is 1)")
 	rootCmd.Flags().String("redis_password", "", "Password for authenticating with the Redis server (if required)")
+	rootCmd.Flags().Int("case_timeout_hours", 24, "Case idle timeout (hours) before a peer's open case is closed as timed out")
 
 	// Initialize logging
 	logrus.SetFormatter(joonix.NewFormatter())


### PR DESCRIPTION
Fixes a production CrashLoopBackOff in contact-manager caused by a missing CLI flag registration.

VOIP-1228 (contact-case-management) added a case_timeout_hours flag definition and viper binding inside bin-contact-manager/internal/config's Bootstrap()/InitConfig() functions, but never added the matching rootCmd.Flags() declaration in cmd/contact-manager/main.go's own init(), which manually re-declares each flag on the daemon's root command instead of delegating to config.Bootstrap(). InitConfig() unconditionally calls viper.BindPFlag("case_timeout_hours", cmd.Flags().Lookup("case_timeout_hours")), which returns a nil-flag error when the flag doesn't exist, so the daemon exits before connecting to RabbitMQ or the database. This has been live on main since the VOIP-1228 merge and made contact-manager crash-loop in production.

- bin-contact-manager: Add rootCmd.Flags().Int("case_timeout_hours", 24, ...) to cmd/contact-manager/main.go's init(), matching the pattern used for the other manually-declared flags
- Verified locally: built the binary and ran it against an unreachable DB/RabbitMQ target -- InitConfig() now succeeds and the daemon proceeds to the (expected, in this artificial test) database connection failure, instead of failing immediately on the flag-binding error
- Full verification workflow (go mod tidy/vendor, go generate, go test ./..., golangci-lint) clean in bin-contact-manager