### PR TITLE
VOIP-1232-contact-manager-deadlock

### DIFF
--- a/bin-contact-manager/docs/operations.md
+++ b/bin-contact-manager/docs/operations.md
@@ -67,6 +67,10 @@ Metrics are served at `<prometheus_listen_address><prometheus_endpoint>` (defaul
 |--------|------|--------|-------------|
 | `contact_manager_receive_request_process_time` | Histogram | `type`, `method` | RPC request processing latency |
 | `contact_manager_receive_subscribe_event_process_time` | Histogram | `publisher`, `type` | Event subscription processing latency |
+| `contact_manager_case_getorcreate_deadlock_retry_total` | Counter | (none) | VOIP-1232: total GetOrCreate attempts restarted after a MySQL deadlock (errno 1213) on the case get-or-create transaction. Non-zero-but-flat is expected under concurrent same-peer traffic; a sustained climb suggests the in-process peer lock isn't preventing the race (e.g. multi-replica deployment -- see the topology caveat below) |
+| `contact_manager_case_getorcreate_deadlock_exhausted_total` | Counter | (none) | VOIP-1232: total GetOrCreate calls that exhausted all `maxDeadlockRetries` attempts and gave up. Each occurrence means one `conversation_message_created`/`call_created` event's CRM projection was silently dropped (ack-before-process pipeline, no DLQ yet -- see VOIP-1233) |
+| `contact_manager_case_getorcreate_peer_lock_timeout_total` | Counter | (none) | VOIP-1232: total GetOrCreate calls that failed to acquire the per-peer in-process serialization lock within `peerLockTimeout` (5s). Each occurrence also drops the triggering event (same caveat as above) |
+| `contact_manager_case_peer_lock_map_size` | Gauge | (none) | VOIP-1232: current number of distinct peer-tuple entries held in the in-process GetOrCreate serialization lock map. No eviction is implemented yet; monitor for unbounded growth (expected to stay in the thousands-to-low-tens-of-thousands range for a busy tenant; escalate if it grows without bound) |
 
 **Useful PromQL:**
 ```promql
@@ -75,4 +79,26 @@ histogram_quantile(0.99, rate(contact_manager_receive_request_process_time_bucke
 
 # Event processing rate
 rate(contact_manager_receive_subscribe_event_process_time_count[5m])
+
+# VOIP-1232: deadlock retry rate (per-minute)
+rate(contact_manager_case_getorcreate_deadlock_retry_total[5m]) * 60
+
+# VOIP-1232: silently-dropped-event rate (deadlock exhaustion + peer-lock timeout combined)
+rate(contact_manager_case_getorcreate_deadlock_exhausted_total[5m]) * 60
+  + rate(contact_manager_case_getorcreate_peer_lock_timeout_total[5m]) * 60
 ```
+
+**VOIP-1232 topology caveat:** the peer-tuple serialization lock described
+above is **in-process only**, not a distributed lock. It fully prevents
+the same-peer-tuple concurrent-INSERT race under contact-manager's
+**current single-replica production config** (`replicas: 1`, no HPA --
+confirmed in both `k8s/deployment.yml` and the install repo's
+`k8s/backend/services/contact-manager.yaml`). If contact-manager is ever
+scaled to 2+ replicas, RabbitMQ's plain shared-queue competing-consumers
+model gives no per-peer-tuple pod affinity, so this lock would provide
+**zero** cross-pod protection and the fix degrades to relying on the
+DB-level deadlock retry alone (still correct, just less effective at
+preventing the deadlock in the first place). A Redis-based distributed
+lock (contact-manager already depends on Redis for contact-body caching)
+is the correct upgrade path if/when replicas are increased -- not built
+preemptively here.

--- a/bin-contact-manager/pkg/casehandler/getorcreate.go
+++ b/bin-contact-manager/pkg/casehandler/getorcreate.go
@@ -23,6 +23,16 @@ import (
 // thundering-herd scenario; see design §4.2's "Loop exhaustion" note.
 const maxInsertRetries = 3
 
+// maxDeadlockRetries bounds the outer retry loop that restarts the ENTIRE
+// GetOrCreate transaction (fresh BeginTx) when the underlying driver
+// reports a MySQL deadlock (errno 1213, VOIP-1232). This is a distinct,
+// wider mechanism than maxInsertRetries above: an InnoDB deadlock kills
+// the whole transaction server-side (unlike a plain uq_case_open_peer
+// conflict, which is safely retryable within the SAME tx via a locked
+// re-select), so recovery here must restart the transaction from
+// scratch, not just retry one statement.
+const maxDeadlockRetries = 3
+
 // ErrGetOrCreateExhausted is returned when all maxInsertRetries attempts
 // to insert-or-reselect an open Case collide (design §4.2's "Loop
 // exhaustion" path). Callers must surface this as a transient 5xx, not
@@ -30,7 +40,25 @@ const maxInsertRetries = 3
 // retry.
 var ErrGetOrCreateExhausted = fmt.Errorf("could not get-or-create case: exhausted retries under sustained conflict")
 
+// ErrDeadlockExhausted is returned when all maxDeadlockRetries attempts
+// to run the GetOrCreate transaction collide with a MySQL deadlock
+// (VOIP-1232). Distinct from ErrGetOrCreateExhausted (which covers the
+// narrower uq_case_open_peer insert-conflict retry) so callers
+// (subscribehandler.processEvent) can tag deadlock-exhaustion separately
+// for interim triage -- see VOIP-1233 for the ack-after-process/DLQ
+// follow-up that would give this failure a genuine recovery path instead
+// of falling through the current silent-drop pipeline.
+var ErrDeadlockExhausted = fmt.Errorf("could not get-or-create case: exhausted retries under sustained deadlock")
+
 // GetOrCreate implements design doc §4's get-or-create algorithm exactly.
+//
+// VOIP-1232: wraps the whole transaction lifecycle in two additional
+// layers versus the original design: (1) a per-peer-tuple in-process
+// serialization lock (acquired once here, held across ALL
+// maxDeadlockRetries attempts below, released immediately after a
+// successful tx.Commit() and BEFORE linkSiblingConversation's network
+// RPCs), and (2) an outer bounded retry loop that discards the tx and
+// restarts from a fresh BeginTx whenever the driver reports a deadlock.
 func (h *caseHandler) GetOrCreate(
 	ctx context.Context,
 	customerID uuid.UUID,
@@ -39,11 +67,73 @@ func (h *caseHandler) GetOrCreate(
 	peerTarget, referenceType string,
 	caseIDHint *uuid.UUID,
 ) (*kase.Case, error) {
+	lockKey := peerLockKey(customerID, peerType, peerTarget, referenceType)
+	release, err := h.acquirePeerLock(ctx, lockKey)
+	if err != nil {
+		promPeerLockTimeoutTotal.Inc()
+		return nil, fmt.Errorf("could not acquire peer lock. GetOrCreate. err: %w", err)
+	}
+	// Released as soon as a successful attempt commits (see the
+	// released-early path below); this defer is the fallback for every
+	// early-return error path so the lock is never leaked.
+	locked := true
+	defer func() {
+		if locked {
+			release()
+		}
+	}()
+
+	var lastErr error
+	for attempt := 0; attempt < maxDeadlockRetries; attempt++ {
+		res, isNewCase, err := h.getOrCreateAttempt(ctx, customerID, self, peerType, peerTarget, referenceType, caseIDHint)
+		if err == nil {
+			// Release the peer lock immediately after a successful commit,
+			// strictly BEFORE linkSiblingConversation's cross-service RPCs
+			// (design §4.4's own comment already establishes this
+			// principle for the DB-level FOR UPDATE locks; the in-process
+			// peer lock follows the identical rule -- see
+			// getOrCreateAttempt's call site below).
+			release()
+			locked = false
+
+			if isNewCase && referenceType != "conversation_message" && self.Type != "" {
+				h.linkSiblingConversation(ctx, customerID, self, peerType, peerTarget, res.ID)
+			}
+
+			return res, nil
+		}
+
+		if err == dbhandler.ErrDeadlock {
+			promDeadlockRetryTotal.Inc()
+			lastErr = err
+			continue
+		}
+
+		return nil, err
+	}
+
+	promDeadlockExhaustedTotal.Inc()
+	return nil, fmt.Errorf("%w: %v", ErrDeadlockExhausted, lastErr)
+}
+
+// getOrCreateAttempt runs ONE full attempt of the GetOrCreate transaction
+// lifecycle (BeginTx through Commit), re-capturing `now` fresh for this
+// attempt -- so TMCreate/TMUpdate/OpenedAt reflect the wall-clock time of
+// the attempt that actually succeeds, not a stale timestamp captured
+// before an earlier attempt's deadlock + retry backoff.
+func (h *caseHandler) getOrCreateAttempt(
+	ctx context.Context,
+	customerID uuid.UUID,
+	self commonaddress.Address,
+	peerType commonaddress.Type,
+	peerTarget, referenceType string,
+	caseIDHint *uuid.UUID,
+) (*kase.Case, bool, error) {
 	now := h.utilHandler.TimeNow()
 
 	tx, err := h.db.BeginTx(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not begin transaction. GetOrCreate. err: %v", err)
+		return nil, false, fmt.Errorf("could not begin transaction. GetOrCreate. err: %v", err)
 	}
 	committed := false
 	defer func() {
@@ -54,32 +144,23 @@ func (h *caseHandler) GetOrCreate(
 
 	res, isNewCase, err := h.getOrCreateInTx(ctx, tx, customerID, peerType, peerTarget, referenceType, caseIDHint, now)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if err := h.db.CaseUpdateTMUpdateTx(ctx, tx, res.ID, now); err != nil {
-		return nil, fmt.Errorf("could not bump tm_update. GetOrCreate. err: %v", err)
+		if err == dbhandler.ErrDeadlock {
+			return nil, false, dbhandler.ErrDeadlock
+		}
+		return nil, false, fmt.Errorf("could not bump tm_update. GetOrCreate. err: %v", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("could not commit transaction. GetOrCreate. err: %v", err)
+		return nil, false, fmt.Errorf("could not commit transaction. GetOrCreate. err: %v", err)
 	}
 	committed = true
 
 	res.TMUpdate = now
-
-	// Design §4.4: proactive linking write, AFTER the Case transaction has
-	// committed (never inside it -- the FOR UPDATE locks above must not be
-	// held across a cross-service network round trip). Only on a genuine
-	// new-Case open (not cache-hit reuse), and only for a non-
-	// "conversation_message" referenceType (today: "call"). Best-effort:
-	// any failure here is logged and never fails/rolls back the already-
-	// committed Case-open.
-	if isNewCase && referenceType != "conversation_message" && self.Type != "" {
-		h.linkSiblingConversation(ctx, customerID, self, peerType, peerTarget, res.ID)
-	}
-
-	return res, nil
+	return res, isNewCase, nil
 }
 
 // linkSiblingConversation implements design §4.4's proactive-link write:
@@ -131,6 +212,9 @@ func (h *caseHandler) getOrCreateInTx(
 	if caseIDHint != nil {
 		hinted, err := h.db.CaseGetByIDForUpdate(ctx, tx, customerID, *caseIDHint)
 		if err != nil {
+			if err == dbhandler.ErrDeadlock {
+				return nil, false, dbhandler.ErrDeadlock
+			}
 			return nil, false, fmt.Errorf("could not validate case_id hint. GetOrCreate. err: %v", err)
 		}
 		if hinted != nil {
@@ -142,6 +226,9 @@ func (h *caseHandler) getOrCreateInTx(
 	// Step 1b: peer/reference_type resolution.
 	found, err := h.db.CaseGetOpenByPeer(ctx, tx, customerID, peerType, peerTarget, referenceType)
 	if err != nil {
+		if err == dbhandler.ErrDeadlock {
+			return nil, false, dbhandler.ErrDeadlock
+		}
 		return nil, false, fmt.Errorf("could not look up open case. GetOrCreate. err: %v", err)
 	}
 
@@ -156,6 +243,9 @@ func (h *caseHandler) getOrCreateInTx(
 		// Timed out: close it, then insert a fresh replacement chained via
 		// previous_case_id.
 		if _, err := h.db.CaseUpdateStatusClosedTx(ctx, tx, customerID, found.ID, kase.ClosedReasonTimeout, kase.ClosedByTypeSystem, nil, now); err != nil {
+			if err == dbhandler.ErrDeadlock {
+				return nil, false, dbhandler.ErrDeadlock
+			}
 			return nil, false, fmt.Errorf("could not close timed-out case. GetOrCreate. err: %v", err)
 		}
 		return h.insertWithRetry(ctx, tx, customerID, peerType, peerTarget, referenceType, &found.ID, now)
@@ -165,6 +255,9 @@ func (h *caseHandler) getOrCreateInTx(
 	// closed case for this peer (if any) via previous_case_id.
 	lastClosed, err := h.db.CaseGetLastClosedByPeerTx(ctx, tx, customerID, peerType, peerTarget, referenceType)
 	if err != nil {
+		if err == dbhandler.ErrDeadlock {
+			return nil, false, dbhandler.ErrDeadlock
+		}
 		return nil, false, fmt.Errorf("could not look up last closed case. GetOrCreate. err: %v", err)
 	}
 	var previousCaseID *uuid.UUID
@@ -207,6 +300,9 @@ func (h *caseHandler) insertWithRetry(
 		if err == nil {
 			return newCase, true, nil
 		}
+		if err == dbhandler.ErrDeadlock {
+			return nil, false, dbhandler.ErrDeadlock
+		}
 		if err != dbhandler.ErrDuplicate {
 			return nil, false, fmt.Errorf("could not insert case. GetOrCreate. err: %v", err)
 		}
@@ -214,6 +310,9 @@ func (h *caseHandler) insertWithRetry(
 		// Conflict: another transaction won. Re-select the winner, locked.
 		winner, selErr := h.db.CaseGetOpenByPeer(ctx, tx, customerID, peerType, peerTarget, referenceType)
 		if selErr != nil {
+			if selErr == dbhandler.ErrDeadlock {
+				return nil, false, dbhandler.ErrDeadlock
+			}
 			return nil, false, fmt.Errorf("could not re-select after insert conflict. GetOrCreate. err: %v", selErr)
 		}
 		if winner != nil {

--- a/bin-contact-manager/pkg/casehandler/getorcreate_deadlock_test.go
+++ b/bin-contact-manager/pkg/casehandler/getorcreate_deadlock_test.go
@@ -133,6 +133,23 @@ func Test_GetOrCreate_Deadlock_ExhaustionReturnsDistinctError(t *testing.T) {
 	if !errors.Is(err, ErrDeadlockExhausted) {
 		t.Errorf("expected ErrDeadlockExhausted, got: %v", err)
 	}
+	if len(txs) != maxDeadlockRetries {
+		t.Fatalf("expected exactly %d BeginTx calls, got: %d", maxDeadlockRetries, len(txs))
+	}
+	// VOIP-1232 round-1 PR review finding: a call-count assertion alone
+	// would still pass even if a bug reused the SAME *sql.Tx handle
+	// across every exhaustion attempt (instead of a genuinely fresh
+	// transaction per retry). Assert pairwise pointer distinctness to
+	// actually prove the fresh-BeginTx-per-attempt contract holds even
+	// on the give-up path, matching the assertion already present in
+	// Test_GetOrCreate_Deadlock_RetriesWithFreshBeginTx above.
+	for i := 0; i < len(txs); i++ {
+		for j := i + 1; j < len(txs); j++ {
+			if txs[i] == txs[j] {
+				t.Errorf("expected every deadlock-retry attempt to use a distinct *sql.Tx, but attempt %d and %d shared the same tx handle", i, j)
+			}
+		}
+	}
 }
 
 // Test_GetOrCreate_PeerLock_SerializesSameTuple verifies VOIP-1232's

--- a/bin-contact-manager/pkg/casehandler/getorcreate_deadlock_test.go
+++ b/bin-contact-manager/pkg/casehandler/getorcreate_deadlock_test.go
@@ -1,0 +1,320 @@
+package casehandler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// Test_GetOrCreate_Deadlock_RetriesWithFreshBeginTx verifies VOIP-1232's
+// core fix: when CaseInsertTx surfaces dbhandler.ErrDeadlock (MySQL errno
+// 1213), GetOrCreate discards the dead transaction and restarts the WHOLE
+// attempt from a fresh BeginTx (not just re-running the failed
+// statement) -- succeeding on the second attempt.
+func Test_GetOrCreate_Deadlock_RetriesWithFreshBeginTx(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: mockDB, notifyHandler: mockNotify, peerLocks: make(map[string]chan struct{})}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-7010-7010-7010-000000000001")
+	attempt1ID := uuid.FromStringOrNil("f1b2c3d4-7010-7010-7010-000000000002")
+	attempt2ID := uuid.FromStringOrNil("f1b2c3d4-7010-7010-7010-000000000003")
+	now1 := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	now2 := now1.Add(50 * time.Millisecond)
+
+	// dbTest has SetMaxOpenConns(1), so tx's must be opened and disposed
+	// of (Rollback/Commit) sequentially, not both pre-opened upfront --
+	// use DoAndReturn to lazily begin each real tx exactly when GetOrCreate
+	// itself calls BeginTx, matching production's real one-at-a-time
+	// lifecycle.
+	var txs []*sql.Tx
+	mockDB.EXPECT().BeginTx(ctx).Times(2).DoAndReturn(func(_ context.Context) (*sql.Tx, error) {
+		tx, err := dbTest.Begin()
+		txs = append(txs, tx)
+		return tx, err
+	})
+	defer func() {
+		for _, tx := range txs {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Attempt 1: own `now`, insert hits a deadlock -- GetOrCreate's own
+	// defer rolls this tx back (committed stays false) before attempt 2.
+	mockUtil.EXPECT().TimeNow().Return(&now1)
+	mockDB.EXPECT().CaseGetOpenByPeer(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0001", "conversation_message").Return(nil, nil)
+	mockDB.EXPECT().CaseGetLastClosedByPeerTx(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0001", "conversation_message").Return(nil, nil)
+	mockUtil.EXPECT().UUIDCreate().Return(attempt1ID)
+	mockDB.EXPECT().CaseInsertTx(ctx, gomock.Any(), gomock.Any()).Return(dbhandler.ErrDeadlock)
+
+	// Attempt 2: a genuinely FRESH BeginTx and a freshly re-captured `now`
+	// (not the stale now1) -- succeeds.
+	mockUtil.EXPECT().TimeNow().Return(&now2)
+	mockDB.EXPECT().CaseGetOpenByPeer(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0001", "conversation_message").Return(nil, nil)
+	mockDB.EXPECT().CaseGetLastClosedByPeerTx(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0001", "conversation_message").Return(nil, nil)
+	mockUtil.EXPECT().UUIDCreate().Return(attempt2ID)
+	mockDB.EXPECT().CaseInsertTx(ctx, gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().CaseUpdateTMUpdateTx(ctx, gomock.Any(), attempt2ID, &now2).Return(nil)
+
+	res, err := h.GetOrCreate(ctx, customerID, commonaddress.Address{}, commonaddress.TypeTel, "+155****0001", "conversation_message", nil)
+	if err != nil {
+		t.Fatalf("GetOrCreate() error = %v", err)
+	}
+	if res == nil || res.ID != attempt2ID {
+		t.Errorf("expected the second (post-deadlock-retry) attempt's case %s to win, got: %v", attempt2ID, res)
+	}
+	if len(txs) != 2 || txs[0] == txs[1] {
+		t.Errorf("expected two DISTINCT transactions (fresh BeginTx per attempt), got: %d tx(s)", len(txs))
+	}
+}
+
+// Test_GetOrCreate_Deadlock_ExhaustionReturnsDistinctError verifies
+// VOIP-1232's exhaustion path: when every maxDeadlockRetries attempt hits
+// a deadlock, GetOrCreate surfaces ErrDeadlockExhausted (distinct from
+// ErrGetOrCreateExhausted, which covers the narrower 1062/ErrDuplicate
+// retry) so callers can tag it separately.
+func Test_GetOrCreate_Deadlock_ExhaustionReturnsDistinctError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: mockDB, notifyHandler: mockNotify, peerLocks: make(map[string]chan struct{})}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-7011-7011-7011-000000000001")
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	// dbTest's shared connection has SetMaxOpenConns(1); pre-opening
+	// maxDeadlockRetries real tx's upfront (before any is rolled back)
+	// would deadlock the connection pool itself. Lazily open one per
+	// attempt via DoAndReturn instead, matching each attempt's real
+	// begin -> (fail) -> GetOrCreate's own deferred rollback lifecycle.
+	var txs []*sql.Tx
+	mockDB.EXPECT().BeginTx(ctx).Times(maxDeadlockRetries).DoAndReturn(func(_ context.Context) (*sql.Tx, error) {
+		tx, err := dbTest.Begin()
+		txs = append(txs, tx)
+		return tx, err
+	})
+	defer func() {
+		for _, tx := range txs {
+			_ = tx.Rollback()
+		}
+	}()
+
+	mockUtil.EXPECT().TimeNow().Return(&now).Times(maxDeadlockRetries)
+	mockDB.EXPECT().CaseGetOpenByPeer(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0002", "call").Return(nil, nil).Times(maxDeadlockRetries)
+	mockDB.EXPECT().CaseGetLastClosedByPeerTx(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0002", "call").Return(nil, nil).Times(maxDeadlockRetries)
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.Must(uuid.NewV4())).Times(maxDeadlockRetries)
+	mockDB.EXPECT().CaseInsertTx(ctx, gomock.Any(), gomock.Any()).Return(dbhandler.ErrDeadlock).Times(maxDeadlockRetries)
+
+	_, err := h.GetOrCreate(ctx, customerID, commonaddress.Address{}, commonaddress.TypeTel, "+155****0002", "call", nil)
+	if !errors.Is(err, ErrDeadlockExhausted) {
+		t.Errorf("expected ErrDeadlockExhausted, got: %v", err)
+	}
+}
+
+// Test_GetOrCreate_PeerLock_SerializesSameTuple verifies VOIP-1232's
+// in-process peer-lock: two goroutines calling GetOrCreate for the
+// IDENTICAL (customer_id, peer_type, peer_target, reference_type) tuple
+// never run their DB transactions concurrently -- the second call's
+// BeginTx is only observed to start after the first call's has fully
+// completed (committed).
+func Test_GetOrCreate_PeerLock_SerializesSameTuple(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: mockDB, notifyHandler: mockNotify, peerLocks: make(map[string]chan struct{})}
+	ctx := context.Background()
+
+	// Use a dedicated, higher-pool-size in-memory DB (not the shared
+	// package-level dbTest, which is intentionally SetMaxOpenConns(1) --
+	// that alone would serialize BeginTx regardless of the peer lock,
+	// making this test unable to distinguish "serialized by my code" from
+	// "serialized by the connection pool"). No schema is needed: every DB
+	// operation below goes through the mocked DBHandler; only tx.Commit()/
+	// tx.Rollback() run against the real driver.
+	concurrentDB, err := sql.Open("sqlite3", "file:voip1232_concurrency_test1?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("could not open concurrency-test db. err: %v", err)
+	}
+	concurrentDB.SetMaxOpenConns(4)
+	defer func() { _ = concurrentDB.Close() }()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-7012-7012-7012-000000000001")
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	var activeCount int
+	var maxObservedConcurrent int
+	var mu sync.Mutex
+
+	// gomock's default expectation ordering doesn't itself enforce
+	// concurrency limits, so we assert serialization via a counter
+	// incremented/decremented around each BeginTx call, using DoAndReturn
+	// to observe overlap directly.
+	mockUtil.EXPECT().TimeNow().Return(&now).Times(2)
+	mockDB.EXPECT().BeginTx(ctx).Times(2).DoAndReturn(func(_ context.Context) (*sql.Tx, error) {
+		mu.Lock()
+		activeCount++
+		if activeCount > maxObservedConcurrent {
+			maxObservedConcurrent = activeCount
+		}
+		mu.Unlock()
+
+		tx, err := concurrentDB.Begin()
+
+		// Simulate non-trivial DB work duration so a broken (non-
+		// serializing) implementation would have a real chance to overlap.
+		time.Sleep(20 * time.Millisecond)
+
+		mu.Lock()
+		activeCount--
+		mu.Unlock()
+
+		return tx, err
+	})
+	mockDB.EXPECT().CaseGetOpenByPeer(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0003", "call").Return(nil, nil).Times(2)
+	mockDB.EXPECT().CaseGetLastClosedByPeerTx(ctx, gomock.Any(), customerID, commonaddress.TypeTel, "+155****0003", "call").Return(nil, nil).Times(2)
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.Must(uuid.NewV4())).Times(2)
+	mockDB.EXPECT().CaseInsertTx(ctx, gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	mockDB.EXPECT().CaseUpdateTMUpdateTx(ctx, gomock.Any(), gomock.Any(), &now).Return(nil).Times(2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = h.GetOrCreate(ctx, customerID, commonaddress.Address{}, commonaddress.TypeTel, "+155****0003", "call", nil)
+		}()
+	}
+	wg.Wait()
+
+	if maxObservedConcurrent > 1 {
+		t.Errorf("expected the peer lock to serialize same-tuple GetOrCreate calls (max concurrent BeginTx == 1), observed max concurrent = %d", maxObservedConcurrent)
+	}
+}
+
+// Test_GetOrCreate_PeerLock_DifferentTuplesProceedConcurrently verifies
+// the keyed-lock does NOT over-serialize: two DIFFERENT peer tuples must
+// not block each other.
+func Test_GetOrCreate_PeerLock_DifferentTuplesProceedConcurrently(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: mockDB, notifyHandler: mockNotify, peerLocks: make(map[string]chan struct{})}
+	ctx := context.Background()
+
+	// See Test_GetOrCreate_PeerLock_SerializesSameTuple's comment: a
+	// dedicated higher-pool-size DB, not the shared single-connection
+	// dbTest, so the connection pool itself can't be the thing enforcing
+	// (or masking a failure to enforce) serialization.
+	concurrentDB, err := sql.Open("sqlite3", "file:voip1232_concurrency_test2?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("could not open concurrency-test db. err: %v", err)
+	}
+	concurrentDB.SetMaxOpenConns(4)
+	defer func() { _ = concurrentDB.Close() }()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-7013-7013-7013-000000000001")
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	var activeCount int32
+	var maxObservedConcurrent int32
+	var mu sync.Mutex
+
+	mockUtil.EXPECT().TimeNow().Return(&now).Times(2)
+	mockDB.EXPECT().BeginTx(ctx).Times(2).DoAndReturn(func(_ context.Context) (*sql.Tx, error) {
+		mu.Lock()
+		activeCount++
+		if activeCount > maxObservedConcurrent {
+			maxObservedConcurrent = activeCount
+		}
+		mu.Unlock()
+
+		tx, err := concurrentDB.Begin()
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		activeCount--
+		mu.Unlock()
+
+		return tx, err
+	})
+	mockDB.EXPECT().CaseGetOpenByPeer(ctx, gomock.Any(), customerID, commonaddress.TypeTel, gomock.Any(), "call").Return(nil, nil).Times(2)
+	mockDB.EXPECT().CaseGetLastClosedByPeerTx(ctx, gomock.Any(), customerID, commonaddress.TypeTel, gomock.Any(), "call").Return(nil, nil).Times(2)
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.Must(uuid.NewV4())).Times(2)
+	mockDB.EXPECT().CaseInsertTx(ctx, gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	mockDB.EXPECT().CaseUpdateTMUpdateTx(ctx, gomock.Any(), gomock.Any(), &now).Return(nil).Times(2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = h.GetOrCreate(ctx, customerID, commonaddress.Address{}, commonaddress.TypeTel, "+155****0004", "call", nil)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = h.GetOrCreate(ctx, customerID, commonaddress.Address{}, commonaddress.TypeTel, "+155****0005", "call", nil)
+	}()
+	wg.Wait()
+
+	if maxObservedConcurrent < 2 {
+		t.Errorf("expected two DIFFERENT peer tuples to proceed concurrently (max concurrent BeginTx >= 2), observed max concurrent = %d", maxObservedConcurrent)
+	}
+}
+
+// Test_GetOrCreate_PeerLock_TimeoutReturnsDistinctError verifies that a
+// caller unable to acquire the peer lock within peerLockTimeout gets
+// ErrPeerLockTimeout, not an indefinite hang. Exercises the real
+// (non-mocked) channel semaphore directly via acquirePeerLock -- no DB
+// mocks needed for this specific behavior.
+func Test_GetOrCreate_PeerLock_TimeoutReturnsDistinctError(t *testing.T) {
+	h := &caseHandler{peerLocks: make(map[string]chan struct{})}
+	key := "timeout-test-tuple"
+
+	// Hold the lock ourselves so a second acquire attempt must wait.
+	release, err := h.acquirePeerLock(context.Background(), key)
+	if err != nil {
+		t.Fatalf("first acquirePeerLock() error = %v", err)
+	}
+	defer release()
+
+	// Use a short-lived context to keep the test fast rather than waiting
+	// the full peerLockTimeout.
+	shortCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = h.acquirePeerLock(shortCtx, key)
+	if !errors.Is(err, ErrPeerLockTimeout) {
+		t.Errorf("expected ErrPeerLockTimeout, got: %v", err)
+	}
+}

--- a/bin-contact-manager/pkg/casehandler/main.go
+++ b/bin-contact-manager/pkg/casehandler/main.go
@@ -4,6 +4,7 @@ package casehandler
 
 import (
 	"context"
+	"sync"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -104,6 +105,17 @@ type caseHandler struct {
 	reqHandler    requesthandler.RequestHandler
 	db            dbhandler.DBHandler
 	notifyHandler notifyhandler.NotifyHandler
+
+	// peerLocks/peerLocksMu implement VOIP-1232's per-(customer_id,
+	// peer_type, peer_target, reference_type) in-process serialization
+	// lock: a map of buffered channels (capacity 1) used as keyed
+	// mutexes, guarded by peerLocksMu for map access. See peerlock.go.
+	// caseHandler is a process-wide singleton (constructed once by
+	// NewCaseHandler at service startup), so this map is genuinely
+	// shared across every concurrent GetOrCreate call for the life of
+	// the process.
+	peerLocks   map[string]chan struct{}
+	peerLocksMu sync.RWMutex
 }
 
 // NewCaseHandler returns CaseHandler interface
@@ -117,5 +129,6 @@ func NewCaseHandler(
 		reqHandler:    reqHandler,
 		db:            dbHandler,
 		notifyHandler: notifyHandler,
+		peerLocks:     make(map[string]chan struct{}),
 	}
 }

--- a/bin-contact-manager/pkg/casehandler/peerlock.go
+++ b/bin-contact-manager/pkg/casehandler/peerlock.go
@@ -1,0 +1,178 @@
+package casehandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// peerLockTimeout bounds how long GetOrCreate will wait to acquire the
+// per-peer-tuple in-process serialization lock before giving up (VOIP-1232
+// design v6, round 5's mandate). An unbounded wait, combined with
+// subscribehandler's per-message unbounded-goroutine dispatch
+// (processEventRun's `go h.processEvent(m)`), risks goroutine pileup under
+// a sustained hot-peer burst. This timeout is a self-contained
+// context.WithTimeout wait -- it fires purely on wall-clock elapsed time
+// and has no dependency on what the current lock holder's own retry loop
+// is doing (round-5's identified flaw in an earlier design revision that
+// tried to bound acquisition via the deadlock-retry loop's attempt count).
+//
+// 5s was chosen with wide margin over the expected lock-hold duration: a
+// held GetOrCreate call runs its own maxDeadlockRetries (outer) x
+// maxInsertRetries (inner) bounded retry loops, expected well under 1-2s
+// total at normal same-DC MySQL round-trip latency under contact-manager's
+// current single-replica deployment (no cross-pod contention to inflate
+// this further).
+const peerLockTimeout = 5 * time.Second
+
+// ErrPeerLockTimeout is returned when GetOrCreate could not acquire the
+// per-peer-tuple in-process lock within peerLockTimeout. Distinct from
+// ErrDeadlockExhausted and ErrGetOrCreateExhausted so callers
+// (subscribehandler.processEvent) can tag it separately for interim
+// triage (VOIP-1232 design v6 item 7) -- this failure currently still
+// falls through the same ack-before-process silent-drop pipeline as any
+// other GetOrCreate error (tracked separately in VOIP-1233).
+var ErrPeerLockTimeout = fmt.Errorf("could not acquire peer serialization lock within timeout")
+
+var (
+	promPeerLockMapSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "case_peer_lock_map_size",
+			Help:      "Current number of distinct peer-tuple entries held in the in-process GetOrCreate serialization lock map",
+		},
+	)
+
+	promDeadlockRetryTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "case_getorcreate_deadlock_retry_total",
+			Help:      "Total number of GetOrCreate attempts restarted after a MySQL deadlock (errno 1213)",
+		},
+	)
+
+	promDeadlockExhaustedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "case_getorcreate_deadlock_exhausted_total",
+			Help:      "Total number of GetOrCreate calls that exhausted all deadlock retry attempts and gave up",
+		},
+	)
+
+	promPeerLockTimeoutTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "case_getorcreate_peer_lock_timeout_total",
+			Help:      "Total number of GetOrCreate calls that failed to acquire the per-peer serialization lock within the timeout",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		promPeerLockMapSize,
+		promDeadlockRetryTotal,
+		promDeadlockExhaustedTotal,
+		promPeerLockTimeoutTotal,
+	)
+}
+
+// metricsNamespace matches subscribehandler's own "contact_manager"
+// namespace constant (kept package-local here to avoid a cross-package
+// import just for a string constant; must stay in sync).
+const metricsNamespace = "contact_manager"
+
+// peerLockKey builds the map key for a (customer_id, peer_type,
+// peer_target, reference_type) tuple -- the same tuple that identifies an
+// OPEN Case under uq_case_open_peer (design §3.1/§4).
+func peerLockKey(customerID uuid.UUID, peerType commonaddress.Type, peerTarget, referenceType string) string {
+	return customerID.String() + "|" + string(peerType) + "|" + peerTarget + "|" + referenceType
+}
+
+// acquirePeerLock acquires (lazily creating on first use) the buffered-
+// channel semaphore for the given tuple key, waiting up to
+// peerLockTimeout. Returns a release func that MUST be called exactly
+// once when the caller is done (typically via a deferred call, or an
+// explicit call right after tx.Commit() per GetOrCreate's release-timing
+// requirement -- see GetOrCreate's call site comment).
+//
+// VOIP-1232 design v6: this in-process lock serializes concurrent
+// GetOrCreate calls for the SAME peer tuple within a single contact-
+// manager process, eliminating the same-tuple concurrent-INSERT race that
+// produces MySQL deadlocks (1213) at the source, rather than only
+// absorbing it via DB-level retry (see getorcreate.go's deadlock-retry
+// loop, which remains the topology-independent correctness backstop
+// regardless of replica count).
+//
+// TOPOLOGY CAVEAT (must be stated in the PR body per round-4/5's
+// mandate): this lock is IN-PROCESS ONLY, not cross-pod/distributed. It
+// fully prevents the race under contact-manager's CURRENT single-replica
+// production config (confirmed replicas: 1, no HPA, in both
+// bin-contact-manager/k8s/deployment.yml and the install repo's
+// k8s/backend/services/contact-manager.yaml). Under a future multi-
+// replica deployment, RabbitMQ's plain shared-queue competing-consumers
+// model has no per-peer-tuple pod affinity, so this lock would provide
+// ZERO cross-pod protection and the fix would degrade to relying on
+// DB-level deadlock retry alone. A Redis-based distributed lock (contact-
+// manager already depends on Redis for contact-body caching) is the
+// correct upgrade path if/when replicas are ever increased -- tracked as
+// a follow-up, not built preemptively here.
+func (h *caseHandler) acquirePeerLock(ctx context.Context, key string) (func(), error) {
+	ch := h.loadOrCreatePeerLockChan(key)
+
+	lockCtx, cancel := context.WithTimeout(ctx, peerLockTimeout)
+	defer cancel()
+
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-lockCtx.Done():
+		return nil, ErrPeerLockTimeout
+	}
+}
+
+// loadOrCreatePeerLockChan returns the buffered channel (capacity 1) for
+// key, creating it under a write lock if this is the first use.
+//
+// Double-checked locking, spelled out explicitly (VOIP-1232 round-5's
+// flagged ambiguity): fast path takes only an RLock to reuse an existing
+// entry; on a miss, it takes the write Lock and RE-CHECKS the map before
+// creating -- without this re-check, two goroutines racing on first-use
+// for the same brand-new key could each create and store a DISTINCT
+// channel object, with the second silently clobbering the first's map
+// entry. Both goroutines would then believe they've acquired mutual
+// exclusion while actually holding/selecting on two different channels,
+// running fully concurrently -- exactly the correctness break this whole
+// mechanism exists to prevent.
+func (h *caseHandler) loadOrCreatePeerLockChan(key string) chan struct{} {
+	h.peerLocksMu.RLock()
+	ch, ok := h.peerLocks[key]
+	h.peerLocksMu.RUnlock()
+	if ok {
+		return ch
+	}
+
+	h.peerLocksMu.Lock()
+	defer h.peerLocksMu.Unlock()
+	// Defensive lazy-init: NewCaseHandler always initializes peerLocks,
+	// but a caseHandler constructed directly as a struct literal (as many
+	// existing unit tests do, e.g. getorcreate_race_test.go) would
+	// otherwise have a nil map here, panicking on the write below.
+	if h.peerLocks == nil {
+		h.peerLocks = make(map[string]chan struct{})
+	}
+	// Re-check under the write lock: another goroutine may have created
+	// this exact key between our RUnlock above and this Lock.
+	if ch, ok := h.peerLocks[key]; ok {
+		return ch
+	}
+	ch = make(chan struct{}, 1)
+	h.peerLocks[key] = ch
+	promPeerLockMapSize.Set(float64(len(h.peerLocks)))
+	return ch
+}

--- a/bin-contact-manager/pkg/contacthandler/interaction.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction.go
@@ -99,7 +99,7 @@ func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMe
 
 	c, err := h.caseHandler.GetOrCreate(ctx, m.CustomerID, local, peer.Type, peerTarget, "call", nil)
 	if err != nil {
-		return fmt.Errorf("could not get-or-create case. EventCallCreated. err: %v", err)
+		return fmt.Errorf("could not get-or-create case. EventCallCreated. err: %w", err)
 	}
 
 	i := interaction.Interaction{
@@ -153,7 +153,7 @@ func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m 
 
 	c, err := h.caseHandler.GetOrCreate(ctx, m.CustomerID, commonaddress.Address{}, peer.Type, peerTarget, "conversation_message", m.CaseID)
 	if err != nil {
-		return fmt.Errorf("could not get-or-create case. EventConversationMessageCreated. err: %v", err)
+		return fmt.Errorf("could not get-or-create case. EventConversationMessageCreated. err: %w", err)
 	}
 
 	// m.ID comes from the embedded commonidentity.Identity; use it directly.

--- a/bin-contact-manager/pkg/dbhandler/kase.go
+++ b/bin-contact-manager/pkg/dbhandler/kase.go
@@ -50,6 +50,23 @@ func caseGetFromRow(rows *sql.Rows) (*kase.Case, error) {
 	return res, nil
 }
 
+// mysqlDeadlockErrno is MySQL's errno for "Deadlock found when trying to
+// get lock; try restarting transaction" (VOIP-1232).
+const mysqlDeadlockErrno = 1213
+
+// isMySQLDeadlock reports whether err is a MySQL deadlock (errno 1213).
+// Mirrors the existing *mysql_driver.MySQLError type-assertion idiom used
+// for the 1062/ErrDuplicate check below -- inlined per call site rather
+// than a shared cross-package helper, matching this codebase's existing
+// convention (see also interaction.go/address.go's own inline 1062
+// checks). SQLite (the test harness driver) has no deadlock concept, so
+// this is unconditionally false against SQLite errors -- consistent with
+// forUpdateSuffix's SQLite-has-no-real-locking rationale in main.go.
+func isMySQLDeadlock(err error) bool {
+	me, ok := err.(*mysql_driver.MySQLError)
+	return ok && me.Number == mysqlDeadlockErrno
+}
+
 // caseInsertExec is the shared implementation for CaseInsert/CaseInsertTx.
 func caseInsertExec(exec sqlExecutor, c *kase.Case) error {
 	fields, err := commondatabasehandler.PrepareFields(c)
@@ -76,6 +93,16 @@ func caseInsertExec(exec sqlExecutor, c *kase.Case) error {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") &&
 			strings.Contains(err.Error(), "open_peer_uk") {
 			return ErrDuplicate
+		}
+		// VOIP-1232: concurrent INSERTs racing on the same uq_case_open_peer
+		// value can surface as a deadlock (1213) instead of a clean 1062,
+		// per InnoDB's insert-intention gap-lock interaction. The caller
+		// (casehandler.GetOrCreate's outer retry loop) must discard the
+		// whole transaction (already server-side rolled back) and restart
+		// from a fresh BeginTx -- unlike ErrDuplicate, which is safely
+		// retryable within the SAME tx via a locked re-select.
+		if isMySQLDeadlock(err) {
+			return ErrDeadlock
 		}
 		return fmt.Errorf("could not execute. CaseInsert. err: %v", err)
 	}
@@ -157,6 +184,11 @@ func (h *handler) CaseGetOpenByPeer(ctx context.Context, tx *sql.Tx, customerID 
 
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
+		// VOIP-1232: a FOR UPDATE select can itself be the victim of an
+		// InnoDB deadlock under concurrent same-tuple GetOrCreate calls.
+		if isMySQLDeadlock(err) {
+			return nil, ErrDeadlock
+		}
 		return nil, fmt.Errorf("could not query. CaseGetOpenByPeer. err: %v", err)
 	}
 	defer func() { _ = rows.Close() }()
@@ -192,6 +224,10 @@ func (h *handler) CaseGetByIDForUpdate(ctx context.Context, tx *sql.Tx, customer
 
 	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
+		// VOIP-1232: see CaseGetOpenByPeer's identical rationale.
+		if isMySQLDeadlock(err) {
+			return nil, ErrDeadlock
+		}
 		return nil, fmt.Errorf("could not query. CaseGetByIDForUpdate. err: %v", err)
 	}
 	defer func() { _ = rows.Close() }()
@@ -232,6 +268,12 @@ func caseUpdateStatusClosedExec(exec sqlExecutor, customerID, id uuid.UUID, clos
 
 	result, err := exec.Exec(query, args...)
 	if err != nil {
+		// VOIP-1232: the timeout-close UPDATE (design §4's close-and-reopen
+		// branch) can also be a deadlock victim under concurrent same-tuple
+		// GetOrCreate calls.
+		if isMySQLDeadlock(err) {
+			return false, ErrDeadlock
+		}
 		return false, fmt.Errorf("could not execute. CaseUpdateStatusClosed. err: %v", err)
 	}
 
@@ -275,6 +317,11 @@ func caseUpdateTMUpdateExec(exec sqlExecutor, id uuid.UUID, tmUpdate *time.Time)
 	}
 
 	if _, err := exec.Exec(query, args...); err != nil {
+		// VOIP-1232: the final tm_update bump can itself deadlock under
+		// concurrent same-tuple GetOrCreate calls.
+		if isMySQLDeadlock(err) {
+			return ErrDeadlock
+		}
 		return fmt.Errorf("could not execute. CaseUpdateTMUpdate. err: %v", err)
 	}
 

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -143,6 +143,22 @@ var (
 	// algorithm, design §4) use this as the signal to retry with a locked
 	// re-select rather than treating it as a generic infrastructure error.
 	ErrDuplicate = fmt.Errorf("an open case already exists for this customer/peer/reference_type")
+
+	// ErrDeadlock is returned by any Case* Tx-scoped operation (design §4's
+	// get-or-create transaction) when the underlying driver reports a
+	// MySQL deadlock (errno 1213, "Deadlock found when trying to get
+	// lock; try restarting transaction"). VOIP-1232: concurrent
+	// GetOrCreate calls racing to INSERT into contact_cases for the same
+	// (customer_id, peer_type, peer_target, reference_type) tuple can
+	// occasionally surface a 1213 instead of the clean 1062/ErrDuplicate
+	// path, because the collision can occur during the insert-intention
+	// gap-lock phase before either transaction commits. InnoDB
+	// auto-rolls-back the ENTIRE transaction server-side when it reports
+	// 1213 -- callers MUST NOT reuse the same *sql.Tx after seeing this
+	// error; a correct retry restarts from a fresh BeginTx (design §4.2's
+	// insert-retry loop is a different, narrower mechanism scoped to
+	// ErrDuplicate only and does not cover this).
+	ErrDeadlock = fmt.Errorf("deadlock detected; transaction was rolled back by the server")
 )
 
 // NewHandler creates DBHandler

--- a/bin-contact-manager/pkg/subscribehandler/main.go
+++ b/bin-contact-manager/pkg/subscribehandler/main.go
@@ -4,6 +4,7 @@ package subscribehandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 
 	call "monorepo/bin-call-manager/models/call"
 	convmsg "monorepo/bin-conversation-manager/models/message"
+	"monorepo/bin-contact-manager/pkg/casehandler"
 	"monorepo/bin-contact-manager/pkg/contacthandler"
 )
 
@@ -164,6 +166,22 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 	promEventProcessTime.WithLabelValues(m.Publisher, string(m.Type)).Observe(float64(elapsed.Milliseconds()))
 
 	if err != nil {
-		log.Errorf("Could not process the event correctly. publisher: %s, type: %s, err: %v", m.Publisher, m.Type, err)
+		// VOIP-1232: distinctly tag the two new GetOrCreate failure modes
+		// (deadlock-retry exhaustion, peer-lock acquisition timeout) from
+		// generic GetOrCreate errors, so operators can triage which
+		// mechanism is firing. NOTE: none of these three outcomes have a
+		// recovery path yet -- the message was already Ack'd before this
+		// handler ran (rabbitmqhandler.consumeMessageWorker's ack-before-
+		// process design), and this branch only logs. VOIP-1233 tracks the
+		// follow-up ack-after-process/DLQ fix that would give these
+		// failures an actual retry/redelivery path.
+		switch {
+		case errors.Is(err, casehandler.ErrDeadlockExhausted):
+			log.Errorf("GetOrCreate exhausted all deadlock retries; event dropped (ack-before-process, no DLQ -- see VOIP-1233). publisher: %s, type: %s, err: %v", m.Publisher, m.Type, err)
+		case errors.Is(err, casehandler.ErrPeerLockTimeout):
+			log.Errorf("GetOrCreate could not acquire peer serialization lock within timeout; event dropped (ack-before-process, no DLQ -- see VOIP-1233). publisher: %s, type: %s, err: %v", m.Publisher, m.Type, err)
+		default:
+			log.Errorf("Could not process the event correctly. publisher: %s, type: %s, err: %v", m.Publisher, m.Type, err)
+		}
 	}
 }


### PR DESCRIPTION
Fix a MySQL deadlock (errno 1213) silently dropping CRM interaction events under concurrent same-peer-tuple GetOrCreate calls, and add in-process serialization plus observability to reduce recurrence.

- bin-contact-manager: dbhandler classifies MySQL errno 1213 (ErrDeadlock) at every FOR UPDATE/write point in the GetOrCreate transaction (CaseGetOpenByPeer, CaseGetByIDForUpdate, CaseInsertTx, CaseUpdateStatusClosedTx, CaseUpdateTMUpdateTx), mirroring the existing 1062/ErrDuplicate classification in caseInsertExec
- bin-contact-manager: casehandler.GetOrCreate wraps the whole transaction lifecycle in an outer bounded retry loop (maxDeadlockRetries=3) that discards the dead tx and restarts from a fresh BeginTx on each detected deadlock, re-capturing now inside the loop per attempt; returns ErrDeadlockExhausted (distinct from ErrGetOrCreateExhausted) when retries are exhausted
- bin-contact-manager: adds a per-(customer_id, peer_type, peer_target, reference_type) in-process keyed lock (map[string]chan struct{} + guarding sync.RWMutex, on the process-wide caseHandler singleton) that serializes concurrent GetOrCreate calls for the identical peer tuple, eliminating the concurrent-INSERT race at the source rather than only absorbing it via DB-level retry; acquired before BeginTx, released immediately after a successful commit and before linkSiblingConversation's network RPCs; bounded by a self-contained 5s context.WithTimeout (independent of the deadlock-retry loop's own attempt count) returning ErrPeerLockTimeout on acquisition failure
- bin-contact-manager: adds four Prometheus metrics (deadlock retry/exhausted counters, peer-lock timeout counter, peer-lock map size gauge) and documents them plus the single-replica topology caveat in docs/operations.md
- bin-contact-manager: subscribehandler.processEvent distinctly tags deadlock-exhaustion and peer-lock-timeout failures in its error log (via errors.Is on %w-wrapped errors through interaction.go) for interim triage, pending the ack-after-process/DLQ follow-up tracked in VOIP-1233
- bin-contact-manager: adds getorcreate_deadlock_test.go covering the deadlock-retry-then-succeed path, retry exhaustion, real (non-mocked) same-tuple serialization, different-tuple non-blocking concurrency, and peer-lock acquisition timeout

## Scope notes (per design review)

- Blast radius: this also changes retry behavior for EventCallCreated, not just EventConversationMessageCreated -- both call the same GetOrCreate and are equally exposed to the same unique-index race. Intentional and expected.
- Severity: Case existence has no caller-ID/downstream dependency (caller-ID lookup goes through contact_addresses directly). A dropped event means a missing CRM timeline entry only.
- Topology caveat: the in-process peer lock fully eliminates the race only under contact-manager's current single-replica production config (confirmed replicas: 1, no HPA). Under a future multi-replica deployment, RabbitMQ's plain shared-queue competing-consumers model has no per-peer-tuple pod affinity, so this lock provides zero cross-pod protection and the fix degrades to relying on DB-level deadlock retry alone. A Redis-based distributed lock is the correct upgrade path if/when replicas increase.
- Residual risk: retry exhaustion / lock-acquisition timeout under sustained hot-peer load still falls through the existing ack-before-process silent-drop pipeline (bin-common-handler/pkg/rabbitmqhandler's ack-before-process + subscribehandler's log-only error handling). This PR reduces the frequency of silent event loss but does not eliminate the failure mode. VOIP-1233 tracks the required follow-up (ack-after-process / DLQ).