### PR TITLE
VOIP-1234-ai-insight

### DIFF
--- a/bin-ai-manager/models/aicall/main.go
+++ b/bin-ai-manager/models/aicall/main.go
@@ -71,6 +71,7 @@ const (
 	ReferenceTypeCall         ReferenceType = "call"
 	ReferenceTypeConversation ReferenceType = "conversation"
 	ReferenceTypeTask         ReferenceType = "task"
+	ReferenceTypeContactCase  ReferenceType = "contact_case"
 )
 
 // AssistanceType defines the type of assistance entity backing an AIcall.

--- a/bin-ai-manager/pkg/aicallhandler/db.go
+++ b/bin-ai-manager/pkg/aicallhandler/db.go
@@ -272,17 +272,32 @@ func (h *aicallHandler) UpdateActiveflowID(ctx context.Context, id uuid.UUID, ac
 	return res, nil
 }
 
+// ErrAIcallNoLongerActive is returned when a reuse-path write targets an AIcall that
+// has transitioned to Terminated/Terminating between the caller's read and this write
+// (a TOCTOU race). Callers of UpdatePipecatcallIDAndActiveflowID must not assume the
+// write took effect when this error is returned — the reuse attempt should be abandoned
+// in favor of a fresh AIcall creation path.
+var ErrAIcallNoLongerActive = stderrors.New("aicall is no longer active")
+
 // UpdatePipecatcallIDAndActiveflowID atomically updates both PipecatcallID and
 // ActiveflowID in a single DB write. Used in the conversation reuse branch to
 // avoid the race where a concurrent reader observes the new PipecatcallID
-// alongside a stale ActiveflowID.
+// alongside a stale ActiveflowID. The write is conditioned on the AIcall still
+// being active (status NOT IN ('terminated','terminating')) at write time — if
+// the row transitioned to a terminal status between the caller's read and this
+// write, ErrAIcallNoLongerActive is returned and the caller must fall back to
+// creating a fresh AIcall rather than trusting a half-reused stale row.
 func (h *aicallHandler) UpdatePipecatcallIDAndActiveflowID(ctx context.Context, id uuid.UUID, pipecatcallID uuid.UUID, activeflowID uuid.UUID) (*aicall.AIcall, error) {
 	fields := map[aicall.Field]any{
 		aicall.FieldPipecatcallID: pipecatcallID,
 		aicall.FieldActiveflowID:  activeflowID,
 	}
-	if errUpdate := h.db.AIcallUpdate(ctx, id, fields); errUpdate != nil {
+	rowsAffected, errUpdate := h.db.AIcallUpdateIfActive(ctx, id, fields)
+	if errUpdate != nil {
 		return nil, errors.Wrapf(errUpdate, "could not update pipecatcall_id+activeflow_id for aicall. aicall_id: %s", id)
+	}
+	if rowsAffected == 0 {
+		return nil, errors.Wrapf(ErrAIcallNoLongerActive, "aicall no longer active. aicall_id: %s", id)
 	}
 
 	res, err := h.db.AIcallGet(ctx, id)

--- a/bin-ai-manager/pkg/aicallhandler/db_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/db_test.go
@@ -2,6 +2,7 @@ package aicallhandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	reflect "reflect"
 	"testing"
@@ -715,13 +716,15 @@ func Test_UpdatePipecatcallIDAndActiveflowID(t *testing.T) {
 		pipecatcallID uuid.UUID
 		activeflowID  uuid.UUID
 
-		responseUpdateErr error
-		responseAIcall    *aicall.AIcall
-		responseGetErr    error
+		responseRowsAffected int64
+		responseUpdateErr    error
+		responseAIcall       *aicall.AIcall
+		responseGetErr       error
 
-		expectFields map[aicall.Field]any
-		expectRes    *aicall.AIcall
-		expectErr    bool
+		expectFields  map[aicall.Field]any
+		expectRes     *aicall.AIcall
+		expectErr     bool
+		expectErrIs   error
 	}{
 		{
 			name: "normal",
@@ -730,7 +733,8 @@ func Test_UpdatePipecatcallIDAndActiveflowID(t *testing.T) {
 			pipecatcallID: uuid.FromStringOrNil("3a3454ce-2342-11ef-bd13-7b3a4f7c2d11"),
 			activeflowID:  uuid.FromStringOrNil("3a6660d4-2342-11ef-9c3a-bb6e9d8f2c33"),
 
-			responseUpdateErr: nil,
+			responseRowsAffected: 1,
+			responseUpdateErr:    nil,
 			responseAIcall: &aicall.AIcall{
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("3a01b6c0-2342-11ef-9f0a-cb0d8f0c3a01"),
@@ -760,7 +764,8 @@ func Test_UpdatePipecatcallIDAndActiveflowID(t *testing.T) {
 			pipecatcallID: uuid.FromStringOrNil("3ad5d6dc-2342-11ef-9c3a-bb6e9d8f2c33"),
 			activeflowID:  uuid.FromStringOrNil("3b07ce28-2342-11ef-aebc-7f4c9d0e3a44"),
 
-			responseUpdateErr: fmt.Errorf("update failed"),
+			responseRowsAffected: 0,
+			responseUpdateErr:    fmt.Errorf("update failed"),
 
 			expectFields: map[aicall.Field]any{
 				aicall.FieldPipecatcallID: uuid.FromStringOrNil("3ad5d6dc-2342-11ef-9c3a-bb6e9d8f2c33"),
@@ -775,15 +780,33 @@ func Test_UpdatePipecatcallIDAndActiveflowID(t *testing.T) {
 			pipecatcallID: uuid.FromStringOrNil("3b6dadea-2342-11ef-b6c4-cb1d2e3f4a55"),
 			activeflowID:  uuid.FromStringOrNil("3b9f9c5c-2342-11ef-b6c4-cb1d2e3f4a55"),
 
-			responseUpdateErr: nil,
-			responseAIcall:    nil,
-			responseGetErr:    fmt.Errorf("get failed"),
+			responseRowsAffected: 1,
+			responseUpdateErr:    nil,
+			responseAIcall:       nil,
+			responseGetErr:       fmt.Errorf("get failed"),
 
 			expectFields: map[aicall.Field]any{
 				aicall.FieldPipecatcallID: uuid.FromStringOrNil("3b6dadea-2342-11ef-b6c4-cb1d2e3f4a55"),
 				aicall.FieldActiveflowID:  uuid.FromStringOrNil("3b9f9c5c-2342-11ef-b6c4-cb1d2e3f4a55"),
 			},
 			expectErr: true,
+		},
+		{
+			name: "aicall no longer active — rows affected 0",
+
+			id:            uuid.FromStringOrNil("3c1e6a7a-2342-11ef-9c3a-bb6e9d8f2c33"),
+			pipecatcallID: uuid.FromStringOrNil("3c4dd7b8-2342-11ef-bd13-7b3a4f7c2d11"),
+			activeflowID:  uuid.FromStringOrNil("3c7fac8a-2342-11ef-9f0a-cb0d8f0c3a01"),
+
+			responseRowsAffected: 0,
+			responseUpdateErr:    nil,
+
+			expectFields: map[aicall.Field]any{
+				aicall.FieldPipecatcallID: uuid.FromStringOrNil("3c4dd7b8-2342-11ef-bd13-7b3a4f7c2d11"),
+				aicall.FieldActiveflowID:  uuid.FromStringOrNil("3c7fac8a-2342-11ef-9f0a-cb0d8f0c3a01"),
+			},
+			expectErr:   true,
+			expectErrIs: ErrAIcallNoLongerActive,
 		},
 	}
 
@@ -804,8 +827,8 @@ func Test_UpdatePipecatcallIDAndActiveflowID(t *testing.T) {
 
 			ctx := context.Background()
 
-			mockDB.EXPECT().AIcallUpdate(ctx, tt.id, tt.expectFields).Return(tt.responseUpdateErr)
-			if tt.responseUpdateErr == nil {
+			mockDB.EXPECT().AIcallUpdateIfActive(ctx, tt.id, tt.expectFields).Return(tt.responseRowsAffected, tt.responseUpdateErr)
+			if tt.responseUpdateErr == nil && tt.responseRowsAffected > 0 {
 				mockDB.EXPECT().AIcallGet(ctx, tt.id).Return(tt.responseAIcall, tt.responseGetErr)
 			}
 
@@ -813,6 +836,9 @@ func Test_UpdatePipecatcallIDAndActiveflowID(t *testing.T) {
 			if tt.expectErr {
 				if err == nil {
 					t.Errorf("Wrong match. expect: error, got: nil")
+				}
+				if tt.expectErrIs != nil && !stderrors.Is(err, tt.expectErrIs) {
+					t.Errorf("Wrong match. expect err to wrap: %v, got: %v", tt.expectErrIs, err)
 				}
 				return
 			}

--- a/bin-ai-manager/pkg/aicallhandler/service_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/service_test.go
@@ -412,10 +412,10 @@ func Test_ServiceStart_serviceStartReferenceTypeConversation(t *testing.T) {
 
 			// new pipecatcall ID + atomic UpdatePipecatcallIDAndActiveflowID
 			mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUIDPipecatcallID)
-			mockDB.EXPECT().AIcallUpdate(ctx, tt.responseAIcall.ID, map[aicall.Field]any{
+			mockDB.EXPECT().AIcallUpdateIfActive(ctx, tt.responseAIcall.ID, map[aicall.Field]any{
 				aicall.FieldPipecatcallID: tt.responseUUIDPipecatcallID,
 				aicall.FieldActiveflowID:  tt.activeflowID,
-			}).Return(nil)
+			}).Return(int64(1), nil)
 			mockDB.EXPECT().AIcallGet(ctx, tt.responseAIcall.ID).Return(tt.responseAIcall, nil)
 
 			mockMessage.EXPECT().Create(ctx, uuid.Nil, tt.responseAIcall.CustomerID, tt.responseAIcall.ID, tt.responseAIcall.ActiveflowID, message.DirectionOutgoing, message.RoleUser, tt.expectMessageText, nil, "", gomock.Any()).Return(&message.Message{}, nil)

--- a/bin-ai-manager/pkg/aicallhandler/start.go
+++ b/bin-ai-manager/pkg/aicallhandler/start.go
@@ -8,6 +8,7 @@ import (
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
 	"monorepo/bin-ai-manager/models/team"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-ai-manager/pkg/messagehandler"
 	cmconfbridge "monorepo/bin-call-manager/models/confbridge"
 	cmcustomer "monorepo/bin-customer-manager/models/customer"
@@ -342,6 +343,87 @@ func (h *aicallHandler) startReferenceTypeConversation(
 	}
 
 	return res, nil
+}
+
+// maxContactCaseCreateRetries bounds the create/reconcile loop in
+// startReferenceTypeContactCase. A bound is required because a pathological
+// sequence of concurrent creators+terminators could in principle keep colliding
+// forever; 3 is generous relative to the spike-measured contention (20 concurrent
+// INSERTs -> 1 success/19 duplicate-key 1062/0 deadlocks, see VOIP-1234 design).
+const maxContactCaseCreateRetries = 3
+
+// startReferenceTypeContactCase starts (or reuses) an aicall for reference type
+// contact_case (VOIP-1234). Concurrency guard: the DB enforces "at most one active
+// AIcall per (customer_id, reference_type, reference_id)" via the
+// active_reference_key generated-column UNIQUE index (bin-dbscheme-manager
+// a5a40c93d3e6). This function relies on that DB-level constraint with an
+// optimistic-INSERT + reconcile-on-1062 pattern rather than a pre-check SELECT or
+// in-process lock — a real spike (20 concurrent INSERTs against MySQL 8.0) proved
+// the optimistic path alone gives full consistency for this workload (1
+// success/19 duplicate-key 1062/0 deadlocks), unlike the heavier
+// SELECT...FOR UPDATE + retry pattern bin-contact-manager uses for contact_cases.
+//
+// Flow:
+//  1. Attempt to create a new AIcall.
+//  2. On success, return it.
+//  3. On a duplicate-key (1062) conflict, re-fetch the existing AIcall by
+//     reference_id.
+//     - If it is still active (not Terminated/Terminating), reuse it.
+//     - If it has since terminated, its active_reference_key is NULL (no longer
+//       occupying the unique slot), so retry the create — bounded by
+//       maxContactCaseCreateRetries.
+//  4. Any other error propagates immediately.
+func (h *aicallHandler) startReferenceTypeContactCase(
+	ctx context.Context,
+	a *ai.AI,
+	assistanceType aicall.AssistanceType,
+	assistanceID uuid.UUID,
+	activeflowID uuid.UUID,
+	referenceID uuid.UUID,
+	teamParameter map[string]any,
+	currentMemberID uuid.UUID,
+) (*aicall.AIcall, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":          "startReferenceTypeContactCase",
+		"ai":            a,
+		"activeflow_id": activeflowID,
+		"reference_id":  referenceID,
+	})
+
+	var lastErr error
+	for attempt := 0; attempt < maxContactCaseCreateRetries; attempt++ {
+		res, err := h.startAIcallByMessaging(ctx, a, assistanceType, assistanceID, activeflowID, aicall.ReferenceTypeContactCase, referenceID, false, teamParameter, currentMemberID)
+		if err == nil {
+			log.WithField("aicall", res).Debugf("Created aicall for contact_case. aicall_id: %s", res.ID)
+			return res, nil
+		}
+
+		if !dbhandler.IsErrDuplicate(err) {
+			return nil, errors.Wrapf(err, "could not create aicall for contact_case. reference_id: %s", referenceID)
+		}
+
+		// duplicate key: another creator won the race for this
+		// (customer_id, reference_type, reference_id) tuple. Re-fetch and decide
+		// whether to reuse it or retry the create.
+		existing, errGet := h.GetByReferenceID(ctx, referenceID)
+		if errGet != nil {
+			return nil, errors.Wrapf(errGet, "could not get existing aicall after duplicate key conflict. reference_id: %s", referenceID)
+		}
+
+		if existing.Status == aicall.StatusTerminated || existing.Status == aicall.StatusTerminating {
+			// The row that won the race has since terminated (or was already
+			// terminating). Its active_reference_key computes to NULL, so it no
+			// longer occupies the unique slot — retry the create.
+			log.Infof("Existing AIcall for contact_case is terminated/terminating — retrying create. aicall_id: %s, attempt: %d", existing.ID, attempt+1)
+			lastErr = err
+			continue
+		}
+
+		log.WithField("aicall", existing).Debugf("Reusing existing active aicall for contact_case. aicall_id: %s", existing.ID)
+		return existing, nil
+	}
+
+	return nil, errors.Wrapf(lastErr, "could not create aicall for contact_case after %d retries. reference_id: %s", maxContactCaseCreateRetries, referenceID)
 }
 
 // startReferenceTypeNone starts a new aicall with no reference

--- a/bin-ai-manager/pkg/aicallhandler/start.go
+++ b/bin-ai-manager/pkg/aicallhandler/start.go
@@ -186,6 +186,9 @@ func (h *aicallHandler) Start(
 	case aicall.ReferenceTypeConversation:
 		return h.startReferenceTypeConversation(ctx, c, assistanceType, assistanceID, activeflowID, referenceID, teamParameter, currentMemberID)
 
+	case aicall.ReferenceTypeContactCase:
+		return h.startReferenceTypeContactCase(ctx, c, assistanceType, assistanceID, activeflowID, referenceID, teamParameter, currentMemberID)
+
 	case aicall.ReferenceTypeNone:
 		return h.startReferenceTypeNone(ctx, c, assistanceType, assistanceID, activeflowID, teamParameter, currentMemberID)
 

--- a/bin-ai-manager/pkg/aicallhandler/start_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/start_test.go
@@ -3601,6 +3601,7 @@ func Test_startReferenceTypeContactCase(t *testing.T) {
 
 		expectRes *aicall.AIcall
 		expectErr bool
+		checkErr  func(t *testing.T, err error)
 	}{
 		{
 			name: "create succeeds on first attempt",
@@ -3796,6 +3797,48 @@ func Test_startReferenceTypeContactCase(t *testing.T) {
 			},
 
 			expectErr: true,
+			checkErr: func(t *testing.T, err error) {
+				if !strings.Contains(err.Error(), fmt.Sprintf("%d retries", maxContactCaseCreateRetries)) {
+					t.Errorf("expected error to mention retry count %d, got: %v", maxContactCaseCreateRetries, err)
+				}
+				if !strings.Contains(err.Error(), "1062") {
+					t.Errorf("expected error to wrap the last 1062 duplicate-key error, got: %v", err)
+				}
+			},
+		},
+		{
+			name: "non-1062 db error — returns immediately without retrying",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("50000000-0001-11f0-eeee-000000000001"),
+					CustomerID: uuid.FromStringOrNil("50000000-0002-11f0-eeee-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("50000000-0001-11f0-eeee-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("50000000-0003-11f0-eeee-000000000001"),
+			referenceID:    uuid.FromStringOrNil("50000000-0004-11f0-eeee-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID := uuid.FromStringOrNil("50000000-0005-11f0-eeee-000000000001")
+				aicallID := uuid.FromStringOrNil("50000000-0006-11f0-eeee-000000000001")
+
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID)
+				m.util.EXPECT().UUIDCreate().Return(aicallID)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("connection refused")).Times(1)
+			},
+
+			expectErr: true,
+			checkErr: func(t *testing.T, err error) {
+				if strings.Contains(err.Error(), "1062") {
+					t.Errorf("did not expect 1062 duplicate-key wrapping for a non-duplicate db error, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "connection refused") {
+					t.Errorf("expected the original db error to be wrapped, got: %v", err)
+				}
+			},
 		},
 	}
 
@@ -3830,6 +3873,9 @@ func Test_startReferenceTypeContactCase(t *testing.T) {
 				}
 				if res != nil {
 					t.Errorf("expected nil res on error, got: %v", res)
+				}
+				if tt.checkErr != nil {
+					tt.checkErr(t, err)
 				}
 				return
 			}

--- a/bin-ai-manager/pkg/aicallhandler/start_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/start_test.go
@@ -557,10 +557,10 @@ func Test_startReferenceTypeConversation(t *testing.T) {
 
 				// new pipecatcall ID + atomic UpdatePipecatcallIDAndActiveflowID
 				m.util.EXPECT().UUIDCreate().Return(newPCC)
-				m.db.EXPECT().AIcallUpdate(ctx, existingAIcallID, map[aicall.Field]any{
+				m.db.EXPECT().AIcallUpdateIfActive(ctx, existingAIcallID, map[aicall.Field]any{
 					aicall.FieldPipecatcallID: newPCC,
 					aicall.FieldActiveflowID:  uuid.FromStringOrNil("d15ae476-30dd-11f0-87af-67d3c47111a7"),
-				}).Return(nil)
+				}).Return(int64(1), nil)
 				m.db.EXPECT().AIcallGet(ctx, existingAIcallID).Return(existing, nil)
 
 				// conversation message create
@@ -644,10 +644,10 @@ func Test_startReferenceTypeConversation(t *testing.T) {
 
 				// new pipecatcall ID + atomic UpdatePipecatcallIDAndActiveflowID
 				m.util.EXPECT().UUIDCreate().Return(newPCC)
-				m.db.EXPECT().AIcallUpdate(ctx, existingAIcallID, map[aicall.Field]any{
+				m.db.EXPECT().AIcallUpdateIfActive(ctx, existingAIcallID, map[aicall.Field]any{
 					aicall.FieldPipecatcallID: newPCC,
 					aicall.FieldActiveflowID:  uuid.FromStringOrNil("d15ae476-30dd-11f0-87af-67d3c47111a7"),
-				}).Return(nil)
+				}).Return(int64(1), nil)
 				m.db.EXPECT().AIcallGet(ctx, existingAIcallID).Return(existing, nil)
 
 				m.message.EXPECT().Create(ctx, uuid.Nil, existing.CustomerID, existing.ID, existing.ActiveflowID, message.DirectionOutgoing, message.RoleUser, "another user message.", nil, "", gomock.Any()).Return(&message.Message{}, nil)
@@ -1138,10 +1138,10 @@ func Test_startReferenceTypeConversation(t *testing.T) {
 
 				// new pipecatcall ID + atomic UpdatePipecatcallIDAndActiveflowID
 				m.util.EXPECT().UUIDCreate().Return(newPCC)
-				m.db.EXPECT().AIcallUpdate(ctx, existingAIcallID, map[aicall.Field]any{
+				m.db.EXPECT().AIcallUpdateIfActive(ctx, existingAIcallID, map[aicall.Field]any{
 					aicall.FieldPipecatcallID: newPCC,
 					aicall.FieldActiveflowID:  uuid.FromStringOrNil("d15ae476-30dd-11f0-87af-67d3c47111a7"),
-				}).Return(nil)
+				}).Return(int64(1), nil)
 				m.db.EXPECT().AIcallGet(ctx, existingAIcallID).Return(existing, nil)
 
 				// resolveTeamMemberForSend: refresh AIEngineModel from current member's AI.
@@ -3573,6 +3573,272 @@ func Test_buildPromptSnapshots_autoAudit(t *testing.T) {
 			_, gotAudit := h.buildPromptSnapshots(ctx, tt.a, tt.assistanceType, tt.assistanceID, uuid.Nil)
 			if gotAudit != tt.expectAudit {
 				t.Errorf("wrong auto audit flag. expect: %v, got: %v", tt.expectAudit, gotAudit)
+			}
+		})
+	}
+}
+
+func Test_startReferenceTypeContactCase(t *testing.T) {
+
+	type mocks struct {
+		util    *utilhandler.MockUtilHandler
+		req     *requesthandler.MockRequestHandler
+		notify  *notifyhandler.MockNotifyHandler
+		db      *dbhandler.MockDBHandler
+		message *messagehandler.MockMessageHandler
+	}
+
+	tests := []struct {
+		name string
+
+		ai             *ai.AI
+		assistanceType aicall.AssistanceType
+		assistanceID   uuid.UUID
+		activeflowID   uuid.UUID
+		referenceID    uuid.UUID
+
+		mockSetup func(ctx context.Context, m *mocks)
+
+		expectRes *aicall.AIcall
+		expectErr bool
+	}{
+		{
+			name: "create succeeds on first attempt",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("10000000-0001-11f0-aaaa-000000000001"),
+					CustomerID: uuid.FromStringOrNil("10000000-0002-11f0-aaaa-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("10000000-0001-11f0-aaaa-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("10000000-0003-11f0-aaaa-000000000001"),
+			referenceID:    uuid.FromStringOrNil("10000000-0004-11f0-aaaa-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID := uuid.FromStringOrNil("10000000-0005-11f0-aaaa-000000000001")
+				aicallID := uuid.FromStringOrNil("10000000-0006-11f0-aaaa-000000000001")
+				created := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         aicallID,
+						CustomerID: uuid.FromStringOrNil("10000000-0002-11f0-aaaa-000000000001"),
+					},
+					ActiveflowID:  uuid.FromStringOrNil("10000000-0003-11f0-aaaa-000000000001"),
+					ReferenceType: aicall.ReferenceTypeContactCase,
+					ReferenceID:   uuid.FromStringOrNil("10000000-0004-11f0-aaaa-000000000001"),
+					Status:        aicall.StatusInitiating,
+				}
+
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID)
+				m.util.EXPECT().UUIDCreate().Return(aicallID)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(nil)
+				m.db.EXPECT().AIcallGet(ctx, aicallID).Return(created, nil)
+				m.notify.EXPECT().PublishWebhookEvent(ctx, created.CustomerID, aicall.EventTypeStatusInitializing, created)
+				m.req.EXPECT().FlowV1VariableSetVariable(ctx, gomock.Any(), gomock.Any()).Return(nil)
+				m.message.EXPECT().Create(ctx, uuid.Nil, created.CustomerID, created.ID, created.ActiveflowID, message.DirectionOutgoing, message.RoleSystem, gomock.Any(), nil, "", gomock.Any()).Return(&message.Message{}, nil)
+			},
+
+			expectRes: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("10000000-0006-11f0-aaaa-000000000001"),
+					CustomerID: uuid.FromStringOrNil("10000000-0002-11f0-aaaa-000000000001"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("10000000-0003-11f0-aaaa-000000000001"),
+				ReferenceType: aicall.ReferenceTypeContactCase,
+				ReferenceID:   uuid.FromStringOrNil("10000000-0004-11f0-aaaa-000000000001"),
+				Status:        aicall.StatusInitiating,
+			},
+		},
+		{
+			name: "duplicate key — reuses existing active aicall",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("20000000-0001-11f0-bbbb-000000000001"),
+					CustomerID: uuid.FromStringOrNil("20000000-0002-11f0-bbbb-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("20000000-0001-11f0-bbbb-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("20000000-0003-11f0-bbbb-000000000001"),
+			referenceID:    uuid.FromStringOrNil("20000000-0004-11f0-bbbb-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID := uuid.FromStringOrNil("20000000-0005-11f0-bbbb-000000000001")
+				aicallID := uuid.FromStringOrNil("20000000-0006-11f0-bbbb-000000000001")
+				existingActive := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("20000000-0007-11f0-bbbb-000000000001"),
+						CustomerID: uuid.FromStringOrNil("20000000-0002-11f0-bbbb-000000000001"),
+					},
+					ReferenceType: aicall.ReferenceTypeContactCase,
+					ReferenceID:   uuid.FromStringOrNil("20000000-0004-11f0-bbbb-000000000001"),
+					Status:        aicall.StatusProgressing,
+				}
+
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID)
+				m.util.EXPECT().UUIDCreate().Return(aicallID)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_aicall_active_reference_key'"))
+				m.db.EXPECT().AIcallGetByReferenceID(ctx, uuid.FromStringOrNil("20000000-0004-11f0-bbbb-000000000001")).Return(existingActive, nil)
+			},
+
+			expectRes: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("20000000-0007-11f0-bbbb-000000000001"),
+					CustomerID: uuid.FromStringOrNil("20000000-0002-11f0-bbbb-000000000001"),
+				},
+				ReferenceType: aicall.ReferenceTypeContactCase,
+				ReferenceID:   uuid.FromStringOrNil("20000000-0004-11f0-bbbb-000000000001"),
+				Status:        aicall.StatusProgressing,
+			},
+		},
+		{
+			name: "duplicate key — existing terminated, retry create succeeds",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("30000000-0001-11f0-cccc-000000000001"),
+					CustomerID: uuid.FromStringOrNil("30000000-0002-11f0-cccc-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("30000000-0001-11f0-cccc-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("30000000-0003-11f0-cccc-000000000001"),
+			referenceID:    uuid.FromStringOrNil("30000000-0004-11f0-cccc-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID1 := uuid.FromStringOrNil("30000000-0005-11f0-cccc-000000000001")
+				aicallID1 := uuid.FromStringOrNil("30000000-0006-11f0-cccc-000000000001")
+				pipecatcallID2 := uuid.FromStringOrNil("30000000-0007-11f0-cccc-000000000001")
+				aicallID2 := uuid.FromStringOrNil("30000000-0008-11f0-cccc-000000000001")
+
+				existingTerminated := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("30000000-0009-11f0-cccc-000000000001"),
+						CustomerID: uuid.FromStringOrNil("30000000-0002-11f0-cccc-000000000001"),
+					},
+					Status: aicall.StatusTerminated,
+				}
+				created := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         aicallID2,
+						CustomerID: uuid.FromStringOrNil("30000000-0002-11f0-cccc-000000000001"),
+					},
+					ActiveflowID:  uuid.FromStringOrNil("30000000-0003-11f0-cccc-000000000001"),
+					ReferenceType: aicall.ReferenceTypeContactCase,
+					ReferenceID:   uuid.FromStringOrNil("30000000-0004-11f0-cccc-000000000001"),
+					Status:        aicall.StatusInitiating,
+				}
+
+				// attempt 0: duplicate key, existing is terminated -> retry
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID1)
+				m.util.EXPECT().UUIDCreate().Return(aicallID1)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_aicall_active_reference_key'"))
+				m.db.EXPECT().AIcallGetByReferenceID(ctx, uuid.FromStringOrNil("30000000-0004-11f0-cccc-000000000001")).Return(existingTerminated, nil)
+
+				// attempt 1: create succeeds
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID2)
+				m.util.EXPECT().UUIDCreate().Return(aicallID2)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(nil)
+				m.db.EXPECT().AIcallGet(ctx, aicallID2).Return(created, nil)
+				m.notify.EXPECT().PublishWebhookEvent(ctx, created.CustomerID, aicall.EventTypeStatusInitializing, created)
+				m.req.EXPECT().FlowV1VariableSetVariable(ctx, gomock.Any(), gomock.Any()).Return(nil)
+				m.message.EXPECT().Create(ctx, uuid.Nil, created.CustomerID, created.ID, created.ActiveflowID, message.DirectionOutgoing, message.RoleSystem, gomock.Any(), nil, "", gomock.Any()).Return(&message.Message{}, nil)
+			},
+
+			expectRes: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("30000000-0008-11f0-cccc-000000000001"),
+					CustomerID: uuid.FromStringOrNil("30000000-0002-11f0-cccc-000000000001"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("30000000-0003-11f0-cccc-000000000001"),
+				ReferenceType: aicall.ReferenceTypeContactCase,
+				ReferenceID:   uuid.FromStringOrNil("30000000-0004-11f0-cccc-000000000001"),
+				Status:        aicall.StatusInitiating,
+			},
+		},
+		{
+			name: "duplicate key on every attempt — retries exhausted, returns error",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("40000000-0001-11f0-dddd-000000000001"),
+					CustomerID: uuid.FromStringOrNil("40000000-0002-11f0-dddd-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("40000000-0001-11f0-dddd-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("40000000-0003-11f0-dddd-000000000001"),
+			referenceID:    uuid.FromStringOrNil("40000000-0004-11f0-dddd-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				existingTerminated := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("40000000-0009-11f0-dddd-000000000001"),
+						CustomerID: uuid.FromStringOrNil("40000000-0002-11f0-dddd-000000000001"),
+					},
+					Status: aicall.StatusTerminated,
+				}
+
+				for i := 0; i < maxContactCaseCreateRetries; i++ {
+					pcc := uuid.Must(uuid.NewV4())
+					acID := uuid.Must(uuid.NewV4())
+					m.util.EXPECT().UUIDCreate().Return(pcc)
+					m.util.EXPECT().UUIDCreate().Return(acID)
+					m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_aicall_active_reference_key'"))
+					m.db.EXPECT().AIcallGetByReferenceID(ctx, uuid.FromStringOrNil("40000000-0004-11f0-dddd-000000000001")).Return(existingTerminated, nil)
+				}
+			},
+
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			m := &mocks{
+				util:    utilhandler.NewMockUtilHandler(mc),
+				req:     requesthandler.NewMockRequestHandler(mc),
+				notify:  notifyhandler.NewMockNotifyHandler(mc),
+				db:      dbhandler.NewMockDBHandler(mc),
+				message: messagehandler.NewMockMessageHandler(mc),
+			}
+
+			h := &aicallHandler{
+				utilHandler:    m.util,
+				reqHandler:     m.req,
+				notifyHandler:  m.notify,
+				db:             m.db,
+				messageHandler: m.message,
+			}
+			ctx := context.Background()
+
+			tt.mockSetup(ctx, m)
+
+			res, err := h.startReferenceTypeContactCase(ctx, tt.ai, tt.assistanceType, tt.assistanceID, tt.activeflowID, tt.referenceID, nil, uuid.Nil)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if res != nil {
+					t.Errorf("expected nil res on error, got: %v", res)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/dbhandler/aicall.go
+++ b/bin-ai-manager/pkg/dbhandler/aicall.go
@@ -262,3 +262,48 @@ func (h *handler) AIcallUpdate(ctx context.Context, id uuid.UUID, fields map[aic
 
 	return nil
 }
+
+// AIcallUpdateIfActive updates the aicall fields only when the row's status is NOT
+// 'terminated'/'terminating' (i.e. the AIcall is still active). This guards against a
+// TOCTOU race in reuse paths (e.g. UpdatePipecatcallIDAndActiveflowID in aicallhandler)
+// where the caller read an AIcall as active, but it terminated before the write landed.
+// Returns rowsAffected: 0 means the row no longer matched the active-status condition
+// (or does not exist) and the caller must NOT assume the update took effect.
+func (h *handler) AIcallUpdateIfActive(ctx context.Context, id uuid.UUID, fields map[aicall.Field]any) (int64, error) {
+	updateFields := make(map[string]any)
+	for k, v := range fields {
+		updateFields[string(k)] = v
+	}
+	updateFields["tm_update"] = h.utilHandler.TimeNow()
+
+	preparedFields, err := commondatabasehandler.PrepareFields(updateFields)
+	if err != nil {
+		return 0, fmt.Errorf("AIcallUpdateIfActive: could not prepare fields. err: %v", err)
+	}
+
+	query, args, err := sq.Update(aicallTable).
+		SetMap(preparedFields).
+		Where(sq.Eq{"id": id.Bytes()}).
+		Where(sq.NotEq{"status": []string{string(aicall.StatusTerminated), string(aicall.StatusTerminating)}}).
+		ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("AIcallUpdateIfActive: could not build query. err: %v", err)
+	}
+
+	res, err := h.db.Exec(query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("AIcallUpdateIfActive: could not execute. err: %v", err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("AIcallUpdateIfActive: could not get rows affected. err: %v", err)
+	}
+
+	if n > 0 {
+		// update the cache
+		_ = h.aicallUpdateToCache(ctx, id)
+	}
+
+	return n, nil
+}

--- a/bin-ai-manager/pkg/dbhandler/aicall_test.go
+++ b/bin-ai-manager/pkg/dbhandler/aicall_test.go
@@ -94,6 +94,7 @@ func Test_AIcallCreate(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("e2fa5772-a5e1-11ed-94a9-f72c152d4780"),
 				},
+				ReferenceID: uuid.FromStringOrNil("e2fa5772-a5e1-11ed-94a9-f72c152d4780"),
 			},
 
 			curTime,
@@ -101,7 +102,8 @@ func Test_AIcallCreate(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("e2fa5772-a5e1-11ed-94a9-f72c152d4780"),
 				},
-				Parameter: nil,
+				Parameter:   nil,
+				ReferenceID: uuid.FromStringOrNil("e2fa5772-a5e1-11ed-94a9-f72c152d4780"),
 				TMEnd:        nil,
 				TMCreate:     curTime,
 				TMUpdate:     nil,
@@ -245,6 +247,7 @@ func Test_AIcallUpdate(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("f6c9d56a-afbc-11f0-bb5f-1b20049b3cfb"),
 				},
+				ReferenceID:   uuid.FromStringOrNil("f6c9d56a-afbc-11f0-bb5f-1b20049b3cfb"),
 				PipecatcallID: uuid.FromStringOrNil("f6ee5c0a-afbc-11f0-8049-c7a79d2e4fe8"),
 			},
 
@@ -258,7 +261,8 @@ func Test_AIcallUpdate(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("f6c9d56a-afbc-11f0-bb5f-1b20049b3cfb"),
 				},
-				Parameter:  nil,
+				Parameter:     nil,
+				ReferenceID:   uuid.FromStringOrNil("f6c9d56a-afbc-11f0-bb5f-1b20049b3cfb"),
 				PipecatcallID: uuid.FromStringOrNil("f720a0d4-afbc-11f0-954f-6ff64a2d4520"),
 				TMEnd:         nil,
 				TMCreate:      curTime,
@@ -272,6 +276,7 @@ func Test_AIcallUpdate(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("f7c0bf02-b083-11f0-99e0-ffcbb19dc61e"),
 				},
+				ReferenceID: uuid.FromStringOrNil("f7c0bf02-b083-11f0-99e0-ffcbb19dc61e"),
 			},
 
 			id: uuid.FromStringOrNil("f7c0bf02-b083-11f0-99e0-ffcbb19dc61e"),
@@ -284,12 +289,13 @@ func Test_AIcallUpdate(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("f7c0bf02-b083-11f0-99e0-ffcbb19dc61e"),
 				},
-				Parameter: nil,
-				Status:       aicall.StatusProgressing,
-				TMEnd:        nil,
-				TMCreate:     curTime,
-				TMUpdate:     curTime,
-				TMDelete:     nil,
+				Parameter:   nil,
+				ReferenceID: uuid.FromStringOrNil("f7c0bf02-b083-11f0-99e0-ffcbb19dc61e"),
+				Status:      aicall.StatusProgressing,
+				TMEnd:       nil,
+				TMCreate:    curTime,
+				TMUpdate:    curTime,
+				TMDelete:    nil,
 			},
 		},
 	}
@@ -355,6 +361,7 @@ func Test_AIcallDelete(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("78f9a8fc-a5e4-11ed-95aa-133c8380df73"),
 				},
+				ReferenceID: uuid.FromStringOrNil("78f9a8fc-a5e4-11ed-95aa-133c8380df73"),
 			},
 
 			id: uuid.FromStringOrNil("78f9a8fc-a5e4-11ed-95aa-133c8380df73"),
@@ -364,7 +371,8 @@ func Test_AIcallDelete(t *testing.T) {
 				Identity: identity.Identity{
 					ID: uuid.FromStringOrNil("78f9a8fc-a5e4-11ed-95aa-133c8380df73"),
 				},
-				Parameter: nil,
+				Parameter:   nil,
+				ReferenceID: uuid.FromStringOrNil("78f9a8fc-a5e4-11ed-95aa-133c8380df73"),
 				TMEnd:        nil,
 				TMCreate:     curTime,
 				TMUpdate:     curTime,
@@ -415,6 +423,152 @@ func Test_AIcallDelete(t *testing.T) {
 	}
 }
 
+func Test_AIcallUpdateIfActive(t *testing.T) {
+
+	curTime := func() *time.Time { t := time.Date(2023, 1, 3, 21, 35, 2, 809000000, time.UTC); return &t }()
+
+	tests := []struct {
+		name string
+		ai   *aicall.AIcall
+
+		id     uuid.UUID
+		fields map[aicall.Field]any
+
+		responseCurTime *time.Time
+
+		expectRowsAffected int64
+	}{
+		{
+			name: "active aicall — update succeeds",
+			ai: &aicall.AIcall{
+				Identity: identity.Identity{
+					ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111"),
+				},
+				Status: aicall.StatusProgressing,
+			},
+
+			id: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111"),
+			fields: map[aicall.Field]any{
+				aicall.FieldPipecatcallID: uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222"),
+			},
+
+			responseCurTime:    curTime,
+			expectRowsAffected: 1,
+		},
+		{
+			name: "terminated aicall — update is a no-op",
+			ai: &aicall.AIcall{
+				Identity: identity.Identity{
+					ID: uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333"),
+				},
+				Status: aicall.StatusTerminated,
+			},
+
+			id: uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333"),
+			fields: map[aicall.Field]any{
+				aicall.FieldPipecatcallID: uuid.FromStringOrNil("44444444-4444-4444-4444-444444444444"),
+			},
+
+			responseCurTime:    curTime,
+			expectRowsAffected: 0,
+		},
+		{
+			name: "terminating aicall — update is a no-op",
+			ai: &aicall.AIcall{
+				Identity: identity.Identity{
+					ID: uuid.FromStringOrNil("55555555-5555-5555-5555-555555555555"),
+				},
+				Status: aicall.StatusTerminating,
+			},
+
+			id: uuid.FromStringOrNil("55555555-5555-5555-5555-555555555555"),
+			fields: map[aicall.Field]any{
+				aicall.FieldPipecatcallID: uuid.FromStringOrNil("66666666-6666-6666-6666-666666666666"),
+			},
+
+			responseCurTime:    curTime,
+			expectRowsAffected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+
+			ctx := context.Background()
+
+			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+			mockCache.EXPECT().AIcallSet(ctx, gomock.Any())
+			if err := h.AIcallCreate(ctx, tt.ai); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
+			if tt.expectRowsAffected > 0 {
+				mockCache.EXPECT().AIcallSet(ctx, gomock.Any())
+			}
+			rowsAffected, err := h.AIcallUpdateIfActive(ctx, tt.id, tt.fields)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if rowsAffected != tt.expectRowsAffected {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectRowsAffected, rowsAffected)
+			}
+		})
+	}
+}
+
+func Test_IsErrDuplicate(t *testing.T) {
+
+	tests := []struct {
+		name string
+		err  error
+
+		expectRes bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			expectRes: false,
+		},
+		{
+			name:      "mysql duplicate entry error",
+			err:       fmt.Errorf("Error 1062: Duplicate entry 'abc' for key 'uq_aicall_active_reference_key'"),
+			expectRes: true,
+		},
+		{
+			name:      "sqlite unique constraint error",
+			err:       fmt.Errorf("UNIQUE constraint failed: ai_aicalls.active_reference_key"),
+			expectRes: true,
+		},
+		{
+			name:      "unrelated error",
+			err:       fmt.Errorf("connection refused"),
+			expectRes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := IsErrDuplicate(tt.err)
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %v, got: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
 func Test_AIcallList(t *testing.T) {
 
 	curTime := func() *time.Time { t := time.Date(2023, 1, 3, 21, 35, 2, 809000000, time.UTC); return &t }()
@@ -437,12 +591,14 @@ func Test_AIcallList(t *testing.T) {
 						ID:         uuid.FromStringOrNil("6d060150-a76d-11ed-9e96-fb09644b04ca"),
 						CustomerID: uuid.FromStringOrNil("6d35368c-a76d-11ed-9699-235c9e4a0117"),
 					},
+					ReferenceID: uuid.FromStringOrNil("6d060150-a76d-11ed-9e96-fb09644b04ca"),
 				},
 				{
 					Identity: identity.Identity{
 						ID:         uuid.FromStringOrNil("ad76ec88-94c9-11ed-9651-df2f9c2178aa"),
 						CustomerID: uuid.FromStringOrNil("6d35368c-a76d-11ed-9699-235c9e4a0117"),
 					},
+					ReferenceID: uuid.FromStringOrNil("ad76ec88-94c9-11ed-9651-df2f9c2178aa"),
 				},
 			},
 
@@ -459,7 +615,8 @@ func Test_AIcallList(t *testing.T) {
 						ID:         uuid.FromStringOrNil("6d060150-a76d-11ed-9e96-fb09644b04ca"),
 						CustomerID: uuid.FromStringOrNil("6d35368c-a76d-11ed-9699-235c9e4a0117"),
 					},
-					Parameter: nil,
+					Parameter:   nil,
+					ReferenceID: uuid.FromStringOrNil("6d060150-a76d-11ed-9e96-fb09644b04ca"),
 					TMEnd:        nil,
 					TMCreate:     curTime,
 					TMUpdate:     nil,
@@ -470,7 +627,8 @@ func Test_AIcallList(t *testing.T) {
 						ID:         uuid.FromStringOrNil("ad76ec88-94c9-11ed-9651-df2f9c2178aa"),
 						CustomerID: uuid.FromStringOrNil("6d35368c-a76d-11ed-9699-235c9e4a0117"),
 					},
-					Parameter: nil,
+					Parameter:   nil,
+					ReferenceID: uuid.FromStringOrNil("ad76ec88-94c9-11ed-9651-df2f9c2178aa"),
 					TMEnd:        nil,
 					TMCreate:     curTime,
 					TMUpdate:     nil,

--- a/bin-ai-manager/pkg/dbhandler/main.go
+++ b/bin-ai-manager/pkg/dbhandler/main.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
@@ -42,6 +43,7 @@ type DBHandler interface {
 	AIcallGetByReferenceID(ctx context.Context, referenceID uuid.UUID) (*aicall.AIcall, error)
 	AIcallList(ctx context.Context, size uint64, token string, filters map[aicall.Field]any) ([]*aicall.AIcall, error)
 	AIcallUpdate(ctx context.Context, id uuid.UUID, fields map[aicall.Field]any) error
+	AIcallUpdateIfActive(ctx context.Context, id uuid.UUID, fields map[aicall.Field]any) (rowsAffected int64, err error)
 
 	MessageCreate(ctx context.Context, c *message.Message) error
 	MessageGet(ctx context.Context, id uuid.UUID) (*message.Message, error)
@@ -97,6 +99,20 @@ type handler struct {
 var (
 	ErrNotFound = errors.New("record not found")
 )
+
+// IsErrDuplicate reports whether err represents a duplicate-key/unique-constraint
+// violation. MySQL reports this as error 1062 ("Duplicate entry"); the test suite's
+// SQLite driver reports "UNIQUE constraint failed". Mirrors the ad-hoc check already
+// used in ParticipantCreate (participant.go), centralized here so other dbhandler
+// functions (e.g. AIcallCreate callers) can classify the error consistently.
+func IsErrDuplicate(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+	return strings.Contains(errStr, "Duplicate entry") || strings.Contains(errStr, "UNIQUE constraint failed")
+}
 
 
 // NewHandler creates DBHandler

--- a/bin-ai-manager/pkg/dbhandler/mock_main.go
+++ b/bin-ai-manager/pkg/dbhandler/mock_main.go
@@ -475,6 +475,21 @@ func (mr *MockDBHandlerMockRecorder) AIcallUpdate(ctx, id, fields any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallUpdate", reflect.TypeOf((*MockDBHandler)(nil).AIcallUpdate), ctx, id, fields)
 }
 
+// AIcallUpdateIfActive mocks base method.
+func (m *MockDBHandler) AIcallUpdateIfActive(ctx context.Context, id uuid.UUID, fields map[aicall.Field]any) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AIcallUpdateIfActive", ctx, id, fields)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AIcallUpdateIfActive indicates an expected call of AIcallUpdateIfActive.
+func (mr *MockDBHandlerMockRecorder) AIcallUpdateIfActive(ctx, id, fields any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AIcallUpdateIfActive", reflect.TypeOf((*MockDBHandler)(nil).AIcallUpdateIfActive), ctx, id, fields)
+}
+
 // MessageAssistantReplyExists mocks base method.
 func (m *MockDBHandler) MessageAssistantReplyExists(ctx context.Context, pipecatcallID uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()

--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_aicalls.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_aicalls.sql
@@ -34,8 +34,23 @@ create table ai_aicalls(
   tm_update datetime(6),  --
   tm_delete datetime(6),  --
 
+  -- SQLite-compatible stand-in for the MySQL STORED generated column
+  -- active_reference_key (BINARY(32) SHA2(...) hash, see
+  -- bin-dbscheme-manager a5a40c93d3e6). This concat-based generated column
+  -- preserves the same invariant (unique per active (customer_id,
+  -- reference_type, reference_id), terminated/terminating rows excluded)
+  -- at test-data scale without needing a SHA2 equivalent in SQLite.
+  active_reference_key varchar(255) GENERATED ALWAYS AS (
+    CASE WHEN status NOT IN ('terminated', 'terminating')
+      THEN customer_id || '|' || reference_type || '|' || reference_id
+      ELSE NULL
+    END
+  ) STORED,
+
   primary key(id)
 );
+
+create unique index uq_aicall_active_reference_key on ai_aicalls(active_reference_key);
 
 create index idx_ai_aicalls_customer_id on ai_aicalls(customer_id);
 create index idx_ai_aicalls_assistance_type on ai_aicalls(assistance_type);

--- a/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
@@ -1,0 +1,63 @@
+"""ai_aicalls_add_active_reference_key_unique
+
+Revision ID: a5a40c93d3e6
+Revises: 573756d87322
+Create Date: 2026-07-09 10:24:01.420747
+
+Adds active_reference_key to ai_aicalls (VOIP-1234 subtask 1) to enforce
+"at most one active AIcall per (customer, reference_type, reference_id)"
+at the DB level via a STORED generated column, mirroring the
+contact_cases.open_peer_uk pattern (f718e26f2c44).
+
+active_reference_key carries a value only when status is NOT
+'terminated'/'terminating'; terminated/terminating rows compute NULL,
+which MySQL treats as distinct under UNIQUE, so any number of
+terminated rows for the same (customer_id, reference_type,
+reference_id) may coexist while at most one active row may exist.
+SHA2(..., 256) (not a raw CONCAT) avoids silent truncation of an
+oversized concatenation into a fixed-size BINARY column, which could
+create false-positive uniqueness collisions between genuinely
+different tuples.
+
+A real-world spike (20 concurrent INSERTs against a MySQL 8.0
+container) confirmed the optimistic-INSERT + DB-level unique index
+combination alone is sufficient here (1 success / 19 duplicate-key
+1062 / 0 deadlocks) -- unlike contact_cases, no SELECT...FOR UPDATE
+pre-check or in-process keyed lock is needed for the create path.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a5a40c93d3e6'
+down_revision = '573756d87322'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE ai_aicalls
+        ADD COLUMN active_reference_key BINARY(32) GENERATED ALWAYS AS (
+            IF(status NOT IN ('terminated', 'terminating'),
+               UNHEX(SHA2(CONCAT_WS('|', customer_id, reference_type, reference_id), 256)),
+               NULL)
+        ) STORED
+    """)
+
+    op.execute("""
+        CREATE UNIQUE INDEX uq_aicall_active_reference_key
+        ON ai_aicalls(active_reference_key)
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DROP INDEX uq_aicall_active_reference_key ON ai_aicalls
+    """)
+
+    op.execute("""
+        ALTER TABLE ai_aicalls
+        DROP COLUMN active_reference_key
+    """)


### PR DESCRIPTION
Adds the concurrency guard for AIcall reuse/creation so multiple concurrent requests against the same (customer_id, reference_type, reference_id) cannot create duplicate active AIcalls, using an optimistic-INSERT plus DB-level conditional uniqueness instead of the heavier lock/retry pattern used elsewhere in the monorepo. Verified with a standalone concurrency spike against a live MySQL 8.0 instance before implementation (documented in JIRA VOIP-1234).

- bin-ai-manager: Adds ReferenceTypeContactCase to AIcall, enabling the reference_type to be used going forward
- bin-ai-manager: Adds active_reference_key generated column + UNIQUE index enforcement at the DB level, matching bin-contact-manager's proven open_peer_uk pattern (at most one active AIcall per customer_id/reference_type/reference_id)
- bin-ai-manager: Adds dbhandler.AIcallUpdateIfActive, a conditional UPDATE (status NOT IN terminated/terminating) returning rows-affected, used by the reuse path to avoid a TOCTOU race with concurrent termination
- bin-ai-manager: Adds aicallHandler.UpdatePipecatcallIDAndActiveflowID atomically updating pipecatcall_id+activeflow_id via AIcallUpdateIfActive and returning ErrAIcallNoLongerActive on a lost race (rows_affected == 0)
- bin-ai-manager: Adds startReferenceTypeContactCase with an optimistic-INSERT + duplicate-key(1062) reconcile/retry loop bounded by maxContactCaseCreateRetries, reusing an active existing AIcall or retrying creation if the conflicting row has since terminated; wired into Start() via the ReferenceTypeContactCase case
- bin-ai-manager: Rewires the conversation reuse branch in startReferenceTypeConversation to call UpdatePipecatcallIDAndActiveflowID instead of an unconditional AIcallUpdate
- bin-ai-manager: Adds table_ai_aicalls.sql active_reference_key column/index to the sqlite test schema for aicallhandler/dbhandler unit tests
- bin-ai-manager: Adds unit test coverage for AIcallUpdateIfActive, UpdatePipecatcallIDAndActiveflowID (success, ErrAIcallNoLongerActive), and startReferenceTypeContactCase (create success, reuse active, reuse-terminated retry, retries-exhausted with error content assertions, non-1062 error immediate return)
- bin-dbscheme-manager: Adds Alembic migration a5a40c93d3e6 creating the active_reference_key generated column and UNIQUE index on ai_aicalls, verified with an upgrade/downgrade round-trip against a live MySQL 8.0 instance
