### PR TITLE
VOIP-1234-fix-migration

### DIFF
--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_aicalls.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_aicalls.sql
@@ -38,10 +38,12 @@ create table ai_aicalls(
   -- active_reference_key (BINARY(32) SHA2(...) hash, see
   -- bin-dbscheme-manager a5a40c93d3e6). This concat-based generated column
   -- preserves the same invariant (unique per active (customer_id,
-  -- reference_type, reference_id), terminated/terminating rows excluded)
-  -- at test-data scale without needing a SHA2 equivalent in SQLite.
+  -- reference_type, reference_id), terminated/terminating rows AND legacy
+  -- rows with a zero-value reference_id excluded) at test-data scale
+  -- without needing a SHA2 equivalent in SQLite.
   active_reference_key varchar(255) GENERATED ALWAYS AS (
     CASE WHEN status NOT IN ('terminated', 'terminating')
+      AND reference_id != X'00000000000000000000000000000000'
       THEN customer_id || '|' || reference_type || '|' || reference_id
       ELSE NULL
     END

--- a/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
@@ -37,6 +37,19 @@ data backfill/cleanup as a precondition, and does not weaken the
 invariant we actually want to enforce (uniqueness of a *real*
 reference).
 
+Because that first upgrade attempt failed partway through -- MySQL DDL
+statements commit individually and are not rolled back by a failed
+statement later in the same op.execute() sequence -- ADD COLUMN
+active_reference_key had already succeeded in production before
+CREATE UNIQUE INDEX failed with 1062. A naive retry of the original
+unconditional upgrade() would hit "Duplicate column name" (1060) on
+the ADD COLUMN this time instead. upgrade()/downgrade() now guard each
+statement with information_schema existence checks (the same
+_index_exists()-style pattern already established by
+h2b3c4d5e6f7_billing_billings_idempotency_key_unique.py) so the
+migration is idempotent and safe to retry from this partially-applied
+state, or from a clean state, or after a downgrade.
+
 A real-world spike (20 concurrent INSERTs against a MySQL 8.0
 container) confirmed the optimistic-INSERT + DB-level unique index
 combination alone is sufficient here (1 success / 19 duplicate-key
@@ -54,29 +67,53 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    op.execute("""
-        ALTER TABLE ai_aicalls
-        ADD COLUMN active_reference_key BINARY(32) GENERATED ALWAYS AS (
-            IF(status NOT IN ('terminated', 'terminating')
-               AND reference_id != UNHEX('00000000000000000000000000000000'),
-               UNHEX(SHA2(CONCAT_WS('|', customer_id, reference_type, reference_id), 256)),
-               NULL)
-        ) STORED
-    """)
+def _column_exists(conn, table, column):
+    result = conn.execute(sa.text(
+        "SELECT COUNT(*) FROM information_schema.columns "
+        "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :col"
+    ), {'table': table, 'col': column})
+    return result.scalar() > 0
 
-    op.execute("""
-        CREATE UNIQUE INDEX uq_aicall_active_reference_key
-        ON ai_aicalls(active_reference_key)
-    """)
+
+def _index_exists(conn, table, index):
+    result = conn.execute(sa.text(
+        "SELECT COUNT(*) FROM information_schema.statistics "
+        "WHERE table_schema = DATABASE() AND table_name = :table AND index_name = :idx"
+    ), {'table': table, 'idx': index})
+    return result.scalar() > 0
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _column_exists(conn, 'ai_aicalls', 'active_reference_key'):
+        op.execute("""
+            ALTER TABLE ai_aicalls
+            ADD COLUMN active_reference_key BINARY(32) GENERATED ALWAYS AS (
+                IF(status NOT IN ('terminated', 'terminating')
+                   AND reference_id != UNHEX('00000000000000000000000000000000'),
+                   UNHEX(SHA2(CONCAT_WS('|', customer_id, reference_type, reference_id), 256)),
+                   NULL)
+            ) STORED
+        """)
+
+    if not _index_exists(conn, 'ai_aicalls', 'uq_aicall_active_reference_key'):
+        op.execute("""
+            CREATE UNIQUE INDEX uq_aicall_active_reference_key
+            ON ai_aicalls(active_reference_key)
+        """)
 
 
 def downgrade():
-    op.execute("""
-        DROP INDEX uq_aicall_active_reference_key ON ai_aicalls
-    """)
+    conn = op.get_bind()
 
-    op.execute("""
-        ALTER TABLE ai_aicalls
-        DROP COLUMN active_reference_key
-    """)
+    if _index_exists(conn, 'ai_aicalls', 'uq_aicall_active_reference_key'):
+        op.execute("""
+            DROP INDEX uq_aicall_active_reference_key ON ai_aicalls
+        """)
+
+    if _column_exists(conn, 'ai_aicalls', 'active_reference_key'):
+        op.execute("""
+            ALTER TABLE ai_aicalls
+            DROP COLUMN active_reference_key
+        """)

--- a/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
@@ -10,14 +10,32 @@ at the DB level via a STORED generated column, mirroring the
 contact_cases.open_peer_uk pattern (f718e26f2c44).
 
 active_reference_key carries a value only when status is NOT
-'terminated'/'terminating'; terminated/terminating rows compute NULL,
-which MySQL treats as distinct under UNIQUE, so any number of
-terminated rows for the same (customer_id, reference_type,
-reference_id) may coexist while at most one active row may exist.
+'terminated'/'terminating' AND reference_id is a real (non-zero) UUID;
+terminated/terminating rows AND legacy rows with a zero-value
+reference_id (uuid.UUID{} in Go, produced by older code paths that
+never set a reference) all compute NULL, which MySQL treats as
+distinct under UNIQUE, so any number of such rows for the same
+(customer_id, reference_type, reference_id) may coexist while at most
+one genuinely-active, genuinely-referenced row may exist.
 SHA2(..., 256) (not a raw CONCAT) avoids silent truncation of an
 oversized concatenation into a fixed-size BINARY column, which could
 create false-positive uniqueness collisions between genuinely
 different tuples.
+
+The zero-UUID exclusion was added after the first upgrade attempt
+against the production ai_aicalls table failed with a 1062 on
+CREATE UNIQUE INDEX: 200+ pre-existing rows share
+customer_id + reference_type='' + reference_id=0x00..00 (legacy
+AIcalls created without a reference, some stuck in 'progressing'/
+'initiating' for over a year -- a separate stale-cleanup issue,
+tracked outside this migration). Those rows are not "the same active
+AIcall re-created" in any meaningful sense; they are unrelated rows
+that happen to share the degenerate all-zero key. Excluding
+reference_id = 0x00..00 from the generated column (in addition to the
+status check) makes the migration apply cleanly without needing any
+data backfill/cleanup as a precondition, and does not weaken the
+invariant we actually want to enforce (uniqueness of a *real*
+reference).
 
 A real-world spike (20 concurrent INSERTs against a MySQL 8.0
 container) confirmed the optimistic-INSERT + DB-level unique index
@@ -40,7 +58,8 @@ def upgrade():
     op.execute("""
         ALTER TABLE ai_aicalls
         ADD COLUMN active_reference_key BINARY(32) GENERATED ALWAYS AS (
-            IF(status NOT IN ('terminated', 'terminating'),
+            IF(status NOT IN ('terminated', 'terminating')
+               AND reference_id != UNHEX('00000000000000000000000000000000'),
                UNHEX(SHA2(CONCAT_WS('|', customer_id, reference_type, reference_id), 256)),
                NULL)
         ) STORED


### PR DESCRIPTION
Fixes the ai_aicalls active_reference_key migration (a5a40c93d3e6, VOIP-1234-ai-insight, PR #1065) which failed when applied against the production database: 200+ pre-existing legacy rows share customer_id + reference_type='' + reference_id=zero-UUID, colliding on the new unique index, and MySQL DDL's per-statement commit left the ADD COLUMN half already applied while CREATE UNIQUE INDEX failed. Both issues are fixed and verified with real reproductions against a live MySQL 8.0 instance (production collision pattern, partial-apply retry, downgrade).

- bin-dbscheme-manager: Excludes zero-value reference_id from the active_reference_key generated column, so legacy rows with no real reference no longer collide with each other under the new unique index (genuine duplicate active AIcalls for a real reference_id are still rejected)
- bin-dbscheme-manager: Guards ai_aicalls active_reference_key column/index creation in upgrade() and their removal in downgrade() with information_schema existence checks (same pattern as h2b3c4d5e6f7_billing_billings_idempotency_key_unique.py), making the migration idempotent and safe to retry from a clean state, a partially-applied state, or a fully-applied state
- bin-ai-manager: Mirrors the zero-reference_id exclusion in the sqlite test schema stand-in (table_ai_aicalls.sql)
