### PR TITLE
VOIP-1234-fix-migration-backfill

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py
@@ -50,6 +50,29 @@ h2b3c4d5e6f7_billing_billings_idempotency_key_unique.py) so the
 migration is idempotent and safe to retry from this partially-applied
 state, or from a clean state, or after a downgrade.
 
+A second production retry (after the zero-UUID fix above) still hit a
+1062 on CREATE UNIQUE INDEX, this time with a real (non-zero, non-NULL)
+hash value. Direct inspection confirmed there is currently no *steady
+state* duplicate for any real (customer_id, reference_type,
+reference_id) tuple -- ai_aicalls is a live, actively-written table,
+and the CREATE UNIQUE INDEX scan can observe a transient window where
+two rows are concurrently "active" for the same real reference (the
+exact race this migration exists to prevent going forward) before one
+of them is naturally cleaned up (idle-expire, normal termination,
+etc.) moments later. Because DDL scan timing cannot be controlled and
+the table cannot be quiesced for this migration, the fix is a
+backfill step that runs immediately before CREATE UNIQUE INDEX: for
+every group of currently-active rows sharing a real (customer_id,
+reference_type, reference_id), keep only the most recently updated row
+active and mark the rest 'terminated'. This makes CREATE UNIQUE INDEX
+apply against a table with no coexisting active duplicates regardless
+of what transient state produced them, without guessing at or
+depending on the root cause of any individual duplicate. The backfill
+only runs while the index does not yet exist (i.e. only during the
+one-time transition to enforcing the constraint) since once the index
+exists the constraint itself prevents new active duplicates from
+accumulating.
+
 A real-world spike (20 concurrent INSERTs against a MySQL 8.0
 container) confirmed the optimistic-INSERT + DB-level unique index
 combination alone is sufficient here (1 success / 19 duplicate-key
@@ -98,6 +121,27 @@ def upgrade():
         """)
 
     if not _index_exists(conn, 'ai_aicalls', 'uq_aicall_active_reference_key'):
+        # One-time backfill: collapse any group of currently-active rows
+        # sharing a real reference down to a single active row (keep the
+        # most recently updated, terminate the rest) so the unique index
+        # below can be created cleanly regardless of how those active
+        # duplicates arose.
+        op.execute("""
+            UPDATE ai_aicalls a
+            JOIN (
+                SELECT id, ROW_NUMBER() OVER (
+                    PARTITION BY customer_id, reference_type, reference_id
+                    ORDER BY tm_update DESC, tm_create DESC, id DESC
+                ) AS rn
+                FROM ai_aicalls
+                WHERE status NOT IN ('terminated', 'terminating')
+                  AND reference_id != UNHEX('00000000000000000000000000000000')
+            ) ranked ON a.id = ranked.id AND ranked.rn > 1
+            SET a.status = 'terminated',
+                a.tm_end = COALESCE(a.tm_end, NOW(6)),
+                a.tm_update = NOW(6)
+        """)
+
         op.execute("""
             CREATE UNIQUE INDEX uq_aicall_active_reference_key
             ON ai_aicalls(active_reference_key)


### PR DESCRIPTION
Fixes a second production failure of the ai_aicalls active_reference_key migration (a5a40c93d3e6): after the prior zero-UUID exclusion (PR #1066), CREATE UNIQUE INDEX still hit 1062, this time with a real (non-zero) hash. Direct inspection found no steady-state duplicate for any real reference -- ai_aicalls is a live, actively-written table, so the index-creation scan can observe a transient window where two rows are concurrently active for the same real reference (the exact race this migration exists to prevent going forward) before one is naturally cleaned up moments later.

- bin-dbscheme-manager: Adds a one-time backfill step to the ai_aicalls migration, run immediately before CREATE UNIQUE INDEX (only while the index does not yet exist), that collapses any group of currently-active rows sharing a real (customer_id, reference_type, reference_id) down to a single active row -- keeps the most recently updated, marks the rest terminated (tm_end set via COALESCE, matching the existing UpdateStatus convention). Zero-reference rows and already-terminated/terminating rows are explicitly excluded and untouched.

Verified against a live MySQL 8.0 instance by reproducing real active duplicates (2-way and 3-way, sharing a real reference_id, differing tm_update) alongside zero-reference legacy rows and already-terminated rows in the same table: the backfill leaves exactly the most recently updated row active in every duplicate group, leaves all non-duplicate and zero-reference rows untouched, and CREATE UNIQUE INDEX then applies with no 1062. Re-running the backfill against an already-clean state is a no-op (idempotent).

Known operational trade-off (reviewed and accepted): this backfill runs as raw SQL and does not go through the application layer, so any row it flips to terminated does not get a terminated webhook, cache invalidation, or an explicit PipecatV1PipecatcallTerminate call. In the narrow window where the "losing" row was a genuine concurrent-creation race (both sides briefly had a real pipecat session), that session is not explicitly torn down by this migration -- it will still end on its own via the existing defaultAITaskTimeout delayed-termination mechanism, independent of this row's DB status. Recommended post-deploy follow-up (tracked separately, not blocking this PR): capture the list of rows flipped by the backfill from the migration run, and monitor pipecat-manager active session count vs ai-manager active aicall count for the following hour.
