### PR TITLE
VOIP-1234-contact-case-rate-limit

### DIFF
--- a/bin-ai-manager/internal/config/main.go
+++ b/bin-ai-manager/internal/config/main.go
@@ -32,6 +32,8 @@ type Config struct {
 
 	AIcallConversationIdleTimeoutHours int // Idle timeout (hours) after which a conversation-typed AIcall is treated as expired and a new one is created on the next inbound message.
 
+	AIcallContactCaseRecreateRateLimitMinutes int // Rate limit window (minutes) after a contact_case-typed AIcall terminates during which recreation for the same reference_id is blocked (VOIP-1234).
+
 	AnalysisDefaultModel    string // AnalysisDefaultModel is the default model for the generic analysis gateway.
 	AnalysisAllowedModels   string // AnalysisAllowedModels is a comma-separated allow-set of models the analysis gateway accepts.
 	AnalysisEngineBaseURL   string // AnalysisEngineBaseURL is the base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI).
@@ -65,6 +67,7 @@ func bindConfig(cmd *cobra.Command) error {
 	f.String("engine_key_chatgpt", "", "Engine key for chatgpt")
 	f.String("google_api_key", "", "Google API key for Gemini audit evaluation")
 	f.Int("aicall_conversation_idle_timeout_hours", 24, "Idle timeout (hours) for conversation-typed AIcalls before they expire")
+	f.Int("aicall_contact_case_recreate_rate_limit_minutes", 5, "Rate limit window (minutes) after a contact_case-typed AIcall terminates during which recreation for the same reference_id is blocked")
 	f.String("analysis_default_model", "gemini-2.5-flash", "Default model for the generic analysis gateway")
 	f.String("analysis_allowed_models", "gemini-2.5-flash,gemini-2.5-pro", "Comma-separated allow-set of models for the analysis gateway")
 	f.String("analysis_engine_base_url", "https://generativelanguage.googleapis.com/v1beta/openai/", "Base URL for the analysis gateway LLM engine (Gemini OpenAI-compat by default; clear to use OpenAI)")
@@ -83,7 +86,8 @@ func bindConfig(cmd *cobra.Command) error {
 		"engine_key_chatgpt":        "ENGINE_KEY_CHATGPT",
 		"google_api_key":            "GOOGLE_API_KEY",
 
-		"aicall_conversation_idle_timeout_hours": "AICALL_CONVERSATION_IDLE_TIMEOUT_HOURS",
+		"aicall_conversation_idle_timeout_hours":          "AICALL_CONVERSATION_IDLE_TIMEOUT_HOURS",
+		"aicall_contact_case_recreate_rate_limit_minutes": "AICALL_CONTACT_CASE_RECREATE_RATE_LIMIT_MINUTES",
 
 		"analysis_default_model":     "ANALYSIS_DEFAULT_MODEL",
 		"analysis_allowed_models":    "ANALYSIS_ALLOWED_MODELS",
@@ -128,6 +132,8 @@ func LoadGlobalConfig() {
 
 			AIcallConversationIdleTimeoutHours: viper.GetInt("aicall_conversation_idle_timeout_hours"),
 
+			AIcallContactCaseRecreateRateLimitMinutes: viper.GetInt("aicall_contact_case_recreate_rate_limit_minutes"),
+
 			AnalysisDefaultModel:    viper.GetString("analysis_default_model"),
 			AnalysisAllowedModels:   viper.GetString("analysis_allowed_models"),
 			AnalysisEngineBaseURL:   viper.GetString("analysis_engine_base_url"),
@@ -149,6 +155,14 @@ func initLog() {
 // USE ONLY FROM TESTS.
 func SetAIcallConversationIdleTimeoutHoursForTest(hours int) {
 	globalConfig.AIcallConversationIdleTimeoutHours = hours
+}
+
+// SetAIcallContactCaseRecreateRateLimitMinutesForTest overrides the contact_case
+// recreate rate limit window in the global config without going through the
+// Bootstrap+LoadGlobalConfig path.
+// USE ONLY FROM TESTS.
+func SetAIcallContactCaseRecreateRateLimitMinutesForTest(minutes int) {
+	globalConfig.AIcallContactCaseRecreateRateLimitMinutes = minutes
 }
 
 // InitPrometheus initializes Prometheus metrics server.

--- a/bin-ai-manager/pkg/aicallhandler/metrics_conversation.go
+++ b/bin-ai-manager/pkg/aicallhandler/metrics_conversation.go
@@ -18,10 +18,17 @@ var (
 		},
 		[]string{"result"},
 	)
+	promAIcallContactCaseRecreateRateLimitedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "aicall_contact_case_recreate_rate_limited_total",
+			Help:      "Total times a contact_case AIcall recreation was blocked by the post-terminate rate limit (VOIP-1234).",
+		},
+	)
 )
 
 func init() {
-	prometheus.MustRegister(promAIcallIdleExpiredTotal, promAIcallInterruptAttemptedTotal)
+	prometheus.MustRegister(promAIcallIdleExpiredTotal, promAIcallInterruptAttemptedTotal, promAIcallContactCaseRecreateRateLimitedTotal)
 }
 
 // Test parallelism note:

--- a/bin-ai-manager/pkg/aicallhandler/start.go
+++ b/bin-ai-manager/pkg/aicallhandler/start.go
@@ -3,7 +3,7 @@ package aicallhandler
 import (
 	"context"
 	"fmt"
-	"time"
+	"monorepo/bin-ai-manager/internal/config"
 	"monorepo/bin-ai-manager/models/ai"
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
@@ -13,6 +13,7 @@ import (
 	cmconfbridge "monorepo/bin-call-manager/models/confbridge"
 	cmcustomer "monorepo/bin-customer-manager/models/customer"
 	pmpipecatcall "monorepo/bin-pipecat-manager/models/pipecatcall"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -373,9 +374,24 @@ const maxContactCaseCreateRetries = 3
 //     reference_id.
 //     - If it is still active (not Terminated/Terminating), reuse it.
 //     - If it has since terminated, its active_reference_key is NULL (no longer
-//       occupying the unique slot), so retry the create — bounded by
-//       maxContactCaseCreateRetries.
+//     occupying the unique slot). Before retrying the create, a rate-limit
+//     guard is checked (see below) — if it trips, an error is returned
+//     immediately instead of retrying.
 //  4. Any other error propagates immediately.
+//
+// Recreate rate limit (VOIP-1234 design doc §2-1):
+// Unlike Call/Conversation references, a Contact Case has no natural upper
+// bound on lifetime — there is no "call ended" or "conversation closed" event
+// that stops new questions from arriving. An agent can repeatedly reopen a
+// closed Case and ask questions; each question after the existing AIcall has
+// idle-expired (or otherwise become Terminated/Terminating) would otherwise
+// trigger an unbounded sequence of AIcall recreations, and therefore unbounded
+// LLM spend. To bound this, once an existing AIcall for the reference_id is
+// observed to be Terminated/Terminating, recreation is blocked for
+// config.Get().AIcallContactCaseRecreateRateLimitMinutes minutes measured from
+// that AIcall's end time (TMEnd, falling back to TMUpdate when TMEnd is unset).
+// If neither timestamp is available there is no basis to compute an age, so
+// the guard fails open and the retry proceeds.
 func (h *aicallHandler) startReferenceTypeContactCase(
 	ctx context.Context,
 	a *ai.AI,
@@ -416,7 +432,12 @@ func (h *aicallHandler) startReferenceTypeContactCase(
 		if existing.Status == aicall.StatusTerminated || existing.Status == aicall.StatusTerminating {
 			// The row that won the race has since terminated (or was already
 			// terminating). Its active_reference_key computes to NULL, so it no
-			// longer occupies the unique slot — retry the create.
+			// longer occupies the unique slot — but before retrying the create,
+			// check the recreate rate limit (VOIP-1234 design doc §2-1).
+			if blocked, blockedErr := h.checkContactCaseRecreateRateLimit(referenceID, existing); blocked {
+				return nil, blockedErr
+			}
+
 			log.Infof("Existing AIcall for contact_case is terminated/terminating — retrying create. aicall_id: %s, attempt: %d", existing.ID, attempt+1)
 			lastErr = err
 			continue
@@ -427,6 +448,44 @@ func (h *aicallHandler) startReferenceTypeContactCase(
 	}
 
 	return nil, errors.Wrapf(lastErr, "could not create aicall for contact_case after %d retries. reference_id: %s", maxContactCaseCreateRetries, referenceID)
+}
+
+// checkContactCaseRecreateRateLimit implements the VOIP-1234 §2-1 recreate rate
+// limit for contact_case AIcalls. It returns (true, err) when recreation must be
+// blocked because the given terminated/terminating AIcall ended within the
+// configured rate-limit window; the returned err is ready to be surfaced to the
+// caller as-is. It returns (false, nil) when the retry may proceed — either
+// because the window has elapsed, or because neither TMEnd nor TMUpdate is set
+// on the existing AIcall (fail-open: no timestamp means no basis to block).
+func (h *aicallHandler) checkContactCaseRecreateRateLimit(referenceID uuid.UUID, existing *aicall.AIcall) (bool, error) {
+	terminatedAt := existing.TMEnd
+	if terminatedAt == nil {
+		terminatedAt = existing.TMUpdate
+	}
+	if terminatedAt == nil {
+		// No timestamp to reason about — fail open and allow the retry.
+		return false, nil
+	}
+
+	limitMinutes := config.Get().AIcallContactCaseRecreateRateLimitMinutes
+	elapsed := time.Since(*terminatedAt)
+	limitDuration := time.Duration(limitMinutes) * time.Minute
+	if elapsed >= limitDuration {
+		return false, nil
+	}
+
+	remaining := limitDuration - elapsed
+	remainingMinutes := int(remaining.Minutes())
+	if remaining%time.Minute != 0 {
+		remainingMinutes++
+	}
+
+	promAIcallContactCaseRecreateRateLimitedTotal.Inc()
+
+	return true, fmt.Errorf(
+		"rate limit exceeded: aicall for contact_case reference_id %s was terminated %s ago, recreate blocked for %d more minutes",
+		referenceID, elapsed.Round(time.Second), remainingMinutes,
+	)
 }
 
 // startReferenceTypeNone starts a new aicall with no reference

--- a/bin-ai-manager/pkg/aicallhandler/start_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/start_test.go
@@ -42,7 +42,6 @@ func Test_startReferenceTypeCall(t *testing.T) {
 		activeflowID   uuid.UUID
 		referenceID    uuid.UUID
 
-
 		responseConfbridge        *cmconfbridge.Confbridge
 		responseUUIDPipecatcallID uuid.UUID
 		responseUUIDAIcallID      uuid.UUID
@@ -80,7 +79,6 @@ func Test_startReferenceTypeCall(t *testing.T) {
 			activeflowID:   uuid.FromStringOrNil("a47265a2-f06d-11ef-8317-2bf92ae88a9d"),
 			referenceID:    uuid.FromStringOrNil("a4a663fc-f06d-11ef-aeb9-6b2d8f0da3ac"),
 
-
 			responseConfbridge: &cmconfbridge.Confbridge{
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("ec6d153d-dd5a-4eef-bc27-8fcebe100704"),
@@ -105,8 +103,8 @@ func Test_startReferenceTypeCall(t *testing.T) {
 				ConfbridgeID:   uuid.FromStringOrNil("ec6d153d-dd5a-4eef-bc27-8fcebe100704"),
 				PipecatcallID:  uuid.FromStringOrNil("a4e5c7ae-b539-11f0-ac68-c38f244d145b"),
 
-				STTLanguage:    "en-US",
-				Status:         aicall.StatusInitiating,
+				STTLanguage: "en-US",
+				Status:      aicall.StatusInitiating,
 			},
 			responseMessages: []*message.Message{
 				{
@@ -134,8 +132,8 @@ func Test_startReferenceTypeCall(t *testing.T) {
 				ConfbridgeID:   uuid.FromStringOrNil("ec6d153d-dd5a-4eef-bc27-8fcebe100704"),
 				PipecatcallID:  uuid.FromStringOrNil("a4e5c7ae-b539-11f0-ac68-c38f244d145b"),
 
-				STTLanguage:    "en-US",
-				Status:         aicall.StatusInitiating,
+				STTLanguage: "en-US",
+				Status:      aicall.StatusInitiating,
 			},
 			expectVariables: map[string]string{
 				variableID:            "a6cd01d0-d785-467f-9069-684e46cc2644",
@@ -174,8 +172,8 @@ func Test_startReferenceTypeCall(t *testing.T) {
 				ConfbridgeID:   uuid.FromStringOrNil("ec6d153d-dd5a-4eef-bc27-8fcebe100704"),
 				PipecatcallID:  uuid.FromStringOrNil("a4e5c7ae-b539-11f0-ac68-c38f244d145b"),
 
-				STTLanguage:    "en-US",
-				Status:         aicall.StatusInitiating,
+				STTLanguage: "en-US",
+				Status:      aicall.StatusInitiating,
 			},
 		},
 		{
@@ -374,7 +372,6 @@ func Test_startReferenceTypeNone(t *testing.T) {
 		assistanceType aicall.AssistanceType
 		assistanceID   uuid.UUID
 
-
 		responseUUIDPipecatcallID uuid.UUID
 		responseUUIDAIcallID      uuid.UUID
 		responseAIcall            *aicall.AIcall
@@ -395,7 +392,6 @@ func Test_startReferenceTypeNone(t *testing.T) {
 			},
 			assistanceType: aicall.AssistanceTypeAI,
 			assistanceID:   uuid.FromStringOrNil("1d758ff0-f06f-11ef-bcb1-1ff1f3691915"),
-
 
 			responseUUIDPipecatcallID: uuid.FromStringOrNil("78a31220-b465-11f0-a3f2-b77bb59ccdcd"),
 			responseUUIDAIcallID:      uuid.FromStringOrNil("1e1a95ea-f06f-11ef-b98e-cf0423a1e383"),
@@ -1147,20 +1143,20 @@ func Test_startReferenceTypeConversation(t *testing.T) {
 				// resolveTeamMemberForSend: refresh AIEngineModel from current member's AI.
 				// CurrentMemberID matches a team member, so no fallback / no UpdateCurrentMemberID call.
 				m.team.EXPECT().Get(ctx, teamID).Return(&team.Team{
-					Identity: commonidentity.Identity{ID: teamID},
+					Identity:      commonidentity.Identity{ID: teamID},
 					StartMemberID: uuid.FromStringOrNil("a7777777-0001-11f0-9999-999999999999"),
 					Members: []team.Member{
 						{ID: memberID, AIID: memberAIID},
 					},
 				}, nil)
 				m.ai.EXPECT().Get(ctx, memberAIID).Return(&ai.AI{
-					Identity: commonidentity.Identity{ID: memberAIID},
+					Identity:    commonidentity.Identity{ID: memberAIID},
 					EngineModel: "grok.grok-3", // resolved engine model overrides the stale snapshot
 				}, nil)
 
 				// resolveActiveAIIDFromAIcall: get team to find CurrentMemberID's AIID.
 				m.team.EXPECT().Get(ctx, teamID).Return(&team.Team{
-					Identity: commonidentity.Identity{ID: teamID},
+					Identity:      commonidentity.Identity{ID: teamID},
 					StartMemberID: uuid.FromStringOrNil("a7777777-0001-11f0-9999-999999999999"),
 					Members: []team.Member{
 						{ID: memberID, AIID: memberAIID},
@@ -1819,13 +1815,13 @@ func Test_startAIcallByRealtime(t *testing.T) {
 	tests := []struct {
 		name string
 
-		ai              *ai.AI
-		assistanceType  aicall.AssistanceType
-		assistanceID    uuid.UUID
-		activeflowID    uuid.UUID
-		referenceType   aicall.ReferenceType
-		referenceID     uuid.UUID
-		confbridgeID    uuid.UUID
+		ai             *ai.AI
+		assistanceType aicall.AssistanceType
+		assistanceID   uuid.UUID
+		activeflowID   uuid.UUID
+		referenceType  aicall.ReferenceType
+		referenceID    uuid.UUID
+		confbridgeID   uuid.UUID
 
 		isTask          bool
 		teamParameter   map[string]any
@@ -1863,7 +1859,7 @@ func Test_startAIcallByRealtime(t *testing.T) {
 			referenceID:    uuid.FromStringOrNil("b3662e38-b659-11f0-820a-833195d45f7e"),
 			confbridgeID:   uuid.FromStringOrNil("b3864e5c-b659-11f0-ab17-6b281e446482"),
 
-			isTask:         false,
+			isTask: false,
 
 			responseUUIDPipecatcallID: uuid.FromStringOrNil("b3af613e-b659-11f0-9a72-e3e004fae386"),
 			responseUUIDAIcallID:      uuid.FromStringOrNil("b3af613e-b659-11f0-9a72-e3e004fae386"),
@@ -1882,7 +1878,7 @@ func Test_startAIcallByRealtime(t *testing.T) {
 				ConfbridgeID:  uuid.FromStringOrNil("b3864e5c-b659-11f0-ab17-6b281e446482"),
 				PipecatcallID: uuid.FromStringOrNil("b3af613e-b659-11f0-9a72-e3e004fae386"),
 
-				Status:   aicall.StatusInitiating,
+				Status: aicall.StatusInitiating,
 
 				STTLanguage: "en-US",
 
@@ -1901,9 +1897,9 @@ func Test_startAIcallByRealtime(t *testing.T) {
 				"voipbin.aicall.ai_id":           "b30ecf94-b659-11f0-b8ef-13f90dff9ee8",
 				"voipbin.aicall.confbridge_id":   "b3864e5c-b659-11f0-ab17-6b281e446482",
 
-				"voipbin.aicall.id":              "b3af613e-b659-11f0-9a72-e3e004fae386",
-				"voipbin.aicall.stt_language":        "en-US",
-				"voipbin.aicall.pipecatcall_id":  "b3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.id":             "b3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.stt_language":   "en-US",
+				"voipbin.aicall.pipecatcall_id": "b3af613e-b659-11f0-9a72-e3e004fae386",
 			},
 			expectMessageTexts: []string{
 				defaultCommonAIcallSystemPrompt,
@@ -1923,7 +1919,7 @@ func Test_startAIcallByRealtime(t *testing.T) {
 				ConfbridgeID:  uuid.FromStringOrNil("b3864e5c-b659-11f0-ab17-6b281e446482"),
 				PipecatcallID: uuid.FromStringOrNil("b3af613e-b659-11f0-9a72-e3e004fae386"),
 
-				Status:   aicall.StatusInitiating,
+				Status: aicall.StatusInitiating,
 
 				STTLanguage: "en-US",
 
@@ -1959,7 +1955,7 @@ func Test_startAIcallByRealtime(t *testing.T) {
 			referenceID:    uuid.FromStringOrNil("c3662e38-b659-11f0-820a-833195d45f7e"),
 			confbridgeID:   uuid.FromStringOrNil("c3864e5c-b659-11f0-ab17-6b281e446482"),
 
-			isTask:         false,
+			isTask: false,
 			teamParameter: map[string]any{
 				"shared_key": "team_value",
 				"team_only":  "team_data",
@@ -2002,7 +1998,7 @@ func Test_startAIcallByRealtime(t *testing.T) {
 				ConfbridgeID:  uuid.FromStringOrNil("c3864e5c-b659-11f0-ab17-6b281e446482"),
 				PipecatcallID: uuid.FromStringOrNil("c3af613e-b659-11f0-9a72-e3e004fae386"),
 
-				Status:   aicall.StatusInitiating,
+				Status: aicall.StatusInitiating,
 
 				STTLanguage: "ko-KR",
 
@@ -2021,9 +2017,9 @@ func Test_startAIcallByRealtime(t *testing.T) {
 				"voipbin.aicall.ai_id":           "c40ecf94-b659-11f0-b8ef-13f90dff9ee8",
 				"voipbin.aicall.confbridge_id":   "c3864e5c-b659-11f0-ab17-6b281e446482",
 
-				"voipbin.aicall.id":              "c3af613e-b659-11f0-9a72-e3e004fae386",
-				"voipbin.aicall.stt_language":        "ko-KR",
-				"voipbin.aicall.pipecatcall_id":  "c3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.id":             "c3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.stt_language":   "ko-KR",
+				"voipbin.aicall.pipecatcall_id": "c3af613e-b659-11f0-9a72-e3e004fae386",
 			},
 			expectMessageTexts: []string{
 				defaultCommonAIcallSystemPrompt,
@@ -2048,7 +2044,7 @@ func Test_startAIcallByRealtime(t *testing.T) {
 				ConfbridgeID:  uuid.FromStringOrNil("c3864e5c-b659-11f0-ab17-6b281e446482"),
 				PipecatcallID: uuid.FromStringOrNil("c3af613e-b659-11f0-9a72-e3e004fae386"),
 
-				Status:   aicall.StatusInitiating,
+				Status: aicall.StatusInitiating,
 
 				STTLanguage: "ko-KR",
 
@@ -2153,12 +2149,12 @@ func Test_startAIcallByMessaging(t *testing.T) {
 	tests := []struct {
 		name string
 
-		ai              *ai.AI
-		assistanceType  aicall.AssistanceType
-		assistanceID    uuid.UUID
-		activeflowID    uuid.UUID
-		referenceType   aicall.ReferenceType
-		referenceID     uuid.UUID
+		ai             *ai.AI
+		assistanceType aicall.AssistanceType
+		assistanceID   uuid.UUID
+		activeflowID   uuid.UUID
+		referenceType  aicall.ReferenceType
+		referenceID    uuid.UUID
 
 		isTask          bool
 		teamParameter   map[string]any
@@ -2194,7 +2190,7 @@ func Test_startAIcallByMessaging(t *testing.T) {
 			referenceType:  aicall.ReferenceTypeConversation,
 			referenceID:    uuid.FromStringOrNil("d3662e38-b659-11f0-820a-833195d45f7e"),
 
-			isTask:         false,
+			isTask: false,
 
 			responseUUIDPipecatcallID: uuid.FromStringOrNil("d3af613e-b659-11f0-9a72-e3e004fae386"),
 			responseUUIDAIcallID:      uuid.FromStringOrNil("d3af613e-b659-11f0-9a72-e3e004fae386"),
@@ -2214,7 +2210,7 @@ func Test_startAIcallByMessaging(t *testing.T) {
 				ReferenceID:   uuid.FromStringOrNil("d3662e38-b659-11f0-820a-833195d45f7e"),
 				PipecatcallID: uuid.FromStringOrNil("d3af613e-b659-11f0-9a72-e3e004fae386"),
 
-				Status:   aicall.StatusInitiating,
+				Status: aicall.StatusInitiating,
 
 				STTLanguage: "en-US",
 
@@ -2233,9 +2229,9 @@ func Test_startAIcallByMessaging(t *testing.T) {
 				"voipbin.aicall.ai_id":           "d30ecf94-b659-11f0-b8ef-13f90dff9ee8",
 				"voipbin.aicall.confbridge_id":   uuid.Nil.String(),
 
-				"voipbin.aicall.id":              "d3af613e-b659-11f0-9a72-e3e004fae386",
-				"voipbin.aicall.stt_language":        "en-US",
-				"voipbin.aicall.pipecatcall_id":  "d3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.id":             "d3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.stt_language":   "en-US",
+				"voipbin.aicall.pipecatcall_id": "d3af613e-b659-11f0-9a72-e3e004fae386",
 			},
 			expectMessageTexts: []string{
 				defaultCommonAIcallSystemPrompt,
@@ -2256,7 +2252,7 @@ func Test_startAIcallByMessaging(t *testing.T) {
 				ReferenceID:   uuid.FromStringOrNil("d3662e38-b659-11f0-820a-833195d45f7e"),
 				PipecatcallID: uuid.FromStringOrNil("d3af613e-b659-11f0-9a72-e3e004fae386"),
 
-				Status:   aicall.StatusInitiating,
+				Status: aicall.StatusInitiating,
 
 				STTLanguage: "en-US",
 
@@ -2324,7 +2320,7 @@ func Test_startAIcallByMessaging(t *testing.T) {
 				"voipbin.aicall.ai_id":           "f10ecf94-b659-11f0-b8ef-13f90dff9ee8",
 				"voipbin.aicall.confbridge_id":   uuid.Nil.String(),
 				"voipbin.aicall.id":              "f3af613e-b659-11f0-9a72-e3e004fae386",
-				"voipbin.aicall.stt_language":        "en-US",
+				"voipbin.aicall.stt_language":    "en-US",
 				"voipbin.aicall.pipecatcall_id":  "f3af613e-b659-11f0-9a72-e3e004fae386",
 			},
 			expectMessageTexts: []string{
@@ -2372,7 +2368,7 @@ func Test_startAIcallByMessaging(t *testing.T) {
 			referenceType:  aicall.ReferenceTypeTask,
 			referenceID:    uuid.Nil,
 
-			isTask:         true,
+			isTask: true,
 
 			responseUUIDPipecatcallID: uuid.FromStringOrNil("e3af613e-b659-11f0-9a72-e3e004fae386"),
 			responseUUIDAIcallID:      uuid.FromStringOrNil("e3af613e-b659-11f0-9a72-e3e004fae386"),
@@ -2407,9 +2403,9 @@ func Test_startAIcallByMessaging(t *testing.T) {
 				"voipbin.aicall.ai_id":           "e40ecf94-b659-11f0-b8ef-13f90dff9ee8",
 				"voipbin.aicall.confbridge_id":   uuid.Nil.String(),
 
-				"voipbin.aicall.id":              "e3af613e-b659-11f0-9a72-e3e004fae386",
-				"voipbin.aicall.stt_language":        "",
-				"voipbin.aicall.pipecatcall_id":  "e3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.id":             "e3af613e-b659-11f0-9a72-e3e004fae386",
+				"voipbin.aicall.stt_language":   "",
+				"voipbin.aicall.pipecatcall_id": "e3af613e-b659-11f0-9a72-e3e004fae386",
 			},
 			expectMessageTexts: []string{
 				defaultCommonAItaskSystemPrompt,
@@ -2771,7 +2767,7 @@ func Test_StartTask(t *testing.T) {
 					CustomerID: uuid.FromStringOrNil("da5752be-d798-11f0-9181-d3db413a82d0"),
 				},
 				EngineModel: ai.EngineModelOpenaiGPT5Dot1,
-				Parameter:  map[string]any{},
+				Parameter:   map[string]any{},
 
 				InitPrompt: "",
 			},
@@ -3485,8 +3481,9 @@ func Test_buildPromptSnapshots_autoAudit(t *testing.T) {
 			},
 			assistanceType: aicall.AssistanceTypeAI,
 			assistanceID:   uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001"),
-			mockSetup:      func(_ *teamhandler.MockTeamHandler, _ *aihandler.MockAIHandler, _ *requesthandler.MockRequestHandler) {},
-			expectAudit:    true,
+			mockSetup: func(_ *teamhandler.MockTeamHandler, _ *aihandler.MockAIHandler, _ *requesthandler.MockRequestHandler) {
+			},
+			expectAudit: true,
 		},
 		{
 			name: "single AI with auto audit disabled",
@@ -3496,8 +3493,9 @@ func Test_buildPromptSnapshots_autoAudit(t *testing.T) {
 			},
 			assistanceType: aicall.AssistanceTypeAI,
 			assistanceID:   uuid.FromStringOrNil("11111111-0000-0000-0000-000000000002"),
-			mockSetup:      func(_ *teamhandler.MockTeamHandler, _ *aihandler.MockAIHandler, _ *requesthandler.MockRequestHandler) {},
-			expectAudit:    false,
+			mockSetup: func(_ *teamhandler.MockTeamHandler, _ *aihandler.MockAIHandler, _ *requesthandler.MockRequestHandler) {
+			},
+			expectAudit: false,
 		},
 		{
 			name: "team with any member having auto audit enabled returns true",
@@ -3579,6 +3577,12 @@ func Test_buildPromptSnapshots_autoAudit(t *testing.T) {
 }
 
 func Test_startReferenceTypeContactCase(t *testing.T) {
+	// ensure the recreate rate-limit window is set deterministically for cases
+	// that depend on it (VOIP-1234)
+	config.SetAIcallContactCaseRecreateRateLimitMinutesForTest(5)
+
+	recentTerminatedTM := time.Now().Add(-1 * time.Minute) // inside the 5-minute rate-limit window
+	staleTerminatedTM := time.Now().Add(-10 * time.Minute) // outside the 5-minute rate-limit window
 
 	type mocks struct {
 		util    *utilhandler.MockUtilHandler
@@ -3602,6 +3606,11 @@ func Test_startReferenceTypeContactCase(t *testing.T) {
 		expectRes *aicall.AIcall
 		expectErr bool
 		checkErr  func(t *testing.T, err error)
+
+		// expectRateLimitedInc — when true, the rate-limited counter
+		// (promAIcallContactCaseRecreateRateLimitedTotal) MUST increment by
+		// exactly 1 across the call. When false, it is not asserted.
+		expectRateLimitedInc bool
 	}{
 		{
 			name: "create succeeds on first attempt",
@@ -3840,6 +3849,186 @@ func Test_startReferenceTypeContactCase(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "duplicate key — existing terminated recently, blocked by recreate rate limit",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("60000000-0001-11f0-ffff-000000000001"),
+					CustomerID: uuid.FromStringOrNil("60000000-0002-11f0-ffff-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("60000000-0001-11f0-ffff-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("60000000-0003-11f0-ffff-000000000001"),
+			referenceID:    uuid.FromStringOrNil("60000000-0004-11f0-ffff-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID := uuid.FromStringOrNil("60000000-0005-11f0-ffff-000000000001")
+				aicallID := uuid.FromStringOrNil("60000000-0006-11f0-ffff-000000000001")
+
+				existingTerminated := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("60000000-0009-11f0-ffff-000000000001"),
+						CustomerID: uuid.FromStringOrNil("60000000-0002-11f0-ffff-000000000001"),
+					},
+					Status: aicall.StatusTerminated,
+					TMEnd:  &recentTerminatedTM,
+				}
+
+				// only the first-attempt create; NO retry create call must happen
+				// because the rate-limit guard must block before attempt 2.
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID)
+				m.util.EXPECT().UUIDCreate().Return(aicallID)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_aicall_active_reference_key'"))
+				m.db.EXPECT().AIcallGetByReferenceID(ctx, uuid.FromStringOrNil("60000000-0004-11f0-ffff-000000000001")).Return(existingTerminated, nil)
+			},
+
+			expectErr: true,
+			checkErr: func(t *testing.T, err error) {
+				if !strings.Contains(err.Error(), "rate limit exceeded") {
+					t.Errorf("expected rate limit error, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "60000000-0004-11f0-ffff-000000000001") {
+					t.Errorf("expected error to mention the reference_id, got: %v", err)
+				}
+			},
+			expectRateLimitedInc: true,
+		},
+		{
+			name: "duplicate key — existing terminated outside rate limit window, retries successfully",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("70000000-0001-11f0-1111-000000000001"),
+					CustomerID: uuid.FromStringOrNil("70000000-0002-11f0-1111-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("70000000-0001-11f0-1111-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("70000000-0003-11f0-1111-000000000001"),
+			referenceID:    uuid.FromStringOrNil("70000000-0004-11f0-1111-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID1 := uuid.FromStringOrNil("70000000-0005-11f0-1111-000000000001")
+				aicallID1 := uuid.FromStringOrNil("70000000-0006-11f0-1111-000000000001")
+				pipecatcallID2 := uuid.FromStringOrNil("70000000-0007-11f0-1111-000000000001")
+				aicallID2 := uuid.FromStringOrNil("70000000-0008-11f0-1111-000000000001")
+
+				existingTerminated := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("70000000-0009-11f0-1111-000000000001"),
+						CustomerID: uuid.FromStringOrNil("70000000-0002-11f0-1111-000000000001"),
+					},
+					Status: aicall.StatusTerminated,
+					TMEnd:  &staleTerminatedTM,
+				}
+				created := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         aicallID2,
+						CustomerID: uuid.FromStringOrNil("70000000-0002-11f0-1111-000000000001"),
+					},
+					ActiveflowID:  uuid.FromStringOrNil("70000000-0003-11f0-1111-000000000001"),
+					ReferenceType: aicall.ReferenceTypeContactCase,
+					ReferenceID:   uuid.FromStringOrNil("70000000-0004-11f0-1111-000000000001"),
+					Status:        aicall.StatusInitiating,
+				}
+
+				// attempt 0: duplicate key, existing terminated outside the
+				// rate-limit window -> retry
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID1)
+				m.util.EXPECT().UUIDCreate().Return(aicallID1)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_aicall_active_reference_key'"))
+				m.db.EXPECT().AIcallGetByReferenceID(ctx, uuid.FromStringOrNil("70000000-0004-11f0-1111-000000000001")).Return(existingTerminated, nil)
+
+				// attempt 1: create succeeds
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID2)
+				m.util.EXPECT().UUIDCreate().Return(aicallID2)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(nil)
+				m.db.EXPECT().AIcallGet(ctx, aicallID2).Return(created, nil)
+				m.notify.EXPECT().PublishWebhookEvent(ctx, created.CustomerID, aicall.EventTypeStatusInitializing, created)
+				m.req.EXPECT().FlowV1VariableSetVariable(ctx, gomock.Any(), gomock.Any()).Return(nil)
+				m.message.EXPECT().Create(ctx, uuid.Nil, created.CustomerID, created.ID, created.ActiveflowID, message.DirectionOutgoing, message.RoleSystem, gomock.Any(), nil, "", gomock.Any()).Return(&message.Message{}, nil)
+			},
+
+			expectRes: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("70000000-0008-11f0-1111-000000000001"),
+					CustomerID: uuid.FromStringOrNil("70000000-0002-11f0-1111-000000000001"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("70000000-0003-11f0-1111-000000000001"),
+				ReferenceType: aicall.ReferenceTypeContactCase,
+				ReferenceID:   uuid.FromStringOrNil("70000000-0004-11f0-1111-000000000001"),
+				Status:        aicall.StatusInitiating,
+			},
+		},
+		{
+			name: "duplicate key — existing terminated with no TMEnd/TMUpdate, fail-open retries successfully",
+
+			ai: &ai.AI{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("80000000-0001-11f0-2222-000000000001"),
+					CustomerID: uuid.FromStringOrNil("80000000-0002-11f0-2222-000000000001"),
+				},
+				EngineModel: ai.EngineModelOpenaiGPT5,
+			},
+			assistanceType: aicall.AssistanceTypeAI,
+			assistanceID:   uuid.FromStringOrNil("80000000-0001-11f0-2222-000000000001"),
+			activeflowID:   uuid.FromStringOrNil("80000000-0003-11f0-2222-000000000001"),
+			referenceID:    uuid.FromStringOrNil("80000000-0004-11f0-2222-000000000001"),
+
+			mockSetup: func(ctx context.Context, m *mocks) {
+				pipecatcallID1 := uuid.FromStringOrNil("80000000-0005-11f0-2222-000000000001")
+				aicallID1 := uuid.FromStringOrNil("80000000-0006-11f0-2222-000000000001")
+				pipecatcallID2 := uuid.FromStringOrNil("80000000-0007-11f0-2222-000000000001")
+				aicallID2 := uuid.FromStringOrNil("80000000-0008-11f0-2222-000000000001")
+
+				// no TMEnd and no TMUpdate — fail-open expected
+				existingTerminated := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         uuid.FromStringOrNil("80000000-0009-11f0-2222-000000000001"),
+						CustomerID: uuid.FromStringOrNil("80000000-0002-11f0-2222-000000000001"),
+					},
+					Status: aicall.StatusTerminated,
+				}
+				created := &aicall.AIcall{
+					Identity: commonidentity.Identity{
+						ID:         aicallID2,
+						CustomerID: uuid.FromStringOrNil("80000000-0002-11f0-2222-000000000001"),
+					},
+					ActiveflowID:  uuid.FromStringOrNil("80000000-0003-11f0-2222-000000000001"),
+					ReferenceType: aicall.ReferenceTypeContactCase,
+					ReferenceID:   uuid.FromStringOrNil("80000000-0004-11f0-2222-000000000001"),
+					Status:        aicall.StatusInitiating,
+				}
+
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID1)
+				m.util.EXPECT().UUIDCreate().Return(aicallID1)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_aicall_active_reference_key'"))
+				m.db.EXPECT().AIcallGetByReferenceID(ctx, uuid.FromStringOrNil("80000000-0004-11f0-2222-000000000001")).Return(existingTerminated, nil)
+
+				m.util.EXPECT().UUIDCreate().Return(pipecatcallID2)
+				m.util.EXPECT().UUIDCreate().Return(aicallID2)
+				m.db.EXPECT().AIcallCreate(ctx, gomock.Any()).Return(nil)
+				m.db.EXPECT().AIcallGet(ctx, aicallID2).Return(created, nil)
+				m.notify.EXPECT().PublishWebhookEvent(ctx, created.CustomerID, aicall.EventTypeStatusInitializing, created)
+				m.req.EXPECT().FlowV1VariableSetVariable(ctx, gomock.Any(), gomock.Any()).Return(nil)
+				m.message.EXPECT().Create(ctx, uuid.Nil, created.CustomerID, created.ID, created.ActiveflowID, message.DirectionOutgoing, message.RoleSystem, gomock.Any(), nil, "", gomock.Any()).Return(&message.Message{}, nil)
+			},
+
+			expectRes: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("80000000-0008-11f0-2222-000000000001"),
+					CustomerID: uuid.FromStringOrNil("80000000-0002-11f0-2222-000000000001"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("80000000-0003-11f0-2222-000000000001"),
+				ReferenceType: aicall.ReferenceTypeContactCase,
+				ReferenceID:   uuid.FromStringOrNil("80000000-0004-11f0-2222-000000000001"),
+				Status:        aicall.StatusInitiating,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3866,7 +4055,18 @@ func Test_startReferenceTypeContactCase(t *testing.T) {
 
 			tt.mockSetup(ctx, m)
 
+			var beforeRateLimited float64
+			if tt.expectRateLimitedInc {
+				beforeRateLimited = testutil.ToFloat64(promAIcallContactCaseRecreateRateLimitedTotal)
+			}
+
 			res, err := h.startReferenceTypeContactCase(ctx, tt.ai, tt.assistanceType, tt.assistanceID, tt.activeflowID, tt.referenceID, nil, uuid.Nil)
+			if tt.expectRateLimitedInc {
+				afterRateLimited := testutil.ToFloat64(promAIcallContactCaseRecreateRateLimitedTotal)
+				if afterRateLimited-beforeRateLimited < 1 {
+					t.Errorf("expected rate-limited counter to increment by at least 1, got delta=%f", afterRateLimited-beforeRateLimited)
+				}
+			}
 			if tt.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")


### PR DESCRIPTION
Adds a recreate rate limit for contact_case-typed AIcalls (VOIP-1234 design doc §2-1). Unlike Call/Conversation references, a Contact Case has no natural upper bound on how many times it can be reopened, so an agent repeatedly reopening a closed Case and asking questions could otherwise trigger unbounded AIcall recreation (and unbounded LLM cost) every time the prior session idle-expires.

- bin-ai-manager: Added AIcallContactCaseRecreateRateLimitMinutes config field (default 5 minutes, flag/env/viper-bound, with test setter)
- bin-ai-manager: Added a recreate rate-limit guard in startReferenceTypeContactCase — blocks AIcall recreation for a contact_case reference within the configured window after the prior AIcall's TMEnd (falling back to TMUpdate), fail-open when neither timestamp is set. The guard is checked on every retry attempt, so a Terminated/Terminating row detected on the first attempt is blocked immediately with no further retries.
- bin-ai-manager: Added aicall_contact_case_recreate_rate_limited_total Prometheus counter to observe rate-limit trips
- bin-ai-manager: Added Godoc documenting the rate-limit rationale
- bin-ai-manager: Added test cases for rate-limit-blocked recreation, retry after the window elapses, and fail-open when TMEnd/TMUpdate are both nil
