### PR TITLE
VOIP-1234-in-reply-to-message-id

### DIFF
--- a/bin-ai-manager/models/message/main.go
+++ b/bin-ai-manager/models/message/main.go
@@ -26,6 +26,17 @@ type Message struct {
 	PipecatcallID  uuid.UUID      `json:"-" db:"pipecatcall_id,uuid"`
 	DeliveryStatus DeliveryStatus `json:"-" db:"delivery_status"`
 
+	// InReplyToMessageID is the ID of the user-authored message this assistant
+	// message answers. Populated on assistant messages created via
+	// EventPMMessageBotLLM (echoed from bin-pipecat-manager's
+	// pmmessage.Message.InReplyToMessageID) to disambiguate which inbound
+	// message triggered this response when an AIcall is reused for a rapid
+	// sequence of sends (e.g. an agent asking a second question before the
+	// first bot response arrives). Zero UUID for user messages and for
+	// assistant messages where no correlation was available. See VOIP-1234
+	// design doc §4-1.
+	InReplyToMessageID uuid.UUID `json:"in_reply_to_message_id,omitempty" db:"in_reply_to_message_id,uuid"`
+
 	TMCreate *time.Time `json:"tm_create" db:"tm_create"`
 	TMDelete *time.Time `json:"tm_delete" db:"tm_delete"`
 }

--- a/bin-ai-manager/pkg/aicallhandler/tool_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_test.go
@@ -960,7 +960,7 @@ func Test_toolHandleGetAIcallMessages(t *testing.T) {
 			expectAIcallID: uuid.FromStringOrNil("cfe9753e-d3ea-11f0-a686-3b5c56d58abf"),
 			expectRes: &messageContent{
 				Result:       "success",
-				Message:      `[{"id":"05a8c208-d46b-11f0-b4ce-3f2afb9cba1b","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null},{"id":"05e43a7c-d46b-11f0-ad07-e7fb818d821b","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}]`,
+				Message:      `[{"id":"05a8c208-d46b-11f0-b4ce-3f2afb9cba1b","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null},{"id":"05e43a7c-d46b-11f0-ad07-e7fb818d821b","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}]`,
 				ToolCallID:   "cfb2f874-d3ea-11f0-957d-939b29f6bdf8",
 				ResourceType: "messages",
 				ResourceID:   "cfe9753e-d3ea-11f0-a686-3b5c56d58abf",

--- a/bin-ai-manager/pkg/listenhandler/v1_messages_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_messages_test.go
@@ -60,7 +60,7 @@ func Test_processV1MessagesGet(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`[{"id":"829d8866-f25d-11ef-9b3a-dbb10220cf40","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null},{"id":"82d92b5a-f25d-11ef-8ee2-db3e98ba4d00","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}]`),
+				Data:       []byte(`[{"id":"829d8866-f25d-11ef-9b3a-dbb10220cf40","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null},{"id":"82d92b5a-f25d-11ef-8ee2-db3e98ba4d00","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}]`),
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func Test_processV1MessagesPost(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"id":"532777f8-f25e-11ef-8618-1f7ef1d18d75","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}`),
+				Data:       []byte(`{"id":"532777f8-f25e-11ef-8618-1f7ef1d18d75","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}`),
 			},
 		},
 	}
@@ -195,7 +195,7 @@ func Test_processV1MessagesIDGet(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"id":"e56b73fa-f2c0-11ef-a99b-fb5e1f39d249","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}`),
+				Data:       []byte(`{"id":"e56b73fa-f2c0-11ef-a99b-fb5e1f39d249","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_delete":null}`),
 			},
 		},
 	}

--- a/bin-ai-manager/pkg/messagehandler/db.go
+++ b/bin-ai-manager/pkg/messagehandler/db.go
@@ -64,6 +64,8 @@ func (h *messageHandler) Create(
 
 		PipecatcallID:  p.pipecatcallID,
 		DeliveryStatus: p.deliveryStatus,
+
+		InReplyToMessageID: p.inReplyToMessageID,
 	}
 	if err := h.db.MessageCreate(ctx, m); err != nil {
 		return nil, err

--- a/bin-ai-manager/pkg/messagehandler/event.go
+++ b/bin-ai-manager/pkg/messagehandler/event.go
@@ -147,7 +147,8 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 	// All other pipecat reference types use the legacy "persist and return" path.
 	if evt.PipecatcallReferenceType != pmpipecatcall.ReferenceTypeAICall {
 		tmp, err := h.Create(ctx, evt.ID, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID,
-			message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "")
+			message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "",
+			WithInReplyToMessageID(evt.InReplyToMessageID))
 		if err != nil {
 			log.Errorf("Could not create the message. err: %v", err)
 			return
@@ -168,7 +169,8 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 		activeAIID := h.resolveActiveAIIDFromAIcall(ctx, ac)
 		tmp, errCreate := h.Create(ctx, evt.ID, evt.CustomerID, evt.PipecatcallReferenceID, evt.ActiveflowID,
 			message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "",
-			WithActiveAIID(activeAIID))
+			WithActiveAIID(activeAIID),
+			WithInReplyToMessageID(evt.InReplyToMessageID))
 		if errCreate != nil {
 			log.Errorf("Could not create the message. err: %v", errCreate)
 			return
@@ -194,7 +196,8 @@ func (h *messageHandler) EventPMMessageBotLLM(ctx context.Context, evt *pmmessag
 		message.DirectionIncoming, message.RoleAssistant, evt.Text, nil, "",
 		WithPipecatcallID(evt.PipecatcallID),
 		WithDeliveryStatus(message.DeliveryStatusPending),
-		WithActiveAIID(activeAIID))
+		WithActiveAIID(activeAIID),
+		WithInReplyToMessageID(evt.InReplyToMessageID))
 	if err != nil {
 		log.Errorf("Could not create the message. err: %v", err)
 		return

--- a/bin-ai-manager/pkg/messagehandler/main.go
+++ b/bin-ai-manager/pkg/messagehandler/main.go
@@ -24,9 +24,10 @@ type CreateOption func(*createParams)
 
 // createParams holds optional parameters for Create.
 type createParams struct {
-	pipecatcallID  uuid.UUID
-	deliveryStatus message.DeliveryStatus
-	activeAIID     uuid.UUID
+	pipecatcallID      uuid.UUID
+	deliveryStatus     message.DeliveryStatus
+	activeAIID         uuid.UUID
+	inReplyToMessageID uuid.UUID
 }
 
 // WithPipecatcallID sets the pipecatcall ID on createParams.
@@ -42,6 +43,12 @@ func WithDeliveryStatus(s message.DeliveryStatus) CreateOption {
 // WithActiveAIID sets the active AI ID on createParams.
 func WithActiveAIID(id uuid.UUID) CreateOption {
 	return func(p *createParams) { p.activeAIID = id }
+}
+
+// WithInReplyToMessageID sets the in-reply-to message ID on createParams.
+// See VOIP-1234 design doc §4-1 for the cross-talk prevention this supports.
+func WithInReplyToMessageID(id uuid.UUID) CreateOption {
+	return func(p *createParams) { p.inReplyToMessageID = id }
 }
 
 type MessageHandler interface {

--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_messages.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_messages.sql
@@ -20,6 +20,9 @@ create table ai_messages(
   pipecatcall_id  binary(16),
   delivery_status varchar(16) not null default 'delivered',
 
+  -- reply correlation
+  in_reply_to_message_id binary(16) not null default 0x00000000000000000000000000000000,
+
   -- timestamps
   tm_create datetime(6),  --
   tm_delete datetime(6),

--- a/bin-dbscheme-manager/bin-manager/main/versions/62f4235bc8e0_ai_messages_add_column_in_reply_to_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/62f4235bc8e0_ai_messages_add_column_in_reply_to_.py
@@ -1,0 +1,34 @@
+"""ai_messages_add_column_in_reply_to_message_id
+
+Revision ID: 62f4235bc8e0
+Revises: a5a40c93d3e6
+Create Date: 2026-07-09
+
+Adds in_reply_to_message_id to ai_messages (VOIP-1234 subtask 2). Correlates
+an assistant message with the user-authored message it answers, so agent-
+facing clients can disambiguate responses when an AIcall is reused for a
+rapid sequence of sends (e.g. a second question asked before the first bot
+response arrives). Zero UUID (the existing zero-UUID convention used
+elsewhere in this schema, e.g. ai_aicalls.active_reference_key) for rows with
+no correlation available (user messages, and legacy/voice paths that predate
+this field).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '62f4235bc8e0'
+down_revision = 'a5a40c93d3e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('ai_messages',
+        sa.Column('in_reply_to_message_id', sa.BINARY(16), nullable=False,
+                  server_default=sa.text("0x00000000000000000000000000000000")))
+
+
+def downgrade():
+    op.drop_column('ai_messages', 'in_reply_to_message_id')

--- a/bin-pipecat-manager/models/message/main.go
+++ b/bin-pipecat-manager/models/message/main.go
@@ -20,7 +20,7 @@ type Message struct {
 	// InReplyToMessageID is the ID of the user-authored message (as passed to
 	// SendMessage) that this bot response answers. Snapshotted once per LLM
 	// generation (on the first bot-llm-text token) from
-	// Session.PendingInReplyToMessageID, so every intermediate and final event
+	// Session.SetPendingInReplyToMessageID / SnapshotPendingInReplyToMessageID, so every intermediate and final event
 	// for that generation carries the same value. Zero UUID if the session had
 	// no pending inbound message ID at generation start (e.g. voice calls,
 	// which do not go through the same-aicall-reuse SendMessage path this

--- a/bin-pipecat-manager/models/message/main.go
+++ b/bin-pipecat-manager/models/message/main.go
@@ -17,6 +17,16 @@ type Message struct {
 	PipecatcallReferenceID   uuid.UUID                 `json:"pipecatcall_reference_id,omitempty"`
 	ActiveflowID             uuid.UUID                 `json:"activeflow_id,omitempty"`
 
+	// InReplyToMessageID is the ID of the user-authored message (as passed to
+	// SendMessage) that this bot response answers. Snapshotted once per LLM
+	// generation (on the first bot-llm-text token) from
+	// Session.PendingInReplyToMessageID, so every intermediate and final event
+	// for that generation carries the same value. Zero UUID if the session had
+	// no pending inbound message ID at generation start (e.g. voice calls,
+	// which do not go through the same-aicall-reuse SendMessage path this
+	// field exists to disambiguate). See VOIP-1234 design doc §4-1.
+	InReplyToMessageID uuid.UUID `json:"in_reply_to_message_id,omitempty"`
+
 	Text     string `json:"text,omitempty"`
 	Sequence int    `json:"sequence,omitempty"`
 }

--- a/bin-pipecat-manager/models/pipecatcall/session.go
+++ b/bin-pipecat-manager/models/pipecatcall/session.go
@@ -36,13 +36,12 @@ type Session struct {
 	// InReplyToMessageID correlation (VOIP-1234 §4-1): prevents cross-talk when
 	// an aicall is reused for a rapid sequence of send-text requests (e.g. an
 	// agent sending a second question before the first bot response arrives).
-	// PendingInReplyToMessageID is set by SendMessage each time a message is
-	// sent to the LLM; the WebSocket read loop snapshots it into
-	// LLMInReplyToMessageID exactly once per generation (on the first
-	// bot-llm-text token), so all intermediate/final events for that
-	// generation report which inbound message triggered it, even if
-	// PendingInReplyToMessageID is overwritten by a newer send-text in the
-	// meantime.
+	// SetPendingInReplyToMessageID is called by SendMessage each time a
+	// message is sent to the LLM; the WebSocket read loop snapshots the
+	// pending value into LLMInReplyToMessageID exactly once per generation
+	// (on the first bot-llm-text token), so all intermediate/final events
+	// for that generation report which inbound message triggered it, even if
+	// a later SendMessage overwrites the pending value in the meantime.
 	//
 	// SendMessage is invoked from the RabbitMQ RPC listener's worker pool —
 	// a goroutine distinct from the WebSocket read loop that reads this value

--- a/bin-pipecat-manager/models/pipecatcall/session.go
+++ b/bin-pipecat-manager/models/pipecatcall/session.go
@@ -33,6 +33,21 @@ type Session struct {
 	// llm
 	LLMKey string `json:"-"`
 
+	// InReplyToMessageID correlation (VOIP-1234 §4-1): prevents cross-talk when
+	// an aicall is reused for a rapid sequence of send-text requests (e.g. an
+	// agent sending a second question before the first bot response arrives).
+	// PendingInReplyToMessageID is set by SendMessage each time a message is
+	// sent to the LLM; the WebSocket read loop snapshots it into
+	// LLMInReplyToMessageID exactly once per generation (on the first
+	// bot-llm-text token), so all intermediate/final events for that
+	// generation report which inbound message triggered it, even if
+	// PendingInReplyToMessageID is overwritten by a newer send-text in the
+	// meantime. Managed by the single-goroutine-per-session read loop; no
+	// additional synchronization needed beyond LLMFlushing's existing role as
+	// the generation boundary.
+	PendingInReplyToMessageID uuid.UUID `json:"-"`
+	LLMInReplyToMessageID     uuid.UUID `json:"-"`
+
 	// LLM intermediate event flush coordination.
 	// These fields are managed by the WebSocket read loop (single goroutine per session).
 	// The flush goroutine communicates via channels only — no shared mutable state.

--- a/bin-pipecat-manager/models/pipecatcall/session.go
+++ b/bin-pipecat-manager/models/pipecatcall/session.go
@@ -42,10 +42,21 @@ type Session struct {
 	// bot-llm-text token), so all intermediate/final events for that
 	// generation report which inbound message triggered it, even if
 	// PendingInReplyToMessageID is overwritten by a newer send-text in the
-	// meantime. Managed by the single-goroutine-per-session read loop; no
-	// additional synchronization needed beyond LLMFlushing's existing role as
-	// the generation boundary.
-	PendingInReplyToMessageID uuid.UUID `json:"-"`
+	// meantime.
+	//
+	// SendMessage is invoked from the RabbitMQ RPC listener's worker pool —
+	// a goroutine distinct from the WebSocket read loop that reads this value
+	// (see receiveMessageFrameTypeMessage). uuid.UUID is a plain [16]byte
+	// array with no atomicity guarantee, so pendingInReplyToMessageID MUST be
+	// accessed only through SetPendingInReplyToMessageID (writer) and
+	// SnapshotPendingInReplyToMessageID (reader) below — never read or
+	// written directly — to avoid a data race between the RPC worker and the
+	// read loop. LLMInReplyToMessageID itself has no such race: it is
+	// written only by the read loop and read only by the flush goroutine
+	// after LLMDoneChan/generation-start handoff, both of which already have
+	// happens-before ordering via the existing channel/atomic machinery below.
+	muPendingInReplyTo        sync.Mutex
+	pendingInReplyToMessageID uuid.UUID
 	LLMInReplyToMessageID     uuid.UUID `json:"-"`
 
 	// LLM intermediate event flush coordination.
@@ -61,6 +72,28 @@ type Session struct {
 
 	// audio quality monitoring
 	DroppedFrames atomic.Int64 `json:"-"`
+}
+
+// SetPendingInReplyToMessageID records the message ID that the next LLM
+// generation should be correlated with. Called from SendMessage, which runs
+// on the RabbitMQ RPC listener's worker pool goroutine — safe for concurrent
+// use with SnapshotPendingInReplyToMessageID, called from the WebSocket read
+// loop goroutine. See the field comment on Session for the race this guards
+// against.
+func (s *Session) SetPendingInReplyToMessageID(id uuid.UUID) {
+	s.muPendingInReplyTo.Lock()
+	defer s.muPendingInReplyTo.Unlock()
+	s.pendingInReplyToMessageID = id
+}
+
+// SnapshotPendingInReplyToMessageID returns the current pending in-reply-to
+// message ID. Called from the WebSocket read loop at the start of a new LLM
+// generation to snapshot the correlation before it can be overwritten by a
+// subsequent SendMessage. See SetPendingInReplyToMessageID.
+func (s *Session) SnapshotPendingInReplyToMessageID() uuid.UUID {
+	s.muPendingInReplyTo.Lock()
+	defer s.muPendingInReplyTo.Unlock()
+	return s.pendingInReplyToMessageID
 }
 
 // SetConnAst sets the Asterisk WebSocket connection and signals readiness.

--- a/bin-pipecat-manager/models/pipecatcall/session_test.go
+++ b/bin-pipecat-manager/models/pipecatcall/session_test.go
@@ -1,6 +1,10 @@
 package pipecatcall
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
 
 func TestSession_FlushPrimitives(t *testing.T) {
 	s := &Session{}
@@ -21,4 +25,28 @@ func TestSession_LLMFlushing_isAtomicBool(t *testing.T) {
 	if s.LLMFlushing.Load() {
 		t.Fatalf("expected LLMFlushing false after Store(false)")
 	}
+}
+
+// TestSession_PendingInReplyToMessageID_concurrentAccess is a race-detector
+// regression test (VOIP-1234 §4-1). SetPendingInReplyToMessageID is called
+// from the RabbitMQ RPC worker pool (SendMessage); SnapshotPendingInReplyToMessageID
+// is called from the WebSocket read loop goroutine. Direct field access here
+// would trip `go test -race` because uuid.UUID is a plain [16]byte array with
+// no atomicity guarantee. Run with `go test -race` to verify.
+func TestSession_PendingInReplyToMessageID_concurrentAccess(t *testing.T) {
+	s := &Session{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 1000; i++ {
+			id := uuid.FromStringOrNil("00000000-0000-0000-0000-000000000001")
+			s.SetPendingInReplyToMessageID(id)
+		}
+	}()
+
+	for i := 0; i < 1000; i++ {
+		_ = s.SnapshotPendingInReplyToMessageID()
+	}
+	<-done
 }

--- a/bin-pipecat-manager/pkg/listenhandler/v1_messages_test.go
+++ b/bin-pipecat-manager/pkg/listenhandler/v1_messages_test.go
@@ -56,7 +56,7 @@ func Test_processV1MessagesPost(t *testing.T) {
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"id":"9bee66ae-b3ab-11f0-8bb6-874d8fe199c7","customer_id":"00000000-0000-0000-0000-000000000000","pipecatcall_id":"00000000-0000-0000-0000-000000000000","pipecatcall_reference_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000"}`),
+				Data:       []byte(`{"id":"9bee66ae-b3ab-11f0-8bb6-874d8fe199c7","customer_id":"00000000-0000-0000-0000-000000000000","pipecatcall_id":"00000000-0000-0000-0000-000000000000","pipecatcall_reference_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","in_reply_to_message_id":"00000000-0000-0000-0000-000000000000"}`),
 			},
 		},
 	}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/etc.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/etc.go
@@ -14,6 +14,16 @@ func (h *pipecatcallHandler) SendMessage(ctx context.Context, id uuid.UUID, mess
 		return nil, errors.Wrapf(err, "could not get pipecatcall info")
 	}
 
+	// Record the correlation for the upcoming LLM generation (VOIP-1234 §4-1).
+	// If messageID is not a valid UUID (unexpected but non-fatal — this is a
+	// best-effort correlation hint, not load-bearing for delivery), leave
+	// PendingInReplyToMessageID at its previous value rather than failing the
+	// send; the runner will snapshot whatever is there when the generation
+	// starts.
+	if parsed, errParse := uuid.FromString(messageID); errParse == nil {
+		se.PendingInReplyToMessageID = parsed
+	}
+
 	res := h.newMessageEvent(se, messageText)
 
 	if errSend := h.pipecatframeHandler.SendRTVIText(se, messageID, messageText, runImmediately, audioResponse); errSend != nil {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/etc.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/etc.go
@@ -17,11 +17,13 @@ func (h *pipecatcallHandler) SendMessage(ctx context.Context, id uuid.UUID, mess
 	// Record the correlation for the upcoming LLM generation (VOIP-1234 §4-1).
 	// If messageID is not a valid UUID (unexpected but non-fatal — this is a
 	// best-effort correlation hint, not load-bearing for delivery), leave
-	// PendingInReplyToMessageID at its previous value rather than failing the
+	// pendingInReplyToMessageID at its previous value rather than failing the
 	// send; the runner will snapshot whatever is there when the generation
-	// starts.
+	// starts. Goes through Session's exported setter (not a direct field
+	// write) because SendMessage runs on the RPC worker pool goroutine while
+	// the WebSocket read loop concurrently reads this value.
 	if parsed, errParse := uuid.FromString(messageID); errParse == nil {
-		se.PendingInReplyToMessageID = parsed
+		se.SetPendingInReplyToMessageID(parsed)
 	}
 
 	res := h.newMessageEvent(se, messageText)

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -574,6 +574,12 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 
 		if !se.LLMFlushing.Load() {
 			se.LLMMessageID = h.utilHandler.UUIDCreate()
+			// Snapshot the pending in-reply-to correlation at generation start
+			// (VOIP-1234 §4-1). PendingInReplyToMessageID may be overwritten by
+			// a subsequent SendMessage before this generation finishes; the
+			// snapshot ensures every event this generation emits reports the
+			// message that actually triggered it.
+			se.LLMInReplyToMessageID = se.PendingInReplyToMessageID
 			se.LLMTokenChan = make(chan string, 64)
 			se.LLMStopChan = make(chan struct{})
 			se.LLMDoneChan = make(chan struct{})
@@ -830,6 +836,7 @@ func (h *pipecatcallHandler) publishIntermediateEvent(ctx context.Context, se *p
 		PipecatcallReferenceType: se.PipecatcallReferenceType,
 		PipecatcallReferenceID:   se.PipecatcallReferenceID,
 		ActiveflowID:             se.ActiveflowID,
+		InReplyToMessageID:       se.LLMInReplyToMessageID,
 
 		Text:     delta,
 		Sequence: sequence,
@@ -851,6 +858,7 @@ func (h *pipecatcallHandler) publishFinalBotLLMEvent(ctx context.Context, se *pi
 		PipecatcallReferenceType: se.PipecatcallReferenceType,
 		PipecatcallReferenceID:   se.PipecatcallReferenceID,
 		ActiveflowID:             se.ActiveflowID,
+		InReplyToMessageID:       se.LLMInReplyToMessageID,
 
 		Text: fullText,
 	}

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -575,11 +575,14 @@ func (h *pipecatcallHandler) receiveMessageFrameTypeMessage(se *pipecatcall.Sess
 		if !se.LLMFlushing.Load() {
 			se.LLMMessageID = h.utilHandler.UUIDCreate()
 			// Snapshot the pending in-reply-to correlation at generation start
-			// (VOIP-1234 §4-1). PendingInReplyToMessageID may be overwritten by
-			// a subsequent SendMessage before this generation finishes; the
+			// (VOIP-1234 §4-1). The pending value may be overwritten by a
+			// subsequent SendMessage before this generation finishes; the
 			// snapshot ensures every event this generation emits reports the
-			// message that actually triggered it.
-			se.LLMInReplyToMessageID = se.PendingInReplyToMessageID
+			// message that actually triggered it. Goes through Session's
+			// exported getter (not a direct field read) because SendMessage
+			// writes this value from the RPC worker pool goroutine while this
+			// read loop reads it concurrently.
+			se.LLMInReplyToMessageID = se.SnapshotPendingInReplyToMessageID()
 			se.LLMTokenChan = make(chan string, 64)
 			se.LLMStopChan = make(chan struct{})
 			se.LLMDoneChan = make(chan struct{})

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -883,6 +883,123 @@ func TestRunLLMIntermediateFlush_idleWatchdog_doesNotFireBeforeFirstToken(t *tes
 	<-se.LLMDoneChan
 }
 
+// TestBotLLMText_inReplyToMessageID_snapshotsAtGenerationStart verifies the
+// VOIP-1234 §4-1 cross-talk correlation: receiveMessageFrameTypeMessage
+// snapshots Session.PendingInReplyToMessageID into
+// Session.LLMInReplyToMessageID exactly once, at the start of each LLM
+// generation (the first bot-llm-text token). If SendMessage overwrites
+// PendingInReplyToMessageID with a newer value while a generation is still
+// in flight, that generation's published events must still carry the
+// snapshot taken at its own start -- not the newer pending value -- so an
+// agent-facing client can correctly attribute a response to the message
+// that actually triggered it.
+func TestBotLLMText_inReplyToMessageID_snapshotsAtGenerationStart(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &pipecatcallHandler{
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+
+	gen1MessageID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+	gen2MessageID := uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	inReplyTo1 := uuid.FromStringOrNil("00000001-0000-0000-0000-000000000000")
+	inReplyTo2 := uuid.FromStringOrNil("00000002-0000-0000-0000-000000000000")
+
+	gomock.InOrder(
+		mockUtil.EXPECT().UUIDCreate().Return(gen1MessageID),
+		mockUtil.EXPECT().UUIDCreate().Return(gen2MessageID),
+	)
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLMIntermediate), gomock.Any()).AnyTimes()
+
+	finalInReplyTo := make(chan uuid.UUID, 2)
+	mockNotify.EXPECT().
+		PublishEvent(gomock.Any(), gomock.Eq(message.EventTypeBotLLM), gomock.Any()).
+		DoAndReturn(func(_ any, _ any, evt message.Message) {
+			finalInReplyTo <- evt.InReplyToMessageID
+		}).
+		Times(2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	se := &pipecatcall.Session{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("ffffffff-9999-2222-3333-444444444444"),
+			CustomerID: uuid.FromStringOrNil("dddddddd-9999-2222-3333-444444444444"),
+		},
+		Ctx: ctx,
+	}
+
+	textFrame := func(text string) []byte {
+		return []byte(`{"label":"rtvi-ai","type":"bot-llm-text","data":{"text":"` + text + `"}}`)
+	}
+	stoppedFrame := []byte(`{"label":"rtvi-ai","type":"bot-llm-stopped"}`)
+
+	// --- Generation 1: pending = inReplyTo1 ---
+	se.PendingInReplyToMessageID = inReplyTo1
+	if err := h.receiveMessageFrameTypeMessage(se, textFrame("First")); err != nil {
+		t.Fatalf("gen1 BotLLMText returned unexpected error: %v", err)
+	}
+	if se.LLMInReplyToMessageID != inReplyTo1 {
+		t.Fatalf("gen1: expected LLMInReplyToMessageID snapshot %s, got %s", inReplyTo1, se.LLMInReplyToMessageID)
+	}
+	gen1Done := se.LLMDoneChan
+
+	// Simulate a second SendMessage arriving mid-generation-1, overwriting the
+	// pending value before generation 1 has finished.
+	se.PendingInReplyToMessageID = inReplyTo2
+
+	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
+		t.Fatalf("gen1 BotLLMStopped returned unexpected error: %v", err)
+	}
+	select {
+	case <-gen1Done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("gen1 flush goroutine did not exit within 500ms")
+	}
+
+	// --- Generation 2: pending is now inReplyTo2 ---
+	if err := h.receiveMessageFrameTypeMessage(se, textFrame("Second")); err != nil {
+		t.Fatalf("gen2 BotLLMText returned unexpected error: %v", err)
+	}
+	if se.LLMInReplyToMessageID != inReplyTo2 {
+		t.Fatalf("gen2: expected LLMInReplyToMessageID snapshot %s, got %s", inReplyTo2, se.LLMInReplyToMessageID)
+	}
+	gen2Done := se.LLMDoneChan
+
+	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
+		t.Fatalf("gen2 BotLLMStopped returned unexpected error: %v", err)
+	}
+	select {
+	case <-gen2Done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("gen2 flush goroutine did not exit within 500ms")
+	}
+
+	close(finalInReplyTo)
+	got := []uuid.UUID{}
+	for id := range finalInReplyTo {
+		got = append(got, id)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 final events (one per generation), got %d", len(got))
+	}
+	// Generation 1's final event must report inReplyTo1 (its own snapshot),
+	// NOT inReplyTo2 (the value pending was overwritten to mid-flight).
+	if got[0] != inReplyTo1 {
+		t.Errorf("gen1 final event: expected InReplyToMessageID %s (snapshot at gen1 start), got %s", inReplyTo1, got[0])
+	}
+	if got[1] != inReplyTo2 {
+		t.Errorf("gen2 final event: expected InReplyToMessageID %s (snapshot at gen2 start), got %s", inReplyTo2, got[1])
+	}
+}
+
 // TestFlushAndFinalize_outcomes covers the four observable outcomes of
 // flushAndFinalize, the synchronous helper terminate() will call to
 // deterministically force the flush goroutine to publish its final event

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_flush_test.go
@@ -885,10 +885,11 @@ func TestRunLLMIntermediateFlush_idleWatchdog_doesNotFireBeforeFirstToken(t *tes
 
 // TestBotLLMText_inReplyToMessageID_snapshotsAtGenerationStart verifies the
 // VOIP-1234 §4-1 cross-talk correlation: receiveMessageFrameTypeMessage
-// snapshots Session.PendingInReplyToMessageID into
+// snapshots the pending correlation (set via Session.SetPendingInReplyToMessageID) into
 // Session.LLMInReplyToMessageID exactly once, at the start of each LLM
-// generation (the first bot-llm-text token). If SendMessage overwrites
-// PendingInReplyToMessageID with a newer value while a generation is still
+// generation (the first bot-llm-text token). If a subsequent SendMessage
+// overwrites the pending value via SetPendingInReplyToMessageID while a
+// generation is still
 // in flight, that generation's published events must still carry the
 // snapshot taken at its own start -- not the newer pending value -- so an
 // agent-facing client can correctly attribute a response to the message
@@ -942,7 +943,7 @@ func TestBotLLMText_inReplyToMessageID_snapshotsAtGenerationStart(t *testing.T) 
 	stoppedFrame := []byte(`{"label":"rtvi-ai","type":"bot-llm-stopped"}`)
 
 	// --- Generation 1: pending = inReplyTo1 ---
-	se.PendingInReplyToMessageID = inReplyTo1
+	se.SetPendingInReplyToMessageID(inReplyTo1)
 	if err := h.receiveMessageFrameTypeMessage(se, textFrame("First")); err != nil {
 		t.Fatalf("gen1 BotLLMText returned unexpected error: %v", err)
 	}
@@ -953,7 +954,7 @@ func TestBotLLMText_inReplyToMessageID_snapshotsAtGenerationStart(t *testing.T) 
 
 	// Simulate a second SendMessage arriving mid-generation-1, overwriting the
 	// pending value before generation 1 has finished.
-	se.PendingInReplyToMessageID = inReplyTo2
+	se.SetPendingInReplyToMessageID(inReplyTo2)
 
 	if err := h.receiveMessageFrameTypeMessage(se, stoppedFrame); err != nil {
 		t.Fatalf("gen1 BotLLMStopped returned unexpected error: %v", err)


### PR DESCRIPTION
Adds an in_reply_to_message_id correlation field spanning bin-ai-manager and
bin-pipecat-manager (VOIP-1234 subtask 2) to prevent cross-talk when an
aicall/pipecatcall is reused for a rapid sequence of send-text requests: an
agent asking a second question before the first bot response arrives could
otherwise see a response attributed to the wrong question.

Investigation confirmed the python runner (scripts/pipecat/) does not need
changes: RTVI bot-llm-text/bot-llm-stopped frames carry no correlation
information, so the correlation is resolved entirely in bin-pipecat-manager's
Go session state.

- bin-pipecat-manager: Add InReplyToMessageID to models/message.Message
  (pmmessage wire type), sent on both intermediate and final message_bot_llm
  events
- bin-pipecat-manager: Add pendingInReplyToMessageID/LLMInReplyToMessageID to
  pipecatcall.Session; SendMessage records the caller-supplied messageID as
  pending via SetPendingInReplyToMessageID, the WebSocket read loop snapshots
  it via SnapshotPendingInReplyToMessageID into the per-generation field
  exactly once at the first bot-llm-text token so later overwrites do not
  retroactively change an in-flight generation's correlation
- bin-pipecat-manager: Guard pendingInReplyToMessageID with a mutex and
  private field + accessor methods -- SendMessage runs on the RabbitMQ RPC
  listener's worker pool, a different goroutine from the WebSocket read loop
  that snapshots the value; uuid.UUID has no atomicity guarantee as a plain
  [16]byte array
- bin-pipecat-manager: Add regression tests: one proving the snapshot
  survives a pending-value overwrite mid-generation (two generations each
  report their own snapshot), and a `go test -race` test exercising
  concurrent Set/Snapshot calls from separate goroutines
- bin-ai-manager: Add InReplyToMessageID to models/message.Message
  (ai_messages DB column via db: tag) and a WithInReplyToMessageID
  CreateOption
- bin-ai-manager: EventPMMessageBotLLM forwards evt.InReplyToMessageID into
  every h.Create() call that persists an assistant reply (voice/task legacy
  path, non-conversation path, and the conversation-bridge path) -- these are
  the only three paths that persist an assistant message; the intermediate
  streaming event is not persisted and user/transcription messages are not
  in-reply-to anything, so no other event path needs this field
- bin-ai-manager: Update golden-JSON test fixtures (tool_test.go,
  v1_messages_test.go) for the new field
- bin-dbscheme-manager: Add ai_messages_add_column_in_reply_to_message_id
  migration (zero-UUID default, matching the existing zero-UUID convention
  used elsewhere in this schema)
