### PR TITLE
VOIP-1234-insight-tool-fallback-alert

### DIFF
--- a/bin-pipecat-manager/docs/operations.md
+++ b/bin-pipecat-manager/docs/operations.md
@@ -36,6 +36,7 @@ Exposed at `PROMETHEUS_LISTEN_ADDRESS/PROMETHEUS_ENDPOINT` (default `:2112/metri
 | `pipecat_manager_llm_flush_exit_total` | Counter | — | LLM flush operations that exited cleanly |
 | `pipecat_manager_llm_flush_finalize_outcome_total` | Counter | `outcome` | LLM flush finalization outcomes |
 | `pipecat_manager_llm_idle_watchdog_fired_total` | Counter | — | Idle watchdog triggers |
+| `pipecat_manager_tool_resolve_fallback_total` | Counter | — | runnerStartScript fell back to all tools (GetAll()) after an AI lookup failure. Intentionally fail-open (VOIP-1234 §6); a sustained non-zero rate should be investigated and alerted on, since it means sessions are running with an over-broad tool set instead of the AI's configured whitelist |
 | `receive_request_process_time` | Histogram | `type`, `method` | RPC request latency |
 
 Circuit-breaker metrics from `bin-common-handler/pkg/requesthandler` are also registered under the `pipecat_manager_*` namespace. See [docs/patterns/circuit-breaker.md](../../docs/patterns/circuit-breaker.md).

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go
@@ -32,6 +32,21 @@ var (
 		},
 		[]string{"outcome"},
 	)
+
+	// metricsToolResolveFallbackTotal counts occurrences of the runnerStartScript
+	// fail-open path where resolveAIFromAIcall fails and the session falls back
+	// to GetAll() (all tools, over-broad exposure) instead of the AI's configured
+	// tool whitelist. This path is intentionally fail-open (VOIP-1234 §6 v4) since
+	// it cannot be scoped to Insight-typed AIs specifically and no incident has
+	// been observed to justify a fail-closed change affecting all AICall-backed
+	// sessions. This counter (paired with the Errorf log at the call site) exists
+	// so a real-world spike is observable and can trigger a design revisit.
+	metricsToolResolveFallbackTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pipecat_manager_tool_resolve_fallback_total",
+			Help: "Counter of runnerStartScript falling back to GetAll() (all tools) after an AI lookup failure.",
+		},
+	)
 )
 
 func init() {
@@ -39,5 +54,6 @@ func init() {
 		metricsLLMFlushExit,
 		metricsIdleWatchdogFired,
 		metricsFlushFinalizeOutcome,
+		metricsToolResolveFallbackTotal,
 	)
 }

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -130,7 +130,19 @@ func (h *pipecatcallHandler) runnerStartScript(pc *pipecatcall.Pipecatcall, se *
 			// Single AI: resolve tools from the AI's configuration
 			ai, errAI := h.resolveAIFromAIcall(se.Ctx, aicall)
 			if errAI != nil {
-				log.WithError(errAI).Warnf("Could not resolve AI, returning all tools")
+				// Fail-open by design (VOIP-1234 §6 v4): this AI lookup failure
+				// cannot be scoped to Insight-typed AIs specifically (pipecatcall.ReferenceType
+				// only distinguishes ReferenceTypeCall/ReferenceTypeAICall, not AI.Type), and
+				// there is no observed incident motivating a fail-closed change that would
+				// affect every AICall-backed session (not just Insight). Falling back to
+				// GetAll() keeps the session usable at the cost of over-broad tool exposure
+				// on this rare error path. Metric + alert-worthy log below give operators
+				// visibility so a real incident can be detected and this decision revisited.
+				metricsToolResolveFallbackTotal.Inc()
+				log.WithFields(logrus.Fields{
+					"aicall_id":     aicall.ID,
+					"assistance_id": aicall.AssistanceID,
+				}).WithError(errAI).Errorf("Could not resolve AI for pipecat session %s; falling back to all tools (fail-open, over-broad tool exposure)", pc.ID)
 				tools = h.toolHandler.GetAll()
 			} else {
 				tools = h.toolHandler.GetByNames(ai.ToolNames)
@@ -174,7 +186,6 @@ func (h *pipecatcallHandler) runnerStartScript(pc *pipecatcall.Pipecatcall, se *
 
 	return nil
 }
-
 
 func (h *pipecatcallHandler) RunnerWebsocketHandle(id uuid.UUID, c *gin.Context) error {
 	direction := c.Query("direction")
@@ -471,7 +482,7 @@ func (h *pipecatcallHandler) RunnerMemberSwitchedHandle(id uuid.UUID, c *gin.Con
 	}
 
 	request := struct {
-		TransitionFunctionName string         `json:"transition_function_name"`
+		TransitionFunctionName string             `json:"transition_function_name"`
 		FromMember             message.MemberInfo `json:"from_member"`
 		ToMember               message.MemberInfo `json:"to_member"`
 	}{}
@@ -682,8 +693,8 @@ func (h *pipecatcallHandler) runLLMIntermediateFlush(se *pipecatcall.Session, me
 	defer ticker.Stop()
 	watchdog := time.NewTicker(idleWatchdogTickRate)
 	defer watchdog.Stop()
-	defer close(se.LLMDoneChan)        // close-broadcasts goroutine exit to readers
-	defer se.LLMFlushing.Store(false)  // LIFO: runs before close(LLMDoneChan), so observers see flushing=false
+	defer close(se.LLMDoneChan)       // close-broadcasts goroutine exit to readers
+	defer se.LLMFlushing.Store(false) // LIFO: runs before close(LLMDoneChan), so observers see flushing=false
 
 	var fullText string
 	var deltaBuffer string
@@ -903,4 +914,3 @@ func (h *pipecatcallHandler) runnerWebsocketHandleAudio(se *pipecatcall.Session,
 
 	return nil
 }
-

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_toolfallback_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_toolfallback_test.go
@@ -1,0 +1,85 @@
+package pipecatcallhandler
+
+import (
+	"context"
+	"testing"
+
+	amaicall "monorepo/bin-ai-manager/models/aicall"
+	aitool "monorepo/bin-ai-manager/models/tool"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-pipecat-manager/models/pipecatcall"
+	"monorepo/bin-pipecat-manager/pkg/toolhandler"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	gomock "go.uber.org/mock/gomock"
+)
+
+// Test_runnerStartScript_toolResolveFallback verifies the VOIP-1234 subtask 4
+// fail-open path: when resolveAIFromAIcall fails for a non-team AICall-backed
+// session, runnerStartScript falls back to toolHandler.GetAll() (unchanged
+// behavior) AND now increments metricsToolResolveFallbackTotal so the fallback
+// is observable (see runner.go / metrics.go for the design rationale — this
+// path stays fail-open by design, but must be alertable).
+func Test_runnerStartScript_toolResolveFallback(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockTool := toolhandler.NewMockToolHandler(mc)
+	mockPython := NewMockPythonRunner(mc)
+
+	h := &pipecatcallHandler{
+		requestHandler: mockReq,
+		toolHandler:    mockTool,
+		pythonRunner:   mockPython,
+	}
+
+	aicallID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
+	assistanceID := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
+
+	pc := &pipecatcall.Pipecatcall{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333"),
+		},
+		ReferenceType: pipecatcall.ReferenceTypeAICall,
+		ReferenceID:   aicallID,
+	}
+	se := &pipecatcall.Session{
+		Ctx: context.Background(),
+	}
+
+	ac := &amaicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID: aicallID,
+		},
+		AssistanceType: amaicall.AssistanceTypeAI,
+		AssistanceID:   assistanceID,
+	}
+
+	mockReq.EXPECT().AIV1AIcallGet(gomock.Any(), aicallID).Return(ac, nil)
+	// resolveAIFromAIcall (AssistanceTypeAI path) calls AIV1AIGet; force it to
+	// fail so runnerStartScript takes the fallback branch under test.
+	mockReq.EXPECT().AIV1AIGet(gomock.Any(), assistanceID).Return(nil, errors.New("boom"))
+
+	mockTool.EXPECT().GetAll().Return([]aitool.Tool{})
+
+	mockPython.EXPECT().Start(
+		gomock.Any(), pc.ID, gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil)
+
+	before := testutil.ToFloat64(metricsToolResolveFallbackTotal)
+
+	if err := h.runnerStartScript(pc, se); err != nil {
+		t.Fatalf("runnerStartScript returned unexpected error: %v", err)
+	}
+
+	after := testutil.ToFloat64(metricsToolResolveFallbackTotal)
+	if after != before+1 {
+		t.Errorf("expected metricsToolResolveFallbackTotal to increment by 1, before=%v after=%v", before, after)
+	}
+}


### PR DESCRIPTION
Strengthens observability on the runnerStartScript AI-lookup-failure fallback
path (VOIP-1234 subtask 4 / design doc §6 v4). This fail-open path (falling
back to all tools when resolveAIFromAIcall fails) is kept intentionally
unchanged -- it cannot be scoped to Insight-typed AIs specifically since
pipecatcall.ReferenceType only distinguishes ReferenceTypeCall/
ReferenceTypeAICall, not AI.Type, and no incident has been observed to
justify a fail-closed change affecting every AICall-backed session. What was
missing was visibility: previously this only logged a bare Warnf with no
correlating IDs and no metric.

- bin-pipecat-manager: Add pipecat_manager_tool_resolve_fallback_total
  Prometheus counter, incremented each time runnerStartScript falls back to
  toolHandler.GetAll() after an AI lookup failure
- bin-pipecat-manager: Upgrade the log line from Warnf to Errorf and add
  aicall_id/assistance_id fields so the fallback is both alertable (via the
  counter) and traceable back to the specific AIcall when it fires
- bin-pipecat-manager: Add Test_runnerStartScript_toolResolveFallback,
  exercising runnerStartScript end-to-end (mocked AIV1AIcallGet/AIV1AIGet/
  toolHandler/pythonRunner) and asserting the counter increments by exactly 1
- bin-pipecat-manager: Document the new metric in docs/operations.md
