### PR TITLE
VOIP-1234-service-agents-aimessages

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -16443,6 +16443,129 @@
         }
       }
     },
+    "/service_agents/aimessages": {
+      "get": {
+        "summary": "List aimessages for an aicall",
+        "description": "Retrieves a paginated list of AI messages for the given aicall id. The aicall must belong to the service agent's own customer.",
+        "tags": [
+          "Service Agent"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageToken"
+          },
+          {
+            "name": "aicall_id",
+            "in": "query",
+            "required": true,
+            "description": "The ID of the aicall whose messages should be retrieved. Returned from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls` response.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "example": "5e4a0680-804e-11ec-8477-2fea5968d85b"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of AI messages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonPagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "result": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AIManagerMessage"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "summary": "Send an aimessage",
+        "description": "Creates and sends a new message to the given aicall and returns the details of the created message. The aicall must belong to the service agent's own customer.",
+        "tags": [
+          "Service Agent"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "aicall_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The ID of the aicall to send the message to. Returned from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls` response.",
+                    "example": "5e4a0680-804e-11ec-8477-2fea5968d85b"
+                  },
+                  "role": {
+                    "$ref": "#/components/schemas/AIManagerMessageRole"
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "The message content.",
+                    "example": "Hello, how can I help you today?"
+                  }
+                },
+                "required": [
+                  "aicall_id",
+                  "role",
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created aimessage details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIManagerMessage"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/service_agents/calls/{id}": {
       "get": {
         "summary": "Retrieve detailed information of a specific call",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -6938,6 +6938,30 @@ type PostServiceAgentsAicallsJSONBody struct {
 	ReferenceType AIManagerAIcallReferenceType `json:"reference_type"`
 }
 
+// GetServiceAgentsAimessagesParams defines parameters for GetServiceAgentsAimessages.
+type GetServiceAgentsAimessagesParams struct {
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// AicallId The ID of the aicall whose messages should be retrieved. Returned from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls` response.
+	AicallId openapi_types.UUID `form:"aicall_id" json:"aicall_id"`
+}
+
+// PostServiceAgentsAimessagesJSONBody defines parameters for PostServiceAgentsAimessages.
+type PostServiceAgentsAimessagesJSONBody struct {
+	// AicallId The ID of the aicall to send the message to. Returned from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls` response.
+	AicallId openapi_types.UUID `json:"aicall_id"`
+
+	// Content The message content.
+	Content string `json:"content"`
+
+	// Role Role of the entity in the conversation.
+	Role AIManagerMessageRole `json:"role"`
+}
+
 // GetServiceAgentsCallsParams defines parameters for GetServiceAgentsCalls.
 type GetServiceAgentsCallsParams struct {
 	// PageSize Number of results to return per page.
@@ -7981,6 +8005,9 @@ type PutRoutesIdJSONRequestBody PutRoutesIdJSONBody
 // PostServiceAgentsAicallsJSONRequestBody defines body for PostServiceAgentsAicalls for application/json ContentType.
 type PostServiceAgentsAicallsJSONRequestBody PostServiceAgentsAicallsJSONBody
 
+// PostServiceAgentsAimessagesJSONRequestBody defines body for PostServiceAgentsAimessages for application/json ContentType.
+type PostServiceAgentsAimessagesJSONRequestBody PostServiceAgentsAimessagesJSONBody
+
 // PostServiceAgentsContactAddressesJSONRequestBody defines body for PostServiceAgentsContactAddresses for application/json ContentType.
 type PostServiceAgentsContactAddressesJSONRequestBody PostServiceAgentsContactAddressesJSONBody
 
@@ -8919,6 +8946,12 @@ type ServerInterface interface {
 	// Create an aicall
 	// (POST /service_agents/aicalls)
 	PostServiceAgentsAicalls(c *gin.Context)
+	// List aimessages for an aicall
+	// (GET /service_agents/aimessages)
+	GetServiceAgentsAimessages(c *gin.Context, params GetServiceAgentsAimessagesParams)
+	// Send an aimessage
+	// (POST /service_agents/aimessages)
+	PostServiceAgentsAimessages(c *gin.Context)
 	// Retrieve a list of calls for the given customer
 	// (GET /service_agents/calls)
 	GetServiceAgentsCalls(c *gin.Context, params GetServiceAgentsCallsParams)
@@ -16303,6 +16336,68 @@ func (siw *ServerInterfaceWrapper) PostServiceAgentsAicalls(c *gin.Context) {
 	siw.Handler.PostServiceAgentsAicalls(c)
 }
 
+// GetServiceAgentsAimessages operation middleware
+func (siw *ServerInterfaceWrapper) GetServiceAgentsAimessages(c *gin.Context) {
+
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetServiceAgentsAimessagesParams
+
+	// ------------- Optional query parameter "page_size" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_size", c.Request.URL.Query(), &params.PageSize)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_size: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "page_token" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "page_token", c.Request.URL.Query(), &params.PageToken)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_token: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Required query parameter "aicall_id" -------------
+
+	if paramValue := c.Query("aicall_id"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandler(c, fmt.Errorf("Query argument aicall_id is required, but not found"), http.StatusBadRequest)
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "aicall_id", c.Request.URL.Query(), &params.AicallId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter aicall_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetServiceAgentsAimessages(c, params)
+}
+
+// PostServiceAgentsAimessages operation middleware
+func (siw *ServerInterfaceWrapper) PostServiceAgentsAimessages(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.PostServiceAgentsAimessages(c)
+}
+
 // GetServiceAgentsCalls operation middleware
 func (siw *ServerInterfaceWrapper) GetServiceAgentsCalls(c *gin.Context) {
 
@@ -19528,6 +19623,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/service_agents/agents/:id", wrapper.GetServiceAgentsAgentsId)
 	router.GET(options.BaseURL+"/service_agents/aicalls", wrapper.GetServiceAgentsAicalls)
 	router.POST(options.BaseURL+"/service_agents/aicalls", wrapper.PostServiceAgentsAicalls)
+	router.GET(options.BaseURL+"/service_agents/aimessages", wrapper.GetServiceAgentsAimessages)
+	router.POST(options.BaseURL+"/service_agents/aimessages", wrapper.PostServiceAgentsAimessages)
 	router.GET(options.BaseURL+"/service_agents/calls", wrapper.GetServiceAgentsCalls)
 	router.GET(options.BaseURL+"/service_agents/calls/:id", wrapper.GetServiceAgentsCallsId)
 	router.GET(options.BaseURL+"/service_agents/contact_addresses", wrapper.GetServiceAgentsContactAddresses)
@@ -35455,6 +35552,98 @@ func (response PostServiceAgentsAicalls500JSONResponse) VisitPostServiceAgentsAi
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetServiceAgentsAimessagesRequestObject struct {
+	Params GetServiceAgentsAimessagesParams
+}
+
+type GetServiceAgentsAimessagesResponseObject interface {
+	VisitGetServiceAgentsAimessagesResponse(w http.ResponseWriter) error
+}
+
+type GetServiceAgentsAimessages200JSONResponse struct {
+	// NextPageToken Cursor token for the next page of results. Pass this value as the page_token parameter in the next request.
+	NextPageToken *string             `json:"next_page_token,omitempty"`
+	Result        *[]AIManagerMessage `json:"result,omitempty"`
+}
+
+func (response GetServiceAgentsAimessages200JSONResponse) VisitGetServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsAimessages400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetServiceAgentsAimessages400JSONResponse) VisitGetServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsAimessages401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response GetServiceAgentsAimessages401JSONResponse) VisitGetServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetServiceAgentsAimessages500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetServiceAgentsAimessages500JSONResponse) VisitGetServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsAimessagesRequestObject struct {
+	Body *PostServiceAgentsAimessagesJSONRequestBody
+}
+
+type PostServiceAgentsAimessagesResponseObject interface {
+	VisitPostServiceAgentsAimessagesResponse(w http.ResponseWriter) error
+}
+
+type PostServiceAgentsAimessages200JSONResponse AIManagerMessage
+
+func (response PostServiceAgentsAimessages200JSONResponse) VisitPostServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsAimessages400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PostServiceAgentsAimessages400JSONResponse) VisitPostServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsAimessages401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response PostServiceAgentsAimessages401JSONResponse) VisitPostServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostServiceAgentsAimessages500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response PostServiceAgentsAimessages500JSONResponse) VisitPostServiceAgentsAimessagesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetServiceAgentsCallsRequestObject struct {
 	Params GetServiceAgentsCallsParams
 }
@@ -42489,6 +42678,12 @@ type StrictServerInterface interface {
 	// Create an aicall
 	// (POST /service_agents/aicalls)
 	PostServiceAgentsAicalls(ctx context.Context, request PostServiceAgentsAicallsRequestObject) (PostServiceAgentsAicallsResponseObject, error)
+	// List aimessages for an aicall
+	// (GET /service_agents/aimessages)
+	GetServiceAgentsAimessages(ctx context.Context, request GetServiceAgentsAimessagesRequestObject) (GetServiceAgentsAimessagesResponseObject, error)
+	// Send an aimessage
+	// (POST /service_agents/aimessages)
+	PostServiceAgentsAimessages(ctx context.Context, request PostServiceAgentsAimessagesRequestObject) (PostServiceAgentsAimessagesResponseObject, error)
 	// Retrieve a list of calls for the given customer
 	// (GET /service_agents/calls)
 	GetServiceAgentsCalls(ctx context.Context, request GetServiceAgentsCallsRequestObject) (GetServiceAgentsCallsResponseObject, error)
@@ -51070,6 +51265,66 @@ func (sh *strictHandler) PostServiceAgentsAicalls(ctx *gin.Context) {
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(PostServiceAgentsAicallsResponseObject); ok {
 		if err := validResponse.VisitPostServiceAgentsAicallsResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetServiceAgentsAimessages operation middleware
+func (sh *strictHandler) GetServiceAgentsAimessages(ctx *gin.Context, params GetServiceAgentsAimessagesParams) {
+	var request GetServiceAgentsAimessagesRequestObject
+
+	request.Params = params
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetServiceAgentsAimessages(ctx, request.(GetServiceAgentsAimessagesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetServiceAgentsAimessages")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(GetServiceAgentsAimessagesResponseObject); ok {
+		if err := validResponse.VisitGetServiceAgentsAimessagesResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PostServiceAgentsAimessages operation middleware
+func (sh *strictHandler) PostServiceAgentsAimessages(ctx *gin.Context) {
+	var request PostServiceAgentsAimessagesRequestObject
+
+	var body PostServiceAgentsAimessagesJSONRequestBody
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
+		ctx.Error(err)
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostServiceAgentsAimessages(ctx, request.(PostServiceAgentsAimessagesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostServiceAgentsAimessages")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(PostServiceAgentsAimessagesResponseObject); ok {
+		if err := validResponse.VisitPostServiceAgentsAimessagesResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -1005,6 +1005,11 @@ type ServiceHandler interface {
 		referenceType amaicall.ReferenceType,
 		referenceID uuid.UUID,
 	) (*amaicall.WebhookMessage, error)
+	ServiceAgentAIcallGet(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID) (*amaicall.WebhookMessage, error)
+
+	// service agent aimessage handlers
+	ServiceAgentAImessageList(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID, size uint64, token string) ([]*ammessage.WebhookMessage, error)
+	ServiceAgentAImessageCreate(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID, role ammessage.Role, content string) (*ammessage.WebhookMessage, error)
 
 	// service agent transcribe handlers
 	ServiceAgentTranscribeList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, referenceType string, referenceID uuid.UUID) ([]*tmtranscribe.WebhookMessage, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -4288,6 +4288,21 @@ func (mr *MockServiceHandlerMockRecorder) ServiceAgentAIcallCreate(ctx, a, assis
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentAIcallCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentAIcallCreate), ctx, a, assistanceType, assistanceID, referenceType, referenceID)
 }
 
+// ServiceAgentAIcallGet mocks base method.
+func (m *MockServiceHandler) ServiceAgentAIcallGet(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID) (*aicall.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentAIcallGet", ctx, a, aicallID)
+	ret0, _ := ret[0].(*aicall.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentAIcallGet indicates an expected call of ServiceAgentAIcallGet.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentAIcallGet(ctx, a, aicallID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentAIcallGet", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentAIcallGet), ctx, a, aicallID)
+}
+
 // ServiceAgentAIcallList mocks base method.
 func (m *MockServiceHandler) ServiceAgentAIcallList(ctx context.Context, a *auth.AuthIdentity, size uint64, token, referenceType string, referenceID uuid.UUID, status string) ([]*aicall.WebhookMessage, error) {
 	m.ctrl.T.Helper()
@@ -4301,6 +4316,36 @@ func (m *MockServiceHandler) ServiceAgentAIcallList(ctx context.Context, a *auth
 func (mr *MockServiceHandlerMockRecorder) ServiceAgentAIcallList(ctx, a, size, token, referenceType, referenceID, status any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentAIcallList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentAIcallList), ctx, a, size, token, referenceType, referenceID, status)
+}
+
+// ServiceAgentAImessageCreate mocks base method.
+func (m *MockServiceHandler) ServiceAgentAImessageCreate(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID, role message.Role, content string) (*message.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentAImessageCreate", ctx, a, aicallID, role, content)
+	ret0, _ := ret[0].(*message.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentAImessageCreate indicates an expected call of ServiceAgentAImessageCreate.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentAImessageCreate(ctx, a, aicallID, role, content any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentAImessageCreate", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentAImessageCreate), ctx, a, aicallID, role, content)
+}
+
+// ServiceAgentAImessageList mocks base method.
+func (m *MockServiceHandler) ServiceAgentAImessageList(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID, size uint64, token string) ([]*message.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceAgentAImessageList", ctx, a, aicallID, size, token)
+	ret0, _ := ret[0].([]*message.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceAgentAImessageList indicates an expected call of ServiceAgentAImessageList.
+func (mr *MockServiceHandlerMockRecorder) ServiceAgentAImessageList(ctx, a, aicallID, size, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceAgentAImessageList", reflect.TypeOf((*MockServiceHandler)(nil).ServiceAgentAImessageList), ctx, a, aicallID, size, token)
 }
 
 // ServiceAgentAgentGet mocks base method.

--- a/bin-api-manager/pkg/servicehandler/serviceagent_aicall.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_aicall.go
@@ -88,6 +88,40 @@ func (h *serviceHandler) ServiceAgentAIcallList(ctx context.Context, a *auth.Aut
 	return res, nil
 }
 
+// ServiceAgentAIcallGet sends a request to ai-manager to get the aicall info
+// for the service agent's customer. it returns the aicall info if it succeed.
+// Tenant isolation only -- no ownership check beyond the customer match.
+func (h *serviceHandler) ServiceAgentAIcallGet(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID) (*amaicall.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "ServiceAgentAIcallGet",
+		"customer_id": a.CustomerID,
+		"username":    a.DisplayName(),
+		"aicall_id":   aicallID,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	tmp, err := h.aicallGet(ctx, aicallID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get the aicall info. aicall_id: %v", aicallID)
+	}
+
+	if tmp.CustomerID != a.CustomerID {
+		log.Info("The aicall does not belong to the agent's customer.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	res := tmp.ConvertWebhookMessage()
+	return res, nil
+}
+
 // ServiceAgentAIcallCreate sends a request to ai-manager to create an aicall
 // for the service agent's customer. An activeflow is automatically created
 // and associated with the new aicall, mirroring the top-level AIcallCreate.

--- a/bin-api-manager/pkg/servicehandler/serviceagent_aimessage.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_aimessage.go
@@ -1,0 +1,111 @@
+package servicehandler
+
+import (
+	"context"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	ammessage "monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// ServiceAgentAImessageList sends a request to ai-manager to get a list of
+// aimessages for the given aicall id. The aicall must belong to the service
+// agent's own customer (tenant isolation only, no ownership check).
+func (h *serviceHandler) ServiceAgentAImessageList(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID, size uint64, token string) ([]*ammessage.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "ServiceAgentAImessageList",
+		"customer_id": a.CustomerID,
+		"username":    a.DisplayName(),
+		"aicall_id":   aicallID,
+		"size":        size,
+		"token":       token,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	// confirm the aicall belongs to the agent's own tenant before listing
+	// its messages -- tenant isolation only, no ownership check.
+	if _, err := h.ServiceAgentAIcallGet(ctx, a, aicallID); err != nil {
+		return nil, errors.Wrapf(err, "could not get the aicall info. aicall_id: %v", aicallID)
+	}
+
+	if token == "" {
+		token = h.utilHandler.TimeGetCurTime()
+	}
+
+	if size == 0 {
+		size = 100
+	}
+
+	filters := map[string]string{
+		"deleted":   "false",
+		"aicall_id": aicallID.String(),
+	}
+
+	typedFilters, err := h.convertAImessageFilters(filters)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not convert filters")
+	}
+
+	tmps, err := h.reqHandler.AIV1MessageGetsByAIcallID(ctx, aicallID, token, size, typedFilters)
+	if err != nil {
+		log.Errorf("Could not get aimessages. err: %v", err)
+		return nil, errors.Wrapf(err, "could not get aimessages info")
+	}
+
+	res := []*ammessage.WebhookMessage{}
+	for _, tmp := range tmps {
+		e := tmp.ConvertWebhookMessage()
+		res = append(res, e)
+	}
+
+	return res, nil
+}
+
+// ServiceAgentAImessageCreate sends a request to ai-manager to send a new
+// message to the given aicall. The aicall must belong to the service agent's
+// own customer (tenant isolation only, no ownership check).
+func (h *serviceHandler) ServiceAgentAImessageCreate(ctx context.Context, a *auth.AuthIdentity, aicallID uuid.UUID, role ammessage.Role, content string) (*ammessage.WebhookMessage, error) {
+	if !a.IsAgent() {
+		return nil, serviceerrors.ErrAuthenticationRequired
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "ServiceAgentAImessageCreate",
+		"customer_id": a.CustomerID,
+		"username":    a.DisplayName(),
+		"aicall_id":   aicallID,
+		"role":        role,
+	})
+
+	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionAll) {
+		log.Info("The agent has no permission.")
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	// confirm the aicall belongs to the agent's own tenant before sending a
+	// message to it -- tenant isolation only, no ownership check.
+	if _, err := h.ServiceAgentAIcallGet(ctx, a, aicallID); err != nil {
+		return nil, errors.Wrapf(err, "could not get the aicall info. aicall_id: %v", aicallID)
+	}
+
+	tmp, err := h.reqHandler.AIV1MessageSend(ctx, aicallID, role, content, true, false, 30000)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create a new ai message. err: %v", err)
+	}
+
+	res := tmp.ConvertWebhookMessage()
+	return res, nil
+}

--- a/bin-api-manager/pkg/servicehandler/serviceagent_aimessage_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_aimessage_test.go
@@ -1,0 +1,277 @@
+package servicehandler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	amaicall "monorepo/bin-ai-manager/models/aicall"
+	ammessage "monorepo/bin-ai-manager/models/message"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/dbhandler"
+)
+
+// Test_ServiceAgentAImessageList verifies a plain Agent permission (not
+// Admin/Manager) can list aimessages for an aicall belonging to its own
+// customer via the service_agents surface.
+func Test_ServiceAgentAImessageList(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		agent     *auth.AuthIdentity
+		aicallID  uuid.UUID
+		pageSize  uint64
+		pageToken string
+
+		responseAIcall *amaicall.AIcall
+		response       []ammessage.Message
+
+		expectFilters map[ammessage.Field]any
+		expectRes     []*ammessage.WebhookMessage
+	}{
+		{
+			"agent permission, aicall belongs to the same customer",
+			auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			10,
+			"2020-10-20T01:00:00.995000Z",
+
+			&amaicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+			},
+			[]ammessage.Message{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+					},
+				},
+			},
+
+			map[ammessage.Field]any{
+				ammessage.FieldDeleted:  false,
+				ammessage.FieldAIcallID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			},
+			[]*ammessage.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler:  mockReq,
+				dbHandler:   mockDB,
+				utilHandler: mockUtil,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().AIV1AIcallGet(ctx, tt.aicallID).Return(tt.responseAIcall, nil)
+			mockReq.EXPECT().AIV1MessageGetsByAIcallID(ctx, tt.aicallID, tt.pageToken, tt.pageSize, tt.expectFilters).Return(tt.response, nil)
+
+			res, err := h.ServiceAgentAImessageList(ctx, tt.agent, tt.aicallID, tt.pageSize, tt.pageToken)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+// Test_ServiceAgentAImessageList_TenantIsolation verifies that when the
+// aicall's customer does not match the calling agent's own customer, the
+// request is rejected -- tenant isolation without any ownership/role check
+// beyond that.
+func Test_ServiceAgentAImessageList_TenantIsolation(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler:  mockReq,
+		dbHandler:   mockDB,
+		utilHandler: mockUtil,
+	}
+	ctx := context.Background()
+
+	agent := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		},
+		Permission: amagent.PermissionCustomerAgent,
+	})
+	aicallID := uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b")
+
+	mockReq.EXPECT().AIV1AIcallGet(ctx, aicallID).Return(&amaicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         aicallID,
+			CustomerID: uuid.FromStringOrNil("6a72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+		},
+	}, nil)
+
+	_, err := h.ServiceAgentAImessageList(ctx, agent, aicallID, 10, "")
+	if err == nil {
+		t.Errorf("Wrong match. expect: err, got: ok")
+	}
+}
+
+// Test_ServiceAgentAImessageCreate verifies a plain Agent permission (not
+// Admin/Manager) can send an aimessage to an aicall belonging to its own
+// customer via the service_agents surface.
+func Test_ServiceAgentAImessageCreate(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		agent    *auth.AuthIdentity
+		aicallID uuid.UUID
+		role     ammessage.Role
+		content  string
+
+		responseAIcall *amaicall.AIcall
+		response       *ammessage.Message
+
+		expectRes *ammessage.WebhookMessage
+	}{
+		{
+			"agent permission, aicall belongs to the same customer",
+			auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			ammessage.RoleUser,
+			"hello",
+
+			&amaicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+					CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+				},
+			},
+			&ammessage.Message{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+				},
+			},
+
+			&ammessage.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+			h := &serviceHandler{
+				reqHandler:  mockReq,
+				dbHandler:   mockDB,
+				utilHandler: mockUtil,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().AIV1AIcallGet(ctx, tt.aicallID).Return(tt.responseAIcall, nil)
+			mockReq.EXPECT().AIV1MessageSend(ctx, tt.aicallID, tt.role, tt.content, true, false, 30000).Return(tt.response, nil)
+
+			res, err := h.ServiceAgentAImessageCreate(ctx, tt.agent, tt.aicallID, tt.role, tt.content)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+// Test_ServiceAgentAImessageCreate_TenantIsolation verifies that when the
+// aicall's customer does not match the calling agent's own customer, the
+// request is rejected -- tenant isolation without any ownership/role check
+// beyond that.
+func Test_ServiceAgentAImessageCreate_TenantIsolation(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler:  mockReq,
+		dbHandler:   mockDB,
+		utilHandler: mockUtil,
+	}
+	ctx := context.Background()
+
+	agent := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		},
+		Permission: amagent.PermissionCustomerAgent,
+	})
+	aicallID := uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b")
+
+	mockReq.EXPECT().AIV1AIcallGet(ctx, aicallID).Return(&amaicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         aicallID,
+			CustomerID: uuid.FromStringOrNil("6a72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+		},
+	}, nil)
+
+	_, err := h.ServiceAgentAImessageCreate(ctx, agent, aicallID, ammessage.RoleUser, "hello")
+	if err == nil {
+		t.Errorf("Wrong match. expect: err, got: ok")
+	}
+}

--- a/bin-api-manager/server/service_agents_aimessages.go
+++ b/bin-api-manager/server/service_agents_aimessages.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	ammessage "monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-api-manager/gens/openapi_server"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// GetServiceAgentsAimessages handles GET /service_agents/aimessages
+func (h *server) GetServiceAgentsAimessages(c *gin.Context, params openapi_server.GetServiceAgentsAimessagesParams) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "GetServiceAgentsAimessages",
+		"request_address": c.ClientIP,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithFields(logrus.Fields{
+		"agent": a,
+	})
+
+	pageSize := uint64(100)
+	if params.PageSize != nil {
+		pageSize = uint64(*params.PageSize)
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 100
+		log.Debugf("Invalid requested page size. Set to default. page_size: %d", pageSize)
+	}
+
+	pageToken := ""
+	if params.PageToken != nil {
+		pageToken = *params.PageToken
+	}
+
+	aicallID := uuid.UUID(params.AicallId)
+	if aicallID == uuid.Nil {
+		log.Errorf("Invalid aicall id. aicall_id: %v", params.AicallId)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ID", "The provided id is not a valid UUID."))
+		return
+	}
+
+	tmps, err := h.serviceHandler.ServiceAgentAImessageList(c.Request.Context(), a, aicallID, pageSize, pageToken)
+	if err != nil {
+		log.Errorf("Could not get aimessages info. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	nextToken := ""
+	if len(tmps) > 0 {
+		if tmps[len(tmps)-1].TMCreate != nil {
+			nextToken = tmps[len(tmps)-1].TMCreate.UTC().Format("2006-01-02T15:04:05.000000Z")
+		}
+	}
+
+	res := GenerateListResponse(tmps, nextToken)
+	c.JSON(200, res)
+}
+
+// PostServiceAgentsAimessages handles POST /service_agents/aimessages
+func (h *server) PostServiceAgentsAimessages(c *gin.Context) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "PostServiceAgentsAimessages",
+		"request_address": c.ClientIP,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithFields(logrus.Fields{
+		"agent": a,
+	})
+
+	var req openapi_server.PostServiceAgentsAimessagesJSONBody
+	if err := c.BindJSON(&req); err != nil {
+		log.Errorf("Could not parse the request. err: %v", err)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_JSON_BODY", "The request body is not valid JSON.").Wrap(err))
+		return
+	}
+
+	aicallID := uuid.UUID(req.AicallId)
+
+	res, err := h.serviceHandler.ServiceAgentAImessageCreate(
+		c.Request.Context(),
+		a,
+		aicallID,
+		ammessage.Role(req.Role),
+		req.Content,
+	)
+	if err != nil {
+		log.Errorf("Could not create aimessage. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, res)
+}

--- a/bin-api-manager/server/service_agents_aimessages_test.go
+++ b/bin-api-manager/server/service_agents_aimessages_test.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	ammessage "monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-api-manager/gens/openapi_server"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/servicehandler"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_GetServiceAgentsAimessages(t *testing.T) {
+
+	type test struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+
+		responseAimessages []*ammessage.WebhookMessage
+
+		expectedAIcallID  uuid.UUID
+		expectedPageSize  uint64
+		expectedPageToken string
+		expectedRes       string
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/aimessages?aicall_id=5e4a0680-804e-11ec-8477-2fea5968d85b&page_size=10&page_token=2020-09-20T03:23:20.995000Z",
+
+			responseAimessages: []*ammessage.WebhookMessage{
+				{
+					Identity: commonidentity.Identity{
+						ID: uuid.FromStringOrNil("6e812ad0-828a-11ed-bfe8-9f9b344a834b"),
+					},
+				},
+			},
+
+			expectedAIcallID:  uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			expectedPageSize:  10,
+			expectedPageToken: "2020-09-20T03:23:20.995000Z",
+			expectedRes:       `{"result":[{"id":"6e812ad0-828a-11ed-bfe8-9f9b344a834b","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","role":"","content":"","direction":"","tm_create":null}],"next_page_token":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("GET", tt.reqQuery, nil)
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ServiceAgentAImessageList(req.Context(), tt.agent, tt.expectedAIcallID, tt.expectedPageSize, tt.expectedPageToken).Return(tt.responseAimessages, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			}
+
+			if w.Body.String() != tt.expectedRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectedRes, w.Body)
+			}
+		})
+	}
+}
+
+func Test_PostServiceAgentsAimessages(t *testing.T) {
+
+	type test struct {
+		name  string
+		agent *auth.AuthIdentity
+
+		reqQuery string
+		reqBody  []byte
+
+		responseAimessage *ammessage.WebhookMessage
+
+		expectAIcallID uuid.UUID
+		expectRole     ammessage.Role
+		expectContent  string
+		expectRes      string
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("4e72f3ea-8285-11ed-a55b-6bf44eeb8a87"),
+				},
+			}),
+
+			reqQuery: "/service_agents/aimessages",
+			reqBody:  []byte(`{"aicall_id":"5e4a0680-804e-11ec-8477-2fea5968d85b","role":"user","content":"hello"}`),
+
+			responseAimessage: &ammessage.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("72e68b78-8286-11ed-8875-378ced61c021"),
+				},
+			},
+
+			expectAIcallID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+			expectRole:     ammessage.RoleUser,
+			expectContent:  "hello",
+			expectRes:      `{"id":"72e68b78-8286-11ed-8875-378ced61c021","customer_id":"00000000-0000-0000-0000-000000000000","aicall_id":"00000000-0000-0000-0000-000000000000","activeflow_id":"00000000-0000-0000-0000-000000000000","active_ai_id":"00000000-0000-0000-0000-000000000000","role":"","content":"","direction":"","tm_create":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSvc := servicehandler.NewMockServiceHandler(mc)
+			h := &server{
+				serviceHandler: mockSvc,
+			}
+
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+
+			r.Use(func(c *gin.Context) {
+				c.Set("auth_identity", tt.agent)
+			})
+			openapi_server.RegisterHandlers(r, h)
+
+			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			mockSvc.EXPECT().ServiceAgentAImessageCreate(
+				req.Context(),
+				tt.agent,
+				tt.expectAIcallID,
+				tt.expectRole,
+				tt.expectContent,
+			).Return(tt.responseAimessage, nil)
+
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			}
+
+			if w.Body.String() != tt.expectRes {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
+			}
+		})
+	}
+}

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -9255,6 +9255,30 @@ type PostServiceAgentsAicallsJSONBody struct {
 	ReferenceType AIManagerAIcallReferenceType `json:"reference_type"`
 }
 
+// GetServiceAgentsAimessagesParams defines parameters for GetServiceAgentsAimessages.
+type GetServiceAgentsAimessagesParams struct {
+	// PageSize Number of results to return per page.
+	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
+	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// AicallId The ID of the aicall whose messages should be retrieved. Returned from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls` response.
+	AicallId openapi_types.UUID `form:"aicall_id" json:"aicall_id"`
+}
+
+// PostServiceAgentsAimessagesJSONBody defines parameters for PostServiceAgentsAimessages.
+type PostServiceAgentsAimessagesJSONBody struct {
+	// AicallId The ID of the aicall to send the message to. Returned from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls` response.
+	AicallId openapi_types.UUID `json:"aicall_id"`
+
+	// Content The message content.
+	Content string `json:"content"`
+
+	// Role Role of the entity in the conversation.
+	Role AIManagerMessageRole `json:"role"`
+}
+
 // GetServiceAgentsCallsParams defines parameters for GetServiceAgentsCalls.
 type GetServiceAgentsCallsParams struct {
 	// PageSize Number of results to return per page.
@@ -10297,6 +10321,9 @@ type PutRoutesIdJSONRequestBody PutRoutesIdJSONBody
 
 // PostServiceAgentsAicallsJSONRequestBody defines body for PostServiceAgentsAicalls for application/json ContentType.
 type PostServiceAgentsAicallsJSONRequestBody PostServiceAgentsAicallsJSONBody
+
+// PostServiceAgentsAimessagesJSONRequestBody defines body for PostServiceAgentsAimessages for application/json ContentType.
+type PostServiceAgentsAimessagesJSONRequestBody PostServiceAgentsAimessagesJSONBody
 
 // PostServiceAgentsContactAddressesJSONRequestBody defines body for PostServiceAgentsContactAddresses for application/json ContentType.
 type PostServiceAgentsContactAddressesJSONRequestBody PostServiceAgentsContactAddressesJSONBody

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -8292,6 +8292,8 @@ paths:
     $ref: './paths/service_agents/agents.yaml'
   /service_agents/aicalls:
     $ref: './paths/service_agents/aicalls.yaml'
+  /service_agents/aimessages:
+    $ref: './paths/service_agents/aimessages.yaml'
   /service_agents/calls/{id}:
     $ref: './paths/service_agents/calls_id.yaml'
   /service_agents/calls:

--- a/bin-openapi-manager/openapi/paths/service_agents/aimessages.yaml
+++ b/bin-openapi-manager/openapi/paths/service_agents/aimessages.yaml
@@ -1,0 +1,88 @@
+get:
+  summary: List aimessages for an aicall
+  description: >-
+    Retrieves a paginated list of AI messages for the given aicall id. The
+    aicall must belong to the service agent's own customer.
+  tags:
+    - Service Agent
+  parameters:
+    - $ref: '#/components/parameters/PageSize'
+    - $ref: '#/components/parameters/PageToken'
+    - name: aicall_id
+      in: query
+      required: true
+      description: >-
+        The ID of the aicall whose messages should be retrieved. Returned
+        from the `POST /service_agents/aicalls` or `GET /service_agents/aicalls`
+        response.
+      schema:
+        type: string
+        format: uuid
+      example: "5e4a0680-804e-11ec-8477-2fea5968d85b"
+  responses:
+    '200':
+      description: A list of AI messages.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/CommonPagination'
+              - type: object
+                properties:
+                  result:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AIManagerMessage'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '500':
+      $ref: '#/components/responses/InternalError'
+
+post:
+  summary: Send an aimessage
+  description: >-
+    Creates and sends a new message to the given aicall and returns the
+    details of the created message. The aicall must belong to the service
+    agent's own customer.
+  tags:
+    - Service Agent
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            aicall_id:
+              type: string
+              format: uuid
+              description: >-
+                The ID of the aicall to send the message to. Returned from the
+                `POST /service_agents/aicalls` or `GET /service_agents/aicalls`
+                response.
+              example: "5e4a0680-804e-11ec-8477-2fea5968d85b"
+            role:
+              $ref: '#/components/schemas/AIManagerMessageRole'
+            content:
+              type: string
+              description: The message content.
+              example: "Hello, how can I help you today?"
+          required:
+            - aicall_id
+            - role
+            - content
+  responses:
+    '200':
+      description: The created aimessage details.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AIManagerMessage'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '500':
+      $ref: '#/components/responses/InternalError'


### PR DESCRIPTION
Adds a dedicated Service Agent surface for AImessage list/send
(/service_agents/aimessages), completing the square-talk Insight Q&A flow
started in VOIP-1234 st5 (PR #1074): GET /service_agents/aicalls locates an
in-progress AIcall for a reference (e.g. a contact_case), then
POST /service_agents/aimessages sends a message to it. Mirrors the existing
/service_agents/transcribes and /service_agents/aicalls precedent.

ServiceAgentAIcallGet is also added (single-aicall lookup, PermissionAll,
tenant isolation only) since PR #1074 only shipped List/Create; both new
aimessage functions call it first to enforce tenant isolation before
touching messages, matching the confirmed VOIP-1234 policy (Case owner
permission check not required, tenant isolation only).

- bin-openapi-manager: Add /service_agents/aimessages GET (aicall_id required
  query, pagination) + POST (aicall_id/role/content) spec; reuses the
  existing AIManagerMessage/AIManagerMessageRole schemas
- bin-api-manager: Add ServiceAgentAIcallGet servicehandler method
  (PermissionAll gate, tenant isolation only, single-aicall lookup)
- bin-api-manager: Add ServiceAgentAImessageList/ServiceAgentAImessageCreate
  servicehandler methods (PermissionAll gate, call ServiceAgentAIcallGet
  first for tenant isolation, then reuse existing
  AIV1MessageGetsByAIcallID/AIV1MessageSend RPCs)
- bin-api-manager: Add GetServiceAgentsAimessages/PostServiceAgentsAimessages
  server handlers
- bin-api-manager: Add servicehandler and server-level tests covering
  plain-Agent-permission access and tenant isolation rejection
