### PR TITLE
NOJIRA-contact-case-list-by-contact-id

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -8759,7 +8759,7 @@
     "/contact_cases": {
       "get": {
         "summary": "List cases",
-        "description": "List cases for the customer, optionally filtered by status, owner_type,\nand owner_id.\n",
+        "description": "List cases for the customer, optionally filtered by status, owner_type,\nowner_id, and contact_id.\n",
         "tags": [
           "Case"
         ],
@@ -8794,6 +8794,16 @@
               "type": "string",
               "format": "uuid",
               "example": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+            }
+          },
+          {
+            "name": "contact_id",
+            "in": "query",
+            "description": "Filter to cases attributed to this Contact.",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "b2c3d4e5-f6a7-8901-bcde-f12345678901"
             }
           },
           {

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -5928,6 +5928,9 @@ type GetContactCasesParams struct {
 	// OwnerId Filter by owner ID.
 	OwnerId *openapi_types.UUID `form:"owner_id,omitempty" json:"owner_id,omitempty"`
 
+	// ContactId Filter to cases attributed to this Contact.
+	ContactId *openapi_types.UUID `form:"contact_id,omitempty" json:"contact_id,omitempty"`
+
 	// PageSize Number of results to return per page.
 	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
 
@@ -12562,6 +12565,14 @@ func (siw *ServerInterfaceWrapper) GetContactCases(c *gin.Context) {
 	err = runtime.BindQueryParameter("form", true, false, "owner_id", c.Request.URL.Query(), &params.OwnerId)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter owner_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "contact_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "contact_id", c.Request.URL.Query(), &params.ContactId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter contact_id: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/bin-api-manager/pkg/servicehandler/case.go
+++ b/bin-api-manager/pkg/servicehandler/case.go
@@ -59,6 +59,7 @@ func (h *serviceHandler) CaseList(
 	status string,
 	ownerType string,
 	ownerID uuid.UUID,
+	contactID uuid.UUID,
 ) ([]*cmkase.Case, string, error) {
 	customerID := targetCustomerID
 	if customerID == uuid.Nil {
@@ -78,7 +79,7 @@ func (h *serviceHandler) CaseList(
 		return nil, "", serviceerrors.ErrPermissionDenied
 	}
 
-	items, nextToken, err := h.reqHandler.ContactV1CaseList(ctx, customerID, status, ownerType, ownerID, size, token)
+	items, nextToken, err := h.reqHandler.ContactV1CaseList(ctx, customerID, status, ownerType, ownerID, contactID, size, token)
 	if err != nil {
 		log.Errorf("Could not list cases. err: %v", err)
 		return nil, "", err

--- a/bin-api-manager/pkg/servicehandler/case_test.go
+++ b/bin-api-manager/pkg/servicehandler/case_test.go
@@ -108,11 +108,11 @@ func Test_CaseList(t *testing.T) {
 
 			if !tt.expectErr {
 				mockReq.EXPECT().
-					ContactV1CaseList(ctx, tt.expectCustomerID, tt.status, "", uuid.Nil, tt.size, tt.token).
+					ContactV1CaseList(ctx, tt.expectCustomerID, tt.status, "", uuid.Nil, uuid.Nil, tt.size, tt.token).
 					Return(tt.responseItems, tt.responseToken, nil)
 			}
 
-			items, _, err := h.CaseList(ctx, tt.agent, tt.expectCustomerID, tt.size, tt.token, tt.status, "", uuid.Nil)
+			items, _, err := h.CaseList(ctx, tt.agent, tt.expectCustomerID, tt.size, tt.token, tt.status, "", uuid.Nil, uuid.Nil)
 			if tt.expectErr {
 				if err == nil {
 					t.Errorf("Expected error but got none")

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -483,6 +483,7 @@ type ServiceHandler interface {
 		status string,
 		ownerType string,
 		ownerID uuid.UUID,
+		contactID uuid.UUID,
 	) ([]*cmkase.Case, string, error)
 	CaseListUnresolved(
 		ctx context.Context,

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -1753,9 +1753,9 @@ func (mr *MockServiceHandlerMockRecorder) CaseGet(ctx, a, id any) *gomock.Call {
 }
 
 // CaseList mocks base method.
-func (m *MockServiceHandler) CaseList(ctx context.Context, a *auth.AuthIdentity, targetCustomerID uuid.UUID, size uint64, token, status, ownerType string, ownerID uuid.UUID) ([]*kase.Case, string, error) {
+func (m *MockServiceHandler) CaseList(ctx context.Context, a *auth.AuthIdentity, targetCustomerID uuid.UUID, size uint64, token, status, ownerType string, ownerID, contactID uuid.UUID) ([]*kase.Case, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CaseList", ctx, a, targetCustomerID, size, token, status, ownerType, ownerID)
+	ret := m.ctrl.Call(m, "CaseList", ctx, a, targetCustomerID, size, token, status, ownerType, ownerID, contactID)
 	ret0, _ := ret[0].([]*kase.Case)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -1763,9 +1763,9 @@ func (m *MockServiceHandler) CaseList(ctx context.Context, a *auth.AuthIdentity,
 }
 
 // CaseList indicates an expected call of CaseList.
-func (mr *MockServiceHandlerMockRecorder) CaseList(ctx, a, targetCustomerID, size, token, status, ownerType, ownerID any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) CaseList(ctx, a, targetCustomerID, size, token, status, ownerType, ownerID, contactID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockServiceHandler)(nil).CaseList), ctx, a, targetCustomerID, size, token, status, ownerType, ownerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockServiceHandler)(nil).CaseList), ctx, a, targetCustomerID, size, token, status, ownerType, ownerID, contactID)
 }
 
 // CaseListUnresolved mocks base method.

--- a/bin-api-manager/server/contact_cases.go
+++ b/bin-api-manager/server/contact_cases.go
@@ -55,12 +55,17 @@ func (h *server) GetContactCases(c *gin.Context, params openapi_server.GetContac
 		ownerID = uuid.UUID(*params.OwnerId)
 	}
 
+	contactID := uuid.Nil
+	if params.ContactId != nil {
+		contactID = uuid.UUID(*params.ContactId)
+	}
+
 	// targetCustomerID is always uuid.Nil here -- this endpoint has no
 	// client-supplied customer_id filter, so CaseList always resolves to
 	// the authenticated caller's own a.CustomerID (see CaseList's
 	// targetCustomerID == uuid.Nil default). customer_id is never taken
 	// from client input.
-	items, nextToken, err := h.serviceHandler.CaseList(c.Request.Context(), a, uuid.Nil, pageSize, pageToken, status, ownerType, ownerID)
+	items, nextToken, err := h.serviceHandler.CaseList(c.Request.Context(), a, uuid.Nil, pageSize, pageToken, status, ownerType, ownerID, contactID)
 	if err != nil {
 		log.Errorf("Could not list cases. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/contact_cases_test.go
+++ b/bin-api-manager/server/contact_cases_test.go
@@ -75,7 +75,7 @@ func Test_GetContactCases(t *testing.T) {
 
 			if tt.responseItems != nil && tt.agent != nil {
 				mockSvc.EXPECT().
-					CaseList(req.Context(), tt.agent, uuid.Nil, uint64(100), "", gomock.Any(), gomock.Any(), gomock.Any()).
+					CaseList(req.Context(), tt.agent, uuid.Nil, uint64(100), "", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(tt.responseItems, tt.responseToken, nil)
 			}
 

--- a/bin-api-manager/server/contact_cases_test.go
+++ b/bin-api-manager/server/contact_cases_test.go
@@ -21,6 +21,7 @@ import (
 func Test_GetContactCases(t *testing.T) {
 	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
 	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	contactID := uuid.FromStringOrNil("7a3ec8f0-2c74-11ee-b0e5-8f2ac8c9a111")
 
 	tests := []struct {
 		name  string
@@ -28,9 +29,12 @@ func Test_GetContactCases(t *testing.T) {
 
 		reqQuery string
 
-		responseItems []*cmkase.Case
-		responseToken string
-		expectStatus  int
+		expectOwnerID   uuid.UUID
+		expectContactID uuid.UUID
+
+		responseItems    []*cmkase.Case
+		responseToken    string
+		expectStatusCode int
 	}{
 		{
 			name: "normal",
@@ -40,16 +44,30 @@ func Test_GetContactCases(t *testing.T) {
 					CustomerID: customerID,
 				},
 			}),
-			reqQuery:      "/contact_cases",
-			responseItems: []*cmkase.Case{},
-			responseToken: "",
-			expectStatus:  http.StatusOK,
+			reqQuery:         "/contact_cases",
+			responseItems:    []*cmkase.Case{},
+			responseToken:    "",
+			expectStatusCode: http.StatusOK,
 		},
 		{
-			name:         "unauthenticated",
-			agent:        nil,
-			reqQuery:     "/contact_cases",
-			expectStatus: http.StatusUnauthorized,
+			name: "contact_id filter reaches servicehandler with the exact value",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         agentID,
+					CustomerID: customerID,
+				},
+			}),
+			reqQuery:         "/contact_cases?contact_id=" + contactID.String(),
+			expectContactID:  contactID,
+			responseItems:    []*cmkase.Case{},
+			responseToken:    "",
+			expectStatusCode: http.StatusOK,
+		},
+		{
+			name:             "unauthenticated",
+			agent:            nil,
+			reqQuery:         "/contact_cases",
+			expectStatusCode: http.StatusUnauthorized,
 		},
 	}
 
@@ -75,13 +93,13 @@ func Test_GetContactCases(t *testing.T) {
 
 			if tt.responseItems != nil && tt.agent != nil {
 				mockSvc.EXPECT().
-					CaseList(req.Context(), tt.agent, uuid.Nil, uint64(100), "", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					CaseList(req.Context(), tt.agent, uuid.Nil, uint64(100), "", gomock.Any(), gomock.Any(), tt.expectOwnerID, tt.expectContactID).
 					Return(tt.responseItems, tt.responseToken, nil)
 			}
 
 			r.ServeHTTP(w, req)
-			if w.Code != tt.expectStatus {
-				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatus, w.Code, w.Body.String())
+			if w.Code != tt.expectStatusCode {
+				t.Errorf("Wrong status. expect: %d, got: %d, body: %s", tt.expectStatusCode, w.Code, w.Body.String())
 			}
 		})
 	}

--- a/bin-common-handler/pkg/requesthandler/contact_cases.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases.go
@@ -16,15 +16,16 @@ import (
 )
 
 // ContactV1CaseList lists cases from contact-manager, optionally filtered
-// by status and/or owner (owner_type/owner_id are query-string filters;
-// size/token are accepted for API symmetry with other list clients, but
-// the v1_cases.go listenhandler does not currently implement pagination
+// by status, owner, and/or contact_id (query-string filters; size/token
+// are accepted for API symmetry with other list clients, but the
+// v1_cases.go listenhandler does not currently implement pagination
 // on this route, so nextToken is always returned empty).
 func (r *requestHandler) ContactV1CaseList(
 	ctx context.Context,
 	customerID uuid.UUID,
 	status, ownerType string,
 	ownerID uuid.UUID,
+	contactID uuid.UUID,
 	size uint64,
 	token string,
 ) ([]*cmkase.Case, string, error) {
@@ -37,6 +38,9 @@ func (r *requestHandler) ContactV1CaseList(
 	}
 	if ownerID != uuid.Nil {
 		u.Set("owner_id", ownerID.String())
+	}
+	if contactID != uuid.Nil {
+		u.Set("contact_id", contactID.String())
 	}
 
 	uri := "/v1/cases?" + u.Encode()

--- a/bin-common-handler/pkg/requesthandler/contact_cases_test.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases_test.go
@@ -24,6 +24,7 @@ func Test_ContactV1CaseList(t *testing.T) {
 		status     string
 		ownerType  string
 		ownerID    uuid.UUID
+		contactID  uuid.UUID
 		size       uint64
 		token      string
 
@@ -59,6 +60,30 @@ func Test_ContactV1CaseList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "contact_id filter",
+
+			customerID: uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f3"),
+			contactID:  uuid.FromStringOrNil("7a3ec8f0-2c74-11ee-b0e5-8f2ac8c9a111"),
+
+			expectTarget: "bin-manager.contact-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/cases?contact_id=7a3ec8f0-2c74-11ee-b0e5-8f2ac8c9a111",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeJSON,
+				Data:     []byte(`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f3"}`),
+			},
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`[{"id":"5623e25e-2c74-11ee-87a6-bfa8ae34077f"}]`),
+			},
+			expectRes: []*cmkase.Case{
+				{
+					ID: uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,7 +99,7 @@ func Test_ContactV1CaseList(t *testing.T) {
 			ctx := context.Background()
 			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
 
-			res, nextToken, err := reqHandler.ContactV1CaseList(ctx, tt.customerID, tt.status, tt.ownerType, tt.ownerID, tt.size, tt.token)
+			res, nextToken, err := reqHandler.ContactV1CaseList(ctx, tt.customerID, tt.status, tt.ownerType, tt.ownerID, tt.contactID, tt.size, tt.token)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -925,7 +925,7 @@ type RequestHandler interface {
 	ContactV1ResolutionDelete(ctx context.Context, customerID uuid.UUID, interactionID, resolutionID uuid.UUID) error
 
 	// contact-manager cases (Phase 5, NOJIRA-contact-case-management)
-	ContactV1CaseList(ctx context.Context, customerID uuid.UUID, status, ownerType string, ownerID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
+	ContactV1CaseList(ctx context.Context, customerID uuid.UUID, status, ownerType string, ownerID uuid.UUID, contactID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
 	ContactV1CaseListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
 	ContactV1CaseGet(ctx context.Context, customerID, id uuid.UUID) (*cmkase.Case, error)
 	ContactV1CaseClose(ctx context.Context, customerID, id uuid.UUID, closedByType string, closedByID uuid.UUID) (*cmkase.Case, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -3521,9 +3521,9 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1CaseGet(ctx, customerID, id a
 }
 
 // ContactV1CaseList mocks base method.
-func (m *MockRequestHandler) ContactV1CaseList(ctx context.Context, customerID uuid.UUID, status, ownerType string, ownerID uuid.UUID, size uint64, token string) ([]*kase.Case, string, error) {
+func (m *MockRequestHandler) ContactV1CaseList(ctx context.Context, customerID uuid.UUID, status, ownerType string, ownerID, contactID uuid.UUID, size uint64, token string) ([]*kase.Case, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContactV1CaseList", ctx, customerID, status, ownerType, ownerID, size, token)
+	ret := m.ctrl.Call(m, "ContactV1CaseList", ctx, customerID, status, ownerType, ownerID, contactID, size, token)
 	ret0, _ := ret[0].([]*kase.Case)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -3531,9 +3531,9 @@ func (m *MockRequestHandler) ContactV1CaseList(ctx context.Context, customerID u
 }
 
 // ContactV1CaseList indicates an expected call of ContactV1CaseList.
-func (mr *MockRequestHandlerMockRecorder) ContactV1CaseList(ctx, customerID, status, ownerType, ownerID, size, token any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) ContactV1CaseList(ctx, customerID, status, ownerType, ownerID, contactID, size, token any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseList", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseList), ctx, customerID, status, ownerType, ownerID, size, token)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseList", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseList), ctx, customerID, status, ownerType, ownerID, contactID, size, token)
 }
 
 // ContactV1CaseListUnresolved mocks base method.

--- a/bin-contact-manager/pkg/casehandler/case_list_get.go
+++ b/bin-contact-manager/pkg/casehandler/case_list_get.go
@@ -12,9 +12,9 @@ import (
 
 // CaseList implements design §9's Phase 5 GET /v1/cases?... list
 // surface: a thin, customer-scoped delegation to dbhandler.CaseList,
-// optionally filtered by status and/or owner.
-func (h *caseHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID) ([]*kase.Case, error) {
-	return h.db.CaseList(ctx, customerID, status, ownerType, ownerID)
+// optionally filtered by status, owner, and/or contact_id.
+func (h *caseHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error) {
+	return h.db.CaseList(ctx, customerID, status, ownerType, ownerID, contactID)
 }
 
 // CaseGet implements design §9's Phase 5 GET /v1/cases/{id} route: the

--- a/bin-contact-manager/pkg/casehandler/case_list_get_test.go
+++ b/bin-contact-manager/pkg/casehandler/case_list_get_test.go
@@ -57,7 +57,7 @@ func Test_CaseList_ScopesToCustomerAndAppliesFilters(t *testing.T) {
 		t.Fatalf("CaseInsert() error = %v", err)
 	}
 
-	res, err := h.CaseList(ctx, customerID, "", commonidentity.OwnerTypeNone, uuid.Nil)
+	res, err := h.CaseList(ctx, customerID, "", commonidentity.OwnerTypeNone, uuid.Nil, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList() error = %v", err)
 	}

--- a/bin-contact-manager/pkg/casehandler/main.go
+++ b/bin-contact-manager/pkg/casehandler/main.go
@@ -96,7 +96,7 @@ type CaseHandler interface {
 	// upon by internal callers that already verify ownership themselves
 	// (see verifyCaseOwnership), CaseGet is the public, safe-by-default
 	// entry point for the customer-facing GET /v1/cases/{id} route.
-	CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID) ([]*kase.Case, error)
+	CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error)
 	CaseGet(ctx context.Context, customerID, id uuid.UUID) (*kase.Case, error)
 }
 

--- a/bin-contact-manager/pkg/casehandler/mock_main.go
+++ b/bin-contact-manager/pkg/casehandler/mock_main.go
@@ -62,18 +62,18 @@ func (mr *MockCaseHandlerMockRecorder) CaseGet(ctx, customerID, id any) *gomock.
 }
 
 // CaseList mocks base method.
-func (m *MockCaseHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType identity.OwnerType, ownerID uuid.UUID) ([]*kase.Case, error) {
+func (m *MockCaseHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType identity.OwnerType, ownerID, contactID uuid.UUID) ([]*kase.Case, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, status, ownerType, ownerID)
+	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, status, ownerType, ownerID, contactID)
 	ret0, _ := ret[0].([]*kase.Case)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CaseList indicates an expected call of CaseList.
-func (mr *MockCaseHandlerMockRecorder) CaseList(ctx, customerID, status, ownerType, ownerID any) *gomock.Call {
+func (mr *MockCaseHandlerMockRecorder) CaseList(ctx, customerID, status, ownerType, ownerID, contactID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockCaseHandler)(nil).CaseList), ctx, customerID, status, ownerType, ownerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockCaseHandler)(nil).CaseList), ctx, customerID, status, ownerType, ownerID, contactID)
 }
 
 // CaseListAll mocks base method.

--- a/bin-contact-manager/pkg/dbhandler/kase.go
+++ b/bin-contact-manager/pkg/dbhandler/kase.go
@@ -564,10 +564,11 @@ func (h *handler) CaseGetLastClosedByPeerTx(ctx context.Context, tx *sql.Tx, cus
 }
 
 // CaseList returns Cases scoped to customerID, optionally filtered by
-// status and/or owner (design §9's GET /v1/cases?... list surface).
-// status == "" means no status filter; ownerType == "" or
-// ownerID == uuid.Nil means no owner filter.
-func (h *handler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID) ([]*kase.Case, error) {
+// status, owner, and/or contact_id (design §9's GET /v1/cases?...
+// list surface). status == "" means no status filter; ownerType == ""
+// or ownerID == uuid.Nil means no owner filter; contactID == uuid.Nil
+// means no contact filter.
+func (h *handler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error) {
 	columns := commondatabasehandler.GetDBFields(&kase.Case{})
 
 	builder := sq.Select(columns...).
@@ -580,6 +581,9 @@ func (h *handler) CaseList(ctx context.Context, customerID uuid.UUID, status str
 		builder = builder.
 			Where(sq.Eq{"owner_type": string(ownerType)}).
 			Where(sq.Eq{"owner_id": ownerID.Bytes()})
+	}
+	if contactID != uuid.Nil {
+		builder = builder.Where(sq.Eq{"contact_id": contactID.Bytes()})
 	}
 
 	query, args, err := builder.ToSql()

--- a/bin-contact-manager/pkg/dbhandler/kase_list_test.go
+++ b/bin-contact-manager/pkg/dbhandler/kase_list_test.go
@@ -70,7 +70,7 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 
 	// No filters beyond customer_id: expect all 3 of this customer's cases.
-	all, err := h.CaseList(ctx, customerID, "", "", uuid.Nil)
+	all, err := h.CaseList(ctx, customerID, "", "", uuid.Nil, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList() error = %v", err)
 	}
@@ -86,7 +86,7 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 
 	// status=open filter.
-	openOnly, err := h.CaseList(ctx, customerID, string(kase.StatusOpen), "", uuid.Nil)
+	openOnly, err := h.CaseList(ctx, customerID, string(kase.StatusOpen), "", uuid.Nil, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList(status=open) error = %v", err)
 	}
@@ -102,7 +102,7 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 
 	// owner_type+owner_id filter.
-	ownedOnly, err := h.CaseList(ctx, customerID, "", commonidentity.OwnerTypeAgent, ownerID)
+	ownedOnly, err := h.CaseList(ctx, customerID, "", commonidentity.OwnerTypeAgent, ownerID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList(owner) error = %v", err)
 	}
@@ -115,5 +115,32 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 	if foundOwned[openOtherOwnerCaseID] {
 		t.Errorf("owner filter must exclude the other owner's case")
+	}
+
+	// contact_id filter.
+	contactID := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000004")
+	otherContactID := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000005")
+	contactAttributedCaseID := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000014")
+	if err := h.CaseInsert(ctx, &kase.Case{
+		ID: contactAttributedCaseID, CustomerID: customerID,
+		PeerType: commonaddress.TypeTel, PeerTarget: "+155****1014", ReferenceType: "call",
+		ContactID: &contactID,
+		Status:    kase.StatusOpen, OpenedAt: &opened, TMCreate: &opened, TMUpdate: &opened,
+	}); err != nil {
+		t.Fatalf("CaseInsert(contact-attributed) error = %v", err)
+	}
+	contactOnly, err := h.CaseList(ctx, customerID, "", "", uuid.Nil, contactID)
+	if err != nil {
+		t.Fatalf("CaseList(contact_id) error = %v", err)
+	}
+	if len(contactOnly) != 1 || contactOnly[0].ID != contactAttributedCaseID {
+		t.Errorf("contact_id filter = %v, want exactly [%v]", contactOnly, contactAttributedCaseID)
+	}
+	contactNoMatch, err := h.CaseList(ctx, customerID, "", "", uuid.Nil, otherContactID)
+	if err != nil {
+		t.Fatalf("CaseList(contact_id=other) error = %v", err)
+	}
+	if len(contactNoMatch) != 0 {
+		t.Errorf("contact_id filter for an unmatched contact = %v, want empty", contactNoMatch)
 	}
 }

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -106,7 +106,7 @@ type DBHandler interface {
 	// (ownerType == commonidentity.OwnerTypeNone or ownerID == uuid.Nil =
 	// no owner filter). Backs the Phase 5 RPC/REST GET /v1/cases?...
 	// list surface (design §9).
-	CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID) ([]*kase.Case, error)
+	CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error)
 }
 
 // handler database handler

--- a/bin-contact-manager/pkg/dbhandler/mock_main.go
+++ b/bin-contact-manager/pkg/dbhandler/mock_main.go
@@ -328,18 +328,18 @@ func (mr *MockDBHandlerMockRecorder) CaseInsertTx(ctx, tx, c any) *gomock.Call {
 }
 
 // CaseList mocks base method.
-func (m *MockDBHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType identity.OwnerType, ownerID uuid.UUID) ([]*kase.Case, error) {
+func (m *MockDBHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType identity.OwnerType, ownerID, contactID uuid.UUID) ([]*kase.Case, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, status, ownerType, ownerID)
+	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, status, ownerType, ownerID, contactID)
 	ret0, _ := ret[0].([]*kase.Case)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CaseList indicates an expected call of CaseList.
-func (mr *MockDBHandlerMockRecorder) CaseList(ctx, customerID, status, ownerType, ownerID any) *gomock.Call {
+func (mr *MockDBHandlerMockRecorder) CaseList(ctx, customerID, status, ownerType, ownerID, contactID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockDBHandler)(nil).CaseList), ctx, customerID, status, ownerType, ownerID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockDBHandler)(nil).CaseList), ctx, customerID, status, ownerType, ownerID, contactID)
 }
 
 // CaseListAll mocks base method.

--- a/bin-contact-manager/pkg/listenhandler/v1_cases.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases.go
@@ -37,7 +37,8 @@ func caseSubIDFromURI(uri string) uuid.UUID {
 }
 
 // processV1CasesGet handles GET /v1/cases?... request. Supports
-// optional status and owner_type/owner_id filters (design §9).
+// optional status, owner_type/owner_id, and contact_id filters
+// (design §9).
 func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesGet"})
 	log.WithField("request", req).Debug("Received request.")
@@ -54,6 +55,10 @@ func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request
 	if s := q.Get("owner_id"); s != "" {
 		ownerID = uuid.FromStringOrNil(s)
 	}
+	var contactID uuid.UUID
+	if s := q.Get("contact_id"); s != "" {
+		contactID = uuid.FromStringOrNil(s)
+	}
 
 	var body request.V1DataCasesGet
 	if len(req.Data) > 0 {
@@ -64,7 +69,7 @@ func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request
 		return simpleResponse(400), nil
 	}
 
-	res, err := h.caseHandler.CaseList(ctx, body.CustomerID, status, ownerType, ownerID)
+	res, err := h.caseHandler.CaseList(ctx, body.CustomerID, status, ownerType, ownerID, contactID)
 	if err != nil {
 		log.Errorf("Could not list cases. err: %v", err)
 		return errorResponse(err), nil

--- a/bin-contact-manager/pkg/listenhandler/v1_cases_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases_test.go
@@ -55,7 +55,40 @@ func Test_ProcessV1CasesGet_ListsWithFilters(t *testing.T) {
 		Data:   body,
 	}
 
-	mockCase.EXPECT().CaseList(ctx, customerID, "open", commonidentity.OwnerTypeAgent, ownerID).
+	mockCase.EXPECT().CaseList(ctx, customerID, "open", commonidentity.OwnerTypeAgent, ownerID, uuid.Nil).
+		Return([]*kase.Case{{ID: caseID}}, nil)
+
+	res, err := h.processV1CasesGet(ctx, req)
+	if err != nil {
+		t.Fatalf("processV1CasesGet() error = %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("StatusCode = %v, want 200", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesGet_ContactIDFilter verifies GET /v1/cases?contact_id=...
+// parses the contact_id query filter and passes it through to
+// caseHandler.CaseList, for the Contact-detail "Cases" tab use case
+// (square-admin contacts_detail.js).
+func Test_ProcessV1CasesGet_ContactIDFilter(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, mockCase := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-0002-0002-0002-000000000001")
+	contactID := uuid.FromStringOrNil("aaaaaaaa-0002-0002-0002-000000000002")
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0002-0002-0002-000000000003")
+
+	body, _ := json.Marshal(map[string]any{"customer_id": customerID.String()})
+	req := &sock.Request{
+		URI:    "/v1/cases?contact_id=" + contactID.String(),
+		Method: sock.RequestMethodGet,
+		Data:   body,
+	}
+
+	mockCase.EXPECT().CaseList(ctx, customerID, "", commonidentity.OwnerType(""), uuid.Nil, contactID).
 		Return([]*kase.Case{{ID: caseID}}, nil)
 
 	res, err := h.processV1CasesGet(ctx, req)

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -8245,6 +8245,9 @@ type GetContactCasesParams struct {
 	// OwnerId Filter by owner ID.
 	OwnerId *openapi_types.UUID `form:"owner_id,omitempty" json:"owner_id,omitempty"`
 
+	// ContactId Filter to cases attributed to this Contact.
+	ContactId *openapi_types.UUID `form:"contact_id,omitempty" json:"contact_id,omitempty"`
+
 	// PageSize Number of results to return per page.
 	PageSize *PageSize `form:"page_size,omitempty" json:"page_size,omitempty"`
 

--- a/bin-openapi-manager/openapi/paths/contact_cases/main.yaml
+++ b/bin-openapi-manager/openapi/paths/contact_cases/main.yaml
@@ -2,7 +2,7 @@ get:
   summary: List cases
   description: |
     List cases for the customer, optionally filtered by status, owner_type,
-    and owner_id.
+    owner_id, and contact_id.
   tags:
     - Case
   parameters:
@@ -28,6 +28,13 @@ get:
         type: string
         format: uuid
         example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    - name: contact_id
+      in: query
+      description: Filter to cases attributed to this Contact.
+      schema:
+        type: string
+        format: uuid
+        example: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
     - $ref: '#/components/parameters/PageSize'
     - $ref: '#/components/parameters/PageToken'
   responses:


### PR DESCRIPTION
Add a contact_id query filter to GET /contact_cases so square-admin's
Contact-detail page can list only the Cases attributed to a specific
Contact via the server, instead of client-side filtering the full
customer-wide case list.

- bin-openapi-manager: add contact_id query parameter to GET /contact_cases (openapi/paths/contact_cases/main.yaml), regenerate gens/models/gen.go
- bin-contact-manager: add contactID filter to dbhandler.CaseList (WHERE contact_id = ?), casehandler.CaseList thin wrapper, and listenhandler's processV1CasesGet (parses contact_id query param); regenerate dbhandler/casehandler mocks; add regression tests covering the new filter at all three layers
- bin-common-handler: add contactID parameter to requesthandler.ContactV1CaseList, threading it through as a contact_id query string filter; regenerate mock
- bin-api-manager: thread contactID through servicehandler.CaseList and server.GetContactCases (parses the new OpenAPI-generated ContactId param); regenerate openapi_server/gen.go, openapi_redoc bundle, and servicehandler mock; update existing case_test.go/contact_cases_test.go call sites for the new parameter

All existing filters (status, owner_type/owner_id) remain independently
combinable with contact_id. contact_id == uuid.Nil (omitted) means no
filter on this dimension, matching the existing status/owner filter
convention.

Verified: go mod tidy/vendor/generate/test/golangci-lint all pass in
bin-openapi-manager, bin-common-handler, bin-contact-manager, and
bin-api-manager. No conflicts with origin/main.
