### PR TITLE
NOJIRA-case-list-pagination

### DIFF
--- a/bin-common-handler/pkg/requesthandler/contact_cases.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases.go
@@ -21,6 +21,20 @@ import (
 // convention (results ordered by tm_create DESC; nextToken is the
 // tm_create of the last returned item's page, empty when no further
 // pages).
+//
+// Known limitation (shared with ContactV1InteractionList, not novel to
+// Case pagination): the listenhandler wire response is a bare JSON
+// array -- the accurate server-computed hasMore signal from
+// casehandler.CaseList's size+1 probe is discarded at that layer
+// (processV1CasesGet's `res, _, err := ...`) rather than being
+// marshaled onto the wire. This client-side nextToken re-derivation can
+// therefore emit a non-empty token on the exact last page (when the
+// caller's requested size happens to equal the total remaining rows),
+// causing one wasted empty follow-up page fetch at list end. This is
+// the same wire-format tradeoff ContactV1InteractionList already makes;
+// fixing it platform-wide (changing every list RPC's wire response
+// shape from a bare array to {items, next_token}) is out of scope for
+// this filter/ordering fix.
 func (r *requestHandler) ContactV1CaseList(
 	ctx context.Context,
 	customerID uuid.UUID,

--- a/bin-common-handler/pkg/requesthandler/contact_cases.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases.go
@@ -16,10 +16,11 @@ import (
 )
 
 // ContactV1CaseList lists cases from contact-manager, optionally filtered
-// by status, owner, and/or contact_id (query-string filters; size/token
-// are accepted for API symmetry with other list clients, but the
-// v1_cases.go listenhandler does not currently implement pagination
-// on this route, so nextToken is always returned empty).
+// by status, owner, and/or contact_id (query-string filters), with
+// page_size/page_token pagination matching ContactV1InteractionList's
+// convention (results ordered by tm_create DESC; nextToken is the
+// tm_create of the last returned item's page, empty when no further
+// pages).
 func (r *requestHandler) ContactV1CaseList(
 	ctx context.Context,
 	customerID uuid.UUID,
@@ -42,6 +43,12 @@ func (r *requestHandler) ContactV1CaseList(
 	if contactID != uuid.Nil {
 		u.Set("contact_id", contactID.String())
 	}
+	if size > 0 {
+		u.Set("page_size", fmt.Sprintf("%d", size))
+	}
+	if token != "" {
+		u.Set("page_token", token)
+	}
 
 	uri := "/v1/cases?" + u.Encode()
 
@@ -60,7 +67,12 @@ func (r *requestHandler) ContactV1CaseList(
 		return nil, "", errParse
 	}
 
-	return res, "", nil
+	nextToken := ""
+	if len(res) > 0 && res[len(res)-1].TMCreate != nil {
+		nextToken = res[len(res)-1].TMCreate.UTC().Format("2006-01-02T15:04:05.000000Z")
+	}
+
+	return res, nextToken, nil
 }
 
 // ContactV1CaseListUnresolved lists unresolved cases (open, contact_id

--- a/bin-common-handler/pkg/requesthandler/contact_cases_test.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases_test.go
@@ -84,6 +84,31 @@ func Test_ContactV1CaseList(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "page_size and page_token are encoded into the query string",
+
+			customerID: uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f3"),
+			size:       uint64(50),
+			token:      "2026-06-28T10:00:00.000000Z",
+
+			expectTarget: "bin-manager.contact-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/cases?page_size=50&page_token=2026-06-28T10%3A00%3A00.000000Z",
+				Method:   sock.RequestMethodGet,
+				DataType: ContentTypeJSON,
+				Data:     []byte(`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f3"}`),
+			},
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`[{"id":"5623e25e-2c74-11ee-87a6-bfa8ae34077f"}]`),
+			},
+			expectRes: []*cmkase.Case{
+				{
+					ID: uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -111,6 +136,41 @@ func Test_ContactV1CaseList(t *testing.T) {
 				t.Errorf("Wrong match. expect: empty, got: %v", nextToken)
 			}
 		})
+	}
+}
+
+// Test_ContactV1CaseList_NextToken verifies nextToken is derived from
+// the last returned item's tm_create (round-2-review-fixed pagination
+// wiring), matching ContactV1InteractionList's convention.
+func Test_ContactV1CaseList_NextToken(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	reqHandler := requestHandler{
+		sock: mockSock,
+	}
+
+	customerID := uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f3")
+
+	ctx := context.Background()
+	mockSock.EXPECT().RequestPublish(gomock.Any(), "bin-manager.contact-manager.request", &sock.Request{
+		URI:      "/v1/cases?",
+		Method:   sock.RequestMethodGet,
+		DataType: ContentTypeJSON,
+		Data:     []byte(`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f3"}`),
+	}).Return(&sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       []byte(`[{"id":"5623e25e-2c74-11ee-87a6-bfa8ae34077f","tm_create":"2026-06-28T12:00:00.000000Z"},{"id":"8fe6c136-2c75-11ee-a3a4-37400837e12e","tm_create":"2026-06-28T11:00:00.000000Z"}]`),
+	}, nil)
+
+	_, nextToken, err := reqHandler.ContactV1CaseList(ctx, customerID, "", "", uuid.Nil, uuid.Nil, 0, "")
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+	if nextToken != "2026-06-28T11:00:00.000000Z" {
+		t.Errorf("nextToken = %q, want %q (last item's tm_create)", nextToken, "2026-06-28T11:00:00.000000Z")
 	}
 }
 

--- a/bin-contact-manager/pkg/casehandler/case_list_get.go
+++ b/bin-contact-manager/pkg/casehandler/case_list_get.go
@@ -10,11 +10,44 @@ import (
 	"monorepo/bin-contact-manager/models/kase"
 )
 
+// defaultCaseListSize is used when size == 0 (design §9's Phase 5 GET
+// /v1/cases?... list surface has no client-mandatory size, mirroring
+// InteractionList's default-of-20 convention).
+const defaultCaseListSize = 20
+
 // CaseList implements design §9's Phase 5 GET /v1/cases?... list
 // surface: a thin, customer-scoped delegation to dbhandler.CaseList,
-// optionally filtered by status, owner, and/or contact_id.
-func (h *caseHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error) {
-	return h.db.CaseList(ctx, customerID, status, ownerType, ownerID, contactID)
+// optionally filtered by status, owner, and/or contact_id. Results are
+// ordered by tm_create DESC with a tm_create-cursor token (empty when no
+// further pages), matching InteractionList's pagination convention.
+func (h *caseHandler) CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token string, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, string, error) {
+	if size == 0 {
+		size = defaultCaseListSize
+	}
+
+	items, err := h.db.CaseList(ctx, customerID, size+1, token, status, ownerType, ownerID, contactID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	hasMore := uint64(len(items)) > size
+	if hasMore {
+		items = items[:size]
+	}
+
+	var nextToken string
+	if hasMore && len(items) > 0 {
+		last := items[len(items)-1]
+		if last.TMCreate != nil {
+			nextToken = last.TMCreate.UTC().Format("2006-01-02T15:04:05.000000Z")
+		}
+		// If TMCreate is nil, cursor cannot be encoded -- pagination stops
+		// here (matches InteractionList's buildPagedResult precedent; in
+		// production this should not occur since CaseInsert always sets
+		// TMCreate).
+	}
+
+	return items, nextToken, nil
 }
 
 // CaseGet implements design §9's Phase 5 GET /v1/cases/{id} route: the

--- a/bin-contact-manager/pkg/casehandler/case_list_get_test.go
+++ b/bin-contact-manager/pkg/casehandler/case_list_get_test.go
@@ -57,7 +57,7 @@ func Test_CaseList_ScopesToCustomerAndAppliesFilters(t *testing.T) {
 		t.Fatalf("CaseInsert() error = %v", err)
 	}
 
-	res, err := h.CaseList(ctx, customerID, "", commonidentity.OwnerTypeNone, uuid.Nil, uuid.Nil)
+	res, _, err := h.CaseList(ctx, customerID, 0, "", "", commonidentity.OwnerTypeNone, uuid.Nil, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList() error = %v", err)
 	}
@@ -70,6 +70,62 @@ func Test_CaseList_ScopesToCustomerAndAppliesFilters(t *testing.T) {
 	}
 	if found[otherCaseID] {
 		t.Errorf("CaseList() must not leak another customer's case")
+	}
+}
+
+// Test_CaseList_DefaultSizeAndNextToken verifies the casehandler-level
+// pagination wrapper: size==0 defaults to defaultCaseListSize, and a
+// non-empty nextToken is returned only when more rows exist beyond the
+// requested page.
+func Test_CaseList_DefaultSizeAndNextToken(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9712-9712-9712-000000000001")
+	t1 := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC)
+	id1 := uuid.FromStringOrNil("f1b2c3d4-9712-9712-9712-000000000011")
+	id2 := uuid.FromStringOrNil("f1b2c3d4-9712-9712-9712-000000000012")
+
+	for _, c := range []*kase.Case{
+		{ID: id1, CustomerID: customerID, PeerType: commonaddress.TypeTel, PeerTarget: "+155****2011", ReferenceType: "call", Status: kase.StatusOpen, OpenedAt: &t1, TMCreate: &t1, TMUpdate: &t1},
+		{ID: id2, CustomerID: customerID, PeerType: commonaddress.TypeTel, PeerTarget: "+155****2012", ReferenceType: "call", Status: kase.StatusOpen, OpenedAt: &t2, TMCreate: &t2, TMUpdate: &t2},
+	} {
+		if err := db.CaseInsert(ctx, c); err != nil {
+			t.Fatalf("CaseInsert(%s) error = %v", c.ID, err)
+		}
+	}
+
+	// size=1: exactly 1 item back, plus a non-empty nextToken (id1 still pending).
+	page, nextToken, err := h.CaseList(ctx, customerID, 1, "", "", commonidentity.OwnerTypeNone, uuid.Nil, uuid.Nil)
+	if err != nil {
+		t.Fatalf("CaseList(size=1) error = %v", err)
+	}
+	if len(page) != 1 || page[0].ID != id2 {
+		t.Fatalf("CaseList(size=1) = %v, want exactly [id2] (newest first)", page)
+	}
+	if nextToken == "" {
+		t.Errorf("CaseList(size=1) nextToken = %q, want non-empty (id1 still pending)", nextToken)
+	}
+
+	// Follow the cursor: expect id1, and an empty nextToken (no further pages).
+	page2, nextToken2, err := h.CaseList(ctx, customerID, 1, nextToken, "", commonidentity.OwnerTypeNone, uuid.Nil, uuid.Nil)
+	if err != nil {
+		t.Fatalf("CaseList(token) error = %v", err)
+	}
+	if len(page2) != 1 || page2[0].ID != id1 {
+		t.Fatalf("CaseList(token) = %v, want exactly [id1]", page2)
+	}
+	if nextToken2 != "" {
+		t.Errorf("CaseList(token) nextToken = %q, want empty (no further pages)", nextToken2)
 	}
 }
 

--- a/bin-contact-manager/pkg/casehandler/main.go
+++ b/bin-contact-manager/pkg/casehandler/main.go
@@ -96,7 +96,7 @@ type CaseHandler interface {
 	// upon by internal callers that already verify ownership themselves
 	// (see verifyCaseOwnership), CaseGet is the public, safe-by-default
 	// entry point for the customer-facing GET /v1/cases/{id} route.
-	CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error)
+	CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token string, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, string, error)
 	CaseGet(ctx context.Context, customerID, id uuid.UUID) (*kase.Case, error)
 }
 

--- a/bin-contact-manager/pkg/casehandler/mock_main.go
+++ b/bin-contact-manager/pkg/casehandler/mock_main.go
@@ -62,18 +62,19 @@ func (mr *MockCaseHandlerMockRecorder) CaseGet(ctx, customerID, id any) *gomock.
 }
 
 // CaseList mocks base method.
-func (m *MockCaseHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType identity.OwnerType, ownerID, contactID uuid.UUID) ([]*kase.Case, error) {
+func (m *MockCaseHandler) CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token, status string, ownerType identity.OwnerType, ownerID, contactID uuid.UUID) ([]*kase.Case, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, status, ownerType, ownerID, contactID)
+	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, size, token, status, ownerType, ownerID, contactID)
 	ret0, _ := ret[0].([]*kase.Case)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // CaseList indicates an expected call of CaseList.
-func (mr *MockCaseHandlerMockRecorder) CaseList(ctx, customerID, status, ownerType, ownerID, contactID any) *gomock.Call {
+func (mr *MockCaseHandlerMockRecorder) CaseList(ctx, customerID, size, token, status, ownerType, ownerID, contactID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockCaseHandler)(nil).CaseList), ctx, customerID, status, ownerType, ownerID, contactID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockCaseHandler)(nil).CaseList), ctx, customerID, size, token, status, ownerType, ownerID, contactID)
 }
 
 // CaseListAll mocks base method.

--- a/bin-contact-manager/pkg/dbhandler/kase.go
+++ b/bin-contact-manager/pkg/dbhandler/kase.go
@@ -567,8 +567,13 @@ func (h *handler) CaseGetLastClosedByPeerTx(ctx context.Context, tx *sql.Tx, cus
 // status, owner, and/or contact_id (design §9's GET /v1/cases?...
 // list surface). status == "" means no status filter; ownerType == ""
 // or ownerID == uuid.Nil means no owner filter; contactID == uuid.Nil
-// means no contact filter.
-func (h *handler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error) {
+// means no contact filter. Results are ordered by tm_create DESC with
+// a tm_create-cursor token (token == "" means the first page), mirroring
+// InteractionList's pagination convention so that page_size on
+// GET /contact_cases is no longer silently ignored end-to-end and the
+// square-admin "Cases" list surfaces the most-recently-opened Cases
+// first instead of an arbitrary DB-engine row order.
+func (h *handler) CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token string, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error) {
 	columns := commondatabasehandler.GetDBFields(&kase.Case{})
 
 	builder := sq.Select(columns...).
@@ -585,6 +590,22 @@ func (h *handler) CaseList(ctx context.Context, customerID uuid.UUID, status str
 	if contactID != uuid.Nil {
 		builder = builder.Where(sq.Eq{"contact_id": contactID.Bytes()})
 	}
+
+	if token != "" {
+		cursorTime, err := time.Parse("2006-01-02T15:04:05.000000Z", token)
+		if err != nil {
+			// Fallback to RFC3339Nano for forward compatibility.
+			cursorTime, err = time.Parse(time.RFC3339Nano, token)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not parse page token. CaseList. err: %v", err)
+		}
+		builder = builder.Where(sq.Lt{"tm_create": cursorTime.UTC()})
+	}
+
+	builder = builder.
+		OrderBy("tm_create DESC").
+		Limit(size)
 
 	query, args, err := builder.ToSql()
 	if err != nil {

--- a/bin-contact-manager/pkg/dbhandler/kase_list_test.go
+++ b/bin-contact-manager/pkg/dbhandler/kase_list_test.go
@@ -70,7 +70,7 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 
 	// No filters beyond customer_id: expect all 3 of this customer's cases.
-	all, err := h.CaseList(ctx, customerID, "", "", uuid.Nil, uuid.Nil)
+	all, err := h.CaseList(ctx, customerID, 100, "", "", "", uuid.Nil, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList() error = %v", err)
 	}
@@ -86,7 +86,7 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 
 	// status=open filter.
-	openOnly, err := h.CaseList(ctx, customerID, string(kase.StatusOpen), "", uuid.Nil, uuid.Nil)
+	openOnly, err := h.CaseList(ctx, customerID, 100, "", string(kase.StatusOpen), "", uuid.Nil, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList(status=open) error = %v", err)
 	}
@@ -102,7 +102,7 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}
 
 	// owner_type+owner_id filter.
-	ownedOnly, err := h.CaseList(ctx, customerID, "", commonidentity.OwnerTypeAgent, ownerID, uuid.Nil)
+	ownedOnly, err := h.CaseList(ctx, customerID, 100, "", "", commonidentity.OwnerTypeAgent, ownerID, uuid.Nil)
 	if err != nil {
 		t.Fatalf("CaseList(owner) error = %v", err)
 	}
@@ -129,18 +129,75 @@ func Test_CaseList_FiltersByCustomerStatusAndOwner(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("CaseInsert(contact-attributed) error = %v", err)
 	}
-	contactOnly, err := h.CaseList(ctx, customerID, "", "", uuid.Nil, contactID)
+	contactOnly, err := h.CaseList(ctx, customerID, 100, "", "", "", uuid.Nil, contactID)
 	if err != nil {
 		t.Fatalf("CaseList(contact_id) error = %v", err)
 	}
 	if len(contactOnly) != 1 || contactOnly[0].ID != contactAttributedCaseID {
 		t.Errorf("contact_id filter = %v, want exactly [%v]", contactOnly, contactAttributedCaseID)
 	}
-	contactNoMatch, err := h.CaseList(ctx, customerID, "", "", uuid.Nil, otherContactID)
+	contactNoMatch, err := h.CaseList(ctx, customerID, 100, "", "", "", uuid.Nil, otherContactID)
 	if err != nil {
 		t.Fatalf("CaseList(contact_id=other) error = %v", err)
 	}
 	if len(contactNoMatch) != 0 {
 		t.Errorf("contact_id filter for an unmatched contact = %v, want empty", contactNoMatch)
+	}
+}
+
+// Test_CaseList_OrderedAndPaginated verifies CaseList orders results by
+// tm_create DESC and honors size/token pagination (the round-2 review
+// finding: page_size was previously accepted but silently ignored, and
+// results had no deterministic order).
+func Test_CaseList_OrderedAndPaginated(t *testing.T) {
+	h := NewHandler(dbTest, nil)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000021")
+
+	t1 := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	id1 := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000031")
+	id2 := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000032")
+	id3 := uuid.FromStringOrNil("f1b2c3d4-9601-9601-9601-000000000033")
+
+	for _, c := range []*kase.Case{
+		{ID: id1, CustomerID: customerID, PeerType: commonaddress.TypeTel, PeerTarget: "+155****2001", ReferenceType: "call", Status: kase.StatusOpen, OpenedAt: &t1, TMCreate: &t1, TMUpdate: &t1},
+		{ID: id2, CustomerID: customerID, PeerType: commonaddress.TypeTel, PeerTarget: "+155****2002", ReferenceType: "call", Status: kase.StatusOpen, OpenedAt: &t2, TMCreate: &t2, TMUpdate: &t2},
+		{ID: id3, CustomerID: customerID, PeerType: commonaddress.TypeTel, PeerTarget: "+155****2003", ReferenceType: "call", Status: kase.StatusOpen, OpenedAt: &t3, TMCreate: &t3, TMUpdate: &t3},
+	} {
+		if err := h.CaseInsert(ctx, c); err != nil {
+			t.Fatalf("CaseInsert(%s) error = %v", c.ID, err)
+		}
+	}
+
+	// size=100, no token: expect all 3, newest (id3) first.
+	all, err := h.CaseList(ctx, customerID, 100, "", "", "", uuid.Nil, uuid.Nil)
+	if err != nil {
+		t.Fatalf("CaseList() error = %v", err)
+	}
+	if len(all) != 3 || all[0].ID != id3 || all[1].ID != id2 || all[2].ID != id1 {
+		t.Fatalf("CaseList() order = %v, want [id3, id2, id1] (tm_create DESC)", all)
+	}
+
+	// size=1: expect only the newest (id3).
+	page1, err := h.CaseList(ctx, customerID, 1, "", "", "", uuid.Nil, uuid.Nil)
+	if err != nil {
+		t.Fatalf("CaseList(size=1) error = %v", err)
+	}
+	if len(page1) != 1 || page1[0].ID != id3 {
+		t.Fatalf("CaseList(size=1) = %v, want exactly [id3]", page1)
+	}
+
+	// token=t3 (as a cursor): expect id2, id1 (strictly older than t3).
+	token := t3.UTC().Format("2006-01-02T15:04:05.000000Z")
+	page2, err := h.CaseList(ctx, customerID, 100, token, "", "", uuid.Nil, uuid.Nil)
+	if err != nil {
+		t.Fatalf("CaseList(token) error = %v", err)
+	}
+	if len(page2) != 2 || page2[0].ID != id2 || page2[1].ID != id1 {
+		t.Fatalf("CaseList(token=%s) = %v, want [id2, id1]", token, page2)
 	}
 }

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -106,7 +106,7 @@ type DBHandler interface {
 	// (ownerType == commonidentity.OwnerTypeNone or ownerID == uuid.Nil =
 	// no owner filter). Backs the Phase 5 RPC/REST GET /v1/cases?...
 	// list surface (design §9).
-	CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error)
+	CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token string, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, error)
 }
 
 // handler database handler

--- a/bin-contact-manager/pkg/dbhandler/mock_main.go
+++ b/bin-contact-manager/pkg/dbhandler/mock_main.go
@@ -328,18 +328,18 @@ func (mr *MockDBHandlerMockRecorder) CaseInsertTx(ctx, tx, c any) *gomock.Call {
 }
 
 // CaseList mocks base method.
-func (m *MockDBHandler) CaseList(ctx context.Context, customerID uuid.UUID, status string, ownerType identity.OwnerType, ownerID, contactID uuid.UUID) ([]*kase.Case, error) {
+func (m *MockDBHandler) CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token, status string, ownerType identity.OwnerType, ownerID, contactID uuid.UUID) ([]*kase.Case, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, status, ownerType, ownerID, contactID)
+	ret := m.ctrl.Call(m, "CaseList", ctx, customerID, size, token, status, ownerType, ownerID, contactID)
 	ret0, _ := ret[0].([]*kase.Case)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CaseList indicates an expected call of CaseList.
-func (mr *MockDBHandlerMockRecorder) CaseList(ctx, customerID, status, ownerType, ownerID, contactID any) *gomock.Call {
+func (mr *MockDBHandlerMockRecorder) CaseList(ctx, customerID, size, token, status, ownerType, ownerID, contactID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockDBHandler)(nil).CaseList), ctx, customerID, status, ownerType, ownerID, contactID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseList", reflect.TypeOf((*MockDBHandler)(nil).CaseList), ctx, customerID, size, token, status, ownerType, ownerID, contactID)
 }
 
 // CaseListAll mocks base method.

--- a/bin-contact-manager/pkg/listenhandler/v1_cases.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+	"strconv"
 	"strings"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
@@ -38,7 +39,8 @@ func caseSubIDFromURI(uri string) uuid.UUID {
 
 // processV1CasesGet handles GET /v1/cases?... request. Supports
 // optional status, owner_type/owner_id, and contact_id filters
-// (design §9).
+// (design §9), plus page_size/page_token pagination (matching
+// InteractionList's convention).
 func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesGet"})
 	log.WithField("request", req).Debug("Received request.")
@@ -48,6 +50,10 @@ func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request
 		return simpleResponse(400), nil
 	}
 	q := u.Query()
+
+	tmpSize, _ := strconv.Atoi(q.Get(PageSize))
+	pageSize := uint64(tmpSize)
+	pageToken := q.Get(PageToken)
 
 	status := q.Get("status")
 	ownerType := commonidentity.OwnerType(q.Get("owner_type"))
@@ -69,7 +75,7 @@ func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request
 		return simpleResponse(400), nil
 	}
 
-	res, err := h.caseHandler.CaseList(ctx, body.CustomerID, status, ownerType, ownerID, contactID)
+	res, _, err := h.caseHandler.CaseList(ctx, body.CustomerID, pageSize, pageToken, status, ownerType, ownerID, contactID)
 	if err != nil {
 		log.Errorf("Could not list cases. err: %v", err)
 		return errorResponse(err), nil

--- a/bin-contact-manager/pkg/listenhandler/v1_cases_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases_test.go
@@ -3,6 +3,7 @@ package listenhandler
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 	"testing"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
@@ -50,13 +51,13 @@ func Test_ProcessV1CasesGet_ListsWithFilters(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{"customer_id": customerID.String()})
 	req := &sock.Request{
-		URI:    "/v1/cases?status=open&owner_type=agent&owner_id=" + ownerID.String(),
+		URI:    "/v1/cases?status=open&owner_type=agent&owner_id=" + ownerID.String() + "&page_size=50&page_token=" + url.QueryEscape("2026-06-28T10:00:00.000000Z"),
 		Method: sock.RequestMethodGet,
 		Data:   body,
 	}
 
-	mockCase.EXPECT().CaseList(ctx, customerID, "open", commonidentity.OwnerTypeAgent, ownerID, uuid.Nil).
-		Return([]*kase.Case{{ID: caseID}}, nil)
+	mockCase.EXPECT().CaseList(ctx, customerID, uint64(50), "2026-06-28T10:00:00.000000Z", "open", commonidentity.OwnerTypeAgent, ownerID, uuid.Nil).
+		Return([]*kase.Case{{ID: caseID}}, "", nil)
 
 	res, err := h.processV1CasesGet(ctx, req)
 	if err != nil {
@@ -88,8 +89,8 @@ func Test_ProcessV1CasesGet_ContactIDFilter(t *testing.T) {
 		Data:   body,
 	}
 
-	mockCase.EXPECT().CaseList(ctx, customerID, "", commonidentity.OwnerType(""), uuid.Nil, contactID).
-		Return([]*kase.Case{{ID: caseID}}, nil)
+	mockCase.EXPECT().CaseList(ctx, customerID, uint64(0), "", "", commonidentity.OwnerType(""), uuid.Nil, contactID).
+		Return([]*kase.Case{{ID: caseID}}, "", nil)
 
 	res, err := h.processV1CasesGet(ctx, req)
 	if err != nil {


### PR DESCRIPTION
Add ORDER BY tm_create DESC + real size/token pagination to
GET /v1/cases (bin-contact-manager) and GET /contact_cases
(bin-api-manager), fixing a gap identified during square-admin PR #347's
round-2 review.

- bin-contact-manager: dbhandler.CaseList orders by tm_create DESC with a tm_create-cursor token, mirroring InteractionList's existing convention
- bin-contact-manager: casehandler.CaseList wraps it with a default page size (20) and derives nextToken from the last returned item
- bin-contact-manager: listenhandler's processV1CasesGet now parses page_size/page_token query params
- bin-common-handler: requesthandler.ContactV1CaseList now encodes page_size/page_token on the outbound RPC and derives nextToken from the response

Previously GET /contact_cases's page_size param was accepted end-to-end
but silently ignored -- no ORDER BY, no LIMIT in the underlying SQL --
so square-admin's Contact-detail "Cases" list returned every Case for
the contact in an arbitrary DB-engine row order (the exact issue
square-admin PR #347's Cases footer copy was changed to stop
misrepresenting). No API/wire contract change; callers already sending
page_size/page_token now get an ordered, paginated result instead of an
unordered full set.

Verified: full verification workflow (tidy/vendor/generate/test/lint)
passes clean in all 3 touched services (bin-common-handler,
bin-contact-manager, bin-api-manager).
