### PR TITLE
NOJIRA-Fix-provider-setup-use-fqdn-connection

### DIFF
--- a/bin-route-manager/cmd/route-manager/main.go
+++ b/bin-route-manager/cmd/route-manager/main.go
@@ -131,7 +131,7 @@ func runService(ctx context.Context, sqlDB *sql.DB, cache cachehandler.CacheHand
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameRouteEvent, serviceName)
 
 	routeHandler := routehandler.NewRouteHandler(db, reqHandler, notifyHandler)
-	providerHandler := providerhandler.NewProviderHandler(db, reqHandler, notifyHandler, cfg.SipLBAddresses)
+	providerHandler := providerhandler.NewProviderHandler(db, reqHandler, notifyHandler, cfg.SipGatewayFQDNForPSTN)
 	providerCallHandler := providercallhandler.NewProviderCallHandler(db, reqHandler, notifyHandler)
 
 	// start background provider health check loop

--- a/bin-route-manager/docs/operations.md
+++ b/bin-route-manager/docs/operations.md
@@ -70,7 +70,7 @@ ORDER BY r.priority;
 | `--redis_address` | `REDIS_ADDRESS` | required | Redis cache |
 | `--redis_password` | `REDIS_PASSWORD` | `` | Redis auth password |
 | `--redis_database` | `REDIS_DATABASE` | `` | Redis DB index |
-| `--external_sip_gateway_addresses` | `EXTERNAL_SIP_GATEWAY_ADDRESSES` | `` | Comma-separated SIP gateway IPs for provider setup |
+| `--external_sip_gateway_fqdn_for_pstn` | `EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN` | `` | Public SIP gateway FQDN:port (e.g. `pstn.voipbin.net:5060`) registered on Telnyx as an FQDN connection for provider setup |
 | `--prometheus_endpoint` | `PROMETHEUS_ENDPOINT` | `/metrics` | Metrics path |
 | `--prometheus_listen_address` | `PROMETHEUS_LISTEN_ADDRESS` | `:2112` | Metrics listen address |
 

--- a/bin-route-manager/internal/config/config.go
+++ b/bin-route-manager/internal/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	RedisDatabase           int
 	RedisPassword           string
 	HealthCheckInterval     time.Duration
-	SipLBAddresses          []string
+	SipGatewayFQDNForPSTN   string
 }
 
 // Get returns the current configuration
@@ -45,18 +45,18 @@ func Bootstrap(cmd *cobra.Command) error {
 	f.String("redis_password", "", "Redis password")
 	f.Int("redis_database", 1, "Redis database index")
 	f.Duration("health_check_interval", 30*time.Second, "Provider health check interval")
-	f.String("external_sip_gateway_addresses", "", "Comma-separated list of external SIP gateway addresses (ip:port) registered on Telnyx for IP-auth")
+	f.String("external_sip_gateway_fqdn_for_pstn", "", "Public SIP gateway FQDN:port (e.g. pstn.voipbin.net:5060) registered on Telnyx as an FQDN connection")
 
 	bindings := map[string]string{
-		"rabbitmq_address":          "RABBITMQ_ADDRESS",
-		"prometheus_endpoint":       "PROMETHEUS_ENDPOINT",
-		"prometheus_listen_address": "PROMETHEUS_LISTEN_ADDRESS",
-		"database_dsn":              "DATABASE_DSN",
-		"redis_address":             "REDIS_ADDRESS",
-		"redis_password":            "REDIS_PASSWORD",
-		"redis_database":            "REDIS_DATABASE",
-		"health_check_interval":     "HEALTH_CHECK_INTERVAL",
-		"external_sip_gateway_addresses": "EXTERNAL_SIP_GATEWAY_ADDRESSES",
+		"rabbitmq_address":                   "RABBITMQ_ADDRESS",
+		"prometheus_endpoint":                "PROMETHEUS_ENDPOINT",
+		"prometheus_listen_address":          "PROMETHEUS_LISTEN_ADDRESS",
+		"database_dsn":                       "DATABASE_DSN",
+		"redis_address":                      "REDIS_ADDRESS",
+		"redis_password":                     "REDIS_PASSWORD",
+		"redis_database":                     "REDIS_DATABASE",
+		"health_check_interval":              "HEALTH_CHECK_INTERVAL",
+		"external_sip_gateway_fqdn_for_pstn": "EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN",
 	}
 
 	for flagKey, envKey := range bindings {
@@ -85,7 +85,7 @@ func LoadGlobalConfig() {
 			RedisDatabase:           viper.GetInt("redis_database"),
 			RedisPassword:           viper.GetString("redis_password"),
 			HealthCheckInterval:     viper.GetDuration("health_check_interval"),
-			SipLBAddresses:          viper.GetStringSlice("external_sip_gateway_addresses"),
+			SipGatewayFQDNForPSTN:   viper.GetString("external_sip_gateway_fqdn_for_pstn"),
 		}
 	})
 }

--- a/bin-route-manager/k8s/deployment.yml
+++ b/bin-route-manager/k8s/deployment.yml
@@ -58,11 +58,11 @@ spec:
                 secretKeyRef:
                   name: voipbin
                   key: CLICKHOUSE_ADDRESS
-            - name: EXTERNAL_SIP_GATEWAY_ADDRESSES
+            - name: EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN
               valueFrom:
                 secretKeyRef:
                   name: voipbin
-                  key: EXTERNAL_SIP_GATEWAY_ADDRESSES
+                  key: EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN
           ports:
             - name: metrics
               protocol: "TCP"

--- a/bin-route-manager/pkg/providerhandler/main.go
+++ b/bin-route-manager/pkg/providerhandler/main.go
@@ -15,10 +15,10 @@ import (
 )
 
 type providerHandler struct {
-	db             dbhandler.DBHandler
-	reqHandler     requesthandler.RequestHandler
-	notifyHandler  notifyhandler.NotifyHandler
-	sipLBAddresses []string
+	db                    dbhandler.DBHandler
+	reqHandler            requesthandler.RequestHandler
+	notifyHandler         notifyhandler.NotifyHandler
+	sipGatewayFQDNForPSTN string
 }
 
 // ProviderHandler defines provider management operations.
@@ -66,13 +66,13 @@ func NewProviderHandler(
 	db dbhandler.DBHandler,
 	reqHandler requesthandler.RequestHandler,
 	notifyHandler notifyhandler.NotifyHandler,
-	sipLBAddresses []string,
+	sipGatewayFQDNForPSTN string,
 ) ProviderHandler {
 	h := &providerHandler{
-		db:             db,
-		reqHandler:     reqHandler,
-		notifyHandler:  notifyHandler,
-		sipLBAddresses: sipLBAddresses,
+		db:                    db,
+		reqHandler:            reqHandler,
+		notifyHandler:         notifyHandler,
+		sipGatewayFQDNForPSTN: sipGatewayFQDNForPSTN,
 	}
 
 	return h

--- a/bin-route-manager/pkg/providerhandler/provider_test.go
+++ b/bin-route-manager/pkg/providerhandler/provider_test.go
@@ -527,7 +527,7 @@ func Test_NewProviderHandler(t *testing.T) {
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
 
-	h := NewProviderHandler(mockDB, mockReq, mockNotify, []string{"10.0.0.1:5060"})
+	h := NewProviderHandler(mockDB, mockReq, mockNotify, "pstn.voipbin.net:5060")
 	if h == nil {
 		t.Errorf("Expected handler to be created, got nil")
 	}

--- a/bin-route-manager/pkg/providerhandler/setup.go
+++ b/bin-route-manager/pkg/providerhandler/setup.go
@@ -2,6 +2,8 @@ package providerhandler
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"strconv"
@@ -14,6 +16,75 @@ import (
 )
 
 const telnyxSIPHostname = "sip.telnyx.com"
+
+// generateCredentialSecret returns a random alphanumeric string suitable for
+// a Telnyx FQDN connection's SIP credential user_name/password. Telnyx
+// rejects punctuation/whitespace in these fields ("Must contain only letters
+// and numbers; no spacing allowed" — confirmed empirically against the
+// Telnyx API), so the alphabet is restricted to letters and digits.
+func generateCredentialSecret(n int) (string, error) {
+	// base64 URL-safe encoding without padding only uses [A-Za-z0-9_-];
+	// stripping '_'/'-' leaves a purely alphanumeric string. Over-request
+	// bytes so the stripped result still has at least n characters.
+	buf := make([]byte, n*2)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate random secret: %w", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(buf)
+	out := make([]byte, 0, n)
+	for i := 0; i < len(encoded) && len(out) < n; i++ {
+		c := encoded[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		out = append(out, c)
+	}
+	if len(out) < n {
+		return "", fmt.Errorf("could not generate %d alphanumeric characters", n)
+	}
+	return string(out), nil
+}
+
+// sanitizeCredentialUserName strips everything but letters/digits from name
+// so it is safe to use as (part of) a Telnyx FQDN connection's user_name.
+// Telnyx rejects punctuation/whitespace in user_name (e.g. hyphens, spaces),
+// which provider names commonly contain (confirmed empirically: a request
+// with a hyphenated user_name returns 422 "Must contain only letters and
+// numbers; no spacing allowed").
+func sanitizeCredentialUserName(name string) string {
+	out := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}
+
+// credentialUserNamePrefix is prepended to the sanitized provider name to
+// form the Telnyx FQDN connection's user_name.
+const credentialUserNamePrefix = "voipbinrm"
+
+// telnyxUserNameMaxLen is Telnyx's hard limit on the FQDN connection
+// user_name field (confirmed empirically: a 90-character user_name returns
+// 422 "is too long (maximum is 32 characters)").
+const telnyxUserNameMaxLen = 32
+
+// buildCredentialUserName combines the fixed prefix with a sanitized,
+// length-capped provider name so the result never exceeds Telnyx's 32
+// character user_name limit regardless of how long the provider name is.
+func buildCredentialUserName(name string) string {
+	sanitized := sanitizeCredentialUserName(name)
+	maxSanitizedLen := telnyxUserNameMaxLen - len(credentialUserNamePrefix)
+	if maxSanitizedLen < 0 {
+		maxSanitizedLen = 0
+	}
+	if len(sanitized) > maxSanitizedLen {
+		sanitized = sanitized[:maxSanitizedLen]
+	}
+	return credentialUserNamePrefix + sanitized
+}
 
 // Setup is the public entry point. It constructs a TelnyxClient from apiKey and delegates to setupWithClient.
 func (h *providerHandler) Setup(ctx context.Context, carrier, name, detail, apiKey string) (*provider.Provider, error) {
@@ -33,8 +104,8 @@ func (h *providerHandler) setupWithClient(ctx context.Context, carrier, name, de
 		return nil, fmt.Errorf("unsupported carrier: %s", carrier)
 	}
 
-	if len(h.sipLBAddresses) == 0 {
-		return nil, fmt.Errorf("no SIP gateway addresses configured; set EXTERNAL_SIP_GATEWAY_ADDRESSES")
+	if h.sipGatewayFQDNForPSTN == "" {
+		return nil, fmt.Errorf("no PSTN SIP gateway FQDN configured; set EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN")
 	}
 
 	// Step 1: validate the API key
@@ -51,45 +122,58 @@ func (h *providerHandler) setupWithClient(ctx context.Context, carrier, name, de
 	}
 	log.Debugf("Created Telnyx outbound voice profile. profile_id: %s", profileID)
 
-	// Step 3: create IP connection linked to the voice profile
-	connID, err := client.CreateIPConnection(ctx, name, profileID)
+	// Step 3: create an FQDN connection linked to the voice profile. An FQDN
+	// connection (as opposed to an IP connection) presents inbound calls with
+	// the FQDN as the SIP request-URI domain instead of a raw IP address,
+	// which Kamailio's domain validation (request_from_external_init_connection)
+	// requires. Telnyx requires the connection's credential authentication to
+	// be fully configured before an outbound_voice_profile can be attached, so
+	// a random credential is generated here; it is never used for actual
+	// authentication since inbound routing is FQDN/DNS-based and outbound
+	// dialing uses IP-based tech-prefix auth, but Telnyx still requires the
+	// fields to be populated.
+	credUser := buildCredentialUserName(name)
+	credPassword, err := generateCredentialSecret(32)
 	if err != nil {
-		log.Errorf("Could not create Telnyx IP connection. err: %v", err)
-		h.telnyxCleanup(log, client, nil, "", profileID)
-		return nil, fmt.Errorf("telnyx create ip connection failed: %w", err)
+		log.Errorf("Could not generate Telnyx connection credential. err: %v", err)
+		h.telnyxCleanup(log, client, "", "", profileID)
+		return nil, fmt.Errorf("generate telnyx credential failed: %w", err)
 	}
-	log.Debugf("Created Telnyx IP connection. conn_id: %s", connID)
+	connID, err := client.CreateFQDNConnection(ctx, name, profileID, credUser, credPassword)
+	if err != nil {
+		log.Errorf("Could not create Telnyx FQDN connection. err: %v", err)
+		h.telnyxCleanup(log, client, "", "", profileID)
+		return nil, fmt.Errorf("telnyx create fqdn connection failed: %w", err)
+	}
+	log.Debugf("Created Telnyx FQDN connection. conn_id: %s", connID)
 
-	// Step 4: register each SIP LB address on the connection
-	ipIDs := make([]string, 0, len(h.sipLBAddresses))
-	for _, addr := range h.sipLBAddresses {
-		ip, portStr, parseErr := net.SplitHostPort(addr)
-		if parseErr != nil {
-			log.Errorf("Invalid SIP LB address. addr: %s, err: %v", addr, parseErr)
-			h.telnyxCleanup(log, client, ipIDs, connID, profileID)
-			return nil, fmt.Errorf("invalid sip lb address %q: %w", addr, parseErr)
-		}
-		port, convErr := strconv.Atoi(portStr)
-		if convErr != nil {
-			log.Errorf("Invalid SIP LB port. addr: %s, err: %v", addr, convErr)
-			h.telnyxCleanup(log, client, ipIDs, connID, profileID)
-			return nil, fmt.Errorf("invalid sip lb port in %q: %w", addr, convErr)
-		}
-		ipID, regErr := client.RegisterIP(ctx, connID, ip, port)
-		if regErr != nil {
-			log.Errorf("Could not register SIP LB IP. addr: %s, err: %v", addr, regErr)
-			h.telnyxCleanup(log, client, ipIDs, connID, profileID)
-			return nil, fmt.Errorf("telnyx register ip %q failed: %w", addr, regErr)
-		}
-		log.Debugf("Registered SIP LB IP. addr: %s, ip_id: %s", addr, ipID)
-		ipIDs = append(ipIDs, ipID)
+	// Step 4: register our public PSTN SIP gateway FQDN on the connection.
+	_, portStr, parseErr := net.SplitHostPort(h.sipGatewayFQDNForPSTN)
+	if parseErr != nil {
+		log.Errorf("Invalid PSTN SIP gateway FQDN. fqdn: %s, err: %v", h.sipGatewayFQDNForPSTN, parseErr)
+		h.telnyxCleanup(log, client, "", connID, profileID)
+		return nil, fmt.Errorf("invalid pstn sip gateway fqdn %q: %w", h.sipGatewayFQDNForPSTN, parseErr)
 	}
+	port, convErr := strconv.Atoi(portStr)
+	if convErr != nil {
+		log.Errorf("Invalid PSTN SIP gateway port. fqdn: %s, err: %v", h.sipGatewayFQDNForPSTN, convErr)
+		h.telnyxCleanup(log, client, "", connID, profileID)
+		return nil, fmt.Errorf("invalid pstn sip gateway port in %q: %w", h.sipGatewayFQDNForPSTN, convErr)
+	}
+	fqdnHost, _, _ := net.SplitHostPort(h.sipGatewayFQDNForPSTN)
+	fqdnID, regErr := client.RegisterFQDN(ctx, connID, fqdnHost, port)
+	if regErr != nil {
+		log.Errorf("Could not register PSTN SIP gateway FQDN. fqdn: %s, err: %v", h.sipGatewayFQDNForPSTN, regErr)
+		h.telnyxCleanup(log, client, "", connID, profileID)
+		return nil, fmt.Errorf("telnyx register fqdn %q failed: %w", h.sipGatewayFQDNForPSTN, regErr)
+	}
+	log.Debugf("Registered PSTN SIP gateway FQDN. fqdn: %s, fqdn_id: %s", h.sipGatewayFQDNForPSTN, fqdnID)
 
 	// Step 5: create the VoIPBin provider record
 	res, err := h.Create(ctx, provider.TypeSIP, telnyxSIPHostname, "", "", map[string]string{}, name, detail, "")
 	if err != nil {
 		log.Errorf("Could not create provider record. Attempting Telnyx cleanup. err: %v", err)
-		h.telnyxCleanup(log, client, ipIDs, connID, profileID)
+		h.telnyxCleanup(log, client, fqdnID, connID, profileID)
 		return nil, fmt.Errorf("provider create failed: %w", err)
 	}
 
@@ -101,7 +185,8 @@ func (h *providerHandler) setupWithClient(ctx context.Context, carrier, name, de
 	metadata := map[string]interface{}{
 		"telnyx_profile_id":    profileID,
 		"telnyx_connection_id": connID,
-		"telnyx_ip_ids":        ipIDs,
+		"telnyx_fqdn_id":       fqdnID,
+		"telnyx_fqdn":          h.sipGatewayFQDNForPSTN,
 	}
 	if errMeta := h.db.ProviderUpdate(ctx, res.ID, map[provider.Field]any{
 		provider.FieldMetadata: metadata,
@@ -121,23 +206,23 @@ func (h *providerHandler) setupWithClient(ctx context.Context, carrier, name, de
 // telnyxCleanup attempts to delete Telnyx resources created before a failure.
 // Empty IDs are skipped. Errors are logged but not returned — the caller's
 // original error takes precedence.
-func (h *providerHandler) telnyxCleanup(log *logrus.Entry, client telnyxclient.TelnyxClient, ipIDs []string, connID, profileID string) {
+func (h *providerHandler) telnyxCleanup(log *logrus.Entry, client telnyxclient.TelnyxClient, fqdnID, connID, profileID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	for _, ipID := range ipIDs {
-		if err := client.DeleteIP(ctx, ipID); err != nil {
-			log.Errorf("Telnyx IP cleanup failed. ip_id: %s, err: %v", ipID, err)
+	if fqdnID != "" {
+		if err := client.DeleteFQDN(ctx, fqdnID); err != nil {
+			log.Errorf("Telnyx FQDN cleanup failed. fqdn_id: %s, err: %v", fqdnID, err)
 		} else {
-			log.Infof("Telnyx IP deleted during cleanup. ip_id: %s", ipID)
+			log.Infof("Telnyx FQDN deleted during cleanup. fqdn_id: %s", fqdnID)
 		}
 	}
 
 	if connID != "" {
-		if err := client.DeleteIPConnection(ctx, connID); err != nil {
-			log.Errorf("Telnyx IP connection cleanup failed. conn_id: %s, err: %v", connID, err)
+		if err := client.DeleteFQDNConnection(ctx, connID); err != nil {
+			log.Errorf("Telnyx FQDN connection cleanup failed. conn_id: %s, err: %v", connID, err)
 		} else {
-			log.Infof("Telnyx IP connection deleted during cleanup. conn_id: %s", connID)
+			log.Infof("Telnyx FQDN connection deleted during cleanup. conn_id: %s", connID)
 		}
 	}
 

--- a/bin-route-manager/pkg/providerhandler/setup_test.go
+++ b/bin-route-manager/pkg/providerhandler/setup_test.go
@@ -13,18 +13,18 @@ import (
 	"monorepo/bin-route-manager/pkg/telnyxclient"
 )
 
-const testSipLBAddr = "10.0.0.1:5060"
+const testSipGatewayFQDNForPSTN = "pstn.voipbin.net:5060"
 
 func newTestProviderHandler(ctrl *gomock.Controller) (*providerHandler, *telnyxclient.MockTelnyxClient, *dbhandler.MockDBHandler, *notifyhandler.MockNotifyHandler) {
 	mockClient := telnyxclient.NewMockTelnyxClient(ctrl)
 	mockDB := dbhandler.NewMockDBHandler(ctrl)
 	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
-	h := &providerHandler{db: mockDB, notifyHandler: mockNotify, sipLBAddresses: []string{testSipLBAddr}}
+	h := &providerHandler{db: mockDB, notifyHandler: mockNotify, sipGatewayFQDNForPSTN: testSipGatewayFQDNForPSTN}
 	return h, mockClient, mockDB, mockNotify
 }
 
 func Test_Setup_UnknownCarrier(t *testing.T) {
-	h := &providerHandler{sipLBAddresses: []string{testSipLBAddr}}
+	h := &providerHandler{sipGatewayFQDNForPSTN: testSipGatewayFQDNForPSTN}
 	_, err := h.setupWithClient(context.Background(), "vonage", "name", "detail",
 		telnyxclient.NewTelnyxClient("key"))
 	if err == nil || err.Error() != "unsupported carrier: vonage" {
@@ -32,12 +32,12 @@ func Test_Setup_UnknownCarrier(t *testing.T) {
 	}
 }
 
-func Test_Setup_NoAddressesConfigured(t *testing.T) {
-	h := &providerHandler{sipLBAddresses: nil}
+func Test_Setup_NoFQDNConfigured(t *testing.T) {
+	h := &providerHandler{sipGatewayFQDNForPSTN: ""}
 	_, err := h.setupWithClient(context.Background(), "telnyx", "name", "detail",
 		telnyxclient.NewTelnyxClient("key"))
 	if err == nil {
-		t.Fatal("expected error for empty sipLBAddresses, got nil")
+		t.Fatal("expected error for empty sipGatewayFQDNForPSTN, got nil")
 	}
 }
 
@@ -68,14 +68,14 @@ func Test_Setup_CreateVoiceProfileFails(t *testing.T) {
 	}
 }
 
-func Test_Setup_CreateIPConnectionFails_CleansUpProfile(t *testing.T) {
+func Test_Setup_CreateFQDNConnectionFails_CleansUpProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	h, mockClient, _, _ := newTestProviderHandler(ctrl)
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("", errors.New("telnyx down"))
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("", errors.New("telnyx down"))
 	mockClient.EXPECT().DeleteOutboundVoiceProfile(gomock.Any(), "profile-123").Return(nil)
 
 	_, err := h.setupWithClient(context.Background(), "telnyx", "name", "detail", mockClient)
@@ -84,16 +84,16 @@ func Test_Setup_CreateIPConnectionFails_CleansUpProfile(t *testing.T) {
 	}
 }
 
-func Test_Setup_RegisterIPFails_CleansUpConnectionAndProfile(t *testing.T) {
+func Test_Setup_RegisterFQDNFails_CleansUpConnectionAndProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	h, mockClient, _, _ := newTestProviderHandler(ctrl)
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("", errors.New("ip conflict"))
-	mockClient.EXPECT().DeleteIPConnection(gomock.Any(), "conn-456").Return(nil)
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("conn-456", nil)
+	mockClient.EXPECT().RegisterFQDN(gomock.Any(), "conn-456", "pstn.voipbin.net", 5060).Return("", errors.New("fqdn conflict"))
+	mockClient.EXPECT().DeleteFQDNConnection(gomock.Any(), "conn-456").Return(nil)
 	mockClient.EXPECT().DeleteOutboundVoiceProfile(gomock.Any(), "profile-123").Return(nil)
 
 	_, err := h.setupWithClient(context.Background(), "telnyx", "name", "detail", mockClient)
@@ -109,11 +109,11 @@ func Test_Setup_ProviderCreateFails_CleansUpAll(t *testing.T) {
 	h, mockClient, mockDB, _ := newTestProviderHandler(ctrl)
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("ip-789", nil)
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("conn-456", nil)
+	mockClient.EXPECT().RegisterFQDN(gomock.Any(), "conn-456", "pstn.voipbin.net", 5060).Return("fqdn-789", nil)
 	mockDB.EXPECT().ProviderCreate(gomock.Any(), gomock.Any()).Return(errors.New("db error"))
-	mockClient.EXPECT().DeleteIP(gomock.Any(), "ip-789").Return(nil)
-	mockClient.EXPECT().DeleteIPConnection(gomock.Any(), "conn-456").Return(nil)
+	mockClient.EXPECT().DeleteFQDN(gomock.Any(), "fqdn-789").Return(nil)
+	mockClient.EXPECT().DeleteFQDNConnection(gomock.Any(), "conn-456").Return(nil)
 	mockClient.EXPECT().DeleteOutboundVoiceProfile(gomock.Any(), "profile-123").Return(nil)
 
 	_, err := h.setupWithClient(context.Background(), "telnyx", "name", "detail", mockClient)
@@ -131,43 +131,8 @@ func Test_Setup_Success(t *testing.T) {
 	h, mockClient, mockDB, mockNotify := newTestProviderHandler(ctrl)
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("ip-789", nil)
-	mockDB.EXPECT().ProviderCreate(gomock.Any(), gomock.Any()).Return(nil)
-	mockDB.EXPECT().ProviderGet(gomock.Any(), gomock.Any()).Return(created, nil)
-	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any())
-	mockDB.EXPECT().ProviderUpdate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockDB.EXPECT().ProviderGet(gomock.Any(), gomock.Any()).Return(created, nil)
-
-	res, err := h.setupWithClient(context.Background(), "telnyx", "name", "detail", mockClient)
-	if err != nil {
-		t.Fatalf("expected nil, got %v", err)
-	}
-	if res.Hostname != "sip.telnyx.com" {
-		t.Fatalf("expected sip.telnyx.com, got %s", res.Hostname)
-	}
-}
-
-func Test_Setup_MultipleIPs_Success(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	created := &provider.Provider{Hostname: "sip.telnyx.com", Name: "name"}
-
-	h := &providerHandler{
-		db:             dbhandler.NewMockDBHandler(ctrl),
-		notifyHandler:  notifyhandler.NewMockNotifyHandler(ctrl),
-		sipLBAddresses: []string{"10.0.0.1:5060", "10.0.0.2:5060"},
-	}
-	mockDB := h.db.(*dbhandler.MockDBHandler)
-	mockNotify := h.notifyHandler.(*notifyhandler.MockNotifyHandler)
-	mockClient := telnyxclient.NewMockTelnyxClient(ctrl)
-
-	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
-	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("ip-111", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.2", 5060).Return("ip-222", nil)
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("conn-456", nil)
+	mockClient.EXPECT().RegisterFQDN(gomock.Any(), "conn-456", "pstn.voipbin.net", 5060).Return("fqdn-789", nil)
 	mockDB.EXPECT().ProviderCreate(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().ProviderGet(gomock.Any(), gomock.Any()).Return(created, nil)
 	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any())
@@ -195,8 +160,8 @@ func Test_Setup_MetadataUpdateFails_StillSucceeds(t *testing.T) {
 	h, mockClient, mockDB, mockNotify := newTestProviderHandler(ctrl)
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("ip-789", nil)
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("conn-456", nil)
+	mockClient.EXPECT().RegisterFQDN(gomock.Any(), "conn-456", "pstn.voipbin.net", 5060).Return("fqdn-789", nil)
 	mockDB.EXPECT().ProviderCreate(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().ProviderGet(gomock.Any(), gomock.Any()).Return(created, nil)
 	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any())
@@ -227,8 +192,8 @@ func Test_Setup_MetadataRefetchFails_StillSucceeds(t *testing.T) {
 	h, mockClient, mockDB, mockNotify := newTestProviderHandler(ctrl)
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("ip-789", nil)
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("conn-456", nil)
+	mockClient.EXPECT().RegisterFQDN(gomock.Any(), "conn-456", "pstn.voipbin.net", 5060).Return("fqdn-789", nil)
 	mockDB.EXPECT().ProviderCreate(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().ProviderGet(gomock.Any(), gomock.Any()).Return(created, nil)
 	mockNotify.EXPECT().PublishEvent(gomock.Any(), gomock.Any(), gomock.Any())
@@ -248,28 +213,77 @@ func Test_Setup_MetadataRefetchFails_StillSucceeds(t *testing.T) {
 	}
 }
 
-func Test_Setup_SecondIPFails_CleansUpFirstIPAndRest(t *testing.T) {
+func Test_Setup_InvalidFQDNFormat_CleansUpConnectionAndProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	h := &providerHandler{
-		db:             dbhandler.NewMockDBHandler(ctrl),
-		notifyHandler:  notifyhandler.NewMockNotifyHandler(ctrl),
-		sipLBAddresses: []string{"10.0.0.1:5060", "10.0.0.2:5060"},
+		db:                    dbhandler.NewMockDBHandler(ctrl),
+		notifyHandler:         notifyhandler.NewMockNotifyHandler(ctrl),
+		sipGatewayFQDNForPSTN: "pstn.voipbin.net", // missing :port
 	}
 	mockClient := telnyxclient.NewMockTelnyxClient(ctrl)
 
 	mockClient.EXPECT().ValidateKey(gomock.Any()).Return(nil)
 	mockClient.EXPECT().CreateOutboundVoiceProfile(gomock.Any(), "name").Return("profile-123", nil)
-	mockClient.EXPECT().CreateIPConnection(gomock.Any(), "name", "profile-123").Return("conn-456", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.1", 5060).Return("ip-111", nil)
-	mockClient.EXPECT().RegisterIP(gomock.Any(), "conn-456", "10.0.0.2", 5060).Return("", errors.New("ip conflict"))
-	mockClient.EXPECT().DeleteIP(gomock.Any(), "ip-111").Return(nil)
-	mockClient.EXPECT().DeleteIPConnection(gomock.Any(), "conn-456").Return(nil)
+	mockClient.EXPECT().CreateFQDNConnection(gomock.Any(), "name", "profile-123", gomock.Any(), gomock.Any()).Return("conn-456", nil)
+	mockClient.EXPECT().DeleteFQDNConnection(gomock.Any(), "conn-456").Return(nil)
 	mockClient.EXPECT().DeleteOutboundVoiceProfile(gomock.Any(), "profile-123").Return(nil)
 
 	_, err := h.setupWithClient(context.Background(), "telnyx", "name", "detail", mockClient)
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func Test_GenerateCredentialSecret_AlphanumericOnly(t *testing.T) {
+	secret, err := generateCredentialSecret(32)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if len(secret) != 32 {
+		t.Fatalf("expected length 32, got %d", len(secret))
+	}
+	for _, c := range secret {
+		isAlnum := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !isAlnum {
+			t.Fatalf("expected alphanumeric only, got %q in %q", c, secret)
+		}
+	}
+}
+
+func Test_SanitizeCredentialUserName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"simple", "simple"},
+		{"my-provider-name", "myprovidername"},
+		{"my provider name", "myprovidername"},
+		{"Provider_123!", "Provider123"},
+	}
+	for _, c := range cases {
+		got := sanitizeCredentialUserName(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeCredentialUserName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func Test_BuildCredentialUserName_NeverExceedsTelnyxLimit(t *testing.T) {
+	cases := []string{
+		"short",
+		"a-very-long-provider-name-that-goes-on-and-on-and-on-and-on-and-on",
+		"",
+		"!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
+	}
+	for _, name := range cases {
+		got := buildCredentialUserName(name)
+		if len(got) > telnyxUserNameMaxLen {
+			t.Errorf("buildCredentialUserName(%q) = %q (len %d), exceeds telnyx limit %d", name, got, len(got), telnyxUserNameMaxLen)
+		}
+		if got[:len(credentialUserNamePrefix)] != credentialUserNamePrefix {
+			t.Errorf("buildCredentialUserName(%q) = %q, expected prefix %q", name, got, credentialUserNamePrefix)
+		}
 	}
 }

--- a/bin-route-manager/pkg/telnyxclient/main.go
+++ b/bin-route-manager/pkg/telnyxclient/main.go
@@ -28,17 +28,24 @@ type TelnyxClient interface {
 	// DeleteOutboundVoiceProfile calls DELETE /v2/outbound_voice_profiles/{id}.
 	DeleteOutboundVoiceProfile(ctx context.Context, profileID string) error
 
-	// CreateIPConnection calls POST /v2/ip_connections.
-	// Returns the Telnyx connection ID.
-	CreateIPConnection(ctx context.Context, name string, profileID string) (connID string, err error)
-	// DeleteIPConnection calls DELETE /v2/ip_connections/{id}.
-	DeleteIPConnection(ctx context.Context, connID string) error
+	// CreateFQDNConnection calls POST /v2/fqdn_connections. FQDN connections
+	// (unlike IP connections) present inbound calls with the actual FQDN as
+	// the SIP request-URI domain (e.g. "pstn.voipbin.net") instead of a raw
+	// IP address, which Kamailio's domain validation requires. Telnyx
+	// requires credential authentication to be configured before an
+	// outbound_voice_profile can be attached to an FQDN connection, so
+	// userName/password must be supplied. Returns the Telnyx connection ID.
+	CreateFQDNConnection(ctx context.Context, name, profileID, userName, password string) (connID string, err error)
+	// DeleteFQDNConnection calls DELETE /v2/fqdn_connections/{id}.
+	DeleteFQDNConnection(ctx context.Context, connID string) error
 
-	// RegisterIP calls POST /v2/ips to attach our SIP LB IP to the connection.
-	// Returns the Telnyx IP resource ID.
-	RegisterIP(ctx context.Context, connID string, ipAddress string, port int) (ipID string, err error)
-	// DeleteIP calls DELETE /v2/ips/{id}.
-	DeleteIP(ctx context.Context, ipID string) error
+	// RegisterFQDN calls POST /v2/fqdns to attach our public SIP domain to
+	// the connection. DNS resolution of fqdn to our SIP LB address(es) is
+	// managed outside of Telnyx (see EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN). Returns the
+	// Telnyx FQDN resource ID.
+	RegisterFQDN(ctx context.Context, connID string, fqdn string, port int) (fqdnID string, err error)
+	// DeleteFQDN calls DELETE /v2/fqdns/{id}.
+	DeleteFQDN(ctx context.Context, fqdnID string) error
 }
 
 type telnyxClient struct {

--- a/bin-route-manager/pkg/telnyxclient/mock_main.go
+++ b/bin-route-manager/pkg/telnyxclient/mock_main.go
@@ -40,19 +40,19 @@ func (m *MockTelnyxClient) EXPECT() *MockTelnyxClientMockRecorder {
 	return m.recorder
 }
 
-// CreateIPConnection mocks base method.
-func (m *MockTelnyxClient) CreateIPConnection(ctx context.Context, name, profileID string) (string, error) {
+// CreateFQDNConnection mocks base method.
+func (m *MockTelnyxClient) CreateFQDNConnection(ctx context.Context, name, profileID, userName, password string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateIPConnection", ctx, name, profileID)
+	ret := m.ctrl.Call(m, "CreateFQDNConnection", ctx, name, profileID, userName, password)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateIPConnection indicates an expected call of CreateIPConnection.
-func (mr *MockTelnyxClientMockRecorder) CreateIPConnection(ctx, name, profileID any) *gomock.Call {
+// CreateFQDNConnection indicates an expected call of CreateFQDNConnection.
+func (mr *MockTelnyxClientMockRecorder) CreateFQDNConnection(ctx, name, profileID, userName, password any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIPConnection", reflect.TypeOf((*MockTelnyxClient)(nil).CreateIPConnection), ctx, name, profileID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFQDNConnection", reflect.TypeOf((*MockTelnyxClient)(nil).CreateFQDNConnection), ctx, name, profileID, userName, password)
 }
 
 // CreateOutboundVoiceProfile mocks base method.
@@ -70,32 +70,32 @@ func (mr *MockTelnyxClientMockRecorder) CreateOutboundVoiceProfile(ctx, name any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOutboundVoiceProfile", reflect.TypeOf((*MockTelnyxClient)(nil).CreateOutboundVoiceProfile), ctx, name)
 }
 
-// DeleteIP mocks base method.
-func (m *MockTelnyxClient) DeleteIP(ctx context.Context, ipID string) error {
+// DeleteFQDN mocks base method.
+func (m *MockTelnyxClient) DeleteFQDN(ctx context.Context, fqdnID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteIP", ctx, ipID)
+	ret := m.ctrl.Call(m, "DeleteFQDN", ctx, fqdnID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteIP indicates an expected call of DeleteIP.
-func (mr *MockTelnyxClientMockRecorder) DeleteIP(ctx, ipID any) *gomock.Call {
+// DeleteFQDN indicates an expected call of DeleteFQDN.
+func (mr *MockTelnyxClientMockRecorder) DeleteFQDN(ctx, fqdnID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIP", reflect.TypeOf((*MockTelnyxClient)(nil).DeleteIP), ctx, ipID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFQDN", reflect.TypeOf((*MockTelnyxClient)(nil).DeleteFQDN), ctx, fqdnID)
 }
 
-// DeleteIPConnection mocks base method.
-func (m *MockTelnyxClient) DeleteIPConnection(ctx context.Context, connID string) error {
+// DeleteFQDNConnection mocks base method.
+func (m *MockTelnyxClient) DeleteFQDNConnection(ctx context.Context, connID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteIPConnection", ctx, connID)
+	ret := m.ctrl.Call(m, "DeleteFQDNConnection", ctx, connID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteIPConnection indicates an expected call of DeleteIPConnection.
-func (mr *MockTelnyxClientMockRecorder) DeleteIPConnection(ctx, connID any) *gomock.Call {
+// DeleteFQDNConnection indicates an expected call of DeleteFQDNConnection.
+func (mr *MockTelnyxClientMockRecorder) DeleteFQDNConnection(ctx, connID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIPConnection", reflect.TypeOf((*MockTelnyxClient)(nil).DeleteIPConnection), ctx, connID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFQDNConnection", reflect.TypeOf((*MockTelnyxClient)(nil).DeleteFQDNConnection), ctx, connID)
 }
 
 // DeleteOutboundVoiceProfile mocks base method.
@@ -112,19 +112,19 @@ func (mr *MockTelnyxClientMockRecorder) DeleteOutboundVoiceProfile(ctx, profileI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOutboundVoiceProfile", reflect.TypeOf((*MockTelnyxClient)(nil).DeleteOutboundVoiceProfile), ctx, profileID)
 }
 
-// RegisterIP mocks base method.
-func (m *MockTelnyxClient) RegisterIP(ctx context.Context, connID, ipAddress string, port int) (string, error) {
+// RegisterFQDN mocks base method.
+func (m *MockTelnyxClient) RegisterFQDN(ctx context.Context, connID, fqdn string, port int) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterIP", ctx, connID, ipAddress, port)
+	ret := m.ctrl.Call(m, "RegisterFQDN", ctx, connID, fqdn, port)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RegisterIP indicates an expected call of RegisterIP.
-func (mr *MockTelnyxClientMockRecorder) RegisterIP(ctx, connID, ipAddress, port any) *gomock.Call {
+// RegisterFQDN indicates an expected call of RegisterFQDN.
+func (mr *MockTelnyxClientMockRecorder) RegisterFQDN(ctx, connID, fqdn, port any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterIP", reflect.TypeOf((*MockTelnyxClient)(nil).RegisterIP), ctx, connID, ipAddress, port)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterFQDN", reflect.TypeOf((*MockTelnyxClient)(nil).RegisterFQDN), ctx, connID, fqdn, port)
 }
 
 // ValidateKey mocks base method.

--- a/bin-route-manager/pkg/telnyxclient/telnyx.go
+++ b/bin-route-manager/pkg/telnyxclient/telnyx.go
@@ -193,86 +193,45 @@ func (c *telnyxClient) DeleteOutboundVoiceProfile(ctx context.Context, profileID
 	return nil
 }
 
-func (c *telnyxClient) CreateIPConnection(ctx context.Context, name string, profileID string) (string, error) {
+func (c *telnyxClient) CreateFQDNConnection(ctx context.Context, name, profileID, userName, password string) (string, error) {
+	// Telnyx requires an FQDN connection to have credential authentication
+	// fully configured (user_name + password) before an outbound_voice_profile
+	// can be attached — confirmed empirically against the Telnyx API (a PATCH
+	// setting only outbound_voice_profile_id on a fresh FQDN connection with no
+	// credentials returns 422 "must be fully configured before assigning an
+	// outbound profile"). All three are therefore sent together in a single
+	// create call.
 	body, err := json.Marshal(map[string]interface{}{
 		"connection_name": name,
+		"user_name":       userName,
+		"password":        password,
+		"inbound": map[string]string{
+			// dnis_number_format must match the format VoIPBin stores numbers
+			// in (E.164 with a leading '+'). The Telnyx default ("e164", no
+			// leading '+') causes number-manager lookups for the called
+			// number to silently return zero results.
+			"ani_number_format":  "+E.164",
+			"dnis_number_format": "+e164",
+		},
 		"outbound": map[string]string{
 			"outbound_voice_profile_id": profileID,
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("marshal create ip connection request: %w", err)
+		return "", fmt.Errorf("marshal create fqdn connection request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/ip_connections",
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/fqdn_connections",
 		bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("build create ip connection request: %w", err)
+		return "", fmt.Errorf("build create fqdn connection request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("create ip connection request failed: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return "", ErrInvalidKey
-	}
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("telnyx create ip connection returned unexpected status %d", resp.StatusCode)
-	}
-
-	var res idResponse
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return "", fmt.Errorf("decode create ip connection response: %w", err)
-	}
-	return res.Data.ID, nil
-}
-
-func (c *telnyxClient) DeleteIPConnection(ctx context.Context, connID string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		fmt.Sprintf("%s/ip_connections/%s", c.baseURL, connID), nil)
-	if err != nil {
-		return fmt.Errorf("build delete ip connection request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("delete ip connection request failed: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("telnyx delete ip connection returned unexpected status %d", resp.StatusCode)
-	}
-	return nil
-}
-
-func (c *telnyxClient) RegisterIP(ctx context.Context, connID string, ipAddress string, port int) (string, error) {
-	body, err := json.Marshal(map[string]interface{}{
-		"connection_id": connID,
-		"ip_address":    ipAddress,
-		"port":          port,
-	})
-	if err != nil {
-		return "", fmt.Errorf("marshal register ip request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/ips",
-		bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("build register ip request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("register ip request failed: %w", err)
+		return "", fmt.Errorf("create fqdn connection request failed: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -281,32 +240,92 @@ func (c *telnyxClient) RegisterIP(ctx context.Context, connID string, ipAddress 
 	}
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		errBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("telnyx register ip returned status %d: %s", resp.StatusCode, string(errBody))
+		return "", fmt.Errorf("telnyx create fqdn connection returned status %d: %s", resp.StatusCode, string(errBody))
 	}
 
 	var res idResponse
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return "", fmt.Errorf("decode register ip response: %w", err)
+		return "", fmt.Errorf("decode create fqdn connection response: %w", err)
 	}
 	return res.Data.ID, nil
 }
 
-func (c *telnyxClient) DeleteIP(ctx context.Context, ipID string) error {
+func (c *telnyxClient) DeleteFQDNConnection(ctx context.Context, connID string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
-		fmt.Sprintf("%s/ips/%s", c.baseURL, ipID), nil)
+		fmt.Sprintf("%s/fqdn_connections/%s", c.baseURL, connID), nil)
 	if err != nil {
-		return fmt.Errorf("build delete ip request: %w", err)
+		return fmt.Errorf("build delete fqdn connection request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("delete ip request failed: %w", err)
+		return fmt.Errorf("delete fqdn connection request failed: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("telnyx delete ip returned unexpected status %d", resp.StatusCode)
+		return fmt.Errorf("telnyx delete fqdn connection returned unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *telnyxClient) RegisterFQDN(ctx context.Context, connID string, fqdn string, port int) (string, error) {
+	body, err := json.Marshal(map[string]interface{}{
+		"connection_id":   connID,
+		"fqdn":            fqdn,
+		"port":            port,
+		"dns_record_type": "a",
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal register fqdn request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/fqdns",
+		bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build register fqdn request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("register fqdn request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return "", ErrInvalidKey
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		errBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("telnyx register fqdn returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	var res idResponse
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return "", fmt.Errorf("decode register fqdn response: %w", err)
+	}
+	return res.Data.ID, nil
+}
+
+func (c *telnyxClient) DeleteFQDN(ctx context.Context, fqdnID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		fmt.Sprintf("%s/fqdns/%s", c.baseURL, fqdnID), nil)
+	if err != nil {
+		return fmt.Errorf("build delete fqdn request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete fqdn request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("telnyx delete fqdn returned unexpected status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/bin-route-manager/pkg/telnyxclient/telnyx_test.go
+++ b/bin-route-manager/pkg/telnyxclient/telnyx_test.go
@@ -74,9 +74,9 @@ func TestDeleteOutboundVoiceProfile_Success(t *testing.T) {
 	}
 }
 
-func TestCreateIPConnection_Success(t *testing.T) {
+func TestCreateFQDNConnection_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/ip_connections" {
+		if r.Method != http.MethodPost || r.URL.Path != "/fqdn_connections" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -87,7 +87,7 @@ func TestCreateIPConnection_Success(t *testing.T) {
 	defer srv.Close()
 
 	c := newTelnyxClientWithBase("testkey", srv.URL)
-	connID, err := c.CreateIPConnection(context.Background(), "My Provider", "profile-abc-123")
+	connID, err := c.CreateFQDNConnection(context.Background(), "My Provider", "profile-abc-123", "myprovideruser", "mypassword123")
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
@@ -96,7 +96,7 @@ func TestCreateIPConnection_Success(t *testing.T) {
 	}
 }
 
-func TestDeleteIPConnection_Success(t *testing.T) {
+func TestDeleteFQDNConnection_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -107,34 +107,34 @@ func TestDeleteIPConnection_Success(t *testing.T) {
 	defer srv.Close()
 
 	c := newTelnyxClientWithBase("testkey", srv.URL)
-	if err := c.DeleteIPConnection(context.Background(), "conn-abc-123"); err != nil {
+	if err := c.DeleteFQDNConnection(context.Background(), "conn-abc-123"); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
 }
 
-func TestRegisterIP_Success(t *testing.T) {
+func TestRegisterFQDN_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/ips" {
+		if r.Method != http.MethodPost || r.URL.Path != "/fqdns" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(`{"data":{"id":"ip-abc-123"}}`)) //nolint:errcheck
+		w.Write([]byte(`{"data":{"id":"fqdn-abc-123"}}`)) //nolint:errcheck
 	}))
 	defer srv.Close()
 
 	c := newTelnyxClientWithBase("testkey", srv.URL)
-	ipID, err := c.RegisterIP(context.Background(), "conn-abc-123", "1.2.3.4", 5060)
+	fqdnID, err := c.RegisterFQDN(context.Background(), "conn-abc-123", "pstn.voipbin.net", 5060)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
-	if ipID != "ip-abc-123" {
-		t.Fatalf("expected ip-abc-123, got %s", ipID)
+	if fqdnID != "fqdn-abc-123" {
+		t.Fatalf("expected fqdn-abc-123, got %s", fqdnID)
 	}
 }
 
-func TestDeleteIP_Success(t *testing.T) {
+func TestDeleteFQDN_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -145,7 +145,7 @@ func TestDeleteIP_Success(t *testing.T) {
 	defer srv.Close()
 
 	c := newTelnyxClientWithBase("testkey", srv.URL)
-	if err := c.DeleteIP(context.Background(), "ip-abc-123"); err != nil {
+	if err := c.DeleteFQDN(context.Background(), "fqdn-abc-123"); err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}
 }


### PR DESCRIPTION
Fix bin-route-manager's Telnyx provider setup to create FQDN connections instead of IP connections, closing the gap that caused a real production inbound-call outage on 2026-07-09.

- bin-route-manager: Replace CreateIPConnection/RegisterIP/DeleteIPConnection/DeleteIP telnyxclient methods with CreateFQDNConnection/RegisterFQDN/DeleteFQDNConnection/DeleteFQDN, calling POST /v2/fqdn_connections and POST /v2/fqdns instead of the IP-connection endpoints
- bin-route-manager: Set inbound.dnis_number_format to "+e164" on the new FQDN connection so number-manager's E.164-with-plus number lookups succeed
- bin-route-manager: Generate a random alphanumeric SIP credential for the FQDN connection at setup time, since Telnyx requires credential authentication to be fully configured before an outbound_voice_profile can be attached
- bin-route-manager: Cap the generated credential user_name at Telnyx's 32-character limit (found during adversarial self-review: an unbounded provider name produces a 422 on connection create)
- bin-route-manager: Replace the sipLBAddresses config (list of ip:port) and provider setup input with a single sipGatewayFQDNForPSTN string (EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN env var). Named explicitly '..._FOR_PSTN' to avoid the ambiguity of a generic 'SIP gateway FQDN' name being mistaken for all SIP traffic rather than just the Telnyx PSTN trunk registration it actually configures
- bin-route-manager: Update tests for the new API surface, including a length-boundary test for the credential user_name builder
- bin-route-manager: Update k8s/deployment.yml and docs/operations.md to reference EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN

Root cause: an IP connection presents the inbound SIP request-URI domain as a raw IP address instead of the FQDN, which Kamailio's domain validation (request_from_external_init_connection) rejects. Every new Telnyx provider set up through /v1/providers/setup was silently born with this defect. Confirmed via a live incident on 2026-07-09 where the production Telnyx connection's IP registration broke inbound calling; a manually-configured FQDN connection with the same field shape as this PR's code was verified end to end against a real inbound call before writing this fix.

Test results: go test ./... all packages pass; golangci-lint run 0 issues.

Depends on infra-secret PR NOJIRA-Add-external-sip-gateway-fqdn-secret, which must be deployed first so EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN exists before this PR's deployment.yml change starts requiring it.