### PR TITLE
VOIP-1243-case-create-rpc

### DIFF
--- a/bin-common-handler/pkg/requesthandler/contact_cases.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases.go
@@ -8,12 +8,56 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
 	"monorepo/bin-common-handler/models/sock"
 
 	cmcasenote "monorepo/bin-contact-manager/models/casenote"
 	cmkase "monorepo/bin-contact-manager/models/kase"
 	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
 )
+
+// ContactV1CaseCreate creates a new case in contact-manager via a plain,
+// explicit Create (design VOIP-1243 §3) -- distinct from the internal
+// GetOrCreate path. self/peerType/peerTarget/referenceType must be
+// derived by the caller from the actual call/conversation context (see
+// design §3.2); name/detail are optional (empty string persisted as
+// the column's empty default, not NULL).
+func (r *requestHandler) ContactV1CaseCreate(
+	ctx context.Context,
+	customerID uuid.UUID,
+	self commonaddress.Address,
+	peerType commonaddress.Type,
+	peerTarget, referenceType, name, detail string,
+) (*cmkase.Case, error) {
+	uri := "/v1/cases"
+
+	data := &cmrequest.V1DataCasesPost{
+		CustomerID:    customerID,
+		Self:          self,
+		PeerType:      peerType,
+		PeerTarget:    peerTarget,
+		ReferenceType: referenceType,
+		Name:          name,
+		Detail:        detail,
+	}
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodPost, "contact/cases", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cmkase.Case
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
 
 // ContactV1CaseList lists cases from contact-manager, optionally filtered
 // by status, owner, and/or contact_id (query-string filters), with

--- a/bin-common-handler/pkg/requesthandler/contact_cases_test.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases_test.go
@@ -8,12 +8,88 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	cmcasenote "monorepo/bin-contact-manager/models/casenote"
 	cmkase "monorepo/bin-contact-manager/models/kase"
 )
+
+func Test_ContactV1CaseCreate(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		customerID    uuid.UUID
+		self          commonaddress.Address
+		peerType      commonaddress.Type
+		peerTarget    string
+		referenceType string
+		caseName      string
+		detail        string
+
+		expectTarget  string
+		expectRequest *sock.Request
+		response      *sock.Response
+
+		expectRes *cmkase.Case
+	}{
+		{
+			name: "normal",
+
+			customerID:    uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f3"),
+			self:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+			peerType:      commonaddress.TypeTel,
+			peerTarget:    "+155****0002",
+			referenceType: "call",
+			caseName:      "VIP escalation",
+			detail:        "customer called about billing",
+
+			expectTarget: "bin-manager.contact-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/cases",
+				Method:   sock.RequestMethodPost,
+				DataType: ContentTypeJSON,
+				Data: []byte(
+					`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f3","self":{"type":"tel","target":"+155****0001"},"peer_type":"tel","peer_target":"+155****0002","reference_type":"call","name":"VIP escalation","detail":"customer called about billing"}`,
+				),
+			},
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"5623e25e-2c74-11ee-87a6-bfa8ae34077f"}`),
+			},
+			expectRes: &cmkase.Case{
+				ID: uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			reqHandler := requestHandler{
+				sock: mockSock,
+			}
+
+			ctx := context.Background()
+			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
+
+			res, err := reqHandler.ContactV1CaseCreate(ctx, tt.customerID, tt.self, tt.peerType, tt.peerTarget, tt.referenceType, tt.caseName, tt.detail)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(tt.expectRes, res) == false {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
 
 func Test_ContactV1CaseList(t *testing.T) {
 

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -925,6 +925,7 @@ type RequestHandler interface {
 	ContactV1ResolutionDelete(ctx context.Context, customerID uuid.UUID, interactionID, resolutionID uuid.UUID) error
 
 	// contact-manager cases (Phase 5, NOJIRA-contact-case-management)
+	ContactV1CaseCreate(ctx context.Context, customerID uuid.UUID, self commonaddress.Address, peerType commonaddress.Type, peerTarget, referenceType, name, detail string) (*cmkase.Case, error)
 	ContactV1CaseList(ctx context.Context, customerID uuid.UUID, status, ownerType string, ownerID uuid.UUID, contactID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
 	ContactV1CaseListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
 	ContactV1CaseGet(ctx context.Context, customerID, id uuid.UUID) (*cmkase.Case, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -3505,6 +3505,21 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1CaseContinue(ctx, customerID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseContinue", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseContinue), ctx, customerID, id, callerType, callerID, callerIsAdmin)
 }
 
+// ContactV1CaseCreate mocks base method.
+func (m *MockRequestHandler) ContactV1CaseCreate(ctx context.Context, customerID uuid.UUID, self address.Address, peerType address.Type, peerTarget, referenceType, name, detail string) (*kase.Case, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1CaseCreate", ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+	ret0, _ := ret[0].(*kase.Case)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1CaseCreate indicates an expected call of ContactV1CaseCreate.
+func (mr *MockRequestHandlerMockRecorder) ContactV1CaseCreate(ctx, customerID, self, peerType, peerTarget, referenceType, name, detail any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseCreate), ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+}
+
 // ContactV1CaseGet mocks base method.
 func (m *MockRequestHandler) ContactV1CaseGet(ctx context.Context, customerID, id uuid.UUID) (*kase.Case, error) {
 	m.ctrl.T.Helper()

--- a/bin-contact-manager/models/kase/kase.go
+++ b/bin-contact-manager/models/kase/kase.go
@@ -34,6 +34,12 @@ type Case struct {
 	// exactly for the design §4 get-or-create join to work.
 	ReferenceType string `json:"reference_type" db:"reference_type"`
 
+	// Name/Detail are optional, freeform case metadata settable only at
+	// creation time via Create (design VOIP-1243 §3.4). Empty string is
+	// persisted as the column's default/empty value, not NULL.
+	Name   string `json:"name,omitempty"   db:"name"`
+	Detail string `json:"detail,omitempty" db:"detail"`
+
 	// ContactID is a nullable denormalized cache; single source of truth
 	// is Resolution (see resolution.CaseID), single derivation function.
 	ContactID *uuid.UUID `json:"contact_id" db:"contact_id,uuid"`

--- a/bin-contact-manager/pkg/casehandler/create.go
+++ b/bin-contact-manager/pkg/casehandler/create.go
@@ -1,0 +1,67 @@
+package casehandler
+
+import (
+	"context"
+	stderrors "errors"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-contact-manager/models/kase"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// Create implements design doc §3's plain Create semantics -- distinct
+// from GetOrCreate: no transaction, no peer lock, no retry loop, no
+// previous_case_id chaining, no owner auto-assignment. Inserts a single
+// new Case row via the existing dbhandler.CaseInsert primitive and
+// translates its sentinel errors to typed cerrors at this layer (design
+// §3.3 steps 1-2).
+func (h *caseHandler) Create(
+	ctx context.Context,
+	customerID uuid.UUID,
+	self commonaddress.Address,
+	peerType commonaddress.Type,
+	peerTarget, referenceType, name, detail string,
+) (*kase.Case, error) {
+	now := h.utilHandler.TimeNow()
+
+	newCase := &kase.Case{
+		ID:             h.utilHandler.UUIDCreate(),
+		CustomerID:     customerID,
+		PeerType:       peerType,
+		PeerTarget:     peerTarget,
+		ReferenceType:  referenceType,
+		Name:           name,
+		Detail:         detail,
+		Status:         kase.StatusOpen,
+		OpenedAt:       now,
+		PreviousCaseID: nil,
+		TMCreate:       now,
+		TMUpdate:       now,
+	}
+
+	if err := h.db.CaseInsert(ctx, newCase); err != nil {
+		if stderrors.Is(err, dbhandler.ErrDuplicate) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameContactManager,
+				"CASE_ALREADY_EXISTS",
+				"An open case already exists for this peer.",
+			).Wrap(err)
+		}
+		if stderrors.Is(err, dbhandler.ErrDeadlock) {
+			return nil, cerrors.Unavailable(
+				commonoutline.ServiceNameContactManager,
+				"CASE_CREATE_DEADLOCK",
+				"Could not create the case due to a transient database conflict. Please retry.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+
+	return newCase, nil
+}

--- a/bin-contact-manager/pkg/casehandler/create_test.go
+++ b/bin-contact-manager/pkg/casehandler/create_test.go
@@ -1,0 +1,171 @@
+package casehandler
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/kase"
+	"monorepo/bin-contact-manager/pkg/cachehandler"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// Test_Create_HappyPath verifies design VOIP-1243 §3.3: a plain insert
+// with Status=StatusOpen, PreviousCaseID=nil, Owner left zero-value (no
+// auto-assignment), and Name/Detail persisted.
+func Test_Create_HappyPath(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9721-9721-9721-000000000001")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9721-9721-9721-000000000002")
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	mockUtil.EXPECT().UUIDCreate().Return(caseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+
+	res, err := h.Create(
+		ctx, customerID,
+		commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0701"},
+		commonaddress.TypeTel, "+155****9701", "call",
+		"VIP escalation", "customer called about billing",
+	)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if res.ID != caseID {
+		t.Errorf("unexpected ID: %v", res.ID)
+	}
+	if res.CustomerID != customerID {
+		t.Errorf("unexpected CustomerID: %v", res.CustomerID)
+	}
+	if res.Status != kase.StatusOpen {
+		t.Errorf("expected StatusOpen, got: %v", res.Status)
+	}
+	if res.PreviousCaseID != nil {
+		t.Errorf("expected nil PreviousCaseID, got: %v", res.PreviousCaseID)
+	}
+	if res.OwnerType != "" || res.OwnerID != uuid.Nil {
+		t.Errorf("expected zero-value Owner (no auto-assignment), got: type=%v id=%v", res.OwnerType, res.OwnerID)
+	}
+	if res.Name != "VIP escalation" || res.Detail != "customer called about billing" {
+		t.Errorf("unexpected Name/Detail: %q / %q", res.Name, res.Detail)
+	}
+
+	// Confirm it was actually persisted.
+	fetched, err := db.CaseGetByID(ctx, caseID)
+	if err != nil {
+		t.Fatalf("CaseGetByID() error = %v", err)
+	}
+	if fetched.Name != "VIP escalation" || fetched.Detail != "customer called about billing" {
+		t.Errorf("unexpected persisted Name/Detail: %q / %q", fetched.Name, fetched.Detail)
+	}
+}
+
+// Test_Create_DuplicateOpenPeer_TranslatesToAlreadyExists verifies
+// design §3.3 step 2: a uq_case_open_peer violation (dbhandler.ErrDuplicate)
+// is translated to a typed cerrors.AlreadyExists, never a raw error.
+func Test_Create_DuplicateOpenPeer_TranslatesToAlreadyExists(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9722-9722-9722-000000000001")
+	firstCaseID := uuid.FromStringOrNil("f1b2c3d4-9722-9722-9722-000000000002")
+	secondCaseID := uuid.FromStringOrNil("f1b2c3d4-9722-9722-9722-000000000003")
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	self := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0702"}
+	peerType := commonaddress.TypeTel
+	peerTarget := "+155****9702"
+	referenceType := "call"
+
+	mockUtil.EXPECT().UUIDCreate().Return(firstCaseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	if _, err := h.Create(ctx, customerID, self, peerType, peerTarget, referenceType, "", ""); err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+
+	mockUtil.EXPECT().UUIDCreate().Return(secondCaseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	_, err := h.Create(ctx, customerID, self, peerType, peerTarget, referenceType, "", "")
+
+	var ve *cerrors.VoipbinError
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *cerrors.VoipbinError, got: %T (%v)", err, err)
+	}
+	if ve.Status != cerrors.StatusAlreadyExists {
+		t.Errorf("expected StatusAlreadyExists, got: %v", ve.Status)
+	}
+}
+
+// Test_Create_Deadlock_TranslatesToUnavailable verifies design §3.3's
+// ErrDeadlock handling: Create does NOT retry (unlike GetOrCreate); it
+// translates dbhandler.ErrDeadlock to a typed cerrors.Unavailable.
+// Simulated via a fake dbhandler.DBHandler double returning ErrDeadlock
+// directly from CaseInsert.
+func Test_Create_Deadlock_TranslatesToUnavailable(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: mockDB, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9723-9723-9723-000000000001")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9723-9723-9723-000000000002")
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	mockUtil.EXPECT().UUIDCreate().Return(caseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CaseInsert(ctx, gomock.Any()).Return(dbhandler.ErrDeadlock)
+
+	_, err := h.Create(
+		ctx, customerID,
+		commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0703"},
+		commonaddress.TypeTel, "+155****9703", "call", "", "",
+	)
+
+	var ve *cerrors.VoipbinError
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *cerrors.VoipbinError, got: %T (%v)", err, err)
+	}
+	if ve.Status != cerrors.StatusUnavailable {
+		t.Errorf("expected StatusUnavailable, got: %v", ve.Status)
+	}
+}

--- a/bin-contact-manager/pkg/casehandler/main.go
+++ b/bin-contact-manager/pkg/casehandler/main.go
@@ -98,6 +98,15 @@ type CaseHandler interface {
 	// entry point for the customer-facing GET /v1/cases/{id} route.
 	CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token string, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, string, error)
 	CaseGet(ctx context.Context, customerID, id uuid.UUID) (*kase.Case, error)
+
+	// Create implements design VOIP-1243 §3: a plain, explicit Case
+	// creation -- NOT get-or-create. No transaction, no peer lock, no
+	// retry loop, no previous_case_id chaining, no owner
+	// auto-assignment. Reuses the existing dbhandler.CaseInsert
+	// primitive and translates its sentinel errors
+	// (dbhandler.ErrDuplicate / dbhandler.ErrDeadlock) into typed
+	// cerrors.AlreadyExists / cerrors.Unavailable respectively.
+	Create(ctx context.Context, customerID uuid.UUID, self commonaddress.Address, peerType commonaddress.Type, peerTarget, referenceType, name, detail string) (*kase.Case, error)
 }
 
 type caseHandler struct {

--- a/bin-contact-manager/pkg/casehandler/mock_main.go
+++ b/bin-contact-manager/pkg/casehandler/mock_main.go
@@ -224,6 +224,21 @@ func (mr *MockCaseHandlerMockRecorder) Continue(ctx, customerID, id, callerType,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Continue", reflect.TypeOf((*MockCaseHandler)(nil).Continue), ctx, customerID, id, callerType, callerID, callerIsAdmin)
 }
 
+// Create mocks base method.
+func (m *MockCaseHandler) Create(ctx context.Context, customerID uuid.UUID, self address.Address, peerType address.Type, peerTarget, referenceType, name, detail string) (*kase.Case, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+	ret0, _ := ret[0].(*kase.Case)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockCaseHandlerMockRecorder) Create(ctx, customerID, self, peerType, peerTarget, referenceType, name, detail any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCaseHandler)(nil).Create), ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+}
+
 // GetOrCreate mocks base method.
 func (m *MockCaseHandler) GetOrCreate(ctx context.Context, customerID uuid.UUID, self address.Address, peerType address.Type, peerTarget, referenceType string, caseIDHint *uuid.UUID) (*kase.Case, error) {
 	m.ctrl.T.Helper()

--- a/bin-contact-manager/pkg/dbhandler/kase_test.go
+++ b/bin-contact-manager/pkg/dbhandler/kase_test.go
@@ -144,6 +144,7 @@ func Test_CaseGetOpenByPeer(t *testing.T) {
 
 	rowColumns := []string{
 		"id", "customer_id", "peer_type", "peer_target", "reference_type",
+		"name", "detail",
 		"contact_id", "owner_type", "owner_id",
 		"status", "opened_at", "closed_at", "closed_reason", "closed_by_type", "closed_by_id",
 		"previous_case_id", "tm_create", "tm_update",
@@ -157,15 +158,16 @@ func Test_CaseGetOpenByPeer(t *testing.T) {
 	defer func() { _ = tx.Rollback() }()
 
 	mock.ExpectQuery("SELECT .* FROM contact_cases WHERE .* FOR UPDATE").
-		WithArgs(customerID.Bytes(), string(commonaddress.TypeTel), "+15551110003", "call", string(kase.StatusOpen)).
+		WithArgs(customerID.Bytes(), string(commonaddress.TypeTel), "+155****0003", "call", string(kase.StatusOpen)).
 		WillReturnRows(sqlmock.NewRows(rowColumns).AddRow(
-			caseID.Bytes(), customerID.Bytes(), string(commonaddress.TypeTel), "+15551110003", "call",
+			caseID.Bytes(), customerID.Bytes(), string(commonaddress.TypeTel), "+155****0003", "call",
+			"", nil,
 			nil, nil, nil,
 			string(kase.StatusOpen), openedAt, nil, nil, nil, nil,
 			nil, openedAt, openedAt,
 		))
 
-	res, err := h.CaseGetOpenByPeer(ctx, tx, customerID, commonaddress.TypeTel, "+15551110003", "call")
+	res, err := h.CaseGetOpenByPeer(ctx, tx, customerID, commonaddress.TypeTel, "+155****0003", "call")
 	if err != nil {
 		t.Fatalf("CaseGetOpenByPeer() error = %v", err)
 	}

--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -76,6 +76,7 @@ var (
 
 	// v1 cases
 	regV1CasesUnresolved = regexp.MustCompile(`/v1/cases/unresolved(\?.*)?$`)
+	regV1Cases           = regexp.MustCompile(`/v1/cases$`)
 	regV1CasesGet        = regexp.MustCompile(`/v1/cases\?(.*)$`)
 	regV1CasesID         = regexp.MustCompile("/v1/cases/" + regUUID + "$")
 	regV1CasesIDClose    = regexp.MustCompile("/v1/cases/" + regUUID + "/close$")
@@ -339,6 +340,11 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	// GET /cases?...
 	case regV1CasesGet.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
 		response, err = h.processV1CasesGet(ctx, m)
+		requestType = "/v1/cases"
+
+	// POST /cases
+	case regV1Cases.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1CasesPost(ctx, m)
 		requestType = "/v1/cases"
 
 	// GET /cases/{id}

--- a/bin-contact-manager/pkg/listenhandler/models/request/v1_cases.go
+++ b/bin-contact-manager/pkg/listenhandler/models/request/v1_cases.go
@@ -1,6 +1,10 @@
 package request
 
-import "github.com/gofrs/uuid"
+import (
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+)
 
 // V1DataCasesIDClose is the request body for POST /v1/cases/{id}/close.
 type V1DataCasesIDClose struct {
@@ -73,4 +77,15 @@ type V1DataCasesUnresolvedGet struct {
 // V1DataCasesGet is the request body for GET /v1/cases?...
 type V1DataCasesGet struct {
 	CustomerID uuid.UUID `json:"customer_id"`
+}
+
+// V1DataCasesPost is the request body for POST /v1/cases.
+type V1DataCasesPost struct {
+	CustomerID    uuid.UUID             `json:"customer_id"`
+	Self          commonaddress.Address `json:"self"`
+	PeerType      commonaddress.Type    `json:"peer_type"`
+	PeerTarget    string                `json:"peer_target"`
+	ReferenceType string                `json:"reference_type"`
+	Name          string                `json:"name,omitempty"`
+	Detail        string                `json:"detail,omitempty"`
 }

--- a/bin-contact-manager/pkg/listenhandler/v1_cases.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases.go
@@ -89,6 +89,37 @@ func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request
 	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
 }
 
+// processV1CasesPost handles POST /v1/cases request. Implements design
+// VOIP-1243 §3/§4: a plain, explicit Case creation delegated to
+// casehandler.Create -- distinct from the GetOrCreate path used
+// internally by the interaction projection pipeline.
+func (h *listenHandler) processV1CasesPost(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesPost"})
+	log.WithField("request", req).Debug("Received request.")
+
+	var body request.V1DataCasesPost
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		log.Errorf("Could not unmarshal request body. err: %v", err)
+		return simpleResponse(400), nil
+	}
+	if body.CustomerID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.caseHandler.Create(ctx, body.CustomerID, body.Self, body.PeerType, body.PeerTarget, body.ReferenceType, body.Name, body.Detail)
+	if err != nil {
+		log.Errorf("Could not create case. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
 // processV1CasesUnresolvedGet handles GET /v1/cases/unresolved request.
 func (h *listenHandler) processV1CasesUnresolvedGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesUnresolvedGet"})

--- a/bin-contact-manager/pkg/listenhandler/v1_cases_post_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases_post_test.go
@@ -1,0 +1,97 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/kase"
+)
+
+// Test_ProcessV1CasesPost_CreatesCase verifies POST /v1/cases
+// unmarshals the request body and delegates to caseHandler.Create
+// (design VOIP-1243 §4's listenhandler layer).
+func Test_ProcessV1CasesPost_CreatesCase(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, mockCase := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-0101-0101-0101-000000000001")
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0101-0101-0101-000000000002")
+
+	reqBody := map[string]any{
+		"customer_id": customerID.String(),
+		"self":        map[string]any{"type": "tel", "target": "+155****0101"},
+		"peer_type":   "tel",
+		"peer_target": "+155****9101",
+		"reference_type": "call",
+		"name":   "VIP",
+		"detail": "escalated",
+	}
+	body, _ := json.Marshal(reqBody)
+	req := &sock.Request{
+		URI:    "/v1/cases",
+		Method: sock.RequestMethodPost,
+		Data:   body,
+	}
+
+	mockCase.EXPECT().Create(
+		ctx, customerID,
+		commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0101"},
+		commonaddress.TypeTel, "+155****9101", "call", "VIP", "escalated",
+	).Return(&kase.Case{ID: caseID, CustomerID: customerID}, nil)
+
+	res, err := h.processV1CasesPost(ctx, req)
+	if err != nil {
+		t.Fatalf("processV1CasesPost() error = %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("StatusCode = %v, want 200", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesPost_MissingCustomerID verifies a missing
+// customer_id yields 400 without calling caseHandler.Create.
+func Test_ProcessV1CasesPost_MissingCustomerID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, _ := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	body, _ := json.Marshal(map[string]any{})
+	req := &sock.Request{URI: "/v1/cases", Method: sock.RequestMethodPost, Data: body}
+
+	res, err := h.processV1CasesPost(ctx, req)
+	if err != nil {
+		t.Fatalf("processV1CasesPost() error = %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("StatusCode = %v, want 400", res.StatusCode)
+	}
+}
+
+// Test_RouteDispatch_PostCasesVsGetCasesQuery verifies routing-order
+// correctness (design §4's note): a bare POST /v1/cases does not
+// collide with the GET /v1/cases?... query-string route, and vice
+// versa for GET.
+func Test_RouteDispatch_PostCasesVsGetCasesQuery(t *testing.T) {
+	if !regV1Cases.MatchString("/v1/cases") {
+		t.Errorf("regV1Cases should match a bare /v1/cases URI")
+	}
+	if regV1Cases.MatchString("/v1/cases?status=open") {
+		t.Errorf("regV1Cases should NOT match a query-string URI")
+	}
+	if !regV1CasesGet.MatchString("/v1/cases?status=open") {
+		t.Errorf("regV1CasesGet should match a query-string URI")
+	}
+	if regV1CasesGet.MatchString("/v1/cases") {
+		t.Errorf("regV1CasesGet should NOT match a bare /v1/cases URI")
+	}
+}

--- a/bin-contact-manager/scripts/database_scripts_test/contacts.sql
+++ b/bin-contact-manager/scripts/database_scripts_test/contacts.sql
@@ -165,6 +165,9 @@ create table contact_cases (
   peer_target       varchar(255)  not null default '',
   reference_type    varchar(255)  not null default '',
 
+  name              varchar(255)  not null default '',
+  detail            text,
+
   contact_id        binary(16),
 
   owner_type        varchar(255),

--- a/bin-dbscheme-manager/bin-manager/main/versions/a10299e7932a_contact_cases_add_column_name_detail.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/a10299e7932a_contact_cases_add_column_name_detail.py
@@ -1,0 +1,28 @@
+"""contact_cases_add_column_name_detail
+
+Revision ID: a10299e7932a
+Revises: 29ba6e093d30
+Create Date: 2026-07-10 09:42:42.699470
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a10299e7932a'
+down_revision = '29ba6e093d30'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """alter table contact_cases add column name varchar(255) not null default '' after reference_type;"""
+    )
+    op.execute("""alter table contact_cases add column detail text after name;""")
+
+
+def downgrade():
+    op.execute("""alter table contact_cases drop column detail;""")
+    op.execute("""alter table contact_cases drop column name;""")


### PR DESCRIPTION
Add a plain ContactV1CaseCreate RPC (not get-or-create) and the
name/detail Case schema addition, per the VOIP-1243 design doc. This is
the foundation layer for the upcoming case_create Flow action and AI
tool: routes/RPC exist so those layers can call in, but no automatic
trigger or Flow/AI wiring is added in this PR.

- bin-dbscheme-manager: add Alembic migration adding nullable name/detail
  columns to contact_cases (generated via alembic revision, chains onto
  the current head)
- bin-contact-manager: add Name/Detail fields to kase.Case; add a new
  casehandler.Create (plain insert, no transaction/peer-lock/retry loop,
  no owner auto-assignment, no previous_case_id chaining) reusing the
  existing CaseInsert primitive and translating ErrDuplicate/ErrDeadlock
  to typed AlreadyExists/Unavailable errors; add POST /v1/cases route
- bin-common-handler: add ContactV1CaseCreate RPC client, wired into the
  RequestHandler interface next to the existing ContactV1Case* entries
