### PR TITLE
VOIP-1243-case-create-action-wiring

### DIFF
--- a/bin-ai-manager/go.mod
+++ b/bin-ai-manager/go.mod
@@ -85,6 +85,7 @@ require (
 	monorepo/bin-call-manager v0.0.0-20240403030948-51eb7c33cf9a
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
 	monorepo/bin-conference-manager v0.0.0-20240329045829-45dc5f4e4e76
+	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000
 	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000
@@ -158,7 +159,6 @@ require (
 	monorepo/bin-agent-manager v0.0.0-20240328054741-55144017eccd // indirect
 	monorepo/bin-billing-manager v0.0.0-20240408051040-600f0028fbab // indirect
 	monorepo/bin-campaign-manager v0.0.0-20240313031908-f098e3fb6f12 // indirect
-	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0 // indirect
 	monorepo/bin-number-manager v0.0.0-20240328055052-ec1c723aa183 // indirect
 	monorepo/bin-outdial-manager v0.0.0-20240313064601-888fe8578646 // indirect

--- a/bin-ai-manager/models/message/tool.go
+++ b/bin-ai-manager/models/message/tool.go
@@ -41,4 +41,5 @@ const (
 	FunctionCallNameGetCorrelation    FunctionCallName = "get_correlation"
 	FunctionCallNameGetResource       FunctionCallName = "get_resource"
 	FunctionCallNameDescribeAction    FunctionCallName = "describe_action"
+	FunctionCallNameCaseCreate        FunctionCallName = "case_create"
 )

--- a/bin-ai-manager/models/tool/main.go
+++ b/bin-ai-manager/models/tool/main.go
@@ -20,6 +20,7 @@ const (
 	ToolNameGetCorrelation    ToolName = "get_correlation"
 	ToolNameGetResource       ToolName = "get_resource"
 	ToolNameDescribeAction    ToolName = "describe_action"
+	ToolNameCaseCreate        ToolName = "case_create"
 
 	// Insight AI tool set (VOIP-1234). TODO(VOIP-1234): these two tools are not
 	// yet implemented (no toolDefinitions entry / no execution handler exists).
@@ -47,6 +48,7 @@ var AllToolNames = []ToolName{
 	ToolNameGetCorrelation,
 	ToolNameGetResource,
 	ToolNameDescribeAction,
+	ToolNameCaseCreate,
 }
 
 // AllInsightToolNames defines the tool set available to ai.TypeInsight AIs.

--- a/bin-ai-manager/pkg/actioncatalog/main.go
+++ b/bin-ai-manager/pkg/actioncatalog/main.go
@@ -86,6 +86,12 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "default_target_id", Type: "uuid", Required: false, Description: "Action id to go to when no target matches."},
 		{Name: "target_ids", Type: "object (map of value -> action id)", Required: true, Description: "Map of matched value to the action id to jump to."},
 	}},
+	{Type: fmaction.TypeCaseCreate, Summary: "Create a new CRM case for the current call/conversation's contact. No-op if the reference type is not call/conversation, the peer is not CRM-eligible, or a case already exists for this activeflow.", Options: []actionOptionField{
+		{Name: "name", Type: "string", Required: false, Description: "Short case title."},
+		{Name: "detail", Type: "string", Required: false, Description: "Longer free-text description of the issue."},
+		{Name: "note", Type: "string", Required: false, Description: "An initial internal note for the agent (not shown to the customer)."},
+		{Name: "sync", Type: "bool", Required: false, Description: "Whether to wait for the case-create RPC to complete before continuing (matches conversation_send/email_send's sync/async toggle)."},
+	}},
 	{Type: fmaction.TypeCall, Summary: "Originate one or more new outbound calls (each runs its own flow or actions).", Options: []actionOptionField{
 		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id. type is one of tel, sip, extension, agent."},
 		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destinations to call. type is one of tel, sip, extension, agent, conference."},

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -66,6 +66,7 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		message.FunctionCallNameGetCorrelation:      h.toolHandleGetCorrelation,
 		message.FunctionCallNameGetResource:         h.toolHandleGetResource,
 		message.FunctionCallNameDescribeAction:      h.toolHandleDescribeAction,
+		message.FunctionCallNameCaseCreate:          h.toolHandleCaseCreate,
 	}
 
 	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()
@@ -431,6 +432,141 @@ func (h *aicallHandler) toolHandleEmailSend(ctx context.Context, c *aicall.AIcal
 	}
 
 	fillSuccess(res, "email", tmpRes.ID.String(), "Email sent successfully.")
+
+	return res
+}
+
+// caseCreateCRMIneligiblePeerTypes duplicates
+// bin-flow-manager/pkg/activeflowhandler's crmIneligiblePeerTypes (design
+// VOIP-1243 §5.2/§6.3) -- the original is unexported in bin-contact-manager
+// and cannot be imported.
+var caseCreateCRMIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeAgent:      {},
+	commonaddress.TypeAI:         {},
+	commonaddress.TypeAITeam:     {},
+	commonaddress.TypeConference: {},
+	commonaddress.TypeExtension:  {},
+	commonaddress.TypeSIP:        {},
+	"web_session":                {}, // synthetic type; not in commonaddress.Type enum
+}
+
+// isCRMEligiblePeer reports whether the given peer address type can ever
+// represent an external, re-identifiable contact. Duplicated from
+// contacthandler.isCRMEligiblePeer / bin-flow-manager's copy (design
+// VOIP-1243 §6.3).
+func isCRMEligiblePeer(peerType commonaddress.Type) bool {
+	_, ineligible := caseCreateCRMIneligiblePeerTypes[peerType]
+	return !ineligible
+}
+
+// deriveEndpointsForCase resolves which address is the remote peer and
+// which is our local endpoint based on the call direction. Mirrors
+// bin-flow-manager's deriveEndpointsForCase / contacthandler.deriveEndpoints
+// (design VOIP-1243 §6.3).
+func deriveEndpointsForCase(direction string, source, dest commonaddress.Address) (peer commonaddress.Address, self commonaddress.Address) {
+	switch direction {
+	case "incoming":
+		return source, dest
+	case "outgoing":
+		return dest, source
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}
+	}
+}
+
+// deriveCaseEndpointsForAIcall derives the case peer/self/reference_type
+// for an AIcall, mirroring bin-flow-manager's actionHandleCaseCreate
+// derivation logic (design VOIP-1243 §6.3). ok=false means "no defined
+// derivation for this reference type" -- a deliberate scope limit, not an
+// error.
+func (h *aicallHandler) deriveCaseEndpointsForAIcall(ctx context.Context, c *aicall.AIcall) (peer commonaddress.Address, self commonaddress.Address, referenceType string, ok bool) {
+	switch c.ReferenceType {
+	case aicall.ReferenceTypeCall:
+		cl, errGet := h.reqHandler.CallV1CallGet(ctx, c.ReferenceID)
+		if errGet != nil {
+			return commonaddress.Address{}, commonaddress.Address{}, "", false
+		}
+		peer, self = deriveEndpointsForCase(string(cl.Direction), cl.Source, cl.Destination)
+		return peer, self, "call", true
+
+	case aicall.ReferenceTypeConversation:
+		cv, errGet := h.reqHandler.ConversationV1ConversationGet(ctx, c.ReferenceID)
+		if errGet != nil {
+			return commonaddress.Address{}, commonaddress.Address{}, "", false
+		}
+		return cv.Peer, cv.Self, "conversation_message", true
+
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}, "", false
+	}
+}
+
+// toolHandleCaseCreate handles tool call case_create: creates a new
+// contact CRM case for the AIcall's current call/conversation reference.
+// Per design VOIP-1243 §6.3/§8: CRM-ineligibility is reported via
+// fillSuccess (not a failure -- symmetric with the Flow action's silent
+// skip). A ContactV1CaseCreate error (AlreadyExists/Unavailable/other) IS
+// reported to the LLM via fillFailed, unlike the Flow action which only
+// logs -- the tool caller (the LLM) has no other way to learn the
+// attempt did not produce a new case.
+func (h *aicallHandler) toolHandleCaseCreate(ctx context.Context, c *aicall.AIcall, tool *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleCaseCreate",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool case_create.")
+
+	res := newToolResult(tool.ID)
+
+	var tmpOpt fmaction.OptionCaseCreate
+	if errUnmarshal := json.Unmarshal([]byte(tool.Function.Arguments), &tmpOpt); errUnmarshal != nil {
+		fillFailed(res, errUnmarshal)
+		return res
+	}
+
+	peer, self, referenceType, ok := h.deriveCaseEndpointsForAIcall(ctx, c)
+	if !ok {
+		fillSuccess(res, "case", "", "No case was created: this reference type does not support case tracking, or the underlying call/conversation could not be retrieved.")
+		return res
+	}
+
+	if !isCRMEligiblePeer(peer.Type) {
+		fillSuccess(res, "case", "", fmt.Sprintf("No case was created: peer type %s is not eligible for CRM case tracking.", peer.Type))
+		return res
+	}
+
+	// Activeflow-scoped dedup (design VOIP-1243 §3.5): check the
+	// activeflow's own variable store BEFORE calling ContactV1CaseCreate.
+	if v, errVar := h.reqHandler.FlowV1VariableGet(ctx, c.ActiveflowID); errVar == nil && v != nil {
+		if existingCaseID, ok := v.Variables["contact_case_id"]; ok && existingCaseID != "" {
+			fillSuccess(res, "case", existingCaseID, "A case already exists for this call/conversation; no new case was created.")
+			return res
+		}
+	}
+
+	peerTarget, errNormalize := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+	if errNormalize != nil {
+		log.WithError(errNormalize).Warnf("could not normalize peer target; using raw value. peer_type: %s", peer.Type)
+		peerTarget = peer.Target
+	}
+
+	created, errCreate := h.reqHandler.ContactV1CaseCreate(ctx, c.CustomerID, self, peer.Type, peerTarget, referenceType, tmpOpt.Name, tmpOpt.Detail)
+	if errCreate != nil {
+		fillFailed(res, errCreate)
+		return res
+	}
+
+	if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, c.ActiveflowID, map[string]string{"contact_case_id": created.ID.String()}); errSet != nil {
+		log.Errorf("could not set contact_case_id variable. err: %v", errSet) // best-effort; the Case itself was created successfully regardless
+	}
+
+	if tmpOpt.Note != "" {
+		if _, errNote := h.reqHandler.ContactV1CaseNoteCreate(ctx, c.CustomerID, created.ID, "ai", nil, tmpOpt.Note); errNote != nil {
+			log.Errorf("could not create initial case note. err: %v", errNote) // best-effort
+		}
+	}
+
+	fillSuccess(res, "case", created.ID.String(), "Case created successfully.")
 
 	return res
 }

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -441,6 +441,7 @@ func (h *aicallHandler) toolHandleEmailSend(ctx context.Context, c *aicall.AIcal
 // VOIP-1243 §5.2/§6.3) -- the original is unexported in bin-contact-manager
 // and cannot be imported.
 var caseCreateCRMIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeNone:       {}, // zero-value/unknown-direction peer -- never a real contact (VOIP-1243 round-review fix)
 	commonaddress.TypeAgent:      {},
 	commonaddress.TypeAI:         {},
 	commonaddress.TypeAITeam:     {},
@@ -476,28 +477,32 @@ func deriveEndpointsForCase(direction string, source, dest commonaddress.Address
 
 // deriveCaseEndpointsForAIcall derives the case peer/self/reference_type
 // for an AIcall, mirroring bin-flow-manager's actionHandleCaseCreate
-// derivation logic (design VOIP-1243 §6.3). ok=false means "no defined
-// derivation for this reference type" -- a deliberate scope limit, not an
-// error.
-func (h *aicallHandler) deriveCaseEndpointsForAIcall(ctx context.Context, c *aicall.AIcall) (peer commonaddress.Address, self commonaddress.Address, referenceType string, ok bool) {
+// derivation logic (design VOIP-1243 §6.3). supported=false means "no
+// defined derivation for this reference type" -- a deliberate scope
+// limit, not an error, and is reported to the LLM via fillSuccess. A
+// non-nil err means a genuine downstream RPC failure (CallV1CallGet /
+// ConversationV1ConversationGet erroring) and MUST be reported via
+// fillFailed per design §6.3/§8 -- these two outcomes are NOT the same
+// and must not be collapsed into a single bool (round-review fix).
+func (h *aicallHandler) deriveCaseEndpointsForAIcall(ctx context.Context, c *aicall.AIcall) (peer commonaddress.Address, self commonaddress.Address, referenceType string, supported bool, err error) {
 	switch c.ReferenceType {
 	case aicall.ReferenceTypeCall:
 		cl, errGet := h.reqHandler.CallV1CallGet(ctx, c.ReferenceID)
 		if errGet != nil {
-			return commonaddress.Address{}, commonaddress.Address{}, "", false
+			return commonaddress.Address{}, commonaddress.Address{}, "", true, errGet
 		}
 		peer, self = deriveEndpointsForCase(string(cl.Direction), cl.Source, cl.Destination)
-		return peer, self, "call", true
+		return peer, self, "call", true, nil
 
 	case aicall.ReferenceTypeConversation:
 		cv, errGet := h.reqHandler.ConversationV1ConversationGet(ctx, c.ReferenceID)
 		if errGet != nil {
-			return commonaddress.Address{}, commonaddress.Address{}, "", false
+			return commonaddress.Address{}, commonaddress.Address{}, "", true, errGet
 		}
-		return cv.Peer, cv.Self, "conversation_message", true
+		return cv.Peer, cv.Self, "conversation_message", true, nil
 
 	default:
-		return commonaddress.Address{}, commonaddress.Address{}, "", false
+		return commonaddress.Address{}, commonaddress.Address{}, "", false, nil
 	}
 }
 
@@ -524,9 +529,13 @@ func (h *aicallHandler) toolHandleCaseCreate(ctx context.Context, c *aicall.AIca
 		return res
 	}
 
-	peer, self, referenceType, ok := h.deriveCaseEndpointsForAIcall(ctx, c)
-	if !ok {
-		fillSuccess(res, "case", "", "No case was created: this reference type does not support case tracking, or the underlying call/conversation could not be retrieved.")
+	peer, self, referenceType, supported, errDerive := h.deriveCaseEndpointsForAIcall(ctx, c)
+	if errDerive != nil {
+		fillFailed(res, errDerive)
+		return res
+	}
+	if !supported {
+		fillSuccess(res, "case", "", "No case was created: this reference type does not support case tracking.")
 		return res
 	}
 

--- a/bin-ai-manager/pkg/aicallhandler/tool_case_create_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_case_create_test.go
@@ -1,0 +1,377 @@
+package aicallhandler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	cmcall "monorepo/bin-call-manager/models/call"
+	cvconversation "monorepo/bin-conversation-manager/models/conversation"
+	kmkase "monorepo/bin-contact-manager/models/kase"
+	fmvariable "monorepo/bin-flow-manager/models/variable"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/aihandler"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	"monorepo/bin-ai-manager/pkg/messagehandler"
+)
+
+// Test_deriveEndpointsForCase verifies the direction-based peer/self
+// resolution shared with bin-flow-manager's identically-named helper
+// (design VOIP-1243 §6.3).
+func Test_deriveEndpointsForCase(t *testing.T) {
+	source := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"}
+	dest := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"}
+
+	tests := []struct {
+		name       string
+		direction  string
+		expectPeer commonaddress.Address
+		expectSelf commonaddress.Address
+	}{
+		{"incoming", "incoming", source, dest},
+		{"outgoing", "outgoing", dest, source},
+		{"unknown", "unknown", commonaddress.Address{}, commonaddress.Address{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer, self := deriveEndpointsForCase(tt.direction, source, dest)
+			if peer != tt.expectPeer || self != tt.expectSelf {
+				t.Errorf("deriveEndpointsForCase(%s) = (%v, %v), want (%v, %v)", tt.direction, peer, self, tt.expectPeer, tt.expectSelf)
+			}
+		})
+	}
+}
+
+// Test_isCRMEligiblePeer verifies the ineligible-peer-type filter matches
+// bin-flow-manager's / contacthandler's copy (design VOIP-1243 §6.3).
+func Test_isCRMEligiblePeer(t *testing.T) {
+	tests := []struct {
+		name     string
+		peerType commonaddress.Type
+		expect   bool
+	}{
+		{"tel is eligible", commonaddress.TypeTel, true},
+		{"email is eligible", commonaddress.TypeEmail, true},
+		{"agent is not eligible", commonaddress.TypeAgent, false},
+		{"conference is not eligible", commonaddress.TypeConference, false},
+		{"sip is not eligible", commonaddress.TypeSIP, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCRMEligiblePeer(tt.peerType); got != tt.expect {
+				t.Errorf("isCRMEligiblePeer(%s) = %v, want %v", tt.peerType, got, tt.expect)
+			}
+		})
+	}
+}
+
+// Test_deriveCaseEndpointsForAIcall verifies the call/conversation/other
+// dispatch, mirroring bin-flow-manager's actionHandleCaseCreate switch
+// (design VOIP-1243 §6.3).
+func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		aicall *aicall.AIcall
+
+		responseCall         *cmcall.Call
+		responseConversation *cvconversation.Conversation
+
+		expectPeer          commonaddress.Address
+		expectSelf          commonaddress.Address
+		expectReferenceType string
+		expectOK            bool
+	}{
+		{
+			name: "call reference type",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000001"),
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			expectPeer:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+			expectSelf:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			expectReferenceType: "call",
+			expectOK:            true,
+		},
+		{
+			name: "conversation reference type",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeConversation,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000002"),
+			},
+			responseConversation: &cvconversation.Conversation{
+				Self: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0003"},
+				Peer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0004"},
+			},
+			expectPeer:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0004"},
+			expectSelf:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0003"},
+			expectReferenceType: "conversation_message",
+			expectOK:            true,
+		},
+		{
+			name: "unsupported reference type",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeTask,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000003"),
+			},
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq}
+			ctx := context.Background()
+
+			switch tt.aicall.ReferenceType {
+			case aicall.ReferenceTypeCall:
+				mockReq.EXPECT().CallV1CallGet(ctx, tt.aicall.ReferenceID).Return(tt.responseCall, nil)
+			case aicall.ReferenceTypeConversation:
+				mockReq.EXPECT().ConversationV1ConversationGet(ctx, tt.aicall.ReferenceID).Return(tt.responseConversation, nil)
+			}
+
+			peer, self, referenceType, ok := h.deriveCaseEndpointsForAIcall(ctx, tt.aicall)
+			if ok != tt.expectOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.expectOK)
+			}
+			if !tt.expectOK {
+				return
+			}
+			if peer != tt.expectPeer || self != tt.expectSelf || referenceType != tt.expectReferenceType {
+				t.Errorf("got (%v, %v, %s), want (%v, %v, %s)", peer, self, referenceType, tt.expectPeer, tt.expectSelf, tt.expectReferenceType)
+			}
+		})
+	}
+}
+
+// Test_toolHandleCaseCreate covers design VOIP-1243 §6.3/§8/§3.5: happy
+// path, ContactV1CaseCreate error -> fillFailed, CRM-ineligible peer ->
+// fillSuccess (not fillFailed), and the activeflow-scoped dedup skip.
+func Test_toolHandleCaseCreate(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		aicall *aicall.AIcall
+		tool   *message.ToolCall
+
+		responseCall     *cmcall.Call
+		responseVariable *fmvariable.Variable
+		responseCase     *kmkase.Case
+		responseCreateErr error
+
+		expectContactV1CaseCreate bool
+		expectRes                 *messageContent
+	}{
+		{
+			name: "happy path",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000002"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000003"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000004"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000005",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{"name": "VIP escalation", "detail": "billing complaint"}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			responseVariable: &fmvariable.Variable{Variables: map[string]string{}},
+			responseCase: &kmkase.Case{
+				ID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000006"),
+			},
+			expectContactV1CaseCreate: true,
+			expectRes: &messageContent{
+				ToolCallID:   "3a1f2c10-c001-11f0-9000-000000000005",
+				Result:       "success",
+				Message:      "Case created successfully.",
+				ResourceType: "case",
+				ResourceID:   "3a1f2c10-c001-11f0-9000-000000000006",
+			},
+		},
+		{
+			name: "dedup skip: contact_case_id already set",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000011"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000012"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000013"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000014"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000015",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			responseVariable: &fmvariable.Variable{Variables: map[string]string{
+				"contact_case_id": "3a1f2c10-c001-11f0-9000-000000000099",
+			}},
+			expectContactV1CaseCreate: false,
+			expectRes: &messageContent{
+				ToolCallID:   "3a1f2c10-c001-11f0-9000-000000000015",
+				Result:       "success",
+				Message:      "A case already exists for this call/conversation; no new case was created.",
+				ResourceType: "case",
+				ResourceID:   "3a1f2c10-c001-11f0-9000-000000000099",
+			},
+		},
+		{
+			name: "CRM-ineligible peer: fillSuccess, not fillFailed",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000021"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000022"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000023"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000024"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000025",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeAgent, Target: "agent-1"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			expectContactV1CaseCreate: false,
+			expectRes: &messageContent{
+				ToolCallID:   "3a1f2c10-c001-11f0-9000-000000000025",
+				Result:       "success",
+				Message:      "No case was created: peer type agent is not eligible for CRM case tracking.",
+				ResourceType: "case",
+				ResourceID:   "",
+			},
+		},
+		{
+			name: "ContactV1CaseCreate error -> fillFailed",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000031"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000032"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000033"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000034"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000035",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			responseVariable:          &fmvariable.Variable{Variables: map[string]string{}},
+			expectContactV1CaseCreate: true,
+			responseCreateErr:         errTest,
+			expectRes: &messageContent{
+				ToolCallID: "3a1f2c10-c001-11f0-9000-000000000035",
+				Result:     "failed",
+				Message:    errTest.Error(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockAI := aihandler.NewMockAIHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+			h := &aicallHandler{
+				utilHandler:    mockUtil,
+				reqHandler:     mockReq,
+				notifyHandler:  mockNotify,
+				db:             mockDB,
+				aiHandler:      mockAI,
+				messageHandler: mockMessage,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().CallV1CallGet(ctx, tt.aicall.ReferenceID).Return(tt.responseCall, nil)
+			// All fixtures above use DirectionIncoming, so the resolved
+			// peer is always Source (see deriveEndpointsForCase). Whether
+			// FlowV1VariableGet is reached depends on whether that peer
+			// passes isCRMEligiblePeer.
+			if isCRMEligiblePeer(tt.responseCall.Source.Type) {
+				mockReq.EXPECT().FlowV1VariableGet(ctx, tt.aicall.ActiveflowID).Return(tt.responseVariable, nil)
+			}
+
+			if tt.expectContactV1CaseCreate {
+				mockReq.EXPECT().ContactV1CaseCreate(
+					ctx, tt.aicall.CustomerID, gomock.Any(), gomock.Any(), gomock.Any(), "call", gomock.Any(), gomock.Any(),
+				).Return(tt.responseCase, tt.responseCreateErr)
+				if tt.responseCreateErr == nil {
+					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.aicall.ActiveflowID, map[string]string{"contact_case_id": tt.responseCase.ID.String()}).Return(nil)
+				}
+			}
+
+			res := h.toolHandleCaseCreate(ctx, tt.aicall, tt.tool)
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("expected: %v, got: %v", tt.expectRes, res)
+			}
+		})
+	}
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_case_create_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_case_create_test.go
@@ -88,11 +88,13 @@ func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
 
 		responseCall         *cmcall.Call
 		responseConversation *cvconversation.Conversation
+		responseErr          error
 
 		expectPeer          commonaddress.Address
 		expectSelf          commonaddress.Address
 		expectReferenceType string
-		expectOK            bool
+		expectSupported     bool
+		expectErr           bool
 	}{
 		{
 			name: "call reference type",
@@ -108,7 +110,7 @@ func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
 			expectPeer:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
 			expectSelf:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
 			expectReferenceType: "call",
-			expectOK:            true,
+			expectSupported:     true,
 		},
 		{
 			name: "conversation reference type",
@@ -123,7 +125,7 @@ func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
 			expectPeer:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0004"},
 			expectSelf:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0003"},
 			expectReferenceType: "conversation_message",
-			expectOK:            true,
+			expectSupported:     true,
 		},
 		{
 			name: "unsupported reference type",
@@ -131,7 +133,27 @@ func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
 				ReferenceType: aicall.ReferenceTypeTask,
 				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000003"),
 			},
-			expectOK: false,
+			expectSupported: false,
+		},
+		{
+			name: "call reference type - CallV1CallGet errors -> err is returned, not swallowed",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000004"),
+			},
+			responseErr:     errTest,
+			expectSupported: true,
+			expectErr:       true,
+		},
+		{
+			name: "conversation reference type - ConversationV1ConversationGet errors -> err is returned, not swallowed",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeConversation,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000005"),
+			},
+			responseErr:     errTest,
+			expectSupported: true,
+			expectErr:       true,
 		},
 	}
 
@@ -147,16 +169,25 @@ func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
 
 			switch tt.aicall.ReferenceType {
 			case aicall.ReferenceTypeCall:
-				mockReq.EXPECT().CallV1CallGet(ctx, tt.aicall.ReferenceID).Return(tt.responseCall, nil)
+				mockReq.EXPECT().CallV1CallGet(ctx, tt.aicall.ReferenceID).Return(tt.responseCall, tt.responseErr)
 			case aicall.ReferenceTypeConversation:
-				mockReq.EXPECT().ConversationV1ConversationGet(ctx, tt.aicall.ReferenceID).Return(tt.responseConversation, nil)
+				mockReq.EXPECT().ConversationV1ConversationGet(ctx, tt.aicall.ReferenceID).Return(tt.responseConversation, tt.responseErr)
 			}
 
-			peer, self, referenceType, ok := h.deriveCaseEndpointsForAIcall(ctx, tt.aicall)
-			if ok != tt.expectOK {
-				t.Fatalf("ok = %v, want %v", ok, tt.expectOK)
+			peer, self, referenceType, supported, err := h.deriveCaseEndpointsForAIcall(ctx, tt.aicall)
+			if supported != tt.expectSupported {
+				t.Fatalf("supported = %v, want %v", supported, tt.expectSupported)
 			}
-			if !tt.expectOK {
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected a non-nil err, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if !tt.expectSupported {
 				return
 			}
 			if peer != tt.expectPeer || self != tt.expectSelf || referenceType != tt.expectReferenceType {
@@ -373,5 +404,72 @@ func Test_toolHandleCaseCreate(t *testing.T) {
 				t.Errorf("expected: %v, got: %v", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+// Test_toolHandleCaseCreate_UnknownDirection_Skipped is a regression
+// guard (VOIP-1243 round-review fix): an unknown/unrecognized call
+// Direction makes deriveEndpointsForCase return a zero-value peer
+// (commonaddress.TypeNone), which MUST be classified as CRM-ineligible
+// so ContactV1CaseCreate is never called with an empty peer.
+func Test_toolHandleCaseCreate_UnknownDirection_Skipped(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockAI := aihandler.NewMockAIHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+	h := &aicallHandler{
+		utilHandler:    mockUtil,
+		reqHandler:     mockReq,
+		notifyHandler:  mockNotify,
+		db:             mockDB,
+		aiHandler:      mockAI,
+		messageHandler: mockMessage,
+	}
+	ctx := context.Background()
+
+	tc := &aicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("88888888-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("88888888-0000-11f0-8000-000000000002"),
+		},
+		ActiveflowID:  uuid.FromStringOrNil("88888888-0000-11f0-8000-000000000003"),
+		ReferenceType: aicall.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("88888888-0000-11f0-8000-000000000004"),
+	}
+	tool := &message.ToolCall{
+		ID:   "88888888-0000-11f0-8000-000000000005",
+		Type: message.ToolTypeFunction,
+		Function: message.FunctionCall{
+			Name:      message.FunctionCallNameCaseCreate,
+			Arguments: `{}`,
+		},
+	}
+	responseCall := &cmcall.Call{
+		Direction:   "", // unknown direction
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+	}
+
+	mockReq.EXPECT().CallV1CallGet(ctx, tc.ReferenceID).Return(responseCall, nil)
+	// no FlowV1VariableGet/ContactV1CaseCreate expected -- zero-value peer
+	// from an unknown direction must be skipped as CRM-ineligible.
+
+	res := h.toolHandleCaseCreate(ctx, tc, tool)
+
+	expectRes := &messageContent{
+		ToolCallID:   "88888888-0000-11f0-8000-000000000005",
+		Result:       "success",
+		Message:      "No case was created: peer type  is not eligible for CRM case tracking.",
+		ResourceType: "case",
+		ResourceID:   "",
+	}
+	if !reflect.DeepEqual(res, expectRes) {
+		t.Errorf("expected: %v, got: %v", expectRes, res)
 	}
 }

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -722,4 +722,32 @@ run_llm: Set true so you can use the returned schema to build the action.`,
 			"required": []string{"action_type"},
 		},
 	},
+	{
+		Name: tool.ToolNameCaseCreate,
+		Description: `Creates a new CRM case for the current contact/interaction.
+
+WHEN TO USE:
+- The caller's issue is substantive and should be tracked as a case (e.g. a complaint, a multi-step request, something requiring follow-up).
+- An agent or the AI itself judges this interaction needs a trackable record beyond the raw interaction log.
+
+WHEN NOT TO USE:
+- Casual/short interactions with no follow-up need.
+- A case may already be open for this contact/channel -- creating another will fail silently (existing open case is not returned; this call will simply not create a duplicate). Do not retry on failure.
+
+Optional name/detail/note describe the case for a human agent reviewing it later.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to have the assistant mention the case was created (e.g. tell the caller 'I've opened a case for this'). Set false to create silently.",
+					"default":     true,
+				},
+				"name":   map[string]any{"type": "string", "description": "Short case title (optional)."},
+				"detail": map[string]any{"type": "string", "description": "Longer free-text description of the issue (optional)."},
+				"note":   map[string]any{"type": "string", "description": "An initial internal note for the agent (optional, not shown to the customer)."},
+			},
+		},
+		RunLLM: true,
+	},
 }

--- a/bin-ai-manager/pkg/toolhandler/main_test.go
+++ b/bin-ai-manager/pkg/toolhandler/main_test.go
@@ -151,6 +151,7 @@ func TestAllToolNames(t *testing.T) {
 		tool.ToolNameGetCorrelation,
 		tool.ToolNameGetResource,
 		tool.ToolNameDescribeAction,
+		tool.ToolNameCaseCreate,
 	}
 
 	if len(tool.AllToolNames) != len(expectedNames) {

--- a/bin-ai-manager/pkg/toolhandler/whitelist.go
+++ b/bin-ai-manager/pkg/toolhandler/whitelist.go
@@ -19,6 +19,7 @@ var ConversationSafeTools = map[tool.ToolName]bool{
 	tool.ToolNameGetAIcallMessages: true,
 	tool.ToolNameSearchKnowledge:   true,
 	tool.ToolNameDescribeAction:    true,
+	tool.ToolNameCaseCreate:        true,
 }
 
 // FilterToolsForConversation returns the subset of names that are safe for a

--- a/bin-ai-manager/pkg/toolhandler/whitelist_test.go
+++ b/bin-ai-manager/pkg/toolhandler/whitelist_test.go
@@ -63,6 +63,7 @@ func Test_FilterToolsForConversation(t *testing.T) {
 				tool.ToolNameGetAIcallMessages,
 				tool.ToolNameSearchKnowledge,
 				tool.ToolNameDescribeAction,
+				tool.ToolNameCaseCreate,
 			},
 		},
 		{
@@ -82,6 +83,7 @@ func Test_FilterToolsForConversation(t *testing.T) {
 				tool.ToolNameGetAIcallMessages,
 				tool.ToolNameSearchKnowledge,
 				tool.ToolNameDescribeAction,
+				tool.ToolNameCaseCreate,
 			},
 		},
 		{

--- a/bin-flow-manager/go.mod
+++ b/bin-flow-manager/go.mod
@@ -81,6 +81,7 @@ require (
 	monorepo/bin-call-manager v0.0.0-20240403030948-51eb7c33cf9a
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
 	monorepo/bin-conference-manager v0.0.0-20240329045829-45dc5f4e4e76
+	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000
 	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000
@@ -128,7 +129,6 @@ require (
 	monorepo/bin-agent-manager v0.0.0-20240328054741-55144017eccd // indirect
 	monorepo/bin-billing-manager v0.0.0-20240408051040-600f0028fbab // indirect
 	monorepo/bin-campaign-manager v0.0.0-20240313031908-f098e3fb6f12 // indirect
-	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0 // indirect
 	monorepo/bin-number-manager v0.0.0-20240328055052-ec1c723aa183 // indirect
 	monorepo/bin-outdial-manager v0.0.0-20240313064601-888fe8578646 // indirect

--- a/bin-flow-manager/models/action/action.go
+++ b/bin-flow-manager/models/action/action.go
@@ -97,6 +97,11 @@ const (
 	// required media: none
 	TypeCall Type = "call"
 
+	// TypeCaseCreate creates a new contact CRM case for the current call/conversation reference.
+	// contact-manager
+	// required media: none
+	TypeCaseCreate Type = "case_create"
+
 	// TypeConditionCallDigits deprecated. use the TypeConditionVariable instead.
 	// required media: call
 	TypeConditionCallDigits Type = "condition_call_digits" // flow-manager. condition check(call's digits)
@@ -277,6 +282,7 @@ var TypeListAll []Type = []Type{
 	TypeBlock,
 	TypeBranch,
 	TypeCall,
+	TypeCaseCreate,
 	TypeConditionCallDigits,
 	TypeConditionCallStatus,
 	TypeConditionDatetime,
@@ -330,6 +336,7 @@ var MapRequiredMediasByType = map[Type][]MediaType{
 	TypeBlock:               {MediaTypeNonRealTimeCommunication},
 	TypeBranch:              {MediaTypeNone},
 	TypeCall:                {MediaTypeNone},
+	TypeCaseCreate:          {MediaTypeNone},
 	TypeConditionCallDigits: {MediaTypeRealTimeCommunication},
 	TypeConditionCallStatus: {MediaTypeRealTimeCommunication},
 	TypeConditionDatetime:   {MediaTypeNone},

--- a/bin-flow-manager/models/action/option.go
+++ b/bin-flow-manager/models/action/option.go
@@ -221,6 +221,14 @@ type OptionConnect struct {
 	Anonymous string `json:"anonymous,omitempty"`
 }
 
+// OptionCaseCreate defines action case_create's option.
+type OptionCaseCreate struct {
+	Name   string `json:"name,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	Note   string `json:"note,omitempty"`
+	Sync   bool   `json:"sync,omitempty"` // matches conversation_send/email_send's sync/async toggle
+}
+
 // OptionConversationSend defines action conversation_send's optoin.
 type OptionConversationSend struct {
 	ConversationID uuid.UUID `json:"conversation_id,omitempty"` // conversation's id.

--- a/bin-flow-manager/models/action/option_registry.go
+++ b/bin-flow-manager/models/action/option_registry.go
@@ -34,6 +34,7 @@ var OptionStructByType = map[Type]any{
 	TypeBlock:               OptionBlock{},
 	TypeBranch:              OptionBranch{},
 	TypeCall:                OptionCall{},
+	TypeCaseCreate:          OptionCaseCreate{},
 	TypeConditionCallDigits: OptionConditionCallDigits{},
 	TypeConditionCallStatus: OptionConditionCallStatus{},
 	TypeConditionDatetime:   OptionConditionDatetime{},

--- a/bin-flow-manager/pkg/activeflowhandler/actionhandle.go
+++ b/bin-flow-manager/pkg/activeflowhandler/actionhandle.go
@@ -1255,6 +1255,7 @@ func (h *activeflowHandler) actionHandleAITask(ctx context.Context, af *activefl
 // be imported cross-service, so bin-flow-manager and bin-ai-manager each
 // carry their own copy.
 var crmIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeNone:       {}, // zero-value/unknown-direction peer -- never a real contact (VOIP-1243 round-review fix)
 	commonaddress.TypeAgent:      {},
 	commonaddress.TypeAI:         {},
 	commonaddress.TypeAITeam:     {},

--- a/bin-flow-manager/pkg/activeflowhandler/actionhandle.go
+++ b/bin-flow-manager/pkg/activeflowhandler/actionhandle.go
@@ -26,6 +26,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
+
 	"monorepo/bin-flow-manager/models/action"
 	"monorepo/bin-flow-manager/models/activeflow"
 	"monorepo/bin-flow-manager/models/flow"
@@ -1245,3 +1247,145 @@ func (h *activeflowHandler) actionHandleAITask(ctx context.Context, af *activefl
 
 	return nil
 }
+
+// crmIneligiblePeerTypes lists address types that never represent a
+// re-identifiable external contact (customer). This duplicates
+// bin-contact-manager/pkg/contacthandler's unexported crmIneligiblePeerTypes
+// map -- see design VOIP-1243 §5.2's isCRMEligiblePeer reuse note: it cannot
+// be imported cross-service, so bin-flow-manager and bin-ai-manager each
+// carry their own copy.
+var crmIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeAgent:      {},
+	commonaddress.TypeAI:         {},
+	commonaddress.TypeAITeam:     {},
+	commonaddress.TypeConference: {},
+	commonaddress.TypeExtension:  {},
+	commonaddress.TypeSIP:        {},
+	"web_session":                {}, // synthetic type; not in commonaddress.Type enum
+}
+
+// isCRMEligiblePeer reports whether the given peer address type can ever
+// represent an external, re-identifiable contact. Duplicated from
+// contacthandler.isCRMEligiblePeer (see design VOIP-1243 §5.2).
+func isCRMEligiblePeer(peerType commonaddress.Type) bool {
+	_, ineligible := crmIneligiblePeerTypes[peerType]
+	return !ineligible
+}
+
+// deriveEndpointsForCase resolves which address is the remote peer and
+// which is our local endpoint based on the call direction. Mirrors
+// contacthandler.deriveEndpoints's logic but is its own separate
+// implementation in bin-flow-manager (contacthandler.deriveEndpoints is
+// unexported in a different service and cannot be imported) -- see design
+// VOIP-1243 §5.2.
+//
+//   - incoming: the remote party is the source (they called us)
+//   - outgoing: the remote party is the destination (we called them)
+//   - unknown:  both are zero values
+func deriveEndpointsForCase(direction string, source, dest commonaddress.Address) (peer commonaddress.Address, self commonaddress.Address) {
+	switch direction {
+	case "incoming":
+		return source, dest
+	case "outgoing":
+		return dest, source
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}
+	}
+}
+
+// actionHandleCaseCreate handles action case_create with activeflow.
+// It creates a new contact CRM case for the current call/conversation
+// reference. This is a non-critical action: every error path below logs
+// and returns nil, never propagates up to abort the activeflow (see
+// design VOIP-1243 §5.2/§7/§8).
+func (h *activeflowHandler) actionHandleCaseCreate(ctx context.Context, af *activeflow.Activeflow) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":          "actionHandleCaseCreate",
+		"activeflow_id": af.ID,
+	})
+	log.WithField("action", af.CurrentAction).Debugf("Executing action handle. type: %s, action_id: %s", af.CurrentAction.Type, af.CurrentAction.ID)
+
+	tmpOption, err := json.Marshal(af.CurrentAction.Option)
+	if err != nil {
+		log.Errorf("could not marshal the option. err: %v", err)
+		return nil
+	}
+	var opt action.OptionCaseCreate
+	if err := json.Unmarshal(tmpOption, &opt); err != nil {
+		log.Errorf("could not unmarshal the case_create option. err: %v", err)
+		return nil
+	}
+
+	var self, peer commonaddress.Address
+	var referenceType string
+
+	switch af.ReferenceType {
+	case activeflow.ReferenceTypeCall:
+		c, errGet := h.reqHandler.CallV1CallGet(ctx, af.ReferenceID)
+		if errGet != nil {
+			log.Errorf("could not get call. err: %v", errGet)
+			return nil
+		}
+		peer, self = deriveEndpointsForCase(string(c.Direction), c.Source, c.Destination)
+		referenceType = "call"
+
+	case activeflow.ReferenceTypeConversation:
+		cv, errGet := h.reqHandler.ConversationV1ConversationGet(ctx, af.ReferenceID)
+		if errGet != nil {
+			log.Errorf("could not get conversation. err: %v", errGet)
+			return nil
+		}
+		peer, self = cv.Peer, cv.Self
+		referenceType = "conversation_message"
+
+	default:
+		// Deliberate scope limit (design VOIP-1243 §2/§5.2): a Case's
+		// peer/reference_type only has a defined derivation for a live
+		// call or live conversation. Every other reference type is a
+		// silent no-op: log a warning, create no Case, do not error the
+		// activeflow.
+		log.Warnf("case_create is not supported for reference_type: %s", af.ReferenceType)
+		return nil
+	}
+
+	// CRM-eligibility check: a legitimate skip, not a failure.
+	if !isCRMEligiblePeer(peer.Type) {
+		log.Debugf("peer type is not CRM-eligible; skipping case_create. peer_type: %s", peer.Type)
+		return nil
+	}
+
+	// Activeflow-scoped dedup (design VOIP-1243 §3.5): check the
+	// activeflow's own variable store BEFORE calling ContactV1CaseCreate.
+	if v, errVar := h.reqHandler.FlowV1VariableGet(ctx, af.ID); errVar == nil && v != nil {
+		if existingCaseID, ok := v.Variables["contact_case_id"]; ok && existingCaseID != "" {
+			log.Debugf("a case already exists for this activeflow; skipping case_create. contact_case_id: %s", existingCaseID)
+			return nil
+		}
+	} // a FlowV1VariableGet error itself is non-fatal here -- fall through and let ContactV1CaseCreate's own ErrDuplicate backstop catch it if a duplicate does exist
+
+	peerTarget, errNormalize := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+	if errNormalize != nil {
+		log.WithError(errNormalize).Warnf("could not normalize peer target; using raw value. peer_type: %s", peer.Type)
+		peerTarget = peer.Target
+	}
+
+	res, errCreate := h.reqHandler.ContactV1CaseCreate(ctx, af.CustomerID, self, peer.Type, peerTarget, referenceType, opt.Name, opt.Detail)
+	if errCreate != nil {
+		// Covers BOTH cerrors.AlreadyExists and cerrors.Unavailable (design
+		// VOIP-1243 §3.3/§3.5/§8). Neither is escalated, retried, or
+		// distinguished here -- both are simply logged and the activeflow
+		// continues without a new Case.
+		log.Errorf("could not create case. err: %v", errCreate)
+		return nil
+	}
+	if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, af.ID, map[string]string{"contact_case_id": res.ID.String()}); errSet != nil {
+		log.Errorf("could not set contact_case_id variable. err: %v", errSet) // best-effort; the Case itself was created successfully regardless
+	}
+	if opt.Note != "" {
+		if _, errNote := h.reqHandler.ContactV1CaseNoteCreate(ctx, af.CustomerID, res.ID, "system", nil, opt.Note); errNote != nil {
+			log.Errorf("could not create initial case note. err: %v", errNote)
+		}
+	}
+	return nil
+}
+

--- a/bin-flow-manager/pkg/activeflowhandler/actionhandle_case_create_test.go
+++ b/bin-flow-manager/pkg/activeflowhandler/actionhandle_case_create_test.go
@@ -439,3 +439,54 @@ func Test_actionHandleCaseCreate_dispatchRegistration(t *testing.T) {
 		t.Errorf("action.TypeCaseCreate is not registered in action.MapRequiredMediasByType")
 	}
 }
+
+// Test_actionHandleCaseCreate_UnknownDirection_Skipped is a regression
+// guard (VOIP-1243 round-review fix): an unknown/unrecognized call
+// Direction makes deriveEndpointsForCase return a zero-value peer
+// (commonaddress.TypeNone), which MUST be classified as CRM-ineligible
+// so ContactV1CaseCreate is never called with an empty peer.
+func Test_actionHandleCaseCreate_UnknownDirection_Skipped(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000003"),
+		},
+		Direction:   "", // unknown direction
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821****0001"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821****0002"},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	// no FlowV1VariableGet/ContactV1CaseCreate expected -- zero-value peer
+	// from an unknown direction must be skipped as CRM-ineligible.
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}

--- a/bin-flow-manager/pkg/activeflowhandler/actionhandle_case_create_test.go
+++ b/bin-flow-manager/pkg/activeflowhandler/actionhandle_case_create_test.go
@@ -1,0 +1,441 @@
+package activeflowhandler
+
+import (
+	"context"
+	"testing"
+
+	cmkase "monorepo/bin-contact-manager/models/kase"
+	cvconversation "monorepo/bin-conversation-manager/models/conversation"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	cmcall "monorepo/bin-call-manager/models/call"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-flow-manager/models/action"
+	"monorepo/bin-flow-manager/models/activeflow"
+	"monorepo/bin-flow-manager/models/variable"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
+)
+
+func Test_actionHandleCaseCreate_Call(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+			Option: map[string]any{
+				"name":   "test case",
+				"detail": "test detail",
+				"note":   "test note",
+			},
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000003"),
+		},
+		Direction:   cmcall.DirectionIncoming,
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+	}
+
+	responseVariable := &variable.Variable{
+		ID:        af.ID,
+		Variables: map[string]string{},
+	}
+
+	responseCase := &cmkase.Case{
+		ID: uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000005"),
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+	mockReq.EXPECT().ContactV1CaseCreate(ctx, af.CustomerID, responseCall.Destination, commonaddress.TypeTel, responseCall.Source.Target, "call", "test case", "test detail").Return(responseCase, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, af.ID, map[string]string{"contact_case_id": responseCase.ID.String()}).Return(nil)
+	mockReq.EXPECT().ContactV1CaseNoteCreate(ctx, af.CustomerID, responseCase.ID, "system", nil, "test note").Return(nil, nil)
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_Conversation(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeConversation,
+		ReferenceID:   uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseConversation := &cvconversation.Conversation{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000003"),
+		},
+		Self: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000010"},
+		Peer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000011"},
+	}
+
+	responseVariable := &variable.Variable{
+		ID:        af.ID,
+		Variables: map[string]string{},
+	}
+
+	responseCase := &cmkase.Case{
+		ID: uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000005"),
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().ConversationV1ConversationGet(ctx, af.ReferenceID).Return(responseConversation, nil)
+	mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+	mockReq.EXPECT().ContactV1CaseCreate(ctx, af.CustomerID, responseConversation.Self, commonaddress.TypeTel, responseConversation.Peer.Target, "conversation_message", "", "").Return(responseCase, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, af.ID, map[string]string{"contact_case_id": responseCase.ID.String()}).Return(nil)
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_UnsupportedReferenceType(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCampaign,
+		ReferenceID:   uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	// no mock expectations set on mockReq -- asserts neither CallV1CallGet,
+	// ConversationV1ConversationGet, ContactV1CaseCreate, nor
+	// ContactV1CaseNoteCreate are called for an unsupported reference type.
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_CRMIneligiblePeer(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000003"),
+		},
+		Direction:   cmcall.DirectionIncoming,
+		Source:      commonaddress.Address{Type: commonaddress.TypeExtension, Target: "1000"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	// no FlowV1VariableGet/ContactV1CaseCreate expected -- ineligible peer is a skip
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_DedupSkip(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000003"),
+		},
+		Direction:   cmcall.DirectionIncoming,
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+	}
+
+	responseVariable := &variable.Variable{
+		ID:        af.ID,
+		Variables: map[string]string{"contact_case_id": "66666666-0000-11f0-8000-000000000001"},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+	// ContactV1CaseCreate must NOT be called -- design §3.5 dedup check short-circuits it
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_CreateErrorsSwallowed(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		errFunc error
+	}{
+		{
+			name:    "already exists",
+			errFunc: cerrors.AlreadyExists("contact-manager", "duplicate", "case already exists"),
+		},
+		{
+			name:    "unavailable",
+			errFunc: cerrors.Unavailable("contact-manager", "deadlock", "deadlock"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			af := &activeflow.Activeflow{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000002"),
+				},
+				ReferenceType: activeflow.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000003"),
+				CurrentAction: action.Action{
+					ID:   uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000004"),
+					Type: action.TypeCaseCreate,
+				},
+			}
+
+			responseCall := &cmcall.Call{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000003"),
+				},
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+			}
+
+			responseVariable := &variable.Variable{
+				ID:        af.ID,
+				Variables: map[string]string{},
+			}
+
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+
+			h := &activeflowHandler{
+				db:         mockDB,
+				reqHandler: mockReq,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+			mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+			mockReq.EXPECT().ContactV1CaseCreate(ctx, af.CustomerID, responseCall.Destination, commonaddress.TypeTel, responseCall.Source.Target, "call", "", "").Return(nil, tt.errFunc)
+
+			if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+				t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+			}
+		})
+	}
+}
+
+func Test_deriveEndpointsForCase(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		direction string
+		source    commonaddress.Address
+		dest      commonaddress.Address
+
+		expectPeer commonaddress.Address
+		expectSelf commonaddress.Address
+	}{
+		{
+			name:      "incoming",
+			direction: "incoming",
+			source:    commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			dest:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+
+			expectPeer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			expectSelf: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+		},
+		{
+			name:      "outgoing",
+			direction: "outgoing",
+			source:    commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			dest:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+
+			expectPeer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+			expectSelf: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+		},
+		{
+			name:      "unknown",
+			direction: "unknown",
+			source:    commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			dest:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+
+			expectPeer: commonaddress.Address{},
+			expectSelf: commonaddress.Address{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer, self := deriveEndpointsForCase(tt.direction, tt.source, tt.dest)
+			if peer != tt.expectPeer {
+				t.Errorf("Wrong match peer.\nexpect: %v\ngot: %v", tt.expectPeer, peer)
+			}
+			if self != tt.expectSelf {
+				t.Errorf("Wrong match self.\nexpect: %v\ngot: %v", tt.expectSelf, self)
+			}
+		})
+	}
+}
+
+func Test_isCRMEligiblePeer(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		peerType commonaddress.Type
+		expect   bool
+	}{
+		{"tel eligible", commonaddress.TypeTel, true},
+		{"agent ineligible", commonaddress.TypeAgent, false},
+		{"sip ineligible", commonaddress.TypeSIP, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if res := isCRMEligiblePeer(tt.peerType); res != tt.expect {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expect, res)
+			}
+		})
+	}
+}
+
+func Test_actionHandleCaseCreate_dispatchRegistration(t *testing.T) {
+	// Dispatch-switch registration test confirming action.TypeCaseCreate
+	// resolves to actionHandleCaseCreate and does not error at runtime
+	// (design VOIP-1243 §5.3).
+	if _, ok := action.OptionStructByType[action.TypeCaseCreate]; !ok {
+		t.Errorf("action.TypeCaseCreate is not registered in action.OptionStructByType")
+	}
+
+	found := false
+	for _, typ := range action.TypeListAll {
+		if typ == action.TypeCaseCreate {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("action.TypeCaseCreate is not registered in action.TypeListAll")
+	}
+
+	if _, ok := action.MapRequiredMediasByType[action.TypeCaseCreate]; !ok {
+		t.Errorf("action.TypeCaseCreate is not registered in action.MapRequiredMediasByType")
+	}
+}

--- a/bin-flow-manager/pkg/activeflowhandler/execute.go
+++ b/bin-flow-manager/pkg/activeflowhandler/execute.go
@@ -240,6 +240,12 @@ func (h *activeflowHandler) executeAction(ctx context.Context, af *activeflow.Ac
 		}
 		return &action.ActionNext, nil
 
+	case action.TypeCaseCreate:
+		if errHandle := h.actionHandleCaseCreate(ctx, af); errHandle != nil {
+			log.Errorf("Could not create the case correctly. err: %v", errHandle)
+		}
+		return &action.ActionNext, nil
+
 	case action.TypeConversationSend:
 		if errHandle := h.actionHandleConversationSend(ctx, af); errHandle != nil {
 			log.Errorf("Could not send the conversation message correctly. err: %v", errHandle)


### PR DESCRIPTION
Add the case_create Flow action (bin-flow-manager) and case_create AI
tool (bin-ai-manager) per the VOIP-1243 design doc, both in a single PR
because bin-ai-manager's actioncatalog cross-repo parity test requires
the flow action type and its ai-manager catalog entry to land together.

Depends on PR #1080 (VOIP-1243-case-create-rpc, still open): this PR is
based on that branch since ContactV1CaseCreate/casehandler.Create do not
exist on main yet. Retarget this PR's base to main once #1080 merges.

- bin-flow-manager: add action.TypeCaseCreate + action.OptionCaseCreate,
  register in TypeListAll/MapRequiredMediasByType/OptionStructByType,
  add actionHandleCaseCreate (derives peer/self from the call or
  conversation reference, checks CRM-eligibility, checks/sets the
  activeflow-scoped contact_case_id dedup variable, logs and continues
  on AlreadyExists/Unavailable, best-effort initial note), register in
  the activeflowhandler dispatch switch
- bin-ai-manager: add ToolNameCaseCreate + FunctionCallNameCaseCreate,
  tool definition schema (name/detail/note/run_llm), toolHandleCaseCreate
  mirroring the Flow action's derivation/dedup logic but reporting
  ContactV1CaseCreate errors to the LLM via fillFailed (CRM-ineligibility
  is fillSuccess, not a failure), add to ConversationSafeTools, add the
  actioncatalog entry for case_create
