### PR TITLE
VOIP-1243-remove-automatic-case-creation

### DIFF
--- a/bin-ai-manager/go.mod
+++ b/bin-ai-manager/go.mod
@@ -85,6 +85,7 @@ require (
 	monorepo/bin-call-manager v0.0.0-20240403030948-51eb7c33cf9a
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
 	monorepo/bin-conference-manager v0.0.0-20240329045829-45dc5f4e4e76
+	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000
 	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000
@@ -158,7 +159,6 @@ require (
 	monorepo/bin-agent-manager v0.0.0-20240328054741-55144017eccd // indirect
 	monorepo/bin-billing-manager v0.0.0-20240408051040-600f0028fbab // indirect
 	monorepo/bin-campaign-manager v0.0.0-20240313031908-f098e3fb6f12 // indirect
-	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0 // indirect
 	monorepo/bin-number-manager v0.0.0-20240328055052-ec1c723aa183 // indirect
 	monorepo/bin-outdial-manager v0.0.0-20240313064601-888fe8578646 // indirect

--- a/bin-ai-manager/models/message/tool.go
+++ b/bin-ai-manager/models/message/tool.go
@@ -41,4 +41,5 @@ const (
 	FunctionCallNameGetCorrelation    FunctionCallName = "get_correlation"
 	FunctionCallNameGetResource       FunctionCallName = "get_resource"
 	FunctionCallNameDescribeAction    FunctionCallName = "describe_action"
+	FunctionCallNameCaseCreate        FunctionCallName = "case_create"
 )

--- a/bin-ai-manager/models/tool/main.go
+++ b/bin-ai-manager/models/tool/main.go
@@ -20,6 +20,7 @@ const (
 	ToolNameGetCorrelation    ToolName = "get_correlation"
 	ToolNameGetResource       ToolName = "get_resource"
 	ToolNameDescribeAction    ToolName = "describe_action"
+	ToolNameCaseCreate        ToolName = "case_create"
 
 	// Insight AI tool set (VOIP-1234). TODO(VOIP-1234): these two tools are not
 	// yet implemented (no toolDefinitions entry / no execution handler exists).
@@ -47,6 +48,7 @@ var AllToolNames = []ToolName{
 	ToolNameGetCorrelation,
 	ToolNameGetResource,
 	ToolNameDescribeAction,
+	ToolNameCaseCreate,
 }
 
 // AllInsightToolNames defines the tool set available to ai.TypeInsight AIs.

--- a/bin-ai-manager/pkg/actioncatalog/main.go
+++ b/bin-ai-manager/pkg/actioncatalog/main.go
@@ -86,6 +86,12 @@ var actionCatalog = []actionCatalogEntry{
 		{Name: "default_target_id", Type: "uuid", Required: false, Description: "Action id to go to when no target matches."},
 		{Name: "target_ids", Type: "object (map of value -> action id)", Required: true, Description: "Map of matched value to the action id to jump to."},
 	}},
+	{Type: fmaction.TypeCaseCreate, Summary: "Create a new CRM case for the current call/conversation's contact. No-op if the reference type is not call/conversation, the peer is not CRM-eligible, or a case already exists for this activeflow.", Options: []actionOptionField{
+		{Name: "name", Type: "string", Required: false, Description: "Short case title."},
+		{Name: "detail", Type: "string", Required: false, Description: "Longer free-text description of the issue."},
+		{Name: "note", Type: "string", Required: false, Description: "An initial internal note for the agent (not shown to the customer)."},
+		{Name: "sync", Type: "bool", Required: false, Description: "Whether to wait for the case-create RPC to complete before continuing (matches conversation_send/email_send's sync/async toggle)."},
+	}},
 	{Type: fmaction.TypeCall, Summary: "Originate one or more new outbound calls (each runs its own flow or actions).", Options: []actionOptionField{
 		{Name: "source", Type: "address object {type,target,target_name}", Required: false, Description: "Source endpoint / caller id. type is one of tel, sip, extension, agent."},
 		{Name: "destinations", Type: "array of address objects {type,target,target_name}", Required: true, Description: "Destinations to call. type is one of tel, sip, extension, agent, conference."},

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -66,6 +66,7 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		message.FunctionCallNameGetCorrelation:      h.toolHandleGetCorrelation,
 		message.FunctionCallNameGetResource:         h.toolHandleGetResource,
 		message.FunctionCallNameDescribeAction:      h.toolHandleDescribeAction,
+		message.FunctionCallNameCaseCreate:          h.toolHandleCaseCreate,
 	}
 
 	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()
@@ -431,6 +432,141 @@ func (h *aicallHandler) toolHandleEmailSend(ctx context.Context, c *aicall.AIcal
 	}
 
 	fillSuccess(res, "email", tmpRes.ID.String(), "Email sent successfully.")
+
+	return res
+}
+
+// caseCreateCRMIneligiblePeerTypes duplicates
+// bin-flow-manager/pkg/activeflowhandler's crmIneligiblePeerTypes (design
+// VOIP-1243 §5.2/§6.3) -- the original is unexported in bin-contact-manager
+// and cannot be imported.
+var caseCreateCRMIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeAgent:      {},
+	commonaddress.TypeAI:         {},
+	commonaddress.TypeAITeam:     {},
+	commonaddress.TypeConference: {},
+	commonaddress.TypeExtension:  {},
+	commonaddress.TypeSIP:        {},
+	"web_session":                {}, // synthetic type; not in commonaddress.Type enum
+}
+
+// isCRMEligiblePeer reports whether the given peer address type can ever
+// represent an external, re-identifiable contact. Duplicated from
+// contacthandler.isCRMEligiblePeer / bin-flow-manager's copy (design
+// VOIP-1243 §6.3).
+func isCRMEligiblePeer(peerType commonaddress.Type) bool {
+	_, ineligible := caseCreateCRMIneligiblePeerTypes[peerType]
+	return !ineligible
+}
+
+// deriveEndpointsForCase resolves which address is the remote peer and
+// which is our local endpoint based on the call direction. Mirrors
+// bin-flow-manager's deriveEndpointsForCase / contacthandler.deriveEndpoints
+// (design VOIP-1243 §6.3).
+func deriveEndpointsForCase(direction string, source, dest commonaddress.Address) (peer commonaddress.Address, self commonaddress.Address) {
+	switch direction {
+	case "incoming":
+		return source, dest
+	case "outgoing":
+		return dest, source
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}
+	}
+}
+
+// deriveCaseEndpointsForAIcall derives the case peer/self/reference_type
+// for an AIcall, mirroring bin-flow-manager's actionHandleCaseCreate
+// derivation logic (design VOIP-1243 §6.3). ok=false means "no defined
+// derivation for this reference type" -- a deliberate scope limit, not an
+// error.
+func (h *aicallHandler) deriveCaseEndpointsForAIcall(ctx context.Context, c *aicall.AIcall) (peer commonaddress.Address, self commonaddress.Address, referenceType string, ok bool) {
+	switch c.ReferenceType {
+	case aicall.ReferenceTypeCall:
+		cl, errGet := h.reqHandler.CallV1CallGet(ctx, c.ReferenceID)
+		if errGet != nil {
+			return commonaddress.Address{}, commonaddress.Address{}, "", false
+		}
+		peer, self = deriveEndpointsForCase(string(cl.Direction), cl.Source, cl.Destination)
+		return peer, self, "call", true
+
+	case aicall.ReferenceTypeConversation:
+		cv, errGet := h.reqHandler.ConversationV1ConversationGet(ctx, c.ReferenceID)
+		if errGet != nil {
+			return commonaddress.Address{}, commonaddress.Address{}, "", false
+		}
+		return cv.Peer, cv.Self, "conversation_message", true
+
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}, "", false
+	}
+}
+
+// toolHandleCaseCreate handles tool call case_create: creates a new
+// contact CRM case for the AIcall's current call/conversation reference.
+// Per design VOIP-1243 §6.3/§8: CRM-ineligibility is reported via
+// fillSuccess (not a failure -- symmetric with the Flow action's silent
+// skip). A ContactV1CaseCreate error (AlreadyExists/Unavailable/other) IS
+// reported to the LLM via fillFailed, unlike the Flow action which only
+// logs -- the tool caller (the LLM) has no other way to learn the
+// attempt did not produce a new case.
+func (h *aicallHandler) toolHandleCaseCreate(ctx context.Context, c *aicall.AIcall, tool *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleCaseCreate",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool case_create.")
+
+	res := newToolResult(tool.ID)
+
+	var tmpOpt fmaction.OptionCaseCreate
+	if errUnmarshal := json.Unmarshal([]byte(tool.Function.Arguments), &tmpOpt); errUnmarshal != nil {
+		fillFailed(res, errUnmarshal)
+		return res
+	}
+
+	peer, self, referenceType, ok := h.deriveCaseEndpointsForAIcall(ctx, c)
+	if !ok {
+		fillSuccess(res, "case", "", "No case was created: this reference type does not support case tracking, or the underlying call/conversation could not be retrieved.")
+		return res
+	}
+
+	if !isCRMEligiblePeer(peer.Type) {
+		fillSuccess(res, "case", "", fmt.Sprintf("No case was created: peer type %s is not eligible for CRM case tracking.", peer.Type))
+		return res
+	}
+
+	// Activeflow-scoped dedup (design VOIP-1243 §3.5): check the
+	// activeflow's own variable store BEFORE calling ContactV1CaseCreate.
+	if v, errVar := h.reqHandler.FlowV1VariableGet(ctx, c.ActiveflowID); errVar == nil && v != nil {
+		if existingCaseID, ok := v.Variables["contact_case_id"]; ok && existingCaseID != "" {
+			fillSuccess(res, "case", existingCaseID, "A case already exists for this call/conversation; no new case was created.")
+			return res
+		}
+	}
+
+	peerTarget, errNormalize := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+	if errNormalize != nil {
+		log.WithError(errNormalize).Warnf("could not normalize peer target; using raw value. peer_type: %s", peer.Type)
+		peerTarget = peer.Target
+	}
+
+	created, errCreate := h.reqHandler.ContactV1CaseCreate(ctx, c.CustomerID, self, peer.Type, peerTarget, referenceType, tmpOpt.Name, tmpOpt.Detail)
+	if errCreate != nil {
+		fillFailed(res, errCreate)
+		return res
+	}
+
+	if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, c.ActiveflowID, map[string]string{"contact_case_id": created.ID.String()}); errSet != nil {
+		log.Errorf("could not set contact_case_id variable. err: %v", errSet) // best-effort; the Case itself was created successfully regardless
+	}
+
+	if tmpOpt.Note != "" {
+		if _, errNote := h.reqHandler.ContactV1CaseNoteCreate(ctx, c.CustomerID, created.ID, "ai", nil, tmpOpt.Note); errNote != nil {
+			log.Errorf("could not create initial case note. err: %v", errNote) // best-effort
+		}
+	}
+
+	fillSuccess(res, "case", created.ID.String(), "Case created successfully.")
 
 	return res
 }

--- a/bin-ai-manager/pkg/aicallhandler/tool_case_create_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_case_create_test.go
@@ -1,0 +1,377 @@
+package aicallhandler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	cmcall "monorepo/bin-call-manager/models/call"
+	cvconversation "monorepo/bin-conversation-manager/models/conversation"
+	kmkase "monorepo/bin-contact-manager/models/kase"
+	fmvariable "monorepo/bin-flow-manager/models/variable"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/aihandler"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	"monorepo/bin-ai-manager/pkg/messagehandler"
+)
+
+// Test_deriveEndpointsForCase verifies the direction-based peer/self
+// resolution shared with bin-flow-manager's identically-named helper
+// (design VOIP-1243 §6.3).
+func Test_deriveEndpointsForCase(t *testing.T) {
+	source := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"}
+	dest := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"}
+
+	tests := []struct {
+		name       string
+		direction  string
+		expectPeer commonaddress.Address
+		expectSelf commonaddress.Address
+	}{
+		{"incoming", "incoming", source, dest},
+		{"outgoing", "outgoing", dest, source},
+		{"unknown", "unknown", commonaddress.Address{}, commonaddress.Address{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer, self := deriveEndpointsForCase(tt.direction, source, dest)
+			if peer != tt.expectPeer || self != tt.expectSelf {
+				t.Errorf("deriveEndpointsForCase(%s) = (%v, %v), want (%v, %v)", tt.direction, peer, self, tt.expectPeer, tt.expectSelf)
+			}
+		})
+	}
+}
+
+// Test_isCRMEligiblePeer verifies the ineligible-peer-type filter matches
+// bin-flow-manager's / contacthandler's copy (design VOIP-1243 §6.3).
+func Test_isCRMEligiblePeer(t *testing.T) {
+	tests := []struct {
+		name     string
+		peerType commonaddress.Type
+		expect   bool
+	}{
+		{"tel is eligible", commonaddress.TypeTel, true},
+		{"email is eligible", commonaddress.TypeEmail, true},
+		{"agent is not eligible", commonaddress.TypeAgent, false},
+		{"conference is not eligible", commonaddress.TypeConference, false},
+		{"sip is not eligible", commonaddress.TypeSIP, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCRMEligiblePeer(tt.peerType); got != tt.expect {
+				t.Errorf("isCRMEligiblePeer(%s) = %v, want %v", tt.peerType, got, tt.expect)
+			}
+		})
+	}
+}
+
+// Test_deriveCaseEndpointsForAIcall verifies the call/conversation/other
+// dispatch, mirroring bin-flow-manager's actionHandleCaseCreate switch
+// (design VOIP-1243 §6.3).
+func Test_deriveCaseEndpointsForAIcall(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		aicall *aicall.AIcall
+
+		responseCall         *cmcall.Call
+		responseConversation *cvconversation.Conversation
+
+		expectPeer          commonaddress.Address
+		expectSelf          commonaddress.Address
+		expectReferenceType string
+		expectOK            bool
+	}{
+		{
+			name: "call reference type",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000001"),
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			expectPeer:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+			expectSelf:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			expectReferenceType: "call",
+			expectOK:            true,
+		},
+		{
+			name: "conversation reference type",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeConversation,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000002"),
+			},
+			responseConversation: &cvconversation.Conversation{
+				Self: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0003"},
+				Peer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0004"},
+			},
+			expectPeer:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0004"},
+			expectSelf:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0003"},
+			expectReferenceType: "conversation_message",
+			expectOK:            true,
+		},
+		{
+			name: "unsupported reference type",
+			aicall: &aicall.AIcall{
+				ReferenceType: aicall.ReferenceTypeTask,
+				ReferenceID:   uuid.FromStringOrNil("2b6f4c3e-c001-11f0-9000-000000000003"),
+			},
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq}
+			ctx := context.Background()
+
+			switch tt.aicall.ReferenceType {
+			case aicall.ReferenceTypeCall:
+				mockReq.EXPECT().CallV1CallGet(ctx, tt.aicall.ReferenceID).Return(tt.responseCall, nil)
+			case aicall.ReferenceTypeConversation:
+				mockReq.EXPECT().ConversationV1ConversationGet(ctx, tt.aicall.ReferenceID).Return(tt.responseConversation, nil)
+			}
+
+			peer, self, referenceType, ok := h.deriveCaseEndpointsForAIcall(ctx, tt.aicall)
+			if ok != tt.expectOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.expectOK)
+			}
+			if !tt.expectOK {
+				return
+			}
+			if peer != tt.expectPeer || self != tt.expectSelf || referenceType != tt.expectReferenceType {
+				t.Errorf("got (%v, %v, %s), want (%v, %v, %s)", peer, self, referenceType, tt.expectPeer, tt.expectSelf, tt.expectReferenceType)
+			}
+		})
+	}
+}
+
+// Test_toolHandleCaseCreate covers design VOIP-1243 §6.3/§8/§3.5: happy
+// path, ContactV1CaseCreate error -> fillFailed, CRM-ineligible peer ->
+// fillSuccess (not fillFailed), and the activeflow-scoped dedup skip.
+func Test_toolHandleCaseCreate(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		aicall *aicall.AIcall
+		tool   *message.ToolCall
+
+		responseCall     *cmcall.Call
+		responseVariable *fmvariable.Variable
+		responseCase     *kmkase.Case
+		responseCreateErr error
+
+		expectContactV1CaseCreate bool
+		expectRes                 *messageContent
+	}{
+		{
+			name: "happy path",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000002"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000003"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000004"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000005",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{"name": "VIP escalation", "detail": "billing complaint"}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			responseVariable: &fmvariable.Variable{Variables: map[string]string{}},
+			responseCase: &kmkase.Case{
+				ID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000006"),
+			},
+			expectContactV1CaseCreate: true,
+			expectRes: &messageContent{
+				ToolCallID:   "3a1f2c10-c001-11f0-9000-000000000005",
+				Result:       "success",
+				Message:      "Case created successfully.",
+				ResourceType: "case",
+				ResourceID:   "3a1f2c10-c001-11f0-9000-000000000006",
+			},
+		},
+		{
+			name: "dedup skip: contact_case_id already set",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000011"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000012"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000013"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000014"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000015",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			responseVariable: &fmvariable.Variable{Variables: map[string]string{
+				"contact_case_id": "3a1f2c10-c001-11f0-9000-000000000099",
+			}},
+			expectContactV1CaseCreate: false,
+			expectRes: &messageContent{
+				ToolCallID:   "3a1f2c10-c001-11f0-9000-000000000015",
+				Result:       "success",
+				Message:      "A case already exists for this call/conversation; no new case was created.",
+				ResourceType: "case",
+				ResourceID:   "3a1f2c10-c001-11f0-9000-000000000099",
+			},
+		},
+		{
+			name: "CRM-ineligible peer: fillSuccess, not fillFailed",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000021"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000022"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000023"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000024"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000025",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeAgent, Target: "agent-1"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			expectContactV1CaseCreate: false,
+			expectRes: &messageContent{
+				ToolCallID:   "3a1f2c10-c001-11f0-9000-000000000025",
+				Result:       "success",
+				Message:      "No case was created: peer type agent is not eligible for CRM case tracking.",
+				ResourceType: "case",
+				ResourceID:   "",
+			},
+		},
+		{
+			name: "ContactV1CaseCreate error -> fillFailed",
+			aicall: &aicall.AIcall{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000031"),
+					CustomerID: uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000032"),
+				},
+				ActiveflowID:  uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000033"),
+				ReferenceType: aicall.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("3a1f2c10-c001-11f0-9000-000000000034"),
+			},
+			tool: &message.ToolCall{
+				ID:   "3a1f2c10-c001-11f0-9000-000000000035",
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameCaseCreate,
+					Arguments: `{}`,
+				},
+			},
+			responseCall: &cmcall.Call{
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0002"},
+			},
+			responseVariable:          &fmvariable.Variable{Variables: map[string]string{}},
+			expectContactV1CaseCreate: true,
+			responseCreateErr:         errTest,
+			expectRes: &messageContent{
+				ToolCallID: "3a1f2c10-c001-11f0-9000-000000000035",
+				Result:     "failed",
+				Message:    errTest.Error(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockAI := aihandler.NewMockAIHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+			h := &aicallHandler{
+				utilHandler:    mockUtil,
+				reqHandler:     mockReq,
+				notifyHandler:  mockNotify,
+				db:             mockDB,
+				aiHandler:      mockAI,
+				messageHandler: mockMessage,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().CallV1CallGet(ctx, tt.aicall.ReferenceID).Return(tt.responseCall, nil)
+			// All fixtures above use DirectionIncoming, so the resolved
+			// peer is always Source (see deriveEndpointsForCase). Whether
+			// FlowV1VariableGet is reached depends on whether that peer
+			// passes isCRMEligiblePeer.
+			if isCRMEligiblePeer(tt.responseCall.Source.Type) {
+				mockReq.EXPECT().FlowV1VariableGet(ctx, tt.aicall.ActiveflowID).Return(tt.responseVariable, nil)
+			}
+
+			if tt.expectContactV1CaseCreate {
+				mockReq.EXPECT().ContactV1CaseCreate(
+					ctx, tt.aicall.CustomerID, gomock.Any(), gomock.Any(), gomock.Any(), "call", gomock.Any(), gomock.Any(),
+				).Return(tt.responseCase, tt.responseCreateErr)
+				if tt.responseCreateErr == nil {
+					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.aicall.ActiveflowID, map[string]string{"contact_case_id": tt.responseCase.ID.String()}).Return(nil)
+				}
+			}
+
+			res := h.toolHandleCaseCreate(ctx, tt.aicall, tt.tool)
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("expected: %v, got: %v", tt.expectRes, res)
+			}
+		})
+	}
+}

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -722,4 +722,32 @@ run_llm: Set true so you can use the returned schema to build the action.`,
 			"required": []string{"action_type"},
 		},
 	},
+	{
+		Name: tool.ToolNameCaseCreate,
+		Description: `Creates a new CRM case for the current contact/interaction.
+
+WHEN TO USE:
+- The caller's issue is substantive and should be tracked as a case (e.g. a complaint, a multi-step request, something requiring follow-up).
+- An agent or the AI itself judges this interaction needs a trackable record beyond the raw interaction log.
+
+WHEN NOT TO USE:
+- Casual/short interactions with no follow-up need.
+- A case may already be open for this contact/channel -- creating another will fail silently (existing open case is not returned; this call will simply not create a duplicate). Do not retry on failure.
+
+Optional name/detail/note describe the case for a human agent reviewing it later.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to have the assistant mention the case was created (e.g. tell the caller 'I've opened a case for this'). Set false to create silently.",
+					"default":     true,
+				},
+				"name":   map[string]any{"type": "string", "description": "Short case title (optional)."},
+				"detail": map[string]any{"type": "string", "description": "Longer free-text description of the issue (optional)."},
+				"note":   map[string]any{"type": "string", "description": "An initial internal note for the agent (optional, not shown to the customer)."},
+			},
+		},
+		RunLLM: true,
+	},
 }

--- a/bin-ai-manager/pkg/toolhandler/main_test.go
+++ b/bin-ai-manager/pkg/toolhandler/main_test.go
@@ -151,6 +151,7 @@ func TestAllToolNames(t *testing.T) {
 		tool.ToolNameGetCorrelation,
 		tool.ToolNameGetResource,
 		tool.ToolNameDescribeAction,
+		tool.ToolNameCaseCreate,
 	}
 
 	if len(tool.AllToolNames) != len(expectedNames) {

--- a/bin-ai-manager/pkg/toolhandler/whitelist.go
+++ b/bin-ai-manager/pkg/toolhandler/whitelist.go
@@ -19,6 +19,7 @@ var ConversationSafeTools = map[tool.ToolName]bool{
 	tool.ToolNameGetAIcallMessages: true,
 	tool.ToolNameSearchKnowledge:   true,
 	tool.ToolNameDescribeAction:    true,
+	tool.ToolNameCaseCreate:        true,
 }
 
 // FilterToolsForConversation returns the subset of names that are safe for a

--- a/bin-ai-manager/pkg/toolhandler/whitelist_test.go
+++ b/bin-ai-manager/pkg/toolhandler/whitelist_test.go
@@ -63,6 +63,7 @@ func Test_FilterToolsForConversation(t *testing.T) {
 				tool.ToolNameGetAIcallMessages,
 				tool.ToolNameSearchKnowledge,
 				tool.ToolNameDescribeAction,
+				tool.ToolNameCaseCreate,
 			},
 		},
 		{
@@ -82,6 +83,7 @@ func Test_FilterToolsForConversation(t *testing.T) {
 				tool.ToolNameGetAIcallMessages,
 				tool.ToolNameSearchKnowledge,
 				tool.ToolNameDescribeAction,
+				tool.ToolNameCaseCreate,
 			},
 		},
 		{

--- a/bin-common-handler/pkg/requesthandler/contact_cases.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases.go
@@ -8,12 +8,56 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
 	"monorepo/bin-common-handler/models/sock"
 
 	cmcasenote "monorepo/bin-contact-manager/models/casenote"
 	cmkase "monorepo/bin-contact-manager/models/kase"
 	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
 )
+
+// ContactV1CaseCreate creates a new case in contact-manager via a plain,
+// explicit Create (design VOIP-1243 §3) -- distinct from the internal
+// GetOrCreate path. self/peerType/peerTarget/referenceType must be
+// derived by the caller from the actual call/conversation context (see
+// design §3.2); name/detail are optional (empty string persisted as
+// the column's empty default, not NULL).
+func (r *requestHandler) ContactV1CaseCreate(
+	ctx context.Context,
+	customerID uuid.UUID,
+	self commonaddress.Address,
+	peerType commonaddress.Type,
+	peerTarget, referenceType, name, detail string,
+) (*cmkase.Case, error) {
+	uri := "/v1/cases"
+
+	data := &cmrequest.V1DataCasesPost{
+		CustomerID:    customerID,
+		Self:          self,
+		PeerType:      peerType,
+		PeerTarget:    peerTarget,
+		ReferenceType: referenceType,
+		Name:          name,
+		Detail:        detail,
+	}
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodPost, "contact/cases", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cmkase.Case
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
 
 // ContactV1CaseList lists cases from contact-manager, optionally filtered
 // by status, owner, and/or contact_id (query-string filters), with

--- a/bin-common-handler/pkg/requesthandler/contact_cases_test.go
+++ b/bin-common-handler/pkg/requesthandler/contact_cases_test.go
@@ -8,12 +8,88 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	cmcasenote "monorepo/bin-contact-manager/models/casenote"
 	cmkase "monorepo/bin-contact-manager/models/kase"
 )
+
+func Test_ContactV1CaseCreate(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		customerID    uuid.UUID
+		self          commonaddress.Address
+		peerType      commonaddress.Type
+		peerTarget    string
+		referenceType string
+		caseName      string
+		detail        string
+
+		expectTarget  string
+		expectRequest *sock.Request
+		response      *sock.Response
+
+		expectRes *cmkase.Case
+	}{
+		{
+			name: "normal",
+
+			customerID:    uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f3"),
+			self:          commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0001"},
+			peerType:      commonaddress.TypeTel,
+			peerTarget:    "+155****0002",
+			referenceType: "call",
+			caseName:      "VIP escalation",
+			detail:        "customer called about billing",
+
+			expectTarget: "bin-manager.contact-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/cases",
+				Method:   sock.RequestMethodPost,
+				DataType: ContentTypeJSON,
+				Data: []byte(
+					`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f3","self":{"type":"tel","target":"+155****0001"},"peer_type":"tel","peer_target":"+155****0002","reference_type":"call","name":"VIP escalation","detail":"customer called about billing"}`,
+				),
+			},
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"5623e25e-2c74-11ee-87a6-bfa8ae34077f"}`),
+			},
+			expectRes: &cmkase.Case{
+				ID: uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			reqHandler := requestHandler{
+				sock: mockSock,
+			}
+
+			ctx := context.Background()
+			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
+
+			res, err := reqHandler.ContactV1CaseCreate(ctx, tt.customerID, tt.self, tt.peerType, tt.peerTarget, tt.referenceType, tt.caseName, tt.detail)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(tt.expectRes, res) == false {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
 
 func Test_ContactV1CaseList(t *testing.T) {
 

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -925,6 +925,7 @@ type RequestHandler interface {
 	ContactV1ResolutionDelete(ctx context.Context, customerID uuid.UUID, interactionID, resolutionID uuid.UUID) error
 
 	// contact-manager cases (Phase 5, NOJIRA-contact-case-management)
+	ContactV1CaseCreate(ctx context.Context, customerID uuid.UUID, self commonaddress.Address, peerType commonaddress.Type, peerTarget, referenceType, name, detail string) (*cmkase.Case, error)
 	ContactV1CaseList(ctx context.Context, customerID uuid.UUID, status, ownerType string, ownerID uuid.UUID, contactID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
 	ContactV1CaseListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string) ([]*cmkase.Case, string, error)
 	ContactV1CaseGet(ctx context.Context, customerID, id uuid.UUID) (*cmkase.Case, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -3505,6 +3505,21 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1CaseContinue(ctx, customerID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseContinue", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseContinue), ctx, customerID, id, callerType, callerID, callerIsAdmin)
 }
 
+// ContactV1CaseCreate mocks base method.
+func (m *MockRequestHandler) ContactV1CaseCreate(ctx context.Context, customerID uuid.UUID, self address.Address, peerType address.Type, peerTarget, referenceType, name, detail string) (*kase.Case, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1CaseCreate", ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+	ret0, _ := ret[0].(*kase.Case)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1CaseCreate indicates an expected call of ContactV1CaseCreate.
+func (mr *MockRequestHandlerMockRecorder) ContactV1CaseCreate(ctx, customerID, self, peerType, peerTarget, referenceType, name, detail any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseCreate), ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+}
+
 // ContactV1CaseGet mocks base method.
 func (m *MockRequestHandler) ContactV1CaseGet(ctx context.Context, customerID, id uuid.UUID) (*kase.Case, error) {
 	m.ctrl.T.Helper()

--- a/bin-contact-manager/models/kase/kase.go
+++ b/bin-contact-manager/models/kase/kase.go
@@ -34,6 +34,12 @@ type Case struct {
 	// exactly for the design §4 get-or-create join to work.
 	ReferenceType string `json:"reference_type" db:"reference_type"`
 
+	// Name/Detail are optional, freeform case metadata settable only at
+	// creation time via Create (design VOIP-1243 §3.4). Empty string is
+	// persisted as the column's default/empty value, not NULL.
+	Name   string `json:"name,omitempty"   db:"name"`
+	Detail string `json:"detail,omitempty" db:"detail"`
+
 	// ContactID is a nullable denormalized cache; single source of truth
 	// is Resolution (see resolution.CaseID), single derivation function.
 	ContactID *uuid.UUID `json:"contact_id" db:"contact_id,uuid"`

--- a/bin-contact-manager/pkg/casehandler/create.go
+++ b/bin-contact-manager/pkg/casehandler/create.go
@@ -1,0 +1,67 @@
+package casehandler
+
+import (
+	"context"
+	stderrors "errors"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-contact-manager/models/kase"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// Create implements design doc §3's plain Create semantics -- distinct
+// from GetOrCreate: no transaction, no peer lock, no retry loop, no
+// previous_case_id chaining, no owner auto-assignment. Inserts a single
+// new Case row via the existing dbhandler.CaseInsert primitive and
+// translates its sentinel errors to typed cerrors at this layer (design
+// §3.3 steps 1-2).
+func (h *caseHandler) Create(
+	ctx context.Context,
+	customerID uuid.UUID,
+	self commonaddress.Address,
+	peerType commonaddress.Type,
+	peerTarget, referenceType, name, detail string,
+) (*kase.Case, error) {
+	now := h.utilHandler.TimeNow()
+
+	newCase := &kase.Case{
+		ID:             h.utilHandler.UUIDCreate(),
+		CustomerID:     customerID,
+		PeerType:       peerType,
+		PeerTarget:     peerTarget,
+		ReferenceType:  referenceType,
+		Name:           name,
+		Detail:         detail,
+		Status:         kase.StatusOpen,
+		OpenedAt:       now,
+		PreviousCaseID: nil,
+		TMCreate:       now,
+		TMUpdate:       now,
+	}
+
+	if err := h.db.CaseInsert(ctx, newCase); err != nil {
+		if stderrors.Is(err, dbhandler.ErrDuplicate) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameContactManager,
+				"CASE_ALREADY_EXISTS",
+				"An open case already exists for this peer.",
+			).Wrap(err)
+		}
+		if stderrors.Is(err, dbhandler.ErrDeadlock) {
+			return nil, cerrors.Unavailable(
+				commonoutline.ServiceNameContactManager,
+				"CASE_CREATE_DEADLOCK",
+				"Could not create the case due to a transient database conflict. Please retry.",
+			).Wrap(err)
+		}
+		return nil, err
+	}
+
+	return newCase, nil
+}

--- a/bin-contact-manager/pkg/casehandler/create_test.go
+++ b/bin-contact-manager/pkg/casehandler/create_test.go
@@ -1,0 +1,171 @@
+package casehandler
+
+import (
+	"context"
+	stderrors "errors"
+	"testing"
+	"time"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/kase"
+	"monorepo/bin-contact-manager/pkg/cachehandler"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
+)
+
+// Test_Create_HappyPath verifies design VOIP-1243 §3.3: a plain insert
+// with Status=StatusOpen, PreviousCaseID=nil, Owner left zero-value (no
+// auto-assignment), and Name/Detail persisted.
+func Test_Create_HappyPath(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9721-9721-9721-000000000001")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9721-9721-9721-000000000002")
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	mockUtil.EXPECT().UUIDCreate().Return(caseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+
+	res, err := h.Create(
+		ctx, customerID,
+		commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0701"},
+		commonaddress.TypeTel, "+155****9701", "call",
+		"VIP escalation", "customer called about billing",
+	)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if res.ID != caseID {
+		t.Errorf("unexpected ID: %v", res.ID)
+	}
+	if res.CustomerID != customerID {
+		t.Errorf("unexpected CustomerID: %v", res.CustomerID)
+	}
+	if res.Status != kase.StatusOpen {
+		t.Errorf("expected StatusOpen, got: %v", res.Status)
+	}
+	if res.PreviousCaseID != nil {
+		t.Errorf("expected nil PreviousCaseID, got: %v", res.PreviousCaseID)
+	}
+	if res.OwnerType != "" || res.OwnerID != uuid.Nil {
+		t.Errorf("expected zero-value Owner (no auto-assignment), got: type=%v id=%v", res.OwnerType, res.OwnerID)
+	}
+	if res.Name != "VIP escalation" || res.Detail != "customer called about billing" {
+		t.Errorf("unexpected Name/Detail: %q / %q", res.Name, res.Detail)
+	}
+
+	// Confirm it was actually persisted.
+	fetched, err := db.CaseGetByID(ctx, caseID)
+	if err != nil {
+		t.Fatalf("CaseGetByID() error = %v", err)
+	}
+	if fetched.Name != "VIP escalation" || fetched.Detail != "customer called about billing" {
+		t.Errorf("unexpected persisted Name/Detail: %q / %q", fetched.Name, fetched.Detail)
+	}
+}
+
+// Test_Create_DuplicateOpenPeer_TranslatesToAlreadyExists verifies
+// design §3.3 step 2: a uq_case_open_peer violation (dbhandler.ErrDuplicate)
+// is translated to a typed cerrors.AlreadyExists, never a raw error.
+func Test_Create_DuplicateOpenPeer_TranslatesToAlreadyExists(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9722-9722-9722-000000000001")
+	firstCaseID := uuid.FromStringOrNil("f1b2c3d4-9722-9722-9722-000000000002")
+	secondCaseID := uuid.FromStringOrNil("f1b2c3d4-9722-9722-9722-000000000003")
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	self := commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0702"}
+	peerType := commonaddress.TypeTel
+	peerTarget := "+155****9702"
+	referenceType := "call"
+
+	mockUtil.EXPECT().UUIDCreate().Return(firstCaseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	if _, err := h.Create(ctx, customerID, self, peerType, peerTarget, referenceType, "", ""); err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+
+	mockUtil.EXPECT().UUIDCreate().Return(secondCaseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	_, err := h.Create(ctx, customerID, self, peerType, peerTarget, referenceType, "", "")
+
+	var ve *cerrors.VoipbinError
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *cerrors.VoipbinError, got: %T (%v)", err, err)
+	}
+	if ve.Status != cerrors.StatusAlreadyExists {
+		t.Errorf("expected StatusAlreadyExists, got: %v", ve.Status)
+	}
+}
+
+// Test_Create_Deadlock_TranslatesToUnavailable verifies design §3.3's
+// ErrDeadlock handling: Create does NOT retry (unlike GetOrCreate); it
+// translates dbhandler.ErrDeadlock to a typed cerrors.Unavailable.
+// Simulated via a fake dbhandler.DBHandler double returning ErrDeadlock
+// directly from CaseInsert.
+func Test_Create_Deadlock_TranslatesToUnavailable(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: mockDB, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9723-9723-9723-000000000001")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9723-9723-9723-000000000002")
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	mockUtil.EXPECT().UUIDCreate().Return(caseID)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CaseInsert(ctx, gomock.Any()).Return(dbhandler.ErrDeadlock)
+
+	_, err := h.Create(
+		ctx, customerID,
+		commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0703"},
+		commonaddress.TypeTel, "+155****9703", "call", "", "",
+	)
+
+	var ve *cerrors.VoipbinError
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *cerrors.VoipbinError, got: %T (%v)", err, err)
+	}
+	if ve.Status != cerrors.StatusUnavailable {
+		t.Errorf("expected StatusUnavailable, got: %v", ve.Status)
+	}
+}

--- a/bin-contact-manager/pkg/casehandler/main.go
+++ b/bin-contact-manager/pkg/casehandler/main.go
@@ -98,6 +98,15 @@ type CaseHandler interface {
 	// entry point for the customer-facing GET /v1/cases/{id} route.
 	CaseList(ctx context.Context, customerID uuid.UUID, size uint64, token string, status string, ownerType commonidentity.OwnerType, ownerID uuid.UUID, contactID uuid.UUID) ([]*kase.Case, string, error)
 	CaseGet(ctx context.Context, customerID, id uuid.UUID) (*kase.Case, error)
+
+	// Create implements design VOIP-1243 §3: a plain, explicit Case
+	// creation -- NOT get-or-create. No transaction, no peer lock, no
+	// retry loop, no previous_case_id chaining, no owner
+	// auto-assignment. Reuses the existing dbhandler.CaseInsert
+	// primitive and translates its sentinel errors
+	// (dbhandler.ErrDuplicate / dbhandler.ErrDeadlock) into typed
+	// cerrors.AlreadyExists / cerrors.Unavailable respectively.
+	Create(ctx context.Context, customerID uuid.UUID, self commonaddress.Address, peerType commonaddress.Type, peerTarget, referenceType, name, detail string) (*kase.Case, error)
 }
 
 type caseHandler struct {

--- a/bin-contact-manager/pkg/casehandler/mock_main.go
+++ b/bin-contact-manager/pkg/casehandler/mock_main.go
@@ -224,6 +224,21 @@ func (mr *MockCaseHandlerMockRecorder) Continue(ctx, customerID, id, callerType,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Continue", reflect.TypeOf((*MockCaseHandler)(nil).Continue), ctx, customerID, id, callerType, callerID, callerIsAdmin)
 }
 
+// Create mocks base method.
+func (m *MockCaseHandler) Create(ctx context.Context, customerID uuid.UUID, self address.Address, peerType address.Type, peerTarget, referenceType, name, detail string) (*kase.Case, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+	ret0, _ := ret[0].(*kase.Case)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockCaseHandlerMockRecorder) Create(ctx, customerID, self, peerType, peerTarget, referenceType, name, detail any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCaseHandler)(nil).Create), ctx, customerID, self, peerType, peerTarget, referenceType, name, detail)
+}
+
 // GetOrCreate mocks base method.
 func (m *MockCaseHandler) GetOrCreate(ctx context.Context, customerID uuid.UUID, self address.Address, peerType address.Type, peerTarget, referenceType string, caseIDHint *uuid.UUID) (*kase.Case, error) {
 	m.ctrl.T.Helper()

--- a/bin-contact-manager/pkg/contacthandler/interaction.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction.go
@@ -2,7 +2,6 @@ package contacthandler
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 
@@ -97,11 +96,11 @@ func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMe
 	id := h.utilHandler.UUIDCreate()
 	now := h.utilHandler.TimeNow()
 
-	c, err := h.caseHandler.GetOrCreate(ctx, m.CustomerID, local, peer.Type, peerTarget, "call", nil)
-	if err != nil {
-		return fmt.Errorf("could not get-or-create case. EventCallCreated. err: %w", err)
-	}
-
+	// Automatic Case creation removed (design VOIP-1243 §7): Case
+	// creation is now exclusively an explicit action (Flow action
+	// case_create / AI tool case_create), never a side effect of
+	// Interaction projection. Interaction.CaseID is therefore always
+	// nil for newly-projected rows going forward.
 	i := interaction.Interaction{
 		ID:            id,
 		CustomerID:    m.CustomerID,
@@ -112,7 +111,6 @@ func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMe
 		LocalTarget:   localTarget,
 		ReferenceType: "call",
 		ReferenceID:   m.ID,
-		CaseID:        &c.ID,
 		TMInteraction: m.TMCreate,
 		TMCreate:      now,
 	}
@@ -151,11 +149,11 @@ func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m 
 	id := h.utilHandler.UUIDCreate()
 	now := h.utilHandler.TimeNow()
 
-	c, err := h.caseHandler.GetOrCreate(ctx, m.CustomerID, commonaddress.Address{}, peer.Type, peerTarget, "conversation_message", m.CaseID)
-	if err != nil {
-		return fmt.Errorf("could not get-or-create case. EventConversationMessageCreated. err: %w", err)
-	}
-
+	// Automatic Case creation removed (design VOIP-1243 §7): Case
+	// creation is now exclusively an explicit action (Flow action
+	// case_create / AI tool case_create), never a side effect of
+	// Interaction projection. Interaction.CaseID is therefore always
+	// nil for newly-projected rows going forward.
 	// m.ID comes from the embedded commonidentity.Identity; use it directly.
 	i := interaction.Interaction{
 		ID:            id,
@@ -167,7 +165,6 @@ func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m 
 		LocalTarget:   localTarget,
 		ReferenceType: "conversation_message",
 		ReferenceID:   m.ID,
-		CaseID:        &c.ID,
 		TMInteraction: m.TMCreate,
 		TMCreate:      now,
 	}

--- a/bin-contact-manager/pkg/contacthandler/interaction_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_test.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-contact-manager/models/interaction"
-	"monorepo/bin-contact-manager/models/kase"
 	"monorepo/bin-contact-manager/pkg/casehandler"
 	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
@@ -30,7 +29,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 		responseUUID    uuid.UUID
 		responseCurTime *time.Time
-		expectCaseID    uuid.UUID
 
 		expectInteraction *interaction.Interaction
 	}{
@@ -55,7 +53,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("bb000001-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("bb000001-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("bb000001-0000-0000-0000-000000000001"),
@@ -91,7 +88,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("bb000002-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("bb000002-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("bb000002-0000-0000-0000-000000000001"),
@@ -127,7 +123,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("bb000003-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("bb000003-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("bb000003-0000-0000-0000-000000000001"),
@@ -206,9 +201,7 @@ func Test_EventCallCreated(t *testing.T) {
 			ctx := context.Background()
 
 			if tt.expectInteraction != nil {
-				mockCase.EXPECT().GetOrCreate(ctx, tt.expectInteraction.CustomerID, gomock.Any(), commonaddress.Type(tt.expectInteraction.PeerType), tt.expectInteraction.PeerTarget, "call", gomock.Any()).Return(&kase.Case{ID: tt.expectCaseID}, nil)
 				expected := *tt.expectInteraction
-				expected.CaseID = &tt.expectCaseID
 				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
 				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
 				mockDB.EXPECT().InteractionCreate(ctx, &expected).Return(nil)
@@ -231,7 +224,6 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 
 		responseUUID    uuid.UUID
 		responseCurTime *time.Time
-		expectCaseID    uuid.UUID
 
 		expectInteraction *interaction.Interaction
 	}{
@@ -257,7 +249,6 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("dd000001-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001"),
@@ -315,17 +306,7 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 			ctx := context.Background()
 
 			if tt.expectInteraction != nil {
-				// Regression guard for the round-1 review defect: the
-				// message's CaseID hint MUST be forwarded verbatim to
-				// GetOrCreate's caseIDHint parameter, not silently
-				// dropped as a hardcoded nil. gomock.Eq on the actual
-				// pointer VALUE (not gomock.Any()) is required here --
-				// gomock.Any() would pass identically whether the hint
-				// were forwarded or discarded, which is exactly how this
-				// regression escaped detection in round 1.
-				mockCase.EXPECT().GetOrCreate(ctx, tt.expectInteraction.CustomerID, gomock.Any(), commonaddress.Type(tt.expectInteraction.PeerType), tt.expectInteraction.PeerTarget, "conversation_message", tt.message.CaseID).Return(&kase.Case{ID: tt.expectCaseID}, nil)
 				expected := *tt.expectInteraction
-				expected.CaseID = &tt.expectCaseID
 				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
 				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
 				mockDB.EXPECT().InteractionCreate(ctx, &expected).Return(nil)

--- a/bin-contact-manager/pkg/dbhandler/kase_test.go
+++ b/bin-contact-manager/pkg/dbhandler/kase_test.go
@@ -144,6 +144,7 @@ func Test_CaseGetOpenByPeer(t *testing.T) {
 
 	rowColumns := []string{
 		"id", "customer_id", "peer_type", "peer_target", "reference_type",
+		"name", "detail",
 		"contact_id", "owner_type", "owner_id",
 		"status", "opened_at", "closed_at", "closed_reason", "closed_by_type", "closed_by_id",
 		"previous_case_id", "tm_create", "tm_update",
@@ -157,15 +158,16 @@ func Test_CaseGetOpenByPeer(t *testing.T) {
 	defer func() { _ = tx.Rollback() }()
 
 	mock.ExpectQuery("SELECT .* FROM contact_cases WHERE .* FOR UPDATE").
-		WithArgs(customerID.Bytes(), string(commonaddress.TypeTel), "+15551110003", "call", string(kase.StatusOpen)).
+		WithArgs(customerID.Bytes(), string(commonaddress.TypeTel), "+155****0003", "call", string(kase.StatusOpen)).
 		WillReturnRows(sqlmock.NewRows(rowColumns).AddRow(
-			caseID.Bytes(), customerID.Bytes(), string(commonaddress.TypeTel), "+15551110003", "call",
+			caseID.Bytes(), customerID.Bytes(), string(commonaddress.TypeTel), "+155****0003", "call",
+			"", nil,
 			nil, nil, nil,
 			string(kase.StatusOpen), openedAt, nil, nil, nil, nil,
 			nil, openedAt, openedAt,
 		))
 
-	res, err := h.CaseGetOpenByPeer(ctx, tx, customerID, commonaddress.TypeTel, "+15551110003", "call")
+	res, err := h.CaseGetOpenByPeer(ctx, tx, customerID, commonaddress.TypeTel, "+155****0003", "call")
 	if err != nil {
 		t.Fatalf("CaseGetOpenByPeer() error = %v", err)
 	}

--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -76,6 +76,7 @@ var (
 
 	// v1 cases
 	regV1CasesUnresolved = regexp.MustCompile(`/v1/cases/unresolved(\?.*)?$`)
+	regV1Cases           = regexp.MustCompile(`/v1/cases$`)
 	regV1CasesGet        = regexp.MustCompile(`/v1/cases\?(.*)$`)
 	regV1CasesID         = regexp.MustCompile("/v1/cases/" + regUUID + "$")
 	regV1CasesIDClose    = regexp.MustCompile("/v1/cases/" + regUUID + "/close$")
@@ -339,6 +340,11 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	// GET /cases?...
 	case regV1CasesGet.MatchString(m.URI) && m.Method == sock.RequestMethodGet:
 		response, err = h.processV1CasesGet(ctx, m)
+		requestType = "/v1/cases"
+
+	// POST /cases
+	case regV1Cases.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1CasesPost(ctx, m)
 		requestType = "/v1/cases"
 
 	// GET /cases/{id}

--- a/bin-contact-manager/pkg/listenhandler/models/request/v1_cases.go
+++ b/bin-contact-manager/pkg/listenhandler/models/request/v1_cases.go
@@ -1,6 +1,10 @@
 package request
 
-import "github.com/gofrs/uuid"
+import (
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"github.com/gofrs/uuid"
+)
 
 // V1DataCasesIDClose is the request body for POST /v1/cases/{id}/close.
 type V1DataCasesIDClose struct {
@@ -73,4 +77,15 @@ type V1DataCasesUnresolvedGet struct {
 // V1DataCasesGet is the request body for GET /v1/cases?...
 type V1DataCasesGet struct {
 	CustomerID uuid.UUID `json:"customer_id"`
+}
+
+// V1DataCasesPost is the request body for POST /v1/cases.
+type V1DataCasesPost struct {
+	CustomerID    uuid.UUID             `json:"customer_id"`
+	Self          commonaddress.Address `json:"self"`
+	PeerType      commonaddress.Type    `json:"peer_type"`
+	PeerTarget    string                `json:"peer_target"`
+	ReferenceType string                `json:"reference_type"`
+	Name          string                `json:"name,omitempty"`
+	Detail        string                `json:"detail,omitempty"`
 }

--- a/bin-contact-manager/pkg/listenhandler/v1_cases.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases.go
@@ -89,6 +89,37 @@ func (h *listenHandler) processV1CasesGet(ctx context.Context, req *sock.Request
 	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
 }
 
+// processV1CasesPost handles POST /v1/cases request. Implements design
+// VOIP-1243 §3/§4: a plain, explicit Case creation delegated to
+// casehandler.Create -- distinct from the GetOrCreate path used
+// internally by the interaction projection pipeline.
+func (h *listenHandler) processV1CasesPost(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesPost"})
+	log.WithField("request", req).Debug("Received request.")
+
+	var body request.V1DataCasesPost
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		log.Errorf("Could not unmarshal request body. err: %v", err)
+		return simpleResponse(400), nil
+	}
+	if body.CustomerID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.caseHandler.Create(ctx, body.CustomerID, body.Self, body.PeerType, body.PeerTarget, body.ReferenceType, body.Name, body.Detail)
+	if err != nil {
+		log.Errorf("Could not create case. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
 // processV1CasesUnresolvedGet handles GET /v1/cases/unresolved request.
 func (h *listenHandler) processV1CasesUnresolvedGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesUnresolvedGet"})

--- a/bin-contact-manager/pkg/listenhandler/v1_cases_post_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_cases_post_test.go
@@ -1,0 +1,97 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/kase"
+)
+
+// Test_ProcessV1CasesPost_CreatesCase verifies POST /v1/cases
+// unmarshals the request body and delegates to caseHandler.Create
+// (design VOIP-1243 §4's listenhandler layer).
+func Test_ProcessV1CasesPost_CreatesCase(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, mockCase := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-0101-0101-0101-000000000001")
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0101-0101-0101-000000000002")
+
+	reqBody := map[string]any{
+		"customer_id": customerID.String(),
+		"self":        map[string]any{"type": "tel", "target": "+155****0101"},
+		"peer_type":   "tel",
+		"peer_target": "+155****9101",
+		"reference_type": "call",
+		"name":   "VIP",
+		"detail": "escalated",
+	}
+	body, _ := json.Marshal(reqBody)
+	req := &sock.Request{
+		URI:    "/v1/cases",
+		Method: sock.RequestMethodPost,
+		Data:   body,
+	}
+
+	mockCase.EXPECT().Create(
+		ctx, customerID,
+		commonaddress.Address{Type: commonaddress.TypeTel, Target: "+155****0101"},
+		commonaddress.TypeTel, "+155****9101", "call", "VIP", "escalated",
+	).Return(&kase.Case{ID: caseID, CustomerID: customerID}, nil)
+
+	res, err := h.processV1CasesPost(ctx, req)
+	if err != nil {
+		t.Fatalf("processV1CasesPost() error = %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("StatusCode = %v, want 200", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesPost_MissingCustomerID verifies a missing
+// customer_id yields 400 without calling caseHandler.Create.
+func Test_ProcessV1CasesPost_MissingCustomerID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, _ := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	body, _ := json.Marshal(map[string]any{})
+	req := &sock.Request{URI: "/v1/cases", Method: sock.RequestMethodPost, Data: body}
+
+	res, err := h.processV1CasesPost(ctx, req)
+	if err != nil {
+		t.Fatalf("processV1CasesPost() error = %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("StatusCode = %v, want 400", res.StatusCode)
+	}
+}
+
+// Test_RouteDispatch_PostCasesVsGetCasesQuery verifies routing-order
+// correctness (design §4's note): a bare POST /v1/cases does not
+// collide with the GET /v1/cases?... query-string route, and vice
+// versa for GET.
+func Test_RouteDispatch_PostCasesVsGetCasesQuery(t *testing.T) {
+	if !regV1Cases.MatchString("/v1/cases") {
+		t.Errorf("regV1Cases should match a bare /v1/cases URI")
+	}
+	if regV1Cases.MatchString("/v1/cases?status=open") {
+		t.Errorf("regV1Cases should NOT match a query-string URI")
+	}
+	if !regV1CasesGet.MatchString("/v1/cases?status=open") {
+		t.Errorf("regV1CasesGet should match a query-string URI")
+	}
+	if regV1CasesGet.MatchString("/v1/cases") {
+		t.Errorf("regV1CasesGet should NOT match a bare /v1/cases URI")
+	}
+}

--- a/bin-contact-manager/scripts/database_scripts_test/contacts.sql
+++ b/bin-contact-manager/scripts/database_scripts_test/contacts.sql
@@ -165,6 +165,9 @@ create table contact_cases (
   peer_target       varchar(255)  not null default '',
   reference_type    varchar(255)  not null default '',
 
+  name              varchar(255)  not null default '',
+  detail            text,
+
   contact_id        binary(16),
 
   owner_type        varchar(255),

--- a/bin-dbscheme-manager/bin-manager/main/versions/a10299e7932a_contact_cases_add_column_name_detail.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/a10299e7932a_contact_cases_add_column_name_detail.py
@@ -1,0 +1,28 @@
+"""contact_cases_add_column_name_detail
+
+Revision ID: a10299e7932a
+Revises: 29ba6e093d30
+Create Date: 2026-07-10 09:42:42.699470
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a10299e7932a'
+down_revision = '29ba6e093d30'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """alter table contact_cases add column name varchar(255) not null default '' after reference_type;"""
+    )
+    op.execute("""alter table contact_cases add column detail text after name;""")
+
+
+def downgrade():
+    op.execute("""alter table contact_cases drop column detail;""")
+    op.execute("""alter table contact_cases drop column name;""")

--- a/bin-flow-manager/go.mod
+++ b/bin-flow-manager/go.mod
@@ -81,6 +81,7 @@ require (
 	monorepo/bin-call-manager v0.0.0-20240403030948-51eb7c33cf9a
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
 	monorepo/bin-conference-manager v0.0.0-20240329045829-45dc5f4e4e76
+	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000
 	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000
@@ -128,7 +129,6 @@ require (
 	monorepo/bin-agent-manager v0.0.0-20240328054741-55144017eccd // indirect
 	monorepo/bin-billing-manager v0.0.0-20240408051040-600f0028fbab // indirect
 	monorepo/bin-campaign-manager v0.0.0-20240313031908-f098e3fb6f12 // indirect
-	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0 // indirect
 	monorepo/bin-number-manager v0.0.0-20240328055052-ec1c723aa183 // indirect
 	monorepo/bin-outdial-manager v0.0.0-20240313064601-888fe8578646 // indirect

--- a/bin-flow-manager/models/action/action.go
+++ b/bin-flow-manager/models/action/action.go
@@ -97,6 +97,11 @@ const (
 	// required media: none
 	TypeCall Type = "call"
 
+	// TypeCaseCreate creates a new contact CRM case for the current call/conversation reference.
+	// contact-manager
+	// required media: none
+	TypeCaseCreate Type = "case_create"
+
 	// TypeConditionCallDigits deprecated. use the TypeConditionVariable instead.
 	// required media: call
 	TypeConditionCallDigits Type = "condition_call_digits" // flow-manager. condition check(call's digits)
@@ -277,6 +282,7 @@ var TypeListAll []Type = []Type{
 	TypeBlock,
 	TypeBranch,
 	TypeCall,
+	TypeCaseCreate,
 	TypeConditionCallDigits,
 	TypeConditionCallStatus,
 	TypeConditionDatetime,
@@ -330,6 +336,7 @@ var MapRequiredMediasByType = map[Type][]MediaType{
 	TypeBlock:               {MediaTypeNonRealTimeCommunication},
 	TypeBranch:              {MediaTypeNone},
 	TypeCall:                {MediaTypeNone},
+	TypeCaseCreate:          {MediaTypeNone},
 	TypeConditionCallDigits: {MediaTypeRealTimeCommunication},
 	TypeConditionCallStatus: {MediaTypeRealTimeCommunication},
 	TypeConditionDatetime:   {MediaTypeNone},

--- a/bin-flow-manager/models/action/option.go
+++ b/bin-flow-manager/models/action/option.go
@@ -221,6 +221,14 @@ type OptionConnect struct {
 	Anonymous string `json:"anonymous,omitempty"`
 }
 
+// OptionCaseCreate defines action case_create's option.
+type OptionCaseCreate struct {
+	Name   string `json:"name,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	Note   string `json:"note,omitempty"`
+	Sync   bool   `json:"sync,omitempty"` // matches conversation_send/email_send's sync/async toggle
+}
+
 // OptionConversationSend defines action conversation_send's optoin.
 type OptionConversationSend struct {
 	ConversationID uuid.UUID `json:"conversation_id,omitempty"` // conversation's id.

--- a/bin-flow-manager/models/action/option_registry.go
+++ b/bin-flow-manager/models/action/option_registry.go
@@ -34,6 +34,7 @@ var OptionStructByType = map[Type]any{
 	TypeBlock:               OptionBlock{},
 	TypeBranch:              OptionBranch{},
 	TypeCall:                OptionCall{},
+	TypeCaseCreate:          OptionCaseCreate{},
 	TypeConditionCallDigits: OptionConditionCallDigits{},
 	TypeConditionCallStatus: OptionConditionCallStatus{},
 	TypeConditionDatetime:   OptionConditionDatetime{},

--- a/bin-flow-manager/pkg/activeflowhandler/actionhandle.go
+++ b/bin-flow-manager/pkg/activeflowhandler/actionhandle.go
@@ -26,6 +26,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
+
 	"monorepo/bin-flow-manager/models/action"
 	"monorepo/bin-flow-manager/models/activeflow"
 	"monorepo/bin-flow-manager/models/flow"
@@ -1245,3 +1247,145 @@ func (h *activeflowHandler) actionHandleAITask(ctx context.Context, af *activefl
 
 	return nil
 }
+
+// crmIneligiblePeerTypes lists address types that never represent a
+// re-identifiable external contact (customer). This duplicates
+// bin-contact-manager/pkg/contacthandler's unexported crmIneligiblePeerTypes
+// map -- see design VOIP-1243 §5.2's isCRMEligiblePeer reuse note: it cannot
+// be imported cross-service, so bin-flow-manager and bin-ai-manager each
+// carry their own copy.
+var crmIneligiblePeerTypes = map[commonaddress.Type]struct{}{
+	commonaddress.TypeAgent:      {},
+	commonaddress.TypeAI:         {},
+	commonaddress.TypeAITeam:     {},
+	commonaddress.TypeConference: {},
+	commonaddress.TypeExtension:  {},
+	commonaddress.TypeSIP:        {},
+	"web_session":                {}, // synthetic type; not in commonaddress.Type enum
+}
+
+// isCRMEligiblePeer reports whether the given peer address type can ever
+// represent an external, re-identifiable contact. Duplicated from
+// contacthandler.isCRMEligiblePeer (see design VOIP-1243 §5.2).
+func isCRMEligiblePeer(peerType commonaddress.Type) bool {
+	_, ineligible := crmIneligiblePeerTypes[peerType]
+	return !ineligible
+}
+
+// deriveEndpointsForCase resolves which address is the remote peer and
+// which is our local endpoint based on the call direction. Mirrors
+// contacthandler.deriveEndpoints's logic but is its own separate
+// implementation in bin-flow-manager (contacthandler.deriveEndpoints is
+// unexported in a different service and cannot be imported) -- see design
+// VOIP-1243 §5.2.
+//
+//   - incoming: the remote party is the source (they called us)
+//   - outgoing: the remote party is the destination (we called them)
+//   - unknown:  both are zero values
+func deriveEndpointsForCase(direction string, source, dest commonaddress.Address) (peer commonaddress.Address, self commonaddress.Address) {
+	switch direction {
+	case "incoming":
+		return source, dest
+	case "outgoing":
+		return dest, source
+	default:
+		return commonaddress.Address{}, commonaddress.Address{}
+	}
+}
+
+// actionHandleCaseCreate handles action case_create with activeflow.
+// It creates a new contact CRM case for the current call/conversation
+// reference. This is a non-critical action: every error path below logs
+// and returns nil, never propagates up to abort the activeflow (see
+// design VOIP-1243 §5.2/§7/§8).
+func (h *activeflowHandler) actionHandleCaseCreate(ctx context.Context, af *activeflow.Activeflow) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":          "actionHandleCaseCreate",
+		"activeflow_id": af.ID,
+	})
+	log.WithField("action", af.CurrentAction).Debugf("Executing action handle. type: %s, action_id: %s", af.CurrentAction.Type, af.CurrentAction.ID)
+
+	tmpOption, err := json.Marshal(af.CurrentAction.Option)
+	if err != nil {
+		log.Errorf("could not marshal the option. err: %v", err)
+		return nil
+	}
+	var opt action.OptionCaseCreate
+	if err := json.Unmarshal(tmpOption, &opt); err != nil {
+		log.Errorf("could not unmarshal the case_create option. err: %v", err)
+		return nil
+	}
+
+	var self, peer commonaddress.Address
+	var referenceType string
+
+	switch af.ReferenceType {
+	case activeflow.ReferenceTypeCall:
+		c, errGet := h.reqHandler.CallV1CallGet(ctx, af.ReferenceID)
+		if errGet != nil {
+			log.Errorf("could not get call. err: %v", errGet)
+			return nil
+		}
+		peer, self = deriveEndpointsForCase(string(c.Direction), c.Source, c.Destination)
+		referenceType = "call"
+
+	case activeflow.ReferenceTypeConversation:
+		cv, errGet := h.reqHandler.ConversationV1ConversationGet(ctx, af.ReferenceID)
+		if errGet != nil {
+			log.Errorf("could not get conversation. err: %v", errGet)
+			return nil
+		}
+		peer, self = cv.Peer, cv.Self
+		referenceType = "conversation_message"
+
+	default:
+		// Deliberate scope limit (design VOIP-1243 §2/§5.2): a Case's
+		// peer/reference_type only has a defined derivation for a live
+		// call or live conversation. Every other reference type is a
+		// silent no-op: log a warning, create no Case, do not error the
+		// activeflow.
+		log.Warnf("case_create is not supported for reference_type: %s", af.ReferenceType)
+		return nil
+	}
+
+	// CRM-eligibility check: a legitimate skip, not a failure.
+	if !isCRMEligiblePeer(peer.Type) {
+		log.Debugf("peer type is not CRM-eligible; skipping case_create. peer_type: %s", peer.Type)
+		return nil
+	}
+
+	// Activeflow-scoped dedup (design VOIP-1243 §3.5): check the
+	// activeflow's own variable store BEFORE calling ContactV1CaseCreate.
+	if v, errVar := h.reqHandler.FlowV1VariableGet(ctx, af.ID); errVar == nil && v != nil {
+		if existingCaseID, ok := v.Variables["contact_case_id"]; ok && existingCaseID != "" {
+			log.Debugf("a case already exists for this activeflow; skipping case_create. contact_case_id: %s", existingCaseID)
+			return nil
+		}
+	} // a FlowV1VariableGet error itself is non-fatal here -- fall through and let ContactV1CaseCreate's own ErrDuplicate backstop catch it if a duplicate does exist
+
+	peerTarget, errNormalize := commonaddress.NormalizeTarget(peer.Type, peer.Target)
+	if errNormalize != nil {
+		log.WithError(errNormalize).Warnf("could not normalize peer target; using raw value. peer_type: %s", peer.Type)
+		peerTarget = peer.Target
+	}
+
+	res, errCreate := h.reqHandler.ContactV1CaseCreate(ctx, af.CustomerID, self, peer.Type, peerTarget, referenceType, opt.Name, opt.Detail)
+	if errCreate != nil {
+		// Covers BOTH cerrors.AlreadyExists and cerrors.Unavailable (design
+		// VOIP-1243 §3.3/§3.5/§8). Neither is escalated, retried, or
+		// distinguished here -- both are simply logged and the activeflow
+		// continues without a new Case.
+		log.Errorf("could not create case. err: %v", errCreate)
+		return nil
+	}
+	if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, af.ID, map[string]string{"contact_case_id": res.ID.String()}); errSet != nil {
+		log.Errorf("could not set contact_case_id variable. err: %v", errSet) // best-effort; the Case itself was created successfully regardless
+	}
+	if opt.Note != "" {
+		if _, errNote := h.reqHandler.ContactV1CaseNoteCreate(ctx, af.CustomerID, res.ID, "system", nil, opt.Note); errNote != nil {
+			log.Errorf("could not create initial case note. err: %v", errNote)
+		}
+	}
+	return nil
+}
+

--- a/bin-flow-manager/pkg/activeflowhandler/actionhandle_case_create_test.go
+++ b/bin-flow-manager/pkg/activeflowhandler/actionhandle_case_create_test.go
@@ -1,0 +1,441 @@
+package activeflowhandler
+
+import (
+	"context"
+	"testing"
+
+	cmkase "monorepo/bin-contact-manager/models/kase"
+	cvconversation "monorepo/bin-conversation-manager/models/conversation"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	cmcall "monorepo/bin-call-manager/models/call"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-flow-manager/models/action"
+	"monorepo/bin-flow-manager/models/activeflow"
+	"monorepo/bin-flow-manager/models/variable"
+	"monorepo/bin-flow-manager/pkg/dbhandler"
+)
+
+func Test_actionHandleCaseCreate_Call(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+			Option: map[string]any{
+				"name":   "test case",
+				"detail": "test detail",
+				"note":   "test note",
+			},
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000003"),
+		},
+		Direction:   cmcall.DirectionIncoming,
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+	}
+
+	responseVariable := &variable.Variable{
+		ID:        af.ID,
+		Variables: map[string]string{},
+	}
+
+	responseCase := &cmkase.Case{
+		ID: uuid.FromStringOrNil("11111111-0000-11f0-8000-000000000005"),
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+	mockReq.EXPECT().ContactV1CaseCreate(ctx, af.CustomerID, responseCall.Destination, commonaddress.TypeTel, responseCall.Source.Target, "call", "test case", "test detail").Return(responseCase, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, af.ID, map[string]string{"contact_case_id": responseCase.ID.String()}).Return(nil)
+	mockReq.EXPECT().ContactV1CaseNoteCreate(ctx, af.CustomerID, responseCase.ID, "system", nil, "test note").Return(nil, nil)
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_Conversation(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeConversation,
+		ReferenceID:   uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseConversation := &cvconversation.Conversation{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000003"),
+		},
+		Self: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000010"},
+		Peer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000011"},
+	}
+
+	responseVariable := &variable.Variable{
+		ID:        af.ID,
+		Variables: map[string]string{},
+	}
+
+	responseCase := &cmkase.Case{
+		ID: uuid.FromStringOrNil("22222222-0000-11f0-8000-000000000005"),
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().ConversationV1ConversationGet(ctx, af.ReferenceID).Return(responseConversation, nil)
+	mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+	mockReq.EXPECT().ContactV1CaseCreate(ctx, af.CustomerID, responseConversation.Self, commonaddress.TypeTel, responseConversation.Peer.Target, "conversation_message", "", "").Return(responseCase, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, af.ID, map[string]string{"contact_case_id": responseCase.ID.String()}).Return(nil)
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_UnsupportedReferenceType(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCampaign,
+		ReferenceID:   uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("33333333-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	// no mock expectations set on mockReq -- asserts neither CallV1CallGet,
+	// ConversationV1ConversationGet, ContactV1CaseCreate, nor
+	// ContactV1CaseNoteCreate are called for an unsupported reference type.
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_CRMIneligiblePeer(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("44444444-0000-11f0-8000-000000000003"),
+		},
+		Direction:   cmcall.DirectionIncoming,
+		Source:      commonaddress.Address{Type: commonaddress.TypeExtension, Target: "1000"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	// no FlowV1VariableGet/ContactV1CaseCreate expected -- ineligible peer is a skip
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_DedupSkip(t *testing.T) {
+
+	af := &activeflow.Activeflow{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000001"),
+			CustomerID: uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000002"),
+		},
+		ReferenceType: activeflow.ReferenceTypeCall,
+		ReferenceID:   uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000003"),
+		CurrentAction: action.Action{
+			ID:   uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000004"),
+			Type: action.TypeCaseCreate,
+		},
+	}
+
+	responseCall := &cmcall.Call{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("55555555-0000-11f0-8000-000000000003"),
+		},
+		Direction:   cmcall.DirectionIncoming,
+		Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+		Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+	}
+
+	responseVariable := &variable.Variable{
+		ID:        af.ID,
+		Variables: map[string]string{"contact_case_id": "66666666-0000-11f0-8000-000000000001"},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+
+	h := &activeflowHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+	mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+	// ContactV1CaseCreate must NOT be called -- design §3.5 dedup check short-circuits it
+
+	if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+		t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+	}
+}
+
+func Test_actionHandleCaseCreate_CreateErrorsSwallowed(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		errFunc error
+	}{
+		{
+			name:    "already exists",
+			errFunc: cerrors.AlreadyExists("contact-manager", "duplicate", "case already exists"),
+		},
+		{
+			name:    "unavailable",
+			errFunc: cerrors.Unavailable("contact-manager", "deadlock", "deadlock"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			af := &activeflow.Activeflow{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000002"),
+				},
+				ReferenceType: activeflow.ReferenceTypeCall,
+				ReferenceID:   uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000003"),
+				CurrentAction: action.Action{
+					ID:   uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000004"),
+					Type: action.TypeCaseCreate,
+				},
+			}
+
+			responseCall := &cmcall.Call{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("77777777-0000-11f0-8000-000000000003"),
+				},
+				Direction:   cmcall.DirectionIncoming,
+				Source:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+				Destination: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+			}
+
+			responseVariable := &variable.Variable{
+				ID:        af.ID,
+				Variables: map[string]string{},
+			}
+
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+
+			h := &activeflowHandler{
+				db:         mockDB,
+				reqHandler: mockReq,
+			}
+
+			ctx := context.Background()
+
+			mockReq.EXPECT().CallV1CallGet(ctx, af.ReferenceID).Return(responseCall, nil)
+			mockReq.EXPECT().FlowV1VariableGet(ctx, af.ID).Return(responseVariable, nil)
+			mockReq.EXPECT().ContactV1CaseCreate(ctx, af.CustomerID, responseCall.Destination, commonaddress.TypeTel, responseCall.Source.Target, "call", "", "").Return(nil, tt.errFunc)
+
+			if errAction := h.actionHandleCaseCreate(ctx, af); errAction != nil {
+				t.Errorf("Wrong match.\nexpect: ok\ngot: %v", errAction)
+			}
+		})
+	}
+}
+
+func Test_deriveEndpointsForCase(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		direction string
+		source    commonaddress.Address
+		dest      commonaddress.Address
+
+		expectPeer commonaddress.Address
+		expectSelf commonaddress.Address
+	}{
+		{
+			name:      "incoming",
+			direction: "incoming",
+			source:    commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			dest:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+
+			expectPeer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			expectSelf: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+		},
+		{
+			name:      "outgoing",
+			direction: "outgoing",
+			source:    commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			dest:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+
+			expectPeer: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+			expectSelf: commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+		},
+		{
+			name:      "unknown",
+			direction: "unknown",
+			source:    commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000001"},
+			dest:      commonaddress.Address{Type: commonaddress.TypeTel, Target: "+821100000002"},
+
+			expectPeer: commonaddress.Address{},
+			expectSelf: commonaddress.Address{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peer, self := deriveEndpointsForCase(tt.direction, tt.source, tt.dest)
+			if peer != tt.expectPeer {
+				t.Errorf("Wrong match peer.\nexpect: %v\ngot: %v", tt.expectPeer, peer)
+			}
+			if self != tt.expectSelf {
+				t.Errorf("Wrong match self.\nexpect: %v\ngot: %v", tt.expectSelf, self)
+			}
+		})
+	}
+}
+
+func Test_isCRMEligiblePeer(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		peerType commonaddress.Type
+		expect   bool
+	}{
+		{"tel eligible", commonaddress.TypeTel, true},
+		{"agent ineligible", commonaddress.TypeAgent, false},
+		{"sip ineligible", commonaddress.TypeSIP, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if res := isCRMEligiblePeer(tt.peerType); res != tt.expect {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expect, res)
+			}
+		})
+	}
+}
+
+func Test_actionHandleCaseCreate_dispatchRegistration(t *testing.T) {
+	// Dispatch-switch registration test confirming action.TypeCaseCreate
+	// resolves to actionHandleCaseCreate and does not error at runtime
+	// (design VOIP-1243 §5.3).
+	if _, ok := action.OptionStructByType[action.TypeCaseCreate]; !ok {
+		t.Errorf("action.TypeCaseCreate is not registered in action.OptionStructByType")
+	}
+
+	found := false
+	for _, typ := range action.TypeListAll {
+		if typ == action.TypeCaseCreate {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("action.TypeCaseCreate is not registered in action.TypeListAll")
+	}
+
+	if _, ok := action.MapRequiredMediasByType[action.TypeCaseCreate]; !ok {
+		t.Errorf("action.TypeCaseCreate is not registered in action.MapRequiredMediasByType")
+	}
+}

--- a/bin-flow-manager/pkg/activeflowhandler/execute.go
+++ b/bin-flow-manager/pkg/activeflowhandler/execute.go
@@ -240,6 +240,12 @@ func (h *activeflowHandler) executeAction(ctx context.Context, af *activeflow.Ac
 		}
 		return &action.ActionNext, nil
 
+	case action.TypeCaseCreate:
+		if errHandle := h.actionHandleCaseCreate(ctx, af); errHandle != nil {
+			log.Errorf("Could not create the case correctly. err: %v", errHandle)
+		}
+		return &action.ActionNext, nil
+
 	case action.TypeConversationSend:
 		if errHandle := h.actionHandleConversationSend(ctx, af); errHandle != nil {
 			log.Errorf("Could not send the conversation message correctly. err: %v", errHandle)


### PR DESCRIPTION
Remove the automatic Case creation that fired as a side effect of every
projected call/message Interaction, per the VOIP-1243 design doc's
decision to make Case creation exclusively an explicit action (the
case_create Flow action / AI tool added in PR #1081).

Depends on PR #1081 (case_create wiring) and transitively #1080 (the
Create RPC); branched from #1081's branch. This PR's base will need to
become main once the chain (#1080 -> #1081 -> this) merges in order.

- bin-contact-manager: remove the caseHandler.GetOrCreate call from
  EventCallCreated and EventConversationMessageCreated; Interaction.CaseID
  is now always nil for newly-projected rows (Interaction projection
  itself is unchanged otherwise -- CRM-eligibility filtering, direction
  derivation, and normalization all stay exactly as before)
