### PR TITLE
VOIP-1243-remove-automatic-case-creation

### DIFF
--- a/bin-contact-manager/pkg/contacthandler/interaction.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction.go
@@ -2,7 +2,6 @@ package contacthandler
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 
@@ -97,11 +96,11 @@ func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMe
 	id := h.utilHandler.UUIDCreate()
 	now := h.utilHandler.TimeNow()
 
-	c, err := h.caseHandler.GetOrCreate(ctx, m.CustomerID, local, peer.Type, peerTarget, "call", nil)
-	if err != nil {
-		return fmt.Errorf("could not get-or-create case. EventCallCreated. err: %w", err)
-	}
-
+	// Automatic Case creation removed (design VOIP-1243 §7): Case
+	// creation is now exclusively an explicit action (Flow action
+	// case_create / AI tool case_create), never a side effect of
+	// Interaction projection. Interaction.CaseID is therefore always
+	// nil for newly-projected rows going forward.
 	i := interaction.Interaction{
 		ID:            id,
 		CustomerID:    m.CustomerID,
@@ -112,7 +111,6 @@ func (h *contactHandler) EventCallCreated(ctx context.Context, m *call.WebhookMe
 		LocalTarget:   localTarget,
 		ReferenceType: "call",
 		ReferenceID:   m.ID,
-		CaseID:        &c.ID,
 		TMInteraction: m.TMCreate,
 		TMCreate:      now,
 	}
@@ -151,11 +149,11 @@ func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m 
 	id := h.utilHandler.UUIDCreate()
 	now := h.utilHandler.TimeNow()
 
-	c, err := h.caseHandler.GetOrCreate(ctx, m.CustomerID, commonaddress.Address{}, peer.Type, peerTarget, "conversation_message", m.CaseID)
-	if err != nil {
-		return fmt.Errorf("could not get-or-create case. EventConversationMessageCreated. err: %w", err)
-	}
-
+	// Automatic Case creation removed (design VOIP-1243 §7): Case
+	// creation is now exclusively an explicit action (Flow action
+	// case_create / AI tool case_create), never a side effect of
+	// Interaction projection. Interaction.CaseID is therefore always
+	// nil for newly-projected rows going forward.
 	// m.ID comes from the embedded commonidentity.Identity; use it directly.
 	i := interaction.Interaction{
 		ID:            id,
@@ -167,7 +165,6 @@ func (h *contactHandler) EventConversationMessageCreated(ctx context.Context, m 
 		LocalTarget:   localTarget,
 		ReferenceType: "conversation_message",
 		ReferenceID:   m.ID,
-		CaseID:        &c.ID,
 		TMInteraction: m.TMCreate,
 		TMCreate:      now,
 	}

--- a/bin-contact-manager/pkg/contacthandler/interaction_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_test.go
@@ -17,7 +17,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-contact-manager/models/interaction"
-	"monorepo/bin-contact-manager/models/kase"
 	"monorepo/bin-contact-manager/pkg/casehandler"
 	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
@@ -30,7 +29,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 		responseUUID    uuid.UUID
 		responseCurTime *time.Time
-		expectCaseID    uuid.UUID
 
 		expectInteraction *interaction.Interaction
 	}{
@@ -55,7 +53,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("bb000001-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("bb000001-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("bb000001-0000-0000-0000-000000000001"),
@@ -91,7 +88,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("bb000002-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 11, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("bb000002-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("bb000002-0000-0000-0000-000000000001"),
@@ -127,7 +123,6 @@ func Test_EventCallCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("bb000003-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("bb000003-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("bb000003-0000-0000-0000-000000000001"),
@@ -206,9 +201,7 @@ func Test_EventCallCreated(t *testing.T) {
 			ctx := context.Background()
 
 			if tt.expectInteraction != nil {
-				mockCase.EXPECT().GetOrCreate(ctx, tt.expectInteraction.CustomerID, gomock.Any(), commonaddress.Type(tt.expectInteraction.PeerType), tt.expectInteraction.PeerTarget, "call", gomock.Any()).Return(&kase.Case{ID: tt.expectCaseID}, nil)
 				expected := *tt.expectInteraction
-				expected.CaseID = &tt.expectCaseID
 				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
 				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
 				mockDB.EXPECT().InteractionCreate(ctx, &expected).Return(nil)
@@ -231,7 +224,6 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 
 		responseUUID    uuid.UUID
 		responseCurTime *time.Time
-		expectCaseID    uuid.UUID
 
 		expectInteraction *interaction.Interaction
 	}{
@@ -257,7 +249,6 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 
 			responseUUID:    uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001"),
 			responseCurTime: func() *time.Time { t := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC); return &t }(),
-			expectCaseID:    uuid.FromStringOrNil("dd000001-0000-0000-0000-0000000000ca"),
 
 			expectInteraction: &interaction.Interaction{
 				ID:            uuid.FromStringOrNil("dd000001-0000-0000-0000-000000000001"),
@@ -315,17 +306,7 @@ func Test_EventConversationMessageCreated(t *testing.T) {
 			ctx := context.Background()
 
 			if tt.expectInteraction != nil {
-				// Regression guard for the round-1 review defect: the
-				// message's CaseID hint MUST be forwarded verbatim to
-				// GetOrCreate's caseIDHint parameter, not silently
-				// dropped as a hardcoded nil. gomock.Eq on the actual
-				// pointer VALUE (not gomock.Any()) is required here --
-				// gomock.Any() would pass identically whether the hint
-				// were forwarded or discarded, which is exactly how this
-				// regression escaped detection in round 1.
-				mockCase.EXPECT().GetOrCreate(ctx, tt.expectInteraction.CustomerID, gomock.Any(), commonaddress.Type(tt.expectInteraction.PeerType), tt.expectInteraction.PeerTarget, "conversation_message", tt.message.CaseID).Return(&kase.Case{ID: tt.expectCaseID}, nil)
 				expected := *tt.expectInteraction
-				expected.CaseID = &tt.expectCaseID
 				mockUtil.EXPECT().UUIDCreate().Return(tt.responseUUID)
 				mockUtil.EXPECT().TimeNow().Return(tt.responseCurTime)
 				mockDB.EXPECT().InteractionCreate(ctx, &expected).Return(nil)


### PR DESCRIPTION
Remove the automatic Case creation that fired as a side effect of every
projected call/message Interaction, per the VOIP-1243 design doc's
decision to make Case creation exclusively an explicit action (the
case_create Flow action / AI tool merged in PR #1083).

Recreated as a new PR against main (original #1082 hit a merge conflict
after PR #1083's round-2 review-fix commit landed on main via squash;
same single commit cherry-picked cleanly onto current main, no other
changes).

- bin-contact-manager: remove the caseHandler.GetOrCreate call from
  EventCallCreated and EventConversationMessageCreated; Interaction.CaseID
  is now always nil for newly-projected rows (Interaction projection
  itself is unchanged otherwise -- CRM-eligibility filtering, direction
  derivation, and normalization all stay exactly as before)
