### PR TITLE
NOJIRA-contact-address-ownership-read-path

### DIFF
--- a/bin-contact-manager/pkg/contacthandler/interaction_read.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_read.go
@@ -124,25 +124,51 @@ func (h *contactHandler) interactionListByContact(
 		)
 	}
 
-	// STEP 1: Expand address set.
-	addrs, err := h.db.AddressListByContactID(ctx, contactID)
+	// STEP 1: Expand the ownership-period set (design §6.2). Replaces
+	// the old "currently-live contact_addresses rows only" expansion:
+	// OwnershipPeriodsListByContactID returns every period (open and
+	// closed) this Contact has ever held, so a target's PAST owner era
+	// still resolves correctly after the target is reassigned away or
+	// the row is deleted -- the core defect this design exists to fix.
+	// AddressListByContactID (dbhandler/address.go) is intentionally
+	// NOT used here (design §6.1): it also backs the public
+	// Contact.Addresses API field via ContactGet/ContactList, and
+	// widening its semantics would leak closed/historical addresses
+	// into GET /v1/contacts/{id}.
+	periods, err := h.db.OwnershipPeriodsListByContactID(ctx, contactID)
 	if err != nil {
-		return nil, "", fmt.Errorf("could not list addresses. interactionListByContact. err: %v", err)
+		return nil, "", fmt.Errorf("could not get ownership periods. interactionListByContact. err: %v", err)
 	}
-	var addressPairs []dbhandler.AddressPair
-	for _, a := range addrs {
-		addressPairs = append(addressPairs, dbhandler.AddressPair{Type: string(a.Type), Target: a.Target})
+	// Missing-period-skew guard (design §6.2 round-41-43/47): a target
+	// this Contact currently, live-owns but that has zero period rows
+	// (an old-binary pod's AddressCreate ran before this rewire and
+	// skipped the period write) would otherwise contribute NO bound to
+	// STEP2 at all -- not unbounded, none -- silently vanishing every
+	// interaction for that target from the Contact's OWN timeline.
+	// Reproduces today's time-agnostic value-match for exactly this
+	// transient population until the next write gives the row a real
+	// period.
+	skewed, err := h.db.MissingPeriodOwnedAddresses(ctx, customerID, contactID)
+	if err != nil {
+		return nil, "", fmt.Errorf("could not get missing-period-skew addresses. interactionListByContact. err: %v", err)
+	}
+	bounds := make([]dbhandler.OwnershipPeriodBound, 0, len(periods)+len(skewed))
+	for _, p := range periods {
+		bounds = append(bounds, dbhandler.OwnershipPeriodBound{Type: p.Type, Target: p.Target, ValidFrom: p.ValidFrom, ValidTo: p.ValidTo})
+	}
+	for _, s := range skewed {
+		bounds = append(bounds, dbhandler.OwnershipPeriodBound{Type: s.Type, Target: s.Target, ValidFrom: nil, ValidTo: nil}) // unbounded
 	}
 
 	// STEP 2: Fetch ALL automatic peer matches (internal cap, not caller page size).
 	var automatic []*interaction.Interaction
-	if len(addressPairs) > 0 {
-		automatic, err = h.db.InteractionList(ctx, customerID, interactionInternalCap, "", "", "", addressPairs, time.Time{})
+	if len(bounds) > 0 {
+		automatic, err = h.db.InteractionListByOwnershipPeriods(ctx, customerID, interactionInternalCap, "", "", "", bounds, time.Time{})
 		if err != nil {
-			return nil, "", fmt.Errorf("could not list interactions by address set. interactionListByContact. err: %v", err)
+			return nil, "", fmt.Errorf("could not list interactions by ownership periods. interactionListByContact. err: %v", err)
 		}
 	}
-	// If addressPairs is empty → automatic stays nil (short-circuit, no IN() query).
+	// If bounds is empty → automatic stays nil (short-circuit, no OR-expanded query).
 
 	// STEP 3: Fetch active resolutions.
 	resolutions, err := h.db.ResolutionListByContact(ctx, customerID, contactID)

--- a/bin-contact-manager/pkg/contacthandler/interaction_read_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_read_test.go
@@ -50,7 +50,8 @@ func Test_interactionListByContact_NilInteractionIDResolution_NoPanic(t *testing
 	mockDB.EXPECT().ContactGet(ctx, contactID).Return(&contact.Contact{
 		Identity: commonidentity.Identity{ID: contactID, CustomerID: customerID},
 	}, nil)
-	mockDB.EXPECT().AddressListByContactID(ctx, contactID).Return(nil, nil)
+	mockDB.EXPECT().OwnershipPeriodsListByContactID(ctx, contactID).Return(nil, nil)
+	mockDB.EXPECT().MissingPeriodOwnedAddresses(ctx, customerID, contactID).Return(nil, nil)
 
 	// One case-level Resolution (InteractionID nil) mixed with one
 	// ordinary interaction-level Resolution -- the panic/mis-keying risk

--- a/bin-contact-manager/pkg/contacthandler/interaction_read_test.go
+++ b/bin-contact-manager/pkg/contacthandler/interaction_read_test.go
@@ -113,3 +113,81 @@ func Test_interactionListByContact_NilInteractionIDResolution_NoPanic(t *testing
 		t.Errorf("expected the real interaction-level positive resolution's interaction to surface, got: %v", items)
 	}
 }
+
+// Test_interactionListByContact_BoundsComposition_STEP1STEP2Wiring is a
+// non-trivial exercise of interaction_read.go's bounds-composition glue
+// (STEP1/STEP2, interaction_read.go's periods+skewed -> bounds loop):
+// unlike Test_interactionListByContact_NilInteractionIDResolution_NoPanic,
+// which stubs OwnershipPeriodsListByContactID/MissingPeriodOwnedAddresses
+// to (nil, nil) and never exercises this composition at all (bounds stays
+// empty, InteractionListByOwnershipPeriods is never even called), this
+// test supplies one real closed period AND one real missing-period-skew
+// address, and asserts InteractionListByOwnershipPeriods is called with
+// exactly the bounds the composition loop is supposed to build from them
+// (design §6.2: periods -> bounded entries, skewed -> unbounded entries).
+func Test_interactionListByContact_BoundsComposition_STEP1STEP2Wiring(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	h := contactHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+		reqHandler:    mockReq,
+		utilHandler:   mockUtil,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9002-9002-9002-000000000001")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-9002-9002-9002-000000000002")
+
+	mockDB.EXPECT().ContactGet(ctx, contactID).Return(&contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID, CustomerID: customerID},
+	}, nil)
+
+	validFrom := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	validTo := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+	mockDB.EXPECT().OwnershipPeriodsListByContactID(ctx, contactID).Return([]dbhandler.OwnershipPeriod{
+		{
+			ID:         uuid.FromStringOrNil("f1b2c3d4-9002-9002-9002-000000000010"),
+			CustomerID: customerID,
+			ContactID:  contactID,
+			Type:       "tel",
+			Target:     "+15559991001",
+			ValidFrom:  &validFrom,
+			ValidTo:    &validTo,
+		},
+	}, nil)
+	mockDB.EXPECT().MissingPeriodOwnedAddresses(ctx, customerID, contactID).Return([]dbhandler.MissingPeriodAddress{
+		{Type: "email", Target: "skewed@example.com"},
+	}, nil)
+
+	// The composition MUST produce exactly two bounds: the period entry
+	// carrying its real [validFrom, validTo) window, and the skewed
+	// entry carrying an UNBOUNDED (nil, nil) window -- asserted via
+	// gomock.Eq's structural match on OwnershipPeriodBound, not a
+	// gomock.Any() passthrough, so this test actually fails if the
+	// composition loop drops a field or gets the bound shape wrong.
+	wantBounds := []dbhandler.OwnershipPeriodBound{
+		{Type: "tel", Target: "+15559991001", ValidFrom: &validFrom, ValidTo: &validTo},
+		{Type: "email", Target: "skewed@example.com", ValidFrom: nil, ValidTo: nil},
+	}
+	interactionID := uuid.FromStringOrNil("f1b2c3d4-9002-9002-9002-000000000011")
+	mockDB.EXPECT().InteractionListByOwnershipPeriods(ctx, customerID, interactionInternalCap, "", "", "", wantBounds, time.Time{}).
+		Return([]*interaction.Interaction{
+			{ID: interactionID, CustomerID: customerID, PeerType: "tel", PeerTarget: "+15559991001"},
+		}, nil)
+
+	mockDB.EXPECT().ResolutionListByContact(ctx, customerID, contactID).Return(nil, nil)
+
+	items, _, err := h.interactionListByContact(ctx, logrus.NewEntry(logrus.New()), customerID, contactID, 20, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != interactionID {
+		t.Errorf("expected exactly the one interaction InteractionListByOwnershipPeriods returned, got: %+v", items)
+	}
+}

--- a/bin-contact-manager/pkg/dbhandler/address_ownership_read.go
+++ b/bin-contact-manager/pkg/dbhandler/address_ownership_read.go
@@ -1,0 +1,172 @@
+package dbhandler
+
+// Contact-address ownership period READ path (Phase 2 of
+// NOJIRA-contact-address-ownership-periods). See
+// docs/plans/2026-07-11-contact-address-ownership-integrity-design.md
+// §6 for the full design and rationale.
+//
+// This file adds the two new STEP1 dbhandler primitives
+// interactionListByContact needs to match interactions against ownership
+// history instead of only currently-live contact_addresses rows:
+//   - OwnershipPeriodsListByContactID: every period (open or closed) this
+//     Contact has ever held.
+//   - missingPeriodOwnedAddresses: rows this Contact currently, live-owns
+//     that have NO open period of their own (design §6.2 round-41-43/47's
+//     missing-period-skew guard -- an old-binary pod's AddressCreate that
+//     ran before this rewire skipped the period write).
+//
+// Neither function touches AddressListByContactID (address.go) --
+// design §6.1 requires that function stay untouched, since it also backs
+// the public Contact.Addresses API field via ContactGet/ContactList.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/gofrs/uuid"
+)
+
+// OwnershipPeriodsListByContactID returns every ownership period (open
+// and closed) this Contact has ever held, across every (type, target) it
+// has owned over its lifetime -- not just its currently-live addresses.
+// Used exclusively by interactionListByContact's STEP1 (design §6.2) and
+// carries no locking (a plain SELECT, unlike
+// OwnershipPeriodsLockAndResolveTx's FOR UPDATE read inside a write
+// transaction).
+func (h *handler) OwnershipPeriodsListByContactID(ctx context.Context, contactID uuid.UUID) ([]OwnershipPeriod, error) {
+	query, args, err := sq.Select("id", "customer_id", "contact_id", "type", "target", "valid_from", "valid_to").
+		From(ownershipPeriodTable).
+		Where(sq.Eq{"contact_id": contactID.Bytes()}).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. OwnershipPeriodsListByContactID. err: %v", err)
+	}
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. OwnershipPeriodsListByContactID. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []OwnershipPeriod
+	for rows.Next() {
+		p, err := scanOwnershipPeriodRowFull(rows)
+		if err != nil {
+			return nil, fmt.Errorf("could not scan the row. OwnershipPeriodsListByContactID. err: %v", err)
+		}
+		res = append(res, *p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. OwnershipPeriodsListByContactID. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// MissingPeriodAddress is a (type, target) pair this Contact currently,
+// live-owns but that has zero ownership-period rows of its own (design
+// §6.2 rounds 41-43/47's missing-period-skew population). Exported: this
+// is a DBHandler interface return type, same visibility rule as every
+// other cross-package dbhandler result type (OwnershipPeriod, AddressPair).
+type MissingPeriodAddress struct {
+	Type   string
+	Target string
+}
+
+// MissingPeriodOwnedAddresses returns (type, target) pairs this Contact
+// currently owns (a live contact_addresses row with contact_id = this
+// Contact) for which contact_address_ownership_periods has NO OPEN period
+// belonging to this SAME contact_id (design §6.2 round-43's final,
+// owner-plus-open-scoped condition -- narrower conditions considered and
+// rejected at rounds 41/42 for missing the reassignment and
+// same-owner-reacquisition cases respectively). Each result is meant to
+// be attached to STEP2 as an unbounded ([nil, nil)) bound, reproducing
+// today's pure value-match for exactly this transient, degraded
+// population until the next write gives the row a real period.
+func (h *handler) MissingPeriodOwnedAddresses(ctx context.Context, customerID, contactID uuid.UUID) ([]MissingPeriodAddress, error) {
+	query, args, err := sq.Select("a.type", "a.target").
+		From(addressTable+" a").
+		Where(sq.Eq{"a.customer_id": customerID.Bytes()}).
+		Where(sq.Eq{"a.contact_id": contactID.Bytes()}).
+		Where(sq.Expr(
+			`NOT EXISTS (
+				SELECT 1 FROM `+ownershipPeriodTable+` p2
+				WHERE p2.customer_id = a.customer_id
+				  AND p2.type = a.type
+				  AND p2.target = a.target
+				  AND p2.contact_id = a.contact_id
+				  AND p2.valid_to IS NULL
+			)`,
+		)).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. missingPeriodOwnedAddresses. err: %v", err)
+	}
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. missingPeriodOwnedAddresses. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []MissingPeriodAddress
+	for rows.Next() {
+		var t, target string
+		if err := rows.Scan(&t, &target); err != nil {
+			return nil, fmt.Errorf("could not scan the row. MissingPeriodOwnedAddresses. err: %v", err)
+		}
+		res = append(res, MissingPeriodAddress{Type: t, Target: target})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. MissingPeriodOwnedAddresses. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// scanOwnershipPeriodRowFull scans a full (id, customer_id, contact_id,
+// type, target, valid_from, valid_to) row -- unlike scanOwnershipPeriodRow
+// (address_ownership.go), which takes customerID/addrType/target as
+// parameters because its caller already knows them (scoped to a single
+// (customer_id, type, target) tuple under lock). OwnershipPeriodsListByContactID
+// spans multiple (type, target) pairs per contact, so type/target must be
+// read from the row itself.
+func scanOwnershipPeriodRowFull(rows *sql.Rows) (*OwnershipPeriod, error) {
+	var idBytes, customerIDBytes, contactIDBytes []byte
+	var addrType, target string
+	var validFrom, validTo sql.NullString
+	if err := rows.Scan(&idBytes, &customerIDBytes, &contactIDBytes, &addrType, &target, &validFrom, &validTo); err != nil {
+		return nil, fmt.Errorf("could not scan the row. scanOwnershipPeriodRowFull. err: %v", err)
+	}
+	id, err := uuid.FromBytes(idBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse id. scanOwnershipPeriodRowFull. err: %v", err)
+	}
+	customerID, err := uuid.FromBytes(customerIDBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse customer_id. scanOwnershipPeriodRowFull. err: %v", err)
+	}
+	contactID, err := uuid.FromBytes(contactIDBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse contact_id. scanOwnershipPeriodRowFull. err: %v", err)
+	}
+	validFromPtr, err := parseNullableDBTime(validFrom)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse valid_from. scanOwnershipPeriodRowFull. err: %v", err)
+	}
+	validToPtr, err := parseNullableDBTime(validTo)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse valid_to. scanOwnershipPeriodRowFull. err: %v", err)
+	}
+	return &OwnershipPeriod{
+		ID:         id,
+		CustomerID: customerID,
+		ContactID:  contactID,
+		Type:       addrType,
+		Target:     target,
+		ValidFrom:  validFromPtr,
+		ValidTo:    validToPtr,
+	}, nil
+}

--- a/bin-contact-manager/pkg/dbhandler/address_ownership_read_test.go
+++ b/bin-contact-manager/pkg/dbhandler/address_ownership_read_test.go
@@ -1,0 +1,342 @@
+package dbhandler
+
+// Scenario tests for the ownership-period READ path (design §6, Phase 2
+// of NOJIRA-contact-address-ownership-periods). Uses the real SQLite
+// test DB and the actual write-path functions (AddressCreate/
+// AddressDelete/AddressClaim) to build real ownership history, then
+// exercises InteractionListByOwnershipPeriods and
+// InteractionListUnresolved directly -- proving the four original
+// defects this whole design exists to fix are actually resolved, not
+// just that the new functions compile.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	commonaddress "monorepo/bin-common-handler/models/address"
+
+	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/models/interaction"
+)
+
+func mustCreateInteraction(t *testing.T, ctx context.Context, h *handler, id, customerID uuid.UUID, peerType, peerTarget string, tmCreate time.Time) {
+	t.Helper()
+	i := &interaction.Interaction{
+		ID:            id,
+		CustomerID:    customerID,
+		Direction:     "incoming",
+		PeerType:      peerType,
+		PeerTarget:    peerTarget,
+		LocalType:     "tel",
+		LocalTarget:   "+155****0000",
+		ReferenceType: "call",
+		ReferenceID:   uuid.Must(uuid.NewV4()),
+		TMCreate:      &tmCreate,
+	}
+	if err := h.InteractionCreate(ctx, i); err != nil {
+		t.Fatalf("InteractionCreate() error = %v", err)
+	}
+}
+
+// Test_InteractionListByOwnershipPeriods_DeletedTarget_HistoryStillMatches
+// is the core "defect #1" regression: today, deleting a phone number from
+// a Contact makes its past interactions vanish from that Contact's
+// timeline, because STEP1 only lists currently-live contact_addresses
+// rows. With the ownership-period rewrite, a CLOSED period (the register
+// -> delete lifecycle) still produces a bound covering the interaction's
+// original tm_create, so it continues to match.
+func Test_InteractionListByOwnershipPeriods_DeletedTarget_HistoryStillMatches(t *testing.T) {
+	h, mc := newOwnershipTestHandler(t, timePtr(time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)))
+	defer mc.Finish()
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("91000000-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("91000000-0000-0000-0000-000000000002")
+	addrID := uuid.FromStringOrNil("91000000-0000-0000-0000-000000000003")
+	target := "+15550001001"
+
+	createTestContact(t, h, ctx, customerID, contactID)
+
+	// Register the number (opens a period), record an interaction while
+	// it's live, then delete the number (closes the period). This is
+	// the exact register -> interact -> delete sequence design §1 calls
+	// out as today's "delete -> history disappears" defect.
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrID,
+		CustomerID: customerID,
+		ContactID:  contactID,
+	}); err != nil {
+		t.Fatalf("AddressCreate() error = %v", err)
+	}
+
+	interactionID := uuid.FromStringOrNil("91000000-0000-0000-0000-000000000004")
+	mustCreateInteraction(t, ctx, h, interactionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 1, 11, 0, 0, 0, time.UTC))
+
+	if err := h.AddressDelete(ctx, addrID); err != nil {
+		t.Fatalf("AddressDelete() error = %v", err)
+	}
+
+	periods, err := h.OwnershipPeriodsListByContactID(ctx, contactID)
+	if err != nil {
+		t.Fatalf("OwnershipPeriodsListByContactID() error = %v", err)
+	}
+	if len(periods) != 1 {
+		t.Fatalf("OwnershipPeriodsListByContactID() len = %d, want 1 (one opened-then-closed period)", len(periods))
+	}
+	if periods[0].ValidTo == nil {
+		t.Fatalf("OwnershipPeriodsListByContactID()[0].ValidTo = nil, want closed (AddressDelete must close the period)")
+	}
+
+	bounds := []OwnershipPeriodBound{{Type: periods[0].Type, Target: periods[0].Target, ValidFrom: periods[0].ValidFrom, ValidTo: periods[0].ValidTo}}
+	got, err := h.InteractionListByOwnershipPeriods(ctx, customerID, 20, "", "", "", bounds, time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListByOwnershipPeriods() error = %v", err)
+	}
+	found := false
+	for _, i := range got {
+		if i.ID == interactionID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("InteractionListByOwnershipPeriods() did not return the pre-delete interaction -- defect #1 (delete -> history disappears) is NOT fixed. got: %+v", got)
+	}
+}
+
+// Test_InteractionListByOwnershipPeriods_Reassignment_NoCrossAttribution
+// is the "defect #2" regression: when a number is deleted from Contact A
+// and re-registered to Contact B, A's past interactions must stay on A's
+// timeline (bounded to A's closed period) and must NOT appear on B's
+// timeline (B's period only opens after the reassignment).
+func Test_InteractionListByOwnershipPeriods_Reassignment_NoCrossAttribution(t *testing.T) {
+	target := "+15550002002"
+	customerID := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000001")
+	contactA := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000002")
+	contactB := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000003")
+	addrIDA := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000004")
+	addrIDB := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000005")
+
+	// A single fixed "now" (design's test convention -- TimeNow mocked
+	// once with AnyTimes()) sits between A's interaction and B's
+	// interaction; AddressCreate(A)/AddressDelete(A)/AddressCreate(B)
+	// all timestamp their period rows at this same instant, which is
+	// enough to prove the bound-membership logic: A's period closes at
+	// `now`, B's period opens at `now`, A's own interaction (before
+	// `now`) must stay out of B's window and B's interaction (after
+	// `now`) must stay out of A's window.
+	now := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	h, mc := newOwnershipTestHandler(t, &now)
+	defer mc.Finish()
+	ctx := context.Background()
+
+	createTestContact(t, h, ctx, customerID, contactA)
+	createTestContact(t, h, ctx, customerID, contactB)
+
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrIDA,
+		CustomerID: customerID,
+		ContactID:  contactA,
+	}); err != nil {
+		t.Fatalf("AddressCreate(A) error = %v", err)
+	}
+
+	interactionA := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000006")
+	mustCreateInteraction(t, ctx, h, interactionA, customerID, string(contact.AddressTypeTel), target,
+		now.Add(-1*time.Hour))
+
+	if err := h.AddressDelete(ctx, addrIDA); err != nil {
+		t.Fatalf("AddressDelete(A) error = %v", err)
+	}
+
+	// Reassignment: B registers the same target (same mocked `now`,
+	// consistent with StepReassign's design §4 Step 4 rule that both
+	// A's close and B's open share the single locking-read transaction
+	// window in a real concurrent scenario).
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrIDB,
+		CustomerID: customerID,
+		ContactID:  contactB,
+	}); err != nil {
+		t.Fatalf("AddressCreate(B) error = %v", err)
+	}
+
+	interactionB := uuid.FromStringOrNil("92000000-0000-0000-0000-000000000007")
+	mustCreateInteraction(t, ctx, h, interactionB, customerID, string(contact.AddressTypeTel), target,
+		now.Add(1*time.Hour))
+
+	periodsA, err := h.OwnershipPeriodsListByContactID(ctx, contactA)
+	if err != nil {
+		t.Fatalf("OwnershipPeriodsListByContactID(A) error = %v", err)
+	}
+	periodsB, err := h.OwnershipPeriodsListByContactID(ctx, contactB)
+	if err != nil {
+		t.Fatalf("OwnershipPeriodsListByContactID(B) error = %v", err)
+	}
+	if len(periodsA) != 1 || len(periodsB) != 1 {
+		t.Fatalf("expected exactly one period each for A/B, got A=%d B=%d", len(periodsA), len(periodsB))
+	}
+
+	boundsA := []OwnershipPeriodBound{{Type: periodsA[0].Type, Target: periodsA[0].Target, ValidFrom: periodsA[0].ValidFrom, ValidTo: periodsA[0].ValidTo}}
+	boundsB := []OwnershipPeriodBound{{Type: periodsB[0].Type, Target: periodsB[0].Target, ValidFrom: periodsB[0].ValidFrom, ValidTo: periodsB[0].ValidTo}}
+
+	gotA, err := h.InteractionListByOwnershipPeriods(ctx, customerID, 20, "", "", "", boundsA, time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListByOwnershipPeriods(A) error = %v", err)
+	}
+	gotB, err := h.InteractionListByOwnershipPeriods(ctx, customerID, 20, "", "", "", boundsB, time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListByOwnershipPeriods(B) error = %v", err)
+	}
+
+	assertContainsOnly(t, "A's timeline", gotA, interactionA)
+	assertContainsOnly(t, "B's timeline", gotB, interactionB)
+}
+
+func assertContainsOnly(t *testing.T, label string, got []*interaction.Interaction, want uuid.UUID) {
+	t.Helper()
+	found := false
+	for _, i := range got {
+		if i.ID == want {
+			found = true
+		} else {
+			t.Errorf("%s unexpectedly contains interaction %v (cross-attribution defect #2 NOT fixed)", label, i.ID)
+		}
+	}
+	if !found {
+		t.Errorf("%s does not contain expected interaction %v", label, want)
+	}
+}
+
+// Test_InteractionListUnresolved_PastOwnerPeriod_NotUnresolved is the
+// "defect #4" regression for a target's PAST owner: once a period is
+// closed (target deleted, never reassigned), that owner's old
+// interactions must NOT resurface in the unresolved queue just because
+// the live contact_addresses row is gone -- design §6.3's first
+// disjunct (ownership-period match) must still suppress them.
+func Test_InteractionListUnresolved_PastOwnerPeriod_NotUnresolved(t *testing.T) {
+	h, mc := newOwnershipTestHandler(t, timePtr(time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)))
+	defer mc.Finish()
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("93000000-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("93000000-0000-0000-0000-000000000002")
+	addrID := uuid.FromStringOrNil("93000000-0000-0000-0000-000000000003")
+	target := "+15550003003"
+
+	createTestContact(t, h, ctx, customerID, contactID)
+
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrID,
+		CustomerID: customerID,
+		ContactID:  contactID,
+	}); err != nil {
+		t.Fatalf("AddressCreate() error = %v", err)
+	}
+
+	interactionID := uuid.FromStringOrNil("93000000-0000-0000-0000-000000000004")
+	mustCreateInteraction(t, ctx, h, interactionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 4, 8, 0, 0, 0, time.UTC))
+
+	if err := h.AddressDelete(ctx, addrID); err != nil {
+		t.Fatalf("AddressDelete() error = %v", err)
+	}
+
+	unresolved, err := h.InteractionListUnresolved(ctx, customerID, 100, "", time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListUnresolved() error = %v", err)
+	}
+	for _, i := range unresolved {
+		if i.ID == interactionID {
+			t.Errorf("InteractionListUnresolved() resurfaced a past-owner-period interaction after target deletion -- defect #4 NOT fixed")
+		}
+	}
+}
+
+// Test_InteractionListUnresolved_LiveOwnedNoPeriod_MissingPeriodSkewSuppressed
+// covers design §6.3's round-40/42/43 missing-period-skew guard directly:
+// a live contact_addresses row with NO period row of its own (simulating
+// an old-binary pod's AddressCreate that predates this rewire, or any
+// out-of-band insert) must NOT have its interactions resurface in the
+// unresolved queue just because it lacks a period.
+func Test_InteractionListUnresolved_LiveOwnedNoPeriod_MissingPeriodSkewSuppressed(t *testing.T) {
+	h, mc := newOwnershipTestHandler(t, timePtr(time.Date(2026, 3, 5, 9, 0, 0, 0, time.UTC)))
+	defer mc.Finish()
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("94000000-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("94000000-0000-0000-0000-000000000002")
+	target := "+15550004004"
+
+	createTestContact(t, h, ctx, customerID, contactID)
+
+	// Simulate the skew: insert a live contact_addresses row directly
+	// (bypassing AddressCreate/OwnershipPeriodsLockAndResolveTx), so no
+	// period row is ever written for it -- exactly the degraded state
+	// an old-binary pod's AddressCreate would leave behind.
+	insertRawAddressNoPeriod(t, ctx, h, customerID, contactID, contact.AddressTypeTel, target)
+
+	interactionID := uuid.FromStringOrNil("94000000-0000-0000-0000-000000000003")
+	mustCreateInteraction(t, ctx, h, interactionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 5, 10, 0, 0, 0, time.UTC))
+
+	unresolved, err := h.InteractionListUnresolved(ctx, customerID, 100, "", time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListUnresolved() error = %v", err)
+	}
+	for _, i := range unresolved {
+		if i.ID == interactionID {
+			t.Errorf("InteractionListUnresolved() resurfaced a live-owned, period-less interaction -- missing-period-skew guard NOT working")
+		}
+	}
+
+	// And STEP1's mirror-image guard: the contact's OWN timeline must
+	// still see it via the missing-period-skew unbounded bound (design
+	// §6.2 round-41-43/47), not lose it entirely.
+	skewed, err := h.MissingPeriodOwnedAddresses(ctx, customerID, contactID)
+	if err != nil {
+		t.Fatalf("MissingPeriodOwnedAddresses() error = %v", err)
+	}
+	found := false
+	for _, s := range skewed {
+		if s.Type == string(contact.AddressTypeTel) && s.Target == target {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("MissingPeriodOwnedAddresses() did not report the period-less owned row -- STEP1's own-timeline guard NOT working. got: %+v", skewed)
+	}
+}
+
+// insertRawAddressNoPeriod inserts a contact_addresses row directly via
+// AddressCreateTx's underlying INSERT, bypassing the ownership-period
+// write entirely -- reproducing the missing-period-skew degraded state
+// without needing an actual old binary.
+func insertRawAddressNoPeriod(t *testing.T, ctx context.Context, h *handler, customerID, contactID uuid.UUID, addrType commonaddress.Type, target string) {
+	t.Helper()
+	tx, err := h.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx() error = %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	a := &contact.Address{
+		Address:    commonaddress.Address{Type: addrType, Target: target},
+		ID:         uuid.Must(uuid.NewV4()),
+		CustomerID: customerID,
+		ContactID:  contactID,
+	}
+	if err := h.addressInsertTx(ctx, tx, a); err != nil {
+		t.Fatalf("addressInsertTx() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit error = %v", err)
+	}
+}

--- a/bin-contact-manager/pkg/dbhandler/address_ownership_read_test.go
+++ b/bin-contact-manager/pkg/dbhandler/address_ownership_read_test.go
@@ -731,8 +731,9 @@ func newMonotonicTimeUtilHandler(t *testing.T, mc *gomock.Controller, start time
 // TimeNow() (confirmed against createTestContact's existing usage
 // pattern, which shares the same AnyTimes() mock as every other write in
 // its test), so this exists only to make that non-consumption explicit
-// at call sites using the strict, ordered newSequentialTimeUtilHandler
-// mock above, where an unexpected TimeNow() call would fail the test.
+// at call sites using the strict, monotonic-clock newMonotonicTimeUtilHandler
+// mock above, where an unexpected TimeNow() call would still succeed but
+// would shift every subsequent timestamp by one unintended tick.
 func createTestContactNoTimeNow(t *testing.T, h *handler, ctx context.Context, customerID, contactID uuid.UUID) {
 	t.Helper()
 	c := &contact.Contact{

--- a/bin-contact-manager/pkg/dbhandler/address_ownership_read_test.go
+++ b/bin-contact-manager/pkg/dbhandler/address_ownership_read_test.go
@@ -3,11 +3,23 @@ package dbhandler
 // Scenario tests for the ownership-period READ path (design §6, Phase 2
 // of NOJIRA-contact-address-ownership-periods). Uses the real SQLite
 // test DB and the actual write-path functions (AddressCreate/
-// AddressDelete/AddressClaim) to build real ownership history, then
-// exercises InteractionListByOwnershipPeriods and
-// InteractionListUnresolved directly -- proving the four original
+// AddressDelete/AddressClaim/CreateUnresolvedAddress) to build real
+// ownership history, then exercises InteractionListByOwnershipPeriods
+// and InteractionListUnresolved directly -- proving the four original
 // defects this whole design exists to fix are actually resolved, not
 // just that the new functions compile.
+//
+// UUID prefix convention: like address_ownership_test.go, this file
+// shares one process-wide SQLite DB (dbTest, main_test.go) across every
+// test in the package with no per-test truncation/cleanup. Isolation is
+// achieved purely by giving each test function its own customerID/
+// contactID UUID prefix (91xxxxxx.. through 98xxxxxx.. in this file;
+// address_ownership_test.go separately owns 70xxxxxx../72xxxxxx../
+// 73xxxxxx..). Every query in this package is customer_id-scoped, so
+// distinct prefixes are sufficient for isolation -- but there is no
+// compile-time or lint guard against a future test reusing a prefix and
+// silently corrupting another test's fixture. Pick an unused prefix
+// (grep the byte before checking one in) when adding a new test here.
 
 import (
 	"context"
@@ -15,11 +27,15 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"monorepo/bin-contact-manager/models/contact"
 	"monorepo/bin-contact-manager/models/interaction"
+	"monorepo/bin-contact-manager/pkg/cachehandler"
 )
 
 func mustCreateInteraction(t *testing.T, ctx context.Context, h *handler, id, customerID uuid.UUID, peerType, peerTarget string, tmCreate time.Time) {
@@ -338,5 +354,405 @@ func insertRawAddressNoPeriod(t *testing.T, ctx context.Context, h *handler, cus
 	}
 	if err := tx.Commit(); err != nil {
 		t.Fatalf("commit error = %v", err)
+	}
+}
+
+// Test_InteractionListUnresolved_SameOwnerReacquire_MissingPeriodSkewSuppressed
+// covers design §6.3 round-43's BLOCKER fix directly: contact A registers
+// a target, releases it (closed period), then re-registers the SAME
+// target but the new row is written WITHOUT a period (simulating an
+// old-binary pod, same as insertRawAddressNoPeriod). Round-42's
+// owner-scoped-but-not-open-scoped condition would have missed this --
+// it finds A's own OLD closed period and does not fire, leaving the
+// reacquired row's interactions to wrongly resurface in the unresolved
+// queue. Round-43 adds `valid_to IS NULL` to fix exactly this.
+func Test_InteractionListUnresolved_SameOwnerReacquire_MissingPeriodSkewSuppressed(t *testing.T) {
+	h, mc := newOwnershipTestHandler(t, timePtr(time.Date(2026, 3, 6, 9, 0, 0, 0, time.UTC)))
+	defer mc.Finish()
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("95000000-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("95000000-0000-0000-0000-000000000002")
+	addrID := uuid.FromStringOrNil("95000000-0000-0000-0000-000000000003")
+	target := "+15550005005"
+
+	createTestContact(t, h, ctx, customerID, contactID)
+
+	// A registers, then releases -- produces one CLOSED period for A.
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrID,
+		CustomerID: customerID,
+		ContactID:  contactID,
+	}); err != nil {
+		t.Fatalf("AddressCreate() error = %v", err)
+	}
+	if err := h.AddressDelete(ctx, addrID); err != nil {
+		t.Fatalf("AddressDelete() error = %v", err)
+	}
+	closedRows := ownershipPeriodsForTarget(t, ctx, h, customerID, contact.AddressTypeTel, target)
+	if len(closedRows) != 1 || closedRows[0].ValidTo == nil {
+		t.Fatalf("expected exactly one closed period for A before reacquisition, got: %+v", closedRows)
+	}
+
+	// A reacquires the SAME target, but the new row is written without
+	// a period (old-binary-pod simulation) -- round-42's condition
+	// would see A's OLD closed period and wrongly conclude "this owner
+	// has a period," missing the reacquisition.
+	insertRawAddressNoPeriod(t, ctx, h, customerID, contactID, contact.AddressTypeTel, target)
+
+	interactionID := uuid.FromStringOrNil("95000000-0000-0000-0000-000000000004")
+	mustCreateInteraction(t, ctx, h, interactionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 6, 10, 0, 0, 0, time.UTC))
+
+	unresolved, err := h.InteractionListUnresolved(ctx, customerID, 100, "", time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListUnresolved() error = %v", err)
+	}
+	for _, i := range unresolved {
+		if i.ID == interactionID {
+			t.Errorf("InteractionListUnresolved() resurfaced a same-owner-reacquired, period-less interaction -- round-43 fix NOT working (round-42's owner-scoped-only condition regression)")
+		}
+	}
+}
+
+// Test_InteractionListUnresolved_Reassignment_MissingPeriodSkewSuppressed
+// covers design §6.3 round-42's fix: contact A registers a target,
+// releases it (closed period), then a DIFFERENT contact B registers the
+// SAME target but the new row is written WITHOUT a period. Round-41's
+// target-wide condition ("no period row for this target at all") would
+// have missed this -- it sees A's closed period and does not fire,
+// wrongly resurfacing B's interactions in the unresolved queue despite
+// B's live, normal ownership. Round-42 scopes the condition to the
+// OWNER (B), not the target, fixing exactly this.
+func Test_InteractionListUnresolved_Reassignment_MissingPeriodSkewSuppressed(t *testing.T) {
+	h, mc := newOwnershipTestHandler(t, timePtr(time.Date(2026, 3, 7, 9, 0, 0, 0, time.UTC)))
+	defer mc.Finish()
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("96000000-0000-0000-0000-000000000001")
+	contactA := uuid.FromStringOrNil("96000000-0000-0000-0000-000000000002")
+	contactB := uuid.FromStringOrNil("96000000-0000-0000-0000-000000000003")
+	addrIDA := uuid.FromStringOrNil("96000000-0000-0000-0000-000000000004")
+	target := "+15550006006"
+
+	createTestContact(t, h, ctx, customerID, contactA)
+	createTestContact(t, h, ctx, customerID, contactB)
+
+	// A registers, then releases -- produces one CLOSED period for A.
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrIDA,
+		CustomerID: customerID,
+		ContactID:  contactA,
+	}); err != nil {
+		t.Fatalf("AddressCreate(A) error = %v", err)
+	}
+	if err := h.AddressDelete(ctx, addrIDA); err != nil {
+		t.Fatalf("AddressDelete(A) error = %v", err)
+	}
+	closedRows := ownershipPeriodsForTarget(t, ctx, h, customerID, contact.AddressTypeTel, target)
+	if len(closedRows) != 1 || closedRows[0].ContactID != contactA || closedRows[0].ValidTo == nil {
+		t.Fatalf("expected exactly one closed period for A before reassignment, got: %+v", closedRows)
+	}
+
+	// B registers the same target, written without a period
+	// (old-binary-pod simulation): round-41's target-wide anti-join
+	// would see A's closed period and wrongly conclude "this target
+	// isn't period-less overall," missing B's own skew.
+	insertRawAddressNoPeriod(t, ctx, h, customerID, contactB, contact.AddressTypeTel, target)
+
+	interactionID := uuid.FromStringOrNil("96000000-0000-0000-0000-000000000005")
+	mustCreateInteraction(t, ctx, h, interactionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 7, 10, 0, 0, 0, time.UTC))
+
+	unresolved, err := h.InteractionListUnresolved(ctx, customerID, 100, "", time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListUnresolved() error = %v", err)
+	}
+	for _, i := range unresolved {
+		if i.ID == interactionID {
+			t.Errorf("InteractionListUnresolved() resurfaced a reassigned, period-less interaction -- round-42 owner-scoping fix NOT working (round-41's target-wide condition regression)")
+		}
+	}
+}
+
+// Test_InteractionListUnresolved_ClaimOfUnresolved_ImmediatelyPriorGapAttaches
+// covers design §6.3 round-37/38/39: an unresolved (contact_id IS NULL)
+// address that sits directly after a prior owner's closed period, once
+// claimed, must attach interactions from BOTH the unresolved era AND the
+// immediately-prior owner's era (per AddressClaim's valid_from = latest
+// closed valid_to rule) -- neither era's interactions should resurface
+// in the unresolved queue after the claim.
+func Test_InteractionListUnresolved_ClaimOfUnresolved_ImmediatelyPriorGapAttaches(t *testing.T) {
+	h, mc := newOwnershipTestHandler(t, timePtr(time.Date(2026, 3, 8, 0, 0, 0, 0, time.UTC)))
+	defer mc.Finish()
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000001")
+	priorOwner := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000002")
+	claimer := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000003")
+	target := "+15550007007"
+
+	createTestContact(t, h, ctx, customerID, priorOwner)
+	createTestContact(t, h, ctx, customerID, claimer)
+
+	// Prior owner's era: register, interact, release.
+	priorAddrID := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000004")
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         priorAddrID,
+		CustomerID: customerID,
+		ContactID:  priorOwner,
+	}); err != nil {
+		t.Fatalf("AddressCreate(prior owner) error = %v", err)
+	}
+	priorInteractionID := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000005")
+	mustCreateInteraction(t, ctx, h, priorInteractionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 8, 1, 0, 0, 0, time.UTC))
+	if err := h.AddressDelete(ctx, priorAddrID); err != nil {
+		t.Fatalf("AddressDelete(prior owner) error = %v", err)
+	}
+
+	// Unresolved era: an unresolved row for the same target, with an
+	// interaction recorded while it's unresolved.
+	unresolvedAddrID := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000006")
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         unresolvedAddrID,
+		CustomerID: customerID,
+		ContactID:  uuid.Nil,
+	}); err != nil {
+		t.Fatalf("AddressCreate(unresolved) error = %v", err)
+	}
+	unresolvedInteractionID := uuid.FromStringOrNil("97000000-0000-0000-0000-000000000007")
+	mustCreateInteraction(t, ctx, h, unresolvedInteractionID, customerID, string(contact.AddressTypeTel), target,
+		time.Date(2026, 3, 8, 2, 0, 0, 0, time.UTC))
+
+	// Sanity: both interactions ARE unresolved before the claim (prior
+	// owner's era via row-presence-agnostic period suppression should
+	// NOT apply yet since AddressDelete already closed it, and the
+	// unresolved row suppresses by presence) -- this pre-claim baseline
+	// isn't the point of the test, skip asserting it and go straight to
+	// post-claim, which IS the point (round-37/38/39's actual claim).
+	if err := h.AddressClaim(ctx, customerID, unresolvedAddrID, claimer); err != nil {
+		t.Fatalf("AddressClaim() error = %v", err)
+	}
+
+	unresolved, err := h.InteractionListUnresolved(ctx, customerID, 100, "", time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListUnresolved() error = %v", err)
+	}
+	for _, i := range unresolved {
+		if i.ID == priorInteractionID {
+			t.Errorf("InteractionListUnresolved() resurfaced the immediately-prior-gap interaction after claim -- round-37/38/39 fix NOT working (AddressClaim's valid_from=latest-closed-valid_to rule should have covered it)")
+		}
+		if i.ID == unresolvedInteractionID {
+			t.Errorf("InteractionListUnresolved() resurfaced the claimed-unresolved-era interaction after claim -- ownership-period disjunct should now cover it")
+		}
+	}
+
+	// And on the POSITIVE side: the claimer's own timeline must now see
+	// both eras' interactions via its period bound.
+	claimerPeriods, err := h.OwnershipPeriodsListByContactID(ctx, claimer)
+	if err != nil {
+		t.Fatalf("OwnershipPeriodsListByContactID(claimer) error = %v", err)
+	}
+	if len(claimerPeriods) != 1 {
+		t.Fatalf("expected exactly one period for the claimer, got %d: %+v", len(claimerPeriods), claimerPeriods)
+	}
+	bounds := []OwnershipPeriodBound{{Type: claimerPeriods[0].Type, Target: claimerPeriods[0].Target, ValidFrom: claimerPeriods[0].ValidFrom, ValidTo: claimerPeriods[0].ValidTo}}
+	claimerTimeline, err := h.InteractionListByOwnershipPeriods(ctx, customerID, 20, "", "", "", bounds, time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListByOwnershipPeriods(claimer) error = %v", err)
+	}
+	assertContainsIDs(t, "claimer's timeline", claimerTimeline, unresolvedInteractionID, priorInteractionID)
+}
+
+// Test_InteractionListUnresolved_ClaimOfUnresolved_NonAdjacentGapResurfaces
+// covers design §6.3 round-39's correction: "matching today's observable
+// behavior" only extends to the IMMEDIATELY PRIOR gap, not to every
+// earlier gap in a multi-era history. An older, non-adjacent gap
+// (an A-to-B gap preceding a B-to-claimer gap) is NOT covered by the
+// claim-created period and DOES resurface in the unresolved queue once
+// the claim removes the row-presence suppression that had covered it
+// unconditionally. This is accepted design behavior (§4), pinned here
+// so a future change cannot silently alter it either way.
+//
+// Uses a hand-rolled, strictly increasing TimeNow() sequence (rather than
+// newOwnershipTestHandler's single fixed-time convention) because this
+// test needs each era's period boundary to land at a DIFFERENT instant --
+// a single shared "now" (as every other test in this file uses) would
+// collapse every period to the same boundary and make the eras
+// indistinguishable by timestamp, which is exactly what this test needs
+// to tell apart.
+func Test_InteractionListUnresolved_ClaimOfUnresolved_NonAdjacentGapResurfaces(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockUtil := newMonotonicTimeUtilHandler(t, mc, time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC))
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockCache.EXPECT().ContactGet(gomock.Any(), gomock.Any()).Return(nil, ErrNotFound).AnyTimes()
+	mockCache.EXPECT().ContactDelete(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	h := &handler{utilHandler: mockUtil, db: dbTest, cache: mockCache}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000001")
+	ownerA := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000002")
+	ownerB := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000003")
+	claimer := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000004")
+	target := "+15550008008"
+
+	createTestContactNoTimeNow(t, h, ctx, customerID, ownerA)
+	createTestContactNoTimeNow(t, h, ctx, customerID, ownerB)
+	createTestContactNoTimeNow(t, h, ctx, customerID, claimer)
+
+	// Era A: register, interact (strictly between A's create and
+	// delete instants, guaranteed by the monotonic clock), release --
+	// the OLDER, non-adjacent gap.
+	addrA := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000005")
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrA,
+		CustomerID: customerID,
+		ContactID:  ownerA,
+	}); err != nil {
+		t.Fatalf("AddressCreate(A) error = %v", err)
+	}
+	interactionA := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000006")
+	mustCreateInteraction(t, ctx, h, interactionA, customerID, string(contact.AddressTypeTel), target,
+		mockUtil.peek())
+	if err := h.AddressDelete(ctx, addrA); err != nil {
+		t.Fatalf("AddressDelete(A) error = %v", err)
+	}
+	aClosed := ownershipPeriodsForTarget(t, ctx, h, customerID, contact.AddressTypeTel, target)
+	if len(aClosed) != 1 || aClosed[0].ValidTo == nil {
+		t.Fatalf("expected exactly one closed period for A, got: %+v", aClosed)
+	}
+
+	// Era B: register, release -- the IMMEDIATELY PRIOR gap (this is
+	// the one the claim's valid_from will reach back to).
+	addrB := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000007")
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         addrB,
+		CustomerID: customerID,
+		ContactID:  ownerB,
+	}); err != nil {
+		t.Fatalf("AddressCreate(B) error = %v", err)
+	}
+	if err := h.AddressDelete(ctx, addrB); err != nil {
+		t.Fatalf("AddressDelete(B) error = %v", err)
+	}
+	bRows := ownershipPeriodsForTarget(t, ctx, h, customerID, contact.AddressTypeTel, target)
+	var bClosedValidTo *time.Time
+	for _, p := range bRows {
+		if p.ContactID == ownerB && p.ValidTo != nil {
+			bClosedValidTo = p.ValidTo
+		}
+	}
+	if bClosedValidTo == nil {
+		t.Fatalf("expected a closed period for B, got: %+v", bRows)
+	}
+
+	// Unresolved era, then claimed.
+	unresolvedAddrID := uuid.FromStringOrNil("98000000-0000-0000-0000-000000000008")
+	if err := h.AddressCreate(ctx, &contact.Address{
+		Address:    commonaddress.Address{Type: contact.AddressTypeTel, Target: target},
+		ID:         unresolvedAddrID,
+		CustomerID: customerID,
+		ContactID:  uuid.Nil,
+	}); err != nil {
+		t.Fatalf("AddressCreate(unresolved) error = %v", err)
+	}
+	if err := h.AddressClaim(ctx, customerID, unresolvedAddrID, claimer); err != nil {
+		t.Fatalf("AddressClaim() error = %v", err)
+	}
+
+	claimerPeriods, err := h.OwnershipPeriodsListByContactID(ctx, claimer)
+	if err != nil {
+		t.Fatalf("OwnershipPeriodsListByContactID(claimer) error = %v", err)
+	}
+	if len(claimerPeriods) != 1 || claimerPeriods[0].ValidFrom == nil {
+		t.Fatalf("expected exactly one bounded period for the claimer, got: %+v", claimerPeriods)
+	}
+	if !claimerPeriods[0].ValidFrom.Equal(*bClosedValidTo) {
+		t.Fatalf("claimer's valid_from = %v, want %v (B's valid_to, the IMMEDIATELY prior gap) -- test setup assumption violated, cannot proceed", claimerPeriods[0].ValidFrom, bClosedValidTo)
+	}
+
+	unresolved, err := h.InteractionListUnresolved(ctx, customerID, 100, "", time.Time{})
+	if err != nil {
+		t.Fatalf("InteractionListUnresolved() error = %v", err)
+	}
+	found := false
+	for _, i := range unresolved {
+		if i.ID == interactionA {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("InteractionListUnresolved() did NOT resurface the older, non-adjacent-gap interaction after claim -- round-39's accepted (documented) behavior regressed: it should resurface once the row-presence suppression that covered it unconditionally is removed by the claim")
+	}
+}
+
+// newMonotonicTimeUtilHandler returns a mock UtilHandler whose TimeNow()
+// advances by one minute on every call, starting at start -- unlike
+// newOwnershipTestHandler's single fixed instant (AnyTimes() returning
+// the same pointer always), this lets a test construct ownership periods
+// with genuinely distinct, strictly increasing boundaries without having
+// to predict the exact number of internal TimeNow() calls a given write
+// makes (which varies by which §4 step it resolves to). peek() returns
+// the timestamp the NEXT call will produce, without consuming it -- used
+// by callers that need to record an interaction at a time guaranteed to
+// fall strictly between two writes.
+type monotonicTimeUtilHandler struct {
+	*utilhandler.MockUtilHandler
+	next time.Time
+}
+
+func (m *monotonicTimeUtilHandler) peek() time.Time {
+	return m.next
+}
+
+func newMonotonicTimeUtilHandler(t *testing.T, mc *gomock.Controller, start time.Time) *monotonicTimeUtilHandler {
+	t.Helper()
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	m := &monotonicTimeUtilHandler{MockUtilHandler: mockUtil, next: start}
+	mockUtil.EXPECT().TimeNow().DoAndReturn(func() *time.Time {
+		tm := m.next
+		m.next = m.next.Add(time.Minute)
+		return &tm
+	}).AnyTimes()
+	return m
+}
+
+// createTestContactNoTimeNow mirrors createTestContact but does not
+// consume a TimeNow() call budget -- ContactCreate does not call
+// TimeNow() (confirmed against createTestContact's existing usage
+// pattern, which shares the same AnyTimes() mock as every other write in
+// its test), so this exists only to make that non-consumption explicit
+// at call sites using the strict, ordered newSequentialTimeUtilHandler
+// mock above, where an unexpected TimeNow() call would fail the test.
+func createTestContactNoTimeNow(t *testing.T, h *handler, ctx context.Context, customerID, contactID uuid.UUID) {
+	t.Helper()
+	c := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID, CustomerID: customerID},
+		Source:   "manual",
+	}
+	if err := h.ContactCreate(ctx, c); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+}
+
+func assertContainsIDs(t *testing.T, label string, got []*interaction.Interaction, want ...uuid.UUID) {
+	t.Helper()
+	gotSet := make(map[uuid.UUID]bool, len(got))
+	for _, i := range got {
+		gotSet[i.ID] = true
+	}
+	for _, w := range want {
+		if !gotSet[w] {
+			t.Errorf("%s missing expected interaction %v (got: %d items)", label, w, len(got))
+		}
 	}
 }

--- a/bin-contact-manager/pkg/dbhandler/interaction.go
+++ b/bin-contact-manager/pkg/dbhandler/interaction.go
@@ -27,6 +27,21 @@ type AddressPair struct {
 	Target string
 }
 
+// OwnershipPeriodBound is a (type, target, valid_from, valid_to) window
+// used by InteractionListByOwnershipPeriods to time-scope its OR-expanded
+// peer match (design §6.2, round-16/17). Unlike AddressPair's pure
+// equality match, each bound additionally constrains the interaction's
+// effective time (COALESCE(tm_interaction, tm_create)) to fall inside
+// [ValidFrom or -inf, ValidTo or +inf) for that (type, target) pair.
+// ValidFrom == nil means unbounded past; ValidTo == nil means still open
+// (unbounded future).
+type OwnershipPeriodBound struct {
+	Type      string
+	Target    string
+	ValidFrom *time.Time
+	ValidTo   *time.Time
+}
+
 // InteractionCreate inserts an Interaction row into contact_interactions.
 // It is idempotent: a duplicate-key error (MySQL errno 1062) is silently
 // ignored so the caller does not need to guard against at-least-once delivery.
@@ -190,6 +205,124 @@ func (h *handler) InteractionList(
 	return res, nil
 }
 
+// InteractionListByOwnershipPeriods is InteractionList's sibling for
+// interactionListByContact's STEP2 (design §6.2, round-18): time-scoped
+// peer matching against a Contact's full ownership history instead of
+// pure (type, target) equality. Kept as a separate function rather than
+// widening InteractionList's signature, because InteractionList already
+// ends in a variadic-incompatible `since time.Time` parameter (round-18) --
+// InteractionList itself, and every existing call site
+// (interaction_read.go's STEP5/interactionListByAddress,
+// mock_main.go, main.go, interaction_test.go), is unchanged.
+//
+// Each bound in periods contributes one OR'd clause:
+// (peer_type = ? AND peer_target = ?
+//
+//	[AND COALESCE(tm_interaction, tm_create) >= ValidFrom, if set]
+//	[AND COALESCE(tm_interaction, tm_create) <  ValidTo, if set])
+//
+// A nil ValidFrom/ValidTo simply omits that AND-term rather than
+// synthesizing a MySQL-only "+ INTERVAL 1 SECOND" tautology (the design
+// prose's illustrative SQL) -- SQLite (the test harness driver) has no
+// portable equivalent, and an absent AND-term is exactly "no constraint
+// on that side" with no dialect-specific SQL required. The round-21
+// NULL-safety fix (falling back to tm_create when tm_interaction is
+// nullable) and the round-17 rule that a range condition must live
+// inside one raw sq.Expr fragment, never as a value handed to a
+// squirrel column-comparison builder (Eq/Lt/GtOrEq only special-case
+// driver.Valuer, not Sqlizer), both still apply.
+func (h *handler) InteractionListByOwnershipPeriods(
+	ctx context.Context,
+	customerID uuid.UUID,
+	size uint64,
+	token string,
+	peerType, peerTarget string,
+	bounds []OwnershipPeriodBound,
+	since time.Time,
+) ([]*interaction.Interaction, error) {
+	if peerType == "" && peerTarget == "" && len(bounds) == 0 && since.IsZero() {
+		return nil, nil
+	}
+
+	columns := commondatabasehandler.GetDBFields(&interaction.Interaction{})
+
+	builder := sq.Select(columns...).
+		From(interactionTable).
+		Where(sq.Eq{"customer_id": customerID.Bytes()})
+
+	if peerType != "" || peerTarget != "" {
+		builder = builder.Where(sq.Eq{"peer_type": peerType, "peer_target": peerTarget})
+	} else if len(bounds) > 0 {
+		or := sq.Or{}
+		for _, b := range bounds {
+			// Portable across MySQL (production) and SQLite (test
+			// harness): rather than the design's illustrative
+			// "+ INTERVAL 1 SECOND" tautology for an unbounded upper
+			// edge (MySQL-only syntax SQLite has no equivalent for),
+			// each edge is simply OMITTED from the clause when nil --
+			// an absent AND-term is exactly "no constraint on that
+			// side," the same semantics with no dialect-specific SQL.
+			clause := "(peer_type = ? AND peer_target = ?"
+			args := []any{b.Type, b.Target}
+			if b.ValidFrom != nil {
+				clause += " AND COALESCE(tm_interaction, tm_create) >= ?"
+				args = append(args, b.ValidFrom.UTC())
+			}
+			if b.ValidTo != nil {
+				clause += " AND COALESCE(tm_interaction, tm_create) < ?"
+				args = append(args, b.ValidTo.UTC())
+			}
+			clause += ")"
+			or = append(or, sq.Expr(clause, args...))
+		}
+		builder = builder.Where(or)
+	}
+
+	if !since.IsZero() {
+		builder = builder.Where(sq.GtOrEq{"tm_create": since.UTC()})
+	}
+
+	if token != "" {
+		cursorTime, err := time.Parse("2006-01-02T15:04:05.000000Z", token)
+		if err != nil {
+			cursorTime, err = time.Parse(time.RFC3339Nano, token)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not parse page token. InteractionListByOwnershipPeriods. err: %v", err)
+		}
+		builder = builder.Where(sq.Lt{"tm_create": cursorTime.UTC()})
+	}
+
+	builder = builder.
+		OrderBy("tm_create DESC").
+		Limit(size)
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. InteractionListByOwnershipPeriods. err: %v", err)
+	}
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. InteractionListByOwnershipPeriods. err: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []*interaction.Interaction
+	for rows.Next() {
+		item, scanErr := interactionGetFromRow(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("could not scan the row. InteractionListByOwnershipPeriods. err: %v", scanErr)
+		}
+		res = append(res, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error. InteractionListByOwnershipPeriods. err: %v", err)
+	}
+
+	return res, nil
+}
+
 // InteractionListByIDs fetches interactions for a given set of IDs,
 // scoped to customerID (tenant guard).
 func (h *handler) InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error) {
@@ -236,7 +369,20 @@ func (h *handler) InteractionListByIDs(ctx context.Context, customerID uuid.UUID
 }
 
 // InteractionListUnresolved returns interactions that have zero-contact attribution:
-//   - NOT auto-matched to any active contact_address for this customer
+//   - NOT auto-matched to any contact via ownership history (design §6.3:
+//     rewired from live contact_addresses rows to
+//     contact_address_ownership_periods, so a target's PAST owner's
+//     interactions correctly stay resolved even after the target is
+//     reassigned or deleted -- see design §6 for the full rationale)
+//   - NOT suppressed by an unresolved (contact_id IS NULL) row's mere
+//     presence (design §6.3 round-36/37/38/39: preserves today's
+//     CreateUnresolvedAddress suppression-by-presence behavior exactly,
+//     since unresolved rows never get a period per §4 round-10)
+//   - NOT suppressed by the missing-period-skew guard (design §6.3
+//     round-40/42/43: an owned row with no period of its own -- an
+//     old-binary pod's AddressCreate that ran before this rewire --
+//     must not resurface its interactions in the queue just because it
+//     has no period row yet)
 //   - NOT positively resolved to any contact
 //   - peer_type != 'web_session'
 //
@@ -250,6 +396,26 @@ func (h *handler) InteractionListUnresolved(ctx context.Context, customerID uuid
 
 	// Build the unresolved predicate using NOT EXISTS subqueries.
 	// Outer query scans contact_interactions (i) for the customer since the given time.
+	//
+	// Three disjuncts, each suppressing a distinct population from the
+	// unresolved queue (design §6.3):
+	//   1. Ownership-period match: this interaction's effective time
+	//      falls inside a period some contact held this exact
+	//      (type, target) during. The range check is expressed as two
+	//      independently-nullable AND-terms (p.valid_from IS NULL OR ...)
+	//      / (p.valid_to IS NULL OR ...) rather than the design prose's
+	//      illustrative "+ INTERVAL 1 SECOND" tautology for an open
+	//      upper bound -- portable across MySQL (production) and SQLite
+	//      (test harness), which has no INTERVAL equivalent.
+	//   2. Unresolved-row presence: a CreateUnresolvedAddress row
+	//      (contact_id IS NULL) for this exact target suppresses by
+	//      presence alone, time-agnostic, matching today's observable
+	//      behavior (round-36).
+	//   3. Missing-period-skew guard: an owned row (contact_id IS NOT
+	//      NULL) for this exact target with no OPEN period for that
+	//      SAME owner (round-43's final, owner-plus-open-scoped
+	//      condition) suppresses by presence, exactly like an
+	//      unresolved row, until the next write gives it a period.
 	baseSQL := fmt.Sprintf(`
 SELECT %s
 FROM contact_interactions i
@@ -257,10 +423,34 @@ WHERE i.customer_id = ?
   AND i.peer_type != 'web_session'
   AND i.tm_create >= ?
   AND NOT EXISTS (
+      SELECT 1 FROM contact_address_ownership_periods p
+      WHERE p.customer_id = i.customer_id
+        AND p.type = i.peer_type
+        AND p.target = i.peer_target
+        AND (p.valid_from IS NULL OR COALESCE(i.tm_interaction, i.tm_create) >= p.valid_from)
+        AND (p.valid_to IS NULL   OR COALESCE(i.tm_interaction, i.tm_create) <  p.valid_to)
+  )
+  AND NOT EXISTS (
       SELECT 1 FROM contact_addresses a
       WHERE a.customer_id = i.customer_id
         AND a.type = i.peer_type
         AND a.target = i.peer_target
+        AND a.contact_id IS NULL
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM contact_addresses a
+      WHERE a.customer_id = i.customer_id
+        AND a.type = i.peer_type
+        AND a.target = i.peer_target
+        AND a.contact_id IS NOT NULL
+        AND NOT EXISTS (
+            SELECT 1 FROM contact_address_ownership_periods p2
+            WHERE p2.customer_id = a.customer_id
+              AND p2.type = a.type
+              AND p2.target = a.target
+              AND p2.contact_id = a.contact_id
+              AND p2.valid_to IS NULL
+        )
   )
   AND NOT EXISTS (
       SELECT 1 FROM contact_resolutions r

--- a/bin-contact-manager/pkg/dbhandler/main.go
+++ b/bin-contact-manager/pkg/dbhandler/main.go
@@ -58,6 +58,14 @@ type DBHandler interface {
 	AddressResetPrimaryTx(ctx context.Context, tx *sql.Tx, contactID uuid.UUID) error
 	AddressDeleteCompensating(ctx context.Context, customerID, contactID uuid.UUID, addrType commonaddress.Type, target string) error
 
+	// Address ownership-period READ operations (design §6.1/§6.2,
+	// NOJIRA-contact-address-ownership-periods Phase 2). Used exclusively
+	// by interactionListByContact's STEP1 -- AddressListByContactID above
+	// stays untouched, since it also backs the public Contact.Addresses
+	// API field via ContactGet/ContactList (design §6.1).
+	OwnershipPeriodsListByContactID(ctx context.Context, contactID uuid.UUID) ([]OwnershipPeriod, error)
+	MissingPeriodOwnedAddresses(ctx context.Context, customerID, contactID uuid.UUID) ([]MissingPeriodAddress, error)
+
 	// TagAssignment operations
 	TagAssignmentCreate(ctx context.Context, contactID, tagID uuid.UUID) error
 	TagAssignmentDelete(ctx context.Context, contactID, tagID uuid.UUID) error
@@ -67,6 +75,7 @@ type DBHandler interface {
 	InteractionCreate(ctx context.Context, i *interaction.Interaction) error
 	InteractionGet(ctx context.Context, id uuid.UUID) (*interaction.Interaction, error)
 	InteractionList(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, addressSet []AddressPair, since time.Time) ([]*interaction.Interaction, error)
+	InteractionListByOwnershipPeriods(ctx context.Context, customerID uuid.UUID, size uint64, token string, peerType, peerTarget string, bounds []OwnershipPeriodBound, since time.Time) ([]*interaction.Interaction, error)
 	InteractionListByIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) ([]*interaction.Interaction, error)
 	InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, error)
 

--- a/bin-contact-manager/pkg/dbhandler/mock_main.go
+++ b/bin-contact-manager/pkg/dbhandler/mock_main.go
@@ -818,6 +818,21 @@ func (mr *MockDBHandlerMockRecorder) InteractionListByIDs(ctx, customerID, ids a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionListByIDs", reflect.TypeOf((*MockDBHandler)(nil).InteractionListByIDs), ctx, customerID, ids)
 }
 
+// InteractionListByOwnershipPeriods mocks base method.
+func (m *MockDBHandler) InteractionListByOwnershipPeriods(ctx context.Context, customerID uuid.UUID, size uint64, token, peerType, peerTarget string, bounds []OwnershipPeriodBound, since time.Time) ([]*interaction.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InteractionListByOwnershipPeriods", ctx, customerID, size, token, peerType, peerTarget, bounds, since)
+	ret0, _ := ret[0].([]*interaction.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InteractionListByOwnershipPeriods indicates an expected call of InteractionListByOwnershipPeriods.
+func (mr *MockDBHandlerMockRecorder) InteractionListByOwnershipPeriods(ctx, customerID, size, token, peerType, peerTarget, bounds, since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionListByOwnershipPeriods", reflect.TypeOf((*MockDBHandler)(nil).InteractionListByOwnershipPeriods), ctx, customerID, size, token, peerType, peerTarget, bounds, since)
+}
+
 // InteractionListUnresolved mocks base method.
 func (m *MockDBHandler) InteractionListUnresolved(ctx context.Context, customerID uuid.UUID, size uint64, token string, since time.Time) ([]*interaction.Interaction, error) {
 	m.ctrl.T.Helper()
@@ -831,6 +846,36 @@ func (m *MockDBHandler) InteractionListUnresolved(ctx context.Context, customerI
 func (mr *MockDBHandlerMockRecorder) InteractionListUnresolved(ctx, customerID, size, token, since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InteractionListUnresolved", reflect.TypeOf((*MockDBHandler)(nil).InteractionListUnresolved), ctx, customerID, size, token, since)
+}
+
+// MissingPeriodOwnedAddresses mocks base method.
+func (m *MockDBHandler) MissingPeriodOwnedAddresses(ctx context.Context, customerID, contactID uuid.UUID) ([]MissingPeriodAddress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MissingPeriodOwnedAddresses", ctx, customerID, contactID)
+	ret0, _ := ret[0].([]MissingPeriodAddress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MissingPeriodOwnedAddresses indicates an expected call of MissingPeriodOwnedAddresses.
+func (mr *MockDBHandlerMockRecorder) MissingPeriodOwnedAddresses(ctx, customerID, contactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MissingPeriodOwnedAddresses", reflect.TypeOf((*MockDBHandler)(nil).MissingPeriodOwnedAddresses), ctx, customerID, contactID)
+}
+
+// OwnershipPeriodsListByContactID mocks base method.
+func (m *MockDBHandler) OwnershipPeriodsListByContactID(ctx context.Context, contactID uuid.UUID) ([]OwnershipPeriod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OwnershipPeriodsListByContactID", ctx, contactID)
+	ret0, _ := ret[0].([]OwnershipPeriod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OwnershipPeriodsListByContactID indicates an expected call of OwnershipPeriodsListByContactID.
+func (mr *MockDBHandlerMockRecorder) OwnershipPeriodsListByContactID(ctx, contactID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OwnershipPeriodsListByContactID", reflect.TypeOf((*MockDBHandler)(nil).OwnershipPeriodsListByContactID), ctx, contactID)
 }
 
 // OwnershipPeriodsLockAndResolveTx mocks base method.


### PR DESCRIPTION
NOJIRA-contact-address-ownership-read-path

Phase 2 of NOJIRA-contact-address-ownership-periods (design docs/plans/
2026-07-11-contact-address-ownership-integrity-design.md section 6):
wires the interaction read paths onto the contact_address_ownership_periods
table Phase 1 (#1087) introduced. This is the fix for the four original
defects the whole design exists to address -- Phase 1 only laid down the
write-side history table; this PR is what actually makes reads use it.

Went through 3 rounds of independent adversarial subagent review
(correctness + test-coverage reviewers each round): round 1 found the
implementation correct but flagged 5 concrete test-coverage gaps against
design rounds 37-43; round 2 verified all 5 gaps were closed correctly
(fresh subagents, no memory of round 1) and caught one stale comment;
round 3 (fresh, whole-diff) found nothing further. Two consecutive
APPROVE verdicts, minimum-3-round rule satisfied.

- bin-contact-manager: add OwnershipPeriodsListByContactID and
  MissingPeriodOwnedAddresses to dbhandler -- the two new STEP1 read
  primitives interactionListByContact needs. Does not touch
  AddressListByContactID, which stays the backing read for the public
  Contact.Addresses API field (ContactGet/ContactList)
- bin-contact-manager: add OwnershipPeriodBound and
  InteractionListByOwnershipPeriods as a new sibling to InteractionList:
  InteractionList's existing signature and call sites are unchanged; the
  new function time-scopes its OR-expanded peer match against each
  bound's [ValidFrom, ValidTo) window instead of pure (type, target)
  equality
- bin-contact-manager: rewrite InteractionListUnresolved's suppression
  predicate into three disjuncts -- ownership-period membership,
  unresolved-row presence (preserves today's CreateUnresolvedAddress
  suppression exactly), and a missing-period-skew guard scoped to the
  owner AND to open periods (an owned row with no period of its own does
  not resurface, and neither does a same-owner reacquisition or a
  different owner's reassignment)
- bin-contact-manager: wire interactionListByContact's STEP1/STEP2 onto
  the new primitives; STEP0/3-6 are unchanged
- bin-contact-manager: dedicated scenario tests proving all four original
  defects are fixed end-to-end through the real write path
  (AddressCreate/AddressDelete/AddressClaim) and the real SQLite test DB:
  deleted-target history no longer disappears, reassignment no longer
  cross-attributes, past-owner interactions no longer resurface in the
  unresolved queue, the missing-period-skew guard holds for first
  registration, same-owner reacquisition, and reassignment, and the
  claim-of-unresolved-address immediately-prior-gap-attaches /
  non-adjacent-gap-still-resurfaces pair from design rounds 37-39 is
  pinned by test
