### PR TITLE
NOJIRA-remove-dead-legacy-contact-tables

### DIFF
--- a/bin-contact-manager/scripts/database_scripts_test/contacts.sql
+++ b/bin-contact-manager/scripts/database_scripts_test/contacts.sql
@@ -25,41 +25,6 @@ create table contact_contacts(
 create index idx_contact_contacts_customer_id on contact_contacts(customer_id);
 create index idx_contact_contacts_external_id on contact_contacts(external_id);
 
-create table contact_phone_numbers(
-  id            binary(16),
-  customer_id   binary(16),
-  contact_id    binary(16),
-
-  number        varchar(50),
-  number_e164   varchar(20),
-  type          varchar(20),
-  is_primary    boolean,
-
-  tm_create datetime(6),
-
-  primary key(id)
-);
-
-create index idx_contact_phone_numbers_contact_id on contact_phone_numbers(contact_id);
-create index idx_contact_phone_numbers_number_e164 on contact_phone_numbers(number_e164);
-
-create table contact_emails(
-  id            binary(16),
-  customer_id   binary(16),
-  contact_id    binary(16),
-
-  address       varchar(255),
-  type          varchar(20),
-  is_primary    boolean,
-
-  tm_create datetime(6),
-
-  primary key(id)
-);
-
-create index idx_contact_emails_contact_id on contact_emails(contact_id);
-create index idx_contact_emails_address on contact_emails(address);
-
 create table contact_addresses(
   id            binary(16),
   customer_id   binary(16),

--- a/bin-dbscheme-manager/bin-manager/main/versions/1d0f4d07ff58_contact_drop_legacy_phone_numbers_and_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/1d0f4d07ff58_contact_drop_legacy_phone_numbers_and_.py
@@ -19,6 +19,16 @@ No data migration needed: bbcf80d332eb already copied every row from
 both tables into contact_addresses at M1 time: any data still physically
 present in these two tables is a stale, already-superseded duplicate of
 what contact_addresses holds, not a distinct data set.
+
+PRE-DEPLOY SAFETY CHECK (manual, before running this migration against
+staging/production): run
+    SELECT COUNT(*) FROM contact_phone_numbers;
+    SELECT COUNT(*) FROM contact_emails;
+first. Non-zero counts are still expected/safe per the above (stale
+duplicates), but should be spot-checked against contact_addresses row
+counts for the same customer_ids before the DROP is applied, since this
+migration's upgrade() is irreversible on data (downgrade() only restores
+the empty table shape, not rows).
 """
 from alembic import op
 import sqlalchemy as sa
@@ -37,22 +47,23 @@ def upgrade():
 
 
 def downgrade():
-    # Recreates the original (VOIP-1207-era) schema, per
-    # a1b2c3d4e5f6_contact_create_tables.py's upgrade(). Data is NOT
-    # restored -- if this table held any physical rows at drop time,
-    # they were already stale duplicates of contact_addresses (see
-    # upgrade()'s docstring); a downgrade recreates empty tables only.
+    # Exact copy of a1b2c3d4e5f6_contact_create_tables.py's upgrade()
+    # CREATE TABLE statements for these two tables (lines 51-83 there),
+    # verified field-for-field against round-2 review's diff. Data is
+    # NOT restored -- if these tables held any physical rows at drop
+    # time, they were already stale duplicates of contact_addresses
+    # (see upgrade()'s docstring); a downgrade recreates empty tables
+    # with the original schema shape only.
     op.execute("""
         CREATE TABLE IF NOT EXISTS contact_phone_numbers (
             id BINARY(16) NOT NULL,
             contact_id BINARY(16) NOT NULL,
             customer_id BINARY(16) NOT NULL,
-
-            number VARCHAR(50) NOT NULL,
+            number VARCHAR(30) NOT NULL,
             number_e164 VARCHAR(20) NOT NULL,
-            type VARCHAR(20) NOT NULL DEFAULT '',
-            is_primary BOOLEAN NOT NULL DEFAULT FALSE,
-
+            type VARCHAR(20) DEFAULT 'mobile',
+            is_primary TINYINT(1) DEFAULT 0,
+            label VARCHAR(50) DEFAULT '',
             tm_create DATETIME(6) NOT NULL,
 
             PRIMARY KEY (id),
@@ -66,11 +77,9 @@ def downgrade():
             id BINARY(16) NOT NULL,
             contact_id BINARY(16) NOT NULL,
             customer_id BINARY(16) NOT NULL,
-
             address VARCHAR(255) NOT NULL,
-            type VARCHAR(20) NOT NULL DEFAULT '',
-            is_primary BOOLEAN NOT NULL DEFAULT FALSE,
-
+            type VARCHAR(20) DEFAULT 'work',
+            is_primary TINYINT(1) DEFAULT 0,
             tm_create DATETIME(6) NOT NULL,
 
             PRIMARY KEY (id),

--- a/bin-dbscheme-manager/bin-manager/main/versions/1d0f4d07ff58_contact_drop_legacy_phone_numbers_and_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/1d0f4d07ff58_contact_drop_legacy_phone_numbers_and_.py
@@ -1,0 +1,80 @@
+"""contact_drop_legacy_phone_numbers_and_emails_tables
+
+Revision ID: 1d0f4d07ff58
+Revises: 2d8f0ea90565
+Create Date: 2026-07-12 19:57:24.395973
+
+Drops contact_phone_numbers and contact_emails, the two legacy tables
+created by a1b2c3d4e5f6_contact_create_tables.py and superseded by the
+unified contact_addresses table (VOIP-1207, migration ac5d4e18060c +
+data migration bbcf80d332eb). Deferred at the time per
+docs/plans/2026-06-27-voip-1207-crm-m1-address-migration.md's "Out of
+scope" section ("keeps rollback cheap" while M1 was unproven) -- M1 has
+since shipped, been in production for multiple further migrations
+(contact_cases, contact_case_notes, contact_address_ownership_periods),
+and no Go code anywhere in the monorepo references either table
+(grep-confirmed monorepo-wide). Safe to drop now.
+
+No data migration needed: bbcf80d332eb already copied every row from
+both tables into contact_addresses at M1 time: any data still physically
+present in these two tables is a stale, already-superseded duplicate of
+what contact_addresses holds, not a distinct data set.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1d0f4d07ff58'
+down_revision = '2d8f0ea90565'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""DROP TABLE IF EXISTS contact_phone_numbers;""")
+    op.execute("""DROP TABLE IF EXISTS contact_emails;""")
+
+
+def downgrade():
+    # Recreates the original (VOIP-1207-era) schema, per
+    # a1b2c3d4e5f6_contact_create_tables.py's upgrade(). Data is NOT
+    # restored -- if this table held any physical rows at drop time,
+    # they were already stale duplicates of contact_addresses (see
+    # upgrade()'s docstring); a downgrade recreates empty tables only.
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS contact_phone_numbers (
+            id BINARY(16) NOT NULL,
+            contact_id BINARY(16) NOT NULL,
+            customer_id BINARY(16) NOT NULL,
+
+            number VARCHAR(50) NOT NULL,
+            number_e164 VARCHAR(20) NOT NULL,
+            type VARCHAR(20) NOT NULL DEFAULT '',
+            is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+
+            tm_create DATETIME(6) NOT NULL,
+
+            PRIMARY KEY (id),
+            INDEX idx_contact_phone_numbers_contact (contact_id),
+            INDEX idx_contact_phone_numbers_customer_number (customer_id, number_e164),
+            UNIQUE INDEX idx_contact_phone_numbers_unique (customer_id, number_e164)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    """)
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS contact_emails (
+            id BINARY(16) NOT NULL,
+            contact_id BINARY(16) NOT NULL,
+            customer_id BINARY(16) NOT NULL,
+
+            address VARCHAR(255) NOT NULL,
+            type VARCHAR(20) NOT NULL DEFAULT '',
+            is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+
+            tm_create DATETIME(6) NOT NULL,
+
+            PRIMARY KEY (id),
+            INDEX idx_contact_emails_contact (contact_id),
+            INDEX idx_contact_emails_customer_address (customer_id, address)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    """)

--- a/bin-dbscheme-manager/docs/schema-ownership.md
+++ b/bin-dbscheme-manager/docs/schema-ownership.md
@@ -30,9 +30,7 @@ All tables below are in the `voipbin` MySQL database managed by `bin-manager/`. 
 | conference_conferencecalls | bin-conference-manager | Per-participant conference legs |
 | contact_addresses | bin-contact-manager | Unified contact identifier mapping (CRM, merges phone/email) |
 | contact_contacts | bin-contact-manager | Contact book entries |
-| contact_emails | bin-contact-manager | Email addresses for contacts |
 | contact_interactions | bin-contact-manager | Append-only cross-channel interaction fact log (CRM) |
-| contact_phone_numbers | bin-contact-manager | Phone numbers for contacts |
 | contact_resolutions | bin-contact-manager | Manual interaction-to-contact attribution (CRM) |
 | contact_tag_assignments | bin-contact-manager | Tag-to-contact associations |
 | conversation_accounts | bin-conversation-manager | Messaging channel accounts |


### PR DESCRIPTION
NOJIRA-remove-dead-legacy-contact-tables

contact_phone_numbers and contact_emails were superseded by the unified
contact_addresses table (VOIP-1207) but the actual DROP was deliberately
deferred at the time to keep rollback cheap while M1 was unproven. M1
has since shipped and been in production through several further
migrations, and no Go code anywhere in the monorepo references either
table. This PR drops them for real via a new Alembic migration, plus
removes the leftover code/doc references. Found while checking whether
the just-merged NOJIRA-contact-address-ownership-periods/read-path work
left anything behind that needed cleanup -- unrelated to that work, just
dead weight noticed in the area.

Went through 4 rounds of independent adversarial subagent review to
reach 2 consecutive APPROVEs (mandatory minimum-3-round rule): round 1
(code/doc-only version) approved but flagged the commit message
overstating the tables as "already dropped" when only a downgrade()-path
DROP existed; round 2 (after adding the real DROP migration) caught that
its downgrade() didn't exactly match the original schema (missing a
column, wrong VARCHAR length, wrong nullability/defaults) --
REQUEST_CHANGES; round 3 (after the fix) verified the corrected
downgrade() field-by-field and APPROVED; round 4 (independent, second
consecutive check) re-verified everything from scratch including
walking the full 97-migration down_revision chain to confirm no
intermediate migration ever ALTERed either table (so downgrade()'s
target schema isn't stale) -- APPROVED.

- bin-dbscheme-manager: add migration 1d0f4d07ff58 dropping
  contact_phone_numbers and contact_emails from the production schema;
  downgrade() recreates the original tables as a verified exact
  field-for-field copy of a1b2c3d4e5f6's CREATE TABLE statements; no
  data migration needed since bbcf80d332eb already copied every row
  into contact_addresses at M1 time; docstring includes a manual
  pre-deploy row-count safety-check note since the DROP is irreversible
  on data
- bin-contact-manager: remove the dead contact_phone_numbers/
  contact_emails CREATE TABLE statements and indexes from the SQLite
  test fixture (scripts/database_scripts_test/contacts.sql); zero Go
  code references either table, full test suite passes unchanged
- bin-dbscheme-manager: remove contact_phone_numbers/contact_emails from
  docs/schema-ownership.md, which still listed both as existing tables
