### PR TITLE
NOJIRA-add-case-name-detail-to-openapi

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -26610,6 +26610,16 @@
             "description": "ID of the actor that closed the case. Nullable.",
             "example": "2a2ec0ba-8004-11ec-aea5-439829c92a7c"
           },
+          "name": {
+            "type": "string",
+            "description": "Optional freeform case name/title, settable only at creation time.",
+            "example": "Billing dispute follow-up"
+          },
+          "detail": {
+            "type": "string",
+            "description": "Optional freeform case detail, settable only at creation time.",
+            "example": "Customer disputes March invoice charges."
+          },
           "previous_case_id": {
             "type": "string",
             "format": "uuid",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -2708,8 +2708,14 @@ type ContactManagerCase struct {
 	// CustomerId Unique identifier of the associated customer.
 	CustomerId *openapi_types.UUID `json:"customer_id,omitempty"`
 
+	// Detail Optional freeform case detail, settable only at creation time.
+	Detail *string `json:"detail,omitempty"`
+
 	// Id Unique identifier for the case.
 	Id *openapi_types.UUID `json:"id,omitempty"`
+
+	// Name Optional freeform case name/title, settable only at creation time.
+	Name *string `json:"name,omitempty"`
 
 	// OpenedAt Timestamp when the case was opened. Nullable.
 	OpenedAt *time.Time `json:"opened_at,omitempty"`

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -5025,8 +5025,14 @@ type ContactManagerCase struct {
 	// CustomerId Unique identifier of the associated customer.
 	CustomerId *openapi_types.UUID `json:"customer_id,omitempty"`
 
+	// Detail Optional freeform case detail, settable only at creation time.
+	Detail *string `json:"detail,omitempty"`
+
 	// Id Unique identifier for the case.
 	Id *openapi_types.UUID `json:"id,omitempty"`
+
+	// Name Optional freeform case name/title, settable only at creation time.
+	Name *string `json:"name,omitempty"`
 
 	// OpenedAt Timestamp when the case was opened. Nullable.
 	OpenedAt *time.Time `json:"opened_at,omitempty"`

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -3507,6 +3507,14 @@ components:
           format: uuid
           description: ID of the actor that closed the case. Nullable.
           example: "2a2ec0ba-8004-11ec-aea5-439829c92a7c"
+        name:
+          type: string
+          description: Optional freeform case name/title, settable only at creation time.
+          example: "Billing dispute follow-up"
+        detail:
+          type: string
+          description: Optional freeform case detail, settable only at creation time.
+          example: "Customer disputes March invoice charges."
         previous_case_id:
           type: string
           format: uuid


### PR DESCRIPTION
Add missing name/detail fields to the ContactManagerCase OpenAPI schema. The backend has always returned these fields (server/contact_cases.go serializes kase.Case directly, no webhook.go/ConvertWebhookMessage layer exists for Case), but the spec never documented them. square-admin already correctly consumes these fields today — this closes a spec-side documentation gap surfaced during a square-admin drift audit, not a frontend bug.

- bin-openapi-manager: Add name/detail properties to ContactManagerCase schema
- bin-openapi-manager: Regenerate gens/models/gen.go
- bin-api-manager: Regenerate gens/openapi_server/gen.go and gens/openapi_redoc/* from updated spec

Note: bin-api-manager/server package tests are currently broken on main independent of this change (contact_addresses_test.go / contacts_test.go reference removed contact.Address fields from an earlier Address-embedding refactor) — confirmed via git stash comparison, go build ./... passes cleanly with this change.