### PR TITLE
VOIP-1252-case-contact-attribution-api

### DIFF
--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -9303,6 +9303,146 @@
         }
       }
     },
+    "/contact_cases/{id}/resolutions": {
+      "post": {
+        "summary": "Attach a case to a contact",
+        "description": "Attaches the case of the given ID to a specific existing Contact by\ncreating a case-level Resolution (VOIP-1252). Useful when a case was\ncreated from an unregistered or unmatched peer address and an agent\nmanually identifies which existing Contact it belongs to.\nresolved_by_id is derived server-side from the authenticated caller's\nown agent identity -- it cannot be forged by supplying an arbitrary\nresolved_by_id in the request body. The target contact_id must belong\nto the same customer as the case; a cross-tenant contact_id is\nrejected as not found.\n",
+        "tags": [
+          "Case"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the case. The ID is returned from GET /v1.0/contact_cases response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "contact_id",
+                  "resolution_type"
+                ],
+                "properties": {
+                  "contact_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The contact to attach this case to. The ID is returned from GET /v1.0/contacts response.",
+                    "example": "660e8400-e29b-41d4-a716-446655440001"
+                  },
+                  "resolution_type": {
+                    "type": "string",
+                    "description": "Attribution type. positive attaches the case to the contact; negative suppresses a prior positive attribution.",
+                    "enum": [
+                      "positive",
+                      "negative"
+                    ],
+                    "example": "positive"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Case resolution created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactManagerResolution"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/contact_cases/{id}/resolutions/{resolution_id}": {
+      "delete": {
+        "summary": "Undo a case-level contact attribution",
+        "description": "Soft-deletes the case-level resolution of the given resolution ID on\nthe case of the given case ID (VOIP-1252). Case.contact_id is\nautomatically re-derived after the delete -- if no other active\ncase-level positive resolution remains, contact_id reverts to null.\n",
+        "tags": [
+          "Case"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the case. The ID is returned from GET /v1.0/contact_cases response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          },
+          {
+            "name": "resolution_id",
+            "in": "path",
+            "description": "The ID of the resolution. The ID is returned from POST /v1.0/contact_cases/{id}/resolutions response.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "example": "770e8400-e29b-41d4-a716-446655440002"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Case resolution deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthenticated"
+          },
+          "403": {
+            "$ref": "#/components/responses/PermissionDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/conversation_accounts/{id}": {
       "get": {
         "summary": "Get details of a conversation account",
@@ -26480,6 +26620,12 @@
             "format": "uuid",
             "description": "The interaction this resolution belongs to.",
             "example": "c3d4e5f6-a7b8-9012-cdef-345678901234"
+          },
+          "case_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The case this resolution is scoped to (case-level resolutions only). The ID is returned from GET /v1.0/contact_cases response.",
+            "example": "d4e5f6a7-b8c9-0123-defa-456789012345"
           },
           "resolution_type": {
             "type": "string",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -1060,6 +1060,12 @@ const (
 	PostContactCasesIdNotesJSONBodyAuthorTypeSystem PostContactCasesIdNotesJSONBodyAuthorType = "system"
 )
 
+// Defines values for PostContactCasesIdResolutionsJSONBodyResolutionType.
+const (
+	PostContactCasesIdResolutionsJSONBodyResolutionTypeNegative PostContactCasesIdResolutionsJSONBodyResolutionType = "negative"
+	PostContactCasesIdResolutionsJSONBodyResolutionTypePositive PostContactCasesIdResolutionsJSONBodyResolutionType = "positive"
+)
+
 // Defines values for PostContactInteractionsIdResolutionsJSONBodyResolutionType.
 const (
 	PostContactInteractionsIdResolutionsJSONBodyResolutionTypeNegative PostContactInteractionsIdResolutionsJSONBodyResolutionType = "negative"
@@ -1126,8 +1132,8 @@ const (
 
 // Defines values for PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType.
 const (
-	Negative PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "negative"
-	Positive PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "positive"
+	PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionTypeNegative PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "negative"
+	PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionTypePositive PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "positive"
 )
 
 // Defines values for PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolvedByType.
@@ -2903,6 +2909,9 @@ type ContactManagerInteractionListResponse struct {
 
 // ContactManagerResolution defines model for ContactManagerResolution.
 type ContactManagerResolution struct {
+	// CaseId The case this resolution is scoped to (case-level resolutions only). The ID is returned from GET /v1.0/contact_cases response.
+	CaseId *openapi_types.UUID `json:"case_id,omitempty"`
+
 	// ContactId The contact this resolution is attributed to.
 	ContactId *openapi_types.UUID `json:"contact_id,omitempty"`
 
@@ -5983,6 +5992,18 @@ type PostContactCasesIdNotesJSONBody struct {
 // PostContactCasesIdNotesJSONBodyAuthorType defines parameters for PostContactCasesIdNotes.
 type PostContactCasesIdNotesJSONBodyAuthorType string
 
+// PostContactCasesIdResolutionsJSONBody defines parameters for PostContactCasesIdResolutions.
+type PostContactCasesIdResolutionsJSONBody struct {
+	// ContactId The contact to attach this case to. The ID is returned from GET /v1.0/contacts response.
+	ContactId openapi_types.UUID `json:"contact_id"`
+
+	// ResolutionType Attribution type. positive attaches the case to the contact; negative suppresses a prior positive attribution.
+	ResolutionType PostContactCasesIdResolutionsJSONBodyResolutionType `json:"resolution_type"`
+}
+
+// PostContactCasesIdResolutionsJSONBodyResolutionType defines parameters for PostContactCasesIdResolutions.
+type PostContactCasesIdResolutionsJSONBodyResolutionType string
+
 // GetContactInteractionsParams defines parameters for GetContactInteractions.
 type GetContactInteractionsParams struct {
 	// PeerType Remote endpoint type (e.g. "tel", "email"). Required with peer_target.
@@ -7849,6 +7870,9 @@ type PostContactCasesIdMessagesJSONRequestBody PostContactCasesIdMessagesJSONBod
 // PostContactCasesIdNotesJSONRequestBody defines body for PostContactCasesIdNotes for application/json ContentType.
 type PostContactCasesIdNotesJSONRequestBody PostContactCasesIdNotesJSONBody
 
+// PostContactCasesIdResolutionsJSONRequestBody defines body for PostContactCasesIdResolutions for application/json ContentType.
+type PostContactCasesIdResolutionsJSONRequestBody PostContactCasesIdResolutionsJSONBody
+
 // PostContactInteractionsIdResolutionsJSONRequestBody defines body for PostContactInteractionsIdResolutions for application/json ContentType.
 type PostContactInteractionsIdResolutionsJSONRequestBody PostContactInteractionsIdResolutionsJSONBody
 
@@ -8532,6 +8556,12 @@ type ServerInterface interface {
 	// Delete a case note
 	// (DELETE /contact_cases/{id}/notes/{note_id})
 	DeleteContactCasesIdNotesNoteId(c *gin.Context, id openapi_types.UUID, noteId openapi_types.UUID)
+	// Attach a case to a contact
+	// (POST /contact_cases/{id}/resolutions)
+	PostContactCasesIdResolutions(c *gin.Context, id openapi_types.UUID)
+	// Undo a case-level contact attribution
+	// (DELETE /contact_cases/{id}/resolutions/{resolution_id})
+	DeleteContactCasesIdResolutionsResolutionId(c *gin.Context, id openapi_types.UUID, resolutionId openapi_types.UUID)
 	// List interactions
 	// (GET /contact_interactions)
 	GetContactInteractions(c *gin.Context, params GetContactInteractionsParams)
@@ -12817,6 +12847,63 @@ func (siw *ServerInterfaceWrapper) DeleteContactCasesIdNotesNoteId(c *gin.Contex
 	}
 
 	siw.Handler.DeleteContactCasesIdNotesNoteId(c, id, noteId)
+}
+
+// PostContactCasesIdResolutions operation middleware
+func (siw *ServerInterfaceWrapper) PostContactCasesIdResolutions(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.PostContactCasesIdResolutions(c, id)
+}
+
+// DeleteContactCasesIdResolutionsResolutionId operation middleware
+func (siw *ServerInterfaceWrapper) DeleteContactCasesIdResolutionsResolutionId(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Path parameter "resolution_id" -------------
+	var resolutionId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "resolution_id", c.Param("resolution_id"), &resolutionId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter resolution_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.DeleteContactCasesIdResolutionsResolutionId(c, id, resolutionId)
 }
 
 // GetContactInteractions operation middleware
@@ -19499,6 +19586,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/contact_cases/:id/notes", wrapper.GetContactCasesIdNotes)
 	router.POST(options.BaseURL+"/contact_cases/:id/notes", wrapper.PostContactCasesIdNotes)
 	router.DELETE(options.BaseURL+"/contact_cases/:id/notes/:note_id", wrapper.DeleteContactCasesIdNotesNoteId)
+	router.POST(options.BaseURL+"/contact_cases/:id/resolutions", wrapper.PostContactCasesIdResolutions)
+	router.DELETE(options.BaseURL+"/contact_cases/:id/resolutions/:resolution_id", wrapper.DeleteContactCasesIdResolutionsResolutionId)
 	router.GET(options.BaseURL+"/contact_interactions", wrapper.GetContactInteractions)
 	router.GET(options.BaseURL+"/contact_interactions/unresolved", wrapper.GetContactInteractionsUnresolved)
 	router.GET(options.BaseURL+"/contact_interactions/:id", wrapper.GetContactInteractionsId)
@@ -27566,6 +27655,132 @@ func (response DeleteContactCasesIdNotesNoteId404JSONResponse) VisitDeleteContac
 type DeleteContactCasesIdNotesNoteId500JSONResponse struct{ InternalErrorJSONResponse }
 
 func (response DeleteContactCasesIdNotesNoteId500JSONResponse) VisitDeleteContactCasesIdNotesNoteIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostContactCasesIdResolutionsRequestObject struct {
+	Id   openapi_types.UUID `json:"id"`
+	Body *PostContactCasesIdResolutionsJSONRequestBody
+}
+
+type PostContactCasesIdResolutionsResponseObject interface {
+	VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error
+}
+
+type PostContactCasesIdResolutions200JSONResponse ContactManagerResolution
+
+func (response PostContactCasesIdResolutions200JSONResponse) VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostContactCasesIdResolutions400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response PostContactCasesIdResolutions400JSONResponse) VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostContactCasesIdResolutions401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response PostContactCasesIdResolutions401JSONResponse) VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostContactCasesIdResolutions403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response PostContactCasesIdResolutions403JSONResponse) VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostContactCasesIdResolutions404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response PostContactCasesIdResolutions404JSONResponse) VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PostContactCasesIdResolutions500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response PostContactCasesIdResolutions500JSONResponse) VisitPostContactCasesIdResolutionsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteContactCasesIdResolutionsResolutionIdRequestObject struct {
+	Id           openapi_types.UUID `json:"id"`
+	ResolutionId openapi_types.UUID `json:"resolution_id"`
+}
+
+type DeleteContactCasesIdResolutionsResolutionIdResponseObject interface {
+	VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error
+}
+
+type DeleteContactCasesIdResolutionsResolutionId200JSONResponse map[string]interface{}
+
+func (response DeleteContactCasesIdResolutionsResolutionId200JSONResponse) VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteContactCasesIdResolutionsResolutionId400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response DeleteContactCasesIdResolutionsResolutionId400JSONResponse) VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteContactCasesIdResolutionsResolutionId401JSONResponse struct{ UnauthenticatedJSONResponse }
+
+func (response DeleteContactCasesIdResolutionsResolutionId401JSONResponse) VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteContactCasesIdResolutionsResolutionId403JSONResponse struct{ PermissionDeniedJSONResponse }
+
+func (response DeleteContactCasesIdResolutionsResolutionId403JSONResponse) VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteContactCasesIdResolutionsResolutionId404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response DeleteContactCasesIdResolutionsResolutionId404JSONResponse) VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteContactCasesIdResolutionsResolutionId500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response DeleteContactCasesIdResolutionsResolutionId500JSONResponse) VisitDeleteContactCasesIdResolutionsResolutionIdResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -42272,6 +42487,12 @@ type StrictServerInterface interface {
 	// Delete a case note
 	// (DELETE /contact_cases/{id}/notes/{note_id})
 	DeleteContactCasesIdNotesNoteId(ctx context.Context, request DeleteContactCasesIdNotesNoteIdRequestObject) (DeleteContactCasesIdNotesNoteIdResponseObject, error)
+	// Attach a case to a contact
+	// (POST /contact_cases/{id}/resolutions)
+	PostContactCasesIdResolutions(ctx context.Context, request PostContactCasesIdResolutionsRequestObject) (PostContactCasesIdResolutionsResponseObject, error)
+	// Undo a case-level contact attribution
+	// (DELETE /contact_cases/{id}/resolutions/{resolution_id})
+	DeleteContactCasesIdResolutionsResolutionId(ctx context.Context, request DeleteContactCasesIdResolutionsResolutionIdRequestObject) (DeleteContactCasesIdResolutionsResolutionIdResponseObject, error)
 	// List interactions
 	// (GET /contact_interactions)
 	GetContactInteractions(ctx context.Context, request GetContactInteractionsRequestObject) (GetContactInteractionsResponseObject, error)
@@ -47080,6 +47301,69 @@ func (sh *strictHandler) DeleteContactCasesIdNotesNoteId(ctx *gin.Context, id op
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(DeleteContactCasesIdNotesNoteIdResponseObject); ok {
 		if err := validResponse.VisitDeleteContactCasesIdNotesNoteIdResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// PostContactCasesIdResolutions operation middleware
+func (sh *strictHandler) PostContactCasesIdResolutions(ctx *gin.Context, id openapi_types.UUID) {
+	var request PostContactCasesIdResolutionsRequestObject
+
+	request.Id = id
+
+	var body PostContactCasesIdResolutionsJSONRequestBody
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
+		ctx.Error(err)
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.PostContactCasesIdResolutions(ctx, request.(PostContactCasesIdResolutionsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostContactCasesIdResolutions")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(PostContactCasesIdResolutionsResponseObject); ok {
+		if err := validResponse.VisitPostContactCasesIdResolutionsResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteContactCasesIdResolutionsResolutionId operation middleware
+func (sh *strictHandler) DeleteContactCasesIdResolutionsResolutionId(ctx *gin.Context, id openapi_types.UUID, resolutionId openapi_types.UUID) {
+	var request DeleteContactCasesIdResolutionsResolutionIdRequestObject
+
+	request.Id = id
+	request.ResolutionId = resolutionId
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteContactCasesIdResolutionsResolutionId(ctx, request.(DeleteContactCasesIdResolutionsResolutionIdRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteContactCasesIdResolutionsResolutionId")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(DeleteContactCasesIdResolutionsResolutionIdResponseObject); ok {
+		if err := validResponse.VisitDeleteContactCasesIdResolutionsResolutionIdResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {

--- a/bin-api-manager/pkg/servicehandler/case.go
+++ b/bin-api-manager/pkg/servicehandler/case.go
@@ -11,6 +11,7 @@ import (
 	"monorepo/bin-api-manager/pkg/serviceerrors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	cmkase "monorepo/bin-contact-manager/models/kase"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
 )
 
 // Note on ConvertWebhookMessage: cmkase.Case is returned directly as the
@@ -217,4 +218,78 @@ func (h *serviceHandler) CaseContinue(ctx context.Context, a *auth.AuthIdentity,
 	}
 
 	return res, nil
+}
+
+// CaseResolutionCreate attaches a case to a contact (design VOIP-1252) by
+// creating a case-level Resolution in contact-manager. resolved_by_id is
+// derived server-side from the authenticated caller's own agent identity
+// (a.AgentID()), matching CaseClose/CaseContinue's pattern -- never
+// accepted from client input, so attribution cannot be forged.
+func (h *serviceHandler) CaseResolutionCreate(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	id, contactID uuid.UUID,
+	resolutionType string,
+) (*cmresolution.Resolution, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "CaseResolutionCreate",
+		"customer_id": a.CustomerID,
+		"case_id":     id,
+	})
+
+	if a.IsDirect() {
+		return nil, serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	c, err := h.caseGet(ctx, a.CustomerID, id)
+	if err != nil {
+		log.Errorf("Could not get the case info. err: %v", err)
+		return nil, err
+	}
+
+	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	res, err := h.reqHandler.ContactV1CaseResolutionCreate(
+		ctx, a.CustomerID, id, contactID,
+		resolutionType, string(commonidentity.OwnerTypeAgent), a.AgentID(),
+	)
+	if err != nil {
+		log.Errorf("Could not create case resolution. err: %v", err)
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// CaseResolutionDelete undoes a case-level Contact attribution (design
+// VOIP-1252) by soft-deleting the Resolution row in contact-manager.
+func (h *serviceHandler) CaseResolutionDelete(ctx context.Context, a *auth.AuthIdentity, id, resolutionID uuid.UUID) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "CaseResolutionDelete",
+		"customer_id": a.CustomerID,
+		"case_id":     id,
+	})
+
+	if a.IsDirect() {
+		return serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	c, err := h.caseGet(ctx, a.CustomerID, id)
+	if err != nil {
+		log.Errorf("Could not get the case info. err: %v", err)
+		return err
+	}
+
+	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		return serviceerrors.ErrPermissionDenied
+	}
+
+	if err := h.reqHandler.ContactV1CaseResolutionDelete(ctx, a.CustomerID, id, resolutionID); err != nil {
+		log.Errorf("Could not delete case resolution. err: %v", err)
+		return err
+	}
+
+	return nil
 }

--- a/bin-api-manager/pkg/servicehandler/case_message_test.go
+++ b/bin-api-manager/pkg/servicehandler/case_message_test.go
@@ -176,8 +176,8 @@ func Test_CaseMessageSend_DestinationBindingFailure_HasContactID(t *testing.T) {
 	mockReq.EXPECT().
 		ContactV1AddressGet(ctx, contactID).
 		Return([]cmcontact.Address{
-			{Target: "+15550002222"},
-			{Target: "+15550003333"},
+			{Address: commonaddress.Address{Target: "+155****2222"}},
+			{Address: commonaddress.Address{Target: "+155****3333"}},
 		}, nil)
 
 	_, err := h.CaseMessageSend(ctx, a, caseID, "+15551234567", "+15559999999", "hello")
@@ -242,7 +242,7 @@ func Test_CaseMessageSend_AntiOracle(t *testing.T) {
 	mockReq.EXPECT().
 		ContactV1AddressGet(ctx, contactID).
 		Return([]cmcontact.Address{
-			{Target: "+15550002222"},
+			{Address: commonaddress.Address{Target: "+155****2222"}},
 		}, nil)
 	_, err2 := h.CaseMessageSend(ctx, a, caseIDHasContact, "+15551234567", "+15559999999", "hello")
 

--- a/bin-api-manager/pkg/servicehandler/case_resolution_test.go
+++ b/bin-api-manager/pkg/servicehandler/case_resolution_test.go
@@ -1,0 +1,256 @@
+package servicehandler
+
+import (
+	"context"
+	"testing"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	cmkase "monorepo/bin-contact-manager/models/kase"
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+
+	"monorepo/bin-api-manager/pkg/dbhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+)
+
+// Test_CaseResolutionCreate_DerivesResolvedByFromCaller verifies
+// CaseResolutionCreate passes the caller's own a.AgentID() (not a
+// client-suppliable value) as resolved_by_id, matching CaseClose's
+// established pattern.
+func Test_CaseResolutionCreate_DerivesResolvedByFromCaller(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	caseID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000003")
+	resolutionID := uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	ctx := context.Background()
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         agentID,
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	})
+
+	mockReq.EXPECT().
+		ContactV1CaseGet(ctx, customerID, caseID).
+		Return(&cmkase.Case{ID: caseID, CustomerID: customerID, Status: cmkase.StatusOpen}, nil)
+
+	// The key assertion: ContactV1CaseResolutionCreate must be called
+	// with the caller's OWN agentID (a.AgentID()) as resolved_by_id --
+	// gomock's exact-match EXPECT() below fails the test if the code
+	// ever accepts/forwards a different, client-suppliable agent ID.
+	mockReq.EXPECT().
+		ContactV1CaseResolutionCreate(ctx, customerID, caseID, contactID, "positive", string(commonidentity.OwnerTypeAgent), agentID).
+		Return(&cmresolution.Resolution{ID: resolutionID, CaseID: &caseID, ContactID: contactID}, nil)
+
+	res, err := h.CaseResolutionCreate(ctx, a, caseID, contactID, "positive")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Errorf("Expected result but got nil")
+	}
+}
+
+// Test_CaseResolutionCreate_CrossTenantCase verifies a cross-tenant case
+// ID is rejected (via caseGet's tenant check) before any resolution RPC
+// is issued.
+func Test_CaseResolutionCreate_CrossTenantCase(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	caseID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000003")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	ctx := context.Background()
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         agentID,
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	})
+
+	mockReq.EXPECT().
+		ContactV1CaseGet(ctx, customerID, caseID).
+		Return(nil, serviceerrors.ErrNotFound)
+
+	// No ContactV1CaseResolutionCreate EXPECT() set -- gomock fails the
+	// test if the resolution RPC is ever reached for a case that failed
+	// the tenant check.
+	_, err := h.CaseResolutionCreate(ctx, a, caseID, contactID, "positive")
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+// Test_CaseResolutionCreate_PermissionDenied verifies a non-admin/manager
+// agent is rejected.
+func Test_CaseResolutionCreate_PermissionDenied(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	caseID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000003")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	ctx := context.Background()
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         agentID,
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionNone,
+	})
+
+	mockReq.EXPECT().
+		ContactV1CaseGet(ctx, customerID, caseID).
+		Return(&cmkase.Case{ID: caseID, CustomerID: customerID, Status: cmkase.StatusOpen}, nil)
+
+	_, err := h.CaseResolutionCreate(ctx, a, caseID, contactID, "positive")
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+// Test_CaseResolutionCreate_DirectAccessDenied verifies direct-access
+// (accesskey) identities are rejected.
+func Test_CaseResolutionCreate_DirectAccessDenied(t *testing.T) {
+	caseID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	contactID := uuid.FromStringOrNil("33333333-0000-0000-0000-000000000003")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	ctx := context.Background()
+	a := auth.NewDirectIdentity(&auth.DirectScope{CustomerID: uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")})
+
+	_, err := h.CaseResolutionCreate(ctx, a, caseID, contactID, "positive")
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}
+
+// Test_CaseResolutionDelete_DerivesTenantFromCaller verifies
+// CaseResolutionDelete performs the tenant check via caseGet before
+// delegating to ContactV1CaseResolutionDelete.
+func Test_CaseResolutionDelete_DerivesTenantFromCaller(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	caseID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	resolutionID := uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	ctx := context.Background()
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         agentID,
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	})
+
+	mockReq.EXPECT().
+		ContactV1CaseGet(ctx, customerID, caseID).
+		Return(&cmkase.Case{ID: caseID, CustomerID: customerID, Status: cmkase.StatusOpen}, nil)
+
+	mockReq.EXPECT().
+		ContactV1CaseResolutionDelete(ctx, customerID, caseID, resolutionID).
+		Return(nil)
+
+	if err := h.CaseResolutionDelete(ctx, a, caseID, resolutionID); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+// Test_CaseResolutionDelete_CrossTenantCase verifies a cross-tenant case
+// ID is rejected before any delete RPC is issued.
+func Test_CaseResolutionDelete_CrossTenantCase(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	agentID := uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c")
+	caseID := uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001")
+	resolutionID := uuid.FromStringOrNil("44444444-0000-0000-0000-000000000004")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	ctx := context.Background()
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         agentID,
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	})
+
+	mockReq.EXPECT().
+		ContactV1CaseGet(ctx, customerID, caseID).
+		Return(nil, serviceerrors.ErrNotFound)
+
+	if err := h.CaseResolutionDelete(ctx, a, caseID, resolutionID); err == nil {
+		t.Errorf("Expected error but got none")
+	}
+}

--- a/bin-api-manager/pkg/servicehandler/contact_address_test.go
+++ b/bin-api-manager/pkg/servicehandler/contact_address_test.go
@@ -8,6 +8,7 @@ import (
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	cmcontact "monorepo/bin-contact-manager/models/contact"
@@ -33,8 +34,7 @@ func Test_ContactAddressCreateIndependent_Unresolved(t *testing.T) {
 		ID:         uuid.FromStringOrNil("2c9c9f0a-5066-11ec-ab34-23643cfdc1c5"),
 		CustomerID: customerID,
 		ContactID:  uuid.Nil,
-		Type:       "tel",
-		Target:     "+821100000001",
+		Address:    commonaddress.Address{Type: "tel", Target: "+821****0001"},
 	}
 
 	mc := gomock.NewController(t)

--- a/bin-api-manager/pkg/servicehandler/contact_test.go
+++ b/bin-api-manager/pkg/servicehandler/contact_test.go
@@ -7,6 +7,7 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	cmcontact "monorepo/bin-contact-manager/models/contact"
@@ -630,9 +631,8 @@ func Test_ContactAddressCreate(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****1234",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****1234"},
 					},
 				},
 			},
@@ -643,9 +643,8 @@ func Test_ContactAddressCreate(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****1234",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****1234"},
 					},
 				},
 			},
@@ -718,9 +717,8 @@ func Test_ContactAddressUpdate(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****9999",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****9999"},
 					},
 				},
 			},
@@ -731,9 +729,8 @@ func Test_ContactAddressUpdate(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****9999",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****9999"},
 					},
 				},
 			},

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -494,6 +494,8 @@ type ServiceHandler interface {
 	CaseGet(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*cmkase.Case, error)
 	CaseClose(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*cmkase.Case, error)
 	CaseContinue(ctx context.Context, a *auth.AuthIdentity, id uuid.UUID) (*cmkase.Case, error)
+	CaseResolutionCreate(ctx context.Context, a *auth.AuthIdentity, id, contactID uuid.UUID, resolutionType string) (*cmresolution.Resolution, error)
+	CaseResolutionDelete(ctx context.Context, a *auth.AuthIdentity, id, resolutionID uuid.UUID) error
 
 	// case note handlers
 	CaseNoteList(ctx context.Context, a *auth.AuthIdentity, caseID uuid.UUID) ([]*cmcasenote.CaseNote, error)

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -1843,6 +1843,35 @@ func (mr *MockServiceHandlerMockRecorder) CaseNoteList(ctx, a, caseID any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseNoteList", reflect.TypeOf((*MockServiceHandler)(nil).CaseNoteList), ctx, a, caseID)
 }
 
+// CaseResolutionCreate mocks base method.
+func (m *MockServiceHandler) CaseResolutionCreate(ctx context.Context, a *auth.AuthIdentity, id, contactID uuid.UUID, resolutionType string) (*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaseResolutionCreate", ctx, a, id, contactID, resolutionType)
+	ret0, _ := ret[0].(*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaseResolutionCreate indicates an expected call of CaseResolutionCreate.
+func (mr *MockServiceHandlerMockRecorder) CaseResolutionCreate(ctx, a, id, contactID, resolutionType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseResolutionCreate", reflect.TypeOf((*MockServiceHandler)(nil).CaseResolutionCreate), ctx, a, id, contactID, resolutionType)
+}
+
+// CaseResolutionDelete mocks base method.
+func (m *MockServiceHandler) CaseResolutionDelete(ctx context.Context, a *auth.AuthIdentity, id, resolutionID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaseResolutionDelete", ctx, a, id, resolutionID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CaseResolutionDelete indicates an expected call of CaseResolutionDelete.
+func (mr *MockServiceHandlerMockRecorder) CaseResolutionDelete(ctx, a, id, resolutionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaseResolutionDelete", reflect.TypeOf((*MockServiceHandler)(nil).CaseResolutionDelete), ctx, a, id, resolutionID)
+}
+
 // ConferenceCreate mocks base method.
 func (m *MockServiceHandler) ConferenceCreate(ctx context.Context, a *auth.AuthIdentity, conferenceID uuid.UUID, confType conference.Type, name, detail string, data map[string]any, timeout int, preFlowID, postFlowID uuid.UUID) (*conference.WebhookMessage, error) {
 	m.ctrl.T.Helper()

--- a/bin-api-manager/pkg/servicehandler/serviceagent_contact_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_contact_test.go
@@ -8,6 +8,7 @@ import (
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/dbhandler"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	cmcontact "monorepo/bin-contact-manager/models/contact"
@@ -661,9 +662,8 @@ func Test_ServiceAgentContactAddressCreate(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****1234",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****1234"},
 					},
 				},
 			},
@@ -674,9 +674,8 @@ func Test_ServiceAgentContactAddressCreate(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****1234",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****1234"},
 					},
 				},
 			},

--- a/bin-api-manager/server/contact_addresses_test.go
+++ b/bin-api-manager/server/contact_addresses_test.go
@@ -14,8 +14,9 @@ import (
 	openapi_server "monorepo/bin-api-manager/gens/openapi_server"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/servicehandler"
-	cmcontact "monorepo/bin-contact-manager/models/contact"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	cmcontact "monorepo/bin-contact-manager/models/contact"
 )
 
 func Test_PutContactAddressesId(t *testing.T) {
@@ -49,13 +50,12 @@ func Test_PutContactAddressesId(t *testing.T) {
 			responseAddress: &cmcontact.Address{
 				ID:        uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
 				ContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
-				Type:      "tel",
-				Target:    "+121****9999",
+				Address:   commonaddress.Address{Type: "tel", Target: "+121****9999"},
 			},
 
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
 			expectFields:    map[string]any{"target": "+121****9999"},
-			expectRes:       `{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"3147612c-5066-11ec-ab34-23643cfdc1c5","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}`,
+			expectRes:       `{"type":"tel","target":"+121****9999","id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"3147612c-5066-11ec-ab34-23643cfdc1c5","is_primary":false,"tm_create":null}`,
 		},
 		{
 			name: "update name and detail",
@@ -73,15 +73,12 @@ func Test_PutContactAddressesId(t *testing.T) {
 			responseAddress: &cmcontact.Address{
 				ID:        uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
 				ContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
-				Type:      "tel",
-				Target:    "+121****9999",
-				Name:      "Main Office",
-				Detail:    "Primary contact number",
+				Address:   commonaddress.Address{Type: "tel", Target: "+121****9999", Name: "Main Office", Detail: "Primary contact number"},
 			},
 
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
 			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
-			expectRes:       `{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"3147612c-5066-11ec-ab34-23643cfdc1c5","type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","is_primary":false,"tm_create":null}`,
+			expectRes:       `{"type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"3147612c-5066-11ec-ab34-23643cfdc1c5","is_primary":false,"tm_create":null}`,
 		},
 	}
 

--- a/bin-api-manager/server/contact_case_resolutions.go
+++ b/bin-api-manager/server/contact_case_resolutions.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-api-manager/gens/openapi_server"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// PostContactCasesIdResolutions handles POST /contact_cases/{id}/resolutions
+// (VOIP-1252): attaches a case to a contact.
+func (h *server) PostContactCasesIdResolutions(c *gin.Context, id openapi_types.UUID) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "PostContactCasesIdResolutions",
+		"request_address": c.ClientIP(),
+		"id":              id,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	var req openapi_server.PostContactCasesIdResolutionsJSONRequestBody
+	if err := c.BindJSON(&req); err != nil {
+		log.Errorf("Could not parse the request. err: %v", err)
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_JSON_BODY", "The request body is not valid JSON.").Wrap(err))
+		return
+	}
+
+	caseID := uuid.UUID(id)
+	contactID := uuid.UUID(req.ContactId)
+
+	res, err := h.serviceHandler.CaseResolutionCreate(c.Request.Context(), a, caseID, contactID, string(req.ResolutionType))
+	if err != nil {
+		log.Errorf("Could not create case resolution. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, res)
+}
+
+// DeleteContactCasesIdResolutionsResolutionId handles
+// DELETE /contact_cases/{id}/resolutions/{resolution_id} (VOIP-1252): undoes
+// a case-level Contact attribution.
+func (h *server) DeleteContactCasesIdResolutionsResolutionId(c *gin.Context, id openapi_types.UUID, resolutionId openapi_types.UUID) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":            "DeleteContactCasesIdResolutionsResolutionId",
+		"request_address": c.ClientIP(),
+		"id":              id,
+		"resolution_id":   resolutionId,
+	})
+
+	a, ok := getAuthIdentity(c)
+	if !ok {
+		log.Errorf("Could not find auth identity.")
+		abortWithError(c, cerrors.Unauthenticated(commonoutline.ServiceNameAPIManager, "AUTHENTICATION_REQUIRED", "Authentication is required."))
+		return
+	}
+	log = log.WithField("customer_id", a.CustomerID)
+
+	caseID := uuid.UUID(id)
+	resolutionID := uuid.UUID(resolutionId)
+
+	if err := h.serviceHandler.CaseResolutionDelete(c.Request.Context(), a, caseID, resolutionID); err != nil {
+		log.Errorf("Could not delete case resolution. err: %v", err)
+		abortWithServiceError(c, err)
+		return
+	}
+
+	c.JSON(200, gin.H{})
+}

--- a/bin-api-manager/server/contacts_test.go
+++ b/bin-api-manager/server/contacts_test.go
@@ -11,6 +11,7 @@ import (
 	"monorepo/bin-api-manager/lib/middleware"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/servicehandler"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	cmcontact "monorepo/bin-contact-manager/models/contact"
@@ -505,9 +506,8 @@ func Test_PostContactsIdAddresses(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****1234",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****1234"},
 					},
 				},
 			},
@@ -516,7 +516,7 @@ func Test_PostContactsIdAddresses(t *testing.T) {
 			expectAddrType:  "tel",
 			expectTarget:    "+121****1234",
 			expectIsPrimary: false,
-			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****1234","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"type":"tel","target":"+121****1234","id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 
@@ -590,9 +590,8 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****9999",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****9999"},
 					},
 				},
 			},
@@ -600,7 +599,7 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 			expectContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
 			expectFields:    map[string]any{"target": "+121****9999"},
-			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"type":"tel","target":"+121****9999","id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 		{
 			name: "update name and detail",
@@ -621,11 +620,8 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 				},
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
-						Type:   "tel",
-						Target: "+121****9999",
-						Name:   "Main Office",
-						Detail: "Primary contact number",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****9999", Name: "Main Office", Detail: "Primary contact number"},
 					},
 				},
 			},
@@ -633,7 +629,7 @@ func Test_PutContactsIdAddressesAddressId(t *testing.T) {
 			expectContactID: uuid.FromStringOrNil("3147612c-5066-11ec-ab34-23643cfdc1c5"),
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-5066-11ec-ab34-23643cfdc1c5"),
 			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
-			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"3147612c-5066-11ec-ab34-23643cfdc1c5","customer_id":"5f621078-8e5f-11ee-97b2-cfe7337b701c","first_name":"","last_name":"","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","id":"a1b2c3d4-5066-11ec-ab34-23643cfdc1c5","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","is_primary":false,"tm_create":null}],"tm_create":null,"tm_update":null,"tm_delete":null}`,
 		},
 	}
 

--- a/bin-api-manager/server/service_agents_contact_addresses_test.go
+++ b/bin-api-manager/server/service_agents_contact_addresses_test.go
@@ -14,8 +14,9 @@ import (
 	openapi_server "monorepo/bin-api-manager/gens/openapi_server"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/servicehandler"
-	cmcontact "monorepo/bin-contact-manager/models/contact"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	cmcontact "monorepo/bin-contact-manager/models/contact"
 )
 
 func Test_PutServiceAgentsContactAddressesId(t *testing.T) {
@@ -49,13 +50,12 @@ func Test_PutServiceAgentsContactAddressesId(t *testing.T) {
 			responseAddress: &cmcontact.Address{
 				ID:        uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
 				ContactID: uuid.FromStringOrNil("c07ff34e-500d-11ec-8393-2bc7870b7eff"),
-				Type:      "tel",
-				Target:    "+121****9999",
+				Address:   commonaddress.Address{Type: "tel", Target: "+121****9999"},
 			},
 
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
 			expectFields:    map[string]any{"target": "+121****9999"},
-			expectRes:       `{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","type":"tel","target":"+121****9999","name":"","detail":"","is_primary":false,"tm_create":null}`,
+			expectRes:       `{"type":"tel","target":"+121****9999","id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","is_primary":false,"tm_create":null}`,
 		},
 		{
 			name: "update name and detail",
@@ -73,15 +73,12 @@ func Test_PutServiceAgentsContactAddressesId(t *testing.T) {
 			responseAddress: &cmcontact.Address{
 				ID:        uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
 				ContactID: uuid.FromStringOrNil("c07ff34e-500d-11ec-8393-2bc7870b7eff"),
-				Type:      "tel",
-				Target:    "+121****9999",
-				Name:      "Main Office",
-				Detail:    "Primary contact number",
+				Address:   commonaddress.Address{Type: "tel", Target: "+121****9999", Name: "Main Office", Detail: "Primary contact number"},
 			},
 
 			expectAddressID: uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
 			expectFields:    map[string]any{"name": "Main Office", "detail": "Primary contact number"},
-			expectRes:       `{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","is_primary":false,"tm_create":null}`,
+			expectRes:       `{"type":"tel","target":"+121****9999","name":"Main Office","detail":"Primary contact number","id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","is_primary":false,"tm_create":null}`,
 		},
 	}
 

--- a/bin-api-manager/server/service_agents_contacts_test.go
+++ b/bin-api-manager/server/service_agents_contacts_test.go
@@ -11,6 +11,7 @@ import (
 	"monorepo/bin-api-manager/lib/middleware"
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/servicehandler"
+	commonaddress "monorepo/bin-common-handler/models/address"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	cmcontact "monorepo/bin-contact-manager/models/contact"
@@ -639,9 +640,8 @@ func Test_PostServiceAgentsContactsIdAddresses(t *testing.T) {
 				LastName:  "Doe",
 				Addresses: []cmcontact.Address{
 					{
-						ID:     uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
-						Type:   "tel",
-						Target: "+121****1234",
+						ID:      uuid.FromStringOrNil("a1b2c3d4-0001-11ec-0001-000000000001"),
+						Address: commonaddress.Address{Type: "tel", Target: "+121****1234"},
 					},
 				},
 				TMCreate: timePtr("2020-09-20T03:23:21.995Z"),
@@ -651,7 +651,7 @@ func Test_PostServiceAgentsContactsIdAddresses(t *testing.T) {
 			expectAddrType:  "tel",
 			expectTarget:    "+121****1234",
 			expectIsPrimary: false,
-			expectRes:       `{"id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","customer_id":"5f621078-8004-11ec-aea5-d3a320e3b3c0","first_name":"John","last_name":"Doe","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","type":"tel","target":"+121****1234","name":"","detail":"","is_primary":false,"tm_create":null}],"tm_create":"2020-09-20T03:23:21.995Z","tm_update":null,"tm_delete":null}`,
+			expectRes:       `{"id":"c07ff34e-500d-11ec-8393-2bc7870b7eff","customer_id":"5f621078-8004-11ec-aea5-d3a320e3b3c0","first_name":"John","last_name":"Doe","display_name":"","company":"","job_title":"","source":"","external_id":"","notes":"","addresses":[{"type":"tel","target":"+121****1234","id":"a1b2c3d4-0001-11ec-0001-000000000001","customer_id":"00000000-0000-0000-0000-000000000000","contact_id":"00000000-0000-0000-0000-000000000000","is_primary":false,"tm_create":null}],"tm_create":"2020-09-20T03:23:21.995Z","tm_update":null,"tm_delete":null}`,
 		},
 	}
 

--- a/bin-common-handler/pkg/requesthandler/contact_case_resolutions.go
+++ b/bin-common-handler/pkg/requesthandler/contact_case_resolutions.go
@@ -1,0 +1,66 @@
+package requesthandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gofrs/uuid"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+	cmrequest "monorepo/bin-contact-manager/pkg/listenhandler/models/request"
+)
+
+// ContactV1CaseResolutionCreate attaches a case to a contact by creating
+// a case-level Resolution in contact-manager (VOIP-1252).
+func (r *requestHandler) ContactV1CaseResolutionCreate(
+	ctx context.Context,
+	customerID, caseID, contactID uuid.UUID,
+	resolutionType, resolvedByType string,
+	resolvedByID uuid.UUID,
+) (*cmresolution.Resolution, error) {
+	uri := fmt.Sprintf("/v1/cases/%s/resolutions", caseID)
+
+	data := &cmrequest.V1DataCasesIDResolutionsPost{
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		ResolutionType: resolutionType,
+		ResolvedByType: resolvedByType,
+		ResolvedByID:   resolvedByID,
+	}
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodPost, "contact/cases/<id>/resolutions", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cmresolution.Resolution
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+
+	return &res, nil
+}
+
+// ContactV1CaseResolutionDelete undoes a case-level Contact attribution
+// (VOIP-1252) by soft-deleting the Resolution row in contact-manager.
+func (r *requestHandler) ContactV1CaseResolutionDelete(ctx context.Context, customerID, caseID, resolutionID uuid.UUID) error {
+	uri := fmt.Sprintf("/v1/cases/%s/resolutions/%s", caseID, resolutionID)
+
+	data := &cmrequest.V1DataCasesIDResolutionsIDDelete{CustomerID: customerID}
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.sendRequestContact(ctx, uri, sock.RequestMethodDelete, "contact/cases/<id>/resolutions/<resolution-id>", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	return err
+}

--- a/bin-common-handler/pkg/requesthandler/contact_case_resolutions_test.go
+++ b/bin-common-handler/pkg/requesthandler/contact_case_resolutions_test.go
@@ -1,0 +1,134 @@
+package requesthandler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	cmresolution "monorepo/bin-contact-manager/models/resolution"
+)
+
+func Test_ContactV1CaseResolutionCreate(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		customerID     uuid.UUID
+		caseID         uuid.UUID
+		contactID      uuid.UUID
+		resolutionType string
+		resolvedByType string
+		resolvedByID   uuid.UUID
+
+		expectTarget  string
+		expectRequest *sock.Request
+		response      *sock.Response
+
+		expectRes *cmresolution.Resolution
+	}{
+		{
+			name: "normal",
+
+			customerID:     uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f3"),
+			caseID:         uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+			contactID:      uuid.FromStringOrNil("6623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+			resolutionType: "positive",
+			resolvedByType: "agent",
+			resolvedByID:   uuid.FromStringOrNil("7623e25e-2c74-11ee-87a6-bfa8ae34077f"),
+
+			expectTarget: "bin-manager.contact-manager.request",
+			expectRequest: &sock.Request{
+				URI:      "/v1/cases/5623e25e-2c74-11ee-87a6-bfa8ae34077f/resolutions",
+				Method:   sock.RequestMethodPost,
+				DataType: ContentTypeJSON,
+				Data: []byte(
+					`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f3","contact_id":"6623e25e-2c74-11ee-87a6-bfa8ae34077f","resolution_type":"positive","resolved_by_type":"agent","resolved_by_id":"7623e25e-2c74-11ee-87a6-bfa8ae34077f"}`,
+				),
+			},
+			response: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"id":"8fe6c136-2c75-11ee-a3a4-37400837e12e"}`),
+			},
+			expectRes: &cmresolution.Resolution{
+				ID: uuid.FromStringOrNil("8fe6c136-2c75-11ee-a3a4-37400837e12e"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			reqHandler := requestHandler{
+				sock: mockSock,
+			}
+
+			ctx := context.Background()
+			mockSock.EXPECT().RequestPublish(gomock.Any(), tt.expectTarget, tt.expectRequest).Return(tt.response, nil)
+
+			res, err := reqHandler.ContactV1CaseResolutionCreate(ctx, tt.customerID, tt.caseID, tt.contactID, tt.resolutionType, tt.resolvedByType, tt.resolvedByID)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(tt.expectRes, res) == false {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_ContactV1CaseResolutionCreate_Error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	reqHandler := requestHandler{sock: mockSock}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f4")
+	caseID := uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae340780")
+	contactID := uuid.FromStringOrNil("6623e25e-2c74-11ee-87a6-bfa8ae340781")
+	agentID := uuid.FromStringOrNil("7623e25e-2c74-11ee-87a6-bfa8ae340782")
+
+	mockSock.EXPECT().RequestPublish(gomock.Any(), "bin-manager.contact-manager.request", gomock.Any()).Return(&sock.Response{StatusCode: 404}, nil)
+
+	res, err := reqHandler.ContactV1CaseResolutionCreate(ctx, customerID, caseID, contactID, "positive", "agent", agentID)
+	if err == nil {
+		t.Errorf("Wrong match. expect: error, got: %v", res)
+	}
+}
+
+func Test_ContactV1CaseResolutionDelete(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	reqHandler := requestHandler{sock: mockSock}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("55ecfc4e-2c74-11ee-98fb-0762519529f5")
+	caseID := uuid.FromStringOrNil("5623e25e-2c74-11ee-87a6-bfa8ae340783")
+	resolutionID := uuid.FromStringOrNil("6623e25e-2c74-11ee-87a6-bfa8ae340784")
+
+	expectRequest := &sock.Request{
+		URI:      "/v1/cases/5623e25e-2c74-11ee-87a6-bfa8ae340783/resolutions/6623e25e-2c74-11ee-87a6-bfa8ae340784",
+		Method:   sock.RequestMethodDelete,
+		DataType: ContentTypeJSON,
+		Data:     []byte(`{"customer_id":"55ecfc4e-2c74-11ee-98fb-0762519529f5"}`),
+	}
+	mockSock.EXPECT().RequestPublish(gomock.Any(), "bin-manager.contact-manager.request", expectRequest).Return(&sock.Response{StatusCode: 200}, nil)
+
+	if err := reqHandler.ContactV1CaseResolutionDelete(ctx, customerID, caseID, resolutionID); err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+}

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -937,6 +937,8 @@ type RequestHandler interface {
 	ContactV1CaseTagList(ctx context.Context, customerID, caseID uuid.UUID) ([]uuid.UUID, error)
 	ContactV1CaseTagAdd(ctx context.Context, customerID, caseID, tagID uuid.UUID) error
 	ContactV1CaseTagRemove(ctx context.Context, customerID, caseID, tagID uuid.UUID) error
+	ContactV1CaseResolutionCreate(ctx context.Context, customerID, caseID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*cmresolution.Resolution, error)
+	ContactV1CaseResolutionDelete(ctx context.Context, customerID, caseID, resolutionID uuid.UUID) error
 
 	// direct-manager directs
 	DirectV1DirectCreate(ctx context.Context, customerID uuid.UUID, resourceType string, resourceID uuid.UUID) (*dmdirect.Direct, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -3611,6 +3611,35 @@ func (mr *MockRequestHandlerMockRecorder) ContactV1CaseNoteList(ctx, customerID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseNoteList", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseNoteList), ctx, customerID, caseID)
 }
 
+// ContactV1CaseResolutionCreate mocks base method.
+func (m *MockRequestHandler) ContactV1CaseResolutionCreate(ctx context.Context, customerID, caseID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1CaseResolutionCreate", ctx, customerID, caseID, contactID, resolutionType, resolvedByType, resolvedByID)
+	ret0, _ := ret[0].(*resolution.Resolution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContactV1CaseResolutionCreate indicates an expected call of ContactV1CaseResolutionCreate.
+func (mr *MockRequestHandlerMockRecorder) ContactV1CaseResolutionCreate(ctx, customerID, caseID, contactID, resolutionType, resolvedByType, resolvedByID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseResolutionCreate", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseResolutionCreate), ctx, customerID, caseID, contactID, resolutionType, resolvedByType, resolvedByID)
+}
+
+// ContactV1CaseResolutionDelete mocks base method.
+func (m *MockRequestHandler) ContactV1CaseResolutionDelete(ctx context.Context, customerID, caseID, resolutionID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContactV1CaseResolutionDelete", ctx, customerID, caseID, resolutionID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ContactV1CaseResolutionDelete indicates an expected call of ContactV1CaseResolutionDelete.
+func (mr *MockRequestHandlerMockRecorder) ContactV1CaseResolutionDelete(ctx, customerID, caseID, resolutionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContactV1CaseResolutionDelete", reflect.TypeOf((*MockRequestHandler)(nil).ContactV1CaseResolutionDelete), ctx, customerID, caseID, resolutionID)
+}
+
 // ContactV1CaseTagAdd mocks base method.
 func (m *MockRequestHandler) ContactV1CaseTagAdd(ctx context.Context, customerID, caseID, tagID uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
+++ b/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
@@ -8,6 +8,13 @@ Status: Draft, awaiting independent review
 
 ## Changelog
 
+- v0.2 (2026-07-12). Round 1 independent review found a genuine cross-tenant
+  security gap in the underlying domain function (contactID ownership was
+  never validated) -- added Section 4.2b domain-layer fix, updated Section 7
+  to retract the "no changes to ResolutionCreateCaseLevel" claim, updated
+  Section 6 test plan with the new coverage row, resolved Section 8 open
+  question 3 (schema needs a case_id field), and added Section 4.3b
+  documenting the resolved_by_id trust-boundary invariant.
 - v0.1 (2026-07-12). Initial draft.
 
 ## 1. Problem recap
@@ -139,6 +146,54 @@ Register both routes in the listenhandler's route table (wherever
 `processV1CasesIDNotesPost`/`processV1CasesIDNotesIDDelete` are registered --
 same file, same pattern).
 
+### 4.2b Domain-layer fix (REQUIRED, found in Round 1 review)
+
+Round 1 independent review found that `ResolutionCreateCaseLevel`
+(`bin-contact-manager/pkg/casehandler/contact_attribution.go:73-119`) validates
+Case tenant ownership via `verifyCaseOwnership`, but never validates that
+`contactID` belongs to the same `customerID`. Compare the sibling
+interaction-level path, `contacthandler.ResolutionCreate`
+(`bin-contact-manager/pkg/contacthandler/resolution.go:67-76`), which
+explicitly does this via `h.db.ContactGet(ctx, contactID)` +
+`ct.CustomerID != customerID` -> `NotFound`. Without an equivalent check, an
+authenticated agent of tenant A could attach tenant A's Case to an arbitrary
+Contact UUID belonging to tenant B -- a cross-tenant data-linkage exploit,
+and the resulting Resolution/response would leak tenant B's `contact_id`
+back to tenant A's agent.
+
+**This is now in scope for this ticket** (not a separate follow-up): add a
+contact-ownership check inside `ResolutionCreateCaseLevel`, mirroring
+`contacthandler.ResolutionCreate`'s step 2 exactly, BEFORE the transaction
+begins:
+
+```go
+func (h *caseHandler) ResolutionCreateCaseLevel(ctx context.Context, customerID, caseID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
+	if err := verifyCaseOwnership(ctx, h.db, customerID, caseID); err != nil {
+		return nil, err
+	}
+
+	// NEW: verify the target contact exists and belongs to this customer
+	// (mirrors contacthandler.ResolutionCreate's interaction-level check --
+	// see resolution.go:67-76 -- closing the gap Round 1 review found).
+	ct, err := h.db.ContactGet(ctx, contactID)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "The contact was not found.").Wrap(err)
+		}
+		return nil, fmt.Errorf("could not get contact. ResolutionCreateCaseLevel. err: %v", err)
+	}
+	if ct.CustomerID != customerID {
+		return nil, cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "The contact was not found.")
+	}
+
+	// ... existing BeginTx / insert Resolution / deriveCaseContactIDTx / commit
+}
+```
+
+`ResolutionDeleteCaseLevel` does not need this check -- it only takes an
+existing Resolution's own id plus the caseID (already tenant-verified via
+`verifyCaseOwnership`); it never accepts a caller-supplied `contactID`.
+
 ### 4.3 bin-contact-manager: request models
 
 New file `bin-contact-manager/pkg/listenhandler/models/request/v1_case_resolutions.go`:
@@ -170,6 +225,22 @@ Note: unlike `V1DataCasesIDNotesPost` (which allows an optional/system
 "system-initiated" attach path in this design, only agent/admin action. If a
 future automated-attribution path is added, this can loosen the same way
 Notes did.
+
+### 4.3b Trust boundary for resolved_by_type/resolved_by_id (documented per Round 1 review)
+
+`ResolvedByType`/`ResolvedByID` are client-settable JSON fields on
+`V1DataCasesIDResolutionsPost`, and the listenhandler (Section 4.2) forwards
+them to `ResolutionCreateCaseLevel` with no independent validation at the
+contact-manager transport layer. This is safe ONLY because
+`bin-api-manager`'s servicehandler (Section 4.5) is the sole caller and
+always derives these fields server-side from `a.AgentID()`, never from
+client input -- exactly matching the existing, unguarded precedent in
+`CaseClose`'s `V1DataCasesIDClose.ClosedByID`. bin-contact-manager's
+listenhandler/RPC surface implicitly trusts bin-api-manager as the only
+caller of this internal RPC; this invariant is not new to this design (it's
+inherited from the whole `ContactV1Case*` RPC family) but is worth stating
+explicitly here since it directly protects the attribution audit trail's
+integrity.
 
 ### 4.4 bin-common-handler: requesthandler RPC client
 
@@ -313,21 +384,44 @@ Registered in `openapi.yaml` under:
 ```
 
 Request schema `ContactManagerCaseResolutionCreate`: `contact_id` (uuid,
-required), `resolution_type` (enum: positive, negative, required). Response
-schema reuses/extends the existing Resolution webhook schema (verify whether
-`ContactManagerResolution` already exists as a schema from the
-interaction-level `POST /v1/interactions/{id}/resolutions` endpoint -- if so,
-reuse it; `resolution.Resolution` carries no internal-only fields requiring
-a separate webhook type, same rationale as `case.go`'s existing
-`ConvertWebhookMessage` note for Case).
+required), `resolution_type` (enum: positive, negative, required).
+
+**Response schema decision (resolved in v0.2, was Section 8 open question
+3):** `ContactManagerResolution` already exists
+(`bin-openapi-manager/openapi/openapi.yaml:3382-3439`, confirmed by Round 1
+review) but only has `interaction_id`, not `case_id` (fields:
+`id`, `customer_id`, `contact_id`, `interaction_id`, `resolution_type`,
+`resolved_by_type`, `resolved_by_id`, `tm_*`). Reusing it as-is would
+silently drop `case_id` from every case-level resolution response. Decision:
+**extend `ContactManagerResolution` with an optional `case_id` (uuid,
+nullable) field** rather than defining a separate schema -- the Go
+`resolution.Resolution` struct already carries both `InteractionID
+*uuid.UUID` and `CaseID *uuid.UUID` as mutually-exclusive nullable fields
+(see `models/resolution/resolution.go:19-31`), so extending the single
+schema mirrors the Go struct shape exactly and avoids a parallel duplicate
+schema for what is the same underlying row shape at both call sites.
+
+### 4.6b Verified negative-resolution no-op (Round 1 review)
+
+Round 1 review confirmed `firstCaseLevelPositiveContactID`
+(`contact_attribution.go:45-53`) only matches
+`r.ResolutionType == resolution.ResolutionTypePositive`, so submitting a
+negative resolution for a Case with no prior positive resolution correctly
+derives `nil` from `deriveCaseContactID`, and `applyDerivedContactID`
+(`contact_attribution.go:59-64`) calls `CaseClearContactIDTx`, a safe no-op
+when `contact_id` is already NULL. No design change needed; retained here
+as a confirmed-safe citation for the test plan below.
 
 ## 5. Integration plan
 
-1. `bin-contact-manager`: add request models, listenhandler handlers + route
-   registration, mock regeneration (`go generate ./pkg/listenhandler/...`).
+1. `bin-contact-manager`: apply the Section 4.2b domain-layer fix to
+   `ResolutionCreateCaseLevel` FIRST (contact-ownership check), then add
+   request models, listenhandler handlers + route registration, mock
+   regeneration (`go generate ./pkg/listenhandler/...`).
 2. `bin-common-handler`: add requesthandler methods + interface entries,
    mock regeneration.
-3. `bin-openapi-manager`: add path files + schema, `go generate ./...`.
+3. `bin-openapi-manager`: add path files + extend `ContactManagerResolution`
+   with `case_id` (Section 4.6), `go generate ./...`.
 4. `bin-api-manager`: add servicehandler methods + interface + mock, add
    `server/` HTTP handlers wired to the new OpenAPI-generated route
    signatures, `go generate ./...` then `go build ./...`.
@@ -342,26 +436,27 @@ a separate webhook type, same rationale as `case.go`'s existing
 
 | Layer | New test file | Cases covered |
 |---|---|---|
-| bin-contact-manager listenhandler | `v1_case_resolutions_test.go` | 200 success (create/delete), 400 missing customer_id/contact_id, cross-tenant case_id -> propagated NotFound/error, malformed JSON body |
-| bin-contact-manager casehandler | already covered by existing `contact_attribution_write_test.go` -- no new domain-layer tests needed, this ticket only adds a transport wrapper |
+| bin-contact-manager casehandler | `contact_attribution_test.go` additions | **NEW (Round 1 finding): contact_id belongs to a different tenant -> rejected with CONTACT_NOT_FOUND, verified before any Resolution row is inserted or transaction begins**; contact_id does not exist -> CONTACT_NOT_FOUND; existing Test_ResolutionCreateCaseLevel_DerivesContactID coverage unaffected |
+| bin-contact-manager listenhandler | `v1_case_resolutions_test.go` | 200 success (create/delete), 400 missing customer_id/contact_id, cross-tenant case_id -> propagated NotFound/error, cross-tenant contact_id -> propagated NotFound/error (new), malformed JSON body |
 | bin-common-handler requesthandler | `contact_case_resolutions_test.go` | URI construction, success parse, error propagation -- mirrors `Test_ContactV1CaseClose` shape |
 | bin-api-manager servicehandler | `case_test.go` additions | permission denied (non-admin/manager), direct-access rejected, cross-tenant case_id rejected before contact_id is even used, success path asserts `resolved_by_id` is taken from `a.AgentID()` not client input |
 | bin-api-manager server | `case_resolutions_test.go` | HTTP-level request parsing, status code mapping |
 
 ## 7. Risks & tradeoffs
 
-- **Blast radius: small.** No changes to `ResolutionCreateCaseLevel`,
-  `ResolutionDeleteCaseLevel`, or `deriveCaseContactID` -- this is pure
-  transport wiring on top of an already-reviewed, already-tested domain
-  function (contact_attribution_write_test.go). Risk is concentrated in the
-  new listenhandler/servicehandler auth wiring, not in write correctness.
-- **resolution_type=negative use case.** A case-level negative resolution
-  suppresses a positive one for the same (case_id, contact_id) per set-MINUS
-  semantics (see `resolution.go` doc comment) -- this endpoint technically
-  allows an agent to submit a negative resolution for a Case that was never
-  positively attached in the first place, which is a harmless no-op (derives
-  to the same nil contact_id) but worth a unit test to confirm it doesn't
-  error.
+- **Blast radius: MODERATE, revised in v0.2 (was "small" in v0.1).** Round 1
+  independent review found that `ResolutionCreateCaseLevel` requires an
+  actual domain-layer code change (Section 4.2b, the missing contact-tenant
+  check) -- this is NOT pure transport wiring on top of an
+  already-correct function; it's a genuine fix to a previously-undetected
+  cross-tenant gap in existing (already-merged, already-unit-tested) code.
+  `ResolutionDeleteCaseLevel` and `deriveCaseContactID` remain unchanged.
+  Risk is now concentrated in: (a) getting the new contact-ownership check
+  correct without introducing a regression in the existing
+  `Test_ResolutionCreateCaseLevel_DerivesContactID` test, and (b) the new
+  listenhandler/servicehandler auth wiring.
+- **resolution_type=negative use case.** Verified safe as a no-op -- see
+  Section 4.6b.
 - **No GET added.** An agent cannot currently list a Case's resolution
   history via this API surface. Deferred to Section 8 as an open question
   rather than silently included, to keep this ticket's scope matching what
@@ -376,12 +471,15 @@ a separate webhook type, same rationale as `case.go`'s existing
 2. Should the square-admin UI work (a button/flow to search-and-attach a
    Contact from an unresolved Case) be filed as a linked follow-up ticket now,
    or wait until this API ships?
-3. Confirm whether `ContactManagerResolution` already exists as an OpenAPI
-   schema (from the interaction-level resolutions endpoint) to reuse, or
-   whether a new schema needs defining -- flagged for verification during
-   implementation, not blocking design lock-in.
+
+(Former open question 3 -- whether `ContactManagerResolution` already exists
+-- is resolved in Section 4.6: it exists and will be extended with
+`case_id`.)
 
 ## 9. Next steps
 
 Independent subagent review loop (minimum 3 rounds) on this design doc before
 implementation starts, per `voipbin-backend-feature-design` skill policy.
+Round 1 (2026-07-12): CHANGES REQUESTED -- found the cross-tenant contact
+gap (Section 4.2b) and the schema gap (Section 4.6), both now addressed in
+this v0.2. Proceeding to Round 2.

--- a/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
+++ b/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
@@ -1,12 +1,26 @@
-# VOIP-1252 -- Case-Level Manual Contact Attribution API (Design v0.3)
+# VOIP-1252 -- Case-Level Manual Contact Attribution API (Design v0.4)
 
 Repo: voipbin/monorepo
 Ticket: VOIP-1252
 Author: Hermes (CPO) on behalf of pchero (CEO/CTO)
 Date: 2026-07-12
-Status: Draft, awaiting independent review
+Status: APPROVED (Round 3, 2026-07-12) -- ready for implementation
 
 ## Changelog
+
+- v0.4 (2026-07-12). Round 3 independent review APPROVED the design.
+  Confirmed both Round 1 and Round 2 fixes are correct and complete
+  (verified against real source: the two modified tests use distinct
+  contactID/customerID literals so two separate Contact fixtures are
+  genuinely required, matching Section 5's plural phrasing; the four new
+  imports match `contact_attribution.go`'s real current import block; the
+  OpenAPI field-convention fix has no leftover `nullable` language). Applied
+  Round 3's two SHOULD-FIX citation-precision nits: corrected Section 4.2b's
+  citation range to `resolution.go:67-85` (was 67-76, missing the ownership
+  comparison half), and reworded Section 4.4's framing away from
+  "`ContactV1CaseClose`'s exact shape" (which wraps in `CloseResult`) toward
+  the correct bare-struct-decode precedent this design's response actually
+  matches.
 
 - v0.3 (2026-07-12). Round 2 independent review found that Section 4.2b's
   fix, applied as originally written, breaks two existing, currently-passing
@@ -167,13 +181,13 @@ Round 1 independent review found that `ResolutionCreateCaseLevel`
 Case tenant ownership via `verifyCaseOwnership`, but never validates that
 `contactID` belongs to the same `customerID`. Compare the sibling
 interaction-level path, `contacthandler.ResolutionCreate`
-(`bin-contact-manager/pkg/contacthandler/resolution.go:67-76`), which
-explicitly does this via `h.db.ContactGet(ctx, contactID)` +
-`ct.CustomerID != customerID` -> `NotFound`. Without an equivalent check, an
-authenticated agent of tenant A could attach tenant A's Case to an arbitrary
-Contact UUID belonging to tenant B -- a cross-tenant data-linkage exploit,
-and the resulting Resolution/response would leak tenant B's `contact_id`
-back to tenant A's agent.
+(`bin-contact-manager/pkg/contacthandler/resolution.go:67-85`), which
+explicitly does this via `h.db.ContactGet(ctx, contactID)` (lines 67-77) +
+`ct.CustomerID != customerID` -> `NotFound` (lines 79-85). Without an
+equivalent check, an authenticated agent of tenant A could attach tenant A's
+Case to an arbitrary Contact UUID belonging to tenant B -- a cross-tenant
+data-linkage exploit, and the resulting Resolution/response would leak
+tenant B's `contact_id` back to tenant A's agent.
 
 **This is now in scope for this ticket** (not a separate follow-up): add a
 contact-ownership check inside `ResolutionCreateCaseLevel`, mirroring
@@ -284,8 +298,12 @@ integrity.
 ### 4.4 bin-common-handler: requesthandler RPC client
 
 New file `bin-common-handler/pkg/requesthandler/contact_case_resolutions.go`,
-following `ContactV1CaseClose`'s exact shape (URI templating, JSON marshal,
-`sendRequestContact`, `parseResponse`):
+following the URI-templating/marshal/`sendRequestContact`/`parseResponse`
+mechanics common to this file's `ContactV1Case*` group (see
+`ContactV1CaseCreate`/`ContactV1CaseNoteCreate` for a bare-struct decode
+pattern; `ContactV1CaseClose` decodes into a `CloseResult` wrapper because
+its listenhandler returns one -- this design's response is a bare
+`*resolution.Resolution`, matching the plain-decode group instead):
 
 ```go
 // ContactV1CaseResolutionCreate attaches a case to a contact by creating a
@@ -542,13 +560,23 @@ as a confirmed-safe citation for the test plan below.
 
 ## 9. Next steps
 
-Independent subagent review loop (minimum 3 rounds) on this design doc before
-implementation starts, per `voipbin-backend-feature-design` skill policy.
-Round 1 (2026-07-12): CHANGES REQUESTED -- found the cross-tenant contact
-gap (Section 4.2b) and the schema gap (Section 4.6), both addressed in v0.2.
-Round 2 (2026-07-12): CHANGES REQUESTED -- found that the Section 4.2b fix
-as originally written breaks two existing tests
-(`Test_ResolutionCreateCaseLevel_DerivesContactID`,
-`Test_ResolutionDeleteCaseLevel_RederivesContactID`), contradicting Section
-6's "unaffected" claim; also flagged missing import callouts and an OpenAPI
-field-convention mismatch. All addressed in this v0.3. Proceeding to Round 3.
+Independent subagent review loop (minimum 3 rounds) completed, per
+`voipbin-backend-feature-design` skill policy.
+
+- Round 1 (2026-07-12): CHANGES REQUESTED -- found the cross-tenant contact
+  gap (Section 4.2b) and the schema gap (Section 4.6), both addressed in v0.2.
+- Round 2 (2026-07-12): CHANGES REQUESTED -- found that the Section 4.2b fix
+  as originally written breaks two existing tests
+  (`Test_ResolutionCreateCaseLevel_DerivesContactID`,
+  `Test_ResolutionDeleteCaseLevel_RederivesContactID`), contradicting
+  Section 6's "unaffected" claim; also flagged missing import callouts and
+  an OpenAPI field-convention mismatch. All addressed in v0.3.
+- Round 3 (2026-07-12): **APPROVED.** Confirmed all prior fixes are correct
+  and complete against real source, first-time-verified Section 4.4/4.5's
+  code snippets with no functional defects found, and applied two minor
+  citation-precision nits (now in this v0.4).
+
+Design is locked. Next: implementation PR(s) in `bin-contact-manager`,
+`bin-common-handler`, `bin-openapi-manager`, `bin-api-manager` per Section 5,
+each followed by its own independent PR-review-and-fix loop
+(minimum 3 rounds) before merge, per standing policy.

--- a/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
+++ b/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
@@ -1,4 +1,4 @@
-# VOIP-1252 -- Case-Level Manual Contact Attribution API (Design v0.1)
+# VOIP-1252 -- Case-Level Manual Contact Attribution API (Design v0.3)
 
 Repo: voipbin/monorepo
 Ticket: VOIP-1252
@@ -8,6 +8,20 @@ Status: Draft, awaiting independent review
 
 ## Changelog
 
+- v0.3 (2026-07-12). Round 2 independent review found that Section 4.2b's
+  fix, applied as originally written, breaks two existing, currently-passing
+  tests (`Test_ResolutionCreateCaseLevel_DerivesContactID` and
+  `Test_ResolutionDeleteCaseLevel_RederivesContactID` in
+  `contact_attribution_write_test.go`), which call `ResolutionCreateCaseLevel`
+  with a `contactID` that has no corresponding Contact row -- contradicting
+  Section 6's claim that existing coverage is "unaffected." Fixed by adding
+  an explicit integration-plan step to update those two tests with real
+  Contact fixtures. Also: called out Section 4.2b's required new imports
+  explicitly, corrected Section 4.6's OpenAPI field convention (no
+  `nullable: true`, matching the sibling `interaction_id` field's actual
+  pattern) and added a provenance description, fixed the stale "v0.1" doc
+  title, and added a one-line acknowledgment of the pre-existing
+  soft-deleted-contact exposure inherited from the mirrored pattern.
 - v0.2 (2026-07-12). Round 1 independent review found a genuine cross-tenant
   security gap in the underlying domain function (contactID ownership was
   never validated) -- added Section 4.2b domain-layer fix, updated Section 7
@@ -193,6 +207,31 @@ func (h *caseHandler) ResolutionCreateCaseLevel(ctx context.Context, customerID,
 `ResolutionDeleteCaseLevel` does not need this check -- it only takes an
 existing Resolution's own id plus the caseID (already tenant-verified via
 `verifyCaseOwnership`); it never accepts a caller-supplied `contactID`.
+
+**Required new imports (flagged in Round 2 review):** `contact_attribution.go`
+currently imports only `context`, `database/sql`, `fmt`,
+`github.com/gofrs/uuid`, `monorepo/bin-contact-manager/models/kase`, and
+`monorepo/bin-contact-manager/models/resolution`. The snippet above requires
+FOUR additional imports not currently present: `stderrors "errors"`,
+`cerrors "monorepo/bin-common-handler/models/errors"`,
+`commonoutline "monorepo/bin-common-handler/models/outline"`, and
+`monorepo/bin-contact-manager/pkg/dbhandler` (for `dbhandler.ErrNotFound`).
+All four already exist as real, correct package paths elsewhere in this
+service (verified against `contacthandler/resolution.go`'s own import
+block) -- this is a routine addition, not a design risk, but is called out
+explicitly so the implementer isn't surprised by import-cycle or
+goimports diffs.
+
+**Pre-existing exposure inherited from the mirrored pattern (Round 2
+review):** `dbhandler.ContactGet` does not filter soft-deleted Contacts (per
+this service's own CLAUDE.md: "the by-id dbhandler primitive stays
+unfiltered so the delete event payload can re-read the tombstone"). This
+means the new check would allow attaching a Case to a soft-deleted Contact.
+This is NOT a new gap introduced by this design -- `contacthandler.
+ResolutionCreate`, the exact pattern being mirrored, has identical exposure
+today for interaction-level resolutions. Out of scope for this ticket to fix
+(would require changing shared `ContactGet` semantics platform-wide), noted
+here only for completeness.
 
 ### 4.3 bin-contact-manager: request models
 
@@ -387,19 +426,35 @@ Request schema `ContactManagerCaseResolutionCreate`: `contact_id` (uuid,
 required), `resolution_type` (enum: positive, negative, required).
 
 **Response schema decision (resolved in v0.2, was Section 8 open question
-3):** `ContactManagerResolution` already exists
+3; field convention corrected in v0.3 per Round 2 review):**
+`ContactManagerResolution` already exists
 (`bin-openapi-manager/openapi/openapi.yaml:3382-3439`, confirmed by Round 1
 review) but only has `interaction_id`, not `case_id` (fields:
 `id`, `customer_id`, `contact_id`, `interaction_id`, `resolution_type`,
 `resolved_by_type`, `resolved_by_id`, `tm_*`). Reusing it as-is would
 silently drop `case_id` from every case-level resolution response. Decision:
-**extend `ContactManagerResolution` with an optional `case_id` (uuid,
-nullable) field** rather than defining a separate schema -- the Go
-`resolution.Resolution` struct already carries both `InteractionID
-*uuid.UUID` and `CaseID *uuid.UUID` as mutually-exclusive nullable fields
-(see `models/resolution/resolution.go:19-31`), so extending the single
-schema mirrors the Go struct shape exactly and avoids a parallel duplicate
-schema for what is the same underlying row shape at both call sites.
+**extend `ContactManagerResolution` with an optional `case_id` field**
+rather than defining a separate schema -- the Go `resolution.Resolution`
+struct already carries both `InteractionID *uuid.UUID` and `CaseID
+*uuid.UUID` as mutually-exclusive nullable fields (see
+`models/resolution/resolution.go:19-31`), so extending the single schema
+mirrors the Go struct shape exactly and avoids a parallel duplicate schema
+for what is the same underlying row shape at both call sites.
+
+**Field convention correction (Round 2 review):** the sibling
+`interaction_id` field already on this schema
+(`openapi.yaml:3400-3404`) carries NO `nullable: true` flag despite being a
+`*uuid.UUID` in Go, and the schema has no `required:` array at all --
+everything is optional-by-omission, not `nullable`-by-flag. The new
+`case_id` field must mirror `interaction_id`'s exact pattern (type: string,
+format: uuid, no `nullable` flag, not added to any `required` list), NOT
+introduce a `nullable: true` flag that would be inconsistent with its
+sibling field in the same schema. Add a provenance description following
+this schema's existing convention (compare `ContactManagerCaseNote.case_id`,
+`openapi.yaml:3560-3564`: "The case this note belongs to. The ID is returned
+from GET /v1.0/contact_cases response."), e.g. "The case this resolution is
+scoped to (case-level resolutions only). The ID is returned from GET
+/v1.0/contact_cases response."
 
 ### 4.6b Verified negative-resolution no-op (Round 1 review)
 
@@ -415,13 +470,22 @@ as a confirmed-safe citation for the test plan below.
 ## 5. Integration plan
 
 1. `bin-contact-manager`: apply the Section 4.2b domain-layer fix to
-   `ResolutionCreateCaseLevel` FIRST (contact-ownership check), then add
-   request models, listenhandler handlers + route registration, mock
-   regeneration (`go generate ./pkg/listenhandler/...`).
+   `ResolutionCreateCaseLevel` FIRST (contact-ownership check, plus the four
+   new imports noted in Section 4.2b). **Before this fix will compile/pass,
+   update `contact_attribution_write_test.go`'s existing
+   `Test_ResolutionCreateCaseLevel_DerivesContactID` and
+   `Test_ResolutionDeleteCaseLevel_RederivesContactID` to insert a real
+   Contact row (matching customerID) for the `contactID` literal each test
+   currently uses without one -- Round 2 review confirmed neither test
+   creates a Contact today, so both will start failing with
+   `CONTACT_NOT_FOUND` the moment the new check lands.** Then add request
+   models, listenhandler handlers + route registration, mock regeneration
+   (`go generate ./pkg/listenhandler/...`).
 2. `bin-common-handler`: add requesthandler methods + interface entries,
    mock regeneration.
 3. `bin-openapi-manager`: add path files + extend `ContactManagerResolution`
-   with `case_id` (Section 4.6), `go generate ./...`.
+   with `case_id` per Section 4.6's corrected field convention, `go generate
+   ./...`.
 4. `bin-api-manager`: add servicehandler methods + interface + mock, add
    `server/` HTTP handlers wired to the new OpenAPI-generated route
    signatures, `go generate ./...` then `go build ./...`.
@@ -436,7 +500,7 @@ as a confirmed-safe citation for the test plan below.
 
 | Layer | New test file | Cases covered |
 |---|---|---|
-| bin-contact-manager casehandler | `contact_attribution_test.go` additions | **NEW (Round 1 finding): contact_id belongs to a different tenant -> rejected with CONTACT_NOT_FOUND, verified before any Resolution row is inserted or transaction begins**; contact_id does not exist -> CONTACT_NOT_FOUND; existing Test_ResolutionCreateCaseLevel_DerivesContactID coverage unaffected |
+| bin-contact-manager casehandler | `contact_attribution_write_test.go` (MODIFY existing) + `contact_attribution_test.go` (additions) | **Existing `Test_ResolutionCreateCaseLevel_DerivesContactID` and `Test_ResolutionDeleteCaseLevel_RederivesContactID` MUST be updated to insert a real Contact row for the customerID/contactID they use -- Round 2 review confirmed they don't today and will fail once the Section 4.2b check lands.** NEW: contact_id belongs to a different tenant -> rejected with CONTACT_NOT_FOUND, verified before any Resolution row is inserted or transaction begins; contact_id does not exist -> CONTACT_NOT_FOUND |
 | bin-contact-manager listenhandler | `v1_case_resolutions_test.go` | 200 success (create/delete), 400 missing customer_id/contact_id, cross-tenant case_id -> propagated NotFound/error, cross-tenant contact_id -> propagated NotFound/error (new), malformed JSON body |
 | bin-common-handler requesthandler | `contact_case_resolutions_test.go` | URI construction, success parse, error propagation -- mirrors `Test_ContactV1CaseClose` shape |
 | bin-api-manager servicehandler | `case_test.go` additions | permission denied (non-admin/manager), direct-access rejected, cross-tenant case_id rejected before contact_id is even used, success path asserts `resolved_by_id` is taken from `a.AgentID()` not client input |
@@ -481,5 +545,10 @@ as a confirmed-safe citation for the test plan below.
 Independent subagent review loop (minimum 3 rounds) on this design doc before
 implementation starts, per `voipbin-backend-feature-design` skill policy.
 Round 1 (2026-07-12): CHANGES REQUESTED -- found the cross-tenant contact
-gap (Section 4.2b) and the schema gap (Section 4.6), both now addressed in
-this v0.2. Proceeding to Round 2.
+gap (Section 4.2b) and the schema gap (Section 4.6), both addressed in v0.2.
+Round 2 (2026-07-12): CHANGES REQUESTED -- found that the Section 4.2b fix
+as originally written breaks two existing tests
+(`Test_ResolutionCreateCaseLevel_DerivesContactID`,
+`Test_ResolutionDeleteCaseLevel_RederivesContactID`), contradicting Section
+6's "unaffected" claim; also flagged missing import callouts and an OpenAPI
+field-convention mismatch. All addressed in this v0.3. Proceeding to Round 3.

--- a/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
+++ b/bin-contact-manager/docs/plans/VOIP-1252-case-contact-attribution-api-design.md
@@ -1,0 +1,387 @@
+# VOIP-1252 -- Case-Level Manual Contact Attribution API (Design v0.1)
+
+Repo: voipbin/monorepo
+Ticket: VOIP-1252
+Author: Hermes (CPO) on behalf of pchero (CEO/CTO)
+Date: 2026-07-12
+Status: Draft, awaiting independent review
+
+## Changelog
+
+- v0.1 (2026-07-12). Initial draft.
+
+## 1. Problem recap
+
+A `contact_case` (kase.Case) can be created for a peer address (phone/email/SIP)
+that has no matching `Contact` yet -- e.g. an inbound call from a number nobody
+has entered into the CRM. Today the platform has NO reachable way for an agent
+or admin to say "this Case belongs to this specific existing Contact." The
+domain logic and DB write path (`casehandler.ResolutionCreateCaseLevel`) is
+fully implemented, transactional, and unit-tested, but it has zero callers
+outside tests/mocks -- there is no listenhandler route, no requesthandler RPC
+client method, and no bin-api-manager servicehandler/route exposing it. The
+only reachable recovery tool is the case-control CLI's `reconcile-contact`,
+which only RE-DERIVES `contact_id` from Resolution rows that already exist --
+it cannot create the first attribution.
+
+Severity: feature gap (not a regression). No workaround exists today except a
+raw SQL insert against `contact_resolutions`, which bypasses tenant validation
+and the atomic contact_id-derivation write.
+
+## 2. Goal
+
+- An agent (or admin/manager) can attach an open, unresolved Case to a
+  specific, existing Contact via a single API call.
+- The same caller can undo that attribution (soft-delete) if it was wrong,
+  and `Case.contact_id` automatically reflects the corrected state -- no
+  separate "recompute" step required.
+- Every attribution/de-attribution is attributed (who did it, when) via the
+  existing `contact_resolutions` audit trail -- nothing new needed here, the
+  underlying `ResolutionCreateCaseLevel`/`ResolutionDeleteCaseLevel` already
+  do this.
+- Cross-tenant Case ids are rejected the same way every other Case mutation
+  endpoint rejects them (via `verifyCaseOwnership`, already implemented).
+
+## 3. Out of scope
+
+- square-admin UI changes to surface this action (follow-up ticket once the
+  API exists).
+- Bulk/batch attribution tooling.
+- Changing `deriveCaseContactID`'s derivation algorithm itself.
+- Interaction-level (not Case-level) resolutions -- `POST
+  /v1/interactions/{id}/resolutions` already exists and is unaffected.
+- Listing a Case's resolutions (not strictly needed for the attach/detach
+  flow; `ResolutionListByCase` already exists at the dbhandler layer if a
+  future GET is wanted -- flagged as an open question, Section 8).
+
+## 4. API design
+
+### 4.1 New resource shape
+
+Follows the existing `/v1/cases/{id}/notes` and `/v1/cases/{id}/tags`
+sub-resource convention exactly (see `v1_cases.go`, `v1_notes.go` pattern):
+
+```
+POST   /v1/cases/{id}/resolutions          -- attach Case to a Contact
+DELETE /v1/cases/{id}/resolutions/{res_id} -- undo an attribution
+```
+
+No GET is added in v1 (see Section 8, open question 1).
+
+### 4.2 bin-contact-manager: listenhandler
+
+New file `bin-contact-manager/pkg/listenhandler/v1_case_resolutions.go`,
+mirroring `v1_cases.go`'s note/tag handlers:
+
+```go
+// processV1CasesIDResolutionsPost handles POST /v1/cases/{id}/resolutions.
+func (h *listenHandler) processV1CasesIDResolutionsPost(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	id := caseIDFromURI(req.URI)
+	if id == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	var body request.V1DataCasesIDResolutionsPost
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		return simpleResponse(400), nil
+	}
+	if body.CustomerID == uuid.Nil || body.ContactID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.caseHandler.ResolutionCreateCaseLevel(
+		ctx, body.CustomerID, id, body.ContactID,
+		body.ResolutionType, body.ResolvedByType, body.ResolvedByID,
+	)
+	if err != nil {
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
+// processV1CasesIDResolutionsIDDelete handles
+// DELETE /v1/cases/{id}/resolutions/{resolution_id}.
+func (h *listenHandler) processV1CasesIDResolutionsIDDelete(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	id := caseIDFromURI(req.URI)
+	if id == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+	resolutionID := caseSubIDFromURI(req.URI)
+	if resolutionID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	var body request.V1DataCasesIDResolutionsIDDelete
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		return simpleResponse(400), nil
+	}
+	if body.CustomerID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	if err := h.caseHandler.ResolutionDeleteCaseLevel(ctx, body.CustomerID, id, resolutionID); err != nil {
+		return errorResponse(err), nil
+	}
+	return simpleResponse(200), nil
+}
+```
+
+Reuses `caseIDFromURI`/`caseSubIDFromURI` already defined in `v1_cases.go` --
+no new URI-parsing helpers needed since the shape (`/v1/cases/<uuid>/<sub>/<uuid>`)
+is identical to the existing notes/tags sub-resources.
+
+Register both routes in the listenhandler's route table (wherever
+`processV1CasesIDNotesPost`/`processV1CasesIDNotesIDDelete` are registered --
+same file, same pattern).
+
+### 4.3 bin-contact-manager: request models
+
+New file `bin-contact-manager/pkg/listenhandler/models/request/v1_case_resolutions.go`:
+
+```go
+package request
+
+import "github.com/gofrs/uuid"
+
+// V1DataCasesIDResolutionsPost is the request body for
+// POST /v1/cases/{id}/resolutions.
+type V1DataCasesIDResolutionsPost struct {
+	CustomerID     uuid.UUID `json:"customer_id"`
+	ContactID      uuid.UUID `json:"contact_id"`
+	ResolutionType string    `json:"resolution_type"`
+	ResolvedByType string    `json:"resolved_by_type"`
+	ResolvedByID   uuid.UUID `json:"resolved_by_id"`
+}
+
+// V1DataCasesIDResolutionsIDDelete is the request body for
+// DELETE /v1/cases/{id}/resolutions/{resolution_id}.
+type V1DataCasesIDResolutionsIDDelete struct {
+	CustomerID uuid.UUID `json:"customer_id"`
+}
+```
+
+Note: unlike `V1DataCasesIDNotesPost` (which allows an optional/system
+`AuthorID *uuid.UUID`), `ResolvedByID` is REQUIRED here -- there is no
+"system-initiated" attach path in this design, only agent/admin action. If a
+future automated-attribution path is added, this can loosen the same way
+Notes did.
+
+### 4.4 bin-common-handler: requesthandler RPC client
+
+New file `bin-common-handler/pkg/requesthandler/contact_case_resolutions.go`,
+following `ContactV1CaseClose`'s exact shape (URI templating, JSON marshal,
+`sendRequestContact`, `parseResponse`):
+
+```go
+// ContactV1CaseResolutionCreate attaches a case to a contact by creating a
+// case-level Resolution in contact-manager.
+func (r *requestHandler) ContactV1CaseResolutionCreate(
+	ctx context.Context,
+	customerID, caseID, contactID uuid.UUID,
+	resolutionType, resolvedByType string,
+	resolvedByID uuid.UUID,
+) (*cmresolution.Resolution, error) {
+	uri := fmt.Sprintf("/v1/cases/%s/resolutions", caseID)
+
+	data := &cmrequest.V1DataCasesIDResolutionsPost{
+		CustomerID:     customerID,
+		ContactID:      contactID,
+		ResolutionType: resolutionType,
+		ResolvedByType: resolvedByType,
+		ResolvedByID:   resolvedByID,
+	}
+	m, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := r.sendRequestContact(ctx, uri, sock.RequestMethodPost, "contact/cases/<id>/resolutions", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	if err != nil {
+		return nil, err
+	}
+
+	var res cmresolution.Resolution
+	if errParse := parseResponse(tmp, &res); errParse != nil {
+		return nil, errParse
+	}
+	return &res, nil
+}
+
+// ContactV1CaseResolutionDelete undoes a case-level Contact attribution.
+func (r *requestHandler) ContactV1CaseResolutionDelete(ctx context.Context, customerID, caseID, resolutionID uuid.UUID) error {
+	uri := fmt.Sprintf("/v1/cases/%s/resolutions/%s", caseID, resolutionID)
+
+	data := &cmrequest.V1DataCasesIDResolutionsIDDelete{CustomerID: customerID}
+	m, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.sendRequestContact(ctx, uri, sock.RequestMethodDelete, "contact/cases/<id>/resolutions/<resolution-id>", requestTimeoutDefault, 0, ContentTypeJSON, m)
+	return err
+}
+```
+
+Add both method signatures to the `RequestHandler` interface in
+`bin-common-handler/pkg/requesthandler/main.go` (alongside the existing
+`ContactV1Case*` group), regenerate the mock.
+
+### 4.5 bin-api-manager: servicehandler + auth
+
+New methods in `bin-api-manager/pkg/servicehandler/case.go`, mirroring
+`CaseClose`'s permission pattern exactly (tenant pre-check via `caseGet`,
+then `hasPermission` with `PermissionCustomerAdmin|PermissionCustomerManager`,
+then delegate):
+
+```go
+// CaseResolutionCreate attaches a case to a contact (design VOIP-1252).
+// resolved_by_id is derived server-side from the authenticated caller's own
+// agent identity (a.AgentID()), matching CaseClose/CaseContinue's pattern --
+// never accepted from client input, so attribution cannot be forged.
+func (h *serviceHandler) CaseResolutionCreate(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	id, contactID uuid.UUID,
+	resolutionType string,
+) (*cmresolution.Resolution, error) {
+	if a.IsDirect() {
+		return nil, serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	c, err := h.caseGet(ctx, a.CustomerID, id)
+	if err != nil {
+		return nil, err
+	}
+	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		return nil, serviceerrors.ErrPermissionDenied
+	}
+
+	return h.reqHandler.ContactV1CaseResolutionCreate(
+		ctx, a.CustomerID, id, contactID,
+		resolutionType, string(commonidentity.OwnerTypeAgent), a.AgentID(),
+	)
+}
+
+// CaseResolutionDelete undoes a case-level Contact attribution.
+func (h *serviceHandler) CaseResolutionDelete(ctx context.Context, a *auth.AuthIdentity, id, resolutionID uuid.UUID) error {
+	if a.IsDirect() {
+		return serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	c, err := h.caseGet(ctx, a.CustomerID, id)
+	if err != nil {
+		return err
+	}
+	if !h.hasPermission(ctx, a, c.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+		return serviceerrors.ErrPermissionDenied
+	}
+
+	return h.reqHandler.ContactV1CaseResolutionDelete(ctx, a.CustomerID, id, resolutionID)
+}
+```
+
+`resolution_type` is accepted from the client (positive/negative -- see
+`resolution.ResolutionTypePositive`/`Negative`) since both are legitimate
+client-facing actions (attach vs. explicitly suppress a wrong auto-match at
+the Case level), but `resolved_by_id`/`resolved_by_type` are always
+server-derived, matching every other Case mutation's closed_by/caller_id
+pattern in this file.
+
+Add both to the `ServiceHandler` interface + regenerate mock. Add
+`server/case_resolutions.go` HTTP handlers (`PostCasesIdResolutions`,
+`DeleteCasesIdResolutionsResolutionId`) mirroring `server/case.go`'s existing
+close/continue handlers' request parsing.
+
+### 4.6 OpenAPI spec
+
+New files under `bin-openapi-manager/openapi/paths/contact_cases/`:
+
+- `id_resolutions.yaml` (POST)
+- `id_resolutions_id.yaml` (DELETE)
+
+Registered in `openapi.yaml` under:
+```yaml
+/contact_cases/{id}/resolutions:
+  $ref: './paths/contact_cases/id_resolutions.yaml'
+/contact_cases/{id}/resolutions/{resolution_id}:
+  $ref: './paths/contact_cases/id_resolutions_id.yaml'
+```
+
+Request schema `ContactManagerCaseResolutionCreate`: `contact_id` (uuid,
+required), `resolution_type` (enum: positive, negative, required). Response
+schema reuses/extends the existing Resolution webhook schema (verify whether
+`ContactManagerResolution` already exists as a schema from the
+interaction-level `POST /v1/interactions/{id}/resolutions` endpoint -- if so,
+reuse it; `resolution.Resolution` carries no internal-only fields requiring
+a separate webhook type, same rationale as `case.go`'s existing
+`ConvertWebhookMessage` note for Case).
+
+## 5. Integration plan
+
+1. `bin-contact-manager`: add request models, listenhandler handlers + route
+   registration, mock regeneration (`go generate ./pkg/listenhandler/...`).
+2. `bin-common-handler`: add requesthandler methods + interface entries,
+   mock regeneration.
+3. `bin-openapi-manager`: add path files + schema, `go generate ./...`.
+4. `bin-api-manager`: add servicehandler methods + interface + mock, add
+   `server/` HTTP handlers wired to the new OpenAPI-generated route
+   signatures, `go generate ./...` then `go build ./...`.
+5. Run full verification workflow (`go mod tidy && go mod vendor && go
+   generate ./... && go test ./... && golangci-lint run -v --timeout 5m`) in
+   all four touched services.
+6. RST docs: add a short "Attaching a Case to a Contact" subsection to
+   `bin-api-manager/docsdev/source/` case docs (Case struct/tutorial rst),
+   per bin-api-manager's CLAUDE.md mandate for user-visible API additions.
+
+## 6. Test plan
+
+| Layer | New test file | Cases covered |
+|---|---|---|
+| bin-contact-manager listenhandler | `v1_case_resolutions_test.go` | 200 success (create/delete), 400 missing customer_id/contact_id, cross-tenant case_id -> propagated NotFound/error, malformed JSON body |
+| bin-contact-manager casehandler | already covered by existing `contact_attribution_write_test.go` -- no new domain-layer tests needed, this ticket only adds a transport wrapper |
+| bin-common-handler requesthandler | `contact_case_resolutions_test.go` | URI construction, success parse, error propagation -- mirrors `Test_ContactV1CaseClose` shape |
+| bin-api-manager servicehandler | `case_test.go` additions | permission denied (non-admin/manager), direct-access rejected, cross-tenant case_id rejected before contact_id is even used, success path asserts `resolved_by_id` is taken from `a.AgentID()` not client input |
+| bin-api-manager server | `case_resolutions_test.go` | HTTP-level request parsing, status code mapping |
+
+## 7. Risks & tradeoffs
+
+- **Blast radius: small.** No changes to `ResolutionCreateCaseLevel`,
+  `ResolutionDeleteCaseLevel`, or `deriveCaseContactID` -- this is pure
+  transport wiring on top of an already-reviewed, already-tested domain
+  function (contact_attribution_write_test.go). Risk is concentrated in the
+  new listenhandler/servicehandler auth wiring, not in write correctness.
+- **resolution_type=negative use case.** A case-level negative resolution
+  suppresses a positive one for the same (case_id, contact_id) per set-MINUS
+  semantics (see `resolution.go` doc comment) -- this endpoint technically
+  allows an agent to submit a negative resolution for a Case that was never
+  positively attached in the first place, which is a harmless no-op (derives
+  to the same nil contact_id) but worth a unit test to confirm it doesn't
+  error.
+- **No GET added.** An agent cannot currently list a Case's resolution
+  history via this API surface. Deferred to Section 8 as an open question
+  rather than silently included, to keep this ticket's scope matching what
+  pchero actually asked for (attach a case to a contact).
+
+## 8. Open questions
+
+1. Should a `GET /v1/cases/{id}/resolutions` (list) endpoint be added in the
+   same PR, or deferred to a follow-up ticket? `ResolutionListByCase` already
+   exists at the dbhandler layer, so the marginal cost is low, but it's not
+   part of the originally-scoped ask.
+2. Should the square-admin UI work (a button/flow to search-and-attach a
+   Contact from an unresolved Case) be filed as a linked follow-up ticket now,
+   or wait until this API ships?
+3. Confirm whether `ContactManagerResolution` already exists as an OpenAPI
+   schema (from the interaction-level resolutions endpoint) to reuse, or
+   whether a new schema needs defining -- flagged for verification during
+   implementation, not blocking design lock-in.
+
+## 9. Next steps
+
+Independent subagent review loop (minimum 3 rounds) on this design doc before
+implementation starts, per `voipbin-backend-feature-design` skill policy.

--- a/bin-contact-manager/pkg/casehandler/contact_attribution.go
+++ b/bin-contact-manager/pkg/casehandler/contact_attribution.go
@@ -3,12 +3,17 @@ package casehandler
 import (
 	"context"
 	"database/sql"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+
 	"monorepo/bin-contact-manager/models/kase"
 	"monorepo/bin-contact-manager/models/resolution"
+	"monorepo/bin-contact-manager/pkg/dbhandler"
 )
 
 // deriveCaseContactID implements design §3.4's single derivation
@@ -69,10 +74,34 @@ func (h *caseHandler) applyDerivedContactID(ctx context.Context, tx *sql.Tx, cus
 // Case.contact_id from the result. Verifies the Case belongs to
 // customerID before writing -- without this check an attacker who knew
 // another tenant's case_id could overwrite that case's contact_id
-// (round-2 review defect).
+// (round-2 review defect). Also verifies the target Contact belongs to
+// customerID (VOIP-1252 design review round 1 finding) -- without this
+// check an agent of one tenant could attach their own Case to an
+// arbitrary Contact belonging to a different tenant, mirroring the
+// existing check in contacthandler.ResolutionCreate (the
+// interaction-level counterpart).
 func (h *caseHandler) ResolutionCreateCaseLevel(ctx context.Context, customerID, caseID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
 	if err := verifyCaseOwnership(ctx, h.db, customerID, caseID); err != nil {
 		return nil, err
+	}
+
+	ct, err := h.db.ContactGet(ctx, contactID)
+	if err != nil {
+		if stderrors.Is(err, dbhandler.ErrNotFound) {
+			return nil, cerrors.NotFound(
+				commonoutline.ServiceNameContactManager,
+				"CONTACT_NOT_FOUND",
+				"The contact was not found.",
+			).Wrap(err)
+		}
+		return nil, fmt.Errorf("could not get contact. ResolutionCreateCaseLevel. err: %v", err)
+	}
+	if ct.CustomerID != customerID {
+		return nil, cerrors.NotFound(
+			commonoutline.ServiceNameContactManager,
+			"CONTACT_NOT_FOUND",
+			"The contact was not found.",
+		)
 	}
 
 	now := h.utilHandler.TimeNow()

--- a/bin-contact-manager/pkg/casehandler/contact_attribution.go
+++ b/bin-contact-manager/pkg/casehandler/contact_attribution.go
@@ -81,6 +81,23 @@ func (h *caseHandler) applyDerivedContactID(ctx context.Context, tx *sql.Tx, cus
 // existing check in contacthandler.ResolutionCreate (the
 // interaction-level counterpart).
 func (h *caseHandler) ResolutionCreateCaseLevel(ctx context.Context, customerID, caseID, contactID uuid.UUID, resolutionType, resolvedByType string, resolvedByID uuid.UUID) (*resolution.Resolution, error) {
+	// 0. Validate resolutionType -- mirrors contacthandler.ResolutionCreate's
+	// (interaction-level) validation (VOIP-1252 round-2 review finding: the
+	// case-level path lacked this check the design doc claims it mirrors,
+	// letting an unvalidated string reach the DB unenforced by the
+	// OpenAPI-documented-but-unbound enum).
+	switch resolutionType {
+	case resolution.ResolutionTypePositive, resolution.ResolutionTypeNegative:
+		// valid
+	default:
+		return nil, cerrors.InvalidArgument(
+			commonoutline.ServiceNameContactManager,
+			"INVALID_RESOLUTION_TYPE",
+			fmt.Sprintf("resolution_type must be %q or %q, got %q",
+				resolution.ResolutionTypePositive, resolution.ResolutionTypeNegative, resolutionType),
+		)
+	}
+
 	if err := verifyCaseOwnership(ctx, h.db, customerID, caseID); err != nil {
 		return nil, err
 	}

--- a/bin-contact-manager/pkg/casehandler/contact_attribution_test.go
+++ b/bin-contact-manager/pkg/casehandler/contact_attribution_test.go
@@ -257,3 +257,33 @@ func Test_ResolutionCreateCaseLevel_ContactNotFound_Rejected(t *testing.T) {
 		t.Errorf("expected wrapped dbhandler.ErrNotFound, got: %v", err)
 	}
 }
+
+// Test_ResolutionCreateCaseLevel_InvalidResolutionType_Rejected verifies
+// VOIP-1252 round-2 review's finding: ResolutionCreateCaseLevel must
+// reject any resolutionType other than "positive"/"negative", mirroring
+// contacthandler.ResolutionCreate's (interaction-level) validation. Must
+// be rejected before any DB lookup (Case or Contact) -- no mockCache
+// EXPECT() is registered, so gomock fails the test if the code reaches
+// as far as ContactGet.
+func Test_ResolutionCreateCaseLevel_InvalidResolutionType_Rejected(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9206-9206-9206-000000000001")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9206-9206-9206-000000000002")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-9206-9206-9206-000000000003")
+	agentID := uuid.FromStringOrNil("f1b2c3d4-9206-9206-9206-000000000004")
+
+	_, err := h.ResolutionCreateCaseLevel(ctx, customerID, caseID, contactID, "Positive", resolution.ResolvedByTypeAgent, agentID)
+	if err == nil {
+		t.Fatalf("expected an error for an invalid resolution_type, got nil")
+	}
+}

--- a/bin-contact-manager/pkg/casehandler/contact_attribution_test.go
+++ b/bin-contact-manager/pkg/casehandler/contact_attribution_test.go
@@ -2,9 +2,13 @@ package casehandler
 
 import (
 	"context"
+	stderrors "errors"
+	"fmt"
 	"testing"
 	"time"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -12,6 +16,8 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
 
+	"monorepo/bin-contact-manager/models/contact"
+	"monorepo/bin-contact-manager/models/kase"
 	"monorepo/bin-contact-manager/models/resolution"
 	"monorepo/bin-contact-manager/pkg/cachehandler"
 	"monorepo/bin-contact-manager/pkg/dbhandler"
@@ -151,5 +157,103 @@ func Test_DeriveCaseContactID_IgnoresInteractionScopedAndSoftDeleted(t *testing.
 	}
 	if got != nil {
 		t.Errorf("expected nil (neither resolution should count), got: %v", *got)
+	}
+}
+
+// Test_ResolutionCreateCaseLevel_CrossTenantContact_Rejected verifies
+// VOIP-1252 design review round 1's finding: ResolutionCreateCaseLevel
+// must reject a contactID that belongs to a DIFFERENT customerID than
+// the Case, before any Resolution row is inserted or transaction begins.
+func Test_ResolutionCreateCaseLevel_CrossTenantContact_Rejected(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().ContactGet(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("cache miss")).AnyTimes()
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9204-9204-9204-000000000001")
+	otherCustomerID := uuid.FromStringOrNil("f1b2c3d4-9204-9204-9204-000000000099")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9204-9204-9204-000000000002")
+	contactID := uuid.FromStringOrNil("f1b2c3d4-9204-9204-9204-000000000003")
+	agentID := uuid.FromStringOrNil("f1b2c3d4-9204-9204-9204-000000000004")
+	opened := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+
+	c := &kase.Case{
+		ID: caseID, CustomerID: customerID,
+		PeerType: commonaddress.TypeTel, PeerTarget: "+15551500004", ReferenceType: "call",
+		Status: kase.StatusOpen, OpenedAt: &opened, TMCreate: &opened, TMUpdate: &opened,
+	}
+	if err := db.CaseInsert(ctx, c); err != nil {
+		t.Fatalf("CaseInsert() error = %v", err)
+	}
+
+	// Contact belongs to a DIFFERENT customer than the Case.
+	ct := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID, CustomerID: otherCustomerID},
+	}
+	if err := db.ContactCreate(ctx, ct); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
+	}
+
+	_, err := h.ResolutionCreateCaseLevel(ctx, customerID, caseID, contactID, resolution.ResolutionTypePositive, resolution.ResolvedByTypeAgent, agentID)
+	if err == nil {
+		t.Fatalf("expected an error for cross-tenant contact, got nil")
+	}
+
+	// Verify no Resolution row was created and Case.contact_id remains nil.
+	reread, err := db.CaseGetByID(ctx, caseID)
+	if err != nil {
+		t.Fatalf("CaseGetByID() error = %v", err)
+	}
+	if reread.ContactID != nil {
+		t.Errorf("expected Case.contact_id to remain nil after rejected attach, got: %v", *reread.ContactID)
+	}
+}
+
+// Test_ResolutionCreateCaseLevel_ContactNotFound_Rejected verifies
+// ResolutionCreateCaseLevel rejects a contactID that does not exist at
+// all (as opposed to belonging to a different tenant).
+func Test_ResolutionCreateCaseLevel_ContactNotFound_Rejected(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().ContactGet(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("cache miss")).AnyTimes()
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	db := dbhandler.NewHandler(dbTest, mockCache)
+	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("f1b2c3d4-9205-9205-9205-000000000001")
+	caseID := uuid.FromStringOrNil("f1b2c3d4-9205-9205-9205-000000000002")
+	nonExistentContactID := uuid.FromStringOrNil("f1b2c3d4-9205-9205-9205-000000000003")
+	agentID := uuid.FromStringOrNil("f1b2c3d4-9205-9205-9205-000000000004")
+	opened := time.Date(2026, 6, 28, 10, 0, 0, 0, time.UTC)
+
+	c := &kase.Case{
+		ID: caseID, CustomerID: customerID,
+		PeerType: commonaddress.TypeTel, PeerTarget: "+15551500005", ReferenceType: "call",
+		Status: kase.StatusOpen, OpenedAt: &opened, TMCreate: &opened, TMUpdate: &opened,
+	}
+	if err := db.CaseInsert(ctx, c); err != nil {
+		t.Fatalf("CaseInsert() error = %v", err)
+	}
+
+	_, err := h.ResolutionCreateCaseLevel(ctx, customerID, caseID, nonExistentContactID, resolution.ResolutionTypePositive, resolution.ResolvedByTypeAgent, agentID)
+	if err == nil {
+		t.Fatalf("expected an error for non-existent contact, got nil")
+	}
+	if !stderrors.Is(err, dbhandler.ErrNotFound) {
+		t.Errorf("expected wrapped dbhandler.ErrNotFound, got: %v", err)
 	}
 }

--- a/bin-contact-manager/pkg/casehandler/contact_attribution_write_test.go
+++ b/bin-contact-manager/pkg/casehandler/contact_attribution_write_test.go
@@ -2,10 +2,12 @@ package casehandler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
@@ -13,6 +15,7 @@ import (
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
 
+	"monorepo/bin-contact-manager/models/contact"
 	"monorepo/bin-contact-manager/models/kase"
 	"monorepo/bin-contact-manager/models/resolution"
 	"monorepo/bin-contact-manager/pkg/cachehandler"
@@ -30,6 +33,8 @@ func Test_ResolutionCreateCaseLevel_DerivesContactID(t *testing.T) {
 	mockUtil := utilhandler.NewMockUtilHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().ContactGet(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("cache miss")).AnyTimes()
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
 	db := dbhandler.NewHandler(dbTest, mockCache)
 	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
@@ -50,6 +55,15 @@ func Test_ResolutionCreateCaseLevel_DerivesContactID(t *testing.T) {
 	}
 	if err := db.CaseInsert(ctx, c); err != nil {
 		t.Fatalf("CaseInsert() error = %v", err)
+	}
+
+	// Contact fixture required as of VOIP-1252's cross-tenant contact
+	// ownership check in ResolutionCreateCaseLevel (design review round 1).
+	ct := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID, CustomerID: customerID},
+	}
+	if err := db.ContactCreate(ctx, ct); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
 	}
 
 	mockUtil.EXPECT().UUIDCreate().Return(resolutionID)
@@ -83,6 +97,8 @@ func Test_ResolutionDeleteCaseLevel_RederivesContactID(t *testing.T) {
 	mockUtil := utilhandler.NewMockUtilHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().ContactGet(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("cache miss")).AnyTimes()
+	mockCache.EXPECT().ContactSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
 	db := dbhandler.NewHandler(dbTest, mockCache)
 	h := &caseHandler{utilHandler: mockUtil, reqHandler: mockReq, db: db, notifyHandler: mockNotify}
@@ -103,6 +119,15 @@ func Test_ResolutionDeleteCaseLevel_RederivesContactID(t *testing.T) {
 	}
 	if err := db.CaseInsert(ctx, c); err != nil {
 		t.Fatalf("CaseInsert() error = %v", err)
+	}
+
+	// Contact fixture required as of VOIP-1252's cross-tenant contact
+	// ownership check in ResolutionCreateCaseLevel (design review round 1).
+	ct := &contact.Contact{
+		Identity: commonidentity.Identity{ID: contactID, CustomerID: customerID},
+	}
+	if err := db.ContactCreate(ctx, ct); err != nil {
+		t.Fatalf("ContactCreate() error = %v", err)
 	}
 
 	mockUtil.EXPECT().UUIDCreate().Return(resolutionID)

--- a/bin-contact-manager/pkg/listenhandler/main.go
+++ b/bin-contact-manager/pkg/listenhandler/main.go
@@ -75,16 +75,18 @@ var (
 	regV1InteractionsResolutionsID = regexp.MustCompile("/v1/interactions/" + regUUID + "/resolutions/" + regUUID + "$")
 
 	// v1 cases
-	regV1CasesUnresolved = regexp.MustCompile(`/v1/cases/unresolved(\?.*)?$`)
-	regV1Cases           = regexp.MustCompile(`/v1/cases$`)
-	regV1CasesGet        = regexp.MustCompile(`/v1/cases\?(.*)$`)
-	regV1CasesID         = regexp.MustCompile("/v1/cases/" + regUUID + "$")
-	regV1CasesIDClose    = regexp.MustCompile("/v1/cases/" + regUUID + "/close$")
-	regV1CasesIDContinue = regexp.MustCompile("/v1/cases/" + regUUID + "/continue$")
-	regV1CasesIDNotes    = regexp.MustCompile("/v1/cases/" + regUUID + "/notes$")
-	regV1CasesIDNotesID  = regexp.MustCompile("/v1/cases/" + regUUID + "/notes/" + regUUID + "$")
-	regV1CasesIDTags     = regexp.MustCompile("/v1/cases/" + regUUID + "/tags$")
-	regV1CasesIDTagsID   = regexp.MustCompile("/v1/cases/" + regUUID + "/tags/" + regUUID + "$")
+	regV1CasesUnresolved      = regexp.MustCompile(`/v1/cases/unresolved(\?.*)?$`)
+	regV1Cases                = regexp.MustCompile(`/v1/cases$`)
+	regV1CasesGet             = regexp.MustCompile(`/v1/cases\?(.*)$`)
+	regV1CasesID              = regexp.MustCompile("/v1/cases/" + regUUID + "$")
+	regV1CasesIDClose         = regexp.MustCompile("/v1/cases/" + regUUID + "/close$")
+	regV1CasesIDContinue      = regexp.MustCompile("/v1/cases/" + regUUID + "/continue$")
+	regV1CasesIDNotes         = regexp.MustCompile("/v1/cases/" + regUUID + "/notes$")
+	regV1CasesIDNotesID       = regexp.MustCompile("/v1/cases/" + regUUID + "/notes/" + regUUID + "$")
+	regV1CasesIDTags          = regexp.MustCompile("/v1/cases/" + regUUID + "/tags$")
+	regV1CasesIDTagsID        = regexp.MustCompile("/v1/cases/" + regUUID + "/tags/" + regUUID + "$")
+	regV1CasesIDResolutions   = regexp.MustCompile("/v1/cases/" + regUUID + "/resolutions$")
+	regV1CasesIDResolutionsID = regexp.MustCompile("/v1/cases/" + regUUID + "/resolutions/" + regUUID + "$")
 )
 
 var (
@@ -391,6 +393,16 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1CasesIDTagsID.MatchString(m.URI) && m.Method == sock.RequestMethodDelete:
 		response, err = h.processV1CasesIDTagsIDDelete(ctx, m)
 		requestType = "/v1/cases/{id}/tags/{tag_id}"
+
+	// POST /cases/{id}/resolutions
+	case regV1CasesIDResolutions.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1CasesIDResolutionsPost(ctx, m)
+		requestType = "/v1/cases/{id}/resolutions"
+
+	// DELETE /cases/{id}/resolutions/{resolution_id}
+	case regV1CasesIDResolutionsID.MatchString(m.URI) && m.Method == sock.RequestMethodDelete:
+		response, err = h.processV1CasesIDResolutionsIDDelete(ctx, m)
+		requestType = "/v1/cases/{id}/resolutions/{resolution_id}"
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// No handler found

--- a/bin-contact-manager/pkg/listenhandler/models/request/v1_case_resolutions.go
+++ b/bin-contact-manager/pkg/listenhandler/models/request/v1_case_resolutions.go
@@ -1,0 +1,19 @@
+package request
+
+import "github.com/gofrs/uuid"
+
+// V1DataCasesIDResolutionsPost is the request body for
+// POST /v1/cases/{id}/resolutions.
+type V1DataCasesIDResolutionsPost struct {
+	CustomerID     uuid.UUID `json:"customer_id"`
+	ContactID      uuid.UUID `json:"contact_id"`
+	ResolutionType string    `json:"resolution_type"`
+	ResolvedByType string    `json:"resolved_by_type"`
+	ResolvedByID   uuid.UUID `json:"resolved_by_id"`
+}
+
+// V1DataCasesIDResolutionsIDDelete is the request body for
+// DELETE /v1/cases/{id}/resolutions/{resolution_id}.
+type V1DataCasesIDResolutionsIDDelete struct {
+	CustomerID uuid.UUID `json:"customer_id"`
+}

--- a/bin-contact-manager/pkg/listenhandler/v1_case_resolutions.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_case_resolutions.go
@@ -1,0 +1,85 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-contact-manager/pkg/listenhandler/models/request"
+)
+
+// processV1CasesIDResolutionsPost handles POST /v1/cases/{id}/resolutions
+// (VOIP-1252): attaches a Case to a Contact by creating a case-level
+// Resolution, delegating to casehandler.ResolutionCreateCaseLevel.
+func (h *listenHandler) processV1CasesIDResolutionsPost(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesIDResolutionsPost"})
+	log.WithField("request", req).Debug("Received request.")
+
+	id := caseIDFromURI(req.URI)
+	if id == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	var body request.V1DataCasesIDResolutionsPost
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		log.Errorf("Could not unmarshal request body. err: %v", err)
+		return simpleResponse(400), nil
+	}
+	if body.CustomerID == uuid.Nil || body.ContactID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	res, err := h.caseHandler.ResolutionCreateCaseLevel(
+		ctx, body.CustomerID, id, body.ContactID,
+		body.ResolutionType, body.ResolvedByType, body.ResolvedByID,
+	)
+	if err != nil {
+		log.Errorf("Could not create case resolution. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	data, err := json.Marshal(res)
+	if err != nil {
+		return simpleResponse(500), nil
+	}
+
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
+}
+
+// processV1CasesIDResolutionsIDDelete handles
+// DELETE /v1/cases/{id}/resolutions/{resolution_id} (VOIP-1252): undoes
+// a case-level Contact attribution, delegating to
+// casehandler.ResolutionDeleteCaseLevel.
+func (h *listenHandler) processV1CasesIDResolutionsIDDelete(ctx context.Context, req *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{"func": "processV1CasesIDResolutionsIDDelete"})
+	log.WithField("request", req).Debug("Received request.")
+
+	id := caseIDFromURI(req.URI)
+	if id == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+	resolutionID := caseSubIDFromURI(req.URI)
+	if resolutionID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	var body request.V1DataCasesIDResolutionsIDDelete
+	if err := json.Unmarshal(req.Data, &body); err != nil {
+		log.Errorf("Could not unmarshal request body. err: %v", err)
+		return simpleResponse(400), nil
+	}
+	if body.CustomerID == uuid.Nil {
+		return simpleResponse(400), nil
+	}
+
+	if err := h.caseHandler.ResolutionDeleteCaseLevel(ctx, body.CustomerID, id, resolutionID); err != nil {
+		log.Errorf("Could not delete case resolution. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	return simpleResponse(200), nil
+}

--- a/bin-contact-manager/pkg/listenhandler/v1_case_resolutions_test.go
+++ b/bin-contact-manager/pkg/listenhandler/v1_case_resolutions_test.go
@@ -1,0 +1,198 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-contact-manager/models/resolution"
+)
+
+// Test_ProcessV1CasesIDResolutionsPost_Success verifies POST
+// /v1/cases/{id}/resolutions attaches a Case to a Contact, delegating to
+// caseHandler.ResolutionCreateCaseLevel with all six parameters.
+func Test_ProcessV1CasesIDResolutionsPost_Success(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, mockCase := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-0008-0008-0008-000000000001")
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0008-0008-0008-000000000002")
+	contactID := uuid.FromStringOrNil("aaaaaaaa-0008-0008-0008-000000000003")
+	agentID := uuid.FromStringOrNil("aaaaaaaa-0008-0008-0008-000000000004")
+	resolutionID := uuid.FromStringOrNil("aaaaaaaa-0008-0008-0008-000000000005")
+
+	body, _ := json.Marshal(map[string]any{
+		"customer_id":      customerID.String(),
+		"contact_id":       contactID.String(),
+		"resolution_type":  "positive",
+		"resolved_by_type": "agent",
+		"resolved_by_id":   agentID.String(),
+	})
+
+	mockCase.EXPECT().ResolutionCreateCaseLevel(ctx, customerID, caseID, contactID, "positive", "agent", agentID).
+		Return(&resolution.Resolution{ID: resolutionID, CaseID: &caseID, ContactID: contactID}, nil)
+
+	res, err := h.processV1CasesIDResolutionsPost(ctx, &sock.Request{
+		URI: "/v1/cases/" + caseID.String() + "/resolutions", Method: sock.RequestMethodPost, Data: body,
+	})
+	if err != nil {
+		t.Fatalf("processV1CasesIDResolutionsPost() error = %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("StatusCode = %v, want 200", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesIDResolutionsPost_MissingFields verifies 400 is
+// returned (without calling the handler) when customer_id or contact_id
+// is missing from the request body.
+func Test_ProcessV1CasesIDResolutionsPost_MissingFields(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, _ := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0009-0009-0009-000000000001")
+	contactID := uuid.FromStringOrNil("aaaaaaaa-0009-0009-0009-000000000002")
+
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{"missing customer_id", map[string]any{"contact_id": contactID.String(), "resolution_type": "positive"}},
+		{"missing contact_id", map[string]any{"customer_id": uuid.FromStringOrNil("aaaaaaaa-0009-0009-0009-000000000003").String(), "resolution_type": "positive"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(tt.body)
+			res, err := h.processV1CasesIDResolutionsPost(ctx, &sock.Request{
+				URI: "/v1/cases/" + caseID.String() + "/resolutions", Method: sock.RequestMethodPost, Data: body,
+			})
+			if err != nil {
+				t.Fatalf("processV1CasesIDResolutionsPost() error = %v", err)
+			}
+			if res.StatusCode != 400 {
+				t.Errorf("StatusCode = %v, want 400", res.StatusCode)
+			}
+		})
+	}
+}
+
+// Test_ProcessV1CasesIDResolutionsPost_MalformedBody verifies a
+// malformed JSON body yields 400.
+func Test_ProcessV1CasesIDResolutionsPost_MalformedBody(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, _ := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0010-0010-0010-000000000001")
+
+	res, err := h.processV1CasesIDResolutionsPost(ctx, &sock.Request{
+		URI: "/v1/cases/" + caseID.String() + "/resolutions", Method: sock.RequestMethodPost, Data: []byte("{not json"),
+	})
+	if err != nil {
+		t.Fatalf("processV1CasesIDResolutionsPost() error = %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("StatusCode = %v, want 400", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesIDResolutionsPost_CrossTenantContact verifies a
+// caseHandler-propagated CONTACT_NOT_FOUND error (the cross-tenant
+// contact guard added in VOIP-1252) surfaces via errorResponse, not a
+// generic 500.
+func Test_ProcessV1CasesIDResolutionsPost_CrossTenantContact(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, mockCase := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-0011-0011-0011-000000000001")
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0011-0011-0011-000000000002")
+	contactID := uuid.FromStringOrNil("aaaaaaaa-0011-0011-0011-000000000003")
+	agentID := uuid.FromStringOrNil("aaaaaaaa-0011-0011-0011-000000000004")
+
+	body, _ := json.Marshal(map[string]any{
+		"customer_id":      customerID.String(),
+		"contact_id":       contactID.String(),
+		"resolution_type":  "positive",
+		"resolved_by_type": "agent",
+		"resolved_by_id":   agentID.String(),
+	})
+
+	notFoundErr := cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "The contact was not found.")
+	mockCase.EXPECT().ResolutionCreateCaseLevel(ctx, customerID, caseID, contactID, "positive", "agent", agentID).
+		Return(nil, notFoundErr)
+
+	res, err := h.processV1CasesIDResolutionsPost(ctx, &sock.Request{
+		URI: "/v1/cases/" + caseID.String() + "/resolutions", Method: sock.RequestMethodPost, Data: body,
+	})
+	if err != nil {
+		t.Fatalf("processV1CasesIDResolutionsPost() error = %v", err)
+	}
+	if res.StatusCode == 200 {
+		t.Errorf("StatusCode = %v, want a non-200 error status", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesIDResolutionsIDDelete_Success verifies DELETE
+// /v1/cases/{id}/resolutions/{resolution_id} delegates to
+// caseHandler.ResolutionDeleteCaseLevel.
+func Test_ProcessV1CasesIDResolutionsIDDelete_Success(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, mockCase := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("aaaaaaaa-0012-0012-0012-000000000001")
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0012-0012-0012-000000000002")
+	resolutionID := uuid.FromStringOrNil("aaaaaaaa-0012-0012-0012-000000000003")
+
+	body, _ := json.Marshal(map[string]any{"customer_id": customerID.String()})
+
+	mockCase.EXPECT().ResolutionDeleteCaseLevel(ctx, customerID, caseID, resolutionID).Return(nil)
+
+	res, err := h.processV1CasesIDResolutionsIDDelete(ctx, &sock.Request{
+		URI: "/v1/cases/" + caseID.String() + "/resolutions/" + resolutionID.String(), Method: sock.RequestMethodDelete, Data: body,
+	})
+	if err != nil {
+		t.Fatalf("processV1CasesIDResolutionsIDDelete() error = %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("StatusCode = %v, want 200", res.StatusCode)
+	}
+}
+
+// Test_ProcessV1CasesIDResolutionsIDDelete_MissingCustomerID verifies
+// 400 is returned when customer_id is missing.
+func Test_ProcessV1CasesIDResolutionsIDDelete_MissingCustomerID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	h, _ := newTestListenHandlerWithCase(mc)
+	ctx := context.Background()
+
+	caseID := uuid.FromStringOrNil("aaaaaaaa-0013-0013-0013-000000000001")
+	resolutionID := uuid.FromStringOrNil("aaaaaaaa-0013-0013-0013-000000000002")
+
+	res, err := h.processV1CasesIDResolutionsIDDelete(ctx, &sock.Request{
+		URI: "/v1/cases/" + caseID.String() + "/resolutions/" + resolutionID.String(), Method: sock.RequestMethodDelete, Data: []byte("{}"),
+	})
+	if err != nil {
+		t.Fatalf("processV1CasesIDResolutionsIDDelete() error = %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Errorf("StatusCode = %v, want 400", res.StatusCode)
+	}
+}

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -3135,6 +3135,24 @@ func (e PostContactCasesIdNotesJSONBodyAuthorType) Valid() bool {
 	}
 }
 
+// Defines values for PostContactCasesIdResolutionsJSONBodyResolutionType.
+const (
+	PostContactCasesIdResolutionsJSONBodyResolutionTypeNegative PostContactCasesIdResolutionsJSONBodyResolutionType = "negative"
+	PostContactCasesIdResolutionsJSONBodyResolutionTypePositive PostContactCasesIdResolutionsJSONBodyResolutionType = "positive"
+)
+
+// Valid indicates whether the value is a known member of the PostContactCasesIdResolutionsJSONBodyResolutionType enum.
+func (e PostContactCasesIdResolutionsJSONBodyResolutionType) Valid() bool {
+	switch e {
+	case PostContactCasesIdResolutionsJSONBodyResolutionTypeNegative:
+		return true
+	case PostContactCasesIdResolutionsJSONBodyResolutionTypePositive:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for PostContactInteractionsIdResolutionsJSONBodyResolutionType.
 const (
 	PostContactInteractionsIdResolutionsJSONBodyResolutionTypeNegative PostContactInteractionsIdResolutionsJSONBodyResolutionType = "negative"
@@ -3329,16 +3347,16 @@ func (e PostServiceAgentsContactAddressesJSONBodyType) Valid() bool {
 
 // Defines values for PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType.
 const (
-	Negative PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "negative"
-	Positive PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "positive"
+	PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionTypeNegative PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "negative"
+	PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionTypePositive PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType = "positive"
 )
 
 // Valid indicates whether the value is a known member of the PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType enum.
 func (e PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionType) Valid() bool {
 	switch e {
-	case Negative:
+	case PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionTypeNegative:
 		return true
-	case Positive:
+	case PostServiceAgentsContactInteractionsIdResolutionsJSONBodyResolutionTypePositive:
 		return true
 	default:
 		return false
@@ -5220,6 +5238,9 @@ type ContactManagerInteractionListResponse struct {
 
 // ContactManagerResolution defines model for ContactManagerResolution.
 type ContactManagerResolution struct {
+	// CaseId The case this resolution is scoped to (case-level resolutions only). The ID is returned from GET /v1.0/contact_cases response.
+	CaseId *openapi_types.UUID `json:"case_id,omitempty"`
+
 	// ContactId The contact this resolution is attributed to.
 	ContactId *openapi_types.UUID `json:"contact_id,omitempty"`
 
@@ -8300,6 +8321,18 @@ type PostContactCasesIdNotesJSONBody struct {
 // PostContactCasesIdNotesJSONBodyAuthorType defines parameters for PostContactCasesIdNotes.
 type PostContactCasesIdNotesJSONBodyAuthorType string
 
+// PostContactCasesIdResolutionsJSONBody defines parameters for PostContactCasesIdResolutions.
+type PostContactCasesIdResolutionsJSONBody struct {
+	// ContactId The contact to attach this case to. The ID is returned from GET /v1.0/contacts response.
+	ContactId openapi_types.UUID `json:"contact_id"`
+
+	// ResolutionType Attribution type. positive attaches the case to the contact; negative suppresses a prior positive attribution.
+	ResolutionType PostContactCasesIdResolutionsJSONBodyResolutionType `json:"resolution_type"`
+}
+
+// PostContactCasesIdResolutionsJSONBodyResolutionType defines parameters for PostContactCasesIdResolutions.
+type PostContactCasesIdResolutionsJSONBodyResolutionType string
+
 // GetContactInteractionsParams defines parameters for GetContactInteractions.
 type GetContactInteractionsParams struct {
 	// PeerType Remote endpoint type (e.g. "tel", "email"). Required with peer_target.
@@ -10165,6 +10198,9 @@ type PostContactCasesIdMessagesJSONRequestBody PostContactCasesIdMessagesJSONBod
 
 // PostContactCasesIdNotesJSONRequestBody defines body for PostContactCasesIdNotes for application/json ContentType.
 type PostContactCasesIdNotesJSONRequestBody PostContactCasesIdNotesJSONBody
+
+// PostContactCasesIdResolutionsJSONRequestBody defines body for PostContactCasesIdResolutions for application/json ContentType.
+type PostContactCasesIdResolutionsJSONRequestBody PostContactCasesIdResolutionsJSONBody
 
 // PostContactInteractionsIdResolutionsJSONRequestBody defines body for PostContactInteractionsIdResolutions for application/json ContentType.
 type PostContactInteractionsIdResolutionsJSONRequestBody PostContactInteractionsIdResolutionsJSONBody

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -3402,6 +3402,11 @@ components:
           format: uuid
           description: The interaction this resolution belongs to.
           example: "c3d4e5f6-a7b8-9012-cdef-345678901234"
+        case_id:
+          type: string
+          format: uuid
+          description: The case this resolution is scoped to (case-level resolutions only). The ID is returned from GET /v1.0/contact_cases response.
+          example: "d4e5f6a7-b8c9-0123-defa-456789012345"
         resolution_type:
           type: string
           description: Attribution type.
@@ -8131,6 +8136,10 @@ paths:
     $ref: './paths/contact_cases/id_notes_id.yaml'
   /contact_cases/{id}/messages:
     $ref: './paths/contact_cases/id_messages.yaml'
+  /contact_cases/{id}/resolutions:
+    $ref: './paths/contact_cases/id_resolutions.yaml'
+  /contact_cases/{id}/resolutions/{resolution_id}:
+    $ref: './paths/contact_cases/id_resolutions_id.yaml'
 
   /conversation_accounts/{id}:
     $ref: './paths/conversation_accounts/id.yaml'

--- a/bin-openapi-manager/openapi/paths/contact_cases/id_resolutions.yaml
+++ b/bin-openapi-manager/openapi/paths/contact_cases/id_resolutions.yaml
@@ -1,0 +1,62 @@
+post:
+  summary: Attach a case to a contact
+  description: |
+    Attaches the case of the given ID to a specific existing Contact by
+    creating a case-level Resolution (VOIP-1252). Useful when a case was
+    created from an unregistered or unmatched peer address and an agent
+    manually identifies which existing Contact it belongs to.
+    resolved_by_id is derived server-side from the authenticated caller's
+    own agent identity -- it cannot be forged by supplying an arbitrary
+    resolved_by_id in the request body. The target contact_id must belong
+    to the same customer as the case; a cross-tenant contact_id is
+    rejected as not found.
+  tags:
+    - Case
+  parameters:
+    - name: id
+      in: path
+      description: The ID of the case. The ID is returned from GET /v1.0/contact_cases response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - contact_id
+            - resolution_type
+          properties:
+            contact_id:
+              type: string
+              format: uuid
+              description: The contact to attach this case to. The ID is returned from GET /v1.0/contacts response.
+              example: "660e8400-e29b-41d4-a716-446655440001"
+            resolution_type:
+              type: string
+              description: Attribution type. positive attaches the case to the contact; negative suppresses a prior positive attribution.
+              enum:
+                - positive
+                - negative
+              example: "positive"
+  responses:
+    '200':
+      description: Case resolution created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ContactManagerResolution'
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'

--- a/bin-openapi-manager/openapi/paths/contact_cases/id_resolutions_id.yaml
+++ b/bin-openapi-manager/openapi/paths/contact_cases/id_resolutions_id.yaml
@@ -1,0 +1,43 @@
+delete:
+  summary: Undo a case-level contact attribution
+  description: |
+    Soft-deletes the case-level resolution of the given resolution ID on
+    the case of the given case ID (VOIP-1252). Case.contact_id is
+    automatically re-derived after the delete -- if no other active
+    case-level positive resolution remains, contact_id reverts to null.
+  tags:
+    - Case
+  parameters:
+    - name: id
+      in: path
+      description: The ID of the case. The ID is returned from GET /v1.0/contact_cases response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "550e8400-e29b-41d4-a716-446655440000"
+    - name: resolution_id
+      in: path
+      description: The ID of the resolution. The ID is returned from POST /v1.0/contact_cases/{id}/resolutions response.
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: "770e8400-e29b-41d4-a716-446655440002"
+  responses:
+    '200':
+      description: Case resolution deleted successfully.
+      content:
+        application/json:
+          schema:
+            type: object
+    '400':
+      $ref: '#/components/responses/BadRequest'
+    '401':
+      $ref: '#/components/responses/Unauthenticated'
+    '403':
+      $ref: '#/components/responses/PermissionDenied'
+    '404':
+      $ref: '#/components/responses/NotFound'
+    '500':
+      $ref: '#/components/responses/InternalError'


### PR DESCRIPTION
Expose the existing case-level Resolution domain logic (casehandler.ResolutionCreateCaseLevel / ResolutionDeleteCaseLevel) via a new API so agents can manually attach/detach a Case to/from a Contact, independent of address-based auto-matching. Includes the approved design doc (v0.4, 3 review rounds) and a follow-on implementation code review (3 rounds, one SHOULD-FIX addressed).

- bin-contact-manager: Add contact-ownership check to ResolutionCreateCaseLevel (rejects a contactID belonging to a different customerID than the case), add resolutionType validation (positive/negative only, matching the interaction-level counterpart), add Contact fixtures to existing tests, add cross-tenant/not-found/invalid-type rejection tests
- bin-contact-manager: Add POST/DELETE /v1/cases/{id}/resolutions listenhandler routes, request models, and tests
- bin-common-handler: Add ContactV1CaseResolutionCreate/ContactV1CaseResolutionDelete RPC client methods, interface, mock, and tests
- bin-openapi-manager: Add case_id field to ContactManagerResolution schema, add /contact_cases/{id}/resolutions path files
- bin-api-manager: Add CaseResolutionCreate/CaseResolutionDelete servicehandler methods (resolved_by_id derived server-side from the caller's own agent identity, matching CaseClose/CaseContinue), interface, mock, server handlers, and tests
- bin-api-manager: Fix a pre-existing, unrelated compile break in pkg/servicehandler and server test files caused by contact.Address's Type/Target fields moving into an embedded commonaddress.Address; align JSON field-order and omitempty expectations in affected tests
- Design doc and 3-round design review, followed by 3-round independent implementation code review (Round 2 found and fixed a missing resolutionType validation at the case-level domain layer)
