### PR TITLE
VOIP-1234-insight-qa-tools

### DIFF
--- a/bin-ai-manager/docs/plans/2026-07-15-insight-qa-tools-design.md
+++ b/bin-ai-manager/docs/plans/2026-07-15-insight-qa-tools-design.md
@@ -1,0 +1,235 @@
+# Insight Q&A tools (get_contact_interactions / get_conversation_content) design memo
+
+- Date: 2026-07-15
+- Ticket: VOIP-1234 (last remaining subtask)
+- Service: bin-ai-manager (models/tool, pkg/toolhandler, pkg/aicallhandler)
+- Status: **FINAL — all in-scope decisions resolved by 대표님 2026-07-15. Prompt-injection framing (§5/§6-3) explicitly deferred to a separate consolidated ticket, not in scope here. Ready for TDD implementation.**
+
+## 1. Context (already shipped, not touched by this memo)
+
+VOIP-1234's 11 prior subtasks are already merged to `main`: AIcall-Case link
+(`aicall.ReferenceTypeContactCase`, `ReferenceID = Case.ID`), concurrency
+guard, rate limit, `ai.Type` (Normal/Insight) fan-out, `in_reply_to_message_id`
+cross-talk fix, team-membership rejection for Insight AIs, and the
+`service_agents/aicalls` + `service_agents/aimessages` REST surface.
+
+What remains: `tool.ToolNameGetContactInteractions` /
+`tool.ToolNameGetConversationContent` are reserved as names in
+`models/tool/main.go` (`AllInsightToolNames`) but have **no toolDefinitions
+entry and no execution handler**. Today an Insight AI has literally zero
+usable tools. This memo scopes the two missing tools.
+
+## 2. Precedent this design copies
+
+`get_resource` (`pkg/aicallhandler/tool_resource.go`, `docs/plans/
+2026-06-11-add-get-resource-tool-design.md`) already solved the same
+shape of problem: fetcher-map dispatch, single masked "not found" message
+for every not-accessible path (`msgResourceNotFound` / `ErrResourceNotAccessible`
+— IDOR-safe, not an existence oracle), a whole-message rune cap
+(`maxResourceSummaryRunes = 4000`), and a `resourceListPageSize` probe-one-extra
+pagination pattern. Both new tools reuse these primitives verbatim rather than
+inventing new ones.
+
+`get_correlation` -> `get_resource` also sets the precedent this design now
+explicitly follows for Tool 2: a **discover-then-fetch chain** — one tool
+lists candidate ids, a second tool takes an explicit id argument the LLM
+picked from that list. See §5.
+
+## 3. Case scoping — DECIDED: implicit, no id argument, for BOTH tools' target Case
+
+Both tools run only inside an Insight AIcall
+(`c.ReferenceType == aicall.ReferenceTypeContactCase`, `c.ReferenceID = Case.ID`).
+Neither tool accepts a `case_id` or `contact_id` argument. The Case itself is
+always resolved server-side from `c.ReferenceID` — a value the LLM never sees
+and never supplies.
+
+**Rationale (confirmed 2026-07-15):** the Insight AI's system prompt already
+frames its job as "analyze the Case you were opened for." There is no
+approved use case for an Insight AI to inspect a different Case, so accepting
+a case/contact id as an LLM-supplied argument would (a) require re-deriving
+an IDOR-safe ownership check that doesn't need to exist otherwise, (b) create
+a route for prompt-injection or hallucination to redirect the tool at the
+wrong Case, and (c) add test/review surface for a capability nobody asked
+for. Removing the argument removes the bug class entirely rather than
+defending against it. If a future ticket wants cross-Case lookup, that is a
+new, explicitly-scoped tool — not a parameter bolted onto this one.
+
+This decision is scoped to **which Case** the tools operate on. It does
+**not** extend to which conversation/message Tool 2 reads — see §5, which
+reverses the original draft's recommendation on exactly that point.
+
+## 4. Tool 1: get_contact_interactions
+
+**Purpose:** list past interactions (calls, conversation messages) tied to
+the Case's peer, so the Insight AI can answer "has this customer contacted
+us before" / "what's the interaction history" — and to give Tool 2 a set of
+concrete candidate ids to choose from (see §5).
+
+**Resolution path:**
+1. `h.reqHandler.ContactV1CaseGet(ctx, c.CustomerID, c.ReferenceID)` — fetch
+   the Case. Not-found or cross-customer (defensive; tenant is already
+   embedded in the RPC) both fold into `msgResourceNotFound`, mirroring
+   `get_resource`.
+2. If `case.ContactID != nil`: call `ContactV1InteractionList(ctx, customerID,
+   size, token, "", "", *case.ContactID, uuid.Nil, since)` (filter by
+   contact, the strongest signal — covers every address the contact owns,
+   not just this Case's peer).
+3. Else: fall back to `ContactV1InteractionList(ctx, customerID, size, token,
+   string(case.PeerType), case.PeerTarget, uuid.Nil, uuid.Nil, since)` (no
+   linked Contact yet — filter by the Case's own peer address).
+
+**Arguments (LLM-facing):**
+```
+{
+  "run_llm": bool (default true),
+  "limit": int, optional, default 20, hard cap 50 — mirrors resourceListPageSize convention but smaller (this is a summary list, not a resource dump)
+}
+```
+No `contact_id`/`case_id` argument (§3). No `since`/date-range argument in
+v1 — scope is "recent interaction history for this Case," not an open-ended
+CRM query tool; add pagination/date-range only if real usage demands it
+(same "add per demand" philosophy as the `get_resource` design doc's Phase 2
+list).
+
+**Output:** one line per interaction — direction, peer address, reference
+type, **reference id** (this is the value Tool 2 consumes, see §5 — it MUST
+be surfaced, not just used internally), `tm_interaction` — reusing the flat
+"N of M shown" truncation convention `get_resource` and `get_aicall_messages`
+already use. Total output capped at `maxResourceSummaryRunes` (import/reuse
+the constant from `tool_resource.go`, don't redefine it).
+
+**Failure modes:** Case RPC transient failure -> honest tool failure
+(`fillFailed`), never masked. Empty interaction list -> success with
+"no interactions found" (not a failure — a genuinely new contact is a valid
+answer, not an error).
+
+## 5. Tool 2: get_conversation_content — DECIDED: explicit `reference_id` argument, 2-RPC resolution
+
+### Reversed from the original draft
+
+The original draft recommended Tool 2 stay argument-less like Tool 1
+(walk every interaction, fetch every message, N+1 RPCs). 대표님 rejected this
+on two grounds: (a) it is wasteful (an unbounded-shaped RPC fan-out gated
+only by a page-size cap), and (b) more importantly, **which conversation
+to read is a judgment call the LLM should make explicitly, not one the
+server should silently resolve for it** (e.g. picking "the most recent
+interaction" would silently pick the wrong thread if the customer asks
+about an older conversation). This is the same discover-then-fetch shape
+`get_correlation` -> `get_resource` already establishes elsewhere in this
+codebase — Tool 2 should follow it, not diverge from it.
+
+### Final design
+
+**Arguments (LLM-facing):**
+```go
+{
+    Name:   tool.ToolNameGetConversationContent,
+    RunLLM: true,
+    Parameters: map[string]any{
+        "type": "object",
+        "properties": map[string]any{
+            "run_llm": map[string]any{
+                "type": "boolean", "default": true,
+            },
+            "reference_id": map[string]any{
+                "type":        "string",
+                "description": "The reference id of a conversation_message-type interaction, as returned by get_contact_interactions. Call get_contact_interactions first to discover candidate ids.",
+            },
+            "limit": map[string]any{
+                "type": "integer", "default": 20,
+            },
+        },
+        "required": []string{"reference_id"},
+    },
+},
+```
+`reference_id` is **required**. The LLM must call `get_contact_interactions`
+first, see the `conversation_message`-type rows and their reference ids, and
+pass the one relevant to the question being asked (most recent, or a
+specific one the user/agent references). There is no "just give me
+everything" mode — that keeps this tool aligned with the CRM Q&A use case
+(answer a specific question about a specific thread) rather than becoming a
+bulk export.
+
+**Resolution path (fixed 2 RPCs, independent of message/thread count):**
+1. `ConversationV1MessageGet(ctx, referenceID)` — resolve the message the
+   LLM pointed at. **Ownership check here is load-bearing**: if the message
+   is absent OR `msg.CustomerID != c.CustomerID`, mask to
+   `msgResourceNotFound` via the exact same `ErrResourceNotAccessible` /
+   single-masking-site pattern `tool_resource.go` uses for `get_resource` —
+   `reference_id` is an LLM-suppliable value now, so it needs the same
+   IDOR defense `get_resource`'s arbitrary `resource_id` already has. This
+   is the one place in this design where that defense is actually required
+   (§3's implicit-Case decision doesn't cover this argument).
+2. `ConversationV1MessageList(ctx, pageToken, pageSize, filters{
+   message.FieldConversationID: msg.ConversationID})` — one list call,
+   filtered by the resolved `conversation_id`, capped at `limit` (default
+   20, hard cap 50, same convention as Tool 1). Returns the surrounding
+   thread, not just the single referenced message.
+
+Total: **2 RPC calls, fixed**, regardless of how many messages are in the
+conversation — this was the original inefficiency concern (대표님's "무작정
+모든 conversation을 다 조회할 순 없어") and it's resolved by filtering server-side
+on `conversation_id` in one list call rather than fetching messages one at a
+time.
+
+**Output:** chronological message list (direction, text, timestamp),
+truncated to `maxResourceSummaryRunes`. Messages themselves are user content
+— in principle this is attacker-influenceable text flowing into an LLM
+context (a customer could type prompt-injection text into a chat message),
+the same class of concern `tool_resource.go`'s config-block framing
+(`configFrameOpen`/`configFrameClose`) addresses for session-config data.
+**Explicitly OUT OF SCOPE for this subtask (decided 2026-07-15): no
+framing/escaping is added here.** 대표님 wants prompt-injection defense handled
+as a separate, consolidated pass across all tools that return
+user-authored/external content (not just these two), rather than
+one-off per new tool. Ship Tool 1 and Tool 2 WITHOUT this framing now; track
+the consolidated defense as its own follow-up ticket/session. Do not block
+this subtask's implementation or review loop on it, and do not silently add
+ad-hoc framing "just in case" — that would fragment the eventual
+consolidated design.
+
+**Failure modes:** invalid/missing `reference_id` -> `fillFailed` (LLM
+self-correction case, same as `toolHandleSearchKnowledge`'s unmarshal-error
+handling). Not-found / cross-customer message -> masked `msgResourceNotFound`
+(never a distinguishable error — anti-IDOR-oracle). Transient RPC failure on
+either call -> honest `fillFailed`, never masked.
+
+## 6. Decisions — ALL CONFIRMED 2026-07-15
+
+1. **Case scoping**: implicit, no `case_id`/`contact_id` argument on either
+   tool. ✅ Confirmed, unchanged from draft.
+2. **get_conversation_content target resolution**: **explicit `reference_id`
+   argument** (reversed from the draft's Option B). The LLM must discover the
+   id via `get_contact_interactions` first, then request the specific
+   conversation it needs. Resolution is 2 fixed RPC calls
+   (`ConversationV1MessageGet` -> `ConversationV1MessageList` filtered by
+   `conversation_id`), not N+1 per-message fetches and not a silent
+   "most-recent" auto-pick. ✅ Confirmed.
+3. **Prompt-injection framing on quoted message content**: **DEFERRED, not
+   in scope for this subtask.** 대표님 decided (2026-07-15) to handle this as a
+   separate, consolidated effort across all tools that surface
+   user-authored/external content, not as a one-off addition to these two
+   new tools. Tool 1 and Tool 2 ship without this framing. Track separately.
+
+## 7. Scope confirmation
+
+Single service (`bin-ai-manager`). No new RPC (both tools compose existing
+`ContactV1CaseGet`, `ContactV1InteractionList`, `ConversationV1MessageGet`,
+`ConversationV1MessageList`). No OpenAPI/REST change (tools are internal LLM
+function-calling surface only, exposed via existing `GET /v1/tools`). No
+DB/migration change. Matches this skill's "single-file/single-service, not
+the full cross-service fan-out" scoping guidance
+(`voipbin-cross-service-phased-feature-implementation`).
+
+Estimated shape: `models/tool/main.go` (remove TODO comments once real),
+`pkg/toolhandler/definitions.go` (2 new Tool entries, Tool 2's schema has a
+required `reference_id` field per §5), `pkg/aicallhandler/tool.go` (2 new
+dispatch map entries), `pkg/aicallhandler/tool_insight.go` (new file, 2
+handler functions + shared Case-fetch helper for Tool 1 + shared
+IDOR-masking helper for Tool 2, mirroring `resolveResource`'s shape), plus
+test files mirroring `tool_resource.go`'s test conventions (ownership
+masking — now needed for Tool 2's `reference_id` path — rune-cap truncation,
+empty-result-is-success, and a fixed-RPC-count assertion for Tool 2 proving
+no N+1 fan-out regression). No prompt-injection framing/escaping code in this
+subtask (see §5/§6-3 — explicitly deferred).

--- a/bin-ai-manager/models/message/tool.go
+++ b/bin-ai-manager/models/message/tool.go
@@ -42,4 +42,7 @@ const (
 	FunctionCallNameGetResource       FunctionCallName = "get_resource"
 	FunctionCallNameDescribeAction    FunctionCallName = "describe_action"
 	FunctionCallNameCaseCreate        FunctionCallName = "case_create"
+
+	FunctionCallNameGetContactInteractions FunctionCallName = "get_contact_interactions"
+	FunctionCallNameGetConversationContent FunctionCallName = "get_conversation_content"
 )

--- a/bin-ai-manager/models/tool/main.go
+++ b/bin-ai-manager/models/tool/main.go
@@ -22,12 +22,7 @@ const (
 	ToolNameDescribeAction    ToolName = "describe_action"
 	ToolNameCaseCreate        ToolName = "case_create"
 
-	// Insight AI tool set (VOIP-1234). TODO(VOIP-1234): these two tools are not
-	// yet implemented (no toolDefinitions entry / no execution handler exists).
-	// Implementing get_contact_interactions and get_conversation_content is
-	// tracked as a separate follow-up subtask. The names are defined here now
-	// so ai.TypeInsight AIs can already reference/whitelist them via
-	// AllInsightToolNames ahead of the real implementation.
+	// Insight AI tool set (VOIP-1234).
 	ToolNameGetContactInteractions ToolName = "get_contact_interactions"
 	ToolNameGetConversationContent ToolName = "get_conversation_content"
 )
@@ -52,12 +47,6 @@ var AllToolNames = []ToolName{
 }
 
 // AllInsightToolNames defines the tool set available to ai.TypeInsight AIs.
-//
-// TODO(VOIP-1234): get_contact_interactions and get_conversation_content are
-// NOT YET IMPLEMENTED — there is no corresponding toolDefinitions entry or
-// execution handler for either tool yet. This list only reserves the names so
-// the ai.Type / Insight-system-prompt plumbing can be wired end-to-end now;
-// implementing the two tools themselves is a separate follow-up subtask.
 var AllInsightToolNames = []ToolName{
 	ToolNameGetContactInteractions,
 	ToolNameGetConversationContent,

--- a/bin-ai-manager/pkg/aicallhandler/main.go
+++ b/bin-ai-manager/pkg/aicallhandler/main.go
@@ -266,10 +266,6 @@ Keep the message content empty.
 	// Insight AIs are restricted to the Insight tool set (see
 	// tool.AllInsightToolNames) and are used to analyze existing contact/
 	// conversation data rather than to drive a live call or task workflow.
-	//
-	// TODO(VOIP-1234): the two Insight tools (get_contact_interactions,
-	// get_conversation_content) referenced by this prompt are not implemented
-	// yet; this prompt describes the intended behavior ahead of that work.
 	InsightSystemPrompt = `You are an Insight AI for VoIPBin. Your role is to analyze existing contact and conversation
 data to answer questions and surface insights — you do not drive a live call or execute a task workflow.
 

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -52,21 +52,23 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 	log.WithField("message", tmp).Debugf("Created the tool message for the actions. message_id: %s", tmp.ID)
 
 	mapFunctions := map[message.FunctionCallName]func(context.Context, *aicall.AIcall, *message.ToolCall) *messageContent{
-		message.FunctionCallNameConnectCall:       h.toolHandleConnect,
-		message.FunctionCallNameCreateCall:        h.toolHandleCreateCall,
-		message.FunctionCallNameGetVariables:      h.toolHandleGetVariables,
-		message.FunctionCallNameGetAIcallMessages: h.toolHandleGetAIcallMessages,
-		message.FunctionCallNameSendEmail:         h.toolHandleEmailSend,
-		message.FunctionCallNameSendMessage:       h.toolHandleMessageSend,
-		message.FunctionCallNameSetVariables:      h.toolHandleSetVariables,
-		message.FunctionCallNameStopFlow:          h.toolHandleStop,
-		message.FunctionCallNameStopMedia:           h.toolHandleMediaStop,
-		message.FunctionCallNameStopService:         h.toolHandleServiceStop,
-		message.FunctionCallNameSearchKnowledge:     h.toolHandleSearchKnowledge,
-		message.FunctionCallNameGetCorrelation:      h.toolHandleGetCorrelation,
-		message.FunctionCallNameGetResource:         h.toolHandleGetResource,
-		message.FunctionCallNameDescribeAction:      h.toolHandleDescribeAction,
-		message.FunctionCallNameCaseCreate:          h.toolHandleCaseCreate,
+		message.FunctionCallNameConnectCall:            h.toolHandleConnect,
+		message.FunctionCallNameCreateCall:             h.toolHandleCreateCall,
+		message.FunctionCallNameGetVariables:           h.toolHandleGetVariables,
+		message.FunctionCallNameGetAIcallMessages:      h.toolHandleGetAIcallMessages,
+		message.FunctionCallNameSendEmail:              h.toolHandleEmailSend,
+		message.FunctionCallNameSendMessage:            h.toolHandleMessageSend,
+		message.FunctionCallNameSetVariables:           h.toolHandleSetVariables,
+		message.FunctionCallNameStopFlow:               h.toolHandleStop,
+		message.FunctionCallNameStopMedia:              h.toolHandleMediaStop,
+		message.FunctionCallNameStopService:            h.toolHandleServiceStop,
+		message.FunctionCallNameSearchKnowledge:        h.toolHandleSearchKnowledge,
+		message.FunctionCallNameGetCorrelation:         h.toolHandleGetCorrelation,
+		message.FunctionCallNameGetResource:            h.toolHandleGetResource,
+		message.FunctionCallNameDescribeAction:         h.toolHandleDescribeAction,
+		message.FunctionCallNameCaseCreate:             h.toolHandleCaseCreate,
+		message.FunctionCallNameGetContactInteractions: h.toolHandleGetContactInteractions,
+		message.FunctionCallNameGetConversationContent: h.toolHandleGetConversationContent,
 	}
 
 	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()
@@ -1026,4 +1028,3 @@ func formatCorrelationSummary(corr *tmcorrelation.Correlation) string {
 
 	return sb.String()
 }
-

--- a/bin-ai-manager/pkg/aicallhandler/tool_insight.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_insight.go
@@ -1,0 +1,214 @@
+package aicallhandler
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"time"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	cvmessage "monorepo/bin-conversation-manager/models/message"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// insightDefaultListLimit / insightMaxListLimit bound the "limit" argument
+// accepted by both Insight tools. Kept smaller than resourceListPageSize
+// (get_resource's enrichment page size) because these are Insight-facing
+// summary lists, not a full resource dump.
+const (
+	insightDefaultListLimit = 20
+	insightMaxListLimit     = 50
+)
+
+// resolveInsightListLimit clamps an LLM-supplied limit into
+// [1, insightMaxListLimit], defaulting to insightDefaultListLimit when unset
+// or non-positive.
+func resolveInsightListLimit(v int) uint64 {
+	if v <= 0 {
+		return insightDefaultListLimit
+	}
+	if v > insightMaxListLimit {
+		return insightMaxListLimit
+	}
+	return uint64(v)
+}
+
+// toolHandleGetContactInteractions lists past interactions (calls,
+// conversation messages) tied to the Case's peer/contact. Scope is always
+// the current Insight AIcall's own Case (c.ReferenceID) -- there is no
+// case_id/contact_id argument (design VOIP-1234 §3: implicit scoping
+// removes the IDOR-shaped bug class entirely rather than defending against
+// it).
+func (h *aicallHandler) toolHandleGetContactInteractions(ctx context.Context, c *aicall.AIcall, tc *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleGetContactInteractions",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool get_contact_interactions.")
+
+	res := newToolResult(tc.ID)
+
+	var args struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		fillFailed(res, errors.Wrap(err, "invalid arguments"))
+		return res
+	}
+	limit := resolveInsightListLimit(args.Limit)
+
+	if c.ReferenceType != aicall.ReferenceTypeContactCase {
+		fillFailed(res, fmt.Errorf("get_contact_interactions is only supported for contact_case reference type"))
+		return res
+	}
+
+	kase, err := h.reqHandler.ContactV1CaseGet(ctx, c.CustomerID, c.ReferenceID)
+	if err != nil {
+		if stderrors.Is(err, requesthandler.ErrNotFound) {
+			fillSuccess(res, "interaction_list", c.ReferenceID.String(), msgResourceNotFound)
+			return res
+		}
+		log.Errorf("Could not get the case. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+	if kase.CustomerID != c.CustomerID || kase.CustomerID == uuid.Nil {
+		// Defensive: tenant is already embedded in the RPC, but fail closed
+		// on any mismatch rather than trust a foreign response shape.
+		log.Warnf("Cross-customer case access blocked. case_customer_id: %s", kase.CustomerID)
+		fillSuccess(res, "interaction_list", c.ReferenceID.String(), msgResourceNotFound)
+		return res
+	}
+
+	var interactions []*cminteraction.Interaction
+	if kase.ContactID != nil {
+		interactions, _, err = h.reqHandler.ContactV1InteractionList(
+			ctx, c.CustomerID, limit, "", "", "", *kase.ContactID, uuid.Nil, time.Time{})
+	} else {
+		interactions, _, err = h.reqHandler.ContactV1InteractionList(
+			ctx, c.CustomerID, limit, "", string(kase.PeerType), kase.PeerTarget, uuid.Nil, uuid.Nil, time.Time{})
+	}
+	if err != nil {
+		log.Errorf("Could not list interactions. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+
+	if len(interactions) == 0 {
+		fillSuccess(res, "interaction_list", c.ReferenceID.String(), "no interactions found")
+		return res
+	}
+
+	lines := make([]string, 0, len(interactions))
+	for _, it := range interactions {
+		ts := "unknown"
+		if it.TMInteraction != nil {
+			ts = it.TMInteraction.UTC().Format(time.RFC3339)
+		}
+		lines = append(lines, fmt.Sprintf(
+			"[%s] direction=%s peer=%s/%s reference_type=%s reference_id=%s",
+			ts, it.Direction, it.PeerType, it.PeerTarget, it.ReferenceType, it.ReferenceID,
+		))
+	}
+
+	body := renderBodyLines("", lines, uint64(len(interactions)) >= limit, "interactions")
+	fillSuccess(res, "interaction_list", c.ReferenceID.String(), body)
+	return res
+}
+
+// toolHandleGetConversationContent retrieves the message transcript of a
+// conversation, given the reference_id of a conversation_message-type
+// interaction the LLM discovered via get_contact_interactions (design
+// VOIP-1234 §5: explicit target selection, not an implicit
+// server-picks-the-most-recent-thread auto-resolution).
+//
+// Resolution is a FIXED 2 RPC calls regardless of message/thread count:
+//  1. ConversationV1MessageGet(reference_id) -- resolves the message AND is
+//     the ownership/IDOR check (reference_id is now LLM-suppliable, unlike
+//     the implicit Case scoping used elsewhere in this file).
+//  2. ConversationV1MessageList(filters={conversation_id}) -- one list call
+//     for the whole surrounding thread, capped at limit.
+func (h *aicallHandler) toolHandleGetConversationContent(ctx context.Context, c *aicall.AIcall, tc *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleGetConversationContent",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool get_conversation_content.")
+
+	res := newToolResult(tc.ID)
+
+	var args struct {
+		ReferenceID string `json:"reference_id"`
+		Limit       int    `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		fillFailed(res, errors.Wrap(err, "invalid arguments"))
+		return res
+	}
+	if args.ReferenceID == "" {
+		fillFailed(res, fmt.Errorf("reference_id is required, call get_contact_interactions first to discover candidate ids"))
+		return res
+	}
+	refID, err := uuid.FromString(args.ReferenceID)
+	if err != nil || refID == uuid.Nil {
+		fillFailed(res, fmt.Errorf("invalid reference_id"))
+		return res
+	}
+	limit := resolveInsightListLimit(args.Limit)
+
+	// RPC 1/2: resolve the message + ownership check (single masking site,
+	// mirrors resolveResource's IDOR-safe contract in tool_resource.go).
+	msg, err := h.reqHandler.ConversationV1MessageGet(ctx, refID)
+	if err != nil {
+		if stderrors.Is(err, requesthandler.ErrNotFound) {
+			fillSuccess(res, "conversation_content", args.ReferenceID, msgResourceNotFound)
+			return res
+		}
+		log.Errorf("Could not get the message. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+	if msg == nil || msg.CustomerID != c.CustomerID || msg.CustomerID == uuid.Nil {
+		log.Warnf("Cross-customer message access blocked. reference_id: %s", refID)
+		fillSuccess(res, "conversation_content", args.ReferenceID, msgResourceNotFound)
+		return res
+	}
+
+	// RPC 2/2: one list call filtered by conversation_id -- NOT a per-message
+	// fetch loop. This is the fixed-cost path decided in design VOIP-1234 §5
+	// after the original N+1 draft was rejected as wasteful.
+	filters := map[cvmessage.Field]any{
+		cvmessage.FieldConversationID: msg.ConversationID.String(),
+	}
+	msgs, err := h.reqHandler.ConversationV1MessageList(ctx, "", limit, filters)
+	if err != nil {
+		log.Errorf("Could not list conversation messages. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+
+	if len(msgs) == 0 {
+		fillSuccess(res, "conversation_content", args.ReferenceID, "no messages found")
+		return res
+	}
+
+	lines := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		ts := "unknown"
+		if m.TMCreate != nil {
+			ts = m.TMCreate.UTC().Format(time.RFC3339)
+		}
+		lines = append(lines, fmt.Sprintf("[%s %s] %s", ts, m.Direction, m.Text))
+	}
+
+	body := renderBodyLines("", lines, uint64(len(msgs)) >= limit, "messages")
+	fillSuccess(res, "conversation_content", args.ReferenceID, body)
+	return res
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_insight.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_insight.go
@@ -9,6 +9,7 @@ import (
 
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	cminteraction "monorepo/bin-contact-manager/models/interaction"
 	cvmessage "monorepo/bin-conversation-manager/models/message"
@@ -38,6 +39,29 @@ func resolveInsightListLimit(v int) uint64 {
 		return insightMaxListLimit
 	}
 	return uint64(v)
+}
+
+// isNotFoundErr reports whether err represents a "not found" outcome from a
+// downstream RPC, across BOTH error shapes this codebase's managers use:
+//   - legacy: the bare requesthandler.ErrNotFound sentinel (status-code
+//     fallback path in parseResponse), used by e.g. ContactV1CaseGet.
+//   - typed: a *cerrors.VoipbinError with Status == cerrors.StatusNotFound
+//     (the migrated envelope, cerrors.FromResponse takes precedence over
+//     the legacy sentinel in parseResponse), used by e.g. contact-manager's
+//     interactionListByContact (CONTACT_NOT_FOUND, e.g. when the Contact
+//     backing a Case has been soft-deleted).
+//
+// Round-2 adversarial review (VOIP-1234 PR #1100) found that checking only
+// the legacy sentinel silently misclassified a typed NotFound (a routine,
+// user-facing "no history yet" outcome) as an honest RPC failure. Both
+// shapes are checked here so every not-found path -- regardless of which
+// migration state the downstream manager is in -- is treated identically.
+func isNotFoundErr(err error) bool {
+	if stderrors.Is(err, requesthandler.ErrNotFound) {
+		return true
+	}
+	var ve *cerrors.VoipbinError
+	return stderrors.As(err, &ve) && ve.Status == cerrors.StatusNotFound
 }
 
 // toolHandleGetContactInteractions lists past interactions (calls,
@@ -71,7 +95,7 @@ func (h *aicallHandler) toolHandleGetContactInteractions(ctx context.Context, c 
 
 	kase, err := h.reqHandler.ContactV1CaseGet(ctx, c.CustomerID, c.ReferenceID)
 	if err != nil {
-		if stderrors.Is(err, requesthandler.ErrNotFound) {
+		if isNotFoundErr(err) {
 			fillSuccess(res, "interaction_list", c.ReferenceID.String(), msgResourceNotFound)
 			return res
 		}
@@ -96,6 +120,17 @@ func (h *aicallHandler) toolHandleGetContactInteractions(ctx context.Context, c 
 			ctx, c.CustomerID, limit, "", string(kase.PeerType), kase.PeerTarget, uuid.Nil, uuid.Nil, time.Time{})
 	}
 	if err != nil {
+		// Round-2 review finding (VOIP-1234 PR #1100): the Contact backing
+		// this Case may have been soft-deleted (merge, GDPR erasure, etc.)
+		// since the Case was created. contact-manager's interactionListByContact
+		// returns a TYPED NotFound (CONTACT_NOT_FOUND) in that case, which is a
+		// routine "no history to show" outcome for this tool -- not a genuine
+		// downstream failure. Treat it as an empty result (success), same as
+		// the Case-not-found path above, rather than an honest tool failure.
+		if isNotFoundErr(err) {
+			fillSuccess(res, "interaction_list", c.ReferenceID.String(), "no interactions found")
+			return res
+		}
 		log.Errorf("Could not list interactions. err: %v", err)
 		fillFailed(res, fmt.Errorf("resource lookup failed"))
 		return res
@@ -167,7 +202,7 @@ func (h *aicallHandler) toolHandleGetConversationContent(ctx context.Context, c 
 	// mirrors resolveResource's IDOR-safe contract in tool_resource.go).
 	msg, err := h.reqHandler.ConversationV1MessageGet(ctx, refID)
 	if err != nil {
-		if stderrors.Is(err, requesthandler.ErrNotFound) {
+		if isNotFoundErr(err) {
 			fillSuccess(res, "conversation_content", args.ReferenceID, msgResourceNotFound)
 			return res
 		}

--- a/bin-ai-manager/pkg/aicallhandler/tool_insight_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_insight_test.go
@@ -1,0 +1,338 @@
+package aicallhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+
+	cminteraction "monorepo/bin-contact-manager/models/interaction"
+	kmkase "monorepo/bin-contact-manager/models/kase"
+	cvmessage "monorepo/bin-conversation-manager/models/message"
+)
+
+func testAIcallForCase(customerID, caseID uuid.UUID) *aicall.AIcall {
+	return &aicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-000000000001"),
+			CustomerID: customerID,
+		},
+		ReferenceType: aicall.ReferenceTypeContactCase,
+		ReferenceID:   caseID,
+	}
+}
+
+// Test_toolHandleGetContactInteractions covers design VOIP-1234 §4: Case
+// fetch -> contact_id-preferred / peer-fallback interaction list, ownership
+// masking, and empty-result-is-success (never a failure).
+func Test_toolHandleGetContactInteractions(t *testing.T) {
+	customerID := uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-000000000002")
+	caseID := uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-000000000003")
+	contactID := uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-000000000004")
+	toolCallID := "6a1f2c10-c001-11f0-9000-000000000005"
+
+	tc := &message.ToolCall{
+		ID:   toolCallID,
+		Type: message.ToolTypeFunction,
+		Function: message.FunctionCall{
+			Name:      message.FunctionCallNameGetContactInteractions,
+			Arguments: `{}`,
+		},
+	}
+
+	tests := []struct {
+		name string
+
+		responseCase        *kmkase.Case
+		responseCaseErr     error
+		responseInteraction []*cminteraction.Interaction
+		responseListErr     error
+
+		expectContactFilter bool // true: filter by contact_id; false: filter by peer
+		expectResult        string
+		expectMessageEmpty  bool
+	}{
+		{
+			name: "contact_id set -> filter by contact",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  &contactID,
+				PeerType:   "tel",
+				PeerTarget: "+15551500001",
+			},
+			responseInteraction: []*cminteraction.Interaction{
+				{
+					Direction:     "incoming",
+					PeerType:      "tel",
+					PeerTarget:    "+15551500001",
+					ReferenceType: "conversation_message",
+					ReferenceID:   uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-000000000010"),
+					TMInteraction: timePtr(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)),
+				},
+			},
+			expectContactFilter: true,
+			expectResult:        "success",
+		},
+		{
+			name: "no contact_id -> filter by peer",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				PeerType:   "tel",
+				PeerTarget: "+15551500002",
+			},
+			responseInteraction: []*cminteraction.Interaction{
+				{
+					Direction:     "outgoing",
+					PeerType:      "tel",
+					PeerTarget:    "+15551500002",
+					ReferenceType: "call",
+					ReferenceID:   uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-000000000011"),
+				},
+			},
+			expectContactFilter: false,
+			expectResult:        "success",
+		},
+		{
+			name: "empty interaction list -> success, not failed",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				PeerType:   "tel",
+				PeerTarget: "+15551500003",
+			},
+			responseInteraction: []*cminteraction.Interaction{},
+			expectContactFilter: false,
+			expectResult:        "success",
+			expectMessageEmpty:  true,
+		},
+		{
+			name:            "case not found -> masked, not failed",
+			responseCaseErr: requesthandler.ErrNotFound,
+			expectResult:    "success",
+		},
+		{
+			name: "cross-customer case -> masked",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: uuid.FromStringOrNil("6a1f2c10-c001-11f0-9000-0000000000ff"), // different customer
+			},
+			expectResult: "success",
+		},
+		{
+			name:            "case RPC transient failure -> honest failure",
+			responseCaseErr: errTest,
+			expectResult:    "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq}
+			ctx := context.Background()
+			c := testAIcallForCase(customerID, caseID)
+
+			mockReq.EXPECT().ContactV1CaseGet(ctx, customerID, caseID).Return(tt.responseCase, tt.responseCaseErr)
+
+			if tt.responseCaseErr == nil && tt.responseCase != nil && tt.responseCase.CustomerID == customerID {
+				if tt.expectContactFilter {
+					mockReq.EXPECT().ContactV1InteractionList(
+						ctx, customerID, uint64(insightDefaultListLimit), "", "", "", contactID, uuid.Nil, time.Time{},
+					).Return(tt.responseInteraction, "", tt.responseListErr)
+				} else {
+					mockReq.EXPECT().ContactV1InteractionList(
+						ctx, customerID, uint64(insightDefaultListLimit), "", string(tt.responseCase.PeerType), tt.responseCase.PeerTarget, uuid.Nil, uuid.Nil, time.Time{},
+					).Return(tt.responseInteraction, "", tt.responseListErr)
+				}
+			}
+
+			res := h.toolHandleGetContactInteractions(ctx, c, tc)
+
+			if res.Result != tt.expectResult {
+				t.Fatalf("Result = %q, want %q (message: %s)", res.Result, tt.expectResult, res.Message)
+			}
+			if tt.expectResult == "success" && tt.responseCaseErr == nil && tt.responseCase != nil && tt.responseCase.CustomerID == customerID {
+				if tt.expectMessageEmpty && res.Message != "no interactions found" {
+					t.Errorf("expected empty-result message, got: %s", res.Message)
+				}
+			}
+			if tt.responseCaseErr != nil && tt.responseCaseErr != requesthandler.ErrNotFound {
+				if res.Message != "resource lookup failed" {
+					t.Errorf("expected honest failure message, got: %s", res.Message)
+				}
+			}
+		})
+	}
+}
+
+// Test_toolHandleGetConversationContent covers design VOIP-1234 §5: explicit
+// reference_id (LLM must discover it via get_contact_interactions first),
+// ownership masking on the resolved message (IDOR defense), and a FIXED
+// 2-RPC resolution (MessageGet + one MessageList filtered by conversation_id)
+// regardless of message/thread count -- this is the regression guard against
+// the rejected N+1 per-message-fetch draft.
+func Test_toolHandleGetConversationContent(t *testing.T) {
+	customerID := uuid.FromStringOrNil("6b1f2c10-c001-11f0-9000-000000000002")
+	caseID := uuid.FromStringOrNil("6b1f2c10-c001-11f0-9000-000000000003")
+	refID := uuid.FromStringOrNil("6b1f2c10-c001-11f0-9000-000000000010")
+	conversationID := uuid.FromStringOrNil("6b1f2c10-c001-11f0-9000-000000000020")
+	toolCallID := "6b1f2c10-c001-11f0-9000-000000000005"
+
+	c := testAIcallForCase(customerID, caseID)
+
+	t.Run("missing reference_id -> failed, no RPC calls", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq}
+		ctx := context.Background()
+
+		tc := &message.ToolCall{
+			ID:   toolCallID,
+			Type: message.ToolTypeFunction,
+			Function: message.FunctionCall{
+				Name:      message.FunctionCallNameGetConversationContent,
+				Arguments: `{}`,
+			},
+		}
+		res := h.toolHandleGetConversationContent(ctx, c, tc)
+		if res.Result != "failed" {
+			t.Fatalf("Result = %q, want failed", res.Result)
+		}
+	})
+
+	t.Run("happy path: fixed 2 RPCs, one MessageGet + one MessageList filtered by conversation_id", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq}
+		ctx := context.Background()
+
+		tc := &message.ToolCall{
+			ID:   toolCallID,
+			Type: message.ToolTypeFunction,
+			Function: message.FunctionCall{
+				Name:      message.FunctionCallNameGetConversationContent,
+				Arguments: `{"reference_id":"` + refID.String() + `"}`,
+			},
+		}
+
+		resolvedMsg := &cvmessage.Message{
+			Identity:       commonidentity.Identity{ID: refID, CustomerID: customerID},
+			ConversationID: conversationID,
+		}
+		mockReq.EXPECT().ConversationV1MessageGet(ctx, refID).Return(resolvedMsg, nil).Times(1)
+
+		threadMsgs := []cvmessage.Message{
+			{Identity: commonidentity.Identity{CustomerID: customerID}, Direction: "incoming", Text: "hello", TMCreate: timePtr(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))},
+			{Identity: commonidentity.Identity{CustomerID: customerID}, Direction: "outgoing", Text: "hi there", TMCreate: timePtr(time.Date(2026, 7, 1, 0, 1, 0, 0, time.UTC))},
+		}
+		mockReq.EXPECT().ConversationV1MessageList(
+			ctx, "", uint64(insightDefaultListLimit), map[cvmessage.Field]any{cvmessage.FieldConversationID: conversationID.String()},
+		).Return(threadMsgs, nil).Times(1)
+
+		res := h.toolHandleGetConversationContent(ctx, c, tc)
+		if res.Result != "success" {
+			t.Fatalf("Result = %q, want success (message: %s)", res.Result, res.Message)
+		}
+	})
+
+	t.Run("message not found -> masked, not failed", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq}
+		ctx := context.Background()
+
+		tc := &message.ToolCall{
+			ID:   toolCallID,
+			Type: message.ToolTypeFunction,
+			Function: message.FunctionCall{
+				Name:      message.FunctionCallNameGetConversationContent,
+				Arguments: `{"reference_id":"` + refID.String() + `"}`,
+			},
+		}
+		mockReq.EXPECT().ConversationV1MessageGet(ctx, refID).Return(nil, requesthandler.ErrNotFound)
+		// no MessageList call expected -- masking happens before the second RPC.
+
+		res := h.toolHandleGetConversationContent(ctx, c, tc)
+		if res.Result != "success" || res.Message != msgResourceNotFound {
+			t.Fatalf("expected masked not-found, got Result=%q Message=%q", res.Result, res.Message)
+		}
+	})
+
+	t.Run("cross-customer message -> masked (IDOR defense)", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq}
+		ctx := context.Background()
+
+		tc := &message.ToolCall{
+			ID:   toolCallID,
+			Type: message.ToolTypeFunction,
+			Function: message.FunctionCall{
+				Name:      message.FunctionCallNameGetConversationContent,
+				Arguments: `{"reference_id":"` + refID.String() + `"}`,
+			},
+		}
+		foreignMsg := &cvmessage.Message{
+			Identity:       commonidentity.Identity{ID: refID, CustomerID: uuid.FromStringOrNil("6b1f2c10-c001-11f0-9000-0000000000ff")},
+			ConversationID: conversationID,
+		}
+		mockReq.EXPECT().ConversationV1MessageGet(ctx, refID).Return(foreignMsg, nil)
+		// no MessageList call expected -- masking happens before the second RPC.
+
+		res := h.toolHandleGetConversationContent(ctx, c, tc)
+		if res.Result != "success" || res.Message != msgResourceNotFound {
+			t.Fatalf("expected masked not-found, got Result=%q Message=%q", res.Result, res.Message)
+		}
+	})
+
+	t.Run("empty thread -> success, not failed", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+		mockReq := requesthandler.NewMockRequestHandler(mc)
+		h := &aicallHandler{reqHandler: mockReq}
+		ctx := context.Background()
+
+		tc := &message.ToolCall{
+			ID:   toolCallID,
+			Type: message.ToolTypeFunction,
+			Function: message.FunctionCall{
+				Name:      message.FunctionCallNameGetConversationContent,
+				Arguments: `{"reference_id":"` + refID.String() + `"}`,
+			},
+		}
+		resolvedMsg := &cvmessage.Message{
+			Identity:       commonidentity.Identity{ID: refID, CustomerID: customerID},
+			ConversationID: conversationID,
+		}
+		mockReq.EXPECT().ConversationV1MessageGet(ctx, refID).Return(resolvedMsg, nil)
+		mockReq.EXPECT().ConversationV1MessageList(
+			ctx, "", uint64(insightDefaultListLimit), map[cvmessage.Field]any{cvmessage.FieldConversationID: conversationID.String()},
+		).Return([]cvmessage.Message{}, nil)
+
+		res := h.toolHandleGetConversationContent(ctx, c, tc)
+		if res.Result != "success" || res.Message != "no messages found" {
+			t.Fatalf("expected empty-result success, got Result=%q Message=%q", res.Result, res.Message)
+		}
+	})
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/bin-ai-manager/pkg/aicallhandler/tool_insight_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_insight_test.go
@@ -10,7 +10,9 @@ import (
 
 	"monorepo/bin-ai-manager/models/aicall"
 	"monorepo/bin-ai-manager/models/message"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	cminteraction "monorepo/bin-contact-manager/models/interaction"
@@ -131,6 +133,20 @@ func Test_toolHandleGetContactInteractions(t *testing.T) {
 			name:            "case RPC transient failure -> honest failure",
 			responseCaseErr: errTest,
 			expectResult:    "failed",
+		},
+		{
+			name: "Contact soft-deleted (typed CONTACT_NOT_FOUND from InteractionList) -> success, not failed",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  &contactID,
+				PeerType:   "tel",
+				PeerTarget: "+15551500004",
+			},
+			responseListErr:     cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "The contact was not found."),
+			expectContactFilter: true,
+			expectResult:        "success",
+			expectMessageEmpty:  true,
 		},
 	}
 
@@ -335,4 +351,51 @@ func Test_toolHandleGetConversationContent(t *testing.T) {
 
 func timePtr(t time.Time) *time.Time {
 	return &t
+}
+
+// Test_isNotFoundErr covers both error shapes this codebase's downstream
+// managers use for "not found" (Round-2 review finding, VOIP-1234 PR
+// #1100): the legacy requesthandler.ErrNotFound sentinel AND a typed
+// *cerrors.VoipbinError with Status == StatusNotFound. A caller that checks
+// only one shape silently misclassifies the other as an honest failure.
+func Test_isNotFoundErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "legacy sentinel",
+			err:  requesthandler.ErrNotFound,
+			want: true,
+		},
+		{
+			name: "typed VoipbinError NotFound",
+			err:  cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "The contact was not found."),
+			want: true,
+		},
+		{
+			name: "typed VoipbinError, different status -> not a not-found",
+			err:  cerrors.PermissionDenied(commonoutline.ServiceNameContactManager, "X", "x"),
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errTest,
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNotFoundErr(tt.err); got != tt.want {
+				t.Errorf("isNotFoundErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
 }

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -605,7 +605,7 @@ run_llm: Set true (default) to confirm verbally ("I've placed the call").`,
 					"description": "UUID of a pre-existing flow the new call will execute. Provide EITHER flow_id OR actions, not both. Must belong to your account.",
 				},
 				"actions": map[string]any{
-					"type": "array",
+					"type":        "array",
 					"description": "Assemble the call scenario inline as an ordered list of flow actions, INSTEAD OF flow_id. Provide EITHER flow_id OR actions, not both. Each item is a flow action with a 'type' and a type-specific 'option' object. Example to speak a message then hang up: [{\"type\":\"talk\",\"option\":{\"text\":\"Hi, the meeting moved to 3pm\",\"language\":\"en-US\"}},{\"type\":\"hangup\"}].",
 					"items": map[string]any{
 						"type": "object",
@@ -749,5 +749,75 @@ Optional name/detail/note describe the case for a human agent reviewing it later
 			},
 		},
 		RunLLM: true,
+	},
+	{
+		Name:   tool.ToolNameGetContactInteractions,
+		RunLLM: true,
+		Description: `Lists past interactions (calls, conversation messages) with the contact/peer of the Case this Insight AI was opened for.
+
+WHEN TO USE:
+- Answering "has this customer contacted us before" / "what's the interaction history".
+- Discovering candidate conversation message ids to pass into get_conversation_content.
+
+WHEN NOT TO USE:
+- You need the actual message text (use get_conversation_content with a reference_id from this tool's output).
+
+Always scoped to the current Case; there is no argument to target a different Case or contact.
+
+run_llm: Set true to reason about the returned interaction history.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to reason about the retrieved interaction history.",
+					"default":     true,
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Maximum number of interactions to return (default 20, max 50).",
+					"default":     20,
+				},
+			},
+		},
+	},
+	{
+		Name:   tool.ToolNameGetConversationContent,
+		RunLLM: true,
+		Description: `Retrieves the message transcript of a conversation, given the reference_id of a conversation_message-type interaction returned by get_contact_interactions.
+
+WHEN TO USE:
+- You need the actual text of what was said, not just that an interaction happened.
+- You already have a reference_id from get_contact_interactions for the conversation you want to read.
+
+WHEN NOT TO USE:
+- You have not yet called get_contact_interactions -- call it first to discover candidate reference_id values.
+
+ARGUMENTS:
+- reference_id (required): the reference id of a conversation_message-type interaction (a message id), as returned by get_contact_interactions. This tool resolves the message's conversation and returns the surrounding thread.
+
+You can only retrieve conversations owned by your own account; anything else returns "Resource not found."
+
+run_llm: Set true to reason about the retrieved conversation content.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to reason about the retrieved conversation content.",
+					"default":     true,
+				},
+				"reference_id": map[string]any{
+					"type":        "string",
+					"description": "The reference id of a conversation_message-type interaction, as returned by get_contact_interactions. Call get_contact_interactions first to discover candidate ids.",
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Maximum number of messages to return from the resolved conversation (default 20, max 50).",
+					"default":     20,
+				},
+			},
+			"required": []string{"reference_id"},
+		},
 	},
 }


### PR DESCRIPTION
Implement the last remaining VOIP-1234 subtask: the two Insight AI LLM
tools (get_contact_interactions, get_conversation_content) that were
previously reserved as names only, with no toolDefinitions entry or
execution handler. Design finalized in docs/plans/2026-07-15-insight-qa-tools-design.md
after CPO/CEO review (Case scoping stays implicit; get_conversation_content
uses an explicit reference_id argument with a fixed 2-RPC resolution
instead of an N+1 per-message fetch loop; prompt-injection framing on
quoted message content is explicitly deferred to a separate consolidated
ticket, not in scope here).

- bin-ai-manager: Add tool.ToolNameGetContactInteractions/GetConversationContent
  tool definitions (toolhandler); remove now-stale TODO(VOIP-1234) comments
  in models/tool/main.go since both tools are implemented
- bin-ai-manager: Add FunctionCallNameGetContactInteractions/GetConversationContent
  constants
- bin-ai-manager: Implement toolHandleGetContactInteractions -- Case fetch
  (implicit scope from the AIcall's own ReferenceID, no case_id/contact_id
  argument), contact_id-preferred / peer-fallback interaction list,
  IDOR-safe masking mirroring get_resource's resolveResource contract,
  empty-result-is-success (not a failure)
- bin-ai-manager: Implement toolHandleGetConversationContent -- explicit
  required reference_id argument (LLM must discover it via
  get_contact_interactions first), fixed 2 RPC calls
  (ConversationV1MessageGet for ownership-checked resolution +
  ConversationV1MessageList filtered by conversation_id for the thread),
  independent of message/thread count
- bin-ai-manager: Register both tools in aicallhandler's ToolHandle
  dispatch map
- bin-ai-manager: Add tests covering ownership masking (IDOR defense on
  both tools), empty-result-is-success, contact_id vs peer-fallback
  filtering, and the fixed-RPC-count behavior for get_conversation_content
