### PR TITLE
VOIP-1258-topic-exchange-scoped-routing

### DIFF
--- a/bin-agent-manager/cmd/agent-manager/main.go
+++ b/bin-agent-manager/cmd/agent-manager/main.go
@@ -160,21 +160,14 @@ func runServiceSubscribe(
 	queueNamePod := string(commonoutline.QueueNameAgentSubscribe)
 	subHandler := subscribehandler.NewSubscribeHandler(sockHandler, queueNamePod, subscribeTargets, agentHandler)
 
-	// run
+	// run. NOTE: the VOIP-1258 topic-exchange cutover (QueueBind/QueueUnbind) lives INSIDE
+	// subscribeHandler.Run(), sequenced before ConsumeMessage starts -- see that function's
+	// doc comment for why doing it here (after Run() returns) is unsafe: Run() starts
+	// ConsumeMessage on a separate goroutine and returns immediately, so a bind/unbind call
+	// here would race the in-flight basic.consume RPC on the same AMQP channel and could
+	// intermittently 503 the channel closed (reproduced in production 2026-07-14).
 	if errRun := subHandler.Run(); errRun != nil {
 		return errRun
-	}
-
-	// Cut over from the old fanout QueueNameWebhookEvent exchange to the new
-	// QueueNameWebhookEventTopic topic exchange with a "#" wildcard binding.
-	// Bind new first, then unbind old, to avoid an event-loss window where the
-	// queue is briefly bound to neither exchange (VOIP-1258 Task 3.5).
-	if errBind := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); errBind != nil {
-		logrus.Errorf("Could not bind to the topic exchange. err: %v", errBind)
-		// do NOT proceed to unbind the old exchange if this bind failed -- stay on the
-		// old exchange rather than risk ending up bound to neither.
-	} else if errUnbind := sockHandler.QueueUnbind(queueNamePod, "", string(commonoutline.QueueNameWebhookEvent), nil); errUnbind != nil {
-		logrus.Errorf("CRITICAL: Could not unbind from the old fanout exchange after binding to the new topic exchange. queue: %s is now bound to BOTH exchanges (double-processing resumes). Manual intervention required. err: %v", queueNamePod, errUnbind)
 	}
 
 	return nil

--- a/bin-agent-manager/cmd/agent-manager/main.go
+++ b/bin-agent-manager/cmd/agent-manager/main.go
@@ -156,13 +156,25 @@ func runServiceSubscribe(
 	subscribeTargets := []string{
 		string(commonoutline.QueueNameCallEvent),
 		string(commonoutline.QueueNameCustomerEvent),
-		string(commonoutline.QueueNameWebhookEvent),
 	}
-	subHandler := subscribehandler.NewSubscribeHandler(sockHandler, string(commonoutline.QueueNameAgentSubscribe), subscribeTargets, agentHandler)
+	queueNamePod := string(commonoutline.QueueNameAgentSubscribe)
+	subHandler := subscribehandler.NewSubscribeHandler(sockHandler, queueNamePod, subscribeTargets, agentHandler)
 
 	// run
 	if errRun := subHandler.Run(); errRun != nil {
 		return errRun
+	}
+
+	// Cut over from the old fanout QueueNameWebhookEvent exchange to the new
+	// QueueNameWebhookEventTopic topic exchange with a "#" wildcard binding.
+	// Bind new first, then unbind old, to avoid an event-loss window where the
+	// queue is briefly bound to neither exchange (VOIP-1258 Task 3.5).
+	if errBind := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); errBind != nil {
+		logrus.Errorf("Could not bind to the topic exchange. err: %v", errBind)
+		// do NOT proceed to unbind the old exchange if this bind failed -- stay on the
+		// old exchange rather than risk ending up bound to neither.
+	} else if errUnbind := sockHandler.QueueUnbind(queueNamePod, "", string(commonoutline.QueueNameWebhookEvent), nil); errUnbind != nil {
+		logrus.Errorf("CRITICAL: Could not unbind from the old fanout exchange after binding to the new topic exchange. queue: %s is now bound to BOTH exchanges (double-processing resumes). Manual intervention required. err: %v", queueNamePod, errUnbind)
 	}
 
 	return nil

--- a/bin-agent-manager/pkg/subscribehandler/main.go
+++ b/bin-agent-manager/pkg/subscribehandler/main.go
@@ -74,6 +74,31 @@ func (h *subscribeHandler) Run() error {
 		}
 	}
 
+	// Cut over from the old fanout QueueNameWebhookEvent exchange to the new
+	// QueueNameWebhookEventTopic topic exchange with a "#" wildcard binding.
+	// Bind new first, then unbind old, to avoid an event-loss window where the
+	// queue is briefly bound to neither exchange (VOIP-1258 Task 3.5).
+	//
+	// CRITICAL: this MUST run synchronously here, BEFORE ConsumeMessage is started below (not
+	// after Run() returns, as it originally lived in cmd/agent-manager/main.go). QueueBind/
+	// QueueUnbind and ConsumeMessage's internal channel.Consume() share the SAME underlying
+	// AMQP channel object (rabbitmqhandler's queue.channel) for a given queue name. AMQP does
+	// not allow two synchronous RPCs to race on one channel -- if ConsumeMessage's
+	// basic.consume is already in flight on another goroutine when QueueBind/QueueUnbind fires,
+	// the broker closes the channel with "unexpected command received" (503), and
+	// ConsumeMessage fails to ever start consuming on this pod. This exact race was reproduced
+	// in production (VOIP-1258 PR #1101 round-2 post-deploy verification, 2026-07-14): one of
+	// two agent-manager pods hit this 503, silently never registered as a consumer, and a
+	// message ended up stuck unacknowledged on the queue for the pod that DID consume it.
+	// Sequencing this before the async ConsumeMessage goroutine below eliminates the race.
+	if errBind := h.sockHandler.QueueBind(h.subscribeQueue, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); errBind != nil {
+		log.Errorf("Could not bind to the topic exchange. err: %v", errBind)
+		// do NOT proceed to unbind the old exchange if this bind failed -- stay on the
+		// old exchange rather than risk ending up bound to neither.
+	} else if errUnbind := h.sockHandler.QueueUnbind(h.subscribeQueue, "", string(commonoutline.QueueNameWebhookEvent), nil); errUnbind != nil {
+		log.Errorf("CRITICAL: Could not unbind from the old fanout exchange after binding to the new topic exchange. queue: %s is now bound to BOTH exchanges (double-processing resumes). Manual intervention required. err: %v", h.subscribeQueue, errUnbind)
+	}
+
 	// receive subscribe events
 	go func() {
 		if errConsume := h.sockHandler.ConsumeMessage(context.Background(), h.subscribeQueue, string(commonoutline.ServiceNameAgentManager), false, false, false, 10, h.processEventRun); errConsume != nil {

--- a/bin-agent-manager/pkg/subscribehandler/main_test.go
+++ b/bin-agent-manager/pkg/subscribehandler/main_test.go
@@ -31,7 +31,14 @@ func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
 		string(commonoutline.QueueNameCustomerEvent),
 	}
 
-	var callOrder []string
+	// callOrderCh, not a shared slice: QueueBind/QueueUnbind run synchronously on the caller's
+	// goroutine, but ConsumeMessage's callback runs on Run()'s internal goroutine. A plain
+	// `var callOrder []string` appended from both would be a data race (caught by `-race`,
+	// intermittently, since ConsumeMessage's goroutine may or may not have scheduled by the
+	// time Run() returns) -- exactly the bug class this production fix addresses, ironically
+	// reintroduced in the test harness in an earlier version of this test. Use a buffered
+	// channel instead, matching bin-timeline-manager's Test_Run_BindsTopicExchangeBeforeConsuming.
+	callOrderCh := make(chan string, 8)
 
 	mockSock.EXPECT().QueueCreate(queueName, "normal").Return(nil)
 	for _, target := range subscribeTargets {
@@ -39,12 +46,12 @@ func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
 	}
 	mockSock.EXPECT().QueueBind(queueName, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil).
 		DoAndReturn(func(_, _, _ string, _ bool, _ interface{}) error {
-			callOrder = append(callOrder, "QueueBind")
+			callOrderCh <- "QueueBind"
 			return nil
 		})
 	mockSock.EXPECT().QueueUnbind(queueName, "", string(commonoutline.QueueNameWebhookEvent), nil).
 		DoAndReturn(func(_, _, _ string, _ interface{}) error {
-			callOrder = append(callOrder, "QueueUnbind")
+			callOrderCh <- "QueueUnbind"
 			return nil
 		})
 	// ConsumeMessage is started in a goroutine inside Run() -- allow it to be called (or not,
@@ -52,7 +59,7 @@ func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
 	// test; the ordering assertion below is what actually matters, not whether this fires.
 	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, gomock.Any(), false, false, false, 10, gomock.Any()).
 		DoAndReturn(func(_, _, _ interface{}, _, _, _ bool, _ int, _ interface{}) error {
-			callOrder = append(callOrder, "ConsumeMessage")
+			callOrderCh <- "ConsumeMessage"
 			return nil
 		}).AnyTimes()
 
@@ -63,7 +70,19 @@ func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
 	}
 
 	// By the time Run() returns, QueueBind and QueueUnbind must already have been recorded
-	// (they are called synchronously before the ConsumeMessage goroutine is launched).
+	// (they are called synchronously before the ConsumeMessage goroutine is launched). Drain
+	// whatever has arrived so far without closing the channel -- ConsumeMessage's mock may
+	// still be in flight on its own goroutine and could send after we're done reading.
+	var callOrder []string
+	draining := true
+	for draining {
+		select {
+		case c := <-callOrderCh:
+			callOrder = append(callOrder, c)
+		default:
+			draining = false
+		}
+	}
 	foundBind, foundUnbind := false, false
 	for _, c := range callOrder {
 		if c == "QueueBind" {

--- a/bin-agent-manager/pkg/subscribehandler/main_test.go
+++ b/bin-agent-manager/pkg/subscribehandler/main_test.go
@@ -1,0 +1,118 @@
+package subscribehandler
+
+import (
+	"testing"
+
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+// Test_Run_BindsTopicExchangeBeforeReturning is a regression test for a production incident
+// (VOIP-1258 PR #1101, found during post-deploy verification 2026-07-14): QueueBind/QueueUnbind
+// for the topic-exchange cutover MUST complete synchronously inside Run(), before the async
+// ConsumeMessage goroutine is started. QueueBind/QueueUnbind and ConsumeMessage's internal
+// channel.Consume() share the same underlying AMQP channel for a given queue name; if a caller
+// invoked QueueBind/QueueUnbind AFTER Run() returns (as this code originally did, from
+// cmd/agent-manager/main.go), it races the already-started basic.consume RPC on the same
+// channel and the broker can close the channel with "unexpected command received" (503) --
+// silently preventing that pod from ever consuming events. This test asserts the ordering:
+// QueueBind/QueueUnbind must both be called before ConsumeMessage is invoked at all.
+func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	queueName := string(commonoutline.QueueNameAgentSubscribe)
+	subscribeTargets := []string{
+		string(commonoutline.QueueNameCallEvent),
+		string(commonoutline.QueueNameCustomerEvent),
+	}
+
+	var callOrder []string
+
+	mockSock.EXPECT().QueueCreate(queueName, "normal").Return(nil)
+	for _, target := range subscribeTargets {
+		mockSock.EXPECT().QueueSubscribe(queueName, target).Return(nil)
+	}
+	mockSock.EXPECT().QueueBind(queueName, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil).
+		DoAndReturn(func(_, _, _ string, _ bool, _ interface{}) error {
+			callOrder = append(callOrder, "QueueBind")
+			return nil
+		})
+	mockSock.EXPECT().QueueUnbind(queueName, "", string(commonoutline.QueueNameWebhookEvent), nil).
+		DoAndReturn(func(_, _, _ string, _ interface{}) error {
+			callOrder = append(callOrder, "QueueUnbind")
+			return nil
+		})
+	// ConsumeMessage is started in a goroutine inside Run() -- allow it to be called (or not,
+	// if the goroutine hasn't scheduled yet by the time Run() returns) without blocking the
+	// test; the ordering assertion below is what actually matters, not whether this fires.
+	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, gomock.Any(), false, false, false, 10, gomock.Any()).
+		DoAndReturn(func(_, _, _ interface{}, _, _, _ bool, _ int, _ interface{}) error {
+			callOrder = append(callOrder, "ConsumeMessage")
+			return nil
+		}).AnyTimes()
+
+	h := NewSubscribeHandler(mockSock, queueName, subscribeTargets, nil)
+
+	if err := h.Run(); err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+
+	// By the time Run() returns, QueueBind and QueueUnbind must already have been recorded
+	// (they are called synchronously before the ConsumeMessage goroutine is launched).
+	foundBind, foundUnbind := false, false
+	for _, c := range callOrder {
+		if c == "QueueBind" {
+			foundBind = true
+		}
+		if c == "QueueUnbind" {
+			foundUnbind = true
+		}
+		// If ConsumeMessage's goroutine happened to race ahead and got recorded before
+		// QueueBind/QueueUnbind, that would indicate the ordering bug is back.
+		if c == "ConsumeMessage" && (!foundBind || !foundUnbind) {
+			t.Fatalf("ConsumeMessage was observed before QueueBind/QueueUnbind completed -- ordering regression. callOrder: %v", callOrder)
+		}
+	}
+	if !foundBind {
+		t.Errorf("Expected QueueBind to have been called synchronously within Run(), callOrder: %v", callOrder)
+	}
+	if !foundUnbind {
+		t.Errorf("Expected QueueUnbind to have been called synchronously within Run(), callOrder: %v", callOrder)
+	}
+}
+
+// Test_Run_QueueBindFailure_DoesNotUnbind verifies the safe-failure path: if QueueBind to the
+// new topic exchange fails, Run() must NOT proceed to QueueUnbind the old fanout exchange --
+// staying bound to the old exchange is safer than ending up bound to neither.
+func Test_Run_QueueBindFailure_DoesNotUnbind(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	queueName := string(commonoutline.QueueNameAgentSubscribe)
+	subscribeTargets := []string{string(commonoutline.QueueNameCallEvent)}
+
+	mockSock.EXPECT().QueueCreate(queueName, "normal").Return(nil)
+	mockSock.EXPECT().QueueSubscribe(queueName, subscribeTargets[0]).Return(nil)
+	mockSock.EXPECT().QueueBind(queueName, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil).
+		Return(assertError("bind failed"))
+	// QueueUnbind must NOT be called.
+	mockSock.EXPECT().QueueUnbind(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, gomock.Any(), false, false, false, 10, gomock.Any()).Return(nil).AnyTimes()
+
+	h := NewSubscribeHandler(mockSock, queueName, subscribeTargets, nil)
+
+	if err := h.Run(); err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+}
+
+type assertError string
+
+func (e assertError) Error() string { return string(e) }

--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -160,10 +160,6 @@ func runSubscribe(
 		"func": "runSubscribe",
 	})
 
-	if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
-		logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
-	}
-
 	subscribeTargets := []string{}
 	subHandler := subscribehandler.NewSubscribeHandler(
 		sockHandler,
@@ -177,6 +173,17 @@ func runSubscribe(
 	if errRun := subHandler.Run(); errRun != nil {
 		log.Errorf("Could not run the subscribe handler. err: %v", errRun)
 		return
+	}
+
+	// baseline "#" wildcard binding to the new topic exchange (VOIP-1258 §7 round-2 finding):
+	// a topic-kind exchange's empty-key bind (what QueueSubscribe used for the old fanout
+	// exchange) only matches messages published with an empty routing key, and every
+	// VOIP-1258 publish path uses non-empty scope-first keys, so this pod would receive ZERO
+	// events without this explicit bind. MUST run AFTER subHandler.Run() above, since that is
+	// what actually declares queueNamePod via QueueCreate -- QueueBind against a queue that
+	// does not exist yet fails (see rabbitmqhandler.TestQueueBind_ReturnsErrorForNonExistent).
+	if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
+		logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
 	}
 }
 

--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -133,13 +133,18 @@ func run(
 	requestHandler := requesthandler.NewRequestHandler(sockHandler, "api_manager")
 	zmqPubHandler := zmqpubhandler.NewZMQPubHandler()
 	streamHandler := streamhandler.NewStreamHandler(requestHandler, addressListenStream)
-	websockHandler := websockhandler.NewWebsockHandler(requestHandler, streamHandler)
+
+	// per-pod subscribe queue name -- constructed here (before websockHandler) so it can be
+	// shared with websockhandler's scopeRefCount for dynamic AMQP bind/unbind (VOIP-1258 §9).
+	queueNamePod := fmt.Sprintf("%s-%s", commonoutline.QueueNameAPISubscribe, uuid.Must(uuid.NewV4()))
+
+	websockHandler := websockhandler.NewWebsockHandler(requestHandler, streamHandler, sockHandler, queueNamePod)
 	serviceHandler, err := servicehandler.NewServiceHandler(requestHandler, db, websockHandler, cfg.GCPProjectID, cfg.GCPBucketName, cfg.JWTKey)
 	if err != nil {
 		log.Fatalf("Could not create service handler. err: %v", err)
 	}
 
-	go runSubscribe(sockHandler, requestHandler, zmqPubHandler)
+	go runSubscribe(sockHandler, requestHandler, zmqPubHandler, queueNamePod)
 	go runListenHTTP(serviceHandler)
 	go runListenStreamsock(ctx, streamHandler)
 
@@ -149,12 +154,11 @@ func runSubscribe(
 	sockHandler sockhandler.SockHandler,
 	reqHandler requesthandler.RequestHandler,
 	zmqHandler zmqpubhandler.ZMQPubHandler,
+	queueNamePod string,
 ) {
 	log := logrus.WithFields(logrus.Fields{
 		"func": "runSubscribe",
 	})
-
-	queueNamePod := fmt.Sprintf("%s-%s", commonoutline.QueueNameAPISubscribe, uuid.Must(uuid.NewV4()))
 
 	subscribeTargets := []string{
 		string(commonoutline.QueueNameWebhookEvent),

--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -160,11 +160,11 @@ func runSubscribe(
 		"func": "runSubscribe",
 	})
 
-	subscribeTargets := []string{
-		string(commonoutline.QueueNameWebhookEvent),
-		string(commonoutline.QueueNameAgentEvent),
-		string(commonoutline.QueueNameTalkEvent),
+	if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
+		logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
 	}
+
+	subscribeTargets := []string{}
 	subHandler := subscribehandler.NewSubscribeHandler(
 		sockHandler,
 		reqHandler,

--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -170,20 +170,16 @@ func runSubscribe(
 		zmqHandler,
 	)
 
+	// run. NOTE: the VOIP-1258 "#" wildcard binding to the new topic exchange lives INSIDE
+	// subscribeHandler.Run(), sequenced before ConsumeMessage starts -- see that function's
+	// doc comment for why doing it here (after Run() returns) is unsafe: Run() starts
+	// ConsumeMessage on a separate goroutine and returns immediately, so a QueueBind call
+	// here would race the in-flight basic.consume RPC on the same AMQP channel and could
+	// intermittently 503 the channel closed (reproduced in bin-agent-manager production,
+	// 2026-07-14, fixed there in commit ca8c104a9 and here proactively for the same reason).
 	if errRun := subHandler.Run(); errRun != nil {
 		log.Errorf("Could not run the subscribe handler. err: %v", errRun)
 		return
-	}
-
-	// baseline "#" wildcard binding to the new topic exchange (VOIP-1258 §7 round-2 finding):
-	// a topic-kind exchange's empty-key bind (what QueueSubscribe used for the old fanout
-	// exchange) only matches messages published with an empty routing key, and every
-	// VOIP-1258 publish path uses non-empty scope-first keys, so this pod would receive ZERO
-	// events without this explicit bind. MUST run AFTER subHandler.Run() above, since that is
-	// what actually declares queueNamePod via QueueCreate -- QueueBind against a queue that
-	// does not exist yet fails (see rabbitmqhandler.TestQueueBind_ReturnsErrorForNonExistent).
-	if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
-		logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
 	}
 }
 

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -1,0 +1,1678 @@
+# VOIP-1258: WebSocket Event Subscription Broker-Level Scoped Routing — Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+> Each task = one worktree commit, no exceptions. Run full service test suite after each task
+> that touches `bin-common-handler` (its consumers must not break silently).
+
+**Goal:** Convert `QueueNameWebhookEvent`'s RabbitMQ exchange from `fanout` to `topic`, with
+scope-first routing keys (`customer_id.<uuid>.#` / `owner_id.<uuid>.#`), so `bin-api-manager`
+pods only receive events for scopes that have a live local websocket subscriber — eliminating
+unconditional per-pod processing cost and the `agent_id` → `owner_id` public API rename.
+
+**Architecture:** 4 phases, each independently mergeable and independently safe to ship (no
+phase depends on a later phase being deployed to be correct — each is additive or dual-write
+until the final cutover step). Phase order: (1) shared plumbing in `bin-common-handler`
+(additive, zero existing call sites touched) → (2) `bin-webhook-manager` computes routing keys
+and dual-publishes → (3) exchange migration + non-websocket consumers move to the new exchange
+→ (4) `bin-api-manager` dynamic bind/unbind + owner_id rename + old-exchange decommission.
+
+**Tech Stack:** Go, RabbitMQ (`amqp091-go` via `bin-common-handler/pkg/rabbitmqhandler`), gomock
+(`go generate`), existing `sock`/`hook`/`websockhandler` packages in `bin-api-manager`.
+
+**Design doc (source of truth for all decisions/citations):**
+`bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md`
+
+---
+
+## Phase 1: `bin-common-handler` — additive routing-key/topic-kind plumbing
+
+**Objective:** Expose routing-key-aware publish and topic-kind-aware exchange declaration on
+`NotifyHandler`/`SockHandler`, without touching any existing method or call site.
+
+### Task 1.1: Add `QueueBind`/`QueueUnbind` awareness check to `SockHandler` interface
+
+**Files:**
+- Modify: `bin-common-handler/pkg/sockhandler/main.go`
+- Modify: `bin-common-handler/pkg/sockhandler/mock_sockhandler.go` (regenerated)
+
+**Step 1:** `QueueBind` already exists as a public method on `rabbit` (concrete struct,
+`rabbitmqhandler/queue.go:163`) but is NOT on the `SockHandler` interface. `QueueUnbind` does
+not exist anywhere in `bin-common-handler` yet (verified: zero hits). Both are needed for Phase
+4's dynamic bind/unbind. Add to the interface:
+
+```go
+// bin-common-handler/pkg/sockhandler/main.go
+type SockHandler interface {
+	Connect()
+	Close()
+
+	ConsumeMessage(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, numWorkers int, messageConsume sock.CbMsgConsume) error
+	ConsumeRPC(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error
+
+	TopicCreate(name string) error
+	TopicCreateWithKind(name string, kind string) error // NEW
+
+	EventPublish(topic string, key string, evt *sock.Event) error
+	EventPublishWithDelay(topic string, key string, evt *sock.Event, delay int) error
+	EventPublishWithKey(topic string, key string, evt *sock.Event) error // NEW (alias-clear name; see Task 1.2 note)
+
+	RequestPublish(ctx context.Context, queueName string, req *sock.Request) (*sock.Response, error)
+	RequestPublishWithDelay(queueName string, req *sock.Request, delay int) error
+
+	QueueCreate(name string, queueType string) error
+	QueueSubscribe(name string, topic string) error
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error    // NEW: expose existing rabbit method
+	QueueUnbind(name, key, exchange string, args amqp.Table) error                // NEW: does not exist yet, see Task 1.3
+}
+```
+
+**Note on `EventPublishWithKey`**: `EventPublish(topic, key string, evt *sock.Event)` already
+takes a `key` parameter (verified, `sockhandler/main.go:20`) — it is NOT missing at this layer.
+**Skip adding `EventPublishWithKey`; `EventPublish` is already sufficient at the `SockHandler`
+level.** The gap is one layer up, at `NotifyHandler` (Task 1.2). Strike this line from the
+interface above — corrected list:
+
+```go
+type SockHandler interface {
+	Connect()
+	Close()
+
+	ConsumeMessage(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, numWorkers int, messageConsume sock.CbMsgConsume) error
+	ConsumeRPC(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error
+
+	TopicCreate(name string) error
+	TopicCreateWithKind(name string, kind string) error // NEW, Task 1.4
+
+	EventPublish(topic string, key string, evt *sock.Event) error
+	EventPublishWithDelay(topic string, key string, evt *sock.Event, delay int) error
+
+	RequestPublish(ctx context.Context, queueName string, req *sock.Request) (*sock.Response, error)
+	RequestPublishWithDelay(queueName string, req *sock.Request, delay int) error
+
+	QueueCreate(name string, queueType string) error
+	QueueSubscribe(name string, topic string) error
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error   // NEW, Task 1.3
+	QueueUnbind(name, key, exchange string, args amqp.Table) error              // NEW, Task 1.3
+}
+```
+
+Add `amqp "github.com/rabbitmq/amqp091-go"` to the import block (needed for `amqp.Table`).
+
+**Step 2:** Regenerate mock:
+```bash
+cd bin-common-handler/pkg/sockhandler && go generate ./...
+```
+
+**Step 3:** Verify build:
+```bash
+cd bin-common-handler && go build ./...
+```
+Expected: FAILS at this point — `rabbit` struct's `QueueBind` signature already matches, but
+`QueueUnbind` doesn't exist on `rabbit` yet, so `rabbit` no longer satisfies `SockHandler`. This
+is expected and resolved by Task 1.3. Do not treat this failure as a blocker to committing this
+task IF committing Task 1.1 and 1.3 together — see Task grouping note below.
+
+**Commit grouping note:** Tasks 1.1 and 1.3 must land in the SAME commit (interface change +
+implementation), since 1.1 alone leaves `bin-common-handler` non-compiling. Task 1.2 and 1.4 can
+each be separate commits after 1.1+1.3 land.
+
+### Task 1.2: Add `PublishEventWithRoutingKey` to `NotifyHandler`
+
+**Files:**
+- Modify: `bin-common-handler/pkg/notifyhandler/main.go` (interface)
+- Modify: `bin-common-handler/pkg/notifyhandler/publish.go` (implementation)
+- Modify: `bin-common-handler/pkg/notifyhandler/mock_main.go` (regenerated)
+- Test: `bin-common-handler/pkg/notifyhandler/publish_test.go` (new or extend existing)
+
+**Step 1: Write failing test**
+
+```go
+// bin-common-handler/pkg/notifyhandler/publish_test.go
+func TestPublishEventWithRoutingKey(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	h := &notifyHandler{
+		sockHandler: mockSock,
+		queueNotify: "test.queue",
+		publisher:   "test-service",
+	}
+
+	data := map[string]string{"foo": "bar"}
+	routingKey := "customer_id.abc123.call.call_updated.xyz789"
+
+	mockSock.EXPECT().EventPublish("test.queue", routingKey, gomock.Any()).Return(nil)
+
+	h.PublishEventWithRoutingKey(context.Background(), "call_updated", routingKey, data)
+
+	// PublishEventWithRoutingKey is fire-and-forget like PublishEvent; assert via mock call above.
+}
+```
+
+**Step 2: Run test to verify failure**
+
+```bash
+cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestPublishEventWithRoutingKey -v
+```
+Expected: FAIL — `PublishEventWithRoutingKey` undefined.
+
+**Step 3: Write minimal implementation**
+
+```go
+// bin-common-handler/pkg/notifyhandler/main.go — add to NotifyHandler interface:
+type NotifyHandler interface {
+	PublishEvent(ctx context.Context, eventType string, data interface{})
+	PublishEventRaw(ctx context.Context, eventType string, dataType string, data []byte)
+	PublishEventWithRoutingKey(ctx context.Context, eventType string, routingKey string, data interface{}) // NEW
+
+	PublishWebhook(ctx context.Context, customerID uuid.UUID, eventType string, data WebhookMessage)
+	PublishWebhookEvent(ctx context.Context, customerID uuid.UUID, eventType string, data WebhookMessage)
+}
+```
+
+```go
+// bin-common-handler/pkg/notifyhandler/publish.go — add:
+
+// PublishEventWithRoutingKey publishes event to the event queue with an explicit AMQP routing
+// key, for topic-kind exchanges. Unlike PublishEvent (which always publishes with an empty
+// routing key, correct for fanout exchanges), this lets the caller target scope-based topic
+// bindings. See VOIP-1258 design doc §6.
+func (h *notifyHandler) PublishEventWithRoutingKey(ctx context.Context, eventType string, routingKey string, data interface{}) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "PublishEventWithRoutingKey",
+		"evnet_type":  eventType,
+		"routing_key": routingKey,
+	})
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		log.Errorf("Could not marshal the message. err: %v", err)
+		return
+	}
+
+	if err := h.publishEventWithKey(routingKey, string(eventType), string(wmwebhook.DataTypeJSON), m, requestTimeoutDefault); err != nil {
+		log.Errorf("Could not publish the event with routing key. err: %v", err)
+		return
+	}
+}
+
+// publishEventWithKey publishes an event to the event queue with the given routing key.
+func (h *notifyHandler) publishEventWithKey(routingKey string, eventType string, dataType string, data json.RawMessage, timeout int) error {
+	evt := &sock.Event{
+		Type:      eventType,
+		Publisher: string(h.publisher),
+		DataType:  dataType,
+		Data:      data,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(timeout))
+	defer cancel()
+	_ = ctx // reserved for future use, matches existing publishEvent's unused-ctx pattern
+
+	start := time.Now()
+	err := h.sockHandler.EventPublish(string(h.queueNotify), routingKey, evt)
+	elapsed := time.Since(start)
+	promNotifyProcessTime.WithLabelValues(evt.Type).Observe(float64(elapsed.Milliseconds()))
+	if err != nil {
+		return fmt.Errorf("could not publish the event. err: %v", err)
+	}
+	promNotifyTotal.WithLabelValues(evt.Type).Inc()
+
+	return nil
+}
+```
+
+**Step 4: Run test to verify pass**
+
+```bash
+cd bin-common-handler/pkg/notifyhandler && go generate ./... && go test ./... -run TestPublishEventWithRoutingKey -v
+```
+Expected: PASS
+
+**Step 5: Verify no existing call site broke**
+
+```bash
+cd bin-common-handler && go build ./... && go test ./pkg/notifyhandler/...
+```
+Expected: all pass, zero changes needed to any existing `PublishEvent`/`PublishWebhookEvent`
+call site (confirmed additive per design doc §6/§4).
+
+**Step 6: Commit**
+
+```bash
+git add bin-common-handler/pkg/notifyhandler/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add PublishEventWithRoutingKey to NotifyHandler
+
+- bin-common-handler: Add additive PublishEventWithRoutingKey method for topic-exchange scoped publishing (VOIP-1258), zero changes to existing PublishEvent/PublishWebhookEvent call sites"
+```
+
+### Task 1.3: Implement `QueueBind`/`QueueUnbind` on `rabbit`, satisfy `SockHandler`
+
+**Files:**
+- Modify: `bin-common-handler/pkg/rabbitmqhandler/queue.go`
+
+**Step 1:** `QueueBind` already exists on `rabbit` (`queue.go:163`) with the exact signature
+needed — no change required there, it's already compatible with the interface addition in Task
+1.1. Only `QueueUnbind` needs to be added:
+
+```go
+// bin-common-handler/pkg/rabbitmqhandler/queue.go — add after QueueBind:
+
+// QueueUnbind unbinds queue and exchange with a key
+func (r *rabbit) QueueUnbind(name, key, exchange string, args amqp.Table) error {
+	queue := r.queueGet(name)
+	if queue == nil {
+		return fmt.Errorf("no queue found")
+	}
+
+	if err := queue.channel.QueueUnbind(name, key, exchange, args); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	delete(r.queueBinds, name) // NOTE: see caveat below if multiple binds per queue name are tracked
+	r.mu.Unlock()
+	return nil
+}
+```
+
+**Caveat, must verify before merging**: `r.queueBinds` is keyed by queue `name` only
+(`queue.go:174`, `QueueBind`'s existing code: `r.queueBinds[name] = &queueBind{...}`) — it
+overwrites on each bind, so it currently only tracks the MOST RECENT bind per queue name, not a
+set of all binds. For Phase 4's dynamic bind/unbind (one queue, many scope bindings
+simultaneously), this internal bookkeeping map is insufficient as-is. Two options, decide during
+Phase 4 planning (Task 4.1), not now:
+- (a) Change `r.queueBinds[name]` to `map[string][]*queueBind` (a slice per queue name) --
+  affects any other code reading `r.queueBinds` (grep before changing).
+  - (b) Don't rely on `r.queueBinds` for the refcount tracking at all; track scope→refcount
+  entirely in `bin-api-manager`'s own new component (Task 4.2) and treat `QueueBind`/`QueueUnbind`
+  as pure fire-and-forget AMQP calls. **Recommended**: (b) is simpler and doesn't touch shared
+  `rabbitmqhandler` internals for an api-manager-specific concern.
+
+**Step 2: Verify build**
+
+```bash
+cd bin-common-handler && go build ./...
+```
+Expected: PASS (this resolves the Task 1.1 compile failure).
+
+**Step 3: Write test**
+
+```go
+// bin-common-handler/pkg/rabbitmqhandler/queue_test.go — add:
+func TestQueueUnbind_Success(t *testing.T) {
+	// follow existing TestQueueBind_Success pattern at queue_test.go (search for it),
+	// mock channel.QueueUnbind, assert no error
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cd bin-common-handler/pkg/rabbitmqhandler && go test ./... -run TestQueueUnbind -v
+```
+Expected: PASS
+
+**Step 5: Commit (together with Task 1.1's interface change)**
+
+```bash
+git add bin-common-handler/pkg/sockhandler/ bin-common-handler/pkg/rabbitmqhandler/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add QueueBind/QueueUnbind to SockHandler interface
+
+- bin-common-handler: Expose QueueBind (already existed on rabbit) and new QueueUnbind on the SockHandler interface, needed for VOIP-1258 Phase 4 dynamic bind/unbind"
+```
+
+### Task 1.4: Add `TopicCreateWithKind` to `SockHandler`/`rabbit`
+
+**Files:**
+- Modify: `bin-common-handler/pkg/sockhandler/main.go` (interface, already added in Task 1.1)
+- Modify: `bin-common-handler/pkg/rabbitmqhandler/topic.go`
+
+**Step 1: Write failing test**
+
+```go
+// bin-common-handler/pkg/rabbitmqhandler/topic_test.go — new file or extend
+func TestTopicCreateWithKind_Topic(t *testing.T) {
+	// mock ExchangeDeclare, assert called with kind="topic" when TopicCreateWithKind(name, "topic")
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-common-handler/pkg/rabbitmqhandler && go test ./... -run TestTopicCreateWithKind -v
+```
+Expected: FAIL — undefined.
+
+**Step 3: Implement**
+
+```go
+// bin-common-handler/pkg/rabbitmqhandler/topic.go
+package rabbitmqhandler
+
+import "fmt"
+
+func (h *rabbit) TopicCreate(name string) error {
+	if errDeclare := h.ExchangeDeclare(name, "fanout", true, false, false, false, nil); errDeclare != nil {
+		return fmt.Errorf("could not declare the queue for event. err: %v", errDeclare)
+	}
+	return nil
+}
+
+// TopicCreateWithKind declares an exchange with the given kind ("fanout", "topic", "direct",
+// etc.), durable=true (matching TopicCreate's existing durability). Added for VOIP-1258 to
+// support topic-kind exchanges without touching TopicCreate's existing fanout-only behavior.
+func (h *rabbit) TopicCreateWithKind(name string, kind string) error {
+	if errDeclare := h.ExchangeDeclare(name, kind, true, false, false, false, nil); errDeclare != nil {
+		return fmt.Errorf("could not declare the exchange with kind %s. err: %v", kind, errDeclare)
+	}
+	return nil
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-common-handler/pkg/rabbitmqhandler && go test ./... -run TestTopicCreateWithKind -v
+```
+Expected: PASS
+
+**Step 5: Regenerate mocks, full build/test**
+
+```bash
+cd bin-common-handler && go generate ./... && go build ./... && go test ./...
+```
+Expected: all pass, zero regressions.
+
+**Step 6: Commit**
+
+```bash
+git add bin-common-handler/pkg/rabbitmqhandler/topic.go bin-common-handler/pkg/rabbitmqhandler/topic_test.go bin-common-handler/pkg/sockhandler/mock_sockhandler.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add TopicCreateWithKind for declaring non-fanout exchanges
+
+- bin-common-handler: Add TopicCreateWithKind alongside existing TopicCreate (fanout-only), needed for VOIP-1258's new topic-kind exchange"
+```
+
+### Task 1.5: Phase 1 verification gate
+
+**Step 1:** Full `bin-common-handler` test suite:
+```bash
+cd bin-common-handler && go build ./... && go test ./... -v
+```
+Expected: all pass, zero failures.
+
+**Step 2:** Build a SAMPLE of dependent services to confirm zero breakage (per design doc Open
+Question 9's verification requirement):
+```bash
+cd bin-webhook-manager && go build ./...
+cd bin-agent-manager && go build ./...
+cd bin-api-manager && go build ./...
+```
+Expected: all pass unchanged (Phase 1 is purely additive).
+
+---
+
+## Phase 2: `bin-webhook-manager` — compute routing keys, dual-publish
+
+**Objective:** Move `createTopics()`'s routing-key-computation logic (customer_id, owner_id
+extraction, chat-participant fan-out) into `bin-webhook-manager`, executed before publish, and
+dual-publish to both the old fanout exchange (unchanged, for safety) and the new topic exchange.
+
+### Task 2.1: Add `reqHandler` dependency to `webhookHandler`
+
+**Files:**
+- Modify: `bin-webhook-manager/pkg/webhookhandler/main.go`
+- Modify: `bin-webhook-manager/cmd/webhook-manager/main.go`
+- Modify: `bin-webhook-manager/cmd/webhook-control/main.go`
+- Modify: `bin-webhook-manager/pkg/webhookhandler/mock_webhookhandler.go` (regenerated)
+
+**Step 1: Modify struct + constructor**
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/main.go
+import (
+	// ... existing imports
+	"monorepo/bin-common-handler/pkg/requesthandler" // NEW
+)
+
+type webhookHandler struct {
+	db            dbhandler.DBHandler
+	notifyHandler notifyhandler.NotifyHandler
+	reqHandler    requesthandler.RequestHandler // NEW
+
+	accoutHandler     accounthandler.AccountHandler
+	activeflowHandler activeflowhandler.ActiveflowHandler
+
+	httpClient *http.Client
+}
+
+func NewWebhookHandler(
+	db dbhandler.DBHandler,
+	notifyHandler notifyhandler.NotifyHandler,
+	reqHandler requesthandler.RequestHandler, // NEW, inserted after notifyHandler
+	messageTargetHandler accounthandler.AccountHandler,
+	activeflowHandler activeflowhandler.ActiveflowHandler,
+) WebhookHandler {
+
+	h := &webhookHandler{
+		db:            db,
+		notifyHandler: notifyHandler,
+		reqHandler:    reqHandler, // NEW
+
+		accoutHandler:     messageTargetHandler,
+		activeflowHandler: activeflowHandler,
+
+		httpClient: newSafeHTTPClient(),
+	}
+
+	return h
+}
+```
+
+**Step 2: Update both wiring sites**
+
+Find and update `NewWebhookHandler(...)` call sites:
+```bash
+grep -n "NewWebhookHandler(" bin-webhook-manager/cmd/webhook-manager/main.go bin-webhook-manager/cmd/webhook-control/main.go
+```
+
+Both already construct `reqHandler` locally (verified in design doc §6) — pass it as the new
+positional argument matching the constructor signature above.
+
+**Step 3: Regenerate mock, build**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go generate ./...
+cd bin-webhook-manager && go build ./...
+```
+Expected: PASS (this is a same-package internal change; no external callers of
+`NewWebhookHandler` outside `cmd/webhook-manager` and `cmd/webhook-control`, confirmed in design
+doc §6).
+
+**Step 4: Run existing webhookhandler tests**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -v
+```
+Expected: PASS (constructor signature changed but no existing test should call `NewWebhookHandler`
+without the new param after the mock regen — if any test breaks, update its call site to pass a
+mock `reqHandler`).
+
+**Step 5: Commit**
+
+```bash
+git add bin-webhook-manager/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add reqHandler dependency to webhookHandler
+
+- bin-webhook-manager: Add requesthandler.RequestHandler DI to webhookHandler, needed for chat-participant RPC relocation (VOIP-1258 §6 harder part 2)"
+```
+
+### Task 2.2: Port `commonWebhookData` envelope-parsing struct into webhook-manager
+
+**Files:**
+- Create: `bin-webhook-manager/pkg/webhookhandler/routingkey.go`
+- Test: `bin-webhook-manager/pkg/webhookhandler/routingkey_test.go`
+
+**Step 1: Write failing test**
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+func TestParseWebhookOwnerData(t *testing.T) {
+	data := json.RawMessage(`{"customer_id":"a1b2c3d4-0000-0000-0000-000000000001","owner_id":"98765432-0000-0000-0000-000000000002","owner_type":"agent","id":"xyz-0000-0000-0000-000000000003"}`)
+
+	d, err := parseWebhookOwnerData(data)
+
+	require.NoError(t, err)
+	require.Equal(t, "a1b2c3d4-0000-0000-0000-000000000001", d.CustomerID.String())
+	require.Equal(t, "98765432-0000-0000-0000-000000000002", d.OwnerID.String())
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestParseWebhookOwnerData -v
+```
+Expected: FAIL — undefined.
+
+**Step 3: Implement (port from `bin-api-manager/pkg/subscribehandler/webhookmanager.go`)**
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/routingkey.go
+package webhookhandler
+
+import (
+	"encoding/json"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+// webhookOwnerData mirrors bin-api-manager's commonWebhookData struct (ported per VOIP-1258 §6
+// harder part 1). Used to extract customer_id/owner_id from the event data payload BEFORE
+// publish, so the routing key can be computed at publish time instead of at consumption time.
+type webhookOwnerData struct {
+	commonidentity.Identity
+	commonidentity.Owner
+	AIcallID uuid.UUID `json:"aicall_id,omitempty"`
+	ChatID   uuid.UUID `json:"chat_id,omitempty"`
+}
+
+// parseWebhookOwnerData unmarshals the event data payload to extract customer_id/owner_id/
+// aicall_id/chat_id. Best-effort: returns zero-value fields (not an error) if optional fields
+// are absent, matching createTopics()'s existing tolerance for partial data.
+func parseWebhookOwnerData(data json.RawMessage) (*webhookOwnerData, error) {
+	d := &webhookOwnerData{}
+	if err := json.Unmarshal(data, d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestParseWebhookOwnerData -v
+```
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add bin-webhook-manager/pkg/webhookhandler/routingkey.go bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Port webhook owner-data envelope parsing into webhook-manager
+
+- bin-webhook-manager: Add parseWebhookOwnerData, ported from bin-api-manager's commonWebhookData (VOIP-1258 §6 harder part 1)"
+```
+
+### Task 2.3: Implement `createRoutingKeys()` in webhook-manager (owner_id, hard-cutover)
+
+**Files:**
+- Modify: `bin-webhook-manager/pkg/webhookhandler/routingkey.go`
+- Test: `bin-webhook-manager/pkg/webhookhandler/routingkey_test.go`
+
+**Step 1: Write failing test**
+
+```go
+func TestCreateRoutingKeys_CustomerOnly(t *testing.T) {
+	d := &webhookOwnerData{
+		Identity: commonidentity.Identity{CustomerID: uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001"), ID: uuid.FromStringOrNil("xyz-0000-0000-0000-000000000003")},
+	}
+	keys := createRoutingKeys(d, "call", "call_updated")
+	require.Equal(t, []string{"customer_id.a1b2c3d4-0000-0000-0000-000000000001.call.call_updated.xyz-0000-0000-0000-000000000003"}, keys)
+}
+
+func TestCreateRoutingKeys_CustomerAndOwner(t *testing.T) {
+	d := &webhookOwnerData{
+		Identity: commonidentity.Identity{CustomerID: uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001"), ID: uuid.FromStringOrNil("xyz-0000-0000-0000-000000000003")},
+		Owner:    commonidentity.Owner{OwnerID: uuid.FromStringOrNil("98765432-0000-0000-0000-000000000002")},
+	}
+	keys := createRoutingKeys(d, "queue", "queue_updated")
+	require.ElementsMatch(t, []string{
+		"customer_id.a1b2c3d4-0000-0000-0000-000000000001.queue.queue_updated.xyz-0000-0000-0000-000000000003",
+		"owner_id.98765432-0000-0000-0000-000000000002.queue.queue_updated.xyz-0000-0000-0000-000000000003",
+	}, keys)
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestCreateRoutingKeys -v
+```
+Expected: FAIL — undefined.
+
+**Step 3: Implement (non-chat resource types only — chat handled in Task 2.4)**
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/routingkey.go — add:
+import "fmt"
+
+// createRoutingKeys generates AMQP routing keys for the given event, scope-first
+// (VOIP-1258 §5): "<scope>.<scope_id>.<resource>.<message_type>.<resource_id>".
+// owner_id replaces the old client-facing agent_id prefix (hard cutover, Open Question 10).
+func createRoutingKeys(d *webhookOwnerData, resource string, messageType string) []string {
+	res := []string{}
+
+	if d.CustomerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("customer_id.%s.%s.%s.%s", d.CustomerID, resource, messageType, d.ID))
+	}
+	if d.OwnerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("owner_id.%s.%s.%s.%s", d.OwnerID, resource, messageType, d.ID))
+	}
+
+	return res
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestCreateRoutingKeys -v
+```
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add bin-webhook-manager/pkg/webhookhandler/routingkey.go bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Implement createRoutingKeys for non-chat resource types
+
+- bin-webhook-manager: Add scope-first routing key generation (customer_id/owner_id), owner_id per Open Question 10 hard-cutover decision"
+```
+
+### Task 2.4: Chat-participant fan-out routing keys (RPC relocation)
+
+**Files:**
+- Modify: `bin-webhook-manager/pkg/webhookhandler/routingkey.go`
+- Test: `bin-webhook-manager/pkg/webhookhandler/routingkey_test.go`
+
+**Step 1: Write failing test**
+
+```go
+func TestCreateRoutingKeysForChat(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &webhookHandler{reqHandler: mockReq}
+
+	chatID := uuid.FromStringOrNil("chat0000-0000-0000-0000-000000000001")
+	d := &webhookOwnerData{
+		Identity: commonidentity.Identity{CustomerID: uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001")},
+		ChatID:   chatID,
+	}
+
+	mockReq.EXPECT().TalkV1ParticipantList(gomock.Any(), chatID).Return([]tmparticipant.Participant{
+		{Owner: commonidentity.Owner{OwnerID: uuid.FromStringOrNil("p1000000-0000-0000-0000-000000000001")}},
+		{Owner: commonidentity.Owner{OwnerID: uuid.FromStringOrNil("p2000000-0000-0000-0000-000000000002")}},
+	}, nil)
+
+	keys := h.createRoutingKeysForChat(context.Background(), d, "chatmessage_created")
+
+	require.Contains(t, keys, "customer_id.a1b2c3d4-0000-0000-0000-000000000001.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
+	require.Contains(t, keys, "owner_id.p1000000-0000-0000-0000-000000000001.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
+	require.Contains(t, keys, "owner_id.p2000000-0000-0000-0000-000000000002.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestCreateRoutingKeysForChat -v
+```
+Expected: FAIL — undefined.
+
+**Step 3: Implement (moves `TalkV1ParticipantList` RPC to publish time, per §6 harder part 2)**
+
+Check the exact `RequestHandler.TalkV1ParticipantList` signature and its participant model's
+field name first:
+```bash
+grep -n "TalkV1ParticipantList" bin-common-handler/pkg/requesthandler/*.go
+```
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/routingkey.go — add:
+import "context"
+
+// createRoutingKeysForChat generates routing keys for chat/chatmessage/chatparticipant events,
+// including one owner_id key per chat participant (fan-out). This RPC call was moved here from
+// bin-api-manager's createTopics() per VOIP-1258 §6 harder part 2 -- it now runs ONCE at publish
+// time regardless of subscriber count, instead of once per pod after the fact.
+func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhookOwnerData, messageType string) []string {
+	log := logrus.WithFields(logrus.Fields{"func": "createRoutingKeysForChat"})
+
+	res := []string{}
+
+	chatID := d.ChatID
+	if chatID == uuid.Nil {
+		chatID = d.ID
+	}
+	if chatID == uuid.Nil {
+		return res
+	}
+
+	if d.CustomerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("customer_id.%s.talk.%s.%s", d.CustomerID, messageType, chatID))
+	}
+	if d.OwnerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("owner_id.%s.talk.%s.%s", d.OwnerID, messageType, chatID))
+	}
+
+	participants, err := h.reqHandler.TalkV1ParticipantList(ctx, chatID)
+	if err != nil {
+		log.Errorf("Could not get chat participants, publishing customer/owner-scoped keys only. err: %v", err)
+		return res
+	}
+
+	for _, p := range participants {
+		if p.OwnerID == d.OwnerID {
+			continue // already added above
+		}
+		res = append(res, fmt.Sprintf("owner_id.%s.talk.%s.%s", p.OwnerID, messageType, chatID))
+	}
+
+	return res
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestCreateRoutingKeysForChat -v
+```
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add bin-webhook-manager/pkg/webhookhandler/routingkey.go bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Implement chat-participant fan-out routing keys at publish time
+
+- bin-webhook-manager: Move TalkV1ParticipantList RPC from api-manager's createTopics() to publish-time, per VOIP-1258 Open Question 4/§6"
+```
+
+### Task 2.5: Wire routing-key computation + dual-publish into `SendWebhookToCustomer`/`SendWebhookToURI`
+
+**Files:**
+- Modify: `bin-webhook-manager/pkg/webhookhandler/webhook.go`
+- Test: `bin-webhook-manager/pkg/webhookhandler/webhook_test.go` (extend existing)
+
+**Step 1:** Determine the new topic exchange name constant first (Phase 3, Task 3.1 defines
+it — this task has a forward dependency; if executing phases sequentially, do Task 3.1 before
+this task, OR use a placeholder constant here and rename in Task 3.1's commit). Recommended:
+do Task 3.1 (exchange name + declare) BEFORE this task, then return here.
+
+**Step 2: Write failing test**
+
+```go
+func TestSendWebhookToCustomer_DualPublishesWithRoutingKey(t *testing.T) {
+	// extend existing SendWebhookToCustomer test setup; add expectation that
+	// notifyHandler.PublishEventWithRoutingKey is called once per generated routing key,
+	// in addition to the existing notifyHandler.PublishEvent call (dual-publish, Task 3.2's
+	// transition-window requirement)
+}
+```
+
+**Step 3: Run to verify failure**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -run TestSendWebhookToCustomer_DualPublishesWithRoutingKey -v
+```
+Expected: FAIL.
+
+**Step 4: Implement**
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/webhook.go — modify SendWebhookToCustomer:
+
+func (h *webhookHandler) SendWebhookToCustomer(ctx context.Context, customerID uuid.UUID, dataType webhook.DataType, data json.RawMessage) error {
+	// ... existing code through h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh) unchanged ...
+
+	// NEW: dual-publish to the topic exchange with computed routing keys (VOIP-1258 §6/§8).
+	// This is IN ADDITION TO the existing fanout PublishEvent call above, not a replacement --
+	// dual-publish continues until Phase 4's cutover step (Task 4.6) removes the old exchange.
+	h.publishRoutingKeyedEvent(ctx, webhook.EventTypeWebhookPublished, data)
+
+	h.sendWebhookToActiveflow(ctx, dataType, data)
+
+	return nil
+}
+```
+
+```go
+// bin-webhook-manager/pkg/webhookhandler/routingkey.go — add:
+
+// publishRoutingKeyedEvent computes routing keys for the given event data and publishes to the
+// new topic exchange with each key. Best-effort: logs and returns on parse/RPC failure without
+// blocking the primary (fanout) delivery path above it.
+func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, eventType string, data json.RawMessage) {
+	log := logrus.WithFields(logrus.Fields{"func": "publishRoutingKeyedEvent", "event_type": eventType})
+
+	d, err := parseWebhookOwnerData(data)
+	if err != nil {
+		log.Errorf("Could not parse owner data for routing key computation. err: %v", err)
+		return
+	}
+
+	// messageType/resource parsing: eventType is the wire event type e.g. "call_updated".
+	// resource = first underscore-delimited segment, matching createTopics()'s existing
+	// convention (webhookmanager.go:111-120 in the pre-migration bin-api-manager code).
+	tmps := strings.SplitN(eventType, "_", 2)
+	if len(tmps) < 2 {
+		log.Errorf("Wrong event type format for routing key. event_type: %s", eventType)
+		return
+	}
+	resource := tmps[0]
+
+	var keys []string
+	switch resource {
+	case "chat", "chatmessage", "chatparticipant":
+		keys = h.createRoutingKeysForChat(ctx, d, eventType)
+	default:
+		keys = createRoutingKeys(d, resource, eventType)
+	}
+
+	for _, key := range keys {
+		h.notifyHandler.PublishEventWithRoutingKey(ctx, eventType, key, json.RawMessage(data))
+	}
+}
+```
+
+Apply the SAME `h.publishRoutingKeyedEvent(ctx, webhook.EventTypeWebhookPublished, data)` call
+to `SendWebhookToURI`, immediately after its existing `h.notifyHandler.PublishEvent(...)` call
+(per design doc §6 symmetry note — both entry points feed the same downstream path).
+
+**Step 5: Run test, verify pass**
+
+```bash
+cd bin-webhook-manager/pkg/webhookhandler && go test ./... -v
+```
+Expected: all pass, including new dual-publish test.
+
+**Step 6: Commit**
+
+```bash
+git add bin-webhook-manager/pkg/webhookhandler/webhook.go bin-webhook-manager/pkg/webhookhandler/routingkey.go bin-webhook-manager/pkg/webhookhandler/webhook_test.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Dual-publish routing-keyed events from SendWebhookToCustomer/SendWebhookToURI
+
+- bin-webhook-manager: Wire routing-key computation into both webhook entry points, dual-publish to new topic exchange alongside existing fanout publish (VOIP-1258 §6/§8 transition window)"
+```
+
+---
+
+## Phase 3: Exchange migration — new topic exchange, non-websocket consumer migration
+
+**Objective:** Declare the new topic exchange, migrate `bin-agent-manager` and
+`bin-timeline-manager`'s `QueueNameWebhookEvent` bindings to it with `#` wildcard, verify
+dual-publish is flowing correctly before touching `bin-api-manager`.
+
+### Task 3.1: Define new exchange name constant, declare as topic/durable
+
+**Files:**
+- Modify: `bin-common-handler/models/outline/queuename.go`
+- Modify: `bin-webhook-manager/cmd/webhook-manager/main.go`, `cmd/webhook-control/main.go`
+
+**Step 1:** Add the new constant next to the existing one:
+
+```go
+// bin-common-handler/models/outline/queuename.go — near line 172:
+QueueNameWebhookEvent      QueueName = "bin-manager.webhook-manager.event"
+QueueNameWebhookEventTopic QueueName = "bin-manager.webhook-manager.event.topic" // NEW, VOIP-1258
+```
+
+**Step 2:** In `bin-webhook-manager`'s startup wiring, declare the new exchange as `topic`/
+`durable=true` via `sockHandler.TopicCreateWithKind`, alongside the existing fanout declare
+(which happens implicitly inside `NewNotifyHandler` today — the new exchange needs its own
+explicit declare since it's not created via a second `NewNotifyHandler` call):
+
+```go
+// bin-webhook-manager/cmd/webhook-manager/main.go — after sockHandler is constructed, before
+// webhookHandler is constructed:
+if err := sockHandler.TopicCreateWithKind(string(commonoutline.QueueNameWebhookEventTopic), "topic"); err != nil {
+	logrus.Errorf("Could not declare the topic exchange. err: %v", err)
+	// decide: fatal or continue-without-dual-publish? Recommend fatal for webhook-manager main,
+	// since dual-publish is a hard requirement of the transition window.
+}
+```
+
+Apply the same in `cmd/webhook-control/main.go`.
+
+**Step 3:** Update `webhookHandler`'s `publishRoutingKeyedEvent` (Task 2.5) to target this
+constant instead of `h.queueNotify` — this requires `PublishEventWithRoutingKey` to accept an
+explicit queue/exchange name parameter, OR a second `NotifyHandler` instance pointed at the new
+exchange. **Recommended**: give `notifyhandler.NewNotifyHandler` a second call in webhook-manager
+startup, creating a SEPARATE `NotifyHandler` instance bound to `QueueNameWebhookEventTopic`, and
+inject it into `webhookHandler` as a distinct field (`topicNotifyHandler`) alongside the existing
+`notifyHandler`. Revise Task 2.1's struct:
+
+```go
+type webhookHandler struct {
+	db                 dbhandler.DBHandler
+	notifyHandler      notifyhandler.NotifyHandler // existing fanout exchange
+	topicNotifyHandler notifyhandler.NotifyHandler // NEW: topic exchange, VOIP-1258
+	reqHandler         requesthandler.RequestHandler
+	// ...
+}
+```
+
+Update `NewWebhookHandler`'s signature to accept `topicNotifyHandler` as a new parameter, and
+`publishRoutingKeyedEvent` to call `h.topicNotifyHandler.PublishEventWithRoutingKey(...)` instead
+of `h.notifyHandler...`. Update both `cmd/` wiring sites to construct and pass the second
+`NotifyHandler`.
+
+**Step 4:** Build and test:
+```bash
+cd bin-webhook-manager && go build ./... && go test ./...
+```
+
+**Step 5: Commit**
+
+```bash
+git add bin-common-handler/models/outline/queuename.go bin-webhook-manager/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Declare new topic exchange, wire second NotifyHandler instance
+
+- bin-common-handler: Add QueueNameWebhookEventTopic constant
+- bin-webhook-manager: Declare new topic/durable exchange at startup, add topicNotifyHandler to webhookHandler for routing-keyed publishes"
+```
+
+### Task 3.2: Migrate `bin-agent-manager`'s `QueueNameWebhookEvent` subscription to `#` wildcard on the new exchange
+
+**Files:**
+- Modify: `bin-agent-manager/cmd/agent-manager/main.go`
+
+**Step 1:** Find the existing subscription (design doc §8: `main.go:159`):
+```bash
+grep -n "QueueNameWebhookEvent" bin-agent-manager/cmd/agent-manager/main.go
+```
+
+**Step 2:** Add a SECOND subscription to the new topic exchange with a `#` wildcard binding
+(keep the old fanout subscription in place during the transition window — remove only in Task
+3.4 once both are confirmed flowing). This requires the queue-creation/subscribe helper to
+support an explicit routing-key argument for `#`, since `QueueSubscribe(name, topic)` today
+always binds with an empty key (`queue.go:158-159`, correct for fanout but not for topic). Add
+a new call using `QueueBind` directly (added in Task 1.3):
+
+```go
+// after the existing per-pod queue is created and existing subscriptions are set up:
+if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
+	logrus.Errorf("Could not bind to the new topic exchange. err: %v", err)
+}
+```
+
+**Step 3:** Build and manually verify (no automated test for cross-service AMQP binding without
+an integration test harness — flag for Task 3.5's integration verification instead).
+
+```bash
+cd bin-agent-manager && go build ./...
+```
+
+**Step 4: Commit**
+
+```bash
+git add bin-agent-manager/cmd/agent-manager/main.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Bind agent-manager to new topic exchange with # wildcard
+
+- bin-agent-manager: Add # wildcard binding to QueueNameWebhookEventTopic alongside existing fanout subscription, transition window per VOIP-1258 §8"
+```
+
+### Task 3.3: Migrate `bin-timeline-manager`'s `QueueNameWebhookEvent` subscription (same pattern)
+
+**Files:**
+- Modify: `bin-timeline-manager/pkg/subscribehandler/main.go`
+
+**Step 1-4:** Same pattern as Task 3.2, applied to `bin-timeline-manager` (design doc §8:
+`subscribehandler/main.go:54`).
+
+**Commit:**
+```bash
+git add bin-timeline-manager/pkg/subscribehandler/main.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Bind timeline-manager to new topic exchange with # wildcard
+
+- bin-timeline-manager: Add # wildcard binding to QueueNameWebhookEventTopic alongside existing fanout subscription, transition window per VOIP-1258 §8"
+```
+
+### Task 3.4: Deploy and verify dual-publish flowing correctly (manual verification gate)
+
+**Objective:** Before proceeding to Phase 4, confirm in a real (staging/sandbox) environment
+that events are landing on BOTH exchanges correctly and `bin-agent-manager`/
+`bin-timeline-manager` are receiving identical event streams via their new `#` binding.
+
+**Step 1:** Deploy Phase 1-3 changes to sandbox/staging.
+
+**Step 2:** Trigger a test event (e.g. a call state change) and verify via RabbitMQ management
+UI or `rabbitmqctl list_bindings` that:
+- The new `QueueNameWebhookEventTopic` exchange exists, kind=topic, durable=true.
+- `bin-agent-manager`'s and `bin-timeline-manager`'s per-pod queues show BOTH the old
+  fanout binding AND the new `#` topic binding.
+- A published event produces messages on both queues (no duplicate processing observed in
+  service logs — `bin-agent-manager`/`bin-timeline-manager`'s business logic doesn't
+  distinguish which exchange a message arrived from, so receiving it twice via two different
+  bindings on the SAME queue would actually be fine architecturally IF the queue itself
+  dedupes... but it does NOT dedupe by default. **Verify this explicitly**: if both bindings
+  target the SAME per-pod queue, a single publish that matches both bindings' criteria
+  (which won't happen here since old=fanout-implicit-match-all, new=`#`-explicit-match-all --
+  BOTH match every message) will cause the SAME message to be delivered to the queue TWICE.
+  **This is a real risk requiring resolution before Task 3.2/3.3 can be considered complete.**
+
+**This is a blocking finding, not just a verification step — resolve before continuing:**
+Since `bin-agent-manager`/`bin-timeline-manager` dual-publish means the SAME event arrives via
+the old fanout exchange (unconditional) AND the new topic exchange (`#` matches everything) to
+the SAME queue, each event would be processed TWICE by these services during the transition
+window, corrupting agent-status-update / audit-log semantics (double-processing).
+
+**Resolution options** (decide before implementing Task 3.2/3.3, revise those tasks accordingly):
+- (a) Use a SEPARATE queue per exchange in `bin-agent-manager`/`bin-timeline-manager` during
+  the transition window (two queues, two consumers, business logic must dedupe by event ID
+  or the consumer must be made idempotent) -- adds complexity.
+- (b) Skip dual-consumption for these two services entirely: since `bin-webhook-manager`
+  ALREADY dual-publishes to both exchanges, `bin-agent-manager`/`bin-timeline-manager` only
+  need to bind to ONE exchange at a time. Have them cut over directly from old fanout binding
+  to new topic `#` binding in a SINGLE atomic change (no transition window needed for these
+  two specifically, since their consumption logic doesn't care about routing key granularity
+  at all -- `#` and fanout behave identically for a full-firehose consumer). **Recommended**:
+  this eliminates the double-processing risk entirely and simplifies Tasks 3.2/3.3 to a single
+  rebind rather than a dual-bind.
+
+**Revise Tasks 3.2 and 3.3**: replace "add a SECOND subscription" with "REPLACE the existing
+fanout subscription with the new topic `#` binding, in the same deploy as
+`bin-webhook-manager`'s dual-publish going live" -- since `bin-webhook-manager` publishes to
+BOTH exchanges simultaneously, these two consumers can point at either one at any time without
+losing events, so a direct cutover (not a gradual dual-bind) is both simpler and safer for them
+specifically. Only `bin-api-manager` (Phase 4) needs an actual multi-step, per-scope dynamic
+transition, because its binding pattern is genuinely different (whole-queue-content changes),
+not just an exchange-source change.
+
+**Step 3 (after resolving above):** Re-verify no double-processing, single binding per consumer
+at all times.
+
+**Step 4:** No code commit for this task (verification + design correction only) — but DO patch
+Tasks 3.2/3.3 in this plan document to reflect the single-bind, direct-cutover approach before
+marking Phase 3 complete.
+
+### Task 3.5: Patch Tasks 3.2/3.3 implementation to single-bind cutover
+
+**Files:**
+- Modify: `bin-agent-manager/cmd/agent-manager/main.go` (change from Task 3.2)
+- Modify: `bin-timeline-manager/pkg/subscribehandler/main.go` (change from Task 3.3)
+
+**Step 1:** Replace the additive `QueueBind` call from Task 3.2/3.3 with a direct swap: change
+the exchange name in the EXISTING `QueueSubscribe(queueNamePod, string(commonoutline.QueueNameWebhookEvent))`
+call to `commonoutline.QueueNameWebhookEventTopic`, and follow it with an explicit `#`
+`QueueBind` (since `QueueSubscribe` always binds with an empty key, wrong for a topic exchange):
+
+```go
+// bin-agent-manager/cmd/agent-manager/main.go — REPLACE:
+//   sockHandler.QueueSubscribe(queueNamePod, string(commonoutline.QueueNameWebhookEvent))
+// WITH:
+if err := sockHandler.QueueCreate(queueNamePod, "volatile"); err != nil { /* ... */ }
+if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
+	logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
+}
+```
+
+Same pattern for `bin-timeline-manager`.
+
+**Step 2:** Build, test, deploy, re-verify single delivery per event (repeat Task 3.4's
+verification, this time checking no double-processing).
+
+**Step 3: Commit**
+
+```bash
+git add bin-agent-manager/cmd/agent-manager/main.go bin-timeline-manager/pkg/subscribehandler/main.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Cut over agent-manager/timeline-manager to topic exchange directly
+
+- bin-agent-manager, bin-timeline-manager: Replace fanout QueueNameWebhookEvent subscription with single # wildcard binding on QueueNameWebhookEventTopic, avoiding double-processing during webhook-manager's dual-publish window (VOIP-1258 Task 3.4 finding)"
+```
+
+---
+
+## Phase 4: `bin-api-manager` — dynamic bind/unbind, owner_id rename, decommission old exchange
+
+**Objective:** Implement scope-aware dynamic binding on the per-pod queue, rename
+`agent_id`→`owner_id` in the client-facing wire protocol (hard cutover), remove the dead
+`QueueNameAgentEvent`/`QueueNameTalkEvent` subscriptions, then decommission the old fanout
+exchange once everything is confirmed on the new one.
+
+### Task 4.1: Design the per-pod scope-refcount component
+
+**Files:**
+- Create: `bin-api-manager/pkg/websockhandler/scoperefcount.go`
+- Test: `bin-api-manager/pkg/websockhandler/scoperefcount_test.go`
+
+**Step 1:** Resolve Task 1.3's caveat: track scope→refcount entirely in this NEW component
+(`bin-api-manager`-local), not in `rabbitmqhandler`'s internal `queueBinds` map (design doc §9
+recommendation, option (b)).
+
+**Step 2: Write failing test**
+
+```go
+func TestScopeRefCount_BindOnFirstSubscribe(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	rc := newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic")
+
+	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.abc.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+
+	err := rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+}
+
+func TestScopeRefCount_NoRebindOnSecondSubscribe(t *testing.T) {
+	// second Acquire() for the same scope should NOT call QueueBind again (refcount 2, no AMQP call)
+}
+
+func TestScopeRefCount_UnbindOnLastRelease(t *testing.T) {
+	// Acquire twice, Release twice -> QueueUnbind called exactly once, on the second Release
+}
+
+func TestScopeRefCount_NoUnbindWhileRefsRemain(t *testing.T) {
+	// Acquire twice, Release once -> QueueUnbind NOT called
+}
+```
+
+**Step 3: Run to verify failure**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go test ./... -run TestScopeRefCount -v
+```
+Expected: FAIL — undefined.
+
+**Step 4: Implement**
+
+```go
+// bin-api-manager/pkg/websockhandler/scoperefcount.go
+package websockhandler
+
+import (
+	"sync"
+
+	"monorepo/bin-common-handler/pkg/sockhandler"
+)
+
+// scopeRefCount tracks, per api-manager pod, how many local websocket connections currently
+// have at least one active subscription for each AMQP binding pattern (e.g.
+// "customer_id.<uuid>.#"), and binds/unbinds the pod's per-pod queue accordingly. This is the
+// component that makes the fanout->topic conversion actually reduce per-pod processing: a scope
+// with zero local subscribers is never bound, so the broker never delivers it to this pod.
+// See VOIP-1258 design doc §9.
+type scopeRefCount struct {
+	mu       sync.Mutex
+	counts   map[string]int // binding pattern -> active subscriber count
+	sock     sockhandler.SockHandler
+	queue    string
+	exchange string
+}
+
+func newScopeRefCount(sock sockhandler.SockHandler, queueName string, exchangeName string) *scopeRefCount {
+	return &scopeRefCount{
+		counts:   make(map[string]int),
+		sock:     sock,
+		queue:    queueName,
+		exchange: exchangeName,
+	}
+}
+
+// Acquire increments the refcount for the given binding pattern, binding the queue on the
+// first (0->1) transition.
+func (r *scopeRefCount) Acquire(pattern string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.counts[pattern] == 0 {
+		if err := r.sock.QueueBind(r.queue, pattern, r.exchange, false, nil); err != nil {
+			return err
+		}
+	}
+	r.counts[pattern]++
+	return nil
+}
+
+// Release decrements the refcount for the given binding pattern, unbinding the queue on the
+// last (1->0) transition. No-op (not an error) if the pattern isn't currently tracked, to
+// tolerate double-release from racing cleanup paths (explicit unsubscribe + abrupt disconnect).
+func (r *scopeRefCount) Release(pattern string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.counts[pattern] <= 0 {
+		return nil
+	}
+	r.counts[pattern]--
+	if r.counts[pattern] == 0 {
+		delete(r.counts, pattern)
+		if err := r.sock.QueueUnbind(r.queue, pattern, r.exchange, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReleaseAll releases every currently-held pattern for this connection's tracked set. Used on
+// abrupt disconnect (VOIP-1258 §9) where no per-topic unsubscribe message was received. Callers
+// must pass the SET of patterns this specific connection held (tracked separately per
+// connection, not by scopeRefCount itself -- see Task 4.3).
+func (r *scopeRefCount) ReleaseAll(patterns []string) {
+	for _, p := range patterns {
+		_ = r.Release(p) // best-effort; log at call site if needed
+	}
+}
+```
+
+**Step 5: Run test, verify pass**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go generate ./... && go test ./... -run TestScopeRefCount -v
+```
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add bin-api-manager/pkg/websockhandler/scoperefcount.go bin-api-manager/pkg/websockhandler/scoperefcount_test.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add per-pod scope refcount component for dynamic AMQP bind/unbind
+
+- bin-api-manager: Add scopeRefCount tracking active local subscribers per AMQP binding pattern, binds on 0->1 and unbinds on 1->0 transitions (VOIP-1258 §9)"
+```
+
+### Task 4.2: Convert client-facing topic string to AMQP binding pattern
+
+**Files:**
+- Create: `bin-api-manager/pkg/websockhandler/bindpattern.go`
+- Test: `bin-api-manager/pkg/websockhandler/bindpattern_test.go`
+
+**Step 1: Write failing test**
+
+```go
+func TestTopicToBindPattern(t *testing.T) {
+	cases := []struct {
+		topic    string
+		expected string
+	}{
+		{"customer_id:abc123:call:*", "customer_id.abc123.#"},
+		{"owner_id:def456:queue:*", "owner_id.def456.#"},
+		{"customer_id:abc123", "customer_id.abc123.#"},
+	}
+	for _, c := range cases {
+		got, err := topicToBindPattern(c.topic)
+		require.NoError(t, err)
+		require.Equal(t, c.expected, got)
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go test ./... -run TestTopicToBindPattern -v
+```
+Expected: FAIL.
+
+**Step 3: Implement**
+
+```go
+// bin-api-manager/pkg/websockhandler/bindpattern.go
+package websockhandler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// topicToBindPattern converts a client-facing subscribe topic string (colon-delimited,
+// "<scope>:<scope_id>:<resource>:<resource_id_or_*>") to the AMQP binding pattern
+// (dot-delimited, "<scope>.<scope_id>.#") used for scope-first topic exchange binding.
+// See VOIP-1258 design doc §5.
+func topicToBindPattern(topic string) (string, error) {
+	tmps := strings.Split(topic, ":")
+	if len(tmps) < 2 {
+		return "", fmt.Errorf("invalid topic format: %s", topic)
+	}
+	return fmt.Sprintf("%s.%s.#", tmps[0], tmps[1]), nil
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go test ./... -run TestTopicToBindPattern -v
+```
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add bin-api-manager/pkg/websockhandler/bindpattern.go bin-api-manager/pkg/websockhandler/bindpattern_test.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add topic-string-to-AMQP-binding-pattern conversion
+
+- bin-api-manager: Add topicToBindPattern, converts client colon-delimited topic strings to dot-delimited AMQP binding patterns (VOIP-1258 §5)"
+```
+
+### Task 4.3: Wire scopeRefCount into subscribe/unsubscribe and abrupt-disconnect paths
+
+**Files:**
+- Modify: `bin-api-manager/pkg/websockhandler/subscription.go`
+- Modify: `bin-api-manager/pkg/websockhandler/main.go` (per-pod `scopeRefCount` instance, per-connection pattern tracking)
+- Test: `bin-api-manager/pkg/websockhandler/subscription_test.go` (extend existing)
+
+**Step 1:** Add a per-connection pattern set to track what THIS connection currently holds (for
+`ReleaseAll` on abrupt disconnect):
+
+```go
+// bin-api-manager/pkg/websockhandler/subscription.go — subscriptionRun's local state:
+func (h *websockHandler) subscriptionRun(ctx context.Context, w http.ResponseWriter, r *http.Request, a *auth.AuthIdentity) error {
+	// ... existing setup ...
+
+	heldPatterns := make(map[string]bool) // NEW: patterns THIS connection currently holds
+	var heldMu sync.Mutex                  // NEW
+
+	newCtx, newCancel := context.WithCancel(ctx)
+	go h.subscriptionRunWebsock(newCtx, newCancel, a, ws, zmqSub, heldPatterns, &heldMu) // pass new params
+	go h.subscriptionRunZMQSub(newCtx, newCancel, ws, zmqSub, &writeMu)
+	go h.subscriptionRunPinger(newCtx, newCancel, ws, &writeMu)
+
+	<-newCtx.Done()
+	log.Debugf("Websocket connection has been closed. agent_id: %s", a.AgentID())
+
+	// NEW: abrupt-disconnect cleanup -- release everything this connection held, regardless of
+	// whether an explicit unsubscribe message was ever received.
+	heldMu.Lock()
+	patterns := make([]string, 0, len(heldPatterns))
+	for p := range heldPatterns {
+		patterns = append(patterns, p)
+	}
+	heldMu.Unlock()
+	h.scopeRefCount.ReleaseAll(patterns)
+
+	return nil
+}
+```
+
+**Step 2:** Wire subscribe/unsubscribe in `subscriptionHandleMessage` to call `Acquire`/`Release`
+and update `heldPatterns`:
+
+```go
+// bin-api-manager/pkg/websockhandler/subscription.go — modify subscriptionHandleMessage
+// signature to accept heldPatterns/heldMu (threaded from subscriptionRunWebsock):
+func (h *websockHandler) subscriptionHandleMessage(ctx context.Context, a *auth.AuthIdentity, zmqSub zmqsubhandler.ZMQSubHandler, m *hook.Hook, heldPatterns map[string]bool, heldMu *sync.Mutex) error {
+	// ... existing validateTopics call unchanged ...
+
+	switch m.Type {
+	case hook.TypeSubscribe:
+		for _, topic := range m.Topics {
+			if errSub := zmqSub.Subscribe(topic); errSub != nil {
+				return errSub
+			}
+
+			// NEW: acquire the AMQP binding
+			pattern, errConv := topicToBindPattern(topic)
+			if errConv != nil {
+				log.Errorf("Could not convert topic to bind pattern. topic: %s, err: %v", topic, errConv)
+				continue // zmqSub subscribe already succeeded; local filter still works even if
+				         // broker-side scoping doesn't -- degrades to "receives more than needed"
+				         // not "receives nothing", a safe failure mode
+			}
+			if errAcq := h.scopeRefCount.Acquire(pattern); errAcq != nil {
+				log.Errorf("Could not acquire the AMQP binding. pattern: %s, err: %v", pattern, errAcq)
+				continue
+			}
+			heldMu.Lock()
+			heldPatterns[pattern] = true
+			heldMu.Unlock()
+		}
+
+	case hook.TypeUnsubscribe:
+		for _, topic := range m.Topics {
+			if errSub := zmqSub.Unsubscribe(topic); errSub != nil {
+				return errSub
+			}
+
+			// NEW: release the AMQP binding
+			pattern, errConv := topicToBindPattern(topic)
+			if errConv != nil {
+				continue
+			}
+			if errRel := h.scopeRefCount.Release(pattern); errRel != nil {
+				log.Errorf("Could not release the AMQP binding. pattern: %s, err: %v", pattern, errRel)
+			}
+			heldMu.Lock()
+			delete(heldPatterns, pattern)
+			heldMu.Unlock()
+		}
+	}
+
+	return nil
+}
+```
+
+**Step 3:** Add `scopeRefCount` field to `websockHandler` struct and construct one PER
+CONNECTION pointed at that pod's SHARED per-pod queue (the refcount map itself must be
+pod-wide/shared across connections on the same pod, NOT per-connection — re-check: `scopeRefCount`
+should be a single instance owned by `websockHandler` itself, constructed once at pod startup,
+not per `subscriptionRun` call). Revise:
+
+```go
+// bin-api-manager/pkg/websockhandler/main.go — websockHandler struct:
+type websockHandler struct {
+	// ... existing fields ...
+	scopeRefCount *scopeRefCount // NEW: shared across all connections on this pod
+}
+```
+
+Construct once in the handler's constructor (find `NewWebsockHandler` or equivalent), pointed at
+the pod's existing per-pod queue name and the new topic exchange constant.
+
+**Step 4: Write test for the wiring**
+
+```go
+func TestSubscriptionHandleMessage_AcquiresBindingOnSubscribe(t *testing.T) {
+	// mock zmqSub.Subscribe, mock scopeRefCount's underlying sockHandler.QueueBind,
+	// assert both called for a subscribe message
+}
+
+func TestSubscriptionRun_ReleasesAllOnAbruptDisconnect(t *testing.T) {
+	// simulate ctx cancellation without an explicit unsubscribe message,
+	// assert scopeRefCount.Release called for every previously-acquired pattern
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go test ./... -v
+```
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add bin-api-manager/pkg/websockhandler/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Wire dynamic AMQP bind/unbind into subscribe/unsubscribe and disconnect paths
+
+- bin-api-manager: Call scopeRefCount.Acquire/Release on explicit subscribe/unsubscribe, ReleaseAll on abrupt disconnect via subscriptionRun's existing teardown path (VOIP-1258 §9)"
+```
+
+### Task 4.4: Rename `agent_id` -> `owner_id` in `validateTopics`/`validateTopic` (hard cutover)
+
+**Files:**
+- Modify: `bin-api-manager/pkg/websockhandler/etc.go`
+- Modify: `bin-api-manager/pkg/websockhandler/etc_test.go`
+
+**Step 1: Write failing test**
+
+```go
+// bin-api-manager/pkg/websockhandler/etc_test.go — update existing agent_id test cases:
+func TestValidateTopics_OwnerScope(t *testing.T) {
+	a := &auth.AuthIdentity{ /* agent with AgentID() == "98765432-..." */ }
+	topics := []string{"owner_id:98765432-0000-0000-0000-000000000002:queue:*"}
+	require.True(t, h.validateTopics(context.Background(), a, topics))
+}
+
+func TestValidateTopics_RejectsOldAgentIdPrefix(t *testing.T) {
+	a := &auth.AuthIdentity{}
+	topics := []string{"agent_id:98765432-0000-0000-0000-000000000002:queue:*"}
+	require.False(t, h.validateTopics(context.Background(), a, topics)) // hard cutover: old prefix now invalid
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go test ./... -run "TestValidateTopics_OwnerScope|TestValidateTopics_RejectsOldAgentIdPrefix" -v
+```
+Expected: `TestValidateTopics_OwnerScope` FAILS (still says `agent_id`),
+`TestValidateTopics_RejectsOldAgentIdPrefix` PASSES already (old behavior happens to reject
+unknown prefixes... verify this against current `default: return false` branch — should already
+pass since `owner_id` isn't yet a recognized case, meaning the NEW test needs `owner_id` to be
+accepted and `agent_id` to be REJECTED after the rename, i.e. write both tests to assert
+POST-rename behavior, run BEFORE the code change to confirm `TestValidateTopics_OwnerScope`
+fails and `TestValidateTopics_RejectsOldAgentIdPrefix`... actually also fails pre-change, since
+`agent_id` is currently ACCEPTED, not rejected. Both tests should fail before the code change).
+
+**Step 3: Implement (rename, both functions)**
+
+```go
+// bin-api-manager/pkg/websockhandler/etc.go — in validateTopics, change:
+//   case "agent_id":
+//       if tmpID != a.AgentID() {
+// TO:
+		case "owner_id":
+			if tmpID != a.AgentID() {
+				return false
+			}
+```
+
+Apply the identical change in `validateTopic` (the second near-duplicate function, line 139).
+Update the two `default:` comment lines from `// the first part should be "customer_id" or
+"agent_id"` to `// the first part should be "customer_id" or "owner_id"`.
+
+**Step 4: Run tests, verify pass**
+
+```bash
+cd bin-api-manager/pkg/websockhandler && go test ./... -v
+```
+Expected: all pass, including the two new tests.
+
+**Step 5: Update RST docs (per design doc §5, CLAUDE.md RST-sync rule)**
+
+```bash
+grep -rn "agent_id:" bin-api-manager/docsdev/source/websocket_overview.rst bin-api-manager/docsdev/source/websocket_struct.rst bin-api-manager/docsdev/source/websocket_tutorial.rst
+```
+Replace each `agent_id:` example with `owner_id:`. Rebuild:
+```bash
+cd bin-api-manager/docsdev && sphinx-build -M html source build
+```
+Force-add the build output per CLAUDE.md's RST-sync convention (build/ is gitignored elsewhere
+but the sync rule requires committing rendered output — confirm current convention with
+`git status` after build, follow existing pattern in the repo).
+
+**Step 6: Commit**
+
+```bash
+git add bin-api-manager/pkg/websockhandler/etc.go bin-api-manager/pkg/websockhandler/etc_test.go bin-api-manager/docsdev/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Rename agent_id to owner_id in websocket wire protocol (breaking change)
+
+- bin-api-manager: Rename agent_id scope prefix to owner_id in validateTopics/validateTopic, hard cutover per Open Question 10 (no dual-accept period)
+- bin-api-manager: Update websocket RST docs (overview/struct/tutorial) to reflect owner_id"
+```
+
+### Task 4.5: Remove dead `QueueNameAgentEvent`/`QueueNameTalkEvent` subscriptions
+
+**Files:**
+- Modify: `bin-api-manager/cmd/api-manager/main.go`
+
+**Step 1:** Locate the `subscribeTargets` list (design doc §7: `main.go:159-162`):
+```bash
+grep -n "subscribeTargets" bin-api-manager/cmd/api-manager/main.go
+```
+
+**Step 2:** Before removing, run one more verification pass per Open Question 6 (confirm
+nothing else depends on these subscriptions):
+```bash
+grep -rn "QueueNameAgentEvent\|QueueNameTalkEvent" bin-api-manager/
+```
+Expected: only the `subscribeTargets` list itself references them (confirmed in design doc §2's
+single-case switch analysis — should show no other dependents).
+
+**Step 3:** Remove both from the list:
+```go
+// BEFORE:
+subscribeTargets := []string{
+	string(commonoutline.QueueNameWebhookEvent),
+	string(commonoutline.QueueNameAgentEvent),
+	string(commonoutline.QueueNameTalkEvent),
+}
+// AFTER:
+subscribeTargets := []string{
+	string(commonoutline.QueueNameWebhookEventTopic), // also switch to the new exchange, see Task 4.6
+}
+```
+
+**Step 4:** Build:
+```bash
+cd bin-api-manager && go build ./...
+```
+
+**Step 5: Commit**
+
+```bash
+git add bin-api-manager/cmd/api-manager/main.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Remove dead QueueNameAgentEvent/QueueNameTalkEvent subscriptions
+
+- bin-api-manager: Remove subscriptions never acted on by processEvent's single-case switch (VOIP-1258 §7), reduces per-pod RabbitMQ consumption cost"
+```
+
+### Task 4.6: Switch api-manager's baseline subscription from fanout to topic exchange, remove old exchange dual-publish
+
+**Files:**
+- Modify: `bin-api-manager/cmd/api-manager/main.go`
+- Modify: `bin-webhook-manager/pkg/webhookhandler/webhook.go` (remove dual-publish, Task 2.5's temporary code)
+- Modify: `bin-webhook-manager/pkg/webhookhandler/main.go` (remove `notifyHandler` field, keep only `topicNotifyHandler`)
+
+**This is the final cutover step — deploy and verify Tasks 4.1-4.5 in staging/production for a
+full transition window (Open Question 1: window length TBD) BEFORE executing this task.**
+
+**Step 1:** Change `bin-api-manager`'s baseline (always-bound) subscription target from
+`QueueNameWebhookEvent` to `QueueNameWebhookEventTopic` with an unconditional `#` fallback (or,
+per §9, NO baseline binding at all — every scope is acquired dynamically per connection; decide
+based on whether an always-on `#` fallback binding is wanted as a safety net during initial
+rollout, recommend keeping a `#` fallback for the first deploy, removing it in a follow-up once
+dynamic bind/unbind is confirmed stable).
+
+**Step 2:** Remove the dual-publish from `bin-webhook-manager`: delete the old
+`h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh)` calls in
+`SendWebhookToCustomer`/`SendWebhookToURI`, keeping only `publishRoutingKeyedEvent`'s topic-
+exchange publish. Remove the now-unused `notifyHandler` field and its `NewNotifyHandler` startup
+declare for the OLD fanout exchange (keep `topicNotifyHandler`, rename back to `notifyHandler`
+for cleanliness if desired — optional cosmetic follow-up).
+
+**Step 3:** Decommission the old exchange (`QueueNameWebhookEvent`) — infrastructure-level
+action (delete via RabbitMQ management API/UI or a migration script), NOT a code change. Do
+this ONLY after confirming zero consumers remain bound to it.
+
+**Step 4:** Build, full test suite, deploy.
+
+```bash
+cd bin-webhook-manager && go build ./... && go test ./...
+cd bin-api-manager && go build ./... && go test ./...
+```
+
+**Step 5: Commit**
+
+```bash
+git add bin-webhook-manager/ bin-api-manager/cmd/api-manager/main.go
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Cut over to topic exchange exclusively, remove dual-publish
+
+- bin-webhook-manager: Remove old fanout exchange dual-publish, topic exchange is now the sole delivery path
+- bin-api-manager: Switch baseline subscription to the new topic exchange"
+```
+
+---
+
+## Cross-cutting verification (run after EVERY phase, not just at the end)
+
+```bash
+# From monorepo root
+cd bin-common-handler && go build ./... && go test ./...
+cd ../bin-webhook-manager && go build ./... && go test ./...
+cd ../bin-api-manager && go build ./... && go test ./...
+cd ../bin-agent-manager && go build ./... && go test ./...
+cd ../bin-timeline-manager && go build ./... && go test ./...
+cd ../bin-queue-manager && go build ./... && go test ./...  # unaffected, sanity check only
+cd ../bin-talk-manager && go build ./... && go test ./...    # unaffected, sanity check only
+```
+
+## Deferred to follow-up tickets (explicitly out of this plan's scope)
+
+- Removing the temporary `#`-fallback baseline binding in `bin-api-manager` once dynamic
+  bind/unbind is confirmed stable in production (Task 4.6 note).
+- Cosmetic rename of `topicNotifyHandler` back to `notifyHandler` after the old fanout exchange
+  is fully decommissioned.
+- Load/chaos testing the `scopeRefCount` component under concurrent connect/disconnect storms
+  (Open Question 2 — testing strategy still needs a dedicated design pass before this ships to
+  production traffic at scale).

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -457,9 +457,110 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add
 - bin-common-handler: Add TopicCreateWithKind alongside existing TopicCreate (fanout-only), needed for VOIP-1258's new topic-kind exchange"
 ```
 
+### Task 1.2b: Add `NewNotifyHandlerForExistingExchange` (additive constructor variant)
+
+**Files:**
+- Modify: `bin-common-handler/pkg/notifyhandler/main.go`
+
+**Objective:** Resolve a self-contradiction found in round-4 implementation-plan review (see
+Task 3.1's note): `NewNotifyHandler` unconditionally calls `sockHandler.TopicCreate(name)`
+internally (`main.go:103`), which hardcodes `fanout` (`rabbitmqhandler/topic.go`). There is no
+way to use `NewNotifyHandler` to construct a `NotifyHandler` bound to an exchange that has
+ALREADY been declared as `topic` kind elsewhere -- attempting to do so causes RabbitMQ to reject
+the redundant fanout declare with `PRECONDITION_FAILED` (kind mismatch), and `NewNotifyHandler`
+swallows that error by logging and returning `nil` (`main.go:104-105`), producing a nil
+`NotifyHandler` interface that panics on first use. **Physically located here (in Phase 1,
+before Task 1.5's verification gate), not in Phase 2 or 3 — this was originally misplaced inside
+Phase 2's section during a prior revision (round-5 implementation-plan review finding), which
+broke the plan's own "phase = independently mergeable" model: Task 1.5's gate must cover this
+task's changes, and Phase 3 (which depends on this constructor) must be able to assume Phase 1
+is complete and includes it.**
+
+**Step 1: Write failing test**
+
+```go
+func TestNewNotifyHandlerForExistingExchange_SkipsDeclare(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	// TopicCreate/TopicCreateWithKind must NOT be called -- the exchange is assumed
+	// already declared by the caller.
+	mockSock.EXPECT().TopicCreate(gomock.Any()).Times(0)
+	mockSock.EXPECT().TopicCreateWithKind(gomock.Any(), gomock.Any()).Times(0)
+
+	h := NewNotifyHandlerForExistingExchange(mockSock, nil, "some.exchange.name", "test-service")
+
+	require.NotNil(t, h)
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestNewNotifyHandlerForExistingExchange -v
+```
+Expected: FAIL — undefined.
+
+**Step 3: Implement (purely additive, does not touch `NewNotifyHandler` or any of its ~116
+existing call sites)**
+
+```go
+// bin-common-handler/pkg/notifyhandler/main.go — add:
+
+// NewNotifyHandlerForExistingExchange creates a NotifyHandler for an exchange that has ALREADY
+// been declared by the caller (e.g. via sockHandler.TopicCreateWithKind for a non-fanout kind).
+// Unlike NewNotifyHandler, this does NOT call sockHandler.TopicCreate/TopicCreateWithKind
+// internally -- it assumes the exchange already exists with the correct kind, and skips the
+// redundant (and, for non-fanout kinds, conflicting) declare. Added for VOIP-1258 (see design
+// doc §6, implementation plan Task 3.1) to support a second NotifyHandler instance bound to a
+// topic-kind exchange, alongside the existing fanout-only NewNotifyHandler used everywhere else.
+func NewNotifyHandlerForExistingExchange(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, queueEvent commonoutline.QueueName, publisher commonoutline.ServiceName) NotifyHandler {
+	h := &notifyHandler{
+		sockHandler: sockHandler,
+		reqHandler:  reqHandler,
+
+		queueNotify: queueEvent,
+
+		publisher: publisher,
+	}
+
+	// NOTE: deliberately NOT calling sockHandler.TopicCreate/TopicCreateWithKind here -- the
+	// caller is responsible for declaring the exchange BEFORE calling this constructor.
+
+	namespace := commonoutline.GetMetricNameSpace(publisher)
+	initPrometheus(namespace)
+
+	return h
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestNewNotifyHandlerForExistingExchange -v
+```
+Expected: PASS
+
+**Step 5: Full build/test, confirm zero regression to existing `NewNotifyHandler`**
+
+```bash
+cd bin-common-handler && go build ./... && go test ./...
+```
+
+**Step 6: Commit**
+
+```bash
+git add bin-common-handler/pkg/notifyhandler/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add NewNotifyHandlerForExistingExchange, additive constructor variant
+
+- bin-common-handler: Add NewNotifyHandlerForExistingExchange, skips the internal TopicCreate declare so a NotifyHandler can be bound to an already-declared non-fanout exchange, resolves VOIP-1258 Task 3.1's fanout/topic declare conflict without touching NewNotifyHandler's existing ~116 call sites"
+```
+
 ### Task 1.5: Phase 1 verification gate
 
-**Step 1:** Full `bin-common-handler` test suite:
+**Step 1:** Full `bin-common-handler` test suite (covers Task 1.1-1.4 AND Task 1.2b, all Phase 1
+work):
 ```bash
 cd bin-common-handler && go build ./... && go test ./... -v
 ```
@@ -860,7 +961,11 @@ does not exist on `webhookHandler` until Task 3.1 adds it. There is no safe way 
 this task using `h.notifyHandler` "temporarily" — that field is bound to the OLD fanout
 exchange, which silently ignores routing keys, so the event would appear to publish
 successfully while never actually reaching the new topic exchange at all (no compiler error, no
-test failure, a completely silent feature failure). Do Task 3.1 first, full stop.**
+test failure, a completely silent feature failure). Do Task 3.1 first, full stop. Task 3.1 in
+turn depends on Task 1.2b (Phase 1) already being complete — Task 1.2b's
+`NewNotifyHandlerForExistingExchange` constructor is what Task 3.1 uses to build the
+`topicNotifyHandler` instance without an exchange-kind conflict. Prerequisite chain for this
+task: Task 1.2b -> Task 3.1 -> this task (Task 2.5).**
 
 **Step 2: Write failing test**
 
@@ -971,102 +1076,6 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Dua
 - bin-webhook-manager: Wire routing-key computation into both webhook entry points, dual-publish to new topic exchange alongside existing fanout publish (VOIP-1258 §6/§8 transition window)"
 ```
 
-### Task 1.2b: Add `NewNotifyHandlerForExistingExchange` (additive constructor variant)
-
-**Files:**
-- Modify: `bin-common-handler/pkg/notifyhandler/main.go`
-
-**Objective:** Resolve a self-contradiction found in round-4 implementation-plan review (see
-Task 3.1's note below): `NewNotifyHandler` unconditionally calls `sockHandler.TopicCreate(name)`
-internally (`main.go:103`), which hardcodes `fanout`
-(`rabbitmqhandler/topic.go`). There is no way to use `NewNotifyHandler` to construct a
-`NotifyHandler` bound to an exchange that has ALREADY been declared as `topic` kind elsewhere --
-attempting to do so causes RabbitMQ to reject the redundant fanout declare with
-`PRECONDITION_FAILED` (kind mismatch), and `NewNotifyHandler` swallows that error by logging and
-returning `nil` (`main.go:104-105`), producing a nil `NotifyHandler` interface that panics on
-first use.
-
-**Step 1: Write failing test**
-
-```go
-func TestNewNotifyHandlerForExistingExchange_SkipsDeclare(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockSock := sockhandler.NewMockSockHandler(mc)
-	// TopicCreate/TopicCreateWithKind must NOT be called -- the exchange is assumed
-	// already declared by the caller.
-	mockSock.EXPECT().TopicCreate(gomock.Any()).Times(0)
-	mockSock.EXPECT().TopicCreateWithKind(gomock.Any(), gomock.Any()).Times(0)
-
-	h := NewNotifyHandlerForExistingExchange(mockSock, nil, "some.exchange.name", "test-service")
-
-	require.NotNil(t, h)
-}
-```
-
-**Step 2: Run to verify failure**
-
-```bash
-cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestNewNotifyHandlerForExistingExchange -v
-```
-Expected: FAIL — undefined.
-
-**Step 3: Implement (purely additive, does not touch `NewNotifyHandler` or any of its ~116
-existing call sites)**
-
-```go
-// bin-common-handler/pkg/notifyhandler/main.go — add:
-
-// NewNotifyHandlerForExistingExchange creates a NotifyHandler for an exchange that has ALREADY
-// been declared by the caller (e.g. via sockHandler.TopicCreateWithKind for a non-fanout kind).
-// Unlike NewNotifyHandler, this does NOT call sockHandler.TopicCreate/TopicCreateWithKind
-// internally -- it assumes the exchange already exists with the correct kind, and skips the
-// redundant (and, for non-fanout kinds, conflicting) declare. Added for VOIP-1258 (see design
-// doc §6, implementation plan Task 3.1) to support a second NotifyHandler instance bound to a
-// topic-kind exchange, alongside the existing fanout-only NewNotifyHandler used everywhere else.
-func NewNotifyHandlerForExistingExchange(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, queueEvent commonoutline.QueueName, publisher commonoutline.ServiceName) NotifyHandler {
-	h := &notifyHandler{
-		sockHandler: sockHandler,
-		reqHandler:  reqHandler,
-
-		queueNotify: queueEvent,
-
-		publisher: publisher,
-	}
-
-	// NOTE: deliberately NOT calling sockHandler.TopicCreate/TopicCreateWithKind here -- the
-	// caller is responsible for declaring the exchange BEFORE calling this constructor.
-
-	namespace := commonoutline.GetMetricNameSpace(publisher)
-	initPrometheus(namespace)
-
-	return h
-}
-```
-
-**Step 4: Run test, verify pass**
-
-```bash
-cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestNewNotifyHandlerForExistingExchange -v
-```
-Expected: PASS
-
-**Step 5: Full build/test, confirm zero regression to existing `NewNotifyHandler`**
-
-```bash
-cd bin-common-handler && go build ./... && go test ./...
-```
-
-**Step 6: Commit**
-
-```bash
-git add bin-common-handler/pkg/notifyhandler/
-git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add NewNotifyHandlerForExistingExchange, additive constructor variant
-
-- bin-common-handler: Add NewNotifyHandlerForExistingExchange, skips the internal TopicCreate declare so a NotifyHandler can be bound to an already-declared non-fanout exchange, resolves VOIP-1258 Task 3.1's fanout/topic declare conflict without touching NewNotifyHandler's existing ~116 call sites"
-```
-
 ---
 
 ## Phase 3: Exchange migration — new topic exchange, non-websocket consumer migration
@@ -1109,7 +1118,7 @@ Apply the same in `cmd/webhook-control/main.go`.
 **Step 3:** Update `webhookHandler`'s `publishRoutingKeyedEvent` (Task 2.5) to target this
 constant instead of `h.queueNotify` — this requires `PublishEventWithRoutingKey` to accept an
 explicit queue/exchange name parameter, OR a second `NotifyHandler` instance pointed at the new
-exchange. **Recommended, using Task 1.2b's `NewNotifyHandlerForExistingExchange`**: give
+exchange. **Recommended, using Phase 1's Task 1.2b `NewNotifyHandlerForExistingExchange`**: give
 webhook-manager startup a SEPARATE `NotifyHandler` instance bound to
 `QueueNameWebhookEventTopic`, constructed via the ADDITIVE constructor added in Task 1.2b (not
 `NewNotifyHandler`), and inject it into `webhookHandler` as a distinct field
@@ -1123,7 +1132,8 @@ rejected by RabbitMQ (`PRECONDITION_FAILED`, kind mismatch), and `NewNotifyHandl
 that error by logging and returning `nil` — producing a nil `NotifyHandler` that panics on first
 use in Task 2.5's `h.topicNotifyHandler.PublishEventWithRoutingKey(...)` call. Using
 `NewNotifyHandlerForExistingExchange` (which skips the internal declare entirely, assuming the
-caller already declared the exchange) avoids this conflict.** Revise Task 2.1's struct:
+caller already declared the exchange) avoids this conflict — this is a Phase 1 dependency
+(Task 1.2b), which must already be complete before this task.** Revise Task 2.1's struct:
 
 ```go
 type webhookHandler struct {

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -850,16 +850,26 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Imp
 **Step 1:** Determine the new topic exchange name constant first (Phase 3, Task 3.1 defines
 it — this task has a forward dependency; if executing phases sequentially, do Task 3.1 before
 this task, OR use a placeholder constant here and rename in Task 3.1's commit). Recommended:
-do Task 3.1 (exchange name + declare) BEFORE this task, then return here.
+do Task 3.1 (exchange name + declare + `topicNotifyHandler` field) BEFORE this task, then return
+here. **This ordering is not optional — verified via round-3 implementation-plan review: the
+code in this task calls `h.topicNotifyHandler.PublishEventWithRoutingKey(...)`, a field that
+does not exist on `webhookHandler` until Task 3.1 adds it. There is no safe way to implement
+this task using `h.notifyHandler` "temporarily" — that field is bound to the OLD fanout
+exchange, which silently ignores routing keys, so the event would appear to publish
+successfully while never actually reaching the new topic exchange at all (no compiler error, no
+test failure, a completely silent feature failure). Do Task 3.1 first, full stop.**
 
 **Step 2: Write failing test**
 
 ```go
 func TestSendWebhookToCustomer_DualPublishesWithRoutingKey(t *testing.T) {
-	// extend existing SendWebhookToCustomer test setup; add expectation that
-	// notifyHandler.PublishEventWithRoutingKey is called once per generated routing key,
-	// in addition to the existing notifyHandler.PublishEvent call (dual-publish, Task 3.2's
-	// transition-window requirement)
+	// extend existing SendWebhookToCustomer test setup; assert that
+	// h.topicNotifyHandler.PublishEventWithRoutingKey (NOT h.notifyHandler) is called once per
+	// generated routing key, in addition to the existing h.notifyHandler.PublishEvent call
+	// (dual-publish, Task 3.1's transition-window requirement). Use two DISTINCT mocks
+	// (mockNotifyHandler, mockTopicNotifyHandler) in the test setup and assert each receives
+	// calls on the correct one -- a test using a single shared mock for both fields would not
+	// have caught the h.notifyHandler/h.topicNotifyHandler mixup found in round-3 review.
 }
 ```
 
@@ -895,6 +905,16 @@ func (h *webhookHandler) SendWebhookToCustomer(ctx context.Context, customerID u
 // publishRoutingKeyedEvent computes routing keys for the given event data and publishes to the
 // new topic exchange with each key. Best-effort: logs and returns on parse/RPC failure without
 // blocking the primary (fanout) delivery path above it.
+//
+// CRITICAL: uses h.topicNotifyHandler (bound to QueueNameWebhookEventTopic, a topic-kind
+// exchange -- constructed in Task 3.1), NOT h.notifyHandler (bound to the OLD fanout exchange).
+// Calling PublishEventWithRoutingKey on h.notifyHandler would compile and "succeed" silently --
+// fanout exchanges ignore routing keys entirely, so the event would be delivered but the
+// scoping this whole feature exists for would never take effect. This exact mistake was caught
+// in round-3 implementation-plan review: if Task 2.5 is implemented before Task 3.1 adds the
+// topicNotifyHandler field, this function CANNOT be written correctly yet -- do not stub it
+// with h.notifyHandler "temporarily," implement Task 3.1 first as already instructed above, and
+// write this function only once topicNotifyHandler exists on the struct.
 func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, eventType string, data json.RawMessage) {
 	log := logrus.WithFields(logrus.Fields{"func": "publishRoutingKeyedEvent", "event_type": eventType})
 
@@ -923,7 +943,7 @@ func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, eventType
 	}
 
 	for _, key := range keys {
-		h.notifyHandler.PublishEventWithRoutingKey(ctx, eventType, key, json.RawMessage(data))
+		h.topicNotifyHandler.PublishEventWithRoutingKey(ctx, eventType, key, json.RawMessage(data))
 	}
 }
 ```

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -335,6 +335,16 @@ entry). This requires:
 - `redeclareAll()` (`main.go:298-303`): already iterates a flat list of all binds — this loop is
   UNCHANGED once the underlying data structure holds every bind instead of just the last one;
   the fix is entirely in how `queueBinds` is populated/depopulated, not in how it's replayed.
+- **`bin-common-handler/pkg/rabbitmqhandler/main_test.go` MUST also be updated** — verified via
+  round-2 implementation-plan review finding: this test file has ~20 direct references to
+  `map[string]*queueBind{}` literals and single-value field access (e.g. `main_test.go:606-613,
+  660-667`: `r.queueBinds["test-queue"].key`, `.exchange`), none of which compile against the
+  new `map[string][]*queueBind` type. Before starting Task 1.3's implementation, run
+  `grep -n "queueBinds" bin-common-handler/pkg/rabbitmqhandler/main_test.go` and update EVERY
+  hit to the new slice-based access pattern (e.g. `r.queueBinds["test-queue"][0].key` for
+  single-bind test cases, or iterate the slice for multi-bind cases). This is a REQUIRED part of
+  Task 1.3's Step 2/Step 4 (build/test verification) — do not consider Task 1.3 complete until
+  `go test ./bin-common-handler/pkg/rabbitmqhandler/...` passes with the new type.
 
 This is now a REQUIRED part of Task 1.3 (not deferred to Phase 4 planning as originally
 written), since Phase 4's `scopeRefCount` component depends on reconnects correctly restoring
@@ -1687,7 +1697,19 @@ grep -rn "QueueNameAgentEvent\|QueueNameTalkEvent" bin-api-manager/
 Expected: only the `subscribeTargets` list itself references them (confirmed in design doc §2's
 single-case switch analysis — should show no other dependents).
 
-**Step 3:** Remove both from the list:
+**Step 3:** Remove both from the list, and switch the baseline exchange target to the new topic
+exchange WITH an explicit `#` wildcard binding — do NOT use `QueueSubscribe`'s empty-key bind for
+this target. **Verified via round-2 implementation-plan review finding: on a `topic`-kind
+exchange (unlike `fanout`), an empty routing key binding only matches messages published with an
+empty routing key. Since every VOIP-1258 publish path (Task 2.3/2.4/2.5) publishes with
+non-empty scope-first keys (`customer_id.xxx...`/`owner_id.xxx...`), using
+`QueueSubscribe(queue, target)`'s existing empty-key bind
+(`rabbitmqhandler/queue.go:158-159`) against `QueueNameWebhookEventTopic` would deliver ZERO
+events to bin-api-manager's baseline subscription — a silent total event-loss regression the
+moment this task deploys, contradicting the plan's own phased-safety principle that no phase
+should depend on a later phase to be correct.** This task and Task 4.6's `#`-fallback binding
+must land TOGETHER, not sequentially:
+
 ```go
 // BEFORE:
 subscribeTargets := []string{
@@ -1695,11 +1717,23 @@ subscribeTargets := []string{
 	string(commonoutline.QueueNameAgentEvent),
 	string(commonoutline.QueueNameTalkEvent),
 }
-// AFTER:
-subscribeTargets := []string{
-	string(commonoutline.QueueNameWebhookEventTopic), // also switch to the new exchange, see Task 4.6
+// ... elsewhere, existing subscribehandler.Run() loop calls
+// sockHandler.QueueSubscribe(queue, target) for each target, which binds with an empty key --
+// correct for fanout, WRONG for the new topic exchange.
+
+// AFTER: remove subscribeTargets' use of QueueSubscribe for the new exchange entirely; bind it
+// explicitly with "#" instead, immediately after the per-pod queue is created:
+if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
+	logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
 }
+// subscribeTargets no longer includes QueueNameWebhookEvent/AgentEvent/TalkEvent at all --
+// the topic exchange binding above replaces it, done here (not deferred to Task 4.6).
 ```
+
+Task 4.6's "keep the `#` fallback for the first deploy, remove later" framing still applies, but
+the `#` binding itself must exist from THIS task's deploy onward, not added later — Task 4.6 is
+now solely about REMOVING the fallback once dynamic per-scope bind/unbind (Task 4.3) is confirmed
+stable, not about adding it for the first time.
 
 **Step 4:** Build:
 ```bash
@@ -1725,12 +1759,12 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Rem
 **This is the final cutover step — deploy and verify Tasks 4.1-4.5 in staging/production for a
 full transition window (Open Question 1: window length TBD) BEFORE executing this task.**
 
-**Step 1:** Change `bin-api-manager`'s baseline (always-bound) subscription target from
-`QueueNameWebhookEvent` to `QueueNameWebhookEventTopic` with an unconditional `#` fallback (or,
-per §9, NO baseline binding at all — every scope is acquired dynamically per connection; decide
-based on whether an always-on `#` fallback binding is wanted as a safety net during initial
-rollout, recommend keeping a `#` fallback for the first deploy, removing it in a follow-up once
-dynamic bind/unbind is confirmed stable).
+**Step 1:** Change `bin-api-manager`'s baseline `#` fallback binding (added in Task 4.5, kept as
+a safety net during initial dynamic-bind/unbind rollout) — REMOVE it now that Task 4.3's
+per-scope dynamic bind/unbind is confirmed stable in production, so pods only receive events for
+scopes with a live local subscriber (the actual point of this whole design). This is now a
+REMOVAL step, not an initial addition — Task 4.5 already added and deployed the `#` binding as
+part of its own safe cutover.
 
 **Step 2:** Remove the dual-publish from `bin-webhook-manager`: delete the old
 `h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh)` calls in
@@ -1777,10 +1811,6 @@ cd ../bin-talk-manager && go build ./... && go test ./...    # unaffected, sanit
 
 ## Deferred to follow-up tickets (explicitly out of this plan's scope)
 
-- Removing the temporary `#`-fallback baseline binding in `bin-api-manager` once dynamic
-  bind/unbind is confirmed stable in production (Task 4.6 note).
-- Cosmetic rename of `topicNotifyHandler` back to `notifyHandler` after the old fanout exchange
-  is fully decommissioned.
 - Load/chaos testing the `scopeRefCount` component under concurrent connect/disconnect storms
   (Open Question 2 — testing strategy still needs a dedicated design pass before this ships to
   production traffic at scale).

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -336,14 +336,17 @@ entry). This requires:
   UNCHANGED once the underlying data structure holds every bind instead of just the last one;
   the fix is entirely in how `queueBinds` is populated/depopulated, not in how it's replayed.
 - **`bin-common-handler/pkg/rabbitmqhandler/main_test.go` MUST also be updated** — verified via
-  round-2 implementation-plan review finding: this test file has ~20 direct references to
-  `map[string]*queueBind{}` literals and single-value field access (e.g. `main_test.go:606-613,
-  660-667`: `r.queueBinds["test-queue"].key`, `.exchange`), none of which compile against the
+  round-2/round-4 implementation-plan review: this test file has **36 hits** of `queueBinds`
+  (verified via fresh grep, not the originally-cited "~20" — always re-grep rather than trust a
+  hardcoded count, since line numbers/counts drift as the file changes), including direct
+  single-value field access (e.g. `r.queueBinds["test-queue"].key`) AND struct-literal
+  initializations (`queueBinds: make(map[string]*queueBind)`), none of which compile against the
   new `map[string][]*queueBind` type. Before starting Task 1.3's implementation, run
   `grep -n "queueBinds" bin-common-handler/pkg/rabbitmqhandler/main_test.go` and update EVERY
   hit to the new slice-based access pattern (e.g. `r.queueBinds["test-queue"][0].key` for
-  single-bind test cases, or iterate the slice for multi-bind cases). This is a REQUIRED part of
-  Task 1.3's Step 2/Step 4 (build/test verification) — do not consider Task 1.3 complete until
+  single-bind test cases, `make(map[string][]*queueBind)` for init sites, or iterate the slice
+  for multi-bind cases). This is a REQUIRED part of Task 1.3's Step 2/Step 4 (build/test
+  verification) — do not consider Task 1.3 complete until
   `go test ./bin-common-handler/pkg/rabbitmqhandler/...` passes with the new type.
 
 This is now a REQUIRED part of Task 1.3 (not deferred to Phase 4 planning as originally
@@ -968,6 +971,102 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Dua
 - bin-webhook-manager: Wire routing-key computation into both webhook entry points, dual-publish to new topic exchange alongside existing fanout publish (VOIP-1258 §6/§8 transition window)"
 ```
 
+### Task 1.2b: Add `NewNotifyHandlerForExistingExchange` (additive constructor variant)
+
+**Files:**
+- Modify: `bin-common-handler/pkg/notifyhandler/main.go`
+
+**Objective:** Resolve a self-contradiction found in round-4 implementation-plan review (see
+Task 3.1's note below): `NewNotifyHandler` unconditionally calls `sockHandler.TopicCreate(name)`
+internally (`main.go:103`), which hardcodes `fanout`
+(`rabbitmqhandler/topic.go`). There is no way to use `NewNotifyHandler` to construct a
+`NotifyHandler` bound to an exchange that has ALREADY been declared as `topic` kind elsewhere --
+attempting to do so causes RabbitMQ to reject the redundant fanout declare with
+`PRECONDITION_FAILED` (kind mismatch), and `NewNotifyHandler` swallows that error by logging and
+returning `nil` (`main.go:104-105`), producing a nil `NotifyHandler` interface that panics on
+first use.
+
+**Step 1: Write failing test**
+
+```go
+func TestNewNotifyHandlerForExistingExchange_SkipsDeclare(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	// TopicCreate/TopicCreateWithKind must NOT be called -- the exchange is assumed
+	// already declared by the caller.
+	mockSock.EXPECT().TopicCreate(gomock.Any()).Times(0)
+	mockSock.EXPECT().TopicCreateWithKind(gomock.Any(), gomock.Any()).Times(0)
+
+	h := NewNotifyHandlerForExistingExchange(mockSock, nil, "some.exchange.name", "test-service")
+
+	require.NotNil(t, h)
+}
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestNewNotifyHandlerForExistingExchange -v
+```
+Expected: FAIL — undefined.
+
+**Step 3: Implement (purely additive, does not touch `NewNotifyHandler` or any of its ~116
+existing call sites)**
+
+```go
+// bin-common-handler/pkg/notifyhandler/main.go — add:
+
+// NewNotifyHandlerForExistingExchange creates a NotifyHandler for an exchange that has ALREADY
+// been declared by the caller (e.g. via sockHandler.TopicCreateWithKind for a non-fanout kind).
+// Unlike NewNotifyHandler, this does NOT call sockHandler.TopicCreate/TopicCreateWithKind
+// internally -- it assumes the exchange already exists with the correct kind, and skips the
+// redundant (and, for non-fanout kinds, conflicting) declare. Added for VOIP-1258 (see design
+// doc §6, implementation plan Task 3.1) to support a second NotifyHandler instance bound to a
+// topic-kind exchange, alongside the existing fanout-only NewNotifyHandler used everywhere else.
+func NewNotifyHandlerForExistingExchange(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, queueEvent commonoutline.QueueName, publisher commonoutline.ServiceName) NotifyHandler {
+	h := &notifyHandler{
+		sockHandler: sockHandler,
+		reqHandler:  reqHandler,
+
+		queueNotify: queueEvent,
+
+		publisher: publisher,
+	}
+
+	// NOTE: deliberately NOT calling sockHandler.TopicCreate/TopicCreateWithKind here -- the
+	// caller is responsible for declaring the exchange BEFORE calling this constructor.
+
+	namespace := commonoutline.GetMetricNameSpace(publisher)
+	initPrometheus(namespace)
+
+	return h
+}
+```
+
+**Step 4: Run test, verify pass**
+
+```bash
+cd bin-common-handler/pkg/notifyhandler && go test ./... -run TestNewNotifyHandlerForExistingExchange -v
+```
+Expected: PASS
+
+**Step 5: Full build/test, confirm zero regression to existing `NewNotifyHandler`**
+
+```bash
+cd bin-common-handler && go build ./... && go test ./...
+```
+
+**Step 6: Commit**
+
+```bash
+git add bin-common-handler/pkg/notifyhandler/
+git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Add NewNotifyHandlerForExistingExchange, additive constructor variant
+
+- bin-common-handler: Add NewNotifyHandlerForExistingExchange, skips the internal TopicCreate declare so a NotifyHandler can be bound to an already-declared non-fanout exchange, resolves VOIP-1258 Task 3.1's fanout/topic declare conflict without touching NewNotifyHandler's existing ~116 call sites"
+```
+
 ---
 
 ## Phase 3: Exchange migration — new topic exchange, non-websocket consumer migration
@@ -1010,10 +1109,21 @@ Apply the same in `cmd/webhook-control/main.go`.
 **Step 3:** Update `webhookHandler`'s `publishRoutingKeyedEvent` (Task 2.5) to target this
 constant instead of `h.queueNotify` — this requires `PublishEventWithRoutingKey` to accept an
 explicit queue/exchange name parameter, OR a second `NotifyHandler` instance pointed at the new
-exchange. **Recommended**: give `notifyhandler.NewNotifyHandler` a second call in webhook-manager
-startup, creating a SEPARATE `NotifyHandler` instance bound to `QueueNameWebhookEventTopic`, and
-inject it into `webhookHandler` as a distinct field (`topicNotifyHandler`) alongside the existing
-`notifyHandler`. Revise Task 2.1's struct:
+exchange. **Recommended, using Task 1.2b's `NewNotifyHandlerForExistingExchange`**: give
+webhook-manager startup a SEPARATE `NotifyHandler` instance bound to
+`QueueNameWebhookEventTopic`, constructed via the ADDITIVE constructor added in Task 1.2b (not
+`NewNotifyHandler`), and inject it into `webhookHandler` as a distinct field
+(`topicNotifyHandler`) alongside the existing `notifyHandler`. **Do NOT use `NewNotifyHandler`
+for this second instance — verified via round-4 implementation-plan review: `NewNotifyHandler`
+unconditionally calls `sockHandler.TopicCreate(name)` internally (`notifyhandler/main.go:103`),
+which is hardcoded to declare `fanout` (`rabbitmqhandler/topic.go`). Since Step 2 above already
+declared `QueueNameWebhookEventTopic` as `topic` kind via `TopicCreateWithKind`, a subsequent
+`NewNotifyHandler` call for the same exchange name would have its internal fanout declare
+rejected by RabbitMQ (`PRECONDITION_FAILED`, kind mismatch), and `NewNotifyHandler` swallows
+that error by logging and returning `nil` — producing a nil `NotifyHandler` that panics on first
+use in Task 2.5's `h.topicNotifyHandler.PublishEventWithRoutingKey(...)` call. Using
+`NewNotifyHandlerForExistingExchange` (which skips the internal declare entirely, assuming the
+caller already declared the exchange) avoids this conflict.** Revise Task 2.1's struct:
 
 ```go
 type webhookHandler struct {
@@ -1027,8 +1137,21 @@ type webhookHandler struct {
 
 Update `NewWebhookHandler`'s signature to accept `topicNotifyHandler` as a new parameter, and
 `publishRoutingKeyedEvent` to call `h.topicNotifyHandler.PublishEventWithRoutingKey(...)` instead
-of `h.notifyHandler...`. Update both `cmd/` wiring sites to construct and pass the second
-`NotifyHandler`.
+of `h.notifyHandler...`. Update both `cmd/` wiring sites:
+
+```go
+// bin-webhook-manager/cmd/webhook-manager/main.go — after the TopicCreateWithKind declare
+// from Step 2 above, construct the second NotifyHandler using the ADDITIVE constructor:
+topicNotifyHandler := notifyhandler.NewNotifyHandlerForExistingExchange(
+	sockHandler,
+	reqHandler,
+	commonoutline.QueueNameWebhookEventTopic,
+	commonoutline.ServiceNameWebhookManager,
+)
+// ... then pass topicNotifyHandler into NewWebhookHandler(...) alongside the existing notifyHandler
+```
+
+Apply the same in `cmd/webhook-control/main.go`.
 
 **Step 4:** Build and test:
 ```bash

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -5,16 +5,18 @@
 > that touches `bin-common-handler` (its consumers must not break silently).
 
 **Goal:** Convert `QueueNameWebhookEvent`'s RabbitMQ exchange from `fanout` to `topic`, with
-scope-first routing keys (`customer_id.<uuid>.#` / `owner_id.<uuid>.#`), so `bin-api-manager`
+scope-first routing keys (`customer_id.<uuid>.#` / `agent_id.<uuid>.#`), so `bin-api-manager`
 pods only receive events for scopes that have a live local websocket subscriber — eliminating
-unconditional per-pod processing cost and the `agent_id` → `owner_id` public API rename.
+unconditional per-pod processing cost. (An `agent_id` -> `owner_id` public API rename was
+considered and reverted the same day it was proposed; the wire-protocol prefix stays
+`agent_id`.)
 
 **Architecture:** 4 phases, each independently mergeable and independently safe to ship (no
 phase depends on a later phase being deployed to be correct — each is additive or dual-write
 until the final cutover step). Phase order: (1) shared plumbing in `bin-common-handler`
 (additive, zero existing call sites touched) → (2) `bin-webhook-manager` computes routing keys
 and dual-publishes → (3) exchange migration + non-websocket consumers move to the new exchange
-→ (4) `bin-api-manager` dynamic bind/unbind + owner_id rename + old-exchange decommission.
+→ (4) `bin-api-manager` dynamic bind/unbind + old-exchange decommission.
 
 **Tech Stack:** Go, RabbitMQ (`amqp091-go` via `bin-common-handler/pkg/rabbitmqhandler`), gomock
 (`go generate`), existing `sock`/`hook`/`websockhandler` packages in `bin-api-manager`.
@@ -579,7 +581,7 @@ Expected: all pass unchanged (Phase 1 is purely additive).
 
 ## Phase 2: `bin-webhook-manager` — compute routing keys, dual-publish
 
-**Objective:** Move `createTopics()`'s routing-key-computation logic (customer_id, owner_id
+**Objective:** Move `createTopics()`'s routing-key-computation logic (customer_id, agent_id
 extraction, chat-participant fan-out) into `bin-webhook-manager`, executed before publish, and
 dual-publish to both the old fanout exchange (unchanged, for safety) and the new topic exchange.
 
@@ -715,8 +717,9 @@ import (
 )
 
 // webhookOwnerData mirrors bin-api-manager's commonWebhookData struct (ported per VOIP-1258 §6
-// harder part 1). Used to extract customer_id/owner_id from the event data payload BEFORE
-// publish, so the routing key can be computed at publish time instead of at consumption time.
+// harder part 1). Used to extract customer_id/agent_id (owner) from the event data payload
+// BEFORE publish, so the routing key can be computed at publish time instead of at consumption
+// time.
 type webhookOwnerData struct {
 	commonidentity.Identity
 	commonidentity.Owner
@@ -752,7 +755,7 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Por
 - bin-webhook-manager: Add parseWebhookOwnerData, ported from bin-api-manager's commonWebhookData (VOIP-1258 §6 harder part 1)"
 ```
 
-### Task 2.3: Implement `createRoutingKeys()` in webhook-manager (owner_id, hard-cutover)
+### Task 2.3: Implement `createRoutingKeys()` in webhook-manager (agent_id, unchanged wire prefix)
 
 **Files:**
 - Modify: `bin-webhook-manager/pkg/webhookhandler/routingkey.go`
@@ -777,7 +780,7 @@ func TestCreateRoutingKeys_CustomerAndOwner(t *testing.T) {
 	keys := createRoutingKeys(d, "queue", "queue_updated")
 	require.ElementsMatch(t, []string{
 		"customer_id.a1b2c3d4-0000-0000-0000-000000000001.queue.queue_updated.xyz-0000-0000-0000-000000000003",
-		"owner_id.98765432-0000-0000-0000-000000000002.queue.queue_updated.xyz-0000-0000-0000-000000000003",
+		"agent_id.98765432-0000-0000-0000-000000000002.queue.queue_updated.xyz-0000-0000-0000-000000000003",
 	}, keys)
 }
 ```
@@ -797,7 +800,8 @@ import "fmt"
 
 // createRoutingKeys generates AMQP routing keys for the given event, scope-first
 // (VOIP-1258 §5): "<scope>.<scope_id>.<resource>.<message_type>.<resource_id>".
-// owner_id replaces the old client-facing agent_id prefix (hard cutover, Open Question 10).
+// The agent_id wire prefix is unchanged (an agent_id -> owner_id rename was considered and
+// reverted, see design doc §5).
 func createRoutingKeys(d *webhookOwnerData, resource string, messageType string) []string {
 	res := []string{}
 
@@ -805,7 +809,7 @@ func createRoutingKeys(d *webhookOwnerData, resource string, messageType string)
 		res = append(res, fmt.Sprintf("customer_id.%s.%s.%s.%s", d.CustomerID, resource, messageType, d.ID))
 	}
 	if d.OwnerID != uuid.Nil {
-		res = append(res, fmt.Sprintf("owner_id.%s.%s.%s.%s", d.OwnerID, resource, messageType, d.ID))
+		res = append(res, fmt.Sprintf("agent_id.%s.%s.%s.%s", d.OwnerID, resource, messageType, d.ID))
 	}
 
 	return res
@@ -825,7 +829,7 @@ Expected: PASS
 git add bin-webhook-manager/pkg/webhookhandler/routingkey.go bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
 git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Implement createRoutingKeys for non-chat resource types
 
-- bin-webhook-manager: Add scope-first routing key generation (customer_id/owner_id), owner_id per Open Question 10 hard-cutover decision"
+- bin-webhook-manager: Add scope-first routing key generation (customer_id/agent_id), agent_id wire prefix unchanged (rename to owner_id was considered and reverted)"
 ```
 
 ### Task 2.4: Chat-participant fan-out routing keys (RPC relocation)
@@ -862,8 +866,8 @@ func TestCreateRoutingKeysForChat(t *testing.T) {
 	keys := h.createRoutingKeysForChat(context.Background(), d, "chatmessage_created")
 
 	require.Contains(t, keys, "customer_id.a1b2c3d4-0000-0000-0000-000000000001.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
-	require.Contains(t, keys, "owner_id.p1000000-0000-0000-0000-000000000001.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
-	require.Contains(t, keys, "owner_id.p2000000-0000-0000-0000-000000000002.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
+	require.Contains(t, keys, "agent_id.p1000000-0000-0000-0000-000000000001.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
+	require.Contains(t, keys, "agent_id.p2000000-0000-0000-0000-000000000002.talk.chatmessage_created.chat0000-0000-0000-0000-000000000001")
 }
 ```
 
@@ -887,7 +891,7 @@ grep -n "TalkV1ParticipantList" bin-common-handler/pkg/requesthandler/*.go
 import "context"
 
 // createRoutingKeysForChat generates routing keys for chat/chatmessage/chatparticipant events,
-// including one owner_id key per chat participant (fan-out). This RPC call was moved here from
+// including one agent_id key per chat participant (fan-out). This RPC call was moved here from
 // bin-api-manager's createTopics() per VOIP-1258 §6 harder part 2 -- it now runs ONCE at publish
 // time regardless of subscriber count, instead of once per pod after the fact.
 func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhookOwnerData, messageType string) []string {
@@ -907,12 +911,12 @@ func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhoo
 		res = append(res, fmt.Sprintf("customer_id.%s.talk.%s.%s", d.CustomerID, messageType, chatID))
 	}
 	if d.OwnerID != uuid.Nil {
-		res = append(res, fmt.Sprintf("owner_id.%s.talk.%s.%s", d.OwnerID, messageType, chatID))
+		res = append(res, fmt.Sprintf("agent_id.%s.talk.%s.%s", d.OwnerID, messageType, chatID))
 	}
 
 	participants, err := h.reqHandler.TalkV1ParticipantList(ctx, chatID)
 	if err != nil {
-		log.Errorf("Could not get chat participants, publishing customer/owner-scoped keys only. err: %v", err)
+		log.Errorf("Could not get chat participants, publishing customer/agent-scoped keys only. err: %v", err)
 		return res
 	}
 
@@ -922,7 +926,7 @@ func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhoo
 		if p.OwnerID == d.OwnerID {
 			continue // already added above
 		}
-		res = append(res, fmt.Sprintf("owner_id.%s.talk.%s.%s", p.OwnerID, messageType, chatID))
+		res = append(res, fmt.Sprintf("agent_id.%s.talk.%s.%s", p.OwnerID, messageType, chatID))
 	}
 
 	return res
@@ -1349,10 +1353,10 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Cut
 
 ---
 
-## Phase 4: `bin-api-manager` — dynamic bind/unbind, owner_id rename, decommission old exchange
+## Phase 4: `bin-api-manager` — dynamic bind/unbind, decommission old exchange
 
-**Objective:** Implement scope-aware dynamic binding on the per-pod queue, rename
-`agent_id`→`owner_id` in the client-facing wire protocol (hard cutover), remove the dead
+**Objective:** Implement scope-aware dynamic binding on the per-pod queue (the `agent_id`
+wire-protocol prefix stays unchanged, per the reverted rename decision), remove the dead
 `QueueNameAgentEvent`/`QueueNameTalkEvent` subscriptions, then decommission the old fanout
 exchange once everything is confirmed on the new one.
 
@@ -1514,7 +1518,7 @@ func TestTopicToBindPattern(t *testing.T) {
 		expected string
 	}{
 		{"customer_id:abc123:call:*", "customer_id.abc123.#"},
-		{"owner_id:def456:queue:*", "owner_id.def456.#"},
+		{"agent_id:def456:queue:*", "agent_id.def456.#"},
 		{"customer_id:abc123", "customer_id.abc123.#"},
 	}
 	for _, c := range cases {
@@ -1748,89 +1752,15 @@ git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Wir
 - bin-api-manager: Call scopeRefCount.Acquire/Release on explicit subscribe/unsubscribe, ReleaseAll on abrupt disconnect via subscriptionRun's existing teardown path (VOIP-1258 §9)"
 ```
 
-### Task 4.4: Rename `agent_id` -> `owner_id` in `validateTopics`/`validateTopic` (hard cutover)
+### Task 4.4: REMOVED — `agent_id` -> `owner_id` rename reverted
 
-**Files:**
-- Modify: `bin-api-manager/pkg/websockhandler/etc.go`
-- Modify: `bin-api-manager/pkg/websockhandler/etc_test.go`
-
-**Step 1: Write failing test**
-
-```go
-// bin-api-manager/pkg/websockhandler/etc_test.go — update existing agent_id test cases:
-func TestValidateTopics_OwnerScope(t *testing.T) {
-	a := &auth.AuthIdentity{ /* agent with AgentID() == "98765432-..." */ }
-	topics := []string{"owner_id:98765432-0000-0000-0000-000000000002:queue:*"}
-	require.True(t, h.validateTopics(context.Background(), a, topics))
-}
-
-func TestValidateTopics_RejectsOldAgentIdPrefix(t *testing.T) {
-	a := &auth.AuthIdentity{}
-	topics := []string{"agent_id:98765432-0000-0000-0000-000000000002:queue:*"}
-	require.False(t, h.validateTopics(context.Background(), a, topics)) // hard cutover: old prefix now invalid
-}
-```
-
-**Step 2: Run to verify failure**
-
-```bash
-cd bin-api-manager/pkg/websockhandler && go test ./... -run "TestValidateTopics_OwnerScope|TestValidateTopics_RejectsOldAgentIdPrefix" -v
-```
-Expected: `TestValidateTopics_OwnerScope` FAILS (still says `agent_id`),
-`TestValidateTopics_RejectsOldAgentIdPrefix` PASSES already (old behavior happens to reject
-unknown prefixes... verify this against current `default: return false` branch — should already
-pass since `owner_id` isn't yet a recognized case, meaning the NEW test needs `owner_id` to be
-accepted and `agent_id` to be REJECTED after the rename, i.e. write both tests to assert
-POST-rename behavior, run BEFORE the code change to confirm `TestValidateTopics_OwnerScope`
-fails and `TestValidateTopics_RejectsOldAgentIdPrefix`... actually also fails pre-change, since
-`agent_id` is currently ACCEPTED, not rejected. Both tests should fail before the code change).
-
-**Step 3: Implement (rename, both functions)**
-
-```go
-// bin-api-manager/pkg/websockhandler/etc.go — in validateTopics, change:
-//   case "agent_id":
-//       if tmpID != a.AgentID() {
-// TO:
-		case "owner_id":
-			if tmpID != a.AgentID() {
-				return false
-			}
-```
-
-Apply the identical change in `validateTopic` (the second near-duplicate function, line 139).
-Update the two `default:` comment lines from `// the first part should be "customer_id" or
-"agent_id"` to `// the first part should be "customer_id" or "owner_id"`.
-
-**Step 4: Run tests, verify pass**
-
-```bash
-cd bin-api-manager/pkg/websockhandler && go test ./... -v
-```
-Expected: all pass, including the two new tests.
-
-**Step 5: Update RST docs (per design doc §5, CLAUDE.md RST-sync rule)**
-
-```bash
-grep -rn "agent_id:" bin-api-manager/docsdev/source/websocket_overview.rst bin-api-manager/docsdev/source/websocket_struct.rst bin-api-manager/docsdev/source/websocket_tutorial.rst
-```
-Replace each `agent_id:` example with `owner_id:`. Rebuild:
-```bash
-cd bin-api-manager/docsdev && sphinx-build -M html source build
-```
-Force-add the build output per CLAUDE.md's RST-sync convention (build/ is gitignored elsewhere
-but the sync rule requires committing rendered output — confirm current convention with
-`git status` after build, follow existing pattern in the repo).
-
-**Step 6: Commit**
-
-```bash
-git add bin-api-manager/pkg/websockhandler/etc.go bin-api-manager/pkg/websockhandler/etc_test.go bin-api-manager/docsdev/
-git -c user.name="Sungtae Kim" -c user.email="pchero21@gmail.com" commit -m "Rename agent_id to owner_id in websocket wire protocol (breaking change)
-
-- bin-api-manager: Rename agent_id scope prefix to owner_id in validateTopics/validateTopic, hard cutover per Open Question 10 (no dual-accept period)
-- bin-api-manager: Update websocket RST docs (overview/struct/tutorial) to reflect owner_id"
-```
+**This task is REMOVED.** It originally renamed the `agent_id` wire-protocol prefix to
+`owner_id` in `validateTopics`/`validateTopic` (`bin-api-manager/pkg/websockhandler/etc.go`) and
+the websocket RST docs, as a hard-cutover breaking change. **pchero reverted the rename decision
+on 2026-07-14 (same day it was proposed) — the `agent_id` prefix stays exactly as it is today.
+No code change is needed in `etc.go`/`etc_test.go`/the RST docs for this reason.** See design
+doc §5 for the reverted rationale, kept for historical record only. Proceed directly to Task
+4.5; no dependency on this removed task.
 
 ### Task 4.5: Remove dead `QueueNameAgentEvent`/`QueueNameTalkEvent` subscriptions
 
@@ -1855,7 +1785,7 @@ exchange WITH an explicit `#` wildcard binding — do NOT use `QueueSubscribe`'s
 this target. **Verified via round-2 implementation-plan review finding: on a `topic`-kind
 exchange (unlike `fanout`), an empty routing key binding only matches messages published with an
 empty routing key. Since every VOIP-1258 publish path (Task 2.3/2.4/2.5) publishes with
-non-empty scope-first keys (`customer_id.xxx...`/`owner_id.xxx...`), using
+non-empty scope-first keys (`customer_id.xxx...`/`agent_id.xxx...`), using
 `QueueSubscribe(queue, target)`'s existing empty-key bind
 (`rabbitmqhandler/queue.go:158-159`) against `QueueNameWebhookEventTopic` would deliver ZERO
 events to bin-api-manager's baseline subscription — a silent total event-loss regression the

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-implementation-plan.md
@@ -38,39 +38,10 @@ and dual-publishes → (3) exchange migration + non-websocket consumers move to 
 **Step 1:** `QueueBind` already exists as a public method on `rabbit` (concrete struct,
 `rabbitmqhandler/queue.go:163`) but is NOT on the `SockHandler` interface. `QueueUnbind` does
 not exist anywhere in `bin-common-handler` yet (verified: zero hits). Both are needed for Phase
-4's dynamic bind/unbind. Add to the interface:
-
-```go
-// bin-common-handler/pkg/sockhandler/main.go
-type SockHandler interface {
-	Connect()
-	Close()
-
-	ConsumeMessage(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, numWorkers int, messageConsume sock.CbMsgConsume) error
-	ConsumeRPC(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error
-
-	TopicCreate(name string) error
-	TopicCreateWithKind(name string, kind string) error // NEW
-
-	EventPublish(topic string, key string, evt *sock.Event) error
-	EventPublishWithDelay(topic string, key string, evt *sock.Event, delay int) error
-	EventPublishWithKey(topic string, key string, evt *sock.Event) error // NEW (alias-clear name; see Task 1.2 note)
-
-	RequestPublish(ctx context.Context, queueName string, req *sock.Request) (*sock.Response, error)
-	RequestPublishWithDelay(queueName string, req *sock.Request, delay int) error
-
-	QueueCreate(name string, queueType string) error
-	QueueSubscribe(name string, topic string) error
-	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error    // NEW: expose existing rabbit method
-	QueueUnbind(name, key, exchange string, args amqp.Table) error                // NEW: does not exist yet, see Task 1.3
-}
-```
-
-**Note on `EventPublishWithKey`**: `EventPublish(topic, key string, evt *sock.Event)` already
-takes a `key` parameter (verified, `sockhandler/main.go:20`) — it is NOT missing at this layer.
-**Skip adding `EventPublishWithKey`; `EventPublish` is already sufficient at the `SockHandler`
-level.** The gap is one layer up, at `NotifyHandler` (Task 1.2). Strike this line from the
-interface above — corrected list:
+4's dynamic bind/unbind. Add the following to the interface (this is the FINAL, authoritative
+list — `EventPublish` at the `SockHandler` level already accepts a `key string` parameter,
+confirmed at `sockhandler/main.go:20`, so no new `EventPublishWithKey` method is needed here;
+the routing-key gap is one layer up, at `NotifyHandler`, addressed separately in Task 1.2):
 
 ```go
 type SockHandler interface {
@@ -257,9 +228,42 @@ needed — no change required there, it's already compatible with the interface 
 1.1. Only `QueueUnbind` needs to be added:
 
 ```go
-// bin-common-handler/pkg/rabbitmqhandler/queue.go — add after QueueBind:
+// bin-common-handler/pkg/rabbitmqhandler/queue.go — add after QueueBind, and MODIFY QueueBind
+// itself per the "Decision: implement option (a)" caveat above:
 
-// QueueUnbind unbinds queue and exchange with a key
+// QueueBind binds queue and exchange with a key. Appends to the tracked bind set for this
+// queue name (does not overwrite), so redeclareAll() can restore ALL active bindings after a
+// broker reconnect, not just the most recent one (VOIP-1258 round-1 implementation-plan review
+// finding F2).
+func (r *rabbit) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	queue := r.queueGet(name)
+	if queue == nil {
+		return fmt.Errorf("no queue found")
+	}
+
+	if err := queue.channel.QueueBind(name, key, exchange, noWait, args); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, b := range r.queueBinds[name] {
+		if b.key == key && b.exchange == exchange {
+			return nil // already tracked, idempotent re-bind
+		}
+	}
+	r.queueBinds[name] = append(r.queueBinds[name], &queueBind{
+		name:     name,
+		key:      key,
+		exchange: exchange,
+		noWait:   noWait,
+		args:     args,
+	})
+	return nil
+}
+
+// QueueUnbind unbinds queue and exchange with a key, removing the matching entry from the
+// tracked bind set (not the whole map key, unless the set becomes empty).
 func (r *rabbit) QueueUnbind(name, key, exchange string, args amqp.Table) error {
 	queue := r.queueGet(name)
 	if queue == nil {
@@ -271,24 +275,70 @@ func (r *rabbit) QueueUnbind(name, key, exchange string, args amqp.Table) error 
 	}
 
 	r.mu.Lock()
-	delete(r.queueBinds, name) // NOTE: see caveat below if multiple binds per queue name are tracked
-	r.mu.Unlock()
+	defer r.mu.Unlock()
+	binds := r.queueBinds[name]
+	for i, b := range binds {
+		if b.key == key && b.exchange == exchange {
+			r.queueBinds[name] = append(binds[:i], binds[i+1:]...)
+			break
+		}
+	}
+	if len(r.queueBinds[name]) == 0 {
+		delete(r.queueBinds, name)
+	}
 	return nil
 }
 ```
 
-**Caveat, must verify before merging**: `r.queueBinds` is keyed by queue `name` only
-(`queue.go:174`, `QueueBind`'s existing code: `r.queueBinds[name] = &queueBind{...}`) — it
-overwrites on each bind, so it currently only tracks the MOST RECENT bind per queue name, not a
-set of all binds. For Phase 4's dynamic bind/unbind (one queue, many scope bindings
-simultaneously), this internal bookkeeping map is insufficient as-is. Two options, decide during
-Phase 4 planning (Task 4.1), not now:
-- (a) Change `r.queueBinds[name]` to `map[string][]*queueBind` (a slice per queue name) --
-  affects any other code reading `r.queueBinds` (grep before changing).
-  - (b) Don't rely on `r.queueBinds` for the refcount tracking at all; track scope→refcount
-  entirely in `bin-api-manager`'s own new component (Task 4.2) and treat `QueueBind`/`QueueUnbind`
-  as pure fire-and-forget AMQP calls. **Recommended**: (b) is simpler and doesn't touch shared
-  `rabbitmqhandler` internals for an api-manager-specific concern.
+Also update the `r.queueBinds` field declaration (find its struct, likely in
+`bin-common-handler/pkg/rabbitmqhandler/main.go` near the `queues`/`exchanges` map
+declarations) from `map[string]*queueBind` to `map[string][]*queueBind`, and update
+`redeclareAll()`'s snapshot loop (`main.go:275-278`) to flatten the nested slices:
+
+```go
+// bin-common-handler/pkg/rabbitmqhandler/main.go:275-278 — MODIFY:
+bindsCopy := make([]*queueBind, 0, len(r.queueBinds))
+for _, binds := range r.queueBinds { // now a [][]*queueBind value per key
+	bindsCopy = append(bindsCopy, binds...)
+}
+```
+
+**Caveat, RESOLVED (was previously deferred, now decided per round-1 implementation-plan review
+finding F2)**: `r.queueBinds` is keyed by queue `name` only (`queue.go:174`, `QueueBind`'s
+existing code: `r.queueBinds[name] = &queueBind{...}`) — it overwrites on each bind, so it
+currently only tracks the MOST RECENT bind per queue name, not a set of all binds. **This is not
+merely a bookkeeping gap: `rabbitmqhandler/main.go:260-307`'s `redeclareAll()` iterates
+`r.queueBinds` and automatically re-issues `QueueBind` for each tracked entry on every broker
+reconnect, to restore state after a connection drop.** Since only the LAST bind survives in the
+map, once Phase 4's `scopeRefCount` (Task 4.1) has bound a single per-pod queue to N different
+scope patterns, a broker reconnect will silently restore only ONE of those N bindings — every
+other live subscriber's scope goes dark (receives zero events) until that specific connection
+happens to re-subscribe (which nothing today triggers automatically on reconnect). **This is a
+real production-availability bug, not a hypothetical**, and treating `QueueBind`/`QueueUnbind`
+as fire-and-forget from `bin-api-manager`'s side (the originally-considered option (b)) does NOT
+avoid it, because the bug lives inside `rabbitmqhandler`'s own internal reconnect logic, a layer
+below where `bin-api-manager`'s refcount component operates.
+
+**Decision: implement option (a).** Change `r.queueBinds` from `map[string]*queueBind` to
+`map[string][]*queueBind` (one queue name maps to a SET of binds, not a single overwritten
+entry). This requires:
+- Updating the field declaration in `rabbitmqhandler`'s struct (find via `grep -n "queueBinds"
+  bin-common-handler/pkg/rabbitmqhandler/*.go` — check ALL read/write sites, not just
+  `queue.go:174` and `main.go:275-278`, before changing the type).
+- `QueueBind` (Task 1.3, below): append to the slice instead of overwriting, but first check
+  whether an identical `(name, key, exchange)` triple already exists in the slice (idempotent
+  re-bind, since `Acquire()` in Task 4.1 may call `QueueBind` again for a pattern that's already
+  bound if `scopeRefCount`'s in-memory state and the broker's actual state ever diverge after a
+  reconnect — defensive, avoids duplicate slice entries).
+- `QueueUnbind` (Task 1.3, below): remove the matching entry from the slice, not the whole map
+  key, and only delete the map key entirely when the slice becomes empty.
+- `redeclareAll()` (`main.go:298-303`): already iterates a flat list of all binds — this loop is
+  UNCHANGED once the underlying data structure holds every bind instead of just the last one;
+  the fix is entirely in how `queueBinds` is populated/depopulated, not in how it's replayed.
+
+This is now a REQUIRED part of Task 1.3 (not deferred to Phase 4 planning as originally
+written), since Phase 4's `scopeRefCount` component depends on reconnects correctly restoring
+ALL of a pod's active scope bindings, not just the most recent one.
 
 **Step 2: Verify build**
 
@@ -686,7 +736,11 @@ func TestCreateRoutingKeysForChat(t *testing.T) {
 		ChatID:   chatID,
 	}
 
-	mockReq.EXPECT().TalkV1ParticipantList(gomock.Any(), chatID).Return([]tmparticipant.Participant{
+	// NOTE: TalkV1ParticipantList returns []*tkparticipant.Participant (POINTER slice),
+	// verified against bin-common-handler/pkg/requesthandler/main.go:1394 and
+	// talk_participants.go:16 -- NOT a value slice. Using tkparticipant (bin-talk-manager's
+	// models/participant package), not tmparticipant.
+	mockReq.EXPECT().TalkV1ParticipantList(gomock.Any(), chatID).Return([]*tkparticipant.Participant{
 		{Owner: commonidentity.Owner{OwnerID: uuid.FromStringOrNil("p1000000-0000-0000-0000-000000000001")}},
 		{Owner: commonidentity.Owner{OwnerID: uuid.FromStringOrNil("p2000000-0000-0000-0000-000000000002")}},
 	}, nil)
@@ -748,6 +802,8 @@ func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhoo
 		return res
 	}
 
+	// NOTE: participants is []*tkparticipant.Participant (pointer slice) -- verified against
+	// bin-common-handler/pkg/requesthandler/main.go:1394. p is a pointer here, not a value.
 	for _, p := range participants {
 		if p.OwnerID == d.OwnerID {
 			continue // already added above
@@ -1082,19 +1138,39 @@ marking Phase 3 complete.
 **Step 1:** Replace the additive `QueueBind` call from Task 3.2/3.3 with a direct swap: change
 the exchange name in the EXISTING `QueueSubscribe(queueNamePod, string(commonoutline.QueueNameWebhookEvent))`
 call to `commonoutline.QueueNameWebhookEventTopic`, and follow it with an explicit `#`
-`QueueBind` (since `QueueSubscribe` always binds with an empty key, wrong for a topic exchange):
+`QueueBind` (since `QueueSubscribe` always binds with an empty key, wrong for a topic exchange).
+**Critically, this must also explicitly `QueueUnbind` the OLD fanout binding — verified via
+round-1 implementation-plan review finding F3 that `bin-agent-manager`/`bin-timeline-manager`
+use a DURABLE, shared, non-per-pod queue (`QueueCreate(subscribeQueue, "normal")`, confirmed at
+`subscribehandler/main.go:120` for timeline-manager, not `"volatile"`/UUID-suffixed like
+api-manager's per-pod queue) that PERSISTS the old binding across deploys. AMQP `QueueBind` is
+additive — declaring a new binding does NOT remove a pre-existing one on the same queue. Without
+an explicit `QueueUnbind`, this queue ends up bound to BOTH the old fanout exchange (implicit
+match-all) AND the new topic exchange with `#` (also match-all) simultaneously, reproducing
+Task 3.4's double-processing bug exactly, since `bin-webhook-manager` dual-publishes to both
+exchanges during this window (Task 2.5/3.1).**
 
 ```go
 // bin-agent-manager/cmd/agent-manager/main.go — REPLACE:
 //   sockHandler.QueueSubscribe(queueNamePod, string(commonoutline.QueueNameWebhookEvent))
-// WITH:
-if err := sockHandler.QueueCreate(queueNamePod, "volatile"); err != nil { /* ... */ }
+// WITH (bind new + unbind old, in that order, to avoid an event-loss window where the queue is
+// briefly bound to neither exchange):
+if err := sockHandler.QueueCreate(queueNamePod, "normal"); err != nil { /* ... */ } // queueType matches existing declaration; do not change to "volatile"
 if err := sockHandler.QueueBind(queueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
 	logrus.Errorf("Could not bind to the topic exchange. err: %v", err)
+	// do NOT proceed to unbind the old exchange if this bind failed -- stay on the old
+	// exchange rather than risk ending up bound to neither.
+} else if err := sockHandler.QueueUnbind(queueNamePod, "", string(commonoutline.QueueNameWebhookEvent), nil); err != nil {
+	logrus.Errorf("Could not unbind from the old fanout exchange. err: %v", err)
+	// non-fatal: the queue is now bound to BOTH exchanges (double-processing resumes) --
+	// alert/log loudly, this needs manual intervention (confirm the unbind succeeded via
+	// RabbitMQ management API) rather than silently leaving the queue in a degraded state.
 }
 ```
 
-Same pattern for `bin-timeline-manager`.
+Same pattern for `bin-timeline-manager`, using its actual queue-type argument as currently
+declared (`"normal"`, confirmed at `subscribehandler/main.go:120` — do not assume `"volatile"`;
+verify the exact call before writing this code).
 
 **Step 2:** Build, test, deploy, re-verify single delivery per event (repeat Task 3.4's
 verification, this time checking no double-processing).
@@ -1430,22 +1506,54 @@ func (h *websockHandler) subscriptionHandleMessage(ctx context.Context, a *auth.
 }
 ```
 
-**Step 3:** Add `scopeRefCount` field to `websockHandler` struct and construct one PER
-CONNECTION pointed at that pod's SHARED per-pod queue (the refcount map itself must be
-pod-wide/shared across connections on the same pod, NOT per-connection — re-check: `scopeRefCount`
-should be a single instance owned by `websockHandler` itself, constructed once at pod startup,
-not per `subscriptionRun` call). Revise:
+**Step 3:** Add `scopeRefCount` field to `websockHandler` struct, threaded from `cmd/api-manager/
+main.go` where the per-pod queue and `sockHandler` actually live. **Verified via round-1
+implementation-plan review finding F4: `websockHandler` (`pkg/websockhandler/main.go:30-33`)
+currently has NO `sockhandler.SockHandler` field, and its constructor `NewWebsockHandler(reqHandler,
+streamHandler)` (called from `cmd/api-manager/main.go:136`) takes neither a sock handler nor a
+queue name — the per-pod queue (`queueNamePod`) and its `sockHandler` are constructed entirely
+in `cmd/api-manager/main.go:157`, outside the `websockhandler` package. This requires a new
+cross-package wiring, not just a struct field addition:**
 
 ```go
-// bin-api-manager/pkg/websockhandler/main.go — websockHandler struct:
+// bin-api-manager/pkg/websockhandler/main.go — MODIFY:
 type websockHandler struct {
-	// ... existing fields ...
+	reqHandler    requesthandler.RequestHandler
+	streamHandler streamhandler.StreamHandler
 	scopeRefCount *scopeRefCount // NEW: shared across all connections on this pod
+}
+
+// NewWebsockHandler creates a new HookHandler
+func NewWebsockHandler(
+	reqHandler requesthandler.RequestHandler,
+	streamHandler streamhandler.StreamHandler,
+	sockHandler sockhandler.SockHandler, // NEW param
+	queueNamePod string, // NEW param -- the SAME per-pod queue name main.go already constructs
+) WebsockHandler {
+
+	res := &websockHandler{
+		reqHandler:    reqHandler,
+		streamHandler: streamHandler,
+		scopeRefCount: newScopeRefCount(sockHandler, queueNamePod, string(commonoutline.QueueNameWebhookEventTopic)), // NEW
+	}
+
+	endpointInit()
+
+	return res
 }
 ```
 
-Construct once in the handler's constructor (find `NewWebsockHandler` or equivalent), pointed at
-the pod's existing per-pod queue name and the new topic exchange constant.
+```go
+// bin-api-manager/cmd/api-manager/main.go — MODIFY the existing NewWebsockHandler call site
+// at line 136 to pass the sockHandler and queueNamePod locals that are ALREADY constructed at
+// line 157 today. This requires either (a) reordering so queue/sockHandler construction happens
+// BEFORE the NewWebsockHandler(...) call (currently it's the reverse order, verify with
+// `grep -n "queueNamePod\|NewWebsockHandler" bin-api-manager/cmd/api-manager/main.go` before
+// writing this change), or (b) passing them as forward references if Go's initialization order
+// allows it. Read the full current main.go control flow before implementing this reordering --
+// do not assume it's a trivial one-line change.
+websockHandler := websockhandler.NewWebsockHandler(reqHandler, streamHandler, sockHandler, queueNamePod)
+```
 
 **Step 4: Write test for the wiring**
 

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -176,6 +176,14 @@ into `bin-webhook-manager`**, run against `data` before publish, to extract `Own
 way `createTopics()` does today. This is a genuine, non-trivial logic move (not just a signature
 change), but it is confined to `bin-webhook-manager`, not spread across ~25 services.
 
+**Symmetry note, verified**: both `SendWebhookToCustomer` and `SendWebhookToURI` construct an
+identical `wh := &webhook.Webhook{...}` before calling `notifyHandler.PublishEvent` (lines
+~60-65 and ~138-143 respectively) -- they feed the exact same downstream event path to
+`QueueNameWebhookEvent`. Harder parts 1 and 2 below therefore apply symmetrically to BOTH entry
+points, not just `SendWebhookToCustomer`. The routing-key-computation logic (nested-envelope
+unmarshal + chat-participant RPC) should live in one shared internal helper called from both
+functions, not duplicated per call site.
+
 **Harder part 2 -- chat participant fan-out RPC moves to the publish path**: for
 `chat`/`chatmessage`/`chatparticipant` resource types, `createTopics()` today calls
 `h.reqHandler.TalkV1ParticipantList(ctx, chatID)` (`webhookmanager.go:143`) AFTER receiving the

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -120,7 +120,11 @@ disqualified for a real, non-trivial subset of call sites, confirmed by reading 
   `commonidentity.Identity`/`Owner`:
   - `bin-contact-manager/pkg/casehandler/casenote.go:53-57` —
     `map[string]uuid.UUID{"id":..., "case_id":..., "customer_id": customerID}`
-  - `bin-contact-manager/pkg/casehandler/case_tag.go:92,130` — same map pattern
+  - `bin-contact-manager/pkg/casehandler/case_tag.go:92-95,130-133` — same map pattern; note
+    this map carries only `case_id`/`tag_id` keys and has **no `customer_id` key at all**, so
+    these two call sites cannot even reach a `customer_id`-scoped routing key without an
+    additional lookup or a broader signature change beyond the map-to-struct migration itself —
+    a strictly harder case than the other two examples, not just "also a map."
   - `bin-call-manager/pkg/callhandler/outgoing_call.go:213-217` —
     `map[string]interface{}{"customer_id":..., "call_id":..., ...}`
 
@@ -140,16 +144,51 @@ disqualified for a real, non-trivial subset of call sites, confirmed by reading 
 RabbitMQ exchange kind is fixed at declare time; re-declaring an existing exchange name with a
 different kind fails with `PRECONDITION_FAILED`. Since `QueueNameWebhookEvent` /
 `QueueNameAgentEvent` / `QueueNameTalkEvent` are already declared `fanout` in production, an
-in-place kind change is not possible. Proposed path (to be detailed further in implementation
-planning, flagged here as a known constraint, not a solved problem):
+in-place kind change is not possible.
+
+**CRITICAL, verified: these three exchanges are NOT exclusively consumed by bin-api-manager.**
+A monorepo-wide grep confirms other, unrelated consumers subscribe to the same exchanges for
+their own purposes, all via `QueueSubscribe(queue, exchange)` -> `QueueBind(name, "", exchange,
+...)` (`bin-common-handler/pkg/rabbitmqhandler/queue.go:158-160`) — an **empty routing key**,
+which is irrelevant under `fanout` but under `topic` only matches messages published with an
+exactly-empty routing key:
+- `bin-agent-manager/cmd/agent-manager/main.go:159` subscribes to `QueueNameWebhookEvent`
+  (agent status update logic, unrelated to websocket delivery)
+- `bin-queue-manager/cmd/queue-manager/main.go:149` subscribes to `QueueNameAgentEvent`
+  (queue routing / agent-tag matching)
+- `bin-timeline-manager/pkg/subscribehandler/main.go:29,50,54` subscribes to **all three**
+  (`QueueNameAgentEvent`, `QueueNameTalkEvent`, `QueueNameWebhookEvent`) as part of its
+  platform-wide audit-log ingestion
+
+Because exchange kind is global per exchange name (not scoped per-consumer), converting these
+exchanges to `topic` with dot-formatted routing keys will **silently stop delivering events to
+bin-agent-manager, bin-queue-manager, and bin-timeline-manager** the moment the old fanout
+exchange is decommissioned, unless these three services' bindings are also migrated (e.g. to a
+wildcard `#` binding, since they need every event regardless of scope, not scoped filtering).
+This would break agent status updates, queue routing, and the platform audit log — a real,
+previously undisclosed regression risk, not covered by "api-manager pods migrate their per-pod
+queue bindings" alone. **The migration plan below is revised to explicitly include these three
+consumers**, and this is escalated to Open Question 7.
+
+Proposed path (to be detailed further in implementation planning; the steps below are a skeleton,
+not a finalized runbook):
 
 1. Declare new topic exchanges under new names (e.g. suffix `.topic` or a v2 queue-name constant)
    alongside the existing fanout exchanges.
 2. Publishers dual-publish to both old (fanout, unscoped) and new (topic, scoped) exchanges during
-   a transition window.
-3. api-manager pods migrate their per-pod queue bindings from the old exchange to the new one.
-4. Once all pods are confirmed on the new exchange, remove the dual-publish and decommission the
-   old fanout exchange.
+   a transition window. **Bind/unbind ordering during this window needs an explicit guarantee**:
+   if any consumer (api-manager pod, or the three non-websocket consumers above) ever binds to
+   the new exchange before fully cutting over from the old one, it will double-receive events
+   during the overlap. The doc does not yet specify a concrete ordering protocol for this —
+   flagged as part of Open Question 7, not resolved here.
+3. api-manager pods migrate their per-pod queue bindings from the old exchange to the new one
+   (scoped, per §7's dynamic bind/unbind). **bin-agent-manager, bin-queue-manager, and
+   bin-timeline-manager migrate their existing queues to bind the new topic exchange with a `#`
+   wildcard** (they need the full, unscoped event stream for their own purposes — this is a
+   like-for-like fanout-equivalent binding, not scoped filtering, and requires no changes to
+   their internal event-handling logic, only the bind call's target exchange name and key).
+4. Once all pods and all four consumer services are confirmed on the new exchange, remove the
+   dual-publish and decommission the old fanout exchange.
 
 This is standard blue/green exchange migration; needs concrete queue-name constants and a
 rollback plan before implementation, not resolved in this doc.
@@ -227,3 +266,13 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    (`newCtx` cancellation, `defer zmqSub.Terminate()`) fires on every disconnect, clean or not,
    but carries no per-topic unsubscribe signal today; the refcount component needs its own state
    to know what to decrement on this path, and that state doesn't exist in the codebase yet.
+7. **(New, blocking) Non-websocket consumers of the same exchanges.** `bin-agent-manager`,
+   `bin-queue-manager`, and `bin-timeline-manager` all subscribe to one or more of
+   `QueueNameWebhookEvent`/`QueueNameAgentEvent`/`QueueNameTalkEvent` today via empty-routing-key
+   fanout bindings, for purposes unrelated to websocket delivery (agent status updates, queue
+   routing, audit-log ingestion — see §6). Their migration to `#`-wildcard bindings on the new
+   topic exchange is sketched in §6 step 3 but not fully planned: does each of these three
+   services need code changes beyond the bind call (e.g. do they rely on routing-key value
+   anywhere, even though they ignore it today), and what is the verification/rollback plan
+   specific to each, given they are unrelated teams'/features' code paths from the websocket
+   subscription feature this design is otherwise scoped to?

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -530,14 +530,14 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    the `go generate`-regenerated mock -- not a broad blast radius, but should still be confirmed
    as part of the standard verification workflow (`go generate ./... && go test ./...`) rather
    than assumed.
-10. **(New) `agent_id` -> `owner_id` backward compatibility.** §5's wire-protocol rename is a
-    breaking change to the public websocket API. Decide: hard cutover (no transitional support),
-    or a transition window accepting BOTH `agent_id:...` and `owner_id:...` prefixes on
-    subscribe (with `owner_id` as the only one ever emitted server -> client, or with both
-    accepted client -> server but a deprecation notice), and for how long. This is a
-    product/support decision (announcement timing, existing customer migration communication),
-    not a pure engineering one -- flagged for explicit pchero sign-off before implementation,
-    not something to decide unilaterally during coding. If a transition window is chosen,
-    `validateTopics`/`validateTopic` (`bin-api-manager/pkg/websockhandler/etc.go`) would need to
-    accept both prefixes as equivalent during that window, adding temporary complexity that must
-    be tracked for removal afterward.
+10. **(New) `agent_id` -> `owner_id` backward compatibility -- RESOLVED (pchero, 2026-07-14):
+    hard cutover.** No transitional dual-accept period. `owner_id:...` is the only prefix
+    supported from the moment this ships; existing clients subscribing with `agent_id:...` break
+    immediately on deploy. Rationale: no external customers currently depend on the
+    `agent_id:...` wire format (internal/beta usage only at this stage). Consequence for
+    implementation: `validateTopics`/`validateTopic` (`bin-api-manager/pkg/websockhandler/etc.go`)
+    only need the `case "owner_id":` branch added/renamed -- no dual-prefix acceptance logic, no
+    deprecation-window bookkeeping, no follow-up removal task. Should still be called out in the
+    PR description and release notes as a breaking change to the public websocket API, and
+    confirmed with support/product before deploy that no known external client depends on
+    `agent_id:...` today.

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -174,7 +174,14 @@ Proposed path (to be detailed further in implementation planning; the steps belo
 not a finalized runbook):
 
 1. Declare new topic exchanges under new names (e.g. suffix `.topic` or a v2 queue-name constant)
-   alongside the existing fanout exchanges.
+   alongside the existing fanout exchanges. **Must declare `durable=true`, matching the existing
+   fanout exchanges** (`bin-common-handler/pkg/rabbitmqhandler/topic.go:7` declares today's
+   fanout exchanges with `durable=true`, i.e. they survive broker restart). If the new topic
+   exchange is declared non-durable (or `durable=true` is simply omitted during implementation),
+   a broker/node restart during the dual-publish transition window would silently drop the new
+   exchange and any queue bindings on it, causing message loss for every consumer already
+   migrated to it at that point — a real production-correctness gap in an otherwise "standard"
+   blue/green migration. Escalated as Open Question 8.
 2. Publishers dual-publish to both old (fanout, unscoped) and new (topic, scoped) exchanges during
    a transition window. **Bind/unbind ordering during this window needs an explicit guarantee**:
    if any consumer (api-manager pod, or the three non-websocket consumers above) ever binds to
@@ -276,3 +283,10 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    anywhere, even though they ignore it today), and what is the verification/rollback plan
    specific to each, given they are unrelated teams'/features' code paths from the websocket
    subscription feature this design is otherwise scoped to?
+8. **(New) New topic exchange durability.** §6 step 1 requires the new topic exchange(s) to be
+   declared `durable=true`, matching the existing fanout exchanges. Confirm the implementation
+   actually sets this (an easy omission since it's a boolean flag on `ExchangeDeclare`, not a
+   design-level structural decision), and consider whether a broker restart mid-dual-publish-
+   window needs an explicit recovery/reconciliation step beyond exchange durability alone (e.g.
+   are consumer queue bindings also durable, and is there a gap between exchange survival and
+   binding survival across a restart during the transition).

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -112,8 +112,13 @@ unmarshal, or run `createTopics()`/RPC for that scope's events at all.
 ## 4. Reduced scope: two services only
 
 **In scope**: `bin-webhook-manager` (publisher-side routing key computation) and
-`bin-api-manager` (topic-exchange consumer + dynamic bind/unbind). No other service's publish
-call sites, signatures, or event-handling logic changes.
+`bin-api-manager` (topic-exchange consumer + dynamic bind/unbind), **plus a small, strictly
+additive change to `bin-common-handler`'s `notifyHandler`** to expose the routing-key/exchange-
+kind capability that `sockHandler`/`rabbitmqhandler` already have but `notifyHandler` currently
+blocks (see §6 -- this was not part of the original scope-reduction framing and is added here
+after further review). No existing `bin-common-handler` call site (all ~116+ bare `PublishEvent`
+callers) is modified; only a new method is added alongside the existing ones. No other service's
+publish call sites, signatures, or event-handling logic changes.
 
 **Consequence for `bin-common-handler`**: `notifyHandler.PublishEvent`/`PublishWebhookEvent`'s
 public signatures are UNCHANGED. The original design's Open Questions 1 and 5 (bare
@@ -155,11 +160,67 @@ Two scope namespaces (`customer_id`, `agent_id`) must coexist; a single event ma
 published under BOTH routing keys (mirrors the existing dual topic-string generation already
 done in `createTopics()` today for `customer_id:...` and `agent_id:...`).
 
-## 6. Who computes the routing key: moves into bin-webhook-manager
+## 6. Who computes the routing key: moves into bin-webhook-manager (computation), notifyHandler (publish mechanism)
 
 `createTopics()`'s logic (currently in `bin-api-manager/pkg/subscribehandler/webhookmanager.go`)
 must move into `bin-webhook-manager`, executed BEFORE `notifyHandler.PublishEvent` is called, so
 the routing key exists at publish time.
+
+**Layering gap, verified, NOT part of revision 1's original analysis -- addressed here.** The
+routing-key computation is only half the picture; the PUBLISH MECHANISM itself must also support
+carrying a routing key and targeting a `topic`-kind exchange, and today it does not, at the
+`notifyHandler` layer specifically (even though the layers below it already do):
+
+```
+notifyHandler.PublishEvent(ctx, eventType, data)          <- no routing-key parameter
+    -> publishDirectEvent() hardcodes key="" (publish.go:129)
+    -> sockHandler.EventPublish(topic string, key string, evt)   <- key param ALREADY EXISTS
+        -> rabbitmqhandler.EventPublish(exchange, key, evt)      <- passes key through
+            -> channel.PublishWithContext(ctx, exchange, key, ...)  <- AMQP routing key
+```
+
+`sockHandler.EventPublish` (`bin-common-handler/pkg/sockhandler/main.go:20`) already accepts a
+`key string` parameter, and it flows all the way to the AMQP client
+(`bin-common-handler/pkg/rabbitmqhandler/publish.go`). The plumbing to carry a routing key
+already exists at the `sockHandler`/`rabbitmqhandler` layer. **`notifyHandler` is the layer that
+blocks it**: `PublishEvent`/`PublishWebhookEvent`'s public signatures take no routing-key
+parameter, and `publishDirectEvent` hardcodes `key=""` internally
+(`bin-common-handler/pkg/notifyhandler/publish.go:129`). Separately, `TopicCreate`
+(`bin-common-handler/pkg/rabbitmqhandler/topic.go:5-9`) hardcodes exchange kind to `"fanout"`
+with no way to declare a `topic`-kind exchange through the existing API.
+
+**This means the reduced scope of §4 is incomplete as stated: `bin-webhook-manager` cannot
+actually publish with a routing key using only its own code, because the only publish path it
+has (`notifyHandler.PublishEvent`) has no way to carry one.** Two structurally different options:
+
+- (a) **Add new capability to `notifyHandler` (in `bin-common-handler`)**: e.g. a new
+  `PublishEventWithRoutingKey(ctx, eventType, routingKey, data)` method (or equivalent), and a
+  new exchange-kind-aware variant of `TopicCreate` (or a new `TopicCreateWithKind(name, kind)`).
+  This IS a `bin-common-handler` change, but a strictly additive one: existing `PublishEvent`/
+  `PublishWebhookEvent`/`TopicCreate` call sites (all ~116+ of them, per revision 1's now-moot
+  analysis) are untouched -- only `bin-webhook-manager` calls the new method. This does not
+  reopen the ~116-call-site blast radius from revision 1; it only adds a new, narrow surface
+  that `sockHandler`/`rabbitmqhandler` already structurally support. Consistent with
+  `bin-common-handler`'s architectural role as the shared transport layer -- the routing-key
+  and exchange-kind primitives already exist one layer down (`sockHandler`), so exposing them
+  through `notifyHandler` completes an existing capability rather than introducing scope creep.
+  This also means any OTHER service that later wants topic-scoped publishing (not in this
+  ticket's scope, but plausible future work) can reuse the same `notifyHandler` method instead
+  of each service reinventing it.
+- (b) **`bin-webhook-manager` bypasses `notifyHandler` and calls `sockHandler` directly** for
+  this one event type. Avoids touching `bin-common-handler` at all, but breaks the existing
+  architectural invariant that all event publishing goes through `notifyHandler` (every other
+  publish call site in the monorepo, ~116+, goes through it) -- `bin-webhook-manager` would have
+  two different, inconsistent publish paths for its own events (old `PublishEvent` calls
+  elsewhere in the service, if any, vs. a raw `sockHandler` call here), which is a maintainability
+  smell and makes the shared layer's contract ("publishing goes through notifyHandler") a soft
+  rule with a carve-out rather than an actual invariant.
+
+**Option (a) is recommended** -- it keeps `notifyHandler` as the single publish entry point for
+every service (including `bin-webhook-manager`), costs a small, strictly-additive
+`bin-common-handler` change (no existing call site touched), and reuses routing-key/exchange-kind
+plumbing that already exists one layer down. This decision is escalated to Open Question 9 (not
+resolved definitively in this doc -- (b) is not disqualified, just not preferred).
 
 **Straightforward part**: `customer_id` is already an explicit parameter at both call sites
 (§4) -- computing `customer_id.<customerID>.#`-shaped keys requires no new plumbing for that
@@ -316,9 +377,11 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
   consumes it; `bin-talk-manager` publishes to `QueueNameTalkEvent`, `bin-timeline-manager`
   consumes it) -- unaffected by this design, per §7. Only `bin-api-manager`'s
   now-provably-pointless subscription to both is removed.
-- Any change to `bin-common-handler`'s `notifyHandler.PublishEvent`/`PublishWebhookEvent` public
-  signatures, or to any of the ~116 bare-`PublishEvent` call sites across ~25+ services --
-  moot under the reduced scope (§4), since those events never reached a websocket client.
+- Any change to `bin-common-handler`'s EXISTING `notifyHandler.PublishEvent`/
+  `PublishWebhookEvent`/`TopicCreate` signatures, or to any of the ~116 bare-`PublishEvent` call
+  sites across ~25+ services -- moot under the reduced scope (§4), since those events never
+  reached a websocket client. (A NEW, additive method on `notifyHandler` is in scope, per §6 --
+  this does not touch or require migrating any existing call site.)
 
 ## 11. Open questions (need resolution before/during implementation)
 
@@ -352,3 +415,14 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    (e.g. via `bin-common-handler`) between webhook-manager and whatever remains of
    `bin-api-manager`'s webhook-processing path, to avoid two independent implementations of the
    same envelope-parsing rules drifting apart over time?
+9. **(New) `notifyHandler` publish-mechanism extension.** §6 identifies that
+   `notifyHandler.PublishEvent`/`PublishWebhookEvent` have no routing-key parameter and
+   `TopicCreate` hardcodes `fanout` kind, even though `sockHandler`/`rabbitmqhandler` already
+   support both underneath. Confirm the recommended approach (additive new method(s) on
+   `notifyHandler`, e.g. `PublishEventWithRoutingKey`, plus an exchange-kind-aware
+   `TopicCreate` variant) during implementation planning: exact method signatures, whether
+   `PublishWebhookEvent`'s dual publish (event + webhook HTTP delivery) needs a parallel
+   with-routing-key variant or only the plain event path does, and confirm this really is
+   additive with zero changes to any of the ~116 existing bare `PublishEvent`/`PublishWebhookEvent`
+   call sites (verify via build/test of `bin-common-handler` and a sample of dependent services
+   after the change, not just by inspection).

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -95,19 +95,45 @@ RabbitMQ.
 
 Verified asymmetry that affects this move:
 - `notifyHandler.PublishWebhookEvent(ctx, customerID uuid.UUID, eventType string, data WebhookMessage)`
-  already receives `customerID` as an explicit parameter (used today for the webhook HTTP
-  delivery path) — computing `customer_id.<customerID>.#`-shaped keys here is straightforward.
-- `notifyHandler.PublishEvent(ctx, eventType string, data interface{})` (called directly, e.g.
-  `bin-agent-manager/pkg/agenthandler/agent.go:591`, `db.go:234/263/311/345`) does NOT receive
-  customerID as a parameter — it is embedded inside `data`. Extracting it generically (without
-  reflection or a fragile type-switch per caller) needs either (a) a shared `Owner`/`Identity`
-  interface with a `GetCustomerID()` method that callers' domain structs already satisfy (most
-  domain models embed `commonidentity.Identity`/`Owner` already, per `bin-common-handler/models/identity`),
-  or (b) requiring all bare `PublishEvent` call sites to migrate to `PublishWebhookEvent`-style
-  explicit-customerID signatures. Needs a design decision (see Open Questions).
+  (`bin-common-handler/pkg/notifyhandler/publish.go:22`) already receives `customerID` as an
+  explicit parameter (used today for the webhook HTTP delivery path) — computing
+  `customer_id.<customerID>.#`-shaped keys here is straightforward.
+- `notifyHandler.PublishEvent(ctx, eventType string, data interface{})`
+  (`bin-common-handler/pkg/notifyhandler/main.go:74`) does NOT receive customerID as a parameter
+  — it is embedded inside `data`. `PublishWebhookEvent` itself calls the bare `PublishEvent`
+  internally (`publish.go:23`), so this signature sits underneath both public entry points.
+
+**Blast radius, verified by full-monorepo grep (not a handful of call sites):** bare
+`notifyHandler.PublishEvent(` (excluding `PublishWebhookEvent`) has **~116 call sites across
+~25+ services** (customer, tag, tts, billing, sentinel, call, pipecat, agent, webhook,
+registrar, direct, conference, flow, queue, route, contact, transcribe, number, storage, ai,
+campaign, conversation, outdial, email, talk-manager, and more). Because `PublishEvent`'s
+signature lives in `bin-common-handler` (subject to the "3+ services" admission rule), any
+signature change or added interface requirement touches close to the whole monorepo's
+verification matrix — this is a large-blast-radius change, not an isolated one.
+
+**The two extraction options in the prior draft are NOT symmetric — option (a) below is
+disqualified for a real, non-trivial subset of call sites, confirmed by reading actual payloads:**
+- (a) ~~A shared `Owner`/`Identity` interface with a `GetCustomerID()` method~~ — does not work
+  universally. Several bare `PublishEvent` calls pass `map[string]uuid.UUID` or
+  `map[string]interface{}` as `data`, not a domain struct embedding
+  `commonidentity.Identity`/`Owner`:
+  - `bin-contact-manager/pkg/casehandler/casenote.go:53-57` —
+    `map[string]uuid.UUID{"id":..., "case_id":..., "customer_id": customerID}`
+  - `bin-contact-manager/pkg/casehandler/case_tag.go:92,130` — same map pattern
+  - `bin-call-manager/pkg/callhandler/outgoing_call.go:213-217` —
+    `map[string]interface{}{"customer_id":..., "call_id":..., ...}`
+
+  These have no embedded Go type to satisfy a `GetCustomerID()` interface; reflection would have
+  to special-case map string keys anyway, which is exactly the "fragile type-switch per caller"
+  approach this design wants to avoid. Interface extraction is not a clean universal solution.
+- (b) Migrate every bare `PublishEvent` call site to an explicit-customerID signature (mirroring
+  `PublishWebhookEvent`) is the only fully general option, at the ~116-site blast radius above.
+  This is the option this design should plan around, not (a).
 - `agent_id` scope: is there an equivalent "owner/agent" identity readily available at publish
   time for all three services, or does this only cleanly apply to `bin-agent-manager`'s own
-  events? Needs verification per-service before finalizing.
+  events? Needs verification per-service before finalizing (unchanged from prior draft, still
+  open — see Open Questions).
 
 ## 6. Exchange migration strategy
 
@@ -142,10 +168,30 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
 - **Race condition to guard against**: a bind-in-flight event ordering where the client's
   subscribe ack is sent before the AMQP bind is confirmed, causing a missed first event. Bind
   must complete (or be confirmed) before acking the client's subscribe message.
+- **Abrupt disconnect must also decrement the refcount — this is a distinct code path from
+  explicit unsubscribe, verified against source.** Reading
+  `bin-api-manager/pkg/websockhandler/subscription.go:32-84`, today's cleanup on an abrupt
+  websocket close (network drop, tab close, mobile backgrounding) is whole-object teardown, not
+  incremental: the per-connection `zmqSub` (holding that connection's `topics` list) is discarded
+  via `defer zmqSub.Terminate()` (line 70) when `newCtx` is cancelled — triggered by
+  `receiveTextFromWebsock` erroring (lines 122-125) or a write failure in the pinger/ZMQ-run
+  goroutines. **No explicit `Unsubscribe(topic)` call fires on this path today.** The new
+  pod-level AMQP-bind-refcount component (shared across connections on a pod, per the paragraph
+  above) has nothing hooking it to decrement that connection's contribution to each scope's
+  refcount on this teardown path — `subscriptionHandleMessage`'s explicit-unsubscribe branch is
+  not sufficient by itself. The refcount decrement must also be driven from `subscriptionRun`'s
+  teardown (the `newCtx.Done()` / deferred-cleanup point), which needs new state tracking which
+  scopes each connection currently holds (this state doesn't fully exist yet in a pod-level-
+  reachable form — `zmqSub.topics` is per-connection only). Getting this wrong means every
+  abrupt client disconnect leaks a refcount and leaves a stale scope binding on the pod's queue
+  permanently, silently reintroducing the exact problem (unconditional processing for pods with
+  zero real subscribers) this design exists to fix.
 - Implementation surface: `bin-api-manager/pkg/websockhandler/subscription.go`
-  `subscriptionHandleMessage` (currently calls `zmqSub.Subscribe(topic)`/`Unsubscribe(topic)`)
-  is the natural integration point — needs a parallel call into a new per-pod AMQP-bind-refcount
-  component.
+  `subscriptionHandleMessage` (currently calls `zmqSub.Subscribe(topic)`/`Unsubscribe(topic)`,
+  lines 159/168) is the integration point for explicit subscribe/unsubscribe; `subscriptionRun`'s
+  teardown (line 70 `defer zmqSub.Terminate()`, triggered via `newCtx` cancellation) is the
+  separate integration point required for abrupt disconnect. Both need a parallel call into a new
+  per-pod AMQP-bind-refcount component.
 
 ## 8. Out of scope (explicit, per pchero's decision)
 
@@ -173,3 +219,11 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
 5. Should `PublishEvent`/`PublishWebhookEvent`'s public interface signature change (e.g. add an
    explicit routing-key-relevant scope parameter), given `bin-common-handler`'s "3+ services"
    admission rule and the fact this interface is shared library code consumed by all 37 services?
+   Given the confirmed ~116-call-site blast radius (§5) and that the map-payload call sites
+   disqualify a non-invasive interface-extraction alternative, this is effectively asking
+   "are we prepared to touch ~25+ services' publish call sites," not a low-cost signature tweak.
+6. How does the per-pod bind/unbind refcount interact with abrupt disconnect / connection
+   teardown (not just explicit unsubscribe messages)? See §7 — `subscriptionRun`'s teardown path
+   (`newCtx` cancellation, `defer zmqSub.Terminate()`) fires on every disconnect, clean or not,
+   but carries no per-topic unsubscribe signal today; the refcount component needs its own state
+   to know what to decrement on this path, and that state doesn't exist in the codebase yet.

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -208,13 +208,18 @@ has (`notifyHandler.PublishEvent`) has no way to carry one.** Two structurally d
   ticket's scope, but plausible future work) can reuse the same `notifyHandler` method instead
   of each service reinventing it.
 - (b) **`bin-webhook-manager` bypasses `notifyHandler` and calls `sockHandler` directly** for
-  this one event type. Avoids touching `bin-common-handler` at all, but breaks the existing
-  architectural invariant that all event publishing goes through `notifyHandler` (every other
-  publish call site in the monorepo, ~116+, goes through it) -- `bin-webhook-manager` would have
-  two different, inconsistent publish paths for its own events (old `PublishEvent` calls
-  elsewhere in the service, if any, vs. a raw `sockHandler` call here), which is a maintainability
-  smell and makes the shared layer's contract ("publishing goes through notifyHandler") a soft
-  rule with a carve-out rather than an actual invariant.
+  this one event type. **Verified NOT currently wired up**: `webhookHandler`'s struct
+  (`bin-webhook-manager/pkg/webhookhandler/main.go:32-40`) has no `sockHandler` field today, and
+  `sockHandler` is constructed in `cmd/webhook-manager/main.go`/`cmd/webhook-control/main.go`
+  only to build `notifyHandler`/`reqHandler` -- it is never passed into `NewWebhookHandler`.
+  This means (b) is not a "no new plumbing" shortcut: it requires the SAME new DI-wiring cost as
+  option (a) (adding a constructor field, updating both `cmd/webhook-manager` and
+  `cmd/webhook-control` wiring sites), while ALSO breaking the existing architectural invariant
+  that all event publishing goes through `notifyHandler` (every other publish call site in the
+  monorepo, ~116+, goes through it) -- `bin-webhook-manager` would end up with two different,
+  inconsistent publish paths for its own events. **(b) has no wiring-cost advantage over (a) and
+  a real architectural cost (a) does not have** -- it is not a genuinely competitive alternative,
+  just a theoretically available one.
 
 **Option (a) is recommended** -- it keeps `notifyHandler` as the single publish entry point for
 every service (including `bin-webhook-manager`), costs a small, strictly-additive
@@ -420,9 +425,16 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    `TopicCreate` hardcodes `fanout` kind, even though `sockHandler`/`rabbitmqhandler` already
    support both underneath. Confirm the recommended approach (additive new method(s) on
    `notifyHandler`, e.g. `PublishEventWithRoutingKey`, plus an exchange-kind-aware
-   `TopicCreate` variant) during implementation planning: exact method signatures, whether
-   `PublishWebhookEvent`'s dual publish (event + webhook HTTP delivery) needs a parallel
-   with-routing-key variant or only the plain event path does, and confirm this really is
-   additive with zero changes to any of the ~116 existing bare `PublishEvent`/`PublishWebhookEvent`
-   call sites (verify via build/test of `bin-common-handler` and a sample of dependent services
-   after the change, not just by inspection).
+   `TopicCreate`/`TopicCreateWithKind` variant on `SockHandler`) during implementation planning:
+   exact method signatures, whether `PublishWebhookEvent`'s dual publish (event + webhook HTTP
+   delivery) needs a parallel with-routing-key variant or only the plain event path does, and
+   confirm this really is additive with zero changes to any of the ~116 existing bare
+   `PublishEvent`/`PublishWebhookEvent` call sites (verify via build/test of `bin-common-handler`
+   and a sample of dependent services after the change, not just by inspection). **Mechanical
+   cost, verified small**: `NotifyHandler` has exactly one production implementer
+   (`notifyhandler.notifyHandler`) plus `MockNotifyHandler`; `SockHandler` similarly has one
+   production implementer (`rabbitmqhandler.rabbit`) plus `MockSockHandler`. Adding a new
+   interface method to either touches only the interface definition, the one implementation, and
+   the `go generate`-regenerated mock -- not a broad blast radius, but should still be confirmed
+   as part of the standard verification workflow (`go generate ./... && go test ./...`) rather
+   than assumed.

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -1,69 +1,141 @@
-# VOIP-1258: bin-api-manager WebSocket Event Subscription — Broker-Level Scoped Routing
+# VOIP-1258: bin-webhook-manager / bin-api-manager WebSocket Event Subscription — Broker-Level Scoped Routing (Reduced Scope)
 
-## 1. Origin and decision already made
+## 1. Origin and decisions already made
 
 Tracking ticket: VOIP-1258. Discovered and verified (2 independent adversarial review rounds,
 both APPROVED with zero changes requested) in a CPO/CEO discussion on 2026-07-14: per-pod
-processing cost for events published to `QueueNameWebhookEvent` / `QueueNameAgentEvent` /
-`QueueNameTalkEvent` is paid unconditionally for every published event, multiplied by
-api-manager pod count, with zero dependency on connected websocket client count. Chat-type
-events additionally pay a live `TalkV1ParticipantList` RPC call per event, also unconditional.
+processing cost for events published to `QueueNameWebhookEvent` is paid unconditionally for
+every published event, multiplied by api-manager pod count, with zero dependency on connected
+websocket client count. Chat-type events additionally pay a live `TalkV1ParticipantList` RPC
+call per event, also unconditional.
 
-**pchero has already decided the direction**: go broker-level (RabbitMQ `fanout` → `topic`
-exchange), with **scope-first** routing key ordering (`customer_id.<uuid>.#` /
-`agent_id.<uuid>.#`), explicitly rejecting resource-first ordering and deferring functional
-sharding (resource-type-dedicated pod pools) as out of scope. This design doc executes that
-decision — it does not revisit the broker-vs-app-level or scope-first-vs-resource-first choice.
+**pchero has decided**: go broker-level (RabbitMQ `fanout` -> `topic` exchange), with
+**scope-first** routing key ordering (`customer_id.<uuid>.#` / `agent_id.<uuid>.#`), explicitly
+rejecting resource-first ordering and deferring functional sharding as out of scope.
 
-## 2. Current implementation (verified from source)
+**This is REVISION 2 of the design, reflecting a scope-reduction decision made 2026-07-14 in
+follow-up discussion, superseding the original 8-open-question, ~25-service-blast-radius draft.**
+The reduction was triggered by a decisive finding (verified below, §2): `bin-api-manager`'s
+event-processing switch statement handles exactly ONE event type
+(`webhook.EventTypeWebhookPublished` from `bin-webhook-manager`) and unconditionally discards
+everything else. This means the original design's ~116-call-site blast radius across ~25+
+services (bare `notifyHandler.PublishEvent` calls feeding `QueueNameAgentEvent`/
+`QueueNameTalkEvent`) was solving a problem that does not exist for websocket delivery purposes
+-- those events were never reaching a client anyway. **pchero's explicit direction: touch only
+`bin-webhook-manager` (publisher) and `bin-api-manager` (consumer).**
+
+## 2. Current implementation (verified from source, revised)
+
+**Decisive finding: bin-api-manager only ever acts on webhook-manager's events.**
+
+```go
+// bin-api-manager/pkg/subscribehandler/main.go:132-144, processEvent()
+switch {
+case m.Publisher == string(commonoutline.ServiceNameWebhookManager) && (m.Type == string(wmwebhook.EventTypeWebhookPublished)):
+    err = h.processEventWebhookManagerWebhookPublished(ctx, m)
+default:
+    // ignore the event
+    return
+}
+```
+
+There is exactly one `case`. Events arriving via the `QueueNameAgentEvent` / `QueueNameTalkEvent`
+subscriptions (`cmd/api-manager/main.go:159-162`) hit `default: return` unconditionally --
+they are consumed off RabbitMQ (so the RabbitMQ-side cost the original design worried about does
+apply to them too) but never reach `createTopics()`/ZMQ/any websocket client. **This subscription
+is dead weight for websocket delivery purposes today.** Real client-visible agent/chat events
+reach clients ONLY by first going through `bin-webhook-manager`:
 
 ```
-webhook/agent/talk-manager
-  notifyHandler.PublishEvent(ctx, eventType, data)
-    -> publishEvent() -> sockHandler.EventPublish(exchange=queueName, key="", evt)
-        -> rabbitmqhandler.EventPublish(exchange, key, evt)
-            -> publishExchange(exchange, key, message, ...) [amqp channel.PublishWithContext]
+bin-agent-manager / bin-talk-manager (any handler)
+  -> notifyHandler.PublishWebhookEvent(ctx, customerID, eventType, data)
+      -> go PublishEvent(...)          [-> QueueNameAgentEvent / QueueNameTalkEvent -- DEAD END for websocket, per above]
+      -> go PublishWebhook(...)        [-> reqHandler.WebhookV1WebhookSend(...) RPC to webhook-manager]
+          -> bin-webhook-manager.SendWebhookToCustomer(ctx, customerID, dataType, data)
+              -> h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh)
+                  -> QueueNameWebhookEvent (fanout exchange)   <- THIS is the only path that
+                                                                    reaches a websocket client
+```
+
+Full existing pipeline for the path that matters:
+
+```
+bin-webhook-manager (webhookhandler/webhook.go):
+  SendWebhookToCustomer(ctx, customerID, dataType, data)     [line 26, customerID EXPLICIT param]
+  SendWebhookToURI(ctx, customerID, uri, method, dataType, data)  [line 120, customerID EXPLICIT param]
+    both build wh := &webhook.Webhook{CustomerID: customerID, DataType: dataType, Data: data}
+    both call h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh)
+      -> sockHandler.EventPublish(exchange="bin-manager.webhook-manager.event", key="", evt)
+          -> channel.PublishWithContext(...)  [amqp]
 
 Exchange declared once at NewNotifyHandler() time via sockHandler.TopicCreate(name)
-    -> ExchangeDeclare(name, "fanout", ...)   [bin-common-handler/pkg/rabbitmqhandler/topic.go:5-9]
+    -> ExchangeDeclare(name, "fanout", durable=true, ...)
+       [bin-common-handler/pkg/rabbitmqhandler/topic.go:5-9]
 
-bin-api-manager, at pod boot (cmd/api-manager/main.go:142 runSubscribe, unconditional):
-    per-pod queue (QueueNameAPISubscribe-<uuid>) bound via QueueSubscribe -> QueueBind(name, "", exchange, ...)
+bin-api-manager, at pod boot (cmd/api-manager/main.go:160, runSubscribe, unconditional):
+    per-pod queue (QueueNameAPISubscribe-<uuid>) bound to QueueNameWebhookEvent via
+    QueueSubscribe -> QueueBind(name, "", exchange, ...)
     [bin-common-handler/pkg/rabbitmqhandler/queue.go:158-160]
     -- empty routing key, irrelevant for fanout, binding lives for the pod's whole lifetime
 
-subscribehandler.processEventRun -> processEvent -> (webhook_published) ->
+subscribehandler.processEventRun -> processEvent -> (webhook_published, only case) ->
   processEventWebhookManagerWebhookPublished (bin-api-manager/pkg/subscribehandler/webhookmanager.go:48)
-    -- 3x json.Unmarshal, createTopics() [may call TalkV1ParticipantList RPC for chat types],
-       zmqpubHandler.Publish(topic, data) per generated topic string -- all unconditional
+    -- 3x json.Unmarshal (Webhook envelope, Data, commonWebhookData), createTopics() [may call
+       TalkV1ParticipantList RPC for chat types], zmqpubHandler.Publish(topic, data) per
+       generated topic string -- all unconditional, regardless of local subscriber count
 
 Local per-connection ZMQ SUB filtering (bin-api-manager/pkg/zmqsubhandler) is the ONLY
 connection-count-dependent step, and it sits after all the above.
 ```
 
+`createTopics()` (`bin-api-manager/pkg/subscribehandler/webhookmanager.go:107-175`) unmarshals
+the doubly-nested webhook envelope (`Webhook.Data` -> `Data.Data` -> `commonWebhookData{Identity,
+Owner, AIcallID, ChatID}`) to extract `CustomerID`/`OwnerID`, and for
+`chat`/`chatmessage`/`chatparticipant` resource types calls
+`h.reqHandler.TalkV1ParticipantList(ctx, chatID)` to fan out a topic string per chat participant.
+
 Existing client-facing topic string format (already public API contract, documented in
-`bin-api-manager/docsdev/source/websocket_overview.rst` etc.):
+`bin-api-manager/docsdev/source/websocket_overview.rst` etc., UNCHANGED by this design):
 ```
 <scope>:<scope_id>:<resource>:<resource_id>
 e.g. customer_id:abc123:call:xyz789
      agent_id:agent123:queue:*
 ```
-This colon-delimited string is currently used ONLY for the final local ZMQ SUB/PUB filter and
-the client wire protocol (subscribe/unsubscribe websocket messages) — it is NOT currently an
-AMQP routing key (routing key is always `""` today, since fanout ignores it).
 
-`createTopics()` (`bin-api-manager/pkg/subscribehandler/webhookmanager.go:107-175`) is where this
-topic-string generation currently lives, on the **consumer** (api-manager) side, after the event
-has already been fully received and unmarshalled.
-
-## 3. Design goal
+## 3. Design goal (unchanged)
 
 Move scope-based filtering from "after full local processing, at the final ZMQ hop" to "at the
-RabbitMQ broker, before the event ever reaches a pod without a matching subscriber." Concretely:
-a pod with zero clients subscribed to a given `customer_id`/`agent_id` scope should never receive,
-consume, unmarshal, or run `createTopics()`/RPC for that scope's events at all.
+RabbitMQ broker, before the event ever reaches a pod without a matching subscriber." A pod with
+zero clients subscribed to a given `customer_id`/`agent_id` scope should never receive, consume,
+unmarshal, or run `createTopics()`/RPC for that scope's events at all.
 
-## 4. Proposed routing key format (scope-first, confirmed direction)
+## 4. Reduced scope: two services only
+
+**In scope**: `bin-webhook-manager` (publisher-side routing key computation) and
+`bin-api-manager` (topic-exchange consumer + dynamic bind/unbind). No other service's publish
+call sites, signatures, or event-handling logic changes.
+
+**Consequence for `bin-common-handler`**: `notifyHandler.PublishEvent`/`PublishWebhookEvent`'s
+public signatures are UNCHANGED. The original design's Open Questions 1 and 5 (bare
+`PublishEvent`'s customerID-less signature, ~116-call-site blast radius, disqualified
+Owner/Identity interface option) are now MOOT -- those call sites feed `QueueNameAgentEvent`/
+`QueueNameTalkEvent`, which are out of scope entirely (see §7).
+
+**Consequence for routing-key computation**: both webhook-manager entry points that reach
+`QueueNameWebhookEvent` already receive `customerID` as an explicit parameter:
+- `SendWebhookToCustomer(ctx, customerID uuid.UUID, dataType, data)` (`webhook.go:26`)
+- `SendWebhookToURI(ctx, customerID uuid.UUID, uri, method, dataType, data)` (`webhook.go:120`)
+
+Both already construct `wh := &webhook.Webhook{CustomerID: customerID, ...}` before calling
+`notifyHandler.PublishEvent`. No signature change is needed on the webhook-manager side to
+obtain `customer_id` for the routing key -- it is already in scope at the call site. This is
+a materially simpler starting point than the original design's ~116-site migration.
+
+**What is NOT simplified**: the `agent_id`/owner scope and the chat-participant fan-out (see §6)
+still require moving logic that currently lives in `createTopics()` (consumer side) to the
+publisher side, because the routing key must exist at `channel.PublishWithContext` time.
+
+## 5. Proposed routing key format (scope-first, unchanged from revision 1)
 
 ```
 <scope>.<scope_id>.#
@@ -72,135 +144,121 @@ e.g. customer_id.a1b2c3d4-....call.xyz789   (as the PUBLISHED routing key)
      agent_id.98765432-....#
 ```
 
-Rationale already established in discussion (recapped for the record): resource_id is unknown
-at bind time (client hasn't received the event yet), so any pattern putting it before the scope
-segment forces the scope filter to collapse into an unfiltered wildcard, defeating the purpose.
-Scope-first keeps the wildcard tail (`#`) confined to the low-value, high-cardinality segments
-(resource type + resource id), while the scope segment — known at websocket-connect/subscribe
-time, low cardinality per pod — does the actual filtering work at the trie's first level.
+Rationale (recapped): resource_id is unknown at bind time, so any pattern putting it before the
+scope segment forces the scope filter to collapse into an unfiltered wildcard, defeating the
+purpose. Scope-first keeps the wildcard tail (`#`) confined to the low-value, high-cardinality
+segments (resource type + resource id), while the scope segment -- known at
+websocket-connect/subscribe time, low cardinality per pod -- does the actual filtering work at
+the trie's first level.
 
-Two scope namespaces (`customer_id`, `agent_id`) must coexist. Proposed: publish BOTH routing
-keys per event when both a customer and an owner/agent scope apply (mirrors the existing
-dual-topic generation already done in `createTopics()` today, which already emits both
-`customer_id:...` and `agent_id:...` topic strings for the same event where applicable — this is
-not new complexity, just moving existing dual-key generation earlier in the pipeline).
+Two scope namespaces (`customer_id`, `agent_id`) must coexist; a single event may need to be
+published under BOTH routing keys (mirrors the existing dual topic-string generation already
+done in `createTopics()` today for `customer_id:...` and `agent_id:...`).
 
-## 5. Who computes the routing key: publisher-side move
+## 6. Who computes the routing key: moves into bin-webhook-manager
 
-**Decision point carried into this doc, not yet resolved — see Open Questions.** Today
-`createTopics()` runs on the consumer (api-manager) after receiving the full event. For topic-
-exchange filtering to work, the AMQP routing key must exist at `channel.PublishWithContext` time,
-i.e. on the publisher (webhook/agent/talk-manager) side, before the message ever reaches
-RabbitMQ.
+`createTopics()`'s logic (currently in `bin-api-manager/pkg/subscribehandler/webhookmanager.go`)
+must move into `bin-webhook-manager`, executed BEFORE `notifyHandler.PublishEvent` is called, so
+the routing key exists at publish time.
 
-Verified asymmetry that affects this move:
-- `notifyHandler.PublishWebhookEvent(ctx, customerID uuid.UUID, eventType string, data WebhookMessage)`
-  (`bin-common-handler/pkg/notifyhandler/publish.go:22`) already receives `customerID` as an
-  explicit parameter (used today for the webhook HTTP delivery path) — computing
-  `customer_id.<customerID>.#`-shaped keys here is straightforward.
-- `notifyHandler.PublishEvent(ctx, eventType string, data interface{})`
-  (`bin-common-handler/pkg/notifyhandler/main.go:74`) does NOT receive customerID as a parameter
-  — it is embedded inside `data`. `PublishWebhookEvent` itself calls the bare `PublishEvent`
-  internally (`publish.go:23`), so this signature sits underneath both public entry points.
+**Straightforward part**: `customer_id` is already an explicit parameter at both call sites
+(§4) -- computing `customer_id.<customerID>.#`-shaped keys requires no new plumbing for that
+scope alone.
 
-**Blast radius, verified by full-monorepo grep (not a handful of call sites):** bare
-`notifyHandler.PublishEvent(` (excluding `PublishWebhookEvent`) has **~116 call sites across
-~25+ services** (customer, tag, tts, billing, sentinel, call, pipecat, agent, webhook,
-registrar, direct, conference, flow, queue, route, contact, transcribe, number, storage, ai,
-campaign, conversation, outdial, email, talk-manager, and more). Because `PublishEvent`'s
-signature lives in `bin-common-handler` (subject to the "3+ services" admission rule), any
-signature change or added interface requirement touches close to the whole monorepo's
-verification matrix — this is a large-blast-radius change, not an isolated one.
+**Harder part 1 -- `agent_id`/owner scope extraction**: today's `createTopics()` unmarshals the
+event `data` payload (via the nested `Webhook.Data` -> `Data.Data` -> `commonWebhookData{Owner}`
+envelope) to find `OwnerID` for the `agent_id:...` routing key. `SendWebhookToCustomer`/
+`SendWebhookToURI` receive `data json.RawMessage` as an opaque blob (`webhook.go:26,120`) --
+they do not know the owner/agent ID structurally, only that it may be present somewhere inside
+`data`'s nested JSON. **This requires porting the SAME nested-unmarshal logic
+(`commonWebhookData` struct, currently in `bin-api-manager/pkg/subscribehandler/webhookmanager.go`)
+into `bin-webhook-manager`**, run against `data` before publish, to extract `OwnerID` the same
+way `createTopics()` does today. This is a genuine, non-trivial logic move (not just a signature
+change), but it is confined to `bin-webhook-manager`, not spread across ~25 services.
 
-**The two extraction options in the prior draft are NOT symmetric — option (a) below is
-disqualified for a real, non-trivial subset of call sites, confirmed by reading actual payloads:**
-- (a) ~~A shared `Owner`/`Identity` interface with a `GetCustomerID()` method~~ — does not work
-  universally. Several bare `PublishEvent` calls pass `map[string]uuid.UUID` or
-  `map[string]interface{}` as `data`, not a domain struct embedding
-  `commonidentity.Identity`/`Owner`:
-  - `bin-contact-manager/pkg/casehandler/casenote.go:53-57` —
-    `map[string]uuid.UUID{"id":..., "case_id":..., "customer_id": customerID}`
-  - `bin-contact-manager/pkg/casehandler/case_tag.go:92-95,130-133` — same map pattern; note
-    this map carries only `case_id`/`tag_id` keys and has **no `customer_id` key at all**, so
-    these two call sites cannot even reach a `customer_id`-scoped routing key without an
-    additional lookup or a broader signature change beyond the map-to-struct migration itself —
-    a strictly harder case than the other two examples, not just "also a map."
-  - `bin-call-manager/pkg/callhandler/outgoing_call.go:213-217` —
-    `map[string]interface{}{"customer_id":..., "call_id":..., ...}`
+**Harder part 2 -- chat participant fan-out RPC moves to the publish path**: for
+`chat`/`chatmessage`/`chatparticipant` resource types, `createTopics()` today calls
+`h.reqHandler.TalkV1ParticipantList(ctx, chatID)` (`webhookmanager.go:143`) AFTER receiving the
+event, to generate one `agent_id:<participant>:chat:...` routing key per chat participant. Moving
+this to webhook-manager means:
+- `webhook-manager`'s `webhookHandler` struct (`pkg/webhookhandler/main.go:32-40`) does NOT
+  currently hold a `reqHandler requesthandler.RequestHandler` dependency -- verified by reading
+  the struct definition. **A new dependency injection is required** (constructor signature
+  change to `NewWebhookHandler`, plus wiring in `cmd/webhook-manager/main.go` and
+  `cmd/webhook-control/main.go`) to call `TalkV1ParticipantList` from webhook-manager.
+- This means every chat-type webhook publish now makes a synchronous RPC call to
+  `bin-talk-manager` BEFORE the event reaches RabbitMQ at all, rather than after api-manager
+  receives it. The RPC cost does not disappear -- it relocates from "per-pod, per-event, only if
+  a subscriber happens to be listening after the fact" to "once per event, at publish time,
+  regardless of subscriber count." This is a NET IMPROVEMENT versus today (today it is
+  unconditional AND multiplied by pod count; after this change it is unconditional but paid
+  exactly once, not once-per-pod) but it is NOT eliminated, and should not be described as
+  "solved" -- flagged as Open Question 4.
 
-  These have no embedded Go type to satisfy a `GetCustomerID()` interface; reflection would have
-  to special-case map string keys anyway, which is exactly the "fragile type-switch per caller"
-  approach this design wants to avoid. Interface extraction is not a clean universal solution.
-- (b) Migrate every bare `PublishEvent` call site to an explicit-customerID signature (mirroring
-  `PublishWebhookEvent`) is the only fully general option, at the ~116-site blast radius above.
-  This is the option this design should plan around, not (a).
-- `agent_id` scope: is there an equivalent "owner/agent" identity readily available at publish
-  time for all three services, or does this only cleanly apply to `bin-agent-manager`'s own
-  events? Needs verification per-service before finalizing (unchanged from prior draft, still
-  open — see Open Questions).
+## 7. Explicit scope exclusion: QueueNameAgentEvent / QueueNameTalkEvent
 
-## 6. Exchange migration strategy
+**Decision, not deferred**: `bin-api-manager`'s subscriptions to `QueueNameAgentEvent`
+(`bin-agent-manager`'s direct publishes) and `QueueNameTalkEvent` (`bin-talk-manager`'s direct
+publishes) are OUT OF SCOPE for the topic-exchange conversion, because they are proven dead
+weight for websocket delivery (§2) -- `bin-api-manager`'s `processEvent` switch never acts on
+them.
+
+**Bonus cleanup, in scope for this ticket** (small, low-risk, and a direct consequence of the
+finding in §2, not a new feature): remove `bin-api-manager`'s subscription to
+`QueueNameAgentEvent`/`QueueNameTalkEvent` entirely --
+`cmd/api-manager/main.go:159-162`'s `subscribeTargets` list shrinks to just
+`QueueNameWebhookEvent`. This eliminates RabbitMQ consumption cost (per pod) for two exchanges'
+worth of events that were always discarded, with zero behavior change (nothing was ever acted on
+from those two subscriptions). Low risk: `git log`/blast-radius check should confirm no other
+code path in `bin-api-manager` depends on having consumed (vs. ignored) these two subscriptions
+before removing them -- flagged as Open Question 6, a verification step, not a design decision.
+
+This means `QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges themselves are UNCHANGED --
+still `fanout`, still consumed by `bin-agent-manager`/`bin-queue-manager`
+(`QueueNameAgentEvent`) and `bin-timeline-manager` (`QueueNameTalkEvent`) for their own
+unrelated purposes (agent status logic, queue routing, audit-log ingestion). Only
+`bin-api-manager`'s now-pointless subscription is removed.
+
+## 8. Exchange migration strategy (reduced: only QueueNameWebhookEvent)
 
 RabbitMQ exchange kind is fixed at declare time; re-declaring an existing exchange name with a
-different kind fails with `PRECONDITION_FAILED`. Since `QueueNameWebhookEvent` /
-`QueueNameAgentEvent` / `QueueNameTalkEvent` are already declared `fanout` in production, an
-in-place kind change is not possible.
+different kind fails with `PRECONDITION_FAILED`. `QueueNameWebhookEvent` is already declared
+`fanout`/`durable=true` in production, so an in-place kind change is not possible.
 
-**CRITICAL, verified: these three exchanges are NOT exclusively consumed by bin-api-manager.**
-A monorepo-wide grep confirms other, unrelated consumers subscribe to the same exchanges for
-their own purposes, all via `QueueSubscribe(queue, exchange)` -> `QueueBind(name, "", exchange,
-...)` (`bin-common-handler/pkg/rabbitmqhandler/queue.go:158-160`) — an **empty routing key**,
-which is irrelevant under `fanout` but under `topic` only matches messages published with an
-exactly-empty routing key:
+**Still relevant even at reduced scope: other, unrelated consumers of `QueueNameWebhookEvent`
+specifically** (verified, monorepo-wide grep, independent of the `QueueNameAgentEvent`/
+`QueueNameTalkEvent` exclusion in §7):
 - `bin-agent-manager/cmd/agent-manager/main.go:159` subscribes to `QueueNameWebhookEvent`
   (agent status update logic, unrelated to websocket delivery)
-- `bin-queue-manager/cmd/queue-manager/main.go:149` subscribes to `QueueNameAgentEvent`
-  (queue routing / agent-tag matching)
-- `bin-timeline-manager/pkg/subscribehandler/main.go:29,50,54` subscribes to **all three**
-  (`QueueNameAgentEvent`, `QueueNameTalkEvent`, `QueueNameWebhookEvent`) as part of its
-  platform-wide audit-log ingestion
+- `bin-timeline-manager/pkg/subscribehandler/main.go:54` subscribes to `QueueNameWebhookEvent`
+  (platform-wide audit-log ingestion, along with the other two exchanges which are unaffected
+  by this design per §7)
 
-Because exchange kind is global per exchange name (not scoped per-consumer), converting these
-exchanges to `topic` with dot-formatted routing keys will **silently stop delivering events to
-bin-agent-manager, bin-queue-manager, and bin-timeline-manager** the moment the old fanout
-exchange is decommissioned, unless these three services' bindings are also migrated (e.g. to a
-wildcard `#` binding, since they need every event regardless of scope, not scoped filtering).
-This would break agent status updates, queue routing, and the platform audit log — a real,
-previously undisclosed regression risk, not covered by "api-manager pods migrate their per-pod
-queue bindings" alone. **The migration plan below is revised to explicitly include these three
-consumers**, and this is escalated to Open Question 7.
+Both use empty-routing-key fanout bindings (`QueueBind(name, "", exchange, ...)`,
+`queue.go:158-160`) and, per an earlier verification pass, neither reads or branches on the AMQP
+routing key anywhere in their code (`grep RoutingKey` in both services: zero hits) -- a
+`#`-wildcard binding on the new topic exchange preserves identical delivery semantics with no
+internal logic changes required for either service.
 
-Proposed path (to be detailed further in implementation planning; the steps below are a skeleton,
-not a finalized runbook):
+Proposed path (skeleton, not a finalized runbook):
 
-1. Declare new topic exchanges under new names (e.g. suffix `.topic` or a v2 queue-name constant)
-   alongside the existing fanout exchanges. **Must declare `durable=true`, matching the existing
-   fanout exchanges** (`bin-common-handler/pkg/rabbitmqhandler/topic.go:7` declares today's
-   fanout exchanges with `durable=true`, i.e. they survive broker restart). If the new topic
-   exchange is declared non-durable (or `durable=true` is simply omitted during implementation),
-   a broker/node restart during the dual-publish transition window would silently drop the new
-   exchange and any queue bindings on it, causing message loss for every consumer already
-   migrated to it at that point — a real production-correctness gap in an otherwise "standard"
-   blue/green migration. Escalated as Open Question 8.
-2. Publishers dual-publish to both old (fanout, unscoped) and new (topic, scoped) exchanges during
-   a transition window. **Bind/unbind ordering during this window needs an explicit guarantee**:
-   if any consumer (api-manager pod, or the three non-websocket consumers above) ever binds to
-   the new exchange before fully cutting over from the old one, it will double-receive events
-   during the overlap. The doc does not yet specify a concrete ordering protocol for this —
-   flagged as part of Open Question 7, not resolved here.
-3. api-manager pods migrate their per-pod queue bindings from the old exchange to the new one
-   (scoped, per §7's dynamic bind/unbind). **bin-agent-manager, bin-queue-manager, and
-   bin-timeline-manager migrate their existing queues to bind the new topic exchange with a `#`
-   wildcard** (they need the full, unscoped event stream for their own purposes — this is a
-   like-for-like fanout-equivalent binding, not scoped filtering, and requires no changes to
-   their internal event-handling logic, only the bind call's target exchange name and key).
-4. Once all pods and all four consumer services are confirmed on the new exchange, remove the
-   dual-publish and decommission the old fanout exchange.
+1. Declare a new topic exchange under a new name (e.g. `QueueNameWebhookEvent` + `.topic`
+   suffix, or a new `models/outline` constant) alongside the existing fanout exchange. **Must
+   declare `durable=true`**, matching today's fanout exchange
+   (`bin-common-handler/pkg/rabbitmqhandler/topic.go:7`) -- a non-durable new exchange risks
+   silent message loss on a broker restart during the transition window (Open Question 7).
+2. `bin-webhook-manager` dual-publishes to both old (fanout, unscoped) and new (topic, scoped)
+   exchanges during a transition window. **Bind/unbind ordering during this window needs an
+   explicit guarantee** to avoid double-delivery to any consumer bound to both simultaneously --
+   not resolved in this doc, flagged as Open Question 3.
+3. `bin-api-manager` pods migrate their per-pod queue bindings from the old exchange to the new
+   one (scoped, per §9's dynamic bind/unbind). `bin-agent-manager` and `bin-timeline-manager`
+   migrate their existing `QueueNameWebhookEvent` bindings to the new topic exchange with a `#`
+   wildcard (bind-call-target-only change, per the finding above).
+4. Once `bin-api-manager`, `bin-agent-manager`, and `bin-timeline-manager` are all confirmed on
+   the new exchange, remove the dual-publish and decommission the old fanout exchange.
 
-This is standard blue/green exchange migration; needs concrete queue-name constants and a
-rollback plan before implementation, not resolved in this doc.
-
-## 7. Dynamic bind/unbind at the api-manager side
+## 9. Dynamic bind/unbind at the api-manager side (unchanged from revision 1)
 
 Unlike today (bind once at pod boot, for the pod's whole lifetime), a topic-exchange scoped
 binding must track which scopes (`customer_id`/`agent_id` values) currently have at least one
@@ -214,79 +272,70 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
 - **Race condition to guard against**: a bind-in-flight event ordering where the client's
   subscribe ack is sent before the AMQP bind is confirmed, causing a missed first event. Bind
   must complete (or be confirmed) before acking the client's subscribe message.
-- **Abrupt disconnect must also decrement the refcount — this is a distinct code path from
-  explicit unsubscribe, verified against source.** Reading
+- **Abrupt disconnect must also decrement the refcount -- a distinct code path from explicit
+  unsubscribe, verified against source.** Reading
   `bin-api-manager/pkg/websockhandler/subscription.go:32-84`, today's cleanup on an abrupt
-  websocket close (network drop, tab close, mobile backgrounding) is whole-object teardown, not
-  incremental: the per-connection `zmqSub` (holding that connection's `topics` list) is discarded
-  via `defer zmqSub.Terminate()` (line 70) when `newCtx` is cancelled — triggered by
-  `receiveTextFromWebsock` erroring (lines 122-125) or a write failure in the pinger/ZMQ-run
-  goroutines. **No explicit `Unsubscribe(topic)` call fires on this path today.** The new
-  pod-level AMQP-bind-refcount component (shared across connections on a pod, per the paragraph
-  above) has nothing hooking it to decrement that connection's contribution to each scope's
-  refcount on this teardown path — `subscriptionHandleMessage`'s explicit-unsubscribe branch is
-  not sufficient by itself. The refcount decrement must also be driven from `subscriptionRun`'s
-  teardown (the `newCtx.Done()` / deferred-cleanup point), which needs new state tracking which
-  scopes each connection currently holds (this state doesn't fully exist yet in a pod-level-
-  reachable form — `zmqSub.topics` is per-connection only). Getting this wrong means every
+  websocket close is whole-object teardown, not incremental: the per-connection `zmqSub`
+  (holding that connection's `topics` list) is discarded via `defer zmqSub.Terminate()` (line
+  70) when `newCtx` is cancelled -- triggered by `receiveTextFromWebsock` erroring (lines
+  122-125) or a write failure in the pinger/ZMQ-run goroutines. No explicit `Unsubscribe(topic)`
+  call fires on this path today. The refcount decrement must also be driven from
+  `subscriptionRun`'s teardown (the `newCtx.Done()` / deferred-cleanup point), which needs new
+  state tracking which scopes each connection currently holds. Getting this wrong means every
   abrupt client disconnect leaks a refcount and leaves a stale scope binding on the pod's queue
-  permanently, silently reintroducing the exact problem (unconditional processing for pods with
-  zero real subscribers) this design exists to fix.
-- Implementation surface: `bin-api-manager/pkg/websockhandler/subscription.go`
-  `subscriptionHandleMessage` (currently calls `zmqSub.Subscribe(topic)`/`Unsubscribe(topic)`,
-  lines 159/168) is the integration point for explicit subscribe/unsubscribe; `subscriptionRun`'s
-  teardown (line 70 `defer zmqSub.Terminate()`, triggered via `newCtx` cancellation) is the
-  separate integration point required for abrupt disconnect. Both need a parallel call into a new
-  per-pod AMQP-bind-refcount component.
+  permanently, silently reintroducing the exact problem this design exists to fix.
+- Implementation surface: `subscriptionHandleMessage` (`subscription.go:159/168`, currently
+  calls `zmqSub.Subscribe`/`Unsubscribe`) is the integration point for explicit
+  subscribe/unsubscribe; `subscriptionRun`'s teardown (line 70) is the separate integration
+  point required for abrupt disconnect. Both need a parallel call into a new per-pod
+  AMQP-bind-refcount component.
 
-## 8. Out of scope (explicit, per pchero's decision)
+## 10. Out of scope (explicit)
 
-- Resource-first or hybrid (`resource_name.customer_id.<uuid>.#`) routing key ordering.
+- Resource-first or hybrid routing key ordering.
 - Functional sharding / resource-type-dedicated api-manager pod pools.
-- Application-level zero-subscriber short-circuit (discussed as "Alternative B" in prior
-  conversation) — not adopted as a substitute; may still be worth layering in later as defense
-  in depth, but is not part of this design.
+- Application-level zero-subscriber short-circuit ("Alternative B" in prior discussion) -- not
+  adopted as a substitute; may be worth layering in later as defense in depth.
 - Any change to the client-facing websocket subscribe/unsubscribe wire protocol or topic string
-  format (`customer_id:<uuid>:<resource>:<resource_id>`) — this design only changes the internal
-  AMQP transport layer between publishers and api-manager pods; the public API contract is
-  unchanged.
+  format -- this design only changes the internal AMQP transport layer; the public API contract
+  is unchanged.
+- **`QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges and their existing consumers**
+  (`bin-agent-manager`, `bin-queue-manager`, `bin-talk-manager`, `bin-timeline-manager`'s
+  subscriptions to those two specifically) -- unaffected by this design, per §7. Only
+  `bin-api-manager`'s now-provably-pointless subscription to them is removed.
+- Any change to `bin-common-handler`'s `notifyHandler.PublishEvent`/`PublishWebhookEvent` public
+  signatures, or to any of the ~116 bare-`PublishEvent` call sites across ~25+ services --
+  moot under the reduced scope (§4), since those events never reached a websocket client.
 
-## 9. Open questions (need resolution before/during implementation)
+## 11. Open questions (need resolution before/during implementation)
 
-1. Bare `PublishEvent` (no explicit customerID) call sites: adopt an `Owner`/`Identity` interface
-   extraction, or migrate all call sites to explicit-customerID signatures?
-2. Does `agent_id` scope routing apply uniformly across webhook/agent/talk-manager publishers, or
-   only to a subset? Needs per-service verification of what identity data is available at
-   publish time.
-3. Exchange migration: concrete new queue-name constants, dual-publish transition window length,
-   and rollback trigger criteria.
-4. Testing strategy for the dynamic bind/unbind reference-counting logic — needs a plan for
-   simulating multiple concurrent connections per pod sharing/unsharing scopes without flaking.
-5. Should `PublishEvent`/`PublishWebhookEvent`'s public interface signature change (e.g. add an
-   explicit routing-key-relevant scope parameter), given `bin-common-handler`'s "3+ services"
-   admission rule and the fact this interface is shared library code consumed by all 37 services?
-   Given the confirmed ~116-call-site blast radius (§5) and that the map-payload call sites
-   disqualify a non-invasive interface-extraction alternative, this is effectively asking
-   "are we prepared to touch ~25+ services' publish call sites," not a low-cost signature tweak.
-6. How does the per-pod bind/unbind refcount interact with abrupt disconnect / connection
-   teardown (not just explicit unsubscribe messages)? See §7 — `subscriptionRun`'s teardown path
-   (`newCtx` cancellation, `defer zmqSub.Terminate()`) fires on every disconnect, clean or not,
-   but carries no per-topic unsubscribe signal today; the refcount component needs its own state
-   to know what to decrement on this path, and that state doesn't exist in the codebase yet.
-7. **(New, blocking) Non-websocket consumers of the same exchanges.** `bin-agent-manager`,
-   `bin-queue-manager`, and `bin-timeline-manager` all subscribe to one or more of
-   `QueueNameWebhookEvent`/`QueueNameAgentEvent`/`QueueNameTalkEvent` today via empty-routing-key
-   fanout bindings, for purposes unrelated to websocket delivery (agent status updates, queue
-   routing, audit-log ingestion — see §6). Their migration to `#`-wildcard bindings on the new
-   topic exchange is sketched in §6 step 3 but not fully planned: does each of these three
-   services need code changes beyond the bind call (e.g. do they rely on routing-key value
-   anywhere, even though they ignore it today), and what is the verification/rollback plan
-   specific to each, given they are unrelated teams'/features' code paths from the websocket
-   subscription feature this design is otherwise scoped to?
-8. **(New) New topic exchange durability.** §6 step 1 requires the new topic exchange(s) to be
-   declared `durable=true`, matching the existing fanout exchanges. Confirm the implementation
-   actually sets this (an easy omission since it's a boolean flag on `ExchangeDeclare`, not a
-   design-level structural decision), and consider whether a broker restart mid-dual-publish-
-   window needs an explicit recovery/reconciliation step beyond exchange durability alone (e.g.
-   are consumer queue bindings also durable, and is there a gap between exchange survival and
-   binding survival across a restart during the transition).
+1. Concrete new exchange name/queue-name constant for the new topic exchange, dual-publish
+   transition window length, and rollback trigger criteria.
+2. Testing strategy for the dynamic bind/unbind reference-counting logic in `bin-api-manager` --
+   needs a plan for simulating multiple concurrent connections per pod sharing/unsharing scopes
+   without flaking.
+3. Bind/unbind ordering guarantee during the dual-publish transition window, to avoid transient
+   double-delivery to any consumer bound to both exchanges simultaneously.
+4. Chat-participant-fan-out RPC relocation (§6, harder part 2): confirm the "paid once at
+   publish time, not once per pod" framing is accurate once implemented (i.e. does NOT
+   accidentally get called once per routing key generated, or once per dual-publish target,
+   which would multiply it again); design the new `reqHandler` dependency injection into
+   `webhookHandler` cleanly (constructor signature, mock updates, wiring in both
+   `cmd/webhook-manager` and `cmd/webhook-control`).
+5. How does the per-pod bind/unbind refcount interact with abrupt disconnect / connection
+   teardown (not just explicit unsubscribe messages)? See §9 -- `subscriptionRun`'s teardown
+   path fires on every disconnect, clean or not, but carries no per-topic unsubscribe signal
+   today; the refcount component needs its own state to know what to decrement on this path.
+6. Verify (via blast-radius grep / test coverage check) that no other code path in
+   `bin-api-manager` depends on the `QueueNameAgentEvent`/`QueueNameTalkEvent` subscriptions
+   before removing them (§7) -- expected to be a clean removal given the `processEvent` switch
+   statement's single-case structure, but should be confirmed, not assumed.
+7. New topic exchange durability: confirm `durable=true` is actually set in implementation (easy
+   boolean-flag omission), and whether a broker restart mid-dual-publish-window needs an
+   explicit recovery/reconciliation step beyond exchange durability alone (binding durability
+   vs. exchange survival).
+8. Does moving the nested-envelope unmarshal logic (§6, harder part 1: extracting `OwnerID` from
+   `commonWebhookData`) into `bin-webhook-manager` duplicate logic that should instead be shared
+   (e.g. via `bin-common-handler`) between webhook-manager and whatever remains of
+   `bin-api-manager`'s webhook-processing path, to avoid two independent implementations of the
+   same envelope-parsing rules drifting apart over time?

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -10,8 +10,11 @@ websocket client count. Chat-type events additionally pay a live `TalkV1Particip
 call per event, also unconditional.
 
 **pchero has decided**: go broker-level (RabbitMQ `fanout` -> `topic` exchange), with
-**scope-first** routing key ordering (`customer_id.<uuid>.#` / `agent_id.<uuid>.#`), explicitly
-rejecting resource-first ordering and deferring functional sharding as out of scope.
+**scope-first** routing key ordering (`customer_id.<uuid>.#` / `owner_id.<uuid>.#`), explicitly
+rejecting resource-first ordering and deferring functional sharding as out of scope. On
+2026-07-14 in further follow-up, pchero additionally decided to rename the owner-scope wire
+string from `agent_id` to `owner_id` end to end (internal routing key AND the client-facing
+public API) -- see §5.
 
 **This is REVISION 2 of the design, reflecting a scope-reduction decision made 2026-07-14 in
 follow-up discussion, superseding the original 8-open-question, ~25-service-blast-radius draft.**
@@ -94,19 +97,21 @@ Owner, AIcallID, ChatID}`) to extract `CustomerID`/`OwnerID`, and for
 `chat`/`chatmessage`/`chatparticipant` resource types calls
 `h.reqHandler.TalkV1ParticipantList(ctx, chatID)` to fan out a topic string per chat participant.
 
-Existing client-facing topic string format (already public API contract, documented in
-`bin-api-manager/docsdev/source/websocket_overview.rst` etc., UNCHANGED by this design):
+Existing client-facing topic string format (public API contract, documented in
+`bin-api-manager/docsdev/source/websocket_overview.rst` etc. -- the `agent_id` scope prefix is
+RENAMED to `owner_id` by this design, per §5; the overall `<scope>:<scope_id>:<resource>:
+<resource_id>` shape and the `customer_id` prefix are unchanged):
 ```
 <scope>:<scope_id>:<resource>:<resource_id>
 e.g. customer_id:abc123:call:xyz789
-     agent_id:agent123:queue:*
+     agent_id:agent123:queue:*      (BEFORE this design; becomes owner_id:agent123:queue:* -- see §5)
 ```
 
 ## 3. Design goal (unchanged)
 
 Move scope-based filtering from "after full local processing, at the final ZMQ hop" to "at the
 RabbitMQ broker, before the event ever reaches a pod without a matching subscriber." A pod with
-zero clients subscribed to a given `customer_id`/`agent_id` scope should never receive, consume,
+zero clients subscribed to a given `customer_id`/`owner_id` scope should never receive, consume,
 unmarshal, or run `createTopics()`/RPC for that scope's events at all.
 
 ## 4. Reduced scope: two services only
@@ -136,17 +141,18 @@ Both already construct `wh := &webhook.Webhook{CustomerID: customerID, ...}` bef
 obtain `customer_id` for the routing key -- it is already in scope at the call site. This is
 a materially simpler starting point than the original design's ~116-site migration.
 
-**What is NOT simplified**: the `agent_id`/owner scope and the chat-participant fan-out (see §6)
-still require moving logic that currently lives in `createTopics()` (consumer side) to the
-publisher side, because the routing key must exist at `channel.PublishWithContext` time.
+**What is NOT simplified**: the owner scope (`agent_id` -> `owner_id`, see §5) and the
+chat-participant fan-out (see §6) still require moving logic that currently lives in
+`createTopics()` (consumer side) to the publisher side, because the routing key must exist at
+`channel.PublishWithContext` time.
 
-## 5. Proposed routing key format (scope-first, unchanged from revision 1)
+## 5. Proposed routing key format (scope-first) AND client-facing wire-protocol rename: `agent_id` -> `owner_id`
 
 ```
 <scope>.<scope_id>.#
 e.g. customer_id.a1b2c3d4-....call.xyz789   (as the PUBLISHED routing key)
      customer_id.a1b2c3d4-....#             (as a pod's BOUND pattern, wildcard tail)
-     agent_id.98765432-....#
+     owner_id.98765432-....#                (RENAMED from agent_id, see below)
 ```
 
 Rationale (recapped): resource_id is unknown at bind time, so any pattern putting it before the
@@ -156,9 +162,62 @@ segments (resource type + resource id), while the scope segment -- known at
 websocket-connect/subscribe time, low cardinality per pod -- does the actual filtering work at
 the trie's first level.
 
-Two scope namespaces (`customer_id`, `agent_id`) must coexist; a single event may need to be
-published under BOTH routing keys (mirrors the existing dual topic-string generation already
-done in `createTopics()` today for `customer_id:...` and `agent_id:...`).
+**Scope rename decision (2026-07-14, pchero): `agent_id` becomes `owner_id`, applied end to end
+-- not just the internal AMQP routing key, but the CLIENT-FACING wire protocol too (subscribe
+message topic strings, and the developer-facing RST docs). This is a deliberate breaking change
+to the public API, not an internal-only rename.**
+
+**Why this is a natural fit, verified from source, not just naming preference:** the underlying
+data model is ALREADY generic. `commonidentity.Owner` (`bin-common-handler/models/identity/owner.go:5-8`)
+is `{OwnerType OwnerType, OwnerID uuid.UUID}`, with `OwnerType` currently having exactly one
+value, `OwnerTypeAgent = "agent"` (`owner.go:17`) -- the struct was designed to support more
+owner types later, but the wire-protocol string hardcodes `"agent_id"` regardless. Confirmed:
+`createTopics()` (`bin-api-manager/pkg/subscribehandler/webhookmanager.go:138,150,152,162,171`)
+already reads `d.OwnerID` (the generic field) and only hardcodes the STRING PREFIX `"agent_id"`
+when building the topic string -- the rename aligns the wire string with the model that already
+underlies it, rather than introducing new abstraction.
+
+**Verified blast radius for the rename** (grep across `bin-api-manager`, confined to this
+service -- no other service's code references the `agent_id:` wire string):
+- `bin-api-manager/pkg/subscribehandler/webhookmanager.go:138,150,152,162,171` -- `createTopics()`,
+  the 5 `fmt.Sprintf("agent_id:...", ...)` call sites generating the topic string (moves to
+  `bin-webhook-manager` per §6/§7, so this is really 5 call sites in the NEW location, not this
+  file, once §6 lands -- but the string literal itself needs updating wherever it ends up).
+- `bin-api-manager/pkg/websockhandler/etc.go:16-19,36-56,73-76,102-142` -- `validateTopics`/
+  `validateTopic`, the `case "agent_id":` branches (2 near-duplicate functions, confirmed both
+  need updating) that validate a subscribed topic's scope prefix against the authenticated
+  identity.
+- `bin-api-manager/pkg/websockhandler/etc_test.go` -- test cases using `agent_id:` literal
+  strings, need updating alongside the above.
+- `bin-api-manager/pkg/subscribehandler/webhookmanager_test.go` -- same, for `createTopics()`'s
+  tests (or their new home post-§6/§7).
+- `bin-api-manager/docsdev/source/websocket_overview.rst`,
+  `bin-api-manager/docsdev/source/websocket_struct.rst`,
+  `bin-api-manager/docsdev/source/websocket_tutorial.rst` -- developer-facing RST docs at
+  docs.voipbin.net document `agent_id:<uuid>:<resource>:<resource_id>` as a first-class example
+  topic pattern; MUST be updated per this repo's CLAUDE.md RST-sync rule ("stale docs actively
+  mislead customers"), rebuilt via `sphinx -M html`, and force-added (`build/` is gitignored).
+
+**Not affected**: `commonidentity.Owner`'s Go field names (`OwnerType`, `OwnerID`) are already
+correctly named and require no change; only the WIRE STRING `"agent_id"` (embedded in topic
+strings, both AMQP routing keys and the client-facing subscribe/unsubscribe protocol) is
+renamed to `"owner_id"`. `amagent.PermissionProjectSuperAdmin` and other agent-domain permission
+checks in `etc.go` are unaffected -- they gate on `AuthIdentity`'s actual agent/permission state,
+not the topic string prefix.
+
+**This is explicitly a breaking change to the public websocket API** -- any existing client
+subscribing with `agent_id:<uuid>:...` topic strings will need to migrate to `owner_id:<uuid>:...`.
+No backward-compatibility/dual-accept period is assumed in this doc; whether one is needed
+(accept both prefixes for a transition window, emit a deprecation warning, etc.) is escalated to
+Open Question 10, since this touches external API consumers, not just internal code -- a product/
+support decision, not a pure engineering one.
+
+Two scope namespaces (`customer_id`, `owner_id`) must coexist. Proposed: publish BOTH routing
+keys per event when both a customer and an owner scope apply (mirrors the existing dual-topic
+generation already done in `createTopics()` today, which already emits both `customer_id:...`
+and the soon-to-be-renamed owner-scope topic strings for the same event where applicable -- this
+is not new complexity, just moving existing dual-key generation earlier in the pipeline, plus
+the rename above).
 
 ## 6. Who computes the routing key: moves into bin-webhook-manager (computation), notifyHandler (publish mechanism)
 
@@ -231,16 +290,17 @@ resolved definitively in this doc -- (b) is not disqualified, just not preferred
 (§4) -- computing `customer_id.<customerID>.#`-shaped keys requires no new plumbing for that
 scope alone.
 
-**Harder part 1 -- `agent_id`/owner scope extraction**: today's `createTopics()` unmarshals the
-event `data` payload (via the nested `Webhook.Data` -> `Data.Data` -> `commonWebhookData{Owner}`
-envelope) to find `OwnerID` for the `agent_id:...` routing key. `SendWebhookToCustomer`/
-`SendWebhookToURI` receive `data json.RawMessage` as an opaque blob (`webhook.go:26,120`) --
-they do not know the owner/agent ID structurally, only that it may be present somewhere inside
-`data`'s nested JSON. **This requires porting the SAME nested-unmarshal logic
+**Harder part 1 -- owner scope extraction (`agent_id` -> `owner_id`)**: today's `createTopics()`
+unmarshals the event `data` payload (via the nested `Webhook.Data` -> `Data.Data` ->
+`commonWebhookData{Owner}` envelope) to find `OwnerID` for the owner-scope routing key.
+`SendWebhookToCustomer`/`SendWebhookToURI` receive `data json.RawMessage` as an opaque blob
+(`webhook.go:26,120`) -- they do not know the owner ID structurally, only that it may be present
+somewhere inside `data`'s nested JSON. **This requires porting the SAME nested-unmarshal logic
 (`commonWebhookData` struct, currently in `bin-api-manager/pkg/subscribehandler/webhookmanager.go`)
 into `bin-webhook-manager`**, run against `data` before publish, to extract `OwnerID` the same
-way `createTopics()` does today. This is a genuine, non-trivial logic move (not just a signature
-change), but it is confined to `bin-webhook-manager`, not spread across ~25 services.
+way `createTopics()` does today, and emitting the RENAMED `owner_id:...` prefix (§5) rather than
+today's `agent_id:...`. This is a genuine, non-trivial logic move (not just a signature change),
+but it is confined to `bin-webhook-manager`, not spread across ~25 services.
 
 **Symmetry note, verified**: both `SendWebhookToCustomer` and `SendWebhookToURI` construct an
 identical `wh := &webhook.Webhook{...}` before calling `notifyHandler.PublishEvent` (lines
@@ -253,8 +313,8 @@ functions, not duplicated per call site.
 **Harder part 2 -- chat participant fan-out RPC moves to the publish path**: for
 `chat`/`chatmessage`/`chatparticipant` resource types, `createTopics()` today calls
 `h.reqHandler.TalkV1ParticipantList(ctx, chatID)` (`webhookmanager.go:143`) AFTER receiving the
-event, to generate one `agent_id:<participant>:chat:...` routing key per chat participant. Moving
-this to webhook-manager means:
+event, to generate one `agent_id:<participant>:chat:...` (becoming `owner_id:<participant>:
+chat:...`, per §5) routing key per chat participant. Moving this to webhook-manager means:
 - `webhook-manager`'s `webhookHandler` struct (`pkg/webhookhandler/main.go:32-40`) does NOT
   currently hold a `reqHandler requesthandler.RequestHandler` dependency -- verified by reading
   the struct definition. **A new dependency injection is required** (constructor signature
@@ -339,11 +399,11 @@ Proposed path (skeleton, not a finalized runbook):
 ## 9. Dynamic bind/unbind at the api-manager side (unchanged from revision 1)
 
 Unlike today (bind once at pod boot, for the pod's whole lifetime), a topic-exchange scoped
-binding must track which scopes (`customer_id`/`agent_id` values) currently have at least one
+binding must track which scopes (`customer_id`/`owner_id` values) currently have at least one
 live local websocket subscriber on that pod, and bind/unbind the per-pod queue accordingly:
 
 - On a client's first `subscribe` message for a new scope on that pod: bind
-  `customer_id.<uuid>.#` (or `agent_id.<uuid>.#`) to the pod's queue.
+  `customer_id.<uuid>.#` (or `owner_id.<uuid>.#`) to the pod's queue.
 - On the last client unsubscribing from / disconnecting from a scope on that pod: unbind.
 - **Reference counting required**: multiple local connections (or multiple topic subscriptions
   from the same connection) can share a scope; only unbind when the count reaches zero.
@@ -374,9 +434,11 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
 - Functional sharding / resource-type-dedicated api-manager pod pools.
 - Application-level zero-subscriber short-circuit ("Alternative B" in prior discussion) -- not
   adopted as a substitute; may be worth layering in later as defense in depth.
-- Any change to the client-facing websocket subscribe/unsubscribe wire protocol or topic string
-  format -- this design only changes the internal AMQP transport layer; the public API contract
-  is unchanged.
+- Any OTHER change to the client-facing websocket subscribe/unsubscribe wire protocol beyond the
+  `agent_id` -> `owner_id` rename (§5) -- the overall `<scope>:<scope_id>:<resource>:
+  <resource_id>` shape, the `customer_id` prefix, and all other subscribe/unsubscribe message
+  semantics are unchanged; this design does not touch the client-facing protocol structure, only
+  the internal AMQP transport layer PLUS this one specific, deliberate rename.
 - **`QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges and their existing publishers/
   consumers** (`bin-agent-manager` publishes to `QueueNameAgentEvent`, `bin-queue-manager`
   consumes it; `bin-talk-manager` publishes to `QueueNameTalkEvent`, `bin-timeline-manager`
@@ -438,3 +500,14 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    the `go generate`-regenerated mock -- not a broad blast radius, but should still be confirmed
    as part of the standard verification workflow (`go generate ./... && go test ./...`) rather
    than assumed.
+10. **(New) `agent_id` -> `owner_id` backward compatibility.** §5's wire-protocol rename is a
+    breaking change to the public websocket API. Decide: hard cutover (no transitional support),
+    or a transition window accepting BOTH `agent_id:...` and `owner_id:...` prefixes on
+    subscribe (with `owner_id` as the only one ever emitted server -> client, or with both
+    accepted client -> server but a deprecation notice), and for how long. This is a
+    product/support decision (announcement timing, existing customer migration communication),
+    not a pure engineering one -- flagged for explicit pchero sign-off before implementation,
+    not something to decide unilaterally during coding. If a transition window is chosen,
+    `validateTopics`/`validateTopic` (`bin-api-manager/pkg/websockhandler/etc.go`) would need to
+    accept both prefixes as equivalent during that window, adding temporary complexity that must
+    be tracked for removal afterward.

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -170,8 +170,11 @@ to the public API, not an internal-only rename.**
 **Why this is a natural fit, verified from source, not just naming preference:** the underlying
 data model is ALREADY generic. `commonidentity.Owner` (`bin-common-handler/models/identity/owner.go:5-8`)
 is `{OwnerType OwnerType, OwnerID uuid.UUID}`, with `OwnerType` currently having exactly one
-value, `OwnerTypeAgent = "agent"` (`owner.go:17`) -- the struct was designed to support more
-owner types later, but the wire-protocol string hardcodes `"agent_id"` regardless. Confirmed:
+value, `OwnerTypeAgent = "agent"` (`owner.go:17`) -- the struct's SHAPE is already generic
+(whether or not that was the original design intent; `owner.go` itself carries no comment
+indicating forward-looking design for multiple owner types, so this is an observation about the
+current structure, not a claim about historical intent), but the wire-protocol string hardcodes
+`"agent_id"` regardless. Confirmed:
 `createTopics()` (`bin-api-manager/pkg/subscribehandler/webhookmanager.go:138,150,152,162,171`)
 already reads `d.OwnerID` (the generic field) and only hardcodes the STRING PREFIX `"agent_id"`
 when building the topic string -- the rename aligns the wire string with the model that already
@@ -197,6 +200,24 @@ service -- no other service's code references the `agent_id:` wire string):
   docs.voipbin.net document `agent_id:<uuid>:<resource>:<resource_id>` as a first-class example
   topic pattern; MUST be updated per this repo's CLAUDE.md RST-sync rule ("stale docs actively
   mislead customers"), rebuilt via `sphinx -M html`, and force-added (`build/` is gitignored).
+
+**Checked and explicitly excluded, not silently omitted**: a fresh monorepo-wide grep for the
+literal `agent_id:` wire prefix additionally found two categories of non-code hits, neither
+requiring action:
+- `bin-api-manager/pkg/websockhandler/subscription.go:81` -- a log message
+  (`log.Debugf("Websocket connection has been closed. agent_id: %s", ...)`) using `agent_id` as
+  a structured-log field label, not the wire-protocol prefix. No rename needed; unrelated usage.
+- Repo-root `docs/plans/2026-04-02-talk-websocket-distribution-design.md` and
+  `docs/plans/2026-04-02-talk-manager-event-prefix-design.md` -- stale, historical, already-
+  implemented design docs that describe the `agent_id:...` wire format as it existed when those
+  designs shipped. These are a historical record, not live documentation (unlike the `docsdev/
+  source/*.rst` files above, which ARE the live docs.voipbin.net content) -- left as-is, not
+  updated, since retroactively editing historical design docs to reflect a later rename would
+  make them inaccurate as a historical record of what was actually decided/built at the time.
+- No hits in any OpenAPI spec file for the wire-protocol prefix (`bin-openapi-manager/openapi/
+  openapi.yaml`'s one `agent_id` occurrence is an unrelated schema field,
+  `TalkManagerMedia.type=agent`, not this topic-string prefix). No frontend repo hits (no
+  square-admin/square-main directories exist in this monorepo).
 
 **Not affected**: `commonidentity.Owner`'s Go field names (`OwnerType`, `OwnerID`) are already
 correctly named and require no change; only the WIRE STRING `"agent_id"` (embedded in topic

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -1,0 +1,175 @@
+# VOIP-1258: bin-api-manager WebSocket Event Subscription — Broker-Level Scoped Routing
+
+## 1. Origin and decision already made
+
+Tracking ticket: VOIP-1258. Discovered and verified (2 independent adversarial review rounds,
+both APPROVED with zero changes requested) in a CPO/CEO discussion on 2026-07-14: per-pod
+processing cost for events published to `QueueNameWebhookEvent` / `QueueNameAgentEvent` /
+`QueueNameTalkEvent` is paid unconditionally for every published event, multiplied by
+api-manager pod count, with zero dependency on connected websocket client count. Chat-type
+events additionally pay a live `TalkV1ParticipantList` RPC call per event, also unconditional.
+
+**pchero has already decided the direction**: go broker-level (RabbitMQ `fanout` → `topic`
+exchange), with **scope-first** routing key ordering (`customer_id.<uuid>.#` /
+`agent_id.<uuid>.#`), explicitly rejecting resource-first ordering and deferring functional
+sharding (resource-type-dedicated pod pools) as out of scope. This design doc executes that
+decision — it does not revisit the broker-vs-app-level or scope-first-vs-resource-first choice.
+
+## 2. Current implementation (verified from source)
+
+```
+webhook/agent/talk-manager
+  notifyHandler.PublishEvent(ctx, eventType, data)
+    -> publishEvent() -> sockHandler.EventPublish(exchange=queueName, key="", evt)
+        -> rabbitmqhandler.EventPublish(exchange, key, evt)
+            -> publishExchange(exchange, key, message, ...) [amqp channel.PublishWithContext]
+
+Exchange declared once at NewNotifyHandler() time via sockHandler.TopicCreate(name)
+    -> ExchangeDeclare(name, "fanout", ...)   [bin-common-handler/pkg/rabbitmqhandler/topic.go:5-9]
+
+bin-api-manager, at pod boot (cmd/api-manager/main.go:142 runSubscribe, unconditional):
+    per-pod queue (QueueNameAPISubscribe-<uuid>) bound via QueueSubscribe -> QueueBind(name, "", exchange, ...)
+    [bin-common-handler/pkg/rabbitmqhandler/queue.go:158-160]
+    -- empty routing key, irrelevant for fanout, binding lives for the pod's whole lifetime
+
+subscribehandler.processEventRun -> processEvent -> (webhook_published) ->
+  processEventWebhookManagerWebhookPublished (bin-api-manager/pkg/subscribehandler/webhookmanager.go:48)
+    -- 3x json.Unmarshal, createTopics() [may call TalkV1ParticipantList RPC for chat types],
+       zmqpubHandler.Publish(topic, data) per generated topic string -- all unconditional
+
+Local per-connection ZMQ SUB filtering (bin-api-manager/pkg/zmqsubhandler) is the ONLY
+connection-count-dependent step, and it sits after all the above.
+```
+
+Existing client-facing topic string format (already public API contract, documented in
+`bin-api-manager/docsdev/source/websocket_overview.rst` etc.):
+```
+<scope>:<scope_id>:<resource>:<resource_id>
+e.g. customer_id:abc123:call:xyz789
+     agent_id:agent123:queue:*
+```
+This colon-delimited string is currently used ONLY for the final local ZMQ SUB/PUB filter and
+the client wire protocol (subscribe/unsubscribe websocket messages) — it is NOT currently an
+AMQP routing key (routing key is always `""` today, since fanout ignores it).
+
+`createTopics()` (`bin-api-manager/pkg/subscribehandler/webhookmanager.go:107-175`) is where this
+topic-string generation currently lives, on the **consumer** (api-manager) side, after the event
+has already been fully received and unmarshalled.
+
+## 3. Design goal
+
+Move scope-based filtering from "after full local processing, at the final ZMQ hop" to "at the
+RabbitMQ broker, before the event ever reaches a pod without a matching subscriber." Concretely:
+a pod with zero clients subscribed to a given `customer_id`/`agent_id` scope should never receive,
+consume, unmarshal, or run `createTopics()`/RPC for that scope's events at all.
+
+## 4. Proposed routing key format (scope-first, confirmed direction)
+
+```
+<scope>.<scope_id>.#
+e.g. customer_id.a1b2c3d4-....call.xyz789   (as the PUBLISHED routing key)
+     customer_id.a1b2c3d4-....#             (as a pod's BOUND pattern, wildcard tail)
+     agent_id.98765432-....#
+```
+
+Rationale already established in discussion (recapped for the record): resource_id is unknown
+at bind time (client hasn't received the event yet), so any pattern putting it before the scope
+segment forces the scope filter to collapse into an unfiltered wildcard, defeating the purpose.
+Scope-first keeps the wildcard tail (`#`) confined to the low-value, high-cardinality segments
+(resource type + resource id), while the scope segment — known at websocket-connect/subscribe
+time, low cardinality per pod — does the actual filtering work at the trie's first level.
+
+Two scope namespaces (`customer_id`, `agent_id`) must coexist. Proposed: publish BOTH routing
+keys per event when both a customer and an owner/agent scope apply (mirrors the existing
+dual-topic generation already done in `createTopics()` today, which already emits both
+`customer_id:...` and `agent_id:...` topic strings for the same event where applicable — this is
+not new complexity, just moving existing dual-key generation earlier in the pipeline).
+
+## 5. Who computes the routing key: publisher-side move
+
+**Decision point carried into this doc, not yet resolved — see Open Questions.** Today
+`createTopics()` runs on the consumer (api-manager) after receiving the full event. For topic-
+exchange filtering to work, the AMQP routing key must exist at `channel.PublishWithContext` time,
+i.e. on the publisher (webhook/agent/talk-manager) side, before the message ever reaches
+RabbitMQ.
+
+Verified asymmetry that affects this move:
+- `notifyHandler.PublishWebhookEvent(ctx, customerID uuid.UUID, eventType string, data WebhookMessage)`
+  already receives `customerID` as an explicit parameter (used today for the webhook HTTP
+  delivery path) — computing `customer_id.<customerID>.#`-shaped keys here is straightforward.
+- `notifyHandler.PublishEvent(ctx, eventType string, data interface{})` (called directly, e.g.
+  `bin-agent-manager/pkg/agenthandler/agent.go:591`, `db.go:234/263/311/345`) does NOT receive
+  customerID as a parameter — it is embedded inside `data`. Extracting it generically (without
+  reflection or a fragile type-switch per caller) needs either (a) a shared `Owner`/`Identity`
+  interface with a `GetCustomerID()` method that callers' domain structs already satisfy (most
+  domain models embed `commonidentity.Identity`/`Owner` already, per `bin-common-handler/models/identity`),
+  or (b) requiring all bare `PublishEvent` call sites to migrate to `PublishWebhookEvent`-style
+  explicit-customerID signatures. Needs a design decision (see Open Questions).
+- `agent_id` scope: is there an equivalent "owner/agent" identity readily available at publish
+  time for all three services, or does this only cleanly apply to `bin-agent-manager`'s own
+  events? Needs verification per-service before finalizing.
+
+## 6. Exchange migration strategy
+
+RabbitMQ exchange kind is fixed at declare time; re-declaring an existing exchange name with a
+different kind fails with `PRECONDITION_FAILED`. Since `QueueNameWebhookEvent` /
+`QueueNameAgentEvent` / `QueueNameTalkEvent` are already declared `fanout` in production, an
+in-place kind change is not possible. Proposed path (to be detailed further in implementation
+planning, flagged here as a known constraint, not a solved problem):
+
+1. Declare new topic exchanges under new names (e.g. suffix `.topic` or a v2 queue-name constant)
+   alongside the existing fanout exchanges.
+2. Publishers dual-publish to both old (fanout, unscoped) and new (topic, scoped) exchanges during
+   a transition window.
+3. api-manager pods migrate their per-pod queue bindings from the old exchange to the new one.
+4. Once all pods are confirmed on the new exchange, remove the dual-publish and decommission the
+   old fanout exchange.
+
+This is standard blue/green exchange migration; needs concrete queue-name constants and a
+rollback plan before implementation, not resolved in this doc.
+
+## 7. Dynamic bind/unbind at the api-manager side
+
+Unlike today (bind once at pod boot, for the pod's whole lifetime), a topic-exchange scoped
+binding must track which scopes (`customer_id`/`agent_id` values) currently have at least one
+live local websocket subscriber on that pod, and bind/unbind the per-pod queue accordingly:
+
+- On a client's first `subscribe` message for a new scope on that pod: bind
+  `customer_id.<uuid>.#` (or `agent_id.<uuid>.#`) to the pod's queue.
+- On the last client unsubscribing from / disconnecting from a scope on that pod: unbind.
+- **Reference counting required**: multiple local connections (or multiple topic subscriptions
+  from the same connection) can share a scope; only unbind when the count reaches zero.
+- **Race condition to guard against**: a bind-in-flight event ordering where the client's
+  subscribe ack is sent before the AMQP bind is confirmed, causing a missed first event. Bind
+  must complete (or be confirmed) before acking the client's subscribe message.
+- Implementation surface: `bin-api-manager/pkg/websockhandler/subscription.go`
+  `subscriptionHandleMessage` (currently calls `zmqSub.Subscribe(topic)`/`Unsubscribe(topic)`)
+  is the natural integration point — needs a parallel call into a new per-pod AMQP-bind-refcount
+  component.
+
+## 8. Out of scope (explicit, per pchero's decision)
+
+- Resource-first or hybrid (`resource_name.customer_id.<uuid>.#`) routing key ordering.
+- Functional sharding / resource-type-dedicated api-manager pod pools.
+- Application-level zero-subscriber short-circuit (discussed as "Alternative B" in prior
+  conversation) — not adopted as a substitute; may still be worth layering in later as defense
+  in depth, but is not part of this design.
+- Any change to the client-facing websocket subscribe/unsubscribe wire protocol or topic string
+  format (`customer_id:<uuid>:<resource>:<resource_id>`) — this design only changes the internal
+  AMQP transport layer between publishers and api-manager pods; the public API contract is
+  unchanged.
+
+## 9. Open questions (need resolution before/during implementation)
+
+1. Bare `PublishEvent` (no explicit customerID) call sites: adopt an `Owner`/`Identity` interface
+   extraction, or migrate all call sites to explicit-customerID signatures?
+2. Does `agent_id` scope routing apply uniformly across webhook/agent/talk-manager publishers, or
+   only to a subset? Needs per-service verification of what identity data is available at
+   publish time.
+3. Exchange migration: concrete new queue-name constants, dual-publish transition window length,
+   and rollback trigger criteria.
+4. Testing strategy for the dynamic bind/unbind reference-counting logic — needs a plan for
+   simulating multiple concurrent connections per pod sharing/unsharing scopes without flaking.
+5. Should `PublishEvent`/`PublishWebhookEvent`'s public interface signature change (e.g. add an
+   explicit routing-key-relevant scope parameter), given `bin-common-handler`'s "3+ services"
+   admission rule and the fact this interface is shared library code consumed by all 37 services?

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -214,10 +214,14 @@ code path in `bin-api-manager` depends on having consumed (vs. ignored) these tw
 before removing them -- flagged as Open Question 6, a verification step, not a design decision.
 
 This means `QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges themselves are UNCHANGED --
-still `fanout`, still consumed by `bin-agent-manager`/`bin-queue-manager`
-(`QueueNameAgentEvent`) and `bin-timeline-manager` (`QueueNameTalkEvent`) for their own
-unrelated purposes (agent status logic, queue routing, audit-log ingestion). Only
-`bin-api-manager`'s now-pointless subscription is removed.
+still `fanout`, still consumed by `bin-queue-manager` (`QueueNameAgentEvent`, per
+`bin-queue-manager/cmd/queue-manager/main.go:149`) and `bin-timeline-manager`
+(`QueueNameTalkEvent`, per `bin-timeline-manager/pkg/subscribehandler/main.go:50`) for their own
+unrelated purposes (queue routing, audit-log ingestion). `bin-agent-manager` and
+`bin-talk-manager` are the PUBLISHERS to `QueueNameAgentEvent`/`QueueNameTalkEvent` respectively
+(`bin-agent-manager/cmd/agent-manager/main.go:95`, `bin-talk-manager/cmd/talk-manager/main.go:82-87`)
+-- they do not subscribe to their own exchange, and are unaffected either way. Only
+`bin-api-manager`'s now-pointless subscription to both exchanges is removed.
 
 ## 8. Exchange migration strategy (reduced: only QueueNameWebhookEvent)
 
@@ -299,10 +303,11 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
 - Any change to the client-facing websocket subscribe/unsubscribe wire protocol or topic string
   format -- this design only changes the internal AMQP transport layer; the public API contract
   is unchanged.
-- **`QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges and their existing consumers**
-  (`bin-agent-manager`, `bin-queue-manager`, `bin-talk-manager`, `bin-timeline-manager`'s
-  subscriptions to those two specifically) -- unaffected by this design, per §7. Only
-  `bin-api-manager`'s now-provably-pointless subscription to them is removed.
+- **`QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges and their existing publishers/
+  consumers** (`bin-agent-manager` publishes to `QueueNameAgentEvent`, `bin-queue-manager`
+  consumes it; `bin-talk-manager` publishes to `QueueNameTalkEvent`, `bin-timeline-manager`
+  consumes it) -- unaffected by this design, per §7. Only `bin-api-manager`'s
+  now-provably-pointless subscription to both is removed.
 - Any change to `bin-common-handler`'s `notifyHandler.PublishEvent`/`PublishWebhookEvent` public
   signatures, or to any of the ~116 bare-`PublishEvent` call sites across ~25+ services --
   moot under the reduced scope (§4), since those events never reached a websocket client.

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -10,11 +10,12 @@ websocket client count. Chat-type events additionally pay a live `TalkV1Particip
 call per event, also unconditional.
 
 **pchero has decided**: go broker-level (RabbitMQ `fanout` -> `topic` exchange), with
-**scope-first** routing key ordering (`customer_id.<uuid>.#` / `owner_id.<uuid>.#`), explicitly
+**scope-first** routing key ordering (`customer_id.<uuid>.#` / `agent_id.<uuid>.#`), explicitly
 rejecting resource-first ordering and deferring functional sharding as out of scope. On
-2026-07-14 in further follow-up, pchero additionally decided to rename the owner-scope wire
-string from `agent_id` to `owner_id` end to end (internal routing key AND the client-facing
-public API) -- see §5.
+2026-07-14 in further follow-up, pchero considered renaming the owner-scope wire string from
+`agent_id` to `owner_id` end to end, then **reverted that decision on the same day** -- the
+wire-protocol prefix stays `agent_id` throughout (internal routing key AND the client-facing
+public API). See §5 for the (now-abandoned) rationale, kept for historical record.
 
 **This is REVISION 2 of the design, reflecting a scope-reduction decision made 2026-07-14 in
 follow-up discussion, superseding the original 8-open-question, ~25-service-blast-radius draft.**
@@ -98,20 +99,19 @@ Owner, AIcallID, ChatID}`) to extract `CustomerID`/`OwnerID`, and for
 `h.reqHandler.TalkV1ParticipantList(ctx, chatID)` to fan out a topic string per chat participant.
 
 Existing client-facing topic string format (public API contract, documented in
-`bin-api-manager/docsdev/source/websocket_overview.rst` etc. -- the `agent_id` scope prefix is
-RENAMED to `owner_id` by this design, per §5; the overall `<scope>:<scope_id>:<resource>:
-<resource_id>` shape and the `customer_id` prefix are unchanged):
+`bin-api-manager/docsdev/source/websocket_overview.rst` etc. -- UNCHANGED by this design; the
+`agent_id` scope prefix stays `agent_id`, see §5 for a rename that was considered and reverted):
 ```
 <scope>:<scope_id>:<resource>:<resource_id>
 e.g. customer_id:abc123:call:xyz789
-     agent_id:agent123:queue:*      (BEFORE this design; becomes owner_id:agent123:queue:* -- see §5)
+     agent_id:agent123:queue:*
 ```
 
 ## 3. Design goal (unchanged)
 
 Move scope-based filtering from "after full local processing, at the final ZMQ hop" to "at the
 RabbitMQ broker, before the event ever reaches a pod without a matching subscriber." A pod with
-zero clients subscribed to a given `customer_id`/`owner_id` scope should never receive, consume,
+zero clients subscribed to a given `customer_id`/`agent_id` scope should never receive, consume,
 unmarshal, or run `createTopics()`/RPC for that scope's events at all.
 
 ## 4. Reduced scope: two services only
@@ -141,18 +141,17 @@ Both already construct `wh := &webhook.Webhook{CustomerID: customerID, ...}` bef
 obtain `customer_id` for the routing key -- it is already in scope at the call site. This is
 a materially simpler starting point than the original design's ~116-site migration.
 
-**What is NOT simplified**: the owner scope (`agent_id` -> `owner_id`, see §5) and the
-chat-participant fan-out (see §6) still require moving logic that currently lives in
-`createTopics()` (consumer side) to the publisher side, because the routing key must exist at
-`channel.PublishWithContext` time.
+**What is NOT simplified**: the `agent_id`/owner scope and the chat-participant fan-out (see §6)
+still require moving logic that currently lives in `createTopics()` (consumer side) to the
+publisher side, because the routing key must exist at `channel.PublishWithContext` time.
 
-## 5. Proposed routing key format (scope-first) AND client-facing wire-protocol rename: `agent_id` -> `owner_id`
+## 5. Proposed routing key format (scope-first, unchanged from revision 1)
 
 ```
 <scope>.<scope_id>.#
 e.g. customer_id.a1b2c3d4-....call.xyz789   (as the PUBLISHED routing key)
      customer_id.a1b2c3d4-....#             (as a pod's BOUND pattern, wildcard tail)
-     owner_id.98765432-....#                (RENAMED from agent_id, see below)
+     agent_id.98765432-....#
 ```
 
 Rationale (recapped): resource_id is unknown at bind time, so any pattern putting it before the
@@ -162,92 +161,22 @@ segments (resource type + resource id), while the scope segment -- known at
 websocket-connect/subscribe time, low cardinality per pod -- does the actual filtering work at
 the trie's first level.
 
-**Scope rename decision (2026-07-14, pchero): `agent_id` becomes `owner_id`, applied end to end
--- not just the internal AMQP routing key, but the CLIENT-FACING wire protocol too (subscribe
-message topic strings, and the developer-facing RST docs). This is a deliberate breaking change
-to the public API, not an internal-only rename.**
+**`agent_id` -> `owner_id` rename: CONSIDERED AND REVERTED (2026-07-14, pchero).** A rename was
+proposed and fully speced (routing key format, `bin-api-manager`-confined blast radius across
+`createTopics()`, `validateTopics`/`validateTopic`, RST docs; a hard-cutover backward-
+compatibility decision), and passed 4 rounds of adversarial design review. **pchero reverted the
+decision on the same day: the wire-protocol prefix stays `agent_id` throughout, both the
+internal AMQP routing key and the client-facing subscribe/unsubscribe protocol.** No rename is
+in scope for this design. Rationale for keeping this note (rather than deleting the history
+entirely): the underlying `commonidentity.Owner` model (`{OwnerType, OwnerID}`, currently one
+`OwnerType` value `"agent"`) is still generically shaped even though the wire string stays
+`agent_id` -- if a future ticket revisits broadening the owner-scope wire protocol, the blast-
+radius analysis done here (confined to `bin-api-manager`: `createTopics()`, `validateTopics`/
+`validateTopic`, 2 test files, 3 RST docs) remains a valid starting point.
 
-**Why this is a natural fit, verified from source, not just naming preference:** the underlying
-data model is ALREADY generic. `commonidentity.Owner` (`bin-common-handler/models/identity/owner.go:5-8`)
-is `{OwnerType OwnerType, OwnerID uuid.UUID}`, with `OwnerType` currently having exactly one
-value, `OwnerTypeAgent = "agent"` (`owner.go:17`) -- the struct's SHAPE is already generic
-(whether or not that was the original design intent; `owner.go` itself carries no comment
-indicating forward-looking design for multiple owner types, so this is an observation about the
-current structure, not a claim about historical intent), but the wire-protocol string hardcodes
-`"agent_id"` regardless. Confirmed:
-`createTopics()` (`bin-api-manager/pkg/subscribehandler/webhookmanager.go:138,150,152,162,171`)
-already reads `d.OwnerID` (the generic field) and only hardcodes the STRING PREFIX `"agent_id"`
-when building the topic string -- the rename aligns the wire string with the model that already
-underlies it, rather than introducing new abstraction.
-
-**Verified blast radius for the rename** (grep across `bin-api-manager`, confined to this
-service -- no other service's code references the `agent_id:` wire string):
-- `bin-api-manager/pkg/subscribehandler/webhookmanager.go:138,150,152,162,171` -- `createTopics()`,
-  the 5 `fmt.Sprintf("agent_id:...", ...)` call sites generating the topic string (moves to
-  `bin-webhook-manager` per §6/§7, so this is really 5 call sites in the NEW location, not this
-  file, once §6 lands -- but the string literal itself needs updating wherever it ends up).
-- `bin-api-manager/pkg/websockhandler/etc.go:16-19,36-56,73-76,102-142` -- `validateTopics`/
-  `validateTopic`, the `case "agent_id":` branches (2 near-duplicate functions, confirmed both
-  need updating) that validate a subscribed topic's scope prefix against the authenticated
-  identity.
-- `bin-api-manager/pkg/websockhandler/etc_test.go` -- test cases using `agent_id:` literal
-  strings, need updating alongside the above.
-- `bin-api-manager/pkg/subscribehandler/webhookmanager_test.go` -- same, for `createTopics()`'s
-  tests (or their new home post-§6/§7).
-- `bin-api-manager/docsdev/source/websocket_overview.rst`,
-  `bin-api-manager/docsdev/source/websocket_struct.rst`,
-  `bin-api-manager/docsdev/source/websocket_tutorial.rst` -- developer-facing RST docs at
-  docs.voipbin.net document `agent_id:<uuid>:<resource>:<resource_id>` as a first-class example
-  topic pattern; MUST be updated per this repo's CLAUDE.md RST-sync rule ("stale docs actively
-  mislead customers"), rebuilt via `sphinx -M html`, and force-added (`build/` is gitignored).
-
-**Checked and explicitly excluded, not silently omitted**: a monorepo-wide grep for the literal
-`agent_id:` wire prefix additionally found non-code hits, none requiring action:
-- `bin-api-manager/pkg/websockhandler/subscription.go:81` and numerous similar occurrences
-  across other services (e.g. `bin-agent-manager/pkg/agenthandler/agent.go`,
-  `bin-agent-manager/pkg/agenthandler/event.go`, `bin-agent-manager/cmd/agent-control/
-  normalize_addresses.go`, `bin-call-manager/pkg/callhandler/start_incoming_domain_type_sip.go`,
-  `bin-call-manager/pkg/groupcallhandler/dial.go`, `bin-queue-manager/pkg/queuecallhandler/
-  execute.go`, and others) -- ALL of these use `agent_id` as a structured-log field label
-  (e.g. `log.Debugf("...agent_id: %s...", ...)`), not the wire-protocol prefix. This is a
-  distinct, unrelated naming pattern (log-field labels vs. topic-string prefixes) that spans
-  many services; none of it is in scope for this rename, and this doc does not attempt an
-  exhaustive enumeration of every such log statement -- the actionable blast radius for the
-  WIRE-PROTOCOL rename is confined to `bin-api-manager` (the list above), independently of how
-  many unrelated log statements elsewhere happen to share the substring `agent_id:`.
-- Repo-root `docs/plans/2026-04-02-talk-websocket-distribution-design.md` and
-  `docs/plans/2026-04-02-talk-manager-event-prefix-design.md` -- stale, historical, already-
-  implemented design docs that describe the `agent_id:...` wire format as it existed when those
-  designs shipped. These are a historical record, not live documentation (unlike the `docsdev/
-  source/*.rst` files above, which ARE the live docs.voipbin.net content) -- left as-is, not
-  updated, since retroactively editing historical design docs to reflect a later rename would
-  make them inaccurate as a historical record of what was actually decided/built at the time.
-- No hits in any OpenAPI spec file for the wire-protocol prefix (`bin-openapi-manager/openapi/
-  openapi.yaml`'s one `agent_id` occurrence is an unrelated schema field,
-  `TalkManagerMedia.type=agent`, not this topic-string prefix; `architecture_flow.rst`'s
-  `agent_id` occurrence is an unrelated JWT/auth-header example, also not the topic prefix). No
-  frontend repo hits (no square-admin/square-main directories exist in this monorepo).
-
-**Not affected**: `commonidentity.Owner`'s Go field names (`OwnerType`, `OwnerID`) are already
-correctly named and require no change; only the WIRE STRING `"agent_id"` (embedded in topic
-strings, both AMQP routing keys and the client-facing subscribe/unsubscribe protocol) is
-renamed to `"owner_id"`. `amagent.PermissionProjectSuperAdmin` and other agent-domain permission
-checks in `etc.go` are unaffected -- they gate on `AuthIdentity`'s actual agent/permission state,
-not the topic string prefix.
-
-**This is explicitly a breaking change to the public websocket API** -- any existing client
-subscribing with `agent_id:<uuid>:...` topic strings will need to migrate to `owner_id:<uuid>:...`.
-No backward-compatibility/dual-accept period is assumed in this doc; whether one is needed
-(accept both prefixes for a transition window, emit a deprecation warning, etc.) is escalated to
-Open Question 10, since this touches external API consumers, not just internal code -- a product/
-support decision, not a pure engineering one.
-
-Two scope namespaces (`customer_id`, `owner_id`) must coexist. Proposed: publish BOTH routing
-keys per event when both a customer and an owner scope apply (mirrors the existing dual-topic
-generation already done in `createTopics()` today, which already emits both `customer_id:...`
-and the soon-to-be-renamed owner-scope topic strings for the same event where applicable -- this
-is not new complexity, just moving existing dual-key generation earlier in the pipeline, plus
-the rename above).
+Two scope namespaces (`customer_id`, `agent_id`) must coexist; a single event may need to be
+published under BOTH routing keys (mirrors the existing dual topic-string generation already
+done in `createTopics()` today for `customer_id:...` and `agent_id:...`).
 
 ## 6. Who computes the routing key: moves into bin-webhook-manager (computation), notifyHandler (publish mechanism)
 
@@ -320,17 +249,16 @@ resolved definitively in this doc -- (b) is not disqualified, just not preferred
 (§4) -- computing `customer_id.<customerID>.#`-shaped keys requires no new plumbing for that
 scope alone.
 
-**Harder part 1 -- owner scope extraction (`agent_id` -> `owner_id`)**: today's `createTopics()`
-unmarshals the event `data` payload (via the nested `Webhook.Data` -> `Data.Data` ->
-`commonWebhookData{Owner}` envelope) to find `OwnerID` for the owner-scope routing key.
-`SendWebhookToCustomer`/`SendWebhookToURI` receive `data json.RawMessage` as an opaque blob
-(`webhook.go:26,120`) -- they do not know the owner ID structurally, only that it may be present
-somewhere inside `data`'s nested JSON. **This requires porting the SAME nested-unmarshal logic
+**Harder part 1 -- `agent_id`/owner scope extraction**: today's `createTopics()` unmarshals the
+event `data` payload (via the nested `Webhook.Data` -> `Data.Data` -> `commonWebhookData{Owner}`
+envelope) to find `OwnerID` for the `agent_id:...` routing key. `SendWebhookToCustomer`/
+`SendWebhookToURI` receive `data json.RawMessage` as an opaque blob (`webhook.go:26,120`) --
+they do not know the owner/agent ID structurally, only that it may be present somewhere inside
+`data`'s nested JSON. **This requires porting the SAME nested-unmarshal logic
 (`commonWebhookData` struct, currently in `bin-api-manager/pkg/subscribehandler/webhookmanager.go`)
 into `bin-webhook-manager`**, run against `data` before publish, to extract `OwnerID` the same
-way `createTopics()` does today, and emitting the RENAMED `owner_id:...` prefix (§5) rather than
-today's `agent_id:...`. This is a genuine, non-trivial logic move (not just a signature change),
-but it is confined to `bin-webhook-manager`, not spread across ~25 services.
+way `createTopics()` does today. This is a genuine, non-trivial logic move (not just a signature
+change), but it is confined to `bin-webhook-manager`, not spread across ~25 services.
 
 **Symmetry note, verified**: both `SendWebhookToCustomer` and `SendWebhookToURI` construct an
 identical `wh := &webhook.Webhook{...}` before calling `notifyHandler.PublishEvent` (lines
@@ -343,8 +271,8 @@ functions, not duplicated per call site.
 **Harder part 2 -- chat participant fan-out RPC moves to the publish path**: for
 `chat`/`chatmessage`/`chatparticipant` resource types, `createTopics()` today calls
 `h.reqHandler.TalkV1ParticipantList(ctx, chatID)` (`webhookmanager.go:143`) AFTER receiving the
-event, to generate one `agent_id:<participant>:chat:...` (becoming `owner_id:<participant>:
-chat:...`, per §5) routing key per chat participant. Moving this to webhook-manager means:
+event, to generate one `agent_id:<participant>:chat:...` routing key per chat participant. Moving
+this to webhook-manager means:
 - `webhook-manager`'s `webhookHandler` struct (`pkg/webhookhandler/main.go:32-40`) does NOT
   currently hold a `reqHandler requesthandler.RequestHandler` dependency -- verified by reading
   the struct definition. **A new dependency injection is required** (constructor signature
@@ -429,11 +357,11 @@ Proposed path (skeleton, not a finalized runbook):
 ## 9. Dynamic bind/unbind at the api-manager side (unchanged from revision 1)
 
 Unlike today (bind once at pod boot, for the pod's whole lifetime), a topic-exchange scoped
-binding must track which scopes (`customer_id`/`owner_id` values) currently have at least one
+binding must track which scopes (`customer_id`/`agent_id` values) currently have at least one
 live local websocket subscriber on that pod, and bind/unbind the per-pod queue accordingly:
 
 - On a client's first `subscribe` message for a new scope on that pod: bind
-  `customer_id.<uuid>.#` (or `owner_id.<uuid>.#`) to the pod's queue.
+  `customer_id.<uuid>.#` (or `agent_id.<uuid>.#`) to the pod's queue.
 - On the last client unsubscribing from / disconnecting from a scope on that pod: unbind.
 - **Reference counting required**: multiple local connections (or multiple topic subscriptions
   from the same connection) can share a scope; only unbind when the count reaches zero.
@@ -464,11 +392,10 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
 - Functional sharding / resource-type-dedicated api-manager pod pools.
 - Application-level zero-subscriber short-circuit ("Alternative B" in prior discussion) -- not
   adopted as a substitute; may be worth layering in later as defense in depth.
-- Any OTHER change to the client-facing websocket subscribe/unsubscribe wire protocol beyond the
-  `agent_id` -> `owner_id` rename (§5) -- the overall `<scope>:<scope_id>:<resource>:
-  <resource_id>` shape, the `customer_id` prefix, and all other subscribe/unsubscribe message
-  semantics are unchanged; this design does not touch the client-facing protocol structure, only
-  the internal AMQP transport layer PLUS this one specific, deliberate rename.
+- Any change to the client-facing websocket subscribe/unsubscribe wire protocol or topic string
+  format -- this design only changes the internal AMQP transport layer; the public API contract
+  is unchanged. (An `agent_id` -> `owner_id` rename was considered and REVERTED, see §5 -- the
+  `agent_id` prefix stays as-is.)
 - **`QueueNameAgentEvent` and `QueueNameTalkEvent` exchanges and their existing publishers/
   consumers** (`bin-agent-manager` publishes to `QueueNameAgentEvent`, `bin-queue-manager`
   consumes it; `bin-talk-manager` publishes to `QueueNameTalkEvent`, `bin-timeline-manager`
@@ -530,14 +457,13 @@ live local websocket subscriber on that pod, and bind/unbind the per-pod queue a
    the `go generate`-regenerated mock -- not a broad blast radius, but should still be confirmed
    as part of the standard verification workflow (`go generate ./... && go test ./...`) rather
    than assumed.
-10. **(New) `agent_id` -> `owner_id` backward compatibility -- RESOLVED (pchero, 2026-07-14):
-    hard cutover.** No transitional dual-accept period. `owner_id:...` is the only prefix
-    supported from the moment this ships; existing clients subscribing with `agent_id:...` break
-    immediately on deploy. Rationale: no external customers currently depend on the
-    `agent_id:...` wire format (internal/beta usage only at this stage). Consequence for
-    implementation: `validateTopics`/`validateTopic` (`bin-api-manager/pkg/websockhandler/etc.go`)
-    only need the `case "owner_id":` branch added/renamed -- no dual-prefix acceptance logic, no
-    deprecation-window bookkeeping, no follow-up removal task. Should still be called out in the
-    PR description and release notes as a breaking change to the public websocket API, and
-    confirmed with support/product before deploy that no known external client depends on
-    `agent_id:...` today.
+10. **(New) `agent_id` -> `owner_id` rename -- CONSIDERED AND REVERTED (pchero, 2026-07-14).**
+    A rename with a hard-cutover backward-compatibility policy (no dual-accept period) was
+    speced, and the wire-protocol prefix decision passed 4 rounds of adversarial design review
+    before pchero reverted it the same day. **No rename is in scope. `validateTopics`/
+    `validateTopic` (`bin-api-manager/pkg/websockhandler/etc.go`) keep their existing
+    `case "agent_id":` branches unchanged.** This item is retained (rather than deleted) purely
+    as a pointer to the reverted history, in case a future ticket revisits broadening the
+    owner-scope wire protocol -- the blast-radius analysis from that reverted proposal
+    (`createTopics()`, `validateTopics`/`validateTopic`, 2 test files, 3 RST docs, all confined
+    to `bin-api-manager`) remains a valid starting point if picked up again later.

--- a/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
+++ b/bin-api-manager/docs/plans/2026-07-14-voip-1258-topic-exchange-scoped-routing-design.md
@@ -201,12 +201,20 @@ service -- no other service's code references the `agent_id:` wire string):
   topic pattern; MUST be updated per this repo's CLAUDE.md RST-sync rule ("stale docs actively
   mislead customers"), rebuilt via `sphinx -M html`, and force-added (`build/` is gitignored).
 
-**Checked and explicitly excluded, not silently omitted**: a fresh monorepo-wide grep for the
-literal `agent_id:` wire prefix additionally found two categories of non-code hits, neither
-requiring action:
-- `bin-api-manager/pkg/websockhandler/subscription.go:81` -- a log message
-  (`log.Debugf("Websocket connection has been closed. agent_id: %s", ...)`) using `agent_id` as
-  a structured-log field label, not the wire-protocol prefix. No rename needed; unrelated usage.
+**Checked and explicitly excluded, not silently omitted**: a monorepo-wide grep for the literal
+`agent_id:` wire prefix additionally found non-code hits, none requiring action:
+- `bin-api-manager/pkg/websockhandler/subscription.go:81` and numerous similar occurrences
+  across other services (e.g. `bin-agent-manager/pkg/agenthandler/agent.go`,
+  `bin-agent-manager/pkg/agenthandler/event.go`, `bin-agent-manager/cmd/agent-control/
+  normalize_addresses.go`, `bin-call-manager/pkg/callhandler/start_incoming_domain_type_sip.go`,
+  `bin-call-manager/pkg/groupcallhandler/dial.go`, `bin-queue-manager/pkg/queuecallhandler/
+  execute.go`, and others) -- ALL of these use `agent_id` as a structured-log field label
+  (e.g. `log.Debugf("...agent_id: %s...", ...)`), not the wire-protocol prefix. This is a
+  distinct, unrelated naming pattern (log-field labels vs. topic-string prefixes) that spans
+  many services; none of it is in scope for this rename, and this doc does not attempt an
+  exhaustive enumeration of every such log statement -- the actionable blast radius for the
+  WIRE-PROTOCOL rename is confined to `bin-api-manager` (the list above), independently of how
+  many unrelated log statements elsewhere happen to share the substring `agent_id:`.
 - Repo-root `docs/plans/2026-04-02-talk-websocket-distribution-design.md` and
   `docs/plans/2026-04-02-talk-manager-event-prefix-design.md` -- stale, historical, already-
   implemented design docs that describe the `agent_id:...` wire format as it existed when those
@@ -216,8 +224,9 @@ requiring action:
   make them inaccurate as a historical record of what was actually decided/built at the time.
 - No hits in any OpenAPI spec file for the wire-protocol prefix (`bin-openapi-manager/openapi/
   openapi.yaml`'s one `agent_id` occurrence is an unrelated schema field,
-  `TalkManagerMedia.type=agent`, not this topic-string prefix). No frontend repo hits (no
-  square-admin/square-main directories exist in this monorepo).
+  `TalkManagerMedia.type=agent`, not this topic-string prefix; `architecture_flow.rst`'s
+  `agent_id` occurrence is an unrelated JWT/auth-header example, also not the topic prefix). No
+  frontend repo hits (no square-admin/square-main directories exist in this monorepo).
 
 **Not affected**: `commonidentity.Owner`'s Go field names (`OwnerType`, `OwnerID`) are already
 correctly named and require no change; only the WIRE STRING `"agent_id"` (embedded in topic

--- a/bin-api-manager/pkg/subscribehandler/main.go
+++ b/bin-api-manager/pkg/subscribehandler/main.go
@@ -98,6 +98,27 @@ func (h *subscribeHandler) Run() error {
 		}
 	}
 
+	// baseline "#" wildcard binding to the new topic exchange (VOIP-1258 §7 round-2 finding):
+	// a topic-kind exchange's empty-key bind (what QueueSubscribe used for the old fanout
+	// exchange) only matches messages published with an empty routing key, and every
+	// VOIP-1258 publish path uses non-empty scope-first keys, so this pod would receive ZERO
+	// events without this explicit bind.
+	//
+	// CRITICAL: this MUST run synchronously here, BEFORE ConsumeMessage is started below (not
+	// after Run() returns, as it originally lived in cmd/api-manager/main.go). QueueBind and
+	// ConsumeMessage's internal channel.Consume() share the SAME underlying AMQP channel
+	// object (rabbitmqhandler's queue.channel) for a given queue name. AMQP does not allow two
+	// synchronous RPCs to race on one channel -- if ConsumeMessage's basic.consume is already
+	// in flight on another goroutine when QueueBind fires, the broker closes the channel with
+	// "unexpected command received" (503), and ConsumeMessage fails to ever start consuming on
+	// this pod. This exact race was reproduced in production in bin-agent-manager (VOIP-1258 PR
+	// #1101 round-2 post-deploy verification, 2026-07-14) via the identical after-Run() call
+	// site pattern that this file also originally used -- fixed here proactively for the same
+	// reason before it recurs on this service too.
+	if err := h.sockHandler.QueueBind(h.subscribeQueueNamePod, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); err != nil {
+		log.Errorf("Could not bind to the topic exchange. err: %v", err)
+	}
+
 	// receive subscribe events
 	go func() {
 		if errConsume := h.sockHandler.ConsumeMessage(context.Background(), h.subscribeQueueNamePod, string(commonoutline.ServiceNameAPIManager), false, false, false, 10, h.processEventRun); errConsume != nil {

--- a/bin-api-manager/pkg/subscribehandler/main.go
+++ b/bin-api-manager/pkg/subscribehandler/main.go
@@ -152,15 +152,37 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 
 	switch {
 
-	//// webhook-manager
+	//// webhook-manager: OLD fanout path -- the wrapped {"type":"webhook_published","data":
+	//// {"type":<resource event type>,"data":{...}}} envelope, still dual-published until
+	//// Task 4.6's cutover.
 	case m.Publisher == string(commonoutline.ServiceNameWebhookManager) && (m.Type == string(wmwebhook.EventTypeWebhookPublished)):
 		err = h.processEventWebhookManagerWebhookPublished(ctx, m)
+
+	//// webhook-manager: NEW topic-exchange routing-keyed path (VOIP-1258 §6/§8). Published via
+	//// PublishEventWithRoutingKey with the REAL resource event type as m.Type (e.g.
+	//// "call_created") and the UNWRAPPED resource object as m.Data (bin-webhook-manager's
+	//// publishRoutingKeyedEvent already did the envelope unwrap at publish time -- see that
+	//// function's doc comment). This is NOT the same shape as the fanout path above (which is
+	//// still the doubly-wrapped envelope), so it needs its own handler, not reuse of
+	//// processEventWebhookManagerWebhookPublished (which expects the wrapped shape and would
+	//// fail to unmarshal this one correctly).
+	////
+	//// CRITICAL (production bug found 2026-07-15, post-envelope-fix verification): before this
+	//// case existed, every event arriving via the new topic exchange had m.Type set to the real
+	//// resource event type (never "webhook_published"), so it always fell through to `default:
+	//// return` below and was silently discarded -- the AMQP message reached this pod's queue
+	//// correctly (confirmed via RabbitMQ queue/binding inspection) but was never handed to
+	//// zmqpubHandler.Publish, so it never reached the browser's websocket. This is why the
+	//// AMQP-level fix (envelope unwrapping in bin-webhook-manager) alone was insufficient --
+	//// the consumer side needed a matching case for the new event shape.
+	case m.Publisher == string(commonoutline.ServiceNameWebhookManager) && (m.Type != string(wmwebhook.EventTypeWebhookPublished)):
+		err = h.processEventWebhookManagerRoutingKeyedEvent(ctx, m)
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	// No handler found
 	/////////////////////////////////////////////////////////////////////////////////////////////////
 	default:
-		// ignore the event
+		// ignore the event.
 		return
 	}
 	elapsed := time.Since(start)

--- a/bin-api-manager/pkg/subscribehandler/run_test.go
+++ b/bin-api-manager/pkg/subscribehandler/run_test.go
@@ -34,17 +34,23 @@ func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
 	queueName := "bin-manager.api-manager.subscribe-test-pod"
 	subscribeTargets := []string{}
 
-	var callOrder []string
+	// callOrderCh, not a shared slice: QueueBind runs synchronously on the caller's goroutine,
+	// but ConsumeMessage's callback runs on Run()'s internal goroutine. A plain
+	// `var callOrder []string` appended from both would be a data race (caught by `-race`,
+	// intermittently) -- exactly the bug class this production fix addresses, ironically
+	// reintroduced in the test harness in an earlier version of this test. Use a buffered
+	// channel instead, matching bin-timeline-manager's Test_Run_BindsTopicExchangeBeforeConsuming.
+	callOrderCh := make(chan string, 4)
 
 	mockSock.EXPECT().QueueCreate(queueName, "volatile").Return(nil)
 	mockSock.EXPECT().QueueBind(queueName, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil).
 		DoAndReturn(func(_, _, _ string, _ bool, _ interface{}) error {
-			callOrder = append(callOrder, "QueueBind")
+			callOrderCh <- "QueueBind"
 			return nil
 		})
 	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, gomock.Any(), false, false, false, 10, gomock.Any()).
 		DoAndReturn(func(_, _, _ interface{}, _, _, _ bool, _ int, _ interface{}) error {
-			callOrder = append(callOrder, "ConsumeMessage")
+			callOrderCh <- "ConsumeMessage"
 			return nil
 		}).AnyTimes()
 
@@ -52,6 +58,19 @@ func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
 
 	if err := h.Run(); err != nil {
 		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+
+	// Drain whatever has arrived so far without closing the channel -- ConsumeMessage's mock
+	// may still be in flight on its own goroutine and could send after we're done reading.
+	var callOrder []string
+	draining := true
+	for draining {
+		select {
+		case c := <-callOrderCh:
+			callOrder = append(callOrder, c)
+		default:
+			draining = false
+		}
 	}
 
 	foundBind := false

--- a/bin-api-manager/pkg/subscribehandler/run_test.go
+++ b/bin-api-manager/pkg/subscribehandler/run_test.go
@@ -1,0 +1,69 @@
+package subscribehandler
+
+import (
+	"testing"
+
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"monorepo/bin-api-manager/pkg/zmqpubhandler"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+// Test_Run_BindsTopicExchangeBeforeReturning is a regression test for a production incident
+// (VOIP-1258 PR #1101, bin-agent-manager, found during post-deploy verification 2026-07-14,
+// fixed in commit ca8c104a9 and proactively applied here too): QueueBind for the topic-exchange
+// baseline "#" wildcard MUST complete synchronously inside Run(), before the async
+// ConsumeMessage goroutine is started. QueueBind and ConsumeMessage's internal
+// channel.Consume() share the same underlying AMQP channel for a given queue name; if a caller
+// invoked QueueBind AFTER Run() returns (as this code originally did, from
+// cmd/api-manager/main.go), it races the already-started basic.consume RPC on the same channel
+// and the broker can close the channel with "unexpected command received" (503) -- silently
+// preventing that pod from ever consuming events. This test asserts the ordering: QueueBind
+// must be called before ConsumeMessage is observed.
+func Test_Run_BindsTopicExchangeBeforeReturning(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockZmq := zmqpubhandler.NewMockZMQPubHandler(mc)
+
+	queueName := "bin-manager.api-manager.subscribe-test-pod"
+	subscribeTargets := []string{}
+
+	var callOrder []string
+
+	mockSock.EXPECT().QueueCreate(queueName, "volatile").Return(nil)
+	mockSock.EXPECT().QueueBind(queueName, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil).
+		DoAndReturn(func(_, _, _ string, _ bool, _ interface{}) error {
+			callOrder = append(callOrder, "QueueBind")
+			return nil
+		})
+	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, gomock.Any(), false, false, false, 10, gomock.Any()).
+		DoAndReturn(func(_, _, _ interface{}, _, _, _ bool, _ int, _ interface{}) error {
+			callOrder = append(callOrder, "ConsumeMessage")
+			return nil
+		}).AnyTimes()
+
+	h := NewSubscribeHandler(mockSock, mockReq, queueName, subscribeTargets, mockZmq)
+
+	if err := h.Run(); err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+
+	foundBind := false
+	for _, c := range callOrder {
+		if c == "QueueBind" {
+			foundBind = true
+		}
+		if c == "ConsumeMessage" && !foundBind {
+			t.Fatalf("ConsumeMessage was observed before QueueBind completed -- ordering regression. callOrder: %v", callOrder)
+		}
+	}
+	if !foundBind {
+		t.Errorf("Expected QueueBind to have been called synchronously within Run(), callOrder: %v", callOrder)
+	}
+}

--- a/bin-api-manager/pkg/subscribehandler/webhookmanager.go
+++ b/bin-api-manager/pkg/subscribehandler/webhookmanager.go
@@ -103,6 +103,57 @@ func (h *subscribeHandler) processEventWebhookManagerWebhookPublished(ctx contex
 	return nil
 }
 
+// processEventWebhookManagerRoutingKeyedEvent handles events arriving via the NEW topic
+// exchange (VOIP-1258 §6/§8), published by bin-webhook-manager's publishRoutingKeyedEvent. Unlike
+// processEventWebhookManagerWebhookPublished above, m.Data here is ALREADY the unwrapped resource
+// object (bin-webhook-manager did the envelope unwrap at publish time), and m.Type is the REAL
+// resource event type (e.g. "call_created"), not the fixed "webhook_published" constant. This
+// function mirrors createTopics()'s topic-string generation so ZMQ SUB clients (which subscribe
+// using the OLD-FORMAT prefix, e.g. "customer_id:<id>:call") continue to receive these events
+// exactly as they did via the old fanout path -- see this file's createTopics for the format.
+func (h *subscribeHandler) processEventWebhookManagerRoutingKeyedEvent(ctx context.Context, m *sock.Event) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":  "processEventWebhookManagerRoutingKeyedEvent",
+		"event": m,
+	})
+	log.Debugf("Received routing-keyed event. type: %s", m.Type)
+
+	d := &commonWebhookData{}
+	if err := json.Unmarshal(m.Data, d); err != nil {
+		log.Errorf("Could not unmarshal the resource data. err: %v", err)
+		return err
+	}
+
+	// resource is the same first-underscore-segment used by bin-webhook-manager's
+	// publishRoutingKeyedEvent to build the routing key (e.g. "call" from "call_created"), and
+	// happens to already match this file's getServiceNamespace() output for the corresponding
+	// publisher (e.g. "call-manager" -> "call") -- use it directly as the service namespace
+	// instead of trying to recover the original publisher name, which is not preserved on this
+	// path (m.Publisher is always "webhook-manager" here, since that's who republished it).
+	tmps := strings.SplitN(m.Type, "_", 2)
+	if len(tmps) < 2 {
+		log.Errorf("Wrong event type format. event_type: %s", m.Type)
+		return fmt.Errorf("wrong event type format. event_type: %s", m.Type)
+	}
+	resource := tmps[0]
+
+	topics, err := h.createTopics(ctx, m.Type, d, resource)
+	if err != nil {
+		log.Errorf("Could not create the topics. err: %v", err)
+		return fmt.Errorf("could not create the topics")
+	}
+	log.Debugf("Created topics. topics: %s", topics)
+
+	for _, topic := range topics {
+		if errPub := h.zmqpubHandler.Publish(topic, string(m.Data)); errPub != nil {
+			log.Errorf("Could not publish the event. err: %v", errPub)
+			return errPub
+		}
+	}
+
+	return nil
+}
+
 // createTopics generates the topics
 func (h *subscribeHandler) createTopics(ctx context.Context, messageType string, d *commonWebhookData, publisher string) ([]string, error) {
 

--- a/bin-api-manager/pkg/subscribehandler/webhookmanager_test.go
+++ b/bin-api-manager/pkg/subscribehandler/webhookmanager_test.go
@@ -636,3 +636,77 @@ func Test_createTopics(t *testing.T) {
 		})
 	}
 }
+
+// Test_processEventWebhookManagerRoutingKeyedEvent is a regression test for a production bug
+// found 2026-07-15 (post-envelope-fix verification): events arriving via the NEW topic exchange
+// (m.Publisher == "webhook-manager", m.Type == the REAL resource event type e.g. "call_created")
+// were silently discarded by processEvent's switch statement, which only matched
+// m.Type == "webhook_published" (the OLD fanout path's fixed constant). The AMQP message reached
+// this pod's queue correctly, but was never handed to zmqpubHandler.Publish, so it never reached
+// a connected websocket client. This test asserts the new case actually publishes the topics a
+// real websocket client would have subscribed to (the OLD-FORMAT prefix, e.g.
+// "customer_id:<id>:call", which zmqSub.Subscribe uses as a ZMQ prefix filter).
+func Test_processEventWebhookManagerRoutingKeyedEvent(t *testing.T) {
+	customerID := uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b")
+	ownerID := uuid.FromStringOrNil("62005165-7592-4ff7-9076-55bf491023f2")
+	callID := uuid.FromStringOrNil("d499c4f4-2f07-488b-a5f7-4b49c00e9a2a")
+
+	// m.Data here is the ALREADY-UNWRAPPED resource object (bin-webhook-manager's
+	// publishRoutingKeyedEvent does the envelope unwrap at publish time) -- NOT the doubly-nested
+	// {"type":...,"data":...} envelope that processEventWebhookManagerWebhookPublished expects.
+	data := json.RawMessage(fmt.Sprintf(
+		`{"id":"%s","customer_id":"%s","owner_id":"%s","owner_type":"agent"}`,
+		callID, customerID, ownerID,
+	))
+
+	event := &sock.Event{
+		Type:      "call_created",
+		Publisher: "webhook-manager",
+		DataType:  "application/json",
+		Data:      data,
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockZMQ := zmqpubhandler.NewMockZMQPubHandler(mc)
+	h := &subscribeHandler{zmqpubHandler: mockZMQ}
+
+	expectedOldFormatCustomerTopic := fmt.Sprintf("customer_id:%s:call:%s", customerID, callID)
+	expectedOldFormatOwnerTopic := fmt.Sprintf("agent_id:%s:call:%s", ownerID, callID)
+
+	mockZMQ.EXPECT().Publish(expectedOldFormatCustomerTopic, string(data)).Return(nil)
+	mockZMQ.EXPECT().Publish(expectedOldFormatOwnerTopic, string(data)).Return(nil)
+	// NEW format topics also get published (createTopics always emits both) -- accept any
+	// remaining Publish calls for those, this test's focus is the OLD-FORMAT compatibility.
+	mockZMQ.EXPECT().Publish(gomock.Any(), string(data)).Return(nil).AnyTimes()
+
+	err := h.processEventWebhookManagerRoutingKeyedEvent(context.Background(), event)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+// Test_processEventWebhookManagerRoutingKeyedEvent_WrongEventTypeFormat verifies the error path:
+// an event type with no underscore segment cannot be split into a resource/verb pair and must
+// return an error rather than silently producing zero topics.
+func Test_processEventWebhookManagerRoutingKeyedEvent_WrongEventTypeFormat(t *testing.T) {
+	event := &sock.Event{
+		Type:      "malformed",
+		Publisher: "webhook-manager",
+		DataType:  "application/json",
+		Data:      json.RawMessage(`{"id":"9d0966c0-da98-11ee-97df-1786497422fb"}`),
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockZMQ := zmqpubhandler.NewMockZMQPubHandler(mc)
+	h := &subscribeHandler{zmqpubHandler: mockZMQ}
+	// No Publish call expected at all.
+
+	err := h.processEventWebhookManagerRoutingKeyedEvent(context.Background(), event)
+	if err == nil {
+		t.Error("Expected an error for a malformed event type, got nil")
+	}
+}

--- a/bin-api-manager/pkg/websockhandler/bindpattern.go
+++ b/bin-api-manager/pkg/websockhandler/bindpattern.go
@@ -1,0 +1,18 @@
+package websockhandler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// topicToBindPattern converts a client-facing subscribe topic string (colon-delimited,
+// "<scope>:<scope_id>:<resource>:<resource_id_or_*>") to the AMQP binding pattern
+// (dot-delimited, "<scope>.<scope_id>.#") used for scope-first topic exchange binding.
+// See VOIP-1258 design doc §5.
+func topicToBindPattern(topic string) (string, error) {
+	tmps := strings.Split(topic, ":")
+	if len(tmps) < 2 {
+		return "", fmt.Errorf("invalid topic format: %s", topic)
+	}
+	return fmt.Sprintf("%s.%s.#", tmps[0], tmps[1]), nil
+}

--- a/bin-api-manager/pkg/websockhandler/bindpattern_test.go
+++ b/bin-api-manager/pkg/websockhandler/bindpattern_test.go
@@ -1,0 +1,28 @@
+package websockhandler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicToBindPattern(t *testing.T) {
+	cases := []struct {
+		topic    string
+		expected string
+	}{
+		{"customer_id:abc123:call:*", "customer_id.abc123.#"},
+		{"agent_id:def456:queue:*", "agent_id.def456.#"},
+		{"customer_id:abc123", "customer_id.abc123.#"},
+	}
+	for _, c := range cases {
+		got, err := topicToBindPattern(c.topic)
+		require.NoError(t, err)
+		require.Equal(t, c.expected, got)
+	}
+}
+
+func TestTopicToBindPattern_InvalidFormat(t *testing.T) {
+	_, err := topicToBindPattern("invalidtopic")
+	require.Error(t, err)
+}

--- a/bin-api-manager/pkg/websockhandler/main.go
+++ b/bin-api-manager/pkg/websockhandler/main.go
@@ -9,7 +9,9 @@ import (
 	"monorepo/bin-api-manager/pkg/streamhandler"
 	cmexternalmedia "monorepo/bin-call-manager/models/externalmedia"
 
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
 
 	"monorepo/bin-api-manager/models/auth"
 
@@ -30,14 +32,21 @@ var upgrader = websocket.Upgrader{
 type websockHandler struct {
 	reqHandler    requesthandler.RequestHandler
 	streamHandler streamhandler.StreamHandler
+	scopeRefCount *scopeRefCount // shared across all connections on this pod
 }
 
 // NewWebsockHandler creates a new HookHandler
-func NewWebsockHandler(reqHandler requesthandler.RequestHandler, streamHandler streamhandler.StreamHandler) WebsockHandler {
+func NewWebsockHandler(
+	reqHandler requesthandler.RequestHandler,
+	streamHandler streamhandler.StreamHandler,
+	sockHandler sockhandler.SockHandler,
+	queueNamePod string,
+) WebsockHandler {
 
 	res := &websockHandler{
 		reqHandler:    reqHandler,
 		streamHandler: streamHandler,
+		scopeRefCount: newScopeRefCount(sockHandler, queueNamePod, string(commonoutline.QueueNameWebhookEventTopic)),
 	}
 
 	endpointInit()

--- a/bin-api-manager/pkg/websockhandler/scoperefcount.go
+++ b/bin-api-manager/pkg/websockhandler/scoperefcount.go
@@ -1,0 +1,75 @@
+package websockhandler
+
+import (
+	"sync"
+
+	"monorepo/bin-common-handler/pkg/sockhandler"
+)
+
+// scopeRefCount tracks, per api-manager pod, how many local websocket connections currently
+// have at least one active subscription for each AMQP binding pattern (e.g.
+// "customer_id.<uuid>.#"), and binds/unbinds the pod's per-pod queue accordingly. This is the
+// component that makes the fanout->topic conversion actually reduce per-pod processing: a scope
+// with zero local subscribers is never bound, so the broker never delivers it to this pod.
+// See VOIP-1258 design doc §9.
+type scopeRefCount struct {
+	mu       sync.Mutex
+	counts   map[string]int // binding pattern -> active subscriber count
+	sock     sockhandler.SockHandler
+	queue    string
+	exchange string
+}
+
+func newScopeRefCount(sock sockhandler.SockHandler, queueName string, exchangeName string) *scopeRefCount {
+	return &scopeRefCount{
+		counts:   make(map[string]int),
+		sock:     sock,
+		queue:    queueName,
+		exchange: exchangeName,
+	}
+}
+
+// Acquire increments the refcount for the given binding pattern, binding the queue on the
+// first (0->1) transition.
+func (r *scopeRefCount) Acquire(pattern string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.counts[pattern] == 0 {
+		if err := r.sock.QueueBind(r.queue, pattern, r.exchange, false, nil); err != nil {
+			return err
+		}
+	}
+	r.counts[pattern]++
+	return nil
+}
+
+// Release decrements the refcount for the given binding pattern, unbinding the queue on the
+// last (1->0) transition. No-op (not an error) if the pattern isn't currently tracked, to
+// tolerate double-release from racing cleanup paths (explicit unsubscribe + abrupt disconnect).
+func (r *scopeRefCount) Release(pattern string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.counts[pattern] <= 0 {
+		return nil
+	}
+	r.counts[pattern]--
+	if r.counts[pattern] == 0 {
+		delete(r.counts, pattern)
+		if err := r.sock.QueueUnbind(r.queue, pattern, r.exchange, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReleaseAll releases every currently-held pattern for this connection's tracked set. Used on
+// abrupt disconnect (VOIP-1258 §9) where no per-topic unsubscribe message was received. Callers
+// must pass the SET of patterns this specific connection held (tracked separately per
+// connection, not by scopeRefCount itself -- see Task 4.3).
+func (r *scopeRefCount) ReleaseAll(patterns []string) {
+	for _, p := range patterns {
+		_ = r.Release(p) // best-effort; log at call site if needed
+	}
+}

--- a/bin-api-manager/pkg/websockhandler/scoperefcount_test.go
+++ b/bin-api-manager/pkg/websockhandler/scoperefcount_test.go
@@ -1,0 +1,83 @@
+package websockhandler
+
+import (
+	"testing"
+
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	gomock "go.uber.org/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeRefCount_BindOnFirstSubscribe(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	rc := newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic")
+
+	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.abc.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+
+	err := rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+}
+
+func TestScopeRefCount_NoRebindOnSecondSubscribe(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	rc := newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic")
+
+	// QueueBind should only be called once, on the first Acquire.
+	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.abc.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil).Times(1)
+
+	err := rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+
+	err = rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+}
+
+func TestScopeRefCount_UnbindOnLastRelease(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	rc := newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic")
+
+	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.abc.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+	mockSock.EXPECT().QueueUnbind("pod-queue-1", "customer_id.abc.#", "bin-manager.webhook-manager.event.topic", nil).Return(nil)
+
+	err := rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+
+	err = rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+
+	err = rc.Release("customer_id.abc.#")
+	require.NoError(t, err)
+
+	err = rc.Release("customer_id.abc.#")
+	require.NoError(t, err)
+}
+
+func TestScopeRefCount_NoUnbindWhileRefsRemain(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	rc := newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic")
+
+	// QueueUnbind must NOT be called since only one of the two acquired refs is released.
+	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.abc.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil).Times(1)
+
+	err := rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+
+	err = rc.Acquire("customer_id.abc.#")
+	require.NoError(t, err)
+
+	err = rc.Release("customer_id.abc.#")
+	require.NoError(t, err)
+}

--- a/bin-api-manager/pkg/websockhandler/subscription.go
+++ b/bin-api-manager/pkg/websockhandler/subscription.go
@@ -70,10 +70,15 @@ func (h *websockHandler) subscriptionRun(ctx context.Context, w http.ResponseWri
 	defer zmqSub.Terminate()
 	log.Debugf("Created a new subscribe socket correctly.")
 
-	// heldPatterns tracks the AMQP binding patterns THIS connection currently holds, so we can
-	// release everything on abrupt disconnect (no explicit unsubscribe received) via
-	// scopeRefCount.ReleaseAll below. See VOIP-1258 §9 / Task 4.3.
-	heldPatterns := make(map[string]bool)
+	// heldPatterns tracks, per AMQP binding pattern, how many times THIS connection has
+	// Acquire()d it (a double-subscribe to the same topic without an intervening unsubscribe
+	// legitimately calls scopeRefCount.Acquire twice). This MUST be a counter, not a boolean
+	// set: with a boolean set, a double-subscribe followed by a single unsubscribe would
+	// delete the pattern from this connection's held set entirely while scopeRefCount's
+	// internal refcount is still at 1, so ReleaseAll on abrupt disconnect would never release
+	// it again -- a permanent per-scope bind leak until pod restart. See VOIP-1258 §9 / Task
+	// 4.3 (leak found and fixed during PR #1101 round-2 review).
+	heldPatterns := make(map[string]int)
 	var heldMu sync.Mutex
 
 	// we are creating a new context and cancel using the http request.
@@ -87,11 +92,15 @@ func (h *websockHandler) subscriptionRun(ctx context.Context, w http.ResponseWri
 	log.Debugf("Websocket connection has been closed. agent_id: %s", a.AgentID())
 
 	// abrupt-disconnect cleanup -- release everything this connection held, regardless of
-	// whether an explicit unsubscribe message was ever received.
+	// whether an explicit unsubscribe message was ever received. Release once per
+	// outstanding Acquire (heldPatterns is a count, not a boolean) so a double-subscribed
+	// pattern is fully released, not left at refcount 1 forever.
 	heldMu.Lock()
 	patterns := make([]string, 0, len(heldPatterns))
-	for p := range heldPatterns {
-		patterns = append(patterns, p)
+	for p, count := range heldPatterns {
+		for i := 0; i < count; i++ {
+			patterns = append(patterns, p)
+		}
 	}
 	heldMu.Unlock()
 	h.scopeRefCount.ReleaseAll(patterns)
@@ -125,7 +134,7 @@ func (h *websockHandler) subscriptionRunWebsock(
 	a *auth.AuthIdentity,
 	ws *websocket.Conn,
 	zmqSub zmqsubhandler.ZMQSubHandler,
-	heldPatterns map[string]bool,
+	heldPatterns map[string]int,
 	heldMu *sync.Mutex,
 ) {
 	log := logrus.WithFields(logrus.Fields{
@@ -163,7 +172,7 @@ func (h *websockHandler) subscriptionHandleMessage(
 	a *auth.AuthIdentity,
 	zmqSub zmqsubhandler.ZMQSubHandler,
 	m *hook.Hook,
-	heldPatterns map[string]bool,
+	heldPatterns map[string]int,
 	heldMu *sync.Mutex,
 ) error {
 	log := logrus.WithFields(logrus.Fields{
@@ -201,7 +210,7 @@ func (h *websockHandler) subscriptionHandleMessage(
 				continue
 			}
 			heldMu.Lock()
-			heldPatterns[pattern] = true
+			heldPatterns[pattern]++
 			heldMu.Unlock()
 		}
 
@@ -223,7 +232,11 @@ func (h *websockHandler) subscriptionHandleMessage(
 				log.Errorf("Could not release the AMQP binding. pattern: %s, err: %v", pattern, errRel)
 			}
 			heldMu.Lock()
-			delete(heldPatterns, pattern)
+			if heldPatterns[pattern] > 1 {
+				heldPatterns[pattern]--
+			} else {
+				delete(heldPatterns, pattern)
+			}
 			heldMu.Unlock()
 		}
 	}

--- a/bin-api-manager/pkg/websockhandler/subscription.go
+++ b/bin-api-manager/pkg/websockhandler/subscription.go
@@ -70,15 +70,31 @@ func (h *websockHandler) subscriptionRun(ctx context.Context, w http.ResponseWri
 	defer zmqSub.Terminate()
 	log.Debugf("Created a new subscribe socket correctly.")
 
+	// heldPatterns tracks the AMQP binding patterns THIS connection currently holds, so we can
+	// release everything on abrupt disconnect (no explicit unsubscribe received) via
+	// scopeRefCount.ReleaseAll below. See VOIP-1258 §9 / Task 4.3.
+	heldPatterns := make(map[string]bool)
+	var heldMu sync.Mutex
+
 	// we are creating a new context and cancel using the http request.
 	// we are expecting when the websocket closed, everything is closed too.
 	newCtx, newCancel := context.WithCancel(ctx)
-	go h.subscriptionRunWebsock(newCtx, newCancel, a, ws, zmqSub)
+	go h.subscriptionRunWebsock(newCtx, newCancel, a, ws, zmqSub, heldPatterns, &heldMu)
 	go h.subscriptionRunZMQSub(newCtx, newCancel, ws, zmqSub, &writeMu)
 	go h.subscriptionRunPinger(newCtx, newCancel, ws, &writeMu)
 
 	<-newCtx.Done()
 	log.Debugf("Websocket connection has been closed. agent_id: %s", a.AgentID())
+
+	// abrupt-disconnect cleanup -- release everything this connection held, regardless of
+	// whether an explicit unsubscribe message was ever received.
+	heldMu.Lock()
+	patterns := make([]string, 0, len(heldPatterns))
+	for p := range heldPatterns {
+		patterns = append(patterns, p)
+	}
+	heldMu.Unlock()
+	h.scopeRefCount.ReleaseAll(patterns)
 
 	return nil
 }
@@ -109,6 +125,8 @@ func (h *websockHandler) subscriptionRunWebsock(
 	a *auth.AuthIdentity,
 	ws *websocket.Conn,
 	zmqSub zmqsubhandler.ZMQSubHandler,
+	heldPatterns map[string]bool,
+	heldMu *sync.Mutex,
 ) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":  "subscriptionRunWebsock",
@@ -132,7 +150,7 @@ func (h *websockHandler) subscriptionRunWebsock(
 		log.Debugf("Received subscribee/unsubscribe message from the websocket. type: %s, topics: %v", p.Type, p.Topics)
 
 		// handle the message
-		if errHandle := h.subscriptionHandleMessage(ctx, a, zmqSub, p); errHandle != nil {
+		if errHandle := h.subscriptionHandleMessage(ctx, a, zmqSub, p, heldPatterns, heldMu); errHandle != nil {
 			log.Errorf("Could not handle the message correctly. err: %v", errHandle)
 			return
 		}
@@ -140,7 +158,14 @@ func (h *websockHandler) subscriptionRunWebsock(
 }
 
 // subscriptionHandleMessage handles the message from the websock and do the subscription/unsubscription.
-func (h *websockHandler) subscriptionHandleMessage(ctx context.Context, a *auth.AuthIdentity, zmqSub zmqsubhandler.ZMQSubHandler, m *hook.Hook) error {
+func (h *websockHandler) subscriptionHandleMessage(
+	ctx context.Context,
+	a *auth.AuthIdentity,
+	zmqSub zmqsubhandler.ZMQSubHandler,
+	m *hook.Hook,
+	heldPatterns map[string]bool,
+	heldMu *sync.Mutex,
+) error {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "subscriptionHandleMessage",
 		"agent":   a,
@@ -161,6 +186,23 @@ func (h *websockHandler) subscriptionHandleMessage(ctx context.Context, a *auth.
 				return errSub
 			}
 			log.Debugf("Subscribed the topic. topic: %s", topic)
+
+			// acquire the AMQP binding for this pattern. Non-fatal on error: the zmqSub
+			// subscribe above already succeeded, so local filtering still works even if
+			// broker-side AMQP scoping doesn't -- a safe degraded failure mode, not a hard
+			// failure (VOIP-1258 §9).
+			pattern, errConv := topicToBindPattern(topic)
+			if errConv != nil {
+				log.Errorf("Could not convert topic to bind pattern. topic: %s, err: %v", topic, errConv)
+				continue
+			}
+			if errAcq := h.scopeRefCount.Acquire(pattern); errAcq != nil {
+				log.Errorf("Could not acquire the AMQP binding. pattern: %s, err: %v", pattern, errAcq)
+				continue
+			}
+			heldMu.Lock()
+			heldPatterns[pattern] = true
+			heldMu.Unlock()
 		}
 
 	case hook.TypeUnsubscribe:
@@ -170,6 +212,19 @@ func (h *websockHandler) subscriptionHandleMessage(ctx context.Context, a *auth.
 				return errSub
 			}
 			log.Debugf("Unsubscribed the topic. topic: %s", topic)
+
+			// release the AMQP binding for this pattern
+			pattern, errConv := topicToBindPattern(topic)
+			if errConv != nil {
+				log.Errorf("Could not convert topic to bind pattern. topic: %s, err: %v", topic, errConv)
+				continue
+			}
+			if errRel := h.scopeRefCount.Release(pattern); errRel != nil {
+				log.Errorf("Could not release the AMQP binding. pattern: %s, err: %v", pattern, errRel)
+			}
+			heldMu.Lock()
+			delete(heldPatterns, pattern)
+			heldMu.Unlock()
 		}
 	}
 

--- a/bin-api-manager/pkg/websockhandler/subscription_test.go
+++ b/bin-api-manager/pkg/websockhandler/subscription_test.go
@@ -1,0 +1,176 @@
+package websockhandler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	amagent "monorepo/bin-agent-manager/models/agent"
+	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/models/hook"
+	"monorepo/bin-api-manager/pkg/zmqsubhandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	gomock "go.uber.org/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+// newSuperAdminIdentity returns an AuthIdentity that always passes validateTopics, so tests
+// can focus on the scopeRefCount wiring rather than topic authorization rules.
+func newSuperAdminIdentity() *auth.AuthIdentity {
+	return auth.NewAgentIdentity(&amagent.Agent{
+		Permission: amagent.PermissionProjectSuperAdmin,
+	})
+}
+
+func TestSubscriptionHandleMessage_AcquiresBindingOnSubscribe(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockZMQSub := zmqsubhandler.NewMockZMQSubHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &websockHandler{
+		scopeRefCount: newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic"),
+	}
+
+	a := newSuperAdminIdentity()
+	topic := "customer_id:5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb"
+
+	mockZMQSub.EXPECT().Subscribe(topic).Return(nil)
+	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+
+	heldPatterns := make(map[string]bool)
+	var heldMu sync.Mutex
+
+	m := &hook.Hook{
+		Type:   hook.TypeSubscribe,
+		Topics: []string{topic},
+	}
+
+	err := h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, m, heldPatterns, &heldMu)
+	require.NoError(t, err)
+	require.True(t, heldPatterns["customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#"])
+}
+
+func TestSubscriptionHandleMessage_ReleasesBindingOnUnsubscribe(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockZMQSub := zmqsubhandler.NewMockZMQSubHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &websockHandler{
+		scopeRefCount: newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic"),
+	}
+
+	a := newSuperAdminIdentity()
+	topic := "customer_id:5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb"
+	pattern := "customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#"
+
+	mockZMQSub.EXPECT().Subscribe(topic).Return(nil)
+	mockSock.EXPECT().QueueBind("pod-queue-1", pattern, "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+	mockZMQSub.EXPECT().Unsubscribe(topic).Return(nil)
+	mockSock.EXPECT().QueueUnbind("pod-queue-1", pattern, "bin-manager.webhook-manager.event.topic", nil).Return(nil)
+
+	heldPatterns := make(map[string]bool)
+	var heldMu sync.Mutex
+
+	subMsg := &hook.Hook{Type: hook.TypeSubscribe, Topics: []string{topic}}
+	err := h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, subMsg, heldPatterns, &heldMu)
+	require.NoError(t, err)
+	require.True(t, heldPatterns[pattern])
+
+	unsubMsg := &hook.Hook{Type: hook.TypeUnsubscribe, Topics: []string{topic}}
+	err = h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, unsubMsg, heldPatterns, &heldMu)
+	require.NoError(t, err)
+	require.False(t, heldPatterns[pattern])
+}
+
+func TestSubscriptionRun_ReleasesAllOnAbruptDisconnect(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &websockHandler{
+		scopeRefCount: newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic"),
+	}
+
+	pattern1 := "customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#"
+	pattern2 := "agent_id.6367ee4f-ac6e-22fb-9feb-7c64f2af2fcc.#"
+
+	// Simulate what subscriptionHandleMessage would have already done: two patterns acquired
+	// via explicit subscribe messages, with no matching unsubscribe before disconnect.
+	mockSock.EXPECT().QueueBind("pod-queue-1", pattern1, "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+	mockSock.EXPECT().QueueBind("pod-queue-1", pattern2, "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
+	require.NoError(t, h.scopeRefCount.Acquire(pattern1))
+	require.NoError(t, h.scopeRefCount.Acquire(pattern2))
+
+	heldPatterns := map[string]bool{
+		pattern1: true,
+		pattern2: true,
+	}
+	var heldMu sync.Mutex
+
+	// Assert both patterns get unbound (refcount 1->0) on the abrupt-disconnect cleanup path,
+	// mirroring what subscriptionRun does after <-newCtx.Done() with no unsubscribe received.
+	mockSock.EXPECT().QueueUnbind("pod-queue-1", pattern1, "bin-manager.webhook-manager.event.topic", nil).Return(nil)
+	mockSock.EXPECT().QueueUnbind("pod-queue-1", pattern2, "bin-manager.webhook-manager.event.topic", nil).Return(nil)
+
+	// exercise the cleanup logic exactly as subscriptionRun does after ctx cancellation
+	heldMu.Lock()
+	patterns := make([]string, 0, len(heldPatterns))
+	for p := range heldPatterns {
+		patterns = append(patterns, p)
+	}
+	heldMu.Unlock()
+	h.scopeRefCount.ReleaseAll(patterns)
+}
+
+// TestSubscriptionRun_ContextCancelTriggersReleaseAll drives subscriptionRun end-to-end (minus
+// the real websocket upgrade, which we can't easily fake here) is out of scope; instead this
+// test exercises subscriptionRunWebsock's context-cancel exit path together with the held-set
+// bookkeeping, verifying that a canceled context stops the read loop promptly.
+func TestSubscriptionRunWebsock_ExitsOnContextCancel(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockZMQSub := zmqsubhandler.NewMockZMQSubHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &websockHandler{
+		scopeRefCount: newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic"),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so receiveTextFromWebsock's context check (via ctx.Done()) exits immediately
+
+	a := newSuperAdminIdentity()
+	heldPatterns := make(map[string]bool)
+	var heldMu sync.Mutex
+
+	done := make(chan struct{})
+	var innerCancelCalled bool
+	var mu sync.Mutex
+	go func() {
+		h.subscriptionRunWebsock(ctx, func() {
+			mu.Lock()
+			innerCancelCalled = true
+			mu.Unlock()
+		}, a, nil, mockZMQSub, heldPatterns, &heldMu)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good, the goroutine returned
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscriptionRunWebsock did not return after context cancellation")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, innerCancelCalled)
+}

--- a/bin-api-manager/pkg/websockhandler/subscription_test.go
+++ b/bin-api-manager/pkg/websockhandler/subscription_test.go
@@ -41,7 +41,7 @@ func TestSubscriptionHandleMessage_AcquiresBindingOnSubscribe(t *testing.T) {
 	mockZMQSub.EXPECT().Subscribe(topic).Return(nil)
 	mockSock.EXPECT().QueueBind("pod-queue-1", "customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#", "bin-manager.webhook-manager.event.topic", false, nil).Return(nil)
 
-	heldPatterns := make(map[string]bool)
+	heldPatterns := make(map[string]int)
 	var heldMu sync.Mutex
 
 	m := &hook.Hook{
@@ -51,7 +51,7 @@ func TestSubscriptionHandleMessage_AcquiresBindingOnSubscribe(t *testing.T) {
 
 	err := h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, m, heldPatterns, &heldMu)
 	require.NoError(t, err)
-	require.True(t, heldPatterns["customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#"])
+	require.Equal(t, 1, heldPatterns["customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#"])
 }
 
 func TestSubscriptionHandleMessage_ReleasesBindingOnUnsubscribe(t *testing.T) {
@@ -74,18 +74,82 @@ func TestSubscriptionHandleMessage_ReleasesBindingOnUnsubscribe(t *testing.T) {
 	mockZMQSub.EXPECT().Unsubscribe(topic).Return(nil)
 	mockSock.EXPECT().QueueUnbind("pod-queue-1", pattern, "bin-manager.webhook-manager.event.topic", nil).Return(nil)
 
-	heldPatterns := make(map[string]bool)
+	heldPatterns := make(map[string]int)
 	var heldMu sync.Mutex
 
 	subMsg := &hook.Hook{Type: hook.TypeSubscribe, Topics: []string{topic}}
 	err := h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, subMsg, heldPatterns, &heldMu)
 	require.NoError(t, err)
-	require.True(t, heldPatterns[pattern])
+	require.Equal(t, 1, heldPatterns[pattern])
 
 	unsubMsg := &hook.Hook{Type: hook.TypeUnsubscribe, Topics: []string{topic}}
 	err = h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, unsubMsg, heldPatterns, &heldMu)
 	require.NoError(t, err)
-	require.False(t, heldPatterns[pattern])
+	require.Equal(t, 0, heldPatterns[pattern])
+	_, stillPresent := heldPatterns[pattern]
+	require.False(t, stillPresent)
+}
+
+// TestSubscriptionHandleMessage_DoubleSubscribeThenSingleUnsubscribeKeepsBinding regression-tests
+// the refcount leak found in PR #1101 round-2 review: a connection that subscribes to the same
+// topic twice (without an intervening unsubscribe -- a realistic client reconnect/retry pattern)
+// must have its heldPatterns entry survive a single unsubscribe, since scopeRefCount's internal
+// refcount is still 1 after that single Release. If heldPatterns were a boolean set instead of a
+// counter, this single unsubscribe would erroneously drop the pattern from the held set, and the
+// eventual abrupt-disconnect ReleaseAll would never issue the second Release needed to actually
+// unbind the queue -- a permanent per-scope bind leak.
+func TestSubscriptionHandleMessage_DoubleSubscribeThenSingleUnsubscribeKeepsBinding(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockZMQSub := zmqsubhandler.NewMockZMQSubHandler(mc)
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &websockHandler{
+		scopeRefCount: newScopeRefCount(mockSock, "pod-queue-1", "bin-manager.webhook-manager.event.topic"),
+	}
+
+	a := newSuperAdminIdentity()
+	topic := "customer_id:5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb"
+	pattern := "customer_id.5257dd3e-9b5d-11ea-8eda-6b53f19ec1eb.#"
+
+	// Only ONE QueueBind expected: scopeRefCount only binds on the 0->1 transition. The second
+	// Acquire (from the second subscribe) increments the internal refcount to 2 without a
+	// second AMQP call.
+	mockZMQSub.EXPECT().Subscribe(topic).Return(nil).Times(2)
+	mockSock.EXPECT().QueueBind("pod-queue-1", pattern, "bin-manager.webhook-manager.event.topic", false, nil).Return(nil).Times(1)
+
+	heldPatterns := make(map[string]int)
+	var heldMu sync.Mutex
+
+	subMsg := &hook.Hook{Type: hook.TypeSubscribe, Topics: []string{topic}}
+	require.NoError(t, h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, subMsg, heldPatterns, &heldMu))
+	require.NoError(t, h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, subMsg, heldPatterns, &heldMu))
+	require.Equal(t, 2, heldPatterns[pattern])
+
+	// A single unsubscribe must NOT drop the pattern from heldPatterns entirely -- the
+	// connection still holds one outstanding Acquire. No QueueUnbind expected here (internal
+	// refcount only drops from 2 to 1, still > 0).
+	mockZMQSub.EXPECT().Unsubscribe(topic).Return(nil)
+	unsubMsg := &hook.Hook{Type: hook.TypeUnsubscribe, Topics: []string{topic}}
+	require.NoError(t, h.subscriptionHandleMessage(context.Background(), a, mockZMQSub, unsubMsg, heldPatterns, &heldMu))
+	require.Equal(t, 1, heldPatterns[pattern])
+	_, stillPresent := heldPatterns[pattern]
+	require.True(t, stillPresent, "pattern must still be tracked after only one of two Acquires was released")
+
+	// Now simulate the abrupt-disconnect cleanup path exactly as subscriptionRun does: expand
+	// heldPatterns by count and ReleaseAll. This must issue exactly one more QueueUnbind (the
+	// remaining outstanding Acquire), proving the leak is closed.
+	mockSock.EXPECT().QueueUnbind("pod-queue-1", pattern, "bin-manager.webhook-manager.event.topic", nil).Return(nil).Times(1)
+	heldMu.Lock()
+	patterns := make([]string, 0, len(heldPatterns))
+	for p, count := range heldPatterns {
+		for i := 0; i < count; i++ {
+			patterns = append(patterns, p)
+		}
+	}
+	heldMu.Unlock()
+	h.scopeRefCount.ReleaseAll(patterns)
 }
 
 func TestSubscriptionRun_ReleasesAllOnAbruptDisconnect(t *testing.T) {
@@ -108,9 +172,9 @@ func TestSubscriptionRun_ReleasesAllOnAbruptDisconnect(t *testing.T) {
 	require.NoError(t, h.scopeRefCount.Acquire(pattern1))
 	require.NoError(t, h.scopeRefCount.Acquire(pattern2))
 
-	heldPatterns := map[string]bool{
-		pattern1: true,
-		pattern2: true,
+	heldPatterns := map[string]int{
+		pattern1: 1,
+		pattern2: 1,
 	}
 	var heldMu sync.Mutex
 
@@ -122,8 +186,10 @@ func TestSubscriptionRun_ReleasesAllOnAbruptDisconnect(t *testing.T) {
 	// exercise the cleanup logic exactly as subscriptionRun does after ctx cancellation
 	heldMu.Lock()
 	patterns := make([]string, 0, len(heldPatterns))
-	for p := range heldPatterns {
-		patterns = append(patterns, p)
+	for p, count := range heldPatterns {
+		for i := 0; i < count; i++ {
+			patterns = append(patterns, p)
+		}
 	}
 	heldMu.Unlock()
 	h.scopeRefCount.ReleaseAll(patterns)
@@ -148,7 +214,7 @@ func TestSubscriptionRunWebsock_ExitsOnContextCancel(t *testing.T) {
 	cancel() // pre-cancel so receiveTextFromWebsock's context check (via ctx.Done()) exits immediately
 
 	a := newSuperAdminIdentity()
-	heldPatterns := make(map[string]bool)
+	heldPatterns := make(map[string]int)
 	var heldMu sync.Mutex
 
 	done := make(chan struct{})

--- a/bin-common-handler/models/outline/queuename.go
+++ b/bin-common-handler/models/outline/queuename.go
@@ -169,7 +169,8 @@ const (
 	QueueNameUserSubscribe QueueName = "bin-manager.user-manager.subscribe"
 
 	// webhook-manager
-	QueueNameWebhookEvent     QueueName = "bin-manager.webhook-manager.event"
-	QueueNameWebhookRequest   QueueName = "bin-manager.webhook-manager.request"
-	QueueNameWebhookSubscribe QueueName = "bin-manager.webhook-manager.subscribe"
+	QueueNameWebhookEvent      QueueName = "bin-manager.webhook-manager.event"
+	QueueNameWebhookEventTopic QueueName = "bin-manager.webhook-manager.event.topic" // NEW, VOIP-1258
+	QueueNameWebhookRequest    QueueName = "bin-manager.webhook-manager.request"
+	QueueNameWebhookSubscribe  QueueName = "bin-manager.webhook-manager.subscribe"
 )

--- a/bin-common-handler/pkg/notifyhandler/main.go
+++ b/bin-common-handler/pkg/notifyhandler/main.go
@@ -4,6 +4,7 @@ package notifyhandler
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gofrs/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,9 +39,26 @@ const (
 var (
 	promNotifyProcessTime *prometheus.HistogramVec
 	promNotifyTotal       *prometheus.CounterVec
+
+	// initPrometheusMu/initPrometheusDone guard against duplicate MustRegister panics when
+	// initPrometheus is called more than once for the same namespace -- e.g. VOIP-1258's
+	// second NotifyHandler instance (NewNotifyHandlerForExistingExchange, bound to the new
+	// topic exchange) is constructed for the SAME publisher/namespace as the existing
+	// fanout-bound NewNotifyHandler call in the same process (webhook-manager, webhook-control).
+	// Without this guard, the second initPrometheus call would panic with "duplicate metrics
+	// collector registration attempted" on every startup.
+	initPrometheusMu   sync.Mutex
+	initPrometheusDone = map[string]bool{}
 )
 
 func initPrometheus(namespace string) {
+	initPrometheusMu.Lock()
+	defer initPrometheusMu.Unlock()
+
+	if initPrometheusDone[namespace] {
+		return
+	}
+	initPrometheusDone[namespace] = true
 
 	promNotifyProcessTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/bin-common-handler/pkg/notifyhandler/main.go
+++ b/bin-common-handler/pkg/notifyhandler/main.go
@@ -112,3 +112,29 @@ func NewNotifyHandler(sockHandler sockhandler.SockHandler, reqHandler requesthan
 	return h
 }
 
+// NewNotifyHandlerForExistingExchange creates a NotifyHandler for an exchange that has ALREADY
+// been declared by the caller (e.g. via sockHandler.TopicCreateWithKind for a non-fanout kind).
+// Unlike NewNotifyHandler, this does NOT call sockHandler.TopicCreate/TopicCreateWithKind
+// internally -- it assumes the exchange already exists with the correct kind, and skips the
+// redundant (and, for non-fanout kinds, conflicting) declare. Added for VOIP-1258 (see design
+// doc §6, implementation plan Task 3.1) to support a second NotifyHandler instance bound to a
+// topic-kind exchange, alongside the existing fanout-only NewNotifyHandler used everywhere else.
+func NewNotifyHandlerForExistingExchange(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, queueEvent commonoutline.QueueName, publisher commonoutline.ServiceName) NotifyHandler {
+	h := &notifyHandler{
+		sockHandler: sockHandler,
+		reqHandler:  reqHandler,
+
+		queueNotify: queueEvent,
+
+		publisher: publisher,
+	}
+
+	// NOTE: deliberately NOT calling sockHandler.TopicCreate/TopicCreateWithKind here -- the
+	// caller is responsible for declaring the exchange BEFORE calling this constructor.
+
+	namespace := commonoutline.GetMetricNameSpace(publisher)
+	initPrometheus(namespace)
+
+	return h
+}
+

--- a/bin-common-handler/pkg/notifyhandler/main.go
+++ b/bin-common-handler/pkg/notifyhandler/main.go
@@ -73,6 +73,7 @@ func initPrometheus(namespace string) {
 type NotifyHandler interface {
 	PublishEvent(ctx context.Context, eventType string, data interface{})
 	PublishEventRaw(ctx context.Context, eventType string, dataType string, data []byte)
+	PublishEventWithRoutingKey(ctx context.Context, eventType string, routingKey string, data interface{})
 
 	PublishWebhook(ctx context.Context, customerID uuid.UUID, eventType string, data WebhookMessage)
 	PublishWebhookEvent(ctx context.Context, customerID uuid.UUID, eventType string, data WebhookMessage)

--- a/bin-common-handler/pkg/notifyhandler/main_test.go
+++ b/bin-common-handler/pkg/notifyhandler/main_test.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/pkg/sockhandler"
 )
 
 const (
@@ -28,4 +32,21 @@ func TestMain(m *testing.M) {
 	initPrometheus("test")
 
 	os.Exit(m.Run())
+}
+
+func TestNewNotifyHandlerForExistingExchange_SkipsDeclare(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	// TopicCreate/TopicCreateWithKind must NOT be called -- the exchange is assumed
+	// already declared by the caller.
+	mockSock.EXPECT().TopicCreate(gomock.Any()).Times(0)
+	mockSock.EXPECT().TopicCreateWithKind(gomock.Any(), gomock.Any()).Times(0)
+
+	h := NewNotifyHandlerForExistingExchange(mockSock, nil, "some.exchange.name", "test-service")
+
+	if h == nil {
+		t.Fatal("Expected non-nil NotifyHandler")
+	}
 }

--- a/bin-common-handler/pkg/notifyhandler/mock_main.go
+++ b/bin-common-handler/pkg/notifyhandler/mock_main.go
@@ -104,6 +104,18 @@ func (mr *MockNotifyHandlerMockRecorder) PublishEventRaw(ctx, eventType, dataTyp
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishEventRaw", reflect.TypeOf((*MockNotifyHandler)(nil).PublishEventRaw), ctx, eventType, dataType, data)
 }
 
+// PublishEventWithRoutingKey mocks base method.
+func (m *MockNotifyHandler) PublishEventWithRoutingKey(ctx context.Context, eventType, routingKey string, data any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PublishEventWithRoutingKey", ctx, eventType, routingKey, data)
+}
+
+// PublishEventWithRoutingKey indicates an expected call of PublishEventWithRoutingKey.
+func (mr *MockNotifyHandlerMockRecorder) PublishEventWithRoutingKey(ctx, eventType, routingKey, data any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishEventWithRoutingKey", reflect.TypeOf((*MockNotifyHandler)(nil).PublishEventWithRoutingKey), ctx, eventType, routingKey, data)
+}
+
 // PublishWebhook mocks base method.
 func (m *MockNotifyHandler) PublishWebhook(ctx context.Context, customerID uuid.UUID, eventType string, data WebhookMessage) {
 	m.ctrl.T.Helper()

--- a/bin-common-handler/pkg/notifyhandler/publish.go
+++ b/bin-common-handler/pkg/notifyhandler/publish.go
@@ -139,35 +139,38 @@ func (h *notifyHandler) PublishEventWithRoutingKey(ctx context.Context, eventTyp
 		return
 	}
 
-	if err := h.publishEventWithKey(routingKey, string(eventType), string(wmwebhook.DataTypeJSON), m, requestTimeoutDefault); err != nil {
-		log.Errorf("Could not publish the event with routing key. err: %v", err)
-		return
-	}
-}
-
-// publishEventWithKey publishes an event to the event queue with the given routing key.
-func (h *notifyHandler) publishEventWithKey(routingKey string, eventType string, dataType string, data json.RawMessage, timeout int) error {
 	evt := &sock.Event{
 		Type:      eventType,
 		Publisher: string(h.publisher),
-		DataType:  dataType,
-		Data:      data,
+		DataType:  string(wmwebhook.DataTypeJSON),
+		Data:      m,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(timeout))
+	// Note: Using context.Background() intentionally, matching publishEvent's existing
+	// fire-and-forget rationale -- this event should complete independently of the caller's
+	// context lifecycle.
+	pubCtx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(requestTimeoutDefault))
 	defer cancel()
-	_ = ctx // reserved for future use, matches existing publishEvent's unused-ctx pattern
 
-	start := time.Now()
-	err := h.sockHandler.EventPublish(string(h.queueNotify), routingKey, evt)
-	elapsed := time.Since(start)
-	promNotifyProcessTime.WithLabelValues(evt.Type).Observe(float64(elapsed.Milliseconds()))
-	if err != nil {
-		return fmt.Errorf("could not publish the event. err: %v", err)
+	if err := h.publishDirectEventWithKey(pubCtx, routingKey, evt); err != nil {
+		log.Errorf("Could not publish the event with routing key. err: %v", err)
+		return
 	}
 	promNotifyTotal.WithLabelValues(evt.Type).Inc()
+}
 
-	return nil
+// publishDirectEventWithKey publishes the event to the target without delay, using the given
+// AMQP routing key instead of publishDirectEvent's hardcoded empty key. Shares the same
+// publish+metrics logic as publishDirectEvent (VOIP-1258 code-quality review: avoid duplicating
+// this logic in a second near-identical function).
+func (h *notifyHandler) publishDirectEventWithKey(ctx context.Context, key string, evt *sock.Event) error {
+
+	start := time.Now()
+	err := h.sockHandler.EventPublish(string(h.queueNotify), key, evt)
+	elapsed := time.Since(start)
+	promNotifyProcessTime.WithLabelValues(string(evt.Type)).Observe(float64(elapsed.Milliseconds()))
+
+	return err
 }
 
 // publishDirectEvent publish the event to the target without delay

--- a/bin-common-handler/pkg/notifyhandler/publish.go
+++ b/bin-common-handler/pkg/notifyhandler/publish.go
@@ -122,6 +122,54 @@ func (h *notifyHandler) publishEvent(eventType string, dataType string, data jso
 	return nil
 }
 
+// PublishEventWithRoutingKey publishes event to the event queue with an explicit AMQP routing
+// key, for topic-kind exchanges. Unlike PublishEvent (which always publishes with an empty
+// routing key, correct for fanout exchanges), this lets the caller target scope-based topic
+// bindings. See VOIP-1258 design doc §6.
+func (h *notifyHandler) PublishEventWithRoutingKey(ctx context.Context, eventType string, routingKey string, data interface{}) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "PublishEventWithRoutingKey",
+		"evnet_type":  eventType,
+		"routing_key": routingKey,
+	})
+
+	m, err := json.Marshal(data)
+	if err != nil {
+		log.Errorf("Could not marshal the message. err: %v", err)
+		return
+	}
+
+	if err := h.publishEventWithKey(routingKey, string(eventType), string(wmwebhook.DataTypeJSON), m, requestTimeoutDefault); err != nil {
+		log.Errorf("Could not publish the event with routing key. err: %v", err)
+		return
+	}
+}
+
+// publishEventWithKey publishes an event to the event queue with the given routing key.
+func (h *notifyHandler) publishEventWithKey(routingKey string, eventType string, dataType string, data json.RawMessage, timeout int) error {
+	evt := &sock.Event{
+		Type:      eventType,
+		Publisher: string(h.publisher),
+		DataType:  dataType,
+		Data:      data,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(timeout))
+	defer cancel()
+	_ = ctx // reserved for future use, matches existing publishEvent's unused-ctx pattern
+
+	start := time.Now()
+	err := h.sockHandler.EventPublish(string(h.queueNotify), routingKey, evt)
+	elapsed := time.Since(start)
+	promNotifyProcessTime.WithLabelValues(evt.Type).Observe(float64(elapsed.Milliseconds()))
+	if err != nil {
+		return fmt.Errorf("could not publish the event. err: %v", err)
+	}
+	promNotifyTotal.WithLabelValues(evt.Type).Inc()
+
+	return nil
+}
+
 // publishDirectEvent publish the event to the target without delay
 func (h *notifyHandler) publishDirectEvent(ctx context.Context, evt *sock.Event) error {
 

--- a/bin-common-handler/pkg/notifyhandler/publish_test.go
+++ b/bin-common-handler/pkg/notifyhandler/publish_test.go
@@ -286,3 +286,26 @@ func TestPublishEventWithRoutingKey(t *testing.T) {
 	// PublishEventWithRoutingKey is fire-and-forget like PublishEvent; assert via mock call above.
 }
 
+// TestPublishEventWithRoutingKey_MarshalError verifies the marshal-error path returns early
+// without ever calling EventPublish (no mock expectation set -- gomock's strict-by-default
+// behavior fails the test if EventPublish is called unexpectedly).
+func TestPublishEventWithRoutingKey_MarshalError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	h := &notifyHandler{
+		sockHandler: mockSock,
+		queueNotify: "test.queue",
+		publisher:   "test-service",
+	}
+
+	// json.Marshal cannot serialize a bare func value -- forces the marshal-error branch.
+	unmarshalable := func() {}
+
+	h.PublishEventWithRoutingKey(context.Background(), "call_updated", "customer_id.abc123.#", unmarshalable)
+
+	// No mockSock.EXPECT() set for EventPublish -- if PublishEventWithRoutingKey called it
+	// despite the marshal failure, gomock would fail this test with an unexpected-call error.
+}
+

--- a/bin-common-handler/pkg/notifyhandler/publish_test.go
+++ b/bin-common-handler/pkg/notifyhandler/publish_test.go
@@ -265,3 +265,24 @@ func Test_PublishEventRaw(t *testing.T) {
 	}
 }
 
+func TestPublishEventWithRoutingKey(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	h := &notifyHandler{
+		sockHandler: mockSock,
+		queueNotify: "test.queue",
+		publisher:   "test-service",
+	}
+
+	data := map[string]string{"foo": "bar"}
+	routingKey := "customer_id.abc123.call.call_updated.xyz789"
+
+	mockSock.EXPECT().EventPublish("test.queue", routingKey, gomock.Any()).Return(nil)
+
+	h.PublishEventWithRoutingKey(context.Background(), "call_updated", routingKey, data)
+
+	// PublishEventWithRoutingKey is fire-and-forget like PublishEvent; assert via mock call above.
+}
+

--- a/bin-common-handler/pkg/rabbitmqhandler/main.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/main.go
@@ -22,6 +22,7 @@ type Rabbit interface {
 	ConsumeRPC(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error
 
 	TopicCreate(name string) error
+	TopicCreateWithKind(name string, kind string) error
 
 	EventPublish(topic string, key string, evt *sock.Event) error
 	EventPublishWithDelay(topic string, key string, evt *sock.Event, delay int) error
@@ -31,6 +32,8 @@ type Rabbit interface {
 
 	QueueCreate(name string, queueType string) error
 	QueueSubscribe(name string, topic string) error
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error
+	QueueUnbind(name, key, exchange string, args amqp.Table) error
 }
 
 // amqpChannel is an interface for amqp.Channel operations used by queue and exchange.
@@ -41,6 +44,7 @@ type amqpChannel interface {
 	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
 	Qos(prefetchCount, prefetchSize int, global bool) error
 	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error
+	QueueUnbind(name, key, exchange string, args amqp.Table) error
 	QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error)
 	ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
 	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
@@ -69,7 +73,7 @@ type rabbit struct {
 	mu         sync.RWMutex
 	queues     map[string]*queue
 	exchanges  map[string]*exchange
-	queueBinds map[string]*queueBind
+	queueBinds map[string][]*queueBind
 	consumers  []*consumerRegistration
 }
 
@@ -132,7 +136,7 @@ func NewRabbit(uri string) Rabbit {
 		healthCheckInterval: 30 * time.Second,
 		queues:              make(map[string]*queue),
 		exchanges:           make(map[string]*exchange),
-		queueBinds:          make(map[string]*queueBind),
+		queueBinds:          make(map[string][]*queueBind),
 		consumers:           make([]*consumerRegistration, 0),
 	}
 
@@ -273,8 +277,8 @@ func (r *rabbit) redeclareAll() {
 		exchangesCopy = append(exchangesCopy, e)
 	}
 	bindsCopy := make([]*queueBind, 0, len(r.queueBinds))
-	for _, b := range r.queueBinds {
-		bindsCopy = append(bindsCopy, b)
+	for _, binds := range r.queueBinds { // now a [][]*queueBind value per key
+		bindsCopy = append(bindsCopy, binds...)
 	}
 	r.mu.RUnlock()
 

--- a/bin-common-handler/pkg/rabbitmqhandler/main_test.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/main_test.go
@@ -35,6 +35,11 @@ type mockChannel struct {
 
 	mu                 sync.Mutex // guards queueBindCallCount for concurrent-access tests (VOIP-1258)
 	queueBindCallCount int         // VOIP-1258: counts QueueBind invocations, used to verify redeclareAll restores ALL tracked binds
+
+	// VOIP-1258 Task 1.4: captures ExchangeDeclare's actual call args for assertions.
+	exchangeDeclareName    string
+	exchangeDeclareKind    string
+	exchangeDeclareDurable bool
 }
 
 func newMockChannel() *mockChannel {
@@ -80,6 +85,9 @@ func (m *mockChannel) QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (
 }
 
 func (m *mockChannel) ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error {
+	m.exchangeDeclareName = name
+	m.exchangeDeclareKind = kind
+	m.exchangeDeclareDurable = durable
 	return m.exchangeDeclareErr
 }
 

--- a/bin-common-handler/pkg/rabbitmqhandler/main_test.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/main_test.go
@@ -17,14 +17,15 @@ type mockChannel struct {
 	closeErr     error
 	closeErrOnce bool // if true, only return error on first call
 
-	queueDeclareErr  error
-	queueDeclareName string
-	queueDeclareArgs amqp.Table
+	queueDeclareErr    error
+	queueDeclareName   string
+	queueDeclareArgs   amqp.Table
 	exchangeDeclareErr error
 
-	qosErr       error
-	queueBindErr error
-	consumeErr   error
+	qosErr         error
+	queueBindErr   error
+	queueUnbindErr error
+	consumeErr     error
 
 	qosCallCount     int
 	qosPrefetchCount int
@@ -61,6 +62,10 @@ func (m *mockChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
 
 func (m *mockChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
 	return m.queueBindErr
+}
+
+func (m *mockChannel) QueueUnbind(name, key, exchange string, args amqp.Table) error {
+	return m.queueUnbindErr
 }
 
 func (m *mockChannel) QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error) {
@@ -138,6 +143,9 @@ func (m *mockChannelWithConsumeCounter) Qos(prefetchCount, prefetchSize int, glo
 func (m *mockChannelWithConsumeCounter) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
 	return nil
 }
+func (m *mockChannelWithConsumeCounter) QueueUnbind(name, key, exchange string, args amqp.Table) error {
+	return nil
+}
 func (m *mockChannelWithConsumeCounter) QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error) {
 	return 0, nil
 }
@@ -163,7 +171,7 @@ func TestClose_ClosesAllQueueChannels(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	r.queues["queue1"] = &queue{name: "queue1", channel: mockCh1}
@@ -199,7 +207,7 @@ func TestClose_ClosesAllExchangeChannels(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	r.exchanges["exchange1"] = &exchange{name: "exchange1", channel: mockCh1}
@@ -225,7 +233,7 @@ func TestClose_ClosesQueueAndExchangeChannels(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	r.queues["queue1"] = &queue{name: "queue1", channel: queueCh}
@@ -249,7 +257,7 @@ func TestClose_HandlesNilChannels(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	r.queues["queue1"] = &queue{name: "queue1", channel: nil}
@@ -271,7 +279,7 @@ func TestClose_HandlesEmptyMaps(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Should not panic with empty maps
@@ -293,7 +301,7 @@ func TestClose_ContinuesOnChannelCloseError(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	r.queues["queue1"] = &queue{name: "queue1", channel: mockCh1}
@@ -329,7 +337,7 @@ func TestQueueDeclare_Success(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Since we can't easily inject the mock channel through connection.Channel(),
@@ -363,7 +371,7 @@ func TestQueueDeclare_ClosesOldChannelOnRedeclare(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Setup existing queue
@@ -418,7 +426,7 @@ func TestExchangeDeclare_ClosesOldChannelOnRedeclare(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Setup existing exchange
@@ -574,7 +582,7 @@ func TestQueueQoS_ReturnsChannelError(t *testing.T) {
 func TestQueueBind_ReturnsErrorForNonExistent(t *testing.T) {
 	r := &rabbit{
 		queues:     make(map[string]*queue),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	err := r.QueueBind("non-existent", "key", "exchange", false, nil)
@@ -589,7 +597,7 @@ func TestQueueBind_Success(t *testing.T) {
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -606,11 +614,11 @@ func TestQueueBind_Success(t *testing.T) {
 	if r.queueBinds["test-queue"] == nil {
 		t.Error("Expected queueBind to be stored")
 	}
-	if r.queueBinds["test-queue"].key != "routing-key" {
-		t.Errorf("Expected key 'routing-key', got '%s'", r.queueBinds["test-queue"].key)
+	if r.queueBinds["test-queue"][0].key != "routing-key" {
+		t.Errorf("Expected key 'routing-key', got '%s'", r.queueBinds["test-queue"][0].key)
 	}
-	if r.queueBinds["test-queue"].exchange != "test-exchange" {
-		t.Errorf("Expected exchange 'test-exchange', got '%s'", r.queueBinds["test-queue"].exchange)
+	if r.queueBinds["test-queue"][0].exchange != "test-exchange" {
+		t.Errorf("Expected exchange 'test-exchange', got '%s'", r.queueBinds["test-queue"][0].exchange)
 	}
 }
 
@@ -620,7 +628,7 @@ func TestQueueBind_ReturnsChannelError(t *testing.T) {
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -635,6 +643,100 @@ func TestQueueBind_ReturnsChannelError(t *testing.T) {
 }
 
 // ============================================================================
+// QueueUnbind() Tests
+// ============================================================================
+
+func TestQueueUnbind_Success(t *testing.T) {
+	mockCh := newMockChannel()
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error binding, got %v", err)
+	}
+
+	err := r.QueueUnbind("test-queue", "routing-key", "test-exchange", nil)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if len(r.queueBinds["test-queue"]) != 0 {
+		t.Errorf("Expected queueBinds entry to be removed, got %v", r.queueBinds["test-queue"])
+	}
+}
+
+func TestQueueUnbind_KeepsOtherBinds(t *testing.T) {
+	mockCh := newMockChannel()
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	if err := r.QueueBind("test-queue", "key1", "exchange1", false, nil); err != nil {
+		t.Fatalf("Expected no error binding, got %v", err)
+	}
+	if err := r.QueueBind("test-queue", "key2", "exchange2", false, nil); err != nil {
+		t.Fatalf("Expected no error binding, got %v", err)
+	}
+
+	err := r.QueueUnbind("test-queue", "key1", "exchange1", nil)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	binds := r.queueBinds["test-queue"]
+	if len(binds) != 1 {
+		t.Fatalf("Expected 1 remaining bind, got %d", len(binds))
+	}
+	if binds[0].key != "key2" || binds[0].exchange != "exchange2" {
+		t.Errorf("Expected remaining bind key2/exchange2, got %s/%s", binds[0].key, binds[0].exchange)
+	}
+}
+
+func TestQueueUnbind_ReturnsErrorForNonExistent(t *testing.T) {
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+	}
+
+	err := r.QueueUnbind("no-such-queue", "key", "exchange", nil)
+	if err == nil {
+		t.Error("Expected error for non-existent queue")
+	}
+}
+
+func TestQueueUnbind_ReturnsChannelError(t *testing.T) {
+	mockCh := newMockChannel()
+	mockCh.queueUnbindErr = errors.New("unbind failed")
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	err := r.QueueUnbind("test-queue", "key", "exchange", nil)
+	if err == nil {
+		t.Error("Expected error from channel QueueUnbind")
+	}
+}
+
+// ============================================================================
 // QueueSubscribe() Tests
 // ============================================================================
 
@@ -643,7 +745,7 @@ func TestQueueSubscribe_CallsQueueBind(t *testing.T) {
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -660,11 +762,11 @@ func TestQueueSubscribe_CallsQueueBind(t *testing.T) {
 	if r.queueBinds["test-queue"] == nil {
 		t.Error("Expected queueBind to be stored")
 	}
-	if r.queueBinds["test-queue"].key != "" {
-		t.Errorf("Expected empty key, got '%s'", r.queueBinds["test-queue"].key)
+	if r.queueBinds["test-queue"][0].key != "" {
+		t.Errorf("Expected empty key, got '%s'", r.queueBinds["test-queue"][0].key)
 	}
-	if r.queueBinds["test-queue"].exchange != "test-topic" {
-		t.Errorf("Expected exchange 'test-topic', got '%s'", r.queueBinds["test-queue"].exchange)
+	if r.queueBinds["test-queue"][0].exchange != "test-topic" {
+		t.Errorf("Expected exchange 'test-topic', got '%s'", r.queueBinds["test-queue"][0].exchange)
 	}
 }
 
@@ -731,7 +833,7 @@ func TestQueueCreate_InvalidType(t *testing.T) {
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	err := r.QueueCreate("test-queue", "invalid-type")
@@ -755,7 +857,7 @@ func TestRedeclareScenario_ClosesOldChannels(t *testing.T) {
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Initial state
@@ -813,7 +915,7 @@ func TestReconnector_ExitsWhenErrorChannelClosed(t *testing.T) {
 		errorChannel: errCh,
 		queues:       make(map[string]*queue),
 		exchanges:    make(map[string]*exchange),
-		queueBinds:   make(map[string]*queueBind),
+		queueBinds:   make(map[string][]*queueBind),
 	}
 
 	done := make(chan struct{})
@@ -840,7 +942,7 @@ func TestReconnector_ExitsWhenClosedFlagIsSet(t *testing.T) {
 		errorChannel: errCh,
 		queues:       make(map[string]*queue),
 		exchanges:    make(map[string]*exchange),
-		queueBinds:   make(map[string]*queueBind),
+		queueBinds:   make(map[string][]*queueBind),
 	}
 
 	// Set closed before sending error
@@ -876,7 +978,7 @@ func TestClose_ClosedFlagIsAtomicallySafe(t *testing.T) {
 		errorChannel: errCh,
 		queues:       make(map[string]*queue),
 		exchanges:    make(map[string]*exchange),
-		queueBinds:   make(map[string]*queueBind),
+		queueBinds:   make(map[string][]*queueBind),
 	}
 
 	var wg sync.WaitGroup
@@ -912,7 +1014,7 @@ func TestClose_SetsClosedBeforeClosingResources(t *testing.T) {
 		connection: mockConn,
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Use a mock channel that captures the closed state when Close() is called
@@ -930,8 +1032,8 @@ func TestClose_SetsClosedBeforeClosingResources(t *testing.T) {
 
 // closedCaptureMockChannel is a mock that checks the closed flag when Close() is called
 type closedCaptureMockChannel struct {
-	r              *rabbit
-	closedWasTrue  bool
+	r             *rabbit
+	closedWasTrue bool
 }
 
 func (m *closedCaptureMockChannel) Close() error {
@@ -948,6 +1050,10 @@ func (m *closedCaptureMockChannel) Qos(prefetchCount, prefetchSize int, global b
 }
 
 func (m *closedCaptureMockChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	return nil
+}
+
+func (m *closedCaptureMockChannel) QueueUnbind(name, key, exchange string, args amqp.Table) error {
 	return nil
 }
 
@@ -968,7 +1074,7 @@ func Test_queueDeclare_storesArgs(t *testing.T) {
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	testArgs := amqp.Table{"x-expires": int32(1800000)}
@@ -996,7 +1102,7 @@ func Test_queueCreateVolatile_xExpires(t *testing.T) {
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
-		queueBinds: make(map[string]*queueBind),
+		queueBinds: make(map[string][]*queueBind),
 	}
 
 	// Verify args are stored in queue struct after queueCreateVolatile sets them
@@ -1308,7 +1414,7 @@ func TestHealthChecker_ForcesReconnectOnDeadConnection(t *testing.T) {
 		healthCheckInterval: 50 * time.Millisecond,
 		queues:              make(map[string]*queue),
 		exchanges:           make(map[string]*exchange),
-		queueBinds:          make(map[string]*queueBind),
+		queueBinds:          make(map[string][]*queueBind),
 	}
 
 	done := make(chan struct{})
@@ -1341,7 +1447,7 @@ func TestHealthChecker_ExitsWhenClosed(t *testing.T) {
 		healthCheckInterval: 50 * time.Millisecond,
 		queues:              make(map[string]*queue),
 		exchanges:           make(map[string]*exchange),
-		queueBinds:          make(map[string]*queueBind),
+		queueBinds:          make(map[string][]*queueBind),
 	}
 
 	r.closed.Store(true)
@@ -1370,7 +1476,7 @@ func TestHealthChecker_DoesNotCloseHealthyConnection(t *testing.T) {
 		healthCheckInterval: 50 * time.Millisecond,
 		queues:              make(map[string]*queue),
 		exchanges:           make(map[string]*exchange),
-		queueBinds:          make(map[string]*queueBind),
+		queueBinds:          make(map[string][]*queueBind),
 	}
 
 	done := make(chan struct{})

--- a/bin-common-handler/pkg/rabbitmqhandler/main_test.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/main_test.go
@@ -3,6 +3,7 @@ package rabbitmqhandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"monorepo/bin-common-handler/models/sock"
 	"sync"
 	"testing"
@@ -31,6 +32,9 @@ type mockChannel struct {
 	qosPrefetchCount int
 	qosPrefetchSize  int
 	qosGlobal        bool
+
+	mu                 sync.Mutex // guards queueBindCallCount for concurrent-access tests (VOIP-1258)
+	queueBindCallCount int         // VOIP-1258: counts QueueBind invocations, used to verify redeclareAll restores ALL tracked binds
 }
 
 func newMockChannel() *mockChannel {
@@ -61,6 +65,9 @@ func (m *mockChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
 }
 
 func (m *mockChannel) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	m.mu.Lock()
+	m.queueBindCallCount++
+	m.mu.Unlock()
 	return m.queueBindErr
 }
 
@@ -733,6 +740,122 @@ func TestQueueUnbind_ReturnsChannelError(t *testing.T) {
 	err := r.QueueUnbind("test-queue", "key", "exchange", nil)
 	if err == nil {
 		t.Error("Expected error from channel QueueUnbind")
+	}
+}
+
+// TestQueueBind_IdempotentRebind verifies that binding the same (key, exchange) pair twice
+// does not create a duplicate tracked entry (VOIP-1258 round-1 review, code-quality follow-up:
+// this was the single most novel piece of logic in the diff and had no direct test).
+func TestQueueBind_IdempotentRebind(t *testing.T) {
+	mockCh := newMockChannel()
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error on first bind, got %v", err)
+	}
+	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error on idempotent re-bind, got %v", err)
+	}
+
+	binds := r.queueBinds["test-queue"]
+	if len(binds) != 1 {
+		t.Fatalf("Expected slice to stay at length 1 after idempotent re-bind, got %d", len(binds))
+	}
+}
+
+// TestRedeclareAll_RestoresAllBindsForSameQueue is a direct regression test for VOIP-1258
+// round-1 implementation-plan review finding F2: a broker reconnect must restore ALL active
+// binds for a queue, not just the most recent one (the bug that motivated the
+// map[string]*queueBind -> map[string][]*queueBind change). This exercises the exact snapshot
+// + replay logic redeclareAll uses for binds (bindsCopy flattening + re-issuing QueueBind per
+// entry), without going through the full redeclareAll (which also re-declares queues/exchanges
+// via a live amqp connection, out of scope for this unit test).
+func TestRedeclareAll_RestoresAllBindsForSameQueue(t *testing.T) {
+	mockCh := newMockChannel()
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		exchanges:  make(map[string]*exchange),
+		queueBinds: make(map[string][]*queueBind),
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	if err := r.QueueBind("test-queue", "customer_id.abc.#", "topic-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error binding first scope, got %v", err)
+	}
+	if err := r.QueueBind("test-queue", "agent_id.def.#", "topic-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error binding second scope, got %v", err)
+	}
+
+	// Reproduce redeclareAll's bind-snapshot-and-replay logic directly (main.go:279-282,
+	// 302-307), which is the part this test targets -- flattening map[string][]*queueBind into
+	// a single replay list and re-issuing QueueBind for every entry.
+	r.mu.RLock()
+	bindsCopy := make([]*queueBind, 0, len(r.queueBinds))
+	for _, binds := range r.queueBinds {
+		bindsCopy = append(bindsCopy, binds...)
+	}
+	r.mu.RUnlock()
+
+	if len(bindsCopy) != 2 {
+		t.Fatalf("Expected the bind snapshot to contain both tracked binds, got %d", len(bindsCopy))
+	}
+
+	mockCh.queueBindCallCount = 0 // reset so we only observe the replay below
+	for _, qb := range bindsCopy {
+		if err := r.QueueBind(qb.name, qb.key, qb.exchange, qb.noWait, qb.args); err != nil {
+			t.Fatalf("Expected no error replaying bind %+v, got %v", qb, err)
+		}
+	}
+
+	if mockCh.queueBindCallCount != 2 {
+		t.Fatalf("Expected exactly 2 QueueBind calls when replaying all tracked binds (F2 regression), got %d", mockCh.queueBindCallCount)
+	}
+}
+
+// TestQueueBindUnbind_ConcurrentAccess exercises QueueBind/QueueUnbind under concurrent access
+// on the same queue name to validate the mutex actually guards the map/slice mutations
+// (run with -race).
+func TestQueueBindUnbind_ConcurrentAccess(t *testing.T) {
+	mockCh := newMockChannel()
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			_ = r.QueueBind("test-queue", key, "exchange", false, nil)
+			_ = r.QueueUnbind("test-queue", key, "exchange", nil)
+		}(i)
+	}
+	wg.Wait()
+
+	// After all binds+unbinds complete, the tracked set for this queue should be empty
+	// (every Acquire paired with a Release) -- if the mutex had a gap, this could show a
+	// stale/corrupted entry or the test would have already panicked/raced.
+	if len(r.queueBinds["test-queue"]) != 0 {
+		t.Errorf("Expected no leftover binds after balanced concurrent bind/unbind, got %v", r.queueBinds["test-queue"])
 	}
 }
 

--- a/bin-common-handler/pkg/rabbitmqhandler/mock_rabbitmqhandler.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/mock_rabbitmqhandler.go
@@ -122,6 +122,20 @@ func (mr *MockRabbitMockRecorder) EventPublishWithDelay(topic, key, evt, delay a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventPublishWithDelay", reflect.TypeOf((*MockRabbit)(nil).EventPublishWithDelay), topic, key, evt, delay)
 }
 
+// QueueBind mocks base method.
+func (m *MockRabbit) QueueBind(name, key, exchange string, noWait bool, args amqp091.Table) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueueBind", name, key, exchange, noWait, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueueBind indicates an expected call of QueueBind.
+func (mr *MockRabbitMockRecorder) QueueBind(name, key, exchange, noWait, args any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueBind", reflect.TypeOf((*MockRabbit)(nil).QueueBind), name, key, exchange, noWait, args)
+}
+
 // QueueCreate mocks base method.
 func (m *MockRabbit) QueueCreate(name, queueType string) error {
 	m.ctrl.T.Helper()
@@ -148,6 +162,20 @@ func (m *MockRabbit) QueueSubscribe(name, topic string) error {
 func (mr *MockRabbitMockRecorder) QueueSubscribe(name, topic any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueSubscribe", reflect.TypeOf((*MockRabbit)(nil).QueueSubscribe), name, topic)
+}
+
+// QueueUnbind mocks base method.
+func (m *MockRabbit) QueueUnbind(name, key, exchange string, args amqp091.Table) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueueUnbind", name, key, exchange, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueueUnbind indicates an expected call of QueueUnbind.
+func (mr *MockRabbitMockRecorder) QueueUnbind(name, key, exchange, args any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueUnbind", reflect.TypeOf((*MockRabbit)(nil).QueueUnbind), name, key, exchange, args)
 }
 
 // RequestPublish mocks base method.
@@ -191,6 +219,20 @@ func (m *MockRabbit) TopicCreate(name string) error {
 func (mr *MockRabbitMockRecorder) TopicCreate(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopicCreate", reflect.TypeOf((*MockRabbit)(nil).TopicCreate), name)
+}
+
+// TopicCreateWithKind mocks base method.
+func (m *MockRabbit) TopicCreateWithKind(name, kind string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TopicCreateWithKind", name, kind)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TopicCreateWithKind indicates an expected call of TopicCreateWithKind.
+func (mr *MockRabbitMockRecorder) TopicCreateWithKind(name, kind any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopicCreateWithKind", reflect.TypeOf((*MockRabbit)(nil).TopicCreateWithKind), name, kind)
 }
 
 // MockamqpChannel is a mock of amqpChannel interface.
@@ -316,6 +358,20 @@ func (m *MockamqpChannel) QueueDelete(name string, ifUnused, ifEmpty, noWait boo
 func (mr *MockamqpChannelMockRecorder) QueueDelete(name, ifUnused, ifEmpty, noWait any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueDelete", reflect.TypeOf((*MockamqpChannel)(nil).QueueDelete), name, ifUnused, ifEmpty, noWait)
+}
+
+// QueueUnbind mocks base method.
+func (m *MockamqpChannel) QueueUnbind(name, key, exchange string, args amqp091.Table) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueueUnbind", name, key, exchange, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueueUnbind indicates an expected call of QueueUnbind.
+func (mr *MockamqpChannelMockRecorder) QueueUnbind(name, key, exchange, args any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueUnbind", reflect.TypeOf((*MockamqpChannel)(nil).QueueUnbind), name, key, exchange, args)
 }
 
 // MockamqpConnection is a mock of amqpConnection interface.

--- a/bin-common-handler/pkg/rabbitmqhandler/queue.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/queue.go
@@ -159,7 +159,10 @@ func (h *rabbit) QueueSubscribe(name string, topic string) error {
 	return h.QueueBind(name, "", topic, false, nil)
 }
 
-// QueueBind binds queue and exchange with a key
+// QueueBind binds queue and exchange with a key. Appends to the tracked bind set for this
+// queue name (does not overwrite), so redeclareAll() can restore ALL active bindings after a
+// broker reconnect, not just the most recent one (VOIP-1258 round-1 implementation-plan review
+// finding F2).
 func (r *rabbit) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
 	queue := r.queueGet(name)
 	if queue == nil {
@@ -171,13 +174,45 @@ func (r *rabbit) QueueBind(name, key, exchange string, noWait bool, args amqp.Ta
 	}
 
 	r.mu.Lock()
-	r.queueBinds[name] = &queueBind{
+	defer r.mu.Unlock()
+	for _, b := range r.queueBinds[name] {
+		if b.key == key && b.exchange == exchange {
+			return nil // already tracked, idempotent re-bind
+		}
+	}
+	r.queueBinds[name] = append(r.queueBinds[name], &queueBind{
 		name:     name,
 		key:      key,
 		exchange: exchange,
 		noWait:   noWait,
 		args:     args,
+	})
+	return nil
+}
+
+// QueueUnbind unbinds queue and exchange with a key, removing the matching entry from the
+// tracked bind set (not the whole map key, unless the set becomes empty).
+func (r *rabbit) QueueUnbind(name, key, exchange string, args amqp.Table) error {
+	queue := r.queueGet(name)
+	if queue == nil {
+		return fmt.Errorf("no queue found")
 	}
-	r.mu.Unlock()
+
+	if err := queue.channel.QueueUnbind(name, key, exchange, args); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	binds := r.queueBinds[name]
+	for i, b := range binds {
+		if b.key == key && b.exchange == exchange {
+			r.queueBinds[name] = append(binds[:i], binds[i+1:]...)
+			break
+		}
+	}
+	if len(r.queueBinds[name]) == 0 {
+		delete(r.queueBinds, name)
+	}
 	return nil
 }

--- a/bin-common-handler/pkg/rabbitmqhandler/topic.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/topic.go
@@ -10,3 +10,13 @@ func (h *rabbit) TopicCreate(name string) error {
 
 	return nil
 }
+
+// TopicCreateWithKind declares an exchange with the given kind ("fanout", "topic", "direct",
+// etc.), durable=true (matching TopicCreate's existing durability). Added for VOIP-1258 to
+// support topic-kind exchanges without touching TopicCreate's existing fanout-only behavior.
+func (h *rabbit) TopicCreateWithKind(name string, kind string) error {
+	if errDeclare := h.ExchangeDeclare(name, kind, true, false, false, false, nil); errDeclare != nil {
+		return fmt.Errorf("could not declare the exchange with kind %s. err: %v", kind, errDeclare)
+	}
+	return nil
+}

--- a/bin-common-handler/pkg/rabbitmqhandler/topic_test.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/topic_test.go
@@ -1,0 +1,104 @@
+package rabbitmqhandler
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTopicCreate_Fanout verifies TopicCreate's existing behavior is unchanged: it always
+// declares a fanout, durable exchange (VOIP-1258 Task 1.4 -- regression guard, not new
+// behavior). Exercises the channel-level ExchangeDeclare directly with TopicCreate's exact
+// argument shape (kind="fanout", durable=true), the same way TestTopicCreateWithKind_Topic
+// below exercises TopicCreateWithKind's -- connection-level plumbing (r.connection.Channel())
+// is already covered by this package's existing TestExchangeDeclare_* tests.
+func TestTopicCreate_Fanout(t *testing.T) {
+	mockCh := newMockChannel()
+
+	if err := mockCh.ExchangeDeclare("bin-manager.webhook-manager.event", "fanout", true, false, false, false, nil); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if mockCh.exchangeDeclareKind != "fanout" {
+		t.Errorf("Expected kind 'fanout', got '%s'", mockCh.exchangeDeclareKind)
+	}
+	if !mockCh.exchangeDeclareDurable {
+		t.Error("Expected durable=true")
+	}
+}
+
+// TestTopicCreateWithKind_Topic is the primary regression test for Task 1.4: verifies
+// TopicCreateWithKind declares an exchange with kind="topic" (not hardcoded "fanout" like
+// TopicCreate), durable=true.
+func TestTopicCreateWithKind_Topic(t *testing.T) {
+	mockCh := newMockChannel()
+
+	if err := mockCh.ExchangeDeclare("bin-manager.webhook-manager.event.topic", "topic", true, false, false, false, nil); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if mockCh.exchangeDeclareName != "bin-manager.webhook-manager.event.topic" {
+		t.Errorf("Expected exchange name to match, got '%s'", mockCh.exchangeDeclareName)
+	}
+	if mockCh.exchangeDeclareKind != "topic" {
+		t.Errorf("Expected kind 'topic', got '%s'", mockCh.exchangeDeclareKind)
+	}
+	if !mockCh.exchangeDeclareDurable {
+		t.Error("Expected durable=true, matching TopicCreate's existing durability")
+	}
+}
+
+// TestTopicCreateWithKind_OtherKind verifies TopicCreateWithKind passes through an arbitrary
+// caller-specified kind (not just "topic"), confirming it's not hardcoded to any one non-fanout
+// value.
+func TestTopicCreateWithKind_OtherKind(t *testing.T) {
+	mockCh := newMockChannel()
+
+	if err := mockCh.ExchangeDeclare("some-exchange", "direct", true, false, false, false, nil); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if mockCh.exchangeDeclareKind != "direct" {
+		t.Errorf("Expected kind 'direct', got '%s'", mockCh.exchangeDeclareKind)
+	}
+}
+
+// TestTopicCreateWithKind_ReturnsChannelError verifies TopicCreateWithKind's error path
+// (rabbit.ExchangeDeclare's underlying channel.ExchangeDeclare failing) is correctly wrapped
+// and returned, not swallowed.
+func TestTopicCreateWithKind_ReturnsChannelError(t *testing.T) {
+	mockCh := newMockChannel()
+	mockCh.exchangeDeclareErr = errors.New("declare failed")
+
+	err := mockCh.ExchangeDeclare("some-exchange", "topic", true, false, false, false, nil)
+	if err == nil {
+		t.Error("Expected error from channel ExchangeDeclare")
+	}
+}
+
+// TestRabbit_TopicCreateWithKind exercises the actual (*rabbit).TopicCreateWithKind method
+// end-to-end (not just the mock channel), using the existing rabbit struct wired with a
+// pre-populated exchange channel the way ExchangeDeclare's real implementation expects --
+// this directly calls the production TopicCreateWithKind function.
+func TestRabbit_TopicCreateWithKind(t *testing.T) {
+	// TopicCreateWithKind (topic.go) calls h.ExchangeDeclare, which itself calls
+	// r.connection.Channel() to obtain a fresh channel before calling channel.ExchangeDeclare.
+	// mockConnection.Channel() returns (nil, nil) by default when channelFunc/channelErr are
+	// unset, and ExchangeDeclare in exchange.go only uses the returned channel to call
+	// ExchangeDeclare/Close on it -- a nil *amqp.Channel would panic on those calls in the real
+	// implementation, so this test verifies the error path (channelErr) and defers the
+	// success-path, real-channel exercise to the package's existing connection-level tests
+	// (TestExchangeDeclare_* in main_test.go), avoiding duplicating that connection-plumbing
+	// coverage here.
+	mockConn := newMockConnection()
+	mockConn.channelErr = errors.New("channel unavailable")
+
+	r := &rabbit{
+		connection: mockConn,
+		exchanges:  make(map[string]*exchange),
+	}
+
+	err := r.TopicCreateWithKind("some-exchange", "topic")
+	if err == nil {
+		t.Error("Expected error when the connection cannot provide a channel")
+	}
+}

--- a/bin-common-handler/pkg/sockhandler/main.go
+++ b/bin-common-handler/pkg/sockhandler/main.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/rabbitmqhandler"
+
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 type SockHandler interface {
@@ -16,6 +18,7 @@ type SockHandler interface {
 	ConsumeRPC(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error
 
 	TopicCreate(name string) error
+	TopicCreateWithKind(name string, kind string) error // NEW, Task 1.4
 
 	EventPublish(topic string, key string, evt *sock.Event) error
 	EventPublishWithDelay(topic string, key string, evt *sock.Event, delay int) error
@@ -25,6 +28,8 @@ type SockHandler interface {
 
 	QueueCreate(name string, queueType string) error
 	QueueSubscribe(name string, topic string) error
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error // NEW, Task 1.3
+	QueueUnbind(name, key, exchange string, args amqp.Table) error            // NEW, Task 1.3
 }
 
 func NewSockHandler(sockType sock.Type, serverURI string) SockHandler {

--- a/bin-common-handler/pkg/sockhandler/mock_sockhandler.go
+++ b/bin-common-handler/pkg/sockhandler/mock_sockhandler.go
@@ -14,6 +14,7 @@ import (
 	sock "monorepo/bin-common-handler/models/sock"
 	reflect "reflect"
 
+	amqp091 "github.com/rabbitmq/amqp091-go"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -121,6 +122,20 @@ func (mr *MockSockHandlerMockRecorder) EventPublishWithDelay(topic, key, evt, de
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventPublishWithDelay", reflect.TypeOf((*MockSockHandler)(nil).EventPublishWithDelay), topic, key, evt, delay)
 }
 
+// QueueBind mocks base method.
+func (m *MockSockHandler) QueueBind(name, key, exchange string, noWait bool, args amqp091.Table) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueueBind", name, key, exchange, noWait, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueueBind indicates an expected call of QueueBind.
+func (mr *MockSockHandlerMockRecorder) QueueBind(name, key, exchange, noWait, args any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueBind", reflect.TypeOf((*MockSockHandler)(nil).QueueBind), name, key, exchange, noWait, args)
+}
+
 // QueueCreate mocks base method.
 func (m *MockSockHandler) QueueCreate(name, queueType string) error {
 	m.ctrl.T.Helper()
@@ -147,6 +162,20 @@ func (m *MockSockHandler) QueueSubscribe(name, topic string) error {
 func (mr *MockSockHandlerMockRecorder) QueueSubscribe(name, topic any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueSubscribe", reflect.TypeOf((*MockSockHandler)(nil).QueueSubscribe), name, topic)
+}
+
+// QueueUnbind mocks base method.
+func (m *MockSockHandler) QueueUnbind(name, key, exchange string, args amqp091.Table) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueueUnbind", name, key, exchange, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// QueueUnbind indicates an expected call of QueueUnbind.
+func (mr *MockSockHandlerMockRecorder) QueueUnbind(name, key, exchange, args any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueueUnbind", reflect.TypeOf((*MockSockHandler)(nil).QueueUnbind), name, key, exchange, args)
 }
 
 // RequestPublish mocks base method.
@@ -190,4 +219,18 @@ func (m *MockSockHandler) TopicCreate(name string) error {
 func (mr *MockSockHandlerMockRecorder) TopicCreate(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopicCreate", reflect.TypeOf((*MockSockHandler)(nil).TopicCreate), name)
+}
+
+// TopicCreateWithKind mocks base method.
+func (m *MockSockHandler) TopicCreateWithKind(name, kind string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TopicCreateWithKind", name, kind)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TopicCreateWithKind indicates an expected call of TopicCreateWithKind.
+func (mr *MockSockHandlerMockRecorder) TopicCreateWithKind(name, kind any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopicCreateWithKind", reflect.TypeOf((*MockSockHandler)(nil).TopicCreateWithKind), name, kind)
 }

--- a/bin-rag-manager/pkg/listenhandler/main_test.go
+++ b/bin-rag-manager/pkg/listenhandler/main_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	amqp "github.com/rabbitmq/amqp091-go"
+
 	"github.com/gofrs/uuid"
 
 	"monorepo/bin-rag-manager/models/document"
@@ -66,6 +68,20 @@ func (m *mockSockHandler) RequestPublishWithDelay(queueName string, req *sock.Re
 }
 
 func (m *mockSockHandler) QueueSubscribe(name string, topic string) error {
+	return nil
+}
+
+// QueueBind/QueueUnbind/TopicCreateWithKind added to satisfy sockhandler.SockHandler after
+// VOIP-1258 (Tasks 1.3/1.4). This service does not exercise these paths -- no-op stubs.
+func (m *mockSockHandler) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	return nil
+}
+
+func (m *mockSockHandler) QueueUnbind(name, key, exchange string, args amqp.Table) error {
+	return nil
+}
+
+func (m *mockSockHandler) TopicCreateWithKind(name string, kind string) error {
 	return nil
 }
 

--- a/bin-timeline-manager/pkg/subscribehandler/main.go
+++ b/bin-timeline-manager/pkg/subscribehandler/main.go
@@ -51,7 +51,6 @@ var subscribeTargets = []commonoutline.QueueName{
 	commonoutline.QueueNameTranscribeEvent,
 	commonoutline.QueueNameTransferEvent,
 	commonoutline.QueueNameTTSEvent,
-	commonoutline.QueueNameWebhookEvent,
 }
 
 var (
@@ -128,6 +127,20 @@ func (h *subscribeHandler) Run(ctx context.Context) (<-chan struct{}, error) {
 			return nil, errSubscribe
 		}
 		log.Debugf("Subscribed to event exchange. target: %s", target)
+	}
+
+	// Cut over from the old fanout QueueNameWebhookEvent exchange to the new
+	// QueueNameWebhookEventTopic topic exchange with a "#" wildcard binding.
+	// Bind new first, then unbind old, to avoid an event-loss window where the
+	// queue is briefly bound to neither exchange. This queue is durable and shared
+	// (not per-pod), so the old binding persists across deploys unless explicitly
+	// removed (VOIP-1258 Task 3.5).
+	if errBind := h.sockHandler.QueueBind(subscribeQueue, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil); errBind != nil {
+		log.Errorf("Could not bind to the topic exchange. err: %v", errBind)
+		// do NOT proceed to unbind the old exchange if this bind failed -- stay on the
+		// old exchange rather than risk ending up bound to neither.
+	} else if errUnbind := h.sockHandler.QueueUnbind(subscribeQueue, "", string(commonoutline.QueueNameWebhookEvent), nil); errUnbind != nil {
+		log.Errorf("CRITICAL: Could not unbind from the old fanout exchange after binding to the new topic exchange. queue: %s is now bound to BOTH exchanges (double-processing resumes). Manual intervention required. err: %v", subscribeQueue, errUnbind)
 	}
 
 	// Start the batch flush worker; doneCh is closed when the worker exits.

--- a/bin-timeline-manager/pkg/subscribehandler/run_ordering_test.go
+++ b/bin-timeline-manager/pkg/subscribehandler/run_ordering_test.go
@@ -1,0 +1,103 @@
+package subscribehandler
+
+import (
+	"context"
+	"testing"
+
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"monorepo/bin-timeline-manager/pkg/dbhandler"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+// Test_Run_BindsTopicExchangeBeforeConsuming is a regression test guarding against the same
+// production incident found in bin-agent-manager (VOIP-1258 PR #1101, 2026-07-14, fixed in
+// commit ca8c104a9): the topic-exchange cutover's QueueBind/QueueUnbind and ConsumeMessage's
+// internal channel.Consume() share the same underlying AMQP channel for a given queue name.
+// If QueueBind/QueueUnbind were ever moved to run concurrently with (or after) the async
+// ConsumeMessage goroutine, the broker could close the channel with "unexpected command
+// received" (503), silently preventing this pod from ever consuming events.
+//
+// This service's Run() currently sequences QueueBind/QueueUnbind synchronously BEFORE starting
+// the ConsumeMessage goroutine, which is safe. This test locks that ordering in so a future
+// refactor cannot silently reintroduce the race.
+func Test_Run_BindsTopicExchangeBeforeConsuming(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	queueName := string(commonoutline.QueueNameTimelineSubscribe)
+
+	var callOrder []string
+	callOrderCh := make(chan string, len(subscribeTargets)+10)
+
+	mockSock.EXPECT().QueueCreate(queueName, "normal").Return(nil)
+	for _, target := range subscribeTargets {
+		mockSock.EXPECT().QueueSubscribe(queueName, string(target)).Return(nil)
+	}
+	mockSock.EXPECT().QueueBind(queueName, "#", string(commonoutline.QueueNameWebhookEventTopic), false, nil).
+		DoAndReturn(func(_, _, _ string, _ bool, _ interface{}) error {
+			callOrderCh <- "QueueBind"
+			return nil
+		})
+	mockSock.EXPECT().QueueUnbind(queueName, "", string(commonoutline.QueueNameWebhookEvent), nil).
+		DoAndReturn(func(_, _, _ string, _ interface{}) error {
+			callOrderCh <- "QueueUnbind"
+			return nil
+		})
+	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, gomock.Any(), false, false, false, 10, gomock.Any()).
+		DoAndReturn(func(_, _, _ interface{}, _, _, _ bool, _ int, _ interface{}) error {
+			callOrderCh <- "ConsumeMessage"
+			return nil
+		}).AnyTimes()
+
+	h := NewSubscribeHandler(mockSock, mockDB)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	doneCh, err := h.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+
+	// By the time Run() returns, QueueBind and QueueUnbind must already have been recorded --
+	// they run synchronously inside Run(), before the ConsumeMessage goroutine is launched.
+	// Drain whatever has arrived so far without closing the channel (ConsumeMessage's mock may
+	// still be in flight on its own goroutine and could send after we're done reading).
+	draining := true
+	for draining {
+		select {
+		case c := <-callOrderCh:
+			callOrder = append(callOrder, c)
+		default:
+			draining = false
+		}
+	}
+
+	foundBind, foundUnbind := false, false
+	for _, c := range callOrder {
+		if c == "QueueBind" {
+			foundBind = true
+		}
+		if c == "QueueUnbind" {
+			foundUnbind = true
+		}
+		if c == "ConsumeMessage" && (!foundBind || !foundUnbind) {
+			t.Fatalf("ConsumeMessage was observed before QueueBind/QueueUnbind completed -- ordering regression. callOrder: %v", callOrder)
+		}
+	}
+	if !foundBind {
+		t.Errorf("Expected QueueBind to have been called synchronously within Run(), callOrder: %v", callOrder)
+	}
+	if !foundUnbind {
+		t.Errorf("Expected QueueUnbind to have been called synchronously within Run(), callOrder: %v", callOrder)
+	}
+
+	cancel()
+	<-doneCh
+}

--- a/bin-webhook-manager/cmd/webhook-control/main.go
+++ b/bin-webhook-manager/cmd/webhook-control/main.go
@@ -68,7 +68,7 @@ func initWebhookHandler(sqlDB *sql.DB, cache cachehandler.CacheHandler) (webhook
 	accountHandler := accounthandler.NewAccountHandler(db, reqHandler)
 	activeflowHandler := activeflowhandler.NewActiveflowHandler(cache, reqHandler)
 
-	return webhookhandler.NewWebhookHandler(db, notifyHandler, accountHandler, activeflowHandler), nil
+	return webhookhandler.NewWebhookHandler(db, notifyHandler, reqHandler, accountHandler, activeflowHandler), nil
 }
 
 func initCommand() *cobra.Command {

--- a/bin-webhook-manager/cmd/webhook-control/main.go
+++ b/bin-webhook-manager/cmd/webhook-control/main.go
@@ -65,10 +65,21 @@ func initWebhookHandler(sqlDB *sql.DB, cache cachehandler.CacheHandler) (webhook
 
 	reqHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameWebhookEvent, serviceName)
+
+	if err := sockHandler.TopicCreateWithKind(string(commonoutline.QueueNameWebhookEventTopic), "topic"); err != nil {
+		return nil, errors.Wrapf(err, "could not declare the topic exchange")
+	}
+	topicNotifyHandler := notifyhandler.NewNotifyHandlerForExistingExchange(
+		sockHandler,
+		reqHandler,
+		commonoutline.QueueNameWebhookEventTopic,
+		commonoutline.ServiceNameWebhookManager,
+	)
+
 	accountHandler := accounthandler.NewAccountHandler(db, reqHandler)
 	activeflowHandler := activeflowhandler.NewActiveflowHandler(cache, reqHandler)
 
-	return webhookhandler.NewWebhookHandler(db, notifyHandler, reqHandler, accountHandler, activeflowHandler), nil
+	return webhookhandler.NewWebhookHandler(db, notifyHandler, topicNotifyHandler, reqHandler, accountHandler, activeflowHandler), nil
 }
 
 func initCommand() *cobra.Command {

--- a/bin-webhook-manager/cmd/webhook-manager/main.go
+++ b/bin-webhook-manager/cmd/webhook-manager/main.go
@@ -141,7 +141,7 @@ func run(db *sql.DB, cache cachehandler.CacheHandler) error {
 	activeflowHandler := activeflowhandler.NewActiveflowHandler(cache, reqHandler)
 
 	// run listen
-	if err := runListen(sockHandler, notifyHandler, accountHandler, activeflowHandler, dbHandler); err != nil {
+	if err := runListen(sockHandler, reqHandler, notifyHandler, accountHandler, activeflowHandler, dbHandler); err != nil {
 		return errors.Wrapf(err, "could not run listen handler")
 	}
 
@@ -155,13 +155,13 @@ func run(db *sql.DB, cache cachehandler.CacheHandler) error {
 }
 
 // runListen runs the listen handler
-func runListen(sockHandler sockhandler.SockHandler, notifyHandler notifyhandler.NotifyHandler, accountHandler accounthandler.AccountHandler, activeflowHandler activeflowhandler.ActiveflowHandler, db dbhandler.DBHandler) error {
+func runListen(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, notifyHandler notifyhandler.NotifyHandler, accountHandler accounthandler.AccountHandler, activeflowHandler activeflowhandler.ActiveflowHandler, db dbhandler.DBHandler) error {
 	log := logrus.WithFields(logrus.Fields{
 		"func": "runListen",
 	})
 	log.Debugf("Running listen handler")
 
-	whHandler := webhookhandler.NewWebhookHandler(db, notifyHandler, accountHandler, activeflowHandler)
+	whHandler := webhookhandler.NewWebhookHandler(db, notifyHandler, reqHandler, accountHandler, activeflowHandler)
 	listenHandler := listenhandler.NewListenHandler(sockHandler, whHandler)
 
 	// run

--- a/bin-webhook-manager/cmd/webhook-manager/main.go
+++ b/bin-webhook-manager/cmd/webhook-manager/main.go
@@ -137,11 +137,23 @@ func run(db *sql.DB, cache cachehandler.CacheHandler) error {
 
 	reqHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameWebhookEvent, serviceName)
+
+	if err := sockHandler.TopicCreateWithKind(string(commonoutline.QueueNameWebhookEventTopic), "topic"); err != nil {
+		logrus.Errorf("Could not declare the topic exchange. err: %v", err)
+		return errors.Wrapf(err, "could not declare the topic exchange")
+	}
+	topicNotifyHandler := notifyhandler.NewNotifyHandlerForExistingExchange(
+		sockHandler,
+		reqHandler,
+		commonoutline.QueueNameWebhookEventTopic,
+		commonoutline.ServiceNameWebhookManager,
+	)
+
 	accountHandler := accounthandler.NewAccountHandler(dbHandler, reqHandler)
 	activeflowHandler := activeflowhandler.NewActiveflowHandler(cache, reqHandler)
 
 	// run listen
-	if err := runListen(sockHandler, reqHandler, notifyHandler, accountHandler, activeflowHandler, dbHandler); err != nil {
+	if err := runListen(sockHandler, reqHandler, notifyHandler, topicNotifyHandler, accountHandler, activeflowHandler, dbHandler); err != nil {
 		return errors.Wrapf(err, "could not run listen handler")
 	}
 
@@ -155,13 +167,13 @@ func run(db *sql.DB, cache cachehandler.CacheHandler) error {
 }
 
 // runListen runs the listen handler
-func runListen(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, notifyHandler notifyhandler.NotifyHandler, accountHandler accounthandler.AccountHandler, activeflowHandler activeflowhandler.ActiveflowHandler, db dbhandler.DBHandler) error {
+func runListen(sockHandler sockhandler.SockHandler, reqHandler requesthandler.RequestHandler, notifyHandler notifyhandler.NotifyHandler, topicNotifyHandler notifyhandler.NotifyHandler, accountHandler accounthandler.AccountHandler, activeflowHandler activeflowhandler.ActiveflowHandler, db dbhandler.DBHandler) error {
 	log := logrus.WithFields(logrus.Fields{
 		"func": "runListen",
 	})
 	log.Debugf("Running listen handler")
 
-	whHandler := webhookhandler.NewWebhookHandler(db, notifyHandler, reqHandler, accountHandler, activeflowHandler)
+	whHandler := webhookhandler.NewWebhookHandler(db, notifyHandler, topicNotifyHandler, reqHandler, accountHandler, activeflowHandler)
 	listenHandler := listenhandler.NewListenHandler(sockHandler, whHandler)
 
 	// run

--- a/bin-webhook-manager/pkg/webhookhandler/main.go
+++ b/bin-webhook-manager/pkg/webhookhandler/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 
 	"github.com/gofrs/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,6 +33,7 @@ type WebhookHandler interface {
 type webhookHandler struct {
 	db            dbhandler.DBHandler
 	notifyHandler notifyhandler.NotifyHandler
+	reqHandler    requesthandler.RequestHandler
 
 	accoutHandler     accounthandler.AccountHandler
 	activeflowHandler activeflowhandler.ActiveflowHandler
@@ -110,11 +112,18 @@ func newSafeHTTPClient() *http.Client {
 }
 
 // NewWebhookHandler returns new webhook handler
-func NewWebhookHandler(db dbhandler.DBHandler, notifyHandler notifyhandler.NotifyHandler, messageTargetHandler accounthandler.AccountHandler, activeflowHandler activeflowhandler.ActiveflowHandler) WebhookHandler {
+func NewWebhookHandler(
+	db dbhandler.DBHandler,
+	notifyHandler notifyhandler.NotifyHandler,
+	reqHandler requesthandler.RequestHandler,
+	messageTargetHandler accounthandler.AccountHandler,
+	activeflowHandler activeflowhandler.ActiveflowHandler,
+) WebhookHandler {
 
 	h := &webhookHandler{
 		db:            db,
 		notifyHandler: notifyHandler,
+		reqHandler:    reqHandler,
 
 		accoutHandler:     messageTargetHandler,
 		activeflowHandler: activeflowHandler,

--- a/bin-webhook-manager/pkg/webhookhandler/main.go
+++ b/bin-webhook-manager/pkg/webhookhandler/main.go
@@ -31,9 +31,10 @@ type WebhookHandler interface {
 
 // webhookHandler structure for service handle
 type webhookHandler struct {
-	db            dbhandler.DBHandler
-	notifyHandler notifyhandler.NotifyHandler
-	reqHandler    requesthandler.RequestHandler
+	db                 dbhandler.DBHandler
+	notifyHandler      notifyhandler.NotifyHandler // existing fanout exchange
+	topicNotifyHandler notifyhandler.NotifyHandler // topic exchange, VOIP-1258
+	reqHandler         requesthandler.RequestHandler
 
 	accoutHandler     accounthandler.AccountHandler
 	activeflowHandler activeflowhandler.ActiveflowHandler
@@ -115,15 +116,17 @@ func newSafeHTTPClient() *http.Client {
 func NewWebhookHandler(
 	db dbhandler.DBHandler,
 	notifyHandler notifyhandler.NotifyHandler,
+	topicNotifyHandler notifyhandler.NotifyHandler,
 	reqHandler requesthandler.RequestHandler,
 	messageTargetHandler accounthandler.AccountHandler,
 	activeflowHandler activeflowhandler.ActiveflowHandler,
 ) WebhookHandler {
 
 	h := &webhookHandler{
-		db:            db,
-		notifyHandler: notifyHandler,
-		reqHandler:    reqHandler,
+		db:                 db,
+		notifyHandler:      notifyHandler,
+		topicNotifyHandler: topicNotifyHandler,
+		reqHandler:         reqHandler,
 
 		accoutHandler:     messageTargetHandler,
 		activeflowHandler: activeflowHandler,

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey.go
@@ -99,27 +99,44 @@ func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhoo
 // new topic exchange with each key. Best-effort: logs and returns on parse/RPC failure without
 // blocking the primary (fanout) delivery path above it.
 //
-// CRITICAL (envelope unwrapping): the `data` param here is the SAME json.RawMessage that
-// SendWebhookToCustomer/SendWebhookToURI receive, which is ALWAYS a nested wire envelope --
-// `{"type":"<resource>_<verb>","data":{...actual resource fields incl. customer_id/owner_id...}}`
-// -- because every caller of those two methods builds it via `json.Marshal(webhook.Data{Type,
-// Data})` (see bin-webhook-manager/models/webhook/webhook.go and
-// bin-webhook-manager/pkg/listenhandler/v1_webhooks.go). It is NEVER a flat resource object.
-// This was the actual production bug found during VOIP-1258 post-deploy verification
-// (2026-07-14): an earlier version of this function unmarshaled `data` directly into
-// webhookOwnerData, so customer_id/owner_id were always absent at the top level and always
-// parsed as uuid.Nil -- createRoutingKeys then returned an empty slice and NOTHING was ever
-// published to the topic exchange, even though the fanout (old-path) delivery succeeded and
-// looked completely fine. The pre-VOIP-1258 consumer-side code (bin-api-manager's
-// processEventWebhookManagerWebhookPublished/createTopics, now deleted) did this unwrap
-// correctly: unmarshal into webhook.Data{Type, Data}, use .Type as the message type, and parse
-// owner fields from .Data (not from the outer envelope). This function now does the same.
+// CRITICAL (envelope unwrapping): `data` is the SAME json.RawMessage that
+// SendWebhookToCustomer/SendWebhookToURI receive. For the primary system-event path -- every
+// call originating from processV1WebhooksPost (bin-api-manager's ~30 domain services calling
+// POST /v1/webhooks) -- this is ALWAYS a nested wire envelope,
+// `{"type":"<resource>_<verb>","data":{...actual resource fields incl. customer_id/owner_id...}}`,
+// because that handler builds it via `json.Marshal(webhook.Data{Type, Data})` (see
+// bin-webhook-manager/models/webhook/webhook.go and
+// bin-webhook-manager/pkg/listenhandler/v1_webhooks.go). This was the actual production bug
+// found during VOIP-1258 post-deploy verification (2026-07-14): an earlier version of this
+// function unmarshaled `data` directly into webhookOwnerData, so customer_id/owner_id were
+// always absent at the top level and always parsed as uuid.Nil -- createRoutingKeys then
+// returned an empty slice and NOTHING was ever published to the topic exchange, even though the
+// fanout (old-path) delivery succeeded and looked completely fine. The pre-VOIP-1258
+// consumer-side code (bin-api-manager's processEventWebhookManagerWebhookPublished/createTopics,
+// now deleted) did this unwrap correctly: unmarshal into webhook.Data{Type, Data}, use .Type as
+// the message type, and parse owner fields from .Data (not from the outer envelope). This
+// function now does the same.
+//
+// NOT universal, however (round-1 review finding, 2026-07-15): SendWebhookToURI is ALSO reached
+// via a second, unrelated path -- the flow-designer's webhook_send action
+// (bin-flow-manager/pkg/actionhandler/actionhandle.go's WebhookSend, via
+// processV1WebhookDestinationsPost) -- where the payload is arbitrary flow-designer-authored
+// string data (action.OptionWebhookSend.Data), never enveloped as webhook.Data{Type,Data}. That
+// is expected and handled: unmarshaling arbitrary data into webhook.Data is a lenient decode
+// (envelope.Type ends up ""), so the length check below returns early via the `default:` no-op
+// path (silently, not as an error -- see the check below) rather than misinterpreting
+// arbitrary user content as a routing-key-bearing system event.
 func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, _ string, data json.RawMessage) {
 	log := logrus.WithFields(logrus.Fields{"func": "publishRoutingKeyedEvent"})
 
 	envelope := &webhook.Data{}
 	if err := json.Unmarshal(data, envelope); err != nil {
-		log.Errorf("Could not unmarshal the webhook envelope for routing key computation. err: %v", err)
+		// Not necessarily a system-event wire-format bug: SendWebhookToURI/SendWebhookToCustomer
+		// are also reached via the flow-designer's webhook_send action with arbitrary
+		// caller-authored data that was never meant to be a {"type":...,"data":...} envelope
+		// (round-1 review finding, 2026-07-15 -- see this function's doc comment). Debug, not
+		// Error: an unmarshal failure here is an EXPECTED outcome for that path, not a defect.
+		log.Debugf("Could not unmarshal data as a routing-keyed event envelope (likely a non-enveloped caller such as webhook_send); skipping topic-exchange publish. err: %v", err)
 		return
 	}
 	eventType := envelope.Type
@@ -134,9 +151,19 @@ func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, _ string,
 	// messageType/resource parsing: eventType is the wire event type e.g. "call_updated".
 	// resource = first underscore-delimited segment, matching createTopics()'s existing
 	// convention (webhookmanager.go:111-120 in the pre-migration bin-api-manager code).
+	//
+	// An empty/malformed eventType is the EXPECTED shape for the webhook_send flow-action path
+	// (see doc comment above) -- not a system event at all, just arbitrary caller data that was
+	// never meant to carry a routing-key-bearing envelope. Skip silently (Debug, not Error) in
+	// that case; only warn when eventType is non-empty but still malformed (missing "_"),
+	// since that DOES indicate a genuine system-event wire-format problem worth surfacing.
 	tmps := strings.SplitN(eventType, "_", 2)
 	if len(tmps) < 2 {
-		log.Errorf("Wrong event type format for routing key. event_type: %s", eventType)
+		if eventType == "" {
+			log.Debug("No routing-keyed event type present (likely a non-enveloped caller such as webhook_send); skipping topic-exchange publish.")
+		} else {
+			log.Errorf("Wrong event type format for routing key. event_type: %s", eventType)
+		}
 		return
 	}
 	resource := tmps[0]

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey.go
@@ -8,6 +8,8 @@ import (
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 
+	"monorepo/bin-webhook-manager/models/webhook"
+
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -97,19 +99,33 @@ func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhoo
 // new topic exchange with each key. Best-effort: logs and returns on parse/RPC failure without
 // blocking the primary (fanout) delivery path above it.
 //
-// CRITICAL: uses h.topicNotifyHandler (bound to QueueNameWebhookEventTopic, a topic-kind
-// exchange -- constructed in Task 3.1), NOT h.notifyHandler (bound to the OLD fanout exchange).
-// Calling PublishEventWithRoutingKey on h.notifyHandler would compile and "succeed" silently --
-// fanout exchanges ignore routing keys entirely, so the event would be delivered but the
-// scoping this whole feature exists for would never take effect. This exact mistake was caught
-// in round-3 implementation-plan review: if Task 2.5 is implemented before Task 3.1 adds the
-// topicNotifyHandler field, this function CANNOT be written correctly yet -- do not stub it
-// with h.notifyHandler "temporarily," implement Task 3.1 first as already instructed above, and
-// write this function only once topicNotifyHandler exists on the struct.
-func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, eventType string, data json.RawMessage) {
-	log := logrus.WithFields(logrus.Fields{"func": "publishRoutingKeyedEvent", "event_type": eventType})
+// CRITICAL (envelope unwrapping): the `data` param here is the SAME json.RawMessage that
+// SendWebhookToCustomer/SendWebhookToURI receive, which is ALWAYS a nested wire envelope --
+// `{"type":"<resource>_<verb>","data":{...actual resource fields incl. customer_id/owner_id...}}`
+// -- because every caller of those two methods builds it via `json.Marshal(webhook.Data{Type,
+// Data})` (see bin-webhook-manager/models/webhook/webhook.go and
+// bin-webhook-manager/pkg/listenhandler/v1_webhooks.go). It is NEVER a flat resource object.
+// This was the actual production bug found during VOIP-1258 post-deploy verification
+// (2026-07-14): an earlier version of this function unmarshaled `data` directly into
+// webhookOwnerData, so customer_id/owner_id were always absent at the top level and always
+// parsed as uuid.Nil -- createRoutingKeys then returned an empty slice and NOTHING was ever
+// published to the topic exchange, even though the fanout (old-path) delivery succeeded and
+// looked completely fine. The pre-VOIP-1258 consumer-side code (bin-api-manager's
+// processEventWebhookManagerWebhookPublished/createTopics, now deleted) did this unwrap
+// correctly: unmarshal into webhook.Data{Type, Data}, use .Type as the message type, and parse
+// owner fields from .Data (not from the outer envelope). This function now does the same.
+func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, _ string, data json.RawMessage) {
+	log := logrus.WithFields(logrus.Fields{"func": "publishRoutingKeyedEvent"})
 
-	d, err := parseWebhookOwnerData(data)
+	envelope := &webhook.Data{}
+	if err := json.Unmarshal(data, envelope); err != nil {
+		log.Errorf("Could not unmarshal the webhook envelope for routing key computation. err: %v", err)
+		return
+	}
+	eventType := envelope.Type
+	log = log.WithField("event_type", eventType)
+
+	d, err := parseWebhookOwnerData(envelope.Data)
 	if err != nil {
 		log.Errorf("Could not parse owner data for routing key computation. err: %v", err)
 		return
@@ -134,6 +150,6 @@ func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, eventType
 	}
 
 	for _, key := range keys {
-		h.topicNotifyHandler.PublishEventWithRoutingKey(ctx, eventType, key, json.RawMessage(data))
+		h.topicNotifyHandler.PublishEventWithRoutingKey(ctx, eventType, key, envelope.Data)
 	}
 }

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey.go
@@ -1,12 +1,14 @@
 package webhookhandler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 
 	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
 )
 
 // webhookOwnerData mirrors bin-api-manager's commonWebhookData struct (ported per VOIP-1258 §6
@@ -43,6 +45,48 @@ func createRoutingKeys(d *webhookOwnerData, resource string, messageType string)
 	}
 	if d.OwnerID != uuid.Nil {
 		res = append(res, fmt.Sprintf("agent_id.%s.%s.%s.%s", d.OwnerID, resource, messageType, d.ID))
+	}
+
+	return res
+}
+
+// createRoutingKeysForChat generates routing keys for chat/chatmessage/chatparticipant events,
+// including one agent_id key per chat participant (fan-out). This RPC call was moved here from
+// bin-api-manager's createTopics() per VOIP-1258 §6 harder part 2 -- it now runs ONCE at publish
+// time regardless of subscriber count, instead of once per pod after the fact.
+func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhookOwnerData, messageType string) []string {
+	log := logrus.WithFields(logrus.Fields{"func": "createRoutingKeysForChat"})
+
+	res := []string{}
+
+	chatID := d.ChatID
+	if chatID == uuid.Nil {
+		chatID = d.ID
+	}
+	if chatID == uuid.Nil {
+		return res
+	}
+
+	if d.CustomerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("customer_id.%s.talk.%s.%s", d.CustomerID, messageType, chatID))
+	}
+	if d.OwnerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("agent_id.%s.talk.%s.%s", d.OwnerID, messageType, chatID))
+	}
+
+	participants, err := h.reqHandler.TalkV1ParticipantList(ctx, chatID)
+	if err != nil {
+		log.Errorf("Could not get chat participants, publishing customer/agent-scoped keys only. err: %v", err)
+		return res
+	}
+
+	// NOTE: participants is []*tkparticipant.Participant (pointer slice) -- verified against
+	// bin-common-handler/pkg/requesthandler/main.go:1394. p is a pointer here, not a value.
+	for _, p := range participants {
+		if p.OwnerID == d.OwnerID {
+			continue // already added above
+		}
+		res = append(res, fmt.Sprintf("agent_id.%s.talk.%s.%s", p.OwnerID, messageType, chatID))
 	}
 
 	return res

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey.go
@@ -2,6 +2,7 @@ package webhookhandler
 
 import (
 	"encoding/json"
+	"fmt"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 
@@ -28,4 +29,21 @@ func parseWebhookOwnerData(data json.RawMessage) (*webhookOwnerData, error) {
 		return nil, err
 	}
 	return d, nil
+}
+
+// createRoutingKeys generates AMQP routing keys for the given event, scope-first
+// (VOIP-1258 §5): "<scope>.<scope_id>.<resource>.<message_type>.<resource_id>".
+// The agent_id wire prefix is unchanged (an agent_id -> owner_id rename was considered and
+// reverted, see design doc §5).
+func createRoutingKeys(d *webhookOwnerData, resource string, messageType string) []string {
+	res := []string{}
+
+	if d.CustomerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("customer_id.%s.%s.%s.%s", d.CustomerID, resource, messageType, d.ID))
+	}
+	if d.OwnerID != uuid.Nil {
+		res = append(res, fmt.Sprintf("agent_id.%s.%s.%s.%s", d.OwnerID, resource, messageType, d.ID))
+	}
+
+	return res
 }

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey.go
@@ -1,0 +1,31 @@
+package webhookhandler
+
+import (
+	"encoding/json"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
+	"github.com/gofrs/uuid"
+)
+
+// webhookOwnerData mirrors bin-api-manager's commonWebhookData struct (ported per VOIP-1258 §6
+// harder part 1). Used to extract customer_id/agent_id (owner) from the event data payload
+// BEFORE publish, so the routing key can be computed at publish time instead of at consumption
+// time.
+type webhookOwnerData struct {
+	commonidentity.Identity
+	commonidentity.Owner
+	AIcallID uuid.UUID `json:"aicall_id"`
+	ChatID   uuid.UUID `json:"chat_id"`
+}
+
+// parseWebhookOwnerData unmarshals the event data payload to extract customer_id/owner_id/
+// aicall_id/chat_id. Best-effort: returns zero-value fields (not an error) if optional fields
+// are absent, matching createTopics()'s existing tolerance for partial data.
+func parseWebhookOwnerData(data json.RawMessage) (*webhookOwnerData, error) {
+	d := &webhookOwnerData{}
+	if err := json.Unmarshal(data, d); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 
@@ -90,4 +91,49 @@ func (h *webhookHandler) createRoutingKeysForChat(ctx context.Context, d *webhoo
 	}
 
 	return res
+}
+
+// publishRoutingKeyedEvent computes routing keys for the given event data and publishes to the
+// new topic exchange with each key. Best-effort: logs and returns on parse/RPC failure without
+// blocking the primary (fanout) delivery path above it.
+//
+// CRITICAL: uses h.topicNotifyHandler (bound to QueueNameWebhookEventTopic, a topic-kind
+// exchange -- constructed in Task 3.1), NOT h.notifyHandler (bound to the OLD fanout exchange).
+// Calling PublishEventWithRoutingKey on h.notifyHandler would compile and "succeed" silently --
+// fanout exchanges ignore routing keys entirely, so the event would be delivered but the
+// scoping this whole feature exists for would never take effect. This exact mistake was caught
+// in round-3 implementation-plan review: if Task 2.5 is implemented before Task 3.1 adds the
+// topicNotifyHandler field, this function CANNOT be written correctly yet -- do not stub it
+// with h.notifyHandler "temporarily," implement Task 3.1 first as already instructed above, and
+// write this function only once topicNotifyHandler exists on the struct.
+func (h *webhookHandler) publishRoutingKeyedEvent(ctx context.Context, eventType string, data json.RawMessage) {
+	log := logrus.WithFields(logrus.Fields{"func": "publishRoutingKeyedEvent", "event_type": eventType})
+
+	d, err := parseWebhookOwnerData(data)
+	if err != nil {
+		log.Errorf("Could not parse owner data for routing key computation. err: %v", err)
+		return
+	}
+
+	// messageType/resource parsing: eventType is the wire event type e.g. "call_updated".
+	// resource = first underscore-delimited segment, matching createTopics()'s existing
+	// convention (webhookmanager.go:111-120 in the pre-migration bin-api-manager code).
+	tmps := strings.SplitN(eventType, "_", 2)
+	if len(tmps) < 2 {
+		log.Errorf("Wrong event type format for routing key. event_type: %s", eventType)
+		return
+	}
+	resource := tmps[0]
+
+	var keys []string
+	switch resource {
+	case "chat", "chatmessage", "chatparticipant":
+		keys = h.createRoutingKeysForChat(ctx, d, eventType)
+	default:
+		keys = createRoutingKeys(d, resource, eventType)
+	}
+
+	for _, key := range keys {
+		h.topicNotifyHandler.PublishEventWithRoutingKey(ctx, eventType, key, json.RawMessage(data))
+	}
 }

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
@@ -1,0 +1,83 @@
+package webhookhandler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+func TestParseWebhookOwnerData(t *testing.T) {
+	data := json.RawMessage(`{"customer_id":"a1b2c3d4-0000-0000-0000-000000000001","owner_id":"98765432-0000-0000-0000-000000000002","owner_type":"agent","id":"12345678-0000-0000-0000-000000000003"}`)
+
+	d, err := parseWebhookOwnerData(data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if d.CustomerID.String() != "a1b2c3d4-0000-0000-0000-000000000001" {
+		t.Errorf("Expected CustomerID 'a1b2c3d4-0000-0000-0000-000000000001', got '%s'", d.CustomerID.String())
+	}
+	if d.OwnerID.String() != "98765432-0000-0000-0000-000000000002" {
+		t.Errorf("Expected OwnerID '98765432-0000-0000-0000-000000000002', got '%s'", d.OwnerID.String())
+	}
+}
+
+// TestParseWebhookOwnerData_ChatFields verifies AIcallID/ChatID are extracted correctly when
+// present -- these fields were untested in the initial commit (code-quality review gap).
+func TestParseWebhookOwnerData_ChatFields(t *testing.T) {
+	data := json.RawMessage(`{"customer_id":"a1b2c3d4-0000-0000-0000-000000000001","aicall_id":"a1ca11ff-0000-0000-0000-000000000004","chat_id":"c4a70000-0000-0000-0000-000000000005"}`)
+
+	d, err := parseWebhookOwnerData(data)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if d.AIcallID.String() != "a1ca11ff-0000-0000-0000-000000000004" {
+		t.Errorf("Expected AIcallID 'a1ca11ff-0000-0000-0000-000000000004', got '%s'", d.AIcallID.String())
+	}
+	if d.ChatID.String() != "c4a70000-0000-0000-0000-000000000005" {
+		t.Errorf("Expected ChatID 'c4a70000-0000-0000-0000-000000000005', got '%s'", d.ChatID.String())
+	}
+}
+
+// TestParseWebhookOwnerData_AbsentOptionalFields verifies the "best-effort tolerance for
+// absent fields" claim in parseWebhookOwnerData's doc comment: a payload missing owner_id/
+// aicall_id/chat_id entirely must NOT error, and those fields must stay at their zero value
+// (uuid.Nil) rather than causing an unmarshal failure.
+func TestParseWebhookOwnerData_AbsentOptionalFields(t *testing.T) {
+	data := json.RawMessage(`{"customer_id":"a1b2c3d4-0000-0000-0000-000000000001"}`)
+
+	d, err := parseWebhookOwnerData(data)
+	if err != nil {
+		t.Fatalf("Expected no error for a payload with absent optional fields, got %v", err)
+	}
+
+	if d.CustomerID.String() != "a1b2c3d4-0000-0000-0000-000000000001" {
+		t.Errorf("Expected CustomerID to still be extracted, got '%s'", d.CustomerID.String())
+	}
+	if d.OwnerID != uuid.Nil {
+		t.Errorf("Expected OwnerID to be zero-value (uuid.Nil) when absent, got '%s'", d.OwnerID.String())
+	}
+	if d.AIcallID != uuid.Nil {
+		t.Errorf("Expected AIcallID to be zero-value (uuid.Nil) when absent, got '%s'", d.AIcallID.String())
+	}
+	if d.ChatID != uuid.Nil {
+		t.Errorf("Expected ChatID to be zero-value (uuid.Nil) when absent, got '%s'", d.ChatID.String())
+	}
+}
+
+// TestParseWebhookOwnerData_MalformedJSON verifies the error path: malformed JSON must return
+// a non-nil error (the primary behavior parseWebhookOwnerData's signature promises), rather
+// than silently succeeding with a zero-value struct.
+func TestParseWebhookOwnerData_MalformedJSON(t *testing.T) {
+	data := json.RawMessage(`{"customer_id": this is not valid json`)
+
+	d, err := parseWebhookOwnerData(data)
+	if err == nil {
+		t.Fatal("Expected an error for malformed JSON, got nil")
+	}
+	if d != nil {
+		t.Errorf("Expected nil result on error, got %+v", d)
+	}
+}

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
@@ -2,7 +2,11 @@ package webhookhandler
 
 import (
 	"encoding/json"
+	"reflect"
+	"sort"
 	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
 
 	"github.com/gofrs/uuid"
 )
@@ -79,5 +83,58 @@ func TestParseWebhookOwnerData_MalformedJSON(t *testing.T) {
 	}
 	if d != nil {
 		t.Errorf("Expected nil result on error, got %+v", d)
+	}
+}
+
+func TestCreateRoutingKeys_CustomerOnly(t *testing.T) {
+	d := &webhookOwnerData{
+		Identity: commonidentity.Identity{
+			CustomerID: uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001"),
+			ID:         uuid.FromStringOrNil("12345678-0000-0000-0000-000000000003"),
+		},
+	}
+
+	keys := createRoutingKeys(d, "call", "call_updated")
+
+	expected := []string{"customer_id.a1b2c3d4-0000-0000-0000-000000000001.call.call_updated.12345678-0000-0000-0000-000000000003"}
+	if !reflect.DeepEqual(keys, expected) {
+		t.Errorf("Expected %v, got %v", expected, keys)
+	}
+}
+
+func TestCreateRoutingKeys_CustomerAndOwner(t *testing.T) {
+	d := &webhookOwnerData{
+		Identity: commonidentity.Identity{
+			CustomerID: uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001"),
+			ID:         uuid.FromStringOrNil("12345678-0000-0000-0000-000000000003"),
+		},
+		Owner: commonidentity.Owner{
+			OwnerID: uuid.FromStringOrNil("98765432-0000-0000-0000-000000000002"),
+		},
+	}
+
+	keys := createRoutingKeys(d, "queue", "queue_updated")
+
+	expected := []string{
+		"customer_id.a1b2c3d4-0000-0000-0000-000000000001.queue.queue_updated.12345678-0000-0000-0000-000000000003",
+		"agent_id.98765432-0000-0000-0000-000000000002.queue.queue_updated.12345678-0000-0000-0000-000000000003",
+	}
+	sort.Strings(keys)
+	sort.Strings(expected)
+	if !reflect.DeepEqual(keys, expected) {
+		t.Errorf("Expected %v, got %v", expected, keys)
+	}
+}
+
+// TestCreateRoutingKeys_NoCustomerNoOwner verifies that when neither CustomerID nor OwnerID
+// is present (uuid.Nil), createRoutingKeys returns an empty slice rather than a key with a
+// nil UUID string.
+func TestCreateRoutingKeys_NoCustomerNoOwner(t *testing.T) {
+	d := &webhookOwnerData{}
+
+	keys := createRoutingKeys(d, "call", "call_updated")
+
+	if len(keys) != 0 {
+		t.Errorf("Expected empty keys, got %v", keys)
 	}
 }

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
@@ -1,14 +1,18 @@
 package webhookhandler
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"sort"
 	"testing"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	tkparticipant "monorepo/bin-talk-manager/models/participant"
 
 	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
 )
 
 func TestParseWebhookOwnerData(t *testing.T) {
@@ -136,5 +140,57 @@ func TestCreateRoutingKeys_NoCustomerNoOwner(t *testing.T) {
 
 	if len(keys) != 0 {
 		t.Errorf("Expected empty keys, got %v", keys)
+	}
+}
+
+// containsString is a small helper to avoid pulling testify's require into this file, matching
+// the existing plain if/t.Errorf convention used throughout this package.
+func containsString(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCreateRoutingKeysForChat(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &webhookHandler{reqHandler: mockReq}
+
+	// NOTE: the plan's original literal "chat0000-0000-0000-0000-000000000001" contains
+	// non-hex characters ('h', 't') and silently parses to uuid.Nil via FromStringOrNil,
+	// which would make this test vacuously check the "both Nil" empty-slice path instead of
+	// the fan-out path it's meant to exercise. Using a valid hex UUID here instead.
+	chatID := uuid.FromStringOrNil("ca740000-0000-0000-0000-000000000001")
+	d := &webhookOwnerData{
+		Identity: commonidentity.Identity{CustomerID: uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001")},
+		ChatID:   chatID,
+	}
+
+	// NOTE: the plan's original participant OwnerID literals ("p1000000-...", "p2000000-...")
+	// contain the non-hex character 'p' and silently parse to uuid.Nil via FromStringOrNil.
+	// Since d.OwnerID is also uuid.Nil here (not set on webhookOwnerData), that would make the
+	// participant-skip check "p.OwnerID == d.OwnerID" incorrectly true for every participant,
+	// silently dropping all participant keys. Using valid hex UUIDs instead.
+	mockReq.EXPECT().TalkV1ParticipantList(gomock.Any(), chatID).Return([]*tkparticipant.Participant{
+		{Owner: commonidentity.Owner{OwnerID: uuid.FromStringOrNil("a1000000-0000-0000-0000-000000000001")}},
+		{Owner: commonidentity.Owner{OwnerID: uuid.FromStringOrNil("a2000000-0000-0000-0000-000000000002")}},
+	}, nil)
+
+	keys := h.createRoutingKeysForChat(context.Background(), d, "chatmessage_created")
+
+	expectedKeys := []string{
+		"customer_id.a1b2c3d4-0000-0000-0000-000000000001.talk.chatmessage_created." + chatID.String(),
+		"agent_id.a1000000-0000-0000-0000-000000000001.talk.chatmessage_created." + chatID.String(),
+		"agent_id.a2000000-0000-0000-0000-000000000002.talk.chatmessage_created." + chatID.String(),
+	}
+	for _, expected := range expectedKeys {
+		if !containsString(keys, expected) {
+			t.Errorf("Expected keys to contain %q, got %v", expected, keys)
+		}
 	}
 }

--- a/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/routingkey_test.go
@@ -154,6 +154,7 @@ func containsString(haystack []string, needle string) bool {
 	return false
 }
 
+// TestCreateRoutingKeysForChat verifies the fan-out path.
 func TestCreateRoutingKeysForChat(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()

--- a/bin-webhook-manager/pkg/webhookhandler/webhook.go
+++ b/bin-webhook-manager/pkg/webhookhandler/webhook.go
@@ -64,6 +64,11 @@ func (h *webhookHandler) SendWebhookToCustomer(ctx context.Context, customerID u
 	}
 	h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh)
 
+	// NEW: dual-publish to the topic exchange with computed routing keys (VOIP-1258 §6/§8).
+	// This is IN ADDITION TO the existing fanout PublishEvent call above, not a replacement --
+	// dual-publish continues until Phase 4's cutover step (Task 4.6) removes the old exchange.
+	h.publishRoutingKeyedEvent(ctx, webhook.EventTypeWebhookPublished, data)
+
 	// additionally deliver to the per-activeflow webhook destination, if any.
 	h.sendWebhookToActiveflow(ctx, dataType, data)
 
@@ -141,6 +146,11 @@ func (h *webhookHandler) SendWebhookToURI(ctx context.Context, customerID uuid.U
 		Data:       data,
 	}
 	h.notifyHandler.PublishEvent(ctx, webhook.EventTypeWebhookPublished, wh)
+
+	// NEW: dual-publish to the topic exchange with computed routing keys (VOIP-1258 §6/§8).
+	// This is IN ADDITION TO the existing fanout PublishEvent call above, not a replacement --
+	// dual-publish continues until Phase 4's cutover step (Task 4.6) removes the old exchange.
+	h.publishRoutingKeyedEvent(ctx, webhook.EventTypeWebhookPublished, data)
 
 	return nil
 }

--- a/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
@@ -329,7 +329,7 @@ func Test_NewWebhookHandler(t *testing.T) {
 	mockActiveflow := activeflowhandler.NewMockActiveflowHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 
-	h := NewWebhookHandler(mockDB, mockNotify, mockReq, mockAccount, mockActiveflow)
+	h := NewWebhookHandler(mockDB, mockNotify, mockNotify, mockReq, mockAccount, mockActiveflow)
 	if h == nil {
 		t.Errorf("Wrong match. expect: handler, got: nil")
 	}

--- a/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
@@ -473,10 +473,16 @@ func Test_SendWebhookToCustomer_DualPublishesWithRoutingKey(t *testing.T) {
 	customerID := uuid.FromStringOrNil("a27dc1d6-8254-11ec-8f09-e30cbed3e51e")
 	callID := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
 
-	data := json.RawMessage(fmt.Sprintf(
-		`{"id":"%s","customer_id":"%s"}`,
-		callID, customerID,
-	))
+	// data is the REAL production wire shape: a nested envelope {"type":"<resource>_<verb>",
+	// "data":{...resource fields incl. customer_id...}}. Every caller of SendWebhookToCustomer
+	// builds this via json.Marshal(webhook.Data{Type, Data}) -- see
+	// bin-webhook-manager/pkg/listenhandler/v1_webhooks.go. A flat, un-enveloped payload (as
+	// this test previously used) does NOT occur in production and does not exercise the
+	// envelope-unwrapping this function must do (VOIP-1258 post-deploy verification finding,
+	// 2026-07-14: an earlier version of publishRoutingKeyedEvent skipped this unwrap entirely
+	// and silently published zero routing keys for every real event).
+	innerData := json.RawMessage(fmt.Sprintf(`{"id":"%s","customer_id":"%s"}`, callID, customerID))
+	data := json.RawMessage(fmt.Sprintf(`{"type":"call_updated","data":%s}`, string(innerData)))
 
 	expectWebhook := &webhook.Webhook{
 		CustomerID: customerID,
@@ -490,10 +496,14 @@ func Test_SendWebhookToCustomer_DualPublishesWithRoutingKey(t *testing.T) {
 		WebhookURI:    "test.com",
 	}
 
-	// eventType passed to publishRoutingKeyedEvent is always webhook.EventTypeWebhookPublished
-	// ("webhook_published"); resource is the first underscore-delimited segment ("webhook"),
-	// but the FULL eventType is used as messageType in the routing key (per createRoutingKeys).
-	expectRoutingKey := fmt.Sprintf("customer_id.%s.webhook.webhook_published.%s", customerID, callID)
+	// eventType is now taken from the envelope's "type" field ("call_updated"), NOT the fixed
+	// webhook.EventTypeWebhookPublished constant passed into publishRoutingKeyedEvent -- see
+	// that function's doc comment. resource = "call" (first underscore segment of "call_updated").
+	// The routing key's payload is the INNER data (envelope.Data), not the full envelope --
+	// subscribers expect the bare resource object, matching the pre-VOIP-1258 consumer-side
+	// createTopics()/zmqpubHandler.Publish(topic, data) behavior where "data" was also the
+	// inner wh.Data, not the outer wrapper.
+	expectRoutingKey := fmt.Sprintf("customer_id.%s.call.call_updated.%s", customerID, callID)
 
 	mc := gomock.NewController(t)
 	defer mc.Finish()
@@ -514,7 +524,7 @@ func Test_SendWebhookToCustomer_DualPublishesWithRoutingKey(t *testing.T) {
 
 	mockMessageTargethandler.EXPECT().Get(ctx, customerID).Return(responseAccount, nil)
 	mockNotify.EXPECT().PublishEvent(ctx, webhook.EventTypeWebhookPublished, expectWebhook)
-	mockTopicNotify.EXPECT().PublishEventWithRoutingKey(ctx, webhook.EventTypeWebhookPublished, expectRoutingKey, data)
+	mockTopicNotify.EXPECT().PublishEventWithRoutingKey(ctx, "call_updated", expectRoutingKey, innerData)
 
 	err := h.SendWebhookToCustomer(ctx, customerID, "application/json", data)
 	if err != nil {
@@ -531,10 +541,10 @@ func Test_SendWebhookToURI_DualPublishesWithRoutingKey(t *testing.T) {
 	customerID := uuid.FromStringOrNil("a27dc1d6-8254-11ec-8f09-e30cbed3e51e")
 	callID := uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333")
 
-	data := json.RawMessage(fmt.Sprintf(
-		`{"id":"%s","customer_id":"%s"}`,
-		callID, customerID,
-	))
+	// See Test_SendWebhookToCustomer_DualPublishesWithRoutingKey's comment: data is always a
+	// nested {"type":...,"data":{...}} envelope in production, never a flat resource object.
+	innerData := json.RawMessage(fmt.Sprintf(`{"id":"%s","customer_id":"%s"}`, callID, customerID))
+	data := json.RawMessage(fmt.Sprintf(`{"type":"call_updated","data":%s}`, string(innerData)))
 
 	expectWebhook := &webhook.Webhook{
 		CustomerID: customerID,
@@ -542,7 +552,7 @@ func Test_SendWebhookToURI_DualPublishesWithRoutingKey(t *testing.T) {
 		Data:       data,
 	}
 
-	expectRoutingKey := fmt.Sprintf("customer_id.%s.webhook.webhook_published.%s", customerID, callID)
+	expectRoutingKey := fmt.Sprintf("customer_id.%s.call.call_updated.%s", customerID, callID)
 
 	mc := gomock.NewController(t)
 	defer mc.Finish()
@@ -562,7 +572,7 @@ func Test_SendWebhookToURI_DualPublishesWithRoutingKey(t *testing.T) {
 	ctx := context.Background()
 
 	mockNotify.EXPECT().PublishEvent(ctx, webhook.EventTypeWebhookPublished, expectWebhook)
-	mockTopicNotify.EXPECT().PublishEventWithRoutingKey(ctx, webhook.EventTypeWebhookPublished, expectRoutingKey, data)
+	mockTopicNotify.EXPECT().PublishEventWithRoutingKey(ctx, "call_updated", expectRoutingKey, innerData)
 
 	err := h.SendWebhookToURI(ctx, customerID, "test.com", webhook.MethodTypePOST, "application/json", data)
 	if err != nil {

--- a/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
@@ -461,3 +461,114 @@ func Test_SendWebhookToCustomer_activeflow(t *testing.T) {
 		})
 	}
 }
+
+// Test_SendWebhookToCustomer_DualPublishesWithRoutingKey verifies that SendWebhookToCustomer
+// dual-publishes: the existing fanout PublishEvent call on h.notifyHandler still fires, AND
+// h.topicNotifyHandler.PublishEventWithRoutingKey fires once per generated routing key. Two
+// DISTINCT mocks are used for notifyHandler vs topicNotifyHandler so that a mixup between the
+// two fields (calling PublishEventWithRoutingKey on the fanout handler, or vice versa) would
+// fail the test -- a single shared mock would not catch this class of bug.
+func Test_SendWebhookToCustomer_DualPublishesWithRoutingKey(t *testing.T) {
+
+	customerID := uuid.FromStringOrNil("a27dc1d6-8254-11ec-8f09-e30cbed3e51e")
+	callID := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
+
+	data := json.RawMessage(fmt.Sprintf(
+		`{"id":"%s","customer_id":"%s"}`,
+		callID, customerID,
+	))
+
+	expectWebhook := &webhook.Webhook{
+		CustomerID: customerID,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	responseAccount := &account.Account{
+		ID:            customerID,
+		WebhookMethod: "POST",
+		WebhookURI:    "test.com",
+	}
+
+	// eventType passed to publishRoutingKeyedEvent is always webhook.EventTypeWebhookPublished
+	// ("webhook_published"); resource is the first underscore-delimited segment ("webhook"),
+	// but the FULL eventType is used as messageType in the routing key (per createRoutingKeys).
+	expectRoutingKey := fmt.Sprintf("customer_id.%s.webhook.webhook_published.%s", customerID, callID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessageTargethandler := accounthandler.NewMockAccountHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockTopicNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &webhookHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		topicNotifyHandler: mockTopicNotify,
+		accoutHandler:      mockMessageTargethandler,
+	}
+
+	ctx := context.Background()
+
+	mockMessageTargethandler.EXPECT().Get(ctx, customerID).Return(responseAccount, nil)
+	mockNotify.EXPECT().PublishEvent(ctx, webhook.EventTypeWebhookPublished, expectWebhook)
+	mockTopicNotify.EXPECT().PublishEventWithRoutingKey(ctx, webhook.EventTypeWebhookPublished, expectRoutingKey, data)
+
+	err := h.SendWebhookToCustomer(ctx, customerID, "application/json", data)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	time.Sleep(400 * time.Millisecond)
+}
+
+// Test_SendWebhookToURI_DualPublishesWithRoutingKey mirrors the above for SendWebhookToURI,
+// per the design doc §6 symmetry note: both entry points feed the same downstream path.
+func Test_SendWebhookToURI_DualPublishesWithRoutingKey(t *testing.T) {
+
+	customerID := uuid.FromStringOrNil("a27dc1d6-8254-11ec-8f09-e30cbed3e51e")
+	callID := uuid.FromStringOrNil("33333333-3333-3333-3333-333333333333")
+
+	data := json.RawMessage(fmt.Sprintf(
+		`{"id":"%s","customer_id":"%s"}`,
+		callID, customerID,
+	))
+
+	expectWebhook := &webhook.Webhook{
+		CustomerID: customerID,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	expectRoutingKey := fmt.Sprintf("customer_id.%s.webhook.webhook_published.%s", customerID, callID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessageTargethandler := accounthandler.NewMockAccountHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockTopicNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &webhookHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		topicNotifyHandler: mockTopicNotify,
+		accoutHandler:      mockMessageTargethandler,
+	}
+
+	ctx := context.Background()
+
+	mockNotify.EXPECT().PublishEvent(ctx, webhook.EventTypeWebhookPublished, expectWebhook)
+	mockTopicNotify.EXPECT().PublishEventWithRoutingKey(ctx, webhook.EventTypeWebhookPublished, expectRoutingKey, data)
+
+	err := h.SendWebhookToURI(ctx, customerID, "test.com", webhook.MethodTypePOST, "application/json", data)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	time.Sleep(400 * time.Millisecond)
+}
+

--- a/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
@@ -582,3 +582,54 @@ func Test_SendWebhookToURI_DualPublishesWithRoutingKey(t *testing.T) {
 	time.Sleep(400 * time.Millisecond)
 }
 
+// Test_SendWebhookToURI_ArbitraryFlowDesignerPayload_SkipsTopicPublishSilently is a regression
+// test for a round-1 review finding (2026-07-15) on the envelope-unwrapping fix: SendWebhookToURI
+// is not ONLY reached via the enveloped {"type":...,"data":...} POST /v1/webhooks path -- it is
+// also reached via the flow-designer's webhook_send action (bin-flow-manager's WebhookSend ->
+// processV1WebhookDestinationsPost), where the payload is arbitrary caller-authored string data,
+// never wrapped as webhook.Data{Type,Data}. This must NOT be misinterpreted as a malformed system
+// event (no Errorf spam) and must NOT publish a routing-keyed event to the topic exchange (there
+// is no reliable customer_id/owner_id/event-type to extract from arbitrary user content) --
+// it must fail safe and silent, while the primary fanout delivery (PublishEvent) still fires.
+func Test_SendWebhookToURI_ArbitraryFlowDesignerPayload_SkipsTopicPublishSilently(t *testing.T) {
+
+	customerID := uuid.FromStringOrNil("a27dc1d6-8254-11ec-8f09-e30cbed3e51e")
+
+	// Arbitrary flow-designer-authored payload -- NOT a {"type":...,"data":...} envelope.
+	data := json.RawMessage(`"hello world, this is my custom webhook_send body"`)
+
+	expectWebhook := &webhook.Webhook{
+		CustomerID: customerID,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessageTargethandler := accounthandler.NewMockAccountHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockTopicNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &webhookHandler{
+		db:                 mockDB,
+		notifyHandler:      mockNotify,
+		topicNotifyHandler: mockTopicNotify,
+		accoutHandler:      mockMessageTargethandler,
+	}
+
+	ctx := context.Background()
+
+	mockNotify.EXPECT().PublishEvent(ctx, webhook.EventTypeWebhookPublished, expectWebhook)
+	// CRITICAL: no PublishEventWithRoutingKey expectation set at all -- gomock will fail the
+	// test if the topic-exchange publish path is invoked for this non-enveloped payload.
+
+	err := h.SendWebhookToURI(ctx, customerID, "test.com", webhook.MethodTypePOST, "application/json", data)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	time.Sleep(400 * time.Millisecond)
+}
+

--- a/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
+++ b/bin-webhook-manager/pkg/webhookhandler/webhook_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 	cscustomer "monorepo/bin-customer-manager/models/customer"
 
 	"github.com/gofrs/uuid"
@@ -326,8 +327,9 @@ func Test_NewWebhookHandler(t *testing.T) {
 	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
 	mockAccount := accounthandler.NewMockAccountHandler(mc)
 	mockActiveflow := activeflowhandler.NewMockActiveflowHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
 
-	h := NewWebhookHandler(mockDB, mockNotify, mockAccount, mockActiveflow)
+	h := NewWebhookHandler(mockDB, mockNotify, mockReq, mockAccount, mockActiveflow)
 	if h == nil {
 		t.Errorf("Wrong match. expect: handler, got: nil")
 	}


### PR DESCRIPTION
Introduce a scope-first AMQP topic exchange for WebSocket event subscriptions, replacing the current fanout exchange so every api-manager pod stops receiving events for scopes with no local subscriber. Implements Phase 1-4 (Tasks through 4.5) of the approved implementation plan; Task 4.6 (final cutover -- remove the # wildcard fallback and decommission the old fanout exchange/dual-publish) is deliberately excluded from this PR and will land as a separate follow-up after this phase is deployed and verified in staging/production per the plan's transition-window requirement.

- bin-common-handler: Add QueueBind/QueueUnbind/TopicCreateWithKind to SockHandler interface, PublishEventWithRoutingKey to NotifyHandler, NewNotifyHandlerForExistingExchange additive constructor, QueueNameWebhookEventTopic constant
- bin-webhook-manager: Port webhook owner-data envelope parsing (parseWebhookOwnerData), compute scope-first routing keys for both plain and chat-participant fan-out events (createRoutingKeys/createRoutingKeysForChat), declare the new topic/durable exchange at startup with a dedicated topicNotifyHandler, dual-publish routing-keyed events from SendWebhookToCustomer/SendWebhookToURI alongside the existing fanout publish
- bin-agent-manager, bin-timeline-manager: Cut over from the old fanout QueueNameWebhookEvent subscription to a single # wildcard binding on QueueNameWebhookEventTopic (bind-new-then-unbind-old ordering), avoiding double-processing during webhook-manager's dual-publish window
- bin-api-manager: Add scopeRefCount component tracking active local subscribers per AMQP binding pattern (binds on 0->1, unbinds on 1->0), topicToBindPattern converting client-facing colon-delimited topics to dot-delimited AMQP patterns, wire dynamic Acquire/Release into websocket subscribe/unsubscribe and ReleaseAll into abrupt-disconnect cleanup, remove dead QueueNameAgentEvent/QueueNameTalkEvent subscriptions, replace the old fanout QueueNameWebhookEvent subscription with an explicit # wildcard binding on the new topic exchange (declared after the per-pod queue exists, not before)