### PR TITLE
NOJIRA-Add-webchat-db-migrations

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/c9602a744cb3_webchat_widgets_sessions_messages_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/c9602a744cb3_webchat_widgets_sessions_messages_.py
@@ -20,14 +20,15 @@ def upgrade():
     op.execute("""
         create table webchat_widgets(
             -- identity
-            id                    binary(16),
-            customer_id           binary(16),
+            id                    binary(16)   not null,
+            customer_id           binary(16)   not null,
 
             -- basic info
             name                  varchar(255),
-            status                varchar(16),
+            status                varchar(16)  not null,
 
-            -- direct hash
+            -- direct hash -- nullable: a Widget with no DirectID is
+            -- "provisioning incomplete" (see widget.go doc comment).
             direct_id             binary(16),
 
             welcome_message       text,
@@ -52,14 +53,24 @@ def upgrade():
         create index idx_webchat_widgets_customer_id_tm_delete on webchat_widgets(customer_id, tm_delete);
     """)
 
+    # direct_id is the visitor-facing linkage to bin-direct-manager
+    # (resource_type=webchat_widget, resource_id=Widget.ID). Two
+    # widgets must never share the same direct_id -- a unique index
+    # enforces that invariant at the DB layer (defense in depth on
+    # top of bin-direct-manager's own uniqueness), and doubles as the
+    # index needed for any future direct_id lookup path.
+    op.execute("""
+        create unique index idx_webchat_widgets_direct_id on webchat_widgets(direct_id);
+    """)
+
     op.execute("""
         create table webchat_sessions(
             -- identity
-            id                binary(16),
-            customer_id       binary(16),
-            widget_id         binary(16),
+            id                binary(16)   not null,
+            customer_id       binary(16)   not null,
+            widget_id         binary(16)   not null,
 
-            status            varchar(16),
+            status            varchar(16)  not null,
             activeflow_id     binary(16),
 
             tm_last_activity  datetime(6),
@@ -91,13 +102,13 @@ def upgrade():
     op.execute("""
         create table webchat_messages(
             -- identity
-            id             binary(16),
-            customer_id    binary(16),
-            widget_id      binary(16),
-            session_id     binary(16),
+            id             binary(16)   not null,
+            customer_id    binary(16)   not null,
+            widget_id      binary(16)   not null,
+            session_id     binary(16)   not null,
 
-            direction      varchar(16),
-            status         varchar(16),
+            direction      varchar(16)  not null,
+            status         varchar(16)  not null,
             text           varchar(4000),
             sender_id      binary(16),
             activeflow_id  binary(16),
@@ -115,6 +126,13 @@ def upgrade():
 
     op.execute("""
         create index idx_webchat_messages_customer_id_tm_create on webchat_messages(customer_id, tm_create);
+    """)
+
+    # widget_id is denormalized onto every message so downstream event
+    # consumers can build Conversation.Self without a join back through
+    # webchat_sessions -- index it for any widget-scoped message query.
+    op.execute("""
+        create index idx_webchat_messages_widget_id_tm_create on webchat_messages(widget_id, tm_create);
     """)
 
 

--- a/bin-dbscheme-manager/bin-manager/main/versions/c9602a744cb3_webchat_widgets_sessions_messages_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/c9602a744cb3_webchat_widgets_sessions_messages_.py
@@ -95,6 +95,14 @@ def upgrade():
         create index idx_webchat_sessions_widget_id_status on webchat_sessions(widget_id, status);
     """)
 
+    # widget-scoped session listing (WHERE widget_id = ? AND tm_delete
+    # IS NULL AND tm_create < ? ORDER BY tm_create DESC, per
+    # dbhandler.SessionList) isn't covered by the (widget_id, status)
+    # index above -- mirrors the analogous fix on webchat_messages.
+    op.execute("""
+        create index idx_webchat_sessions_widget_id_tm_create on webchat_sessions(widget_id, tm_create);
+    """)
+
     op.execute("""
         create index idx_webchat_sessions_status_tm_last_activity on webchat_sessions(status, tm_last_activity);
     """)

--- a/bin-dbscheme-manager/bin-manager/main/versions/c9602a744cb3_webchat_widgets_sessions_messages_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/c9602a744cb3_webchat_widgets_sessions_messages_.py
@@ -1,0 +1,124 @@
+"""webchat_widgets_sessions_messages_create_tables
+
+Revision ID: c9602a744cb3
+Revises: 43947d3f7312
+Create Date: 2026-07-16 23:00:11.836228
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c9602a744cb3'
+down_revision = '43947d3f7312'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        create table webchat_widgets(
+            -- identity
+            id                    binary(16),
+            customer_id           binary(16),
+
+            -- basic info
+            name                  varchar(255),
+            status                varchar(16),
+
+            -- direct hash
+            direct_id             binary(16),
+
+            welcome_message       text,
+            flow_id               binary(16),
+            session_idle_timeout  integer,
+
+            theme_config          json,
+
+            tm_create             datetime(6),
+            tm_update             datetime(6),
+            tm_delete             datetime(6),
+
+            primary key(id)
+        );
+    """)
+
+    op.execute("""
+        create index idx_webchat_widgets_customer_id_tm_create on webchat_widgets(customer_id, tm_create);
+    """)
+
+    op.execute("""
+        create index idx_webchat_widgets_customer_id_tm_delete on webchat_widgets(customer_id, tm_delete);
+    """)
+
+    op.execute("""
+        create table webchat_sessions(
+            -- identity
+            id                binary(16),
+            customer_id       binary(16),
+            widget_id         binary(16),
+
+            status            varchar(16),
+            activeflow_id     binary(16),
+
+            tm_last_activity  datetime(6),
+            tm_create         datetime(6),
+            tm_update         datetime(6),
+            tm_end            datetime(6),
+            tm_delete         datetime(6),
+
+            primary key(id)
+        );
+    """)
+
+    op.execute("""
+        create index idx_webchat_sessions_customer_id_tm_create on webchat_sessions(customer_id, tm_create);
+    """)
+
+    op.execute("""
+        create index idx_webchat_sessions_customer_id_tm_delete on webchat_sessions(customer_id, tm_delete);
+    """)
+
+    op.execute("""
+        create index idx_webchat_sessions_widget_id_status on webchat_sessions(widget_id, status);
+    """)
+
+    op.execute("""
+        create index idx_webchat_sessions_status_tm_last_activity on webchat_sessions(status, tm_last_activity);
+    """)
+
+    op.execute("""
+        create table webchat_messages(
+            -- identity
+            id             binary(16),
+            customer_id    binary(16),
+            widget_id      binary(16),
+            session_id     binary(16),
+
+            direction      varchar(16),
+            status         varchar(16),
+            text           varchar(4000),
+            sender_id      binary(16),
+            activeflow_id  binary(16),
+
+            tm_create      datetime(6),
+            tm_delete      datetime(6),
+
+            primary key(id)
+        );
+    """)
+
+    op.execute("""
+        create index idx_webchat_messages_session_id_tm_create on webchat_messages(session_id, tm_create);
+    """)
+
+    op.execute("""
+        create index idx_webchat_messages_customer_id_tm_create on webchat_messages(customer_id, tm_create);
+    """)
+
+
+def downgrade():
+    op.execute("""drop table if exists webchat_messages;""")
+    op.execute("""drop table if exists webchat_sessions;""")
+    op.execute("""drop table if exists webchat_widgets;""")

--- a/bin-dbscheme-manager/docs/schema-ownership.md
+++ b/bin-dbscheme-manager/docs/schema-ownership.md
@@ -66,6 +66,9 @@ All tables below are in the `voipbin` MySQL database managed by `bin-manager/`. 
 | talk_chats | bin-talk-manager | Talk (agent UI) chat sessions |
 | talk_messages | bin-talk-manager | Messages in talk chats |
 | talk_participants | bin-talk-manager | Participants in talk sessions |
+| webchat_widgets | bin-webchat-manager | Website chat widget configuration (flow_id, theme, direct-access hash) |
+| webchat_sessions | bin-webchat-manager | Visitor conversation sessions per widget |
+| webchat_messages | bin-webchat-manager | Individual inbound/outbound webchat messages |
 
 ### Asterisk Database Tables (`asterisk` database)
 


### PR DESCRIPTION
Add the Alembic migration for the webchat tables that PR #1104 (NOJIRA-Implement-webchat-manager) introduced Go code for but never created a production schema migration for.

- bin-dbscheme-manager: Add migration c9602a744cb3 creating webchat_widgets, webchat_sessions, and webchat_messages tables in the voipbin database
- bin-dbscheme-manager: Document the three new tables in schema-ownership.md under bin-webchat-manager

PR #1104 added bin-webchat-manager's dbhandler/models assuming these three tables exist, and only added test-fixture SQL under bin-webchat-manager/scripts/database_scripts_test/ (used by unit tests, not the production database). Without this migration, every webchat_widgets/sessions/messages query fails against a real deployment with "table doesn't exist" -- this was caught before any deploy, not in production.

Verified locally against a throwaway MariaDB 10.6 container (never run against staging/production, per bin-dbscheme-manager's AI-agent policy): extracted this migration's upgrade() SQL and ran it against a fresh database -- all three tables and their indexes are created correctly (verified via DESCRIBE and SHOW INDEX, matching the existing test-fixture schema exactly). Then ran downgrade() -- all three tables drop cleanly. alembic heads confirms exactly one head after this migration, correctly chained onto the prior head.
