### PR TITLE
VOIP-1263-webchat-session-message-filters

### DIFF
--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -7869,6 +7869,9 @@ type GetWebchatMessagesParams struct {
 
 	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
 	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// SessionId Filter messages to those belonging to this session. Returned from the `POST /webchat_sessions` or `GET /webchat_sessions` response.
+	SessionId *openapi_types.UUID `form:"session_id,omitempty" json:"session_id,omitempty"`
 }
 
 // PostWebchatMessagesJSONBody defines parameters for PostWebchatMessages.
@@ -7890,6 +7893,9 @@ type GetWebchatSessionsParams struct {
 
 	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
 	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// WidgetId Filter sessions to those belonging to this widget. Returned from the `POST /webchat_widgets` or `GET /webchat_widgets` response.
+	WidgetId *openapi_types.UUID `form:"widget_id,omitempty" json:"widget_id,omitempty"`
 }
 
 // PostWebchatSessionsJSONBody defines parameters for PostWebchatSessions.
@@ -19678,6 +19684,14 @@ func (siw *ServerInterfaceWrapper) GetWebchatMessages(c *gin.Context) {
 		return
 	}
 
+	// ------------- Optional query parameter "session_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "session_id", c.Request.URL.Query(), &params.SessionId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter session_id: %w", err), http.StatusBadRequest)
+		return
+	}
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 		if c.IsAborted() {
@@ -19770,6 +19784,14 @@ func (siw *ServerInterfaceWrapper) GetWebchatSessions(c *gin.Context) {
 	err = runtime.BindQueryParameter("form", true, false, "page_token", c.Request.URL.Query(), &params.PageToken)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter page_token: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "widget_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "widget_id", c.Request.URL.Query(), &params.WidgetId)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter widget_id: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -902,13 +902,13 @@ type ServiceHandler interface {
 	WebchatWidgetDirectHashRegenerate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID) (*wcwidget.WebhookMessage, error)
 
 	WebchatSessionGet(ctx context.Context, a *auth.AuthIdentity, sessionID uuid.UUID) (*wcsession.WebhookMessage, error)
-	WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*wcsession.WebhookMessage, error)
+	WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, widgetID uuid.UUID) ([]*wcsession.WebhookMessage, error)
 	WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID) (*wcsession.WebhookMessage, error)
 	WebchatSessionDelete(ctx context.Context, a *auth.AuthIdentity, sessionID uuid.UUID) (*wcsession.WebhookMessage, error)
 	WebchatSessionEnd(ctx context.Context, a *auth.AuthIdentity, sessionID uuid.UUID) (*wcsession.WebhookMessage, error)
 
 	WebchatMessageGet(ctx context.Context, a *auth.AuthIdentity, messageID uuid.UUID) (*wcmessage.WebhookMessage, error)
-	WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*wcmessage.WebhookMessage, error)
+	WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, sessionID uuid.UUID) ([]*wcmessage.WebhookMessage, error)
 	WebchatMessageCreate(
 		ctx context.Context,
 		a *auth.AuthIdentity,

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -6109,18 +6109,18 @@ func (mr *MockServiceHandlerMockRecorder) WebchatMessageGet(ctx, a, messageID an
 }
 
 // WebchatMessageList mocks base method.
-func (m *MockServiceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*message3.WebhookMessage, error) {
+func (m *MockServiceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, sessionID uuid.UUID) ([]*message3.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WebchatMessageList", ctx, a, size, token)
+	ret := m.ctrl.Call(m, "WebchatMessageList", ctx, a, size, token, sessionID)
 	ret0, _ := ret[0].([]*message3.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WebchatMessageList indicates an expected call of WebchatMessageList.
-func (mr *MockServiceHandlerMockRecorder) WebchatMessageList(ctx, a, size, token any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) WebchatMessageList(ctx, a, size, token, sessionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatMessageList", reflect.TypeOf((*MockServiceHandler)(nil).WebchatMessageList), ctx, a, size, token)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatMessageList", reflect.TypeOf((*MockServiceHandler)(nil).WebchatMessageList), ctx, a, size, token, sessionID)
 }
 
 // WebchatSessionCreate mocks base method.
@@ -6184,18 +6184,18 @@ func (mr *MockServiceHandlerMockRecorder) WebchatSessionGet(ctx, a, sessionID an
 }
 
 // WebchatSessionList mocks base method.
-func (m *MockServiceHandler) WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*session.WebhookMessage, error) {
+func (m *MockServiceHandler) WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, widgetID uuid.UUID) ([]*session.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WebchatSessionList", ctx, a, size, token)
+	ret := m.ctrl.Call(m, "WebchatSessionList", ctx, a, size, token, widgetID)
 	ret0, _ := ret[0].([]*session.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WebchatSessionList indicates an expected call of WebchatSessionList.
-func (mr *MockServiceHandlerMockRecorder) WebchatSessionList(ctx, a, size, token any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) WebchatSessionList(ctx, a, size, token, widgetID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatSessionList", reflect.TypeOf((*MockServiceHandler)(nil).WebchatSessionList), ctx, a, size, token)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatSessionList", reflect.TypeOf((*MockServiceHandler)(nil).WebchatSessionList), ctx, a, size, token, widgetID)
 }
 
 // WebchatWidgetCreate mocks base method.

--- a/bin-api-manager/pkg/servicehandler/webchat_message.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_message.go
@@ -68,7 +68,14 @@ func (h *serviceHandler) WebchatMessageGet(ctx context.Context, a *auth.AuthIden
 }
 
 // WebchatMessageList sends a request to webchat-manager to get a list of messages.
-func (h *serviceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*wcmessage.WebhookMessage, error) {
+// sessionID, if non-nil (uuid.Nil means "no filter"), scopes the list to
+// messages belonging to that session -- e.g. the message timeline shown
+// when an agent clicks into a session from a widget's Sessions tab in
+// square-admin. The session's ownership is verified via sessionGet before
+// the filter is applied, mirroring WebchatMessageCreate's
+// fetch-then-check-owner pattern, so a caller cannot use an arbitrary
+// session_id to enumerate another customer's messages.
+func (h *serviceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, sessionID uuid.UUID) ([]*wcmessage.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "WebchatMessageList",
 		"customer_id": a.CustomerID,
@@ -91,6 +98,19 @@ func (h *serviceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIde
 	filters := map[wcmessage.Field]any{
 		wcmessage.FieldCustomerID: a.CustomerID,
 		wcmessage.FieldDeleted:    false,
+	}
+
+	if sessionID != uuid.Nil {
+		s, err := h.sessionGet(ctx, sessionID)
+		if err != nil {
+			log.Errorf("Could not validate the session info. err: %v", err)
+			return nil, err
+		}
+		if s.CustomerID != a.CustomerID {
+			log.Info("The session does not belong to the requesting customer.")
+			return nil, serviceerrors.ErrPermissionDenied
+		}
+		filters[wcmessage.FieldSessionID] = sessionID
 	}
 
 	tmps, err := h.reqHandler.WebchatV1MessageList(ctx, token, size, filters)

--- a/bin-api-manager/pkg/servicehandler/webchat_message_test.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_message_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -12,11 +11,8 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 
-	csaccesskey "monorepo/bin-customer-manager/models/accesskey"
-
 	wcmessage "monorepo/bin-webchat-manager/models/message"
 	wcsession "monorepo/bin-webchat-manager/models/session"
-	wcwidget "monorepo/bin-webchat-manager/models/widget"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -24,218 +20,120 @@ import (
 	"monorepo/bin-api-manager/models/auth"
 )
 
-// Test_WebchatMessageCreate_Direct verifies the visitor-facing path: a
-// direct-scope JWT scoped to widget A can post a message into a session
-// that genuinely belongs to widget A.
-func Test_WebchatMessageCreate_Direct(t *testing.T) {
+// Test_WebchatMessageList_NoFilter verifies the existing behavior is
+// unchanged when sessionID is uuid.Nil (no filter requested): only
+// customer_id/deleted are applied, and sessionGet is never called.
+func Test_WebchatMessageList_NoFilter(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
+		utilHandler: mockUtil,
 		reqHandler:  mockReq,
 	}
 	ctx := context.Background()
 
 	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9f5e-4762c3c1e4e5")
+	messageID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
 
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	})
+
+	responseMessages := []*wcmessage.Message{
+		{Identity: commonidentity.Identity{ID: messageID, CustomerID: customerID}},
+	}
+
+	mockUtil.EXPECT().TimeGetCurTime().Return("2026-01-01 00:00:00.000000")
+	mockReq.EXPECT().WebchatV1MessageList(ctx, "2026-01-01 00:00:00.000000", uint64(10), map[wcmessage.Field]any{
+		wcmessage.FieldCustomerID: customerID,
+		wcmessage.FieldDeleted:    false,
+	}).Return(responseMessages, nil)
+
+	res, err := h.WebchatMessageList(ctx, a, 10, "", uuid.Nil)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	expectRes := []*wcmessage.WebhookMessage{responseMessages[0].ConvertWebhookMessage()}
+	if !reflect.DeepEqual(res, expectRes) {
+		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectRes, res)
+	}
+}
+
+// Test_WebchatMessageList_SessionFilter verifies that a non-nil sessionID
+// (a) is validated for ownership via sessionGet and (b) is added to the
+// filter map passed to WebchatV1MessageList.
+func Test_WebchatMessageList_SessionFilter(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &serviceHandler{
+		utilHandler: mockUtil,
+		reqHandler:  mockReq,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	sessionID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
 	})
 
 	responseSession := &wcsession.Session{
 		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
 	}
-	responseMessage := &wcmessage.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		SessionID: sessionID,
-		Direction: wcmessage.DirectionInbound,
-		Text:      "hello",
-	}
-	widget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-	}
+	responseMessages := []*wcmessage.Message{}
 
+	mockUtil.EXPECT().TimeGetCurTime().Return("2026-01-01 00:00:00.000000")
 	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(responseSession, nil)
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(widget, nil)
-	mockReq.EXPECT().WebchatV1MessageCreate(ctx, customerID, sessionID, wcmessage.DirectionInbound, uuid.Nil, "hello").Return(responseMessage, nil)
+	mockReq.EXPECT().WebchatV1MessageList(ctx, "2026-01-01 00:00:00.000000", uint64(10), map[wcmessage.Field]any{
+		wcmessage.FieldCustomerID: customerID,
+		wcmessage.FieldDeleted:    false,
+		wcmessage.FieldSessionID:  sessionID,
+	}).Return(responseMessages, nil)
 
-	res, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionInbound, "hello")
+	res, err := h.WebchatMessageList(ctx, a, 10, "", sessionID)
 	if err != nil {
 		t.Fatalf("Wrong match. expect: ok, got: %v", err)
 	}
-
-	expectRes := responseMessage.ConvertWebhookMessage()
-	if !reflect.DeepEqual(res, expectRes) {
-		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectRes, res)
+	if len(res) != 0 {
+		t.Errorf("Wrong match. expect: empty, got: %v", res)
 	}
 }
 
-// Test_WebchatMessageCreate_Direct_CrossTenant_WrongWidgetScope is a
-// regression test for a cross-tenant IDOR: a direct-scope JWT issued for
-// widget A must NOT be able to inject a message into a session that
-// belongs to a different widget B (e.g. by guessing/enumerating a
-// session_id UUID). Before the fix, WebchatMessageCreate's direct-token
-// branch only checked HasAllowedResourceType("webchat_session") and never
-// verified the resolved session's WidgetID against DirectScope.ResourceID.
-func Test_WebchatMessageCreate_Direct_CrossTenant_WrongWidgetScope(t *testing.T) {
+// Test_WebchatMessageList_SessionFilter_CrossTenant is a regression guard:
+// a caller must not be able to pass another customer's session_id to
+// enumerate that customer's messages, even though the caller's own
+// hasPermission check against a.CustomerID trivially passes.
+func Test_WebchatMessageList_SessionFilter_CrossTenant(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	attackerScopedWidgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	victimWidgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
-	victimCustomerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	victimSessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
-		ResourceType:         "webchat_widget",
-		ResourceID:           attackerScopedWidgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	// The victim session genuinely belongs to a different widget/customer.
-	victimSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: victimSessionID, CustomerID: victimCustomerID},
-		WidgetID: victimWidgetID,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, victimSessionID).Return(victimSession, nil)
-
-	if _, err := h.WebchatMessageCreate(ctx, a, victimSessionID, wcmessage.DirectionInbound, "injected"); err == nil {
-		t.Error("Wrong match. expect: permission denied error, got: ok")
-	}
-}
-
-// Test_WebchatSessionEnd_Direct_CrossTenant_WrongWidgetScope is the
-// analogous regression test for WebchatSessionEnd: a visitor JWT scoped to
-// widget A must not be able to forcibly end a session belonging to widget B.
-func Test_WebchatSessionEnd_Direct_CrossTenant_WrongWidgetScope(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	attackerScopedWidgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	victimWidgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
-	victimCustomerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	victimSessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
-		ResourceType:         "webchat_widget",
-		ResourceID:           attackerScopedWidgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	victimSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: victimSessionID, CustomerID: victimCustomerID},
-		WidgetID: victimWidgetID,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, victimSessionID).Return(victimSession, nil)
-
-	if _, err := h.WebchatSessionEnd(ctx, a, victimSessionID); err == nil {
-		t.Error("Wrong match. expect: permission denied error, got: ok")
-	}
-}
-
-// Test_WebchatSessionEnd_Direct verifies the legitimate visitor-initiated
-// end still works once the session's widget matches the JWT's scope.
-func Test_WebchatSessionEnd_Direct(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	session := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-	}
-	ended := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-		Status:   wcsession.StatusEnded,
-	}
-	widget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(session, nil)
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(widget, nil)
-	mockReq.EXPECT().WebchatV1SessionEnd(ctx, sessionID).Return(ended, nil)
-
-	res, err := h.WebchatSessionEnd(ctx, a, sessionID)
-	if err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-
-	expectRes := ended.ConvertWebhookMessage()
-	if !reflect.DeepEqual(res, expectRes) {
-		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectRes, res)
-	}
-}
-
-// Test_WebchatMessageCreate_Agent_CrossTenant_WrongSessionOwner is a
-// regression test for a cross-tenant message-injection bug: an
-// agent/accesskey with admin/manager permission on their OWN customer
-// account must not be able to post a message into a session_id belonging
-// to a DIFFERENT customer's widget -- the reply would be delivered to that
-// other customer's live visitor as if sent by the caller's own agent.
-// Before the fix, the a.IsAgent()||a.IsAccesskey() branch only checked
-// hasPermission(ctx, a, a.CustomerID, ...) -- a tautology that never
-// resolved the session or verified it belonged to the caller's customer.
-func Test_WebchatMessageCreate_Agent_CrossTenant_WrongSessionOwner(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
+		utilHandler: mockUtil,
 		reqHandler:  mockReq,
 	}
 	ctx := context.Background()
 
 	callerCustomerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
 	victimCustomerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	victimWidgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
-	victimSessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
+	victimSessionID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
 
 	a := auth.NewAgentIdentity(&amagent.Agent{
 		Identity: commonidentity.Identity{
@@ -247,433 +145,12 @@ func Test_WebchatMessageCreate_Agent_CrossTenant_WrongSessionOwner(t *testing.T)
 
 	victimSession := &wcsession.Session{
 		Identity: commonidentity.Identity{ID: victimSessionID, CustomerID: victimCustomerID},
-		WidgetID: victimWidgetID,
 	}
 
+	mockUtil.EXPECT().TimeGetCurTime().Return("2026-01-01 00:00:00.000000")
 	mockReq.EXPECT().WebchatV1SessionGet(ctx, victimSessionID).Return(victimSession, nil)
 
-	if _, err := h.WebchatMessageCreate(ctx, a, victimSessionID, wcmessage.DirectionOutbound, "injected reply"); err == nil {
+	if _, err := h.WebchatMessageList(ctx, a, 10, "", victimSessionID); err == nil {
 		t.Error("Wrong match. expect: permission denied error, got: ok")
-	}
-}
-
-// Test_WebchatMessageCreate_Direct_DirectionSpoofIgnored is a regression
-// test for message-direction spoofing (Round 3 finding): a visitor holding
-// only a direct-scope JWT must never be able to author an
-// outbound (agent-authored-looking) message, even if the client explicitly
-// requests direction=outbound in the API call. The server must silently
-// force direction=inbound for this auth path regardless of the caller-
-// supplied value -- verified here by asserting the downstream RPC call is
-// made with DirectionInbound even though the handler was invoked with
-// DirectionOutbound.
-func Test_WebchatMessageCreate_Direct_DirectionSpoofIgnored(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9f5e-4762c3c1e4e5")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	responseSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-	}
-	responseMessage := &wcmessage.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		SessionID: sessionID,
-		Direction: wcmessage.DirectionInbound,
-		Text:      "spoof attempt",
-	}
-	widget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(responseSession, nil)
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(widget, nil)
-	// The mock strictly asserts DirectionInbound -- if the handler forwarded
-	// the caller-supplied DirectionOutbound instead, gomock would reject
-	// the call as unexpected and this test would fail.
-	mockReq.EXPECT().WebchatV1MessageCreate(ctx, customerID, sessionID, wcmessage.DirectionInbound, uuid.Nil, "spoof attempt").Return(responseMessage, nil)
-
-	// Caller explicitly requests DirectionOutbound -- must be overridden.
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionOutbound, "spoof attempt"); err != nil {
-		t.Fatalf("Wrong match. expect: ok (direction silently overridden), got: %v", err)
-	}
-}
-
-// Test_WebchatMessageCreate_Agent_DirectionSpoofIgnored is the symmetric
-// regression test: an authenticated agent/accesskey must never be able to
-// author an inbound (visitor-authored-looking) message, even if the
-// client explicitly requests direction=inbound.
-func Test_WebchatMessageCreate_Agent_DirectionSpoofIgnored(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9f5e-4762c3c1e4e5")
-	agentID := uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979")
-
-	a := auth.NewAgentIdentity(&amagent.Agent{
-		Identity: commonidentity.Identity{
-			ID:         agentID,
-			CustomerID: customerID,
-		},
-		Permission: amagent.PermissionCustomerAdmin,
-	})
-
-	session := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-	}
-	responseMessage := &wcmessage.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		SessionID: sessionID,
-		Direction: wcmessage.DirectionOutbound,
-		SenderID:  agentID,
-		Text:      "spoof attempt",
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(session, nil)
-	mockReq.EXPECT().WebchatV1MessageCreate(ctx, customerID, sessionID, wcmessage.DirectionOutbound, agentID, "spoof attempt").Return(responseMessage, nil)
-
-	// Caller explicitly requests DirectionInbound -- must be overridden.
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionInbound, "spoof attempt"); err != nil {
-		t.Fatalf("Wrong match. expect: ok (direction silently overridden), got: %v", err)
-	}
-}
-
-// Test_WebchatMessageCreate_Agent_SuperAdmin_CrossTenant_OwnerCustomerID is
-// a regression test for a customer_id data-integrity bug: hasPermission
-// short-circuits to true for PermissionProjectSuperAdmin regardless of
-// a.CustomerID vs the session's actual owner. Before this fix,
-// WebchatMessageCreate unconditionally passed the caller's OWN a.CustomerID
-// (the superadmin's, not the session/widget owner's) to
-// WebchatV1MessageCreate -- creating a message tagged with the WRONG
-// customer_id, invisible to the session owner's own
-// WebchatMessageList/Get calls. Verified here by asserting the downstream
-// RPC call is made with the SESSION's customer_id, not the superadmin
-// caller's.
-func Test_WebchatMessageCreate_Agent_SuperAdmin_CrossTenant_OwnerCustomerID(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	superAdminCustomerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	sessionOwnerCustomerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9f5e-4762c3c1e4e5")
-	superAdminAgentID := uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979")
-
-	a := auth.NewAgentIdentity(&amagent.Agent{
-		Identity: commonidentity.Identity{
-			ID:         superAdminAgentID,
-			CustomerID: superAdminCustomerID,
-		},
-		Permission: amagent.PermissionProjectSuperAdmin,
-	})
-
-	session := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: sessionOwnerCustomerID},
-	}
-	responseMessage := &wcmessage.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: sessionOwnerCustomerID},
-		SessionID: sessionID,
-		Direction: wcmessage.DirectionOutbound,
-		SenderID:  superAdminAgentID,
-		Text:      "reply",
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(session, nil)
-	// The mock strictly asserts sessionOwnerCustomerID -- if the handler
-	// forwarded the superadmin's own a.CustomerID instead, gomock would
-	// reject the call as unexpected and this test would fail.
-	mockReq.EXPECT().WebchatV1MessageCreate(ctx, sessionOwnerCustomerID, sessionID, wcmessage.DirectionOutbound, superAdminAgentID, "reply").Return(responseMessage, nil)
-
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionOutbound, "reply"); err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-}
-
-// Test_WebchatMessageGet_SoftDeleted is a regression test for round 7's
-// finding: webchatMessageGet must reject a soft-deleted message
-// (TMDelete set), mirroring flowGet/widgetGet/sessionGet's established
-// "deleted resources are not found" pattern.
-func Test_WebchatMessageGet_SoftDeleted(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9f5e-4762c3c1e4e5")
-	deletedAt := time.Now()
-
-	a := auth.NewAgentIdentity(&amagent.Agent{
-		Identity: commonidentity.Identity{
-			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-			CustomerID: customerID,
-		},
-		Permission: amagent.PermissionCustomerAdmin,
-	})
-
-	deletedMessage := &wcmessage.Message{
-		Identity: commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		TMDelete: &deletedAt,
-	}
-
-	mockReq.EXPECT().WebchatV1MessageGet(ctx, messageID).Return(deletedMessage, nil)
-
-	if _, err := h.WebchatMessageGet(ctx, a, messageID); err == nil {
-		t.Error("Wrong match. expect: not found error, got: ok")
-	}
-}
-
-// Test_WebchatMessageCreate_Accesskey_SenderIDIsAccesskeyID is a
-// regression test for round 8's finding: an accesskey-authenticated
-// caller's a.AgentID() is always uuid.Nil (a.Agent is nil for Accesskey
-// identities), so without an explicit override the created message's
-// SenderID would collapse to the same empty value used for genuinely
-// automated flow/AI-originated messages, losing audit-trail
-// traceability. Verified by asserting the downstream RPC call carries
-// a.AccesskeyID(), not uuid.Nil.
-func Test_WebchatMessageCreate_Accesskey_SenderIDIsAccesskeyID(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	accesskeyID := uuid.FromStringOrNil("22222222-2222-2222-2222-222222222222")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9f5e-4762c3c1e4e5")
-
-	a := auth.NewAccesskeyIdentity(&csaccesskey.Accesskey{
-		ID:         accesskeyID,
-		CustomerID: customerID,
-		Name:       "test-key",
-	})
-
-	session := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-	}
-	responseMessage := &wcmessage.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		SessionID: sessionID,
-		Direction: wcmessage.DirectionOutbound,
-		SenderID:  accesskeyID,
-		Text:      "reply",
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(session, nil)
-	// The mock strictly asserts accesskeyID as the SenderID arg -- if the
-	// handler forwarded a.AgentID() (uuid.Nil) instead, gomock would
-	// reject the call as unexpected and this test would fail.
-	mockReq.EXPECT().WebchatV1MessageCreate(ctx, customerID, sessionID, wcmessage.DirectionOutbound, accesskeyID, "reply").Return(responseMessage, nil)
-
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionOutbound, "reply"); err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-}
-
-// Test_WebchatMessageCreate_Direct_WidgetSoftDeleted is a regression test
-// for round 9's finding: a visitor holding a previously-issued
-// direct-scope JWT for a now-deleted widget must not be able to keep
-// posting new inbound messages into that widget's still-open sessions.
-// Widget deletion is expected to shut off the visitor-facing surface
-// entirely, not just the session/widget-creation paths.
-func Test_WebchatMessageCreate_Direct_WidgetSoftDeleted(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	deletedAt := time.Now()
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	session := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-	}
-	deletedWidget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-		TMDelete: &deletedAt,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(session, nil)
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(deletedWidget, nil)
-
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionInbound, "still trying"); err == nil {
-		t.Error("Wrong match. expect: not found error, got: ok")
-	}
-}
-
-// Test_WebchatSessionEnd_Direct_WidgetSoftDeleted is the WebchatSessionEnd
-// equivalent of the above (round 9 finding).
-func Test_WebchatSessionEnd_Direct_WidgetSoftDeleted(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	deletedAt := time.Now()
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	session := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-	}
-	deletedWidget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-		TMDelete: &deletedAt,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(session, nil)
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(deletedWidget, nil)
-
-	if _, err := h.WebchatSessionEnd(ctx, a, sessionID); err == nil {
-		t.Error("Wrong match. expect: not found error, got: ok")
-	}
-}
-
-// Test_WebchatMessageCreate_Direct_SessionEnded is a regression test for
-// round 10's finding: session.go's own documented lifecycle contract
-// states "ended is terminal; a subsequent message ... creates a NEW
-// Session", but nothing in the call path enforced that -- a visitor
-// could keep posting inbound messages into an already-ended session_id
-// indefinitely, making Status purely cosmetic.
-func Test_WebchatMessageCreate_Direct_SessionEnded(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	endedSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-		Status:   wcsession.StatusEnded,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(endedSession, nil)
-
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionInbound, "zombie message"); err == nil {
-		t.Error("Wrong match. expect: not found error, got: ok")
-	}
-}
-
-// Test_WebchatMessageCreate_Agent_SessionEnded is the agent/accesskey-path
-// equivalent of the above (round 10 finding).
-func Test_WebchatMessageCreate_Agent_SessionEnded(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewAgentIdentity(&amagent.Agent{
-		Identity: commonidentity.Identity{
-			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-			CustomerID: customerID,
-		},
-		Permission: amagent.PermissionCustomerAdmin,
-	})
-
-	endedSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		Status:   wcsession.StatusEnded,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(endedSession, nil)
-
-	if _, err := h.WebchatMessageCreate(ctx, a, sessionID, wcmessage.DirectionOutbound, "reply to zombie"); err == nil {
-		t.Error("Wrong match. expect: not found error, got: ok")
 	}
 }

--- a/bin-api-manager/pkg/servicehandler/webchat_session.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_session.go
@@ -69,7 +69,14 @@ func (h *serviceHandler) WebchatSessionGet(ctx context.Context, a *auth.AuthIden
 }
 
 // WebchatSessionList sends a request to webchat-manager to get a list of sessions.
-func (h *serviceHandler) WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string) ([]*wcsession.WebhookMessage, error) {
+// widgetID, if non-nil (uuid.Nil means "no filter"), scopes the list to
+// sessions belonging to that widget -- e.g. the Sessions tab on a widget's
+// detail page in square-admin. The widget's ownership is verified via
+// widgetGet before the filter is applied, mirroring
+// WebchatSessionCreate/End's fetch-then-check-owner pattern, so a caller
+// cannot use an arbitrary widget_id to enumerate another customer's
+// sessions.
+func (h *serviceHandler) WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, widgetID uuid.UUID) ([]*wcsession.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "WebchatSessionList",
 		"customer_id": a.CustomerID,
@@ -92,6 +99,19 @@ func (h *serviceHandler) WebchatSessionList(ctx context.Context, a *auth.AuthIde
 	filters := map[wcsession.Field]any{
 		wcsession.FieldCustomerID: a.CustomerID,
 		wcsession.FieldDeleted:    false,
+	}
+
+	if widgetID != uuid.Nil {
+		w, err := h.widgetGet(ctx, widgetID)
+		if err != nil {
+			log.Errorf("Could not validate the widget info. err: %v", err)
+			return nil, err
+		}
+		if w.CustomerID != a.CustomerID {
+			log.Info("The widget does not belong to the requesting customer.")
+			return nil, serviceerrors.ErrPermissionDenied
+		}
+		filters[wcsession.FieldWidgetID] = widgetID
 	}
 
 	tmps, err := h.reqHandler.WebchatV1SessionList(ctx, token, size, filters)

--- a/bin-api-manager/pkg/servicehandler/webchat_session_test.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_session_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -21,134 +20,120 @@ import (
 	"monorepo/bin-api-manager/models/auth"
 )
 
-// Test_WebchatSessionCreate_Direct verifies the visitor-facing path: a
-// direct-scope JWT scoped to widget A can create a Session for widget A.
-func Test_WebchatSessionCreate_Direct(t *testing.T) {
+// Test_WebchatSessionList_NoFilter verifies the existing behavior is
+// unchanged when widgetID is uuid.Nil (no filter requested): only
+// customer_id/deleted are applied, and widgetGet is never called.
+func Test_WebchatSessionList_NoFilter(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
+		utilHandler: mockUtil,
+		reqHandler:  mockReq,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	sessionID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
+	})
+
+	responseSessions := []*wcsession.Session{
+		{Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID}},
+	}
+
+	mockUtil.EXPECT().TimeGetCurTime().Return("2026-01-01 00:00:00.000000")
+	mockReq.EXPECT().WebchatV1SessionList(ctx, "2026-01-01 00:00:00.000000", uint64(10), map[wcsession.Field]any{
+		wcsession.FieldCustomerID: customerID,
+		wcsession.FieldDeleted:    false,
+	}).Return(responseSessions, nil)
+
+	res, err := h.WebchatSessionList(ctx, a, 10, "", uuid.Nil)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	expectRes := []*wcsession.WebhookMessage{responseSessions[0].ConvertWebhookMessage()}
+	if !reflect.DeepEqual(res, expectRes) {
+		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectRes, res)
+	}
+}
+
+// Test_WebchatSessionList_WidgetFilter verifies that a non-nil widgetID
+// (a) is validated for ownership via widgetGet and (b) is added to the
+// filter map passed to WebchatV1SessionList.
+func Test_WebchatSessionList_WidgetFilter(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &serviceHandler{
+		utilHandler: mockUtil,
 		reqHandler:  mockReq,
 	}
 	ctx := context.Background()
 
 	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
 	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
 
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
+	a := auth.NewAgentIdentity(&amagent.Agent{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+			CustomerID: customerID,
+		},
+		Permission: amagent.PermissionCustomerAdmin,
 	})
 
-	responseSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-		Status:   wcsession.StatusActive,
-	}
-	widget := &wcwidget.Widget{
+	responseWidget := &wcwidget.Widget{
 		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
 	}
+	responseSessions := []*wcsession.Session{}
 
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(widget, nil)
-	mockReq.EXPECT().WebchatV1SessionCreate(ctx, customerID, widgetID).Return(responseSession, nil)
+	mockUtil.EXPECT().TimeGetCurTime().Return("2026-01-01 00:00:00.000000")
+	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(responseWidget, nil)
+	mockReq.EXPECT().WebchatV1SessionList(ctx, "2026-01-01 00:00:00.000000", uint64(10), map[wcsession.Field]any{
+		wcsession.FieldCustomerID: customerID,
+		wcsession.FieldDeleted:    false,
+		wcsession.FieldWidgetID:   widgetID,
+	}).Return(responseSessions, nil)
 
-	res, err := h.WebchatSessionCreate(ctx, a, widgetID)
+	res, err := h.WebchatSessionList(ctx, a, 10, "", widgetID)
 	if err != nil {
 		t.Fatalf("Wrong match. expect: ok, got: %v", err)
 	}
-
-	expectRes := responseSession.ConvertWebhookMessage()
-	if !reflect.DeepEqual(res, expectRes) {
-		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectRes, res)
+	if len(res) != 0 {
+		t.Errorf("Wrong match. expect: empty, got: %v", res)
 	}
 }
 
-// Test_WebchatSessionCreate_Direct_WrongWidgetScope verifies a direct-scope
-// JWT issued for widget A cannot be reused to create a Session for
-// widget B -- the DirectScope.ResourceID must match the requested
-// widget_id exactly.
-func Test_WebchatSessionCreate_Direct_WrongWidgetScope(t *testing.T) {
+// Test_WebchatSessionList_WidgetFilter_CrossTenant is a regression guard:
+// a caller must not be able to pass another customer's widget_id to
+// enumerate that customer's sessions, even though the caller's own
+// hasPermission check against a.CustomerID trivially passes.
+func Test_WebchatSessionList_WidgetFilter_CrossTenant(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	scopedWidgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	requestedWidgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           scopedWidgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	if _, err := h.WebchatSessionCreate(ctx, a, requestedWidgetID); err == nil {
-		t.Error("Wrong match. expect: permission denied error, got: ok")
-	}
-}
-
-// Test_WebchatSessionCreate_Direct_DisallowedResourceType verifies a
-// direct-scope JWT without "webchat_session" in AllowedResourceTypes is
-// rejected -- confirms the directResourceMapping wiring
-// (webchat_widget -> webchat_session) is actually enforced here, not just
-// documented.
-func Test_WebchatSessionCreate_Direct_DisallowedResourceType(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           customerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{}, // empty -- mis-scoped token
-	})
-
-	if _, err := h.WebchatSessionCreate(ctx, a, widgetID); err == nil {
-		t.Error("Wrong match. expect: permission denied error, got: ok")
-	}
-}
-
-// Test_WebchatSessionCreate_Agent_CrossTenant_WrongWidgetOwner is a
-// regression test for a cross-tenant resource-linkage bug: an
-// agent/accesskey with admin/manager permission on their OWN customer
-// account must not be able to create a session for a widget_id belonging
-// to a DIFFERENT customer -- doing so would trigger that other customer's
-// configured Flow using the wrong customer_id as the activeflow owner.
-// Before the fix, the a.IsAgent()||a.IsAccesskey() branch only checked
-// hasPermission(ctx, a, a.CustomerID, ...) -- a tautology that never
-// resolved the widget or verified it belonged to the caller.
-func Test_WebchatSessionCreate_Agent_CrossTenant_WrongWidgetOwner(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
 	mockReq := requesthandler.NewMockRequestHandler(mc)
 	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
+		utilHandler: mockUtil,
 		reqHandler:  mockReq,
 	}
 	ctx := context.Background()
 
 	callerCustomerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
 	victimCustomerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	victimWidgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
+	victimWidgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
 
 	a := auth.NewAgentIdentity(&amagent.Agent{
 		Identity: commonidentity.Identity{
@@ -162,153 +147,10 @@ func Test_WebchatSessionCreate_Agent_CrossTenant_WrongWidgetOwner(t *testing.T) 
 		Identity: commonidentity.Identity{ID: victimWidgetID, CustomerID: victimCustomerID},
 	}
 
+	mockUtil.EXPECT().TimeGetCurTime().Return("2026-01-01 00:00:00.000000")
 	mockReq.EXPECT().WebchatV1WidgetGet(ctx, victimWidgetID).Return(victimWidget, nil)
 
-	if _, err := h.WebchatSessionCreate(ctx, a, victimWidgetID); err == nil {
+	if _, err := h.WebchatSessionList(ctx, a, 10, "", victimWidgetID); err == nil {
 		t.Error("Wrong match. expect: permission denied error, got: ok")
-	}
-}
-
-// Test_WebchatSessionCreate_Agent_SuperAdmin_CrossTenant_OwnerCustomerID is
-// a regression test for a customer_id data-integrity bug: hasPermission
-// short-circuits to true for PermissionProjectSuperAdmin regardless of
-// a.CustomerID vs the widget's actual owner. Before this fix,
-// WebchatSessionCreate unconditionally passed the caller's OWN a.CustomerID
-// (the superadmin's, not the widget owner's) to WebchatV1SessionCreate --
-// creating a session tagged with the WRONG customer_id, invisible to the
-// widget owner's own WebchatSessionList/Get calls. Verified here by
-// asserting the downstream RPC call is made with the WIDGET's customer_id,
-// not the superadmin caller's.
-func Test_WebchatSessionCreate_Agent_SuperAdmin_CrossTenant_OwnerCustomerID(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	superAdminCustomerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	widgetOwnerCustomerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	widgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewAgentIdentity(&amagent.Agent{
-		Identity: commonidentity.Identity{
-			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-			CustomerID: superAdminCustomerID,
-		},
-		Permission: amagent.PermissionProjectSuperAdmin,
-	})
-
-	widget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: widgetOwnerCustomerID},
-	}
-	responseSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: widgetOwnerCustomerID},
-		WidgetID: widgetID,
-	}
-
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(widget, nil)
-	// The mock strictly asserts widgetOwnerCustomerID -- if the handler
-	// forwarded the superadmin's own a.CustomerID instead, gomock would
-	// reject the call as unexpected and this test would fail.
-	mockReq.EXPECT().WebchatV1SessionCreate(ctx, widgetOwnerCustomerID, widgetID).Return(responseSession, nil)
-
-	if _, err := h.WebchatSessionCreate(ctx, a, widgetID); err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-}
-
-// Test_WebchatSessionCreate_Direct_OwnerCustomerID_ReResolvedFromWidget is a
-// regression test for defense-in-depth found in round 6: the direct-scope
-// (visitor) branch must re-resolve ownerCustomerID from the widget's
-// actual current owner (via widgetGet) rather than trusting the
-// CustomerID claim baked into the direct-scope JWT at boot time --
-// mirroring WebchatMessageCreate's direct branch, which does the same
-// for ownerCustomerID = s.CustomerID. Verified by using a JWT whose
-// DirectScope.CustomerID claim deliberately does NOT match the widget's
-// real w.CustomerID (simulating a stale/rotated-ownership claim) and
-// asserting the downstream RPC call uses the widget's real owner.
-func Test_WebchatSessionCreate_Direct_OwnerCustomerID_ReResolvedFromWidget(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	staleClaimCustomerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	actualWidgetOwnerID := uuid.FromStringOrNil("00000000-0000-0000-0000-0000000000ff")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-
-	a := auth.NewDirectIdentity(&auth.DirectScope{
-		CustomerID:           staleClaimCustomerID,
-		ResourceType:         "webchat_widget",
-		ResourceID:           widgetID,
-		AllowedResourceTypes: []string{"webchat_session"},
-	})
-
-	widget := &wcwidget.Widget{
-		Identity: commonidentity.Identity{ID: widgetID, CustomerID: actualWidgetOwnerID},
-	}
-	responseSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: actualWidgetOwnerID},
-		WidgetID: widgetID,
-	}
-
-	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(widget, nil)
-	// The mock strictly asserts actualWidgetOwnerID -- if the handler
-	// forwarded the JWT's stale staleClaimCustomerID instead, gomock
-	// would reject the call as unexpected and this test would fail.
-	mockReq.EXPECT().WebchatV1SessionCreate(ctx, actualWidgetOwnerID, widgetID).Return(responseSession, nil)
-
-	if _, err := h.WebchatSessionCreate(ctx, a, widgetID); err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-}
-
-// Test_WebchatSessionGet_SoftDeleted is a regression test for round 7's
-// finding: sessionGet must reject a soft-deleted session (TMDelete set),
-// mirroring flowGet/widgetGet's established "deleted resources are not
-// found" pattern.
-func Test_WebchatSessionGet_SoftDeleted(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	mockReq := requesthandler.NewMockRequestHandler(mc)
-	h := &serviceHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  mockReq,
-	}
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	deletedAt := time.Now()
-
-	a := auth.NewAgentIdentity(&amagent.Agent{
-		Identity: commonidentity.Identity{
-			ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
-			CustomerID: customerID,
-		},
-		Permission: amagent.PermissionCustomerAdmin,
-	})
-
-	deletedSession := &wcsession.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		TMDelete: &deletedAt,
-	}
-
-	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(deletedSession, nil)
-
-	if _, err := h.WebchatSessionGet(ctx, a, sessionID); err == nil {
-		t.Error("Wrong match. expect: not found error, got: ok")
 	}
 }

--- a/bin-api-manager/server/webchat_messages.go
+++ b/bin-api-manager/server/webchat_messages.go
@@ -40,7 +40,12 @@ func (h *server) GetWebchatMessages(c *gin.Context, params openapi_server.GetWeb
 		pageToken = *params.PageToken
 	}
 
-	tmps, err := h.serviceHandler.WebchatMessageList(c.Request.Context(), a, pageSize, pageToken)
+	sessionID := uuid.Nil
+	if params.SessionId != nil {
+		sessionID = uuid.FromStringOrNil(params.SessionId.String())
+	}
+
+	tmps, err := h.serviceHandler.WebchatMessageList(c.Request.Context(), a, pageSize, pageToken, sessionID)
 	if err != nil {
 		logrus.Errorf("Could not get webchat messages info. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-api-manager/server/webchat_sessions.go
+++ b/bin-api-manager/server/webchat_sessions.go
@@ -39,7 +39,12 @@ func (h *server) GetWebchatSessions(c *gin.Context, params openapi_server.GetWeb
 		pageToken = *params.PageToken
 	}
 
-	tmps, err := h.serviceHandler.WebchatSessionList(c.Request.Context(), a, pageSize, pageToken)
+	widgetID := uuid.Nil
+	if params.WidgetId != nil {
+		widgetID = uuid.FromStringOrNil(params.WidgetId.String())
+	}
+
+	tmps, err := h.serviceHandler.WebchatSessionList(c.Request.Context(), a, pageSize, pageToken, widgetID)
 	if err != nil {
 		logrus.Errorf("Could not get webchat sessions info. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -10248,6 +10248,9 @@ type GetWebchatMessagesParams struct {
 
 	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
 	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// SessionId Filter messages to those belonging to this session. Returned from the `POST /webchat_sessions` or `GET /webchat_sessions` response.
+	SessionId *openapi_types.UUID `form:"session_id,omitempty" json:"session_id,omitempty"`
 }
 
 // PostWebchatMessagesJSONBody defines parameters for PostWebchatMessages.
@@ -10269,6 +10272,9 @@ type GetWebchatSessionsParams struct {
 
 	// PageToken Cursor token for pagination. Use the `next_page_token` value from the previous response.
 	PageToken *PageToken `form:"page_token,omitempty" json:"page_token,omitempty"`
+
+	// WidgetId Filter sessions to those belonging to this widget. Returned from the `POST /webchat_widgets` or `GET /webchat_widgets` response.
+	WidgetId *openapi_types.UUID `form:"widget_id,omitempty" json:"widget_id,omitempty"`
 }
 
 // PostWebchatSessionsJSONBody defines parameters for PostWebchatSessions.

--- a/bin-openapi-manager/openapi/paths/webchat_messages/main.yaml
+++ b/bin-openapi-manager/openapi/paths/webchat_messages/main.yaml
@@ -6,6 +6,14 @@ get:
   parameters:
     - $ref: '#/components/parameters/PageSize'
     - $ref: '#/components/parameters/PageToken'
+    - name: session_id
+      in: query
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description: "Filter messages to those belonging to this session. Returned from the `POST /webchat_sessions` or `GET /webchat_sessions` response."
+      example: "7a1bcb1a-1b8e-4f5c-9a6d-3e2f1a0b4c5d"
   responses:
     '200':
       description: A list of webchat messages.

--- a/bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml
+++ b/bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml
@@ -6,6 +6,14 @@ get:
   parameters:
     - $ref: '#/components/parameters/PageSize'
     - $ref: '#/components/parameters/PageToken'
+    - name: widget_id
+      in: query
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description: "Filter sessions to those belonging to this widget. Returned from the `POST /webchat_widgets` or `GET /webchat_widgets` response."
+      example: "550e8400-e29b-41d4-a716-446655440000"
   responses:
     '200':
       description: A list of webchat sessions.


### PR DESCRIPTION
Add widget_id filter to GET /webchat_sessions and session_id filter to GET
/webchat_messages, needed so square-admin's upcoming Phase 2 (SQUARE-14,
Session/Message read-only views on the widget detail page) can scope a
session list to one widget and a message timeline to one session.
bin-webchat-manager's DB/RPC layer already supported these filters
(models/session/filters.go, models/message/filters.go); only
bin-api-manager's servicehandler/OpenAPI/server layers were missing the
query parameter.

- bin-openapi-manager: Add optional widget_id query param to GET
  /webchat_sessions, optional session_id query param to GET
  /webchat_messages
- bin-api-manager: WebchatSessionList takes a widgetID parameter; when
  non-nil, verifies the widget belongs to the requesting customer via
  widgetGet before adding it to the filter map (prevents a caller from
  passing an arbitrary widget_id to enumerate another customer's sessions)
- bin-api-manager: WebchatMessageList takes a sessionID parameter; same
  ownership-verification pattern via sessionGet before filtering
- bin-api-manager: Update ServiceHandler interface + regenerate mock
- bin-api-manager: Parse widget_id/session_id query params in
  GetWebchatSessions/GetWebchatMessages server handlers
- bin-api-manager: Add servicehandler tests covering the no-filter
  (unchanged) path, the filtered path, and the cross-tenant rejection for
  both WebchatSessionList and WebchatMessageList