### PR TITLE
VOIP-1265-webchat-widget-runtime-and-realtime

### DIFF
--- a/bin-api-manager/models/webhook/common_data.go
+++ b/bin-api-manager/models/webhook/common_data.go
@@ -1,0 +1,25 @@
+// Package webhook defines the shared shape of a webhook event payload as
+// consumed inside bin-api-manager's subscribehandler package. This lives
+// under models/, not inline in pkg/subscribehandler, following this
+// service's existing convention (see models/auth, models/hook,
+// models/common, models/stream) of keeping small model types out of
+// pkg/*handler files.
+package webhook
+
+import (
+	commonidentity "monorepo/bin-common-handler/models/identity"
+)
+
+// CommonData is the resource-agnostic shape every webhook event payload
+// shares: an Identity (id, customer_id) and an optional Owner
+// (owner_id/owner_type). It intentionally does NOT carry any
+// resource-specific fields (e.g. an aicall_id, chat_id, or session_id) --
+// those vary per event type and belong to that event type's own
+// unmarshal target, not to a struct every publisher's payload is forced
+// through. See pkg/subscribehandler/webhookmanager.go's createTopics for
+// how each resource's own extra fields are decoded locally, scoped to
+// just the switch case that needs them.
+type CommonData struct {
+	commonidentity.Identity
+	commonidentity.Owner
+}

--- a/bin-api-manager/pkg/servicehandler/webchat_message.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_message.go
@@ -75,6 +75,16 @@ func (h *serviceHandler) WebchatMessageGet(ctx context.Context, a *auth.AuthIden
 // the filter is applied, mirroring WebchatMessageCreate's
 // fetch-then-check-owner pattern, so a caller cannot use an arbitrary
 // session_id to enumerate another customer's messages.
+//
+// Also reachable by a direct-scoped caller (a widget visitor) -- added
+// per VOIP-1265, mirroring WebchatMessageCreate's dual-path auth. A
+// visitor can only ever list their own session's messages (session_id is
+// mandatory in that path); widget soft-delete is checked (mirrors
+// Create's direct branch), but an ended session's history remains
+// readable (deliberately -- unlike posting into it, reading the final
+// history of an ended session is a legitimate need, e.g. reconnecting
+// after a network drop to see the last replies before the session
+// ended).
 func (h *serviceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, sessionID uuid.UUID) ([]*wcmessage.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "WebchatMessageList",
@@ -82,35 +92,66 @@ func (h *serviceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIde
 		"username":    a.DisplayName(),
 	})
 
-	if a.IsDirect() {
-		return nil, serviceerrors.ErrDirectAccessNotSupported
-	}
-
 	if token == "" {
 		token = h.utilHandler.TimeGetCurTime()
 	}
 
-	if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
-		log.Info("The agent has no permission.")
-		return nil, serviceerrors.ErrPermissionDenied
-	}
-
 	filters := map[wcmessage.Field]any{
-		wcmessage.FieldCustomerID: a.CustomerID,
-		wcmessage.FieldDeleted:    false,
+		wcmessage.FieldDeleted: false,
 	}
 
-	if sessionID != uuid.Nil {
+	switch {
+	case a.IsDirect():
+		if !a.HasAllowedResourceType("webchat_session") {
+			return nil, serviceerrors.ErrPermissionDenied
+		}
+		if sessionID == uuid.Nil {
+			// A visitor must always scope to their own session; there is
+			// no "list all my messages across sessions" concept for a
+			// direct-scoped caller.
+			return nil, serviceerrors.ErrPermissionDenied
+		}
 		s, err := h.sessionGet(ctx, sessionID)
 		if err != nil {
 			log.Errorf("Could not validate the session info. err: %v", err)
 			return nil, err
 		}
-		if s.CustomerID != a.CustomerID {
-			log.Info("The session does not belong to the requesting customer.")
+		if s.WidgetID != a.DirectScope.ResourceID {
 			return nil, serviceerrors.ErrPermissionDenied
 		}
+		// Confirm the widget itself hasn't been soft-deleted -- mirrors
+		// WebchatMessageCreate's/WebchatSessionCreate's direct branches.
+		if _, err := h.widgetGet(ctx, a.DirectScope.ResourceID); err != nil {
+			log.Errorf("Could not validate the widget info. err: %v", err)
+			return nil, err
+		}
+		// s.CustomerID is authoritative here (already ownership-verified
+		// above via s.WidgetID check) -- set explicitly rather than
+		// trusting a.CustomerID, mirroring WebchatMessageCreate's
+		// ownerCustomerID pattern for the same defense-in-depth reason.
+		filters[wcmessage.FieldCustomerID] = s.CustomerID
 		filters[wcmessage.FieldSessionID] = sessionID
+
+	default:
+		if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+			log.Info("The agent has no permission.")
+			return nil, serviceerrors.ErrPermissionDenied
+		}
+
+		filters[wcmessage.FieldCustomerID] = a.CustomerID
+
+		if sessionID != uuid.Nil {
+			s, err := h.sessionGet(ctx, sessionID)
+			if err != nil {
+				log.Errorf("Could not validate the session info. err: %v", err)
+				return nil, err
+			}
+			if s.CustomerID != a.CustomerID {
+				log.Info("The session does not belong to the requesting customer.")
+				return nil, serviceerrors.ErrPermissionDenied
+			}
+			filters[wcmessage.FieldSessionID] = sessionID
+		}
 	}
 
 	tmps, err := h.reqHandler.WebchatV1MessageList(ctx, token, size, filters)

--- a/bin-api-manager/pkg/servicehandler/webchat_message_test.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_message_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -13,6 +14,7 @@ import (
 
 	wcmessage "monorepo/bin-webchat-manager/models/message"
 	wcsession "monorepo/bin-webchat-manager/models/session"
+	wcwidget "monorepo/bin-webchat-manager/models/widget"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -154,3 +156,176 @@ func Test_WebchatMessageList_SessionFilter_CrossTenant(t *testing.T) {
 		t.Error("Wrong match. expect: permission denied error, got: ok")
 	}
 }
+
+// Test_WebchatMessageList_Direct verifies the new direct-scope (visitor)
+// path: a valid direct JWT scoped to the session's own widget can list
+// that session's messages, filtered by the SESSION's actual customer_id
+// (not the JWT's own DirectScope.CustomerID, defense-in-depth mirroring
+// WebchatMessageCreate's ownerCustomerID pattern -- VOIP-1265 §9.2).
+func Test_WebchatMessageList_Direct(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &serviceHandler{
+		utilHandler: utilhandler.NewUtilHandler(),
+		reqHandler:  mockReq,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	widgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
+	sessionID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+
+	a := auth.NewDirectIdentity(&auth.DirectScope{
+		CustomerID:           customerID,
+		ResourceType:         "webchat_widget",
+		ResourceID:           widgetID,
+		AllowedResourceTypes: []string{"webchat_session"},
+	})
+
+	responseSession := &wcsession.Session{
+		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
+		WidgetID: widgetID,
+	}
+	responseWidget := &wcwidget.Widget{
+		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
+	}
+	responseMessages := []*wcmessage.Message{
+		{Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("cc847807-6cc4-4713-9dec-53a42840e74c"), CustomerID: customerID}},
+	}
+
+	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(responseSession, nil)
+	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(responseWidget, nil)
+	mockReq.EXPECT().WebchatV1MessageList(ctx, gomock.Any(), uint64(10), map[wcmessage.Field]any{
+		wcmessage.FieldCustomerID: customerID,
+		wcmessage.FieldDeleted:    false,
+		wcmessage.FieldSessionID:  sessionID,
+	}).Return(responseMessages, nil)
+
+	res, err := h.WebchatMessageList(ctx, a, 10, "", sessionID)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	expectRes := []*wcmessage.WebhookMessage{responseMessages[0].ConvertWebhookMessage()}
+	if !reflect.DeepEqual(res, expectRes) {
+		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectRes, res)
+	}
+}
+
+// Test_WebchatMessageList_Direct_NoSessionID verifies a direct-scope
+// caller omitting session_id is rejected -- there is no "list all my
+// messages across sessions" concept for a visitor.
+func Test_WebchatMessageList_Direct_NoSessionID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	h := &serviceHandler{
+		utilHandler: utilhandler.NewUtilHandler(),
+	}
+	ctx := context.Background()
+
+	widgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
+	a := auth.NewDirectIdentity(&auth.DirectScope{
+		CustomerID:           uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c"),
+		ResourceType:         "webchat_widget",
+		ResourceID:           widgetID,
+		AllowedResourceTypes: []string{"webchat_session"},
+	})
+
+	if _, err := h.WebchatMessageList(ctx, a, 10, "", uuid.Nil); err == nil {
+		t.Error("Wrong match. expect: permission denied error, got: ok")
+	}
+}
+
+// Test_WebchatMessageList_Direct_WrongWidget is a regression guard: a
+// visitor's direct-scope JWT for widget A must not be able to list
+// messages for a session belonging to widget B, even within the same
+// customer.
+func Test_WebchatMessageList_Direct_WrongWidget(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &serviceHandler{
+		utilHandler: utilhandler.NewUtilHandler(),
+		reqHandler:  mockReq,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	callerWidgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
+	otherWidgetID := uuid.FromStringOrNil("dd847807-6cc4-4713-9dec-53a42840e74c")
+	sessionID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+
+	a := auth.NewDirectIdentity(&auth.DirectScope{
+		CustomerID:           customerID,
+		ResourceType:         "webchat_widget",
+		ResourceID:           callerWidgetID,
+		AllowedResourceTypes: []string{"webchat_session"},
+	})
+
+	otherWidgetSession := &wcsession.Session{
+		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
+		WidgetID: otherWidgetID,
+	}
+
+	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(otherWidgetSession, nil)
+
+	if _, err := h.WebchatMessageList(ctx, a, 10, "", sessionID); err == nil {
+		t.Error("Wrong match. expect: permission denied error, got: ok")
+	}
+}
+
+// Test_WebchatMessageList_Direct_DeletedWidget is a regression guard for
+// the exact CRUD-asymmetry bug class VOIP-1265 fixes: a visitor holding
+// a direct-scope JWT for a now soft-deleted widget must not be able to
+// read message history via List, mirroring WebchatMessageCreate's
+// direct branch which already rejects Create on a deleted widget.
+func Test_WebchatMessageList_Direct_DeletedWidget(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &serviceHandler{
+		utilHandler: utilhandler.NewUtilHandler(),
+		reqHandler:  mockReq,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	widgetID := uuid.FromStringOrNil("bb847807-6cc4-4713-9dec-53a42840e74c")
+	sessionID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+
+	a := auth.NewDirectIdentity(&auth.DirectScope{
+		CustomerID:           customerID,
+		ResourceType:         "webchat_widget",
+		ResourceID:           widgetID,
+		AllowedResourceTypes: []string{"webchat_session"},
+	})
+
+	responseSession := &wcsession.Session{
+		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
+		WidgetID: widgetID,
+	}
+
+	mockReq.EXPECT().WebchatV1SessionGet(ctx, sessionID).Return(responseSession, nil)
+	// widgetGet treats a soft-deleted widget as not-found (see
+	// webchat_widget.go's widgetGet, mirroring flowGet's pattern) -- a
+	// TMDelete-set widget causes WebchatV1WidgetGet's caller-side
+	// wrapper to return ErrNotFound. Simulate that directly since
+	// widgetGet's soft-delete check runs on the *returned* widget, not
+	// inside the mock.
+	deletedWidget := &wcwidget.Widget{
+		Identity: commonidentity.Identity{ID: widgetID, CustomerID: customerID},
+		TMDelete: &deletedAt,
+	}
+	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(deletedWidget, nil)
+
+	if _, err := h.WebchatMessageList(ctx, a, 10, "", sessionID); err == nil {
+		t.Error("Wrong match. expect: not found error (soft-deleted widget), got: ok")
+	}
+}
+
+var deletedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/bin-api-manager/pkg/subscribehandler/webhookmanager.go
+++ b/bin-api-manager/pkg/subscribehandler/webhookmanager.go
@@ -6,21 +6,14 @@ import (
 	"fmt"
 	"strings"
 
-	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/models/sock"
 	wmwebhook "monorepo/bin-webhook-manager/models/webhook"
+
+	apiwebhook "monorepo/bin-api-manager/models/webhook"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 )
-
-type commonWebhookData struct {
-	commonidentity.Identity
-	commonidentity.Owner
-	AIcallID  uuid.UUID `json:"aicall_id,omitempty"`
-	ChatID    uuid.UUID `json:"chat_id,omitempty"`
-	SessionID uuid.UUID `json:"session_id,omitempty"`
-}
 
 // getServiceNamespace maps RabbitMQ publisher name to topic namespace
 func (h *subscribeHandler) getServiceNamespace(publisher string) string {
@@ -72,8 +65,12 @@ func (h *subscribeHandler) processEventWebhookManagerWebhookPublished(ctx contex
 		return err
 	}
 
-	// parse the webhook.data.data
-	d := &commonWebhookData{}
+	// parse the webhook.data.data -- only the resource-agnostic
+	// Identity/Owner fields are decoded into the shared struct here.
+	// Resource-specific fields (aicall_id, chat_id, session_id, ...) are
+	// decoded per-case, locally, inside createTopics -- see that
+	// function and apiwebhook.CommonData's doc comment for why.
+	d := &apiwebhook.CommonData{}
 	if err := json.Unmarshal(whData.Data, d); err != nil {
 		log.Errorf("Could not unmarshal the webhook data. err: %v", err)
 		return err
@@ -87,7 +84,7 @@ func (h *subscribeHandler) processEventWebhookManagerWebhookPublished(ctx contex
 	}
 	log.Debugf("Created data. data: %s", string(data))
 
-	topics, err := h.createTopics(ctx, whData.Type, d, m.Publisher)
+	topics, err := h.createTopics(ctx, whData.Type, d, whData.Data, m.Publisher)
 	if err != nil {
 		log.Errorf("Could not create the topics")
 		return fmt.Errorf("could not create the topics")
@@ -119,7 +116,7 @@ func (h *subscribeHandler) processEventWebhookManagerRoutingKeyedEvent(ctx conte
 	})
 	log.Debugf("Received routing-keyed event. type: %s", m.Type)
 
-	d := &commonWebhookData{}
+	d := &apiwebhook.CommonData{}
 	if err := json.Unmarshal(m.Data, d); err != nil {
 		log.Errorf("Could not unmarshal the resource data. err: %v", err)
 		return err
@@ -138,7 +135,7 @@ func (h *subscribeHandler) processEventWebhookManagerRoutingKeyedEvent(ctx conte
 	}
 	resource := tmps[0]
 
-	topics, err := h.createTopics(ctx, m.Type, d, resource)
+	topics, err := h.createTopics(ctx, m.Type, d, m.Data, resource)
 	if err != nil {
 		log.Errorf("Could not create the topics. err: %v", err)
 		return fmt.Errorf("could not create the topics")
@@ -155,8 +152,13 @@ func (h *subscribeHandler) processEventWebhookManagerRoutingKeyedEvent(ctx conte
 	return nil
 }
 
-// createTopics generates the topics
-func (h *subscribeHandler) createTopics(ctx context.Context, messageType string, d *commonWebhookData, publisher string) ([]string, error) {
+// createTopics generates the topics. d carries only the resource-agnostic
+// Identity/Owner fields; raw is the original event payload bytes, used by
+// individual switch cases below to locally decode whatever
+// resource-specific field they need (aicall_id, chat_id, session_id, ...)
+// without adding that field to the shared apiwebhook.CommonData struct --
+// see that struct's doc comment for why.
+func (h *subscribeHandler) createTopics(ctx context.Context, messageType string, d *apiwebhook.CommonData, raw json.RawMessage, publisher string) ([]string, error) {
 
 	res := []string{}
 
@@ -173,12 +175,26 @@ func (h *subscribeHandler) createTopics(ctx context.Context, messageType string,
 
 	switch resource {
 	case "aimessage":
+		// aicall_id is specific to aimessage events only -- decoded
+		// locally rather than carried on the shared CommonData struct.
+		var extra struct {
+			AIcallID uuid.UUID `json:"aicall_id"`
+		}
+		_ = json.Unmarshal(raw, &extra)
+
 		if d.CustomerID != uuid.Nil {
-			res = append(res, fmt.Sprintf("customer_id:%s:aicall:%s", d.CustomerID, d.AIcallID))
+			res = append(res, fmt.Sprintf("customer_id:%s:aicall:%s", d.CustomerID, extra.AIcallID))
 		}
 
 	case "chat", "chatmessage", "chatparticipant":
-		chatID := d.ChatID
+		// chat_id is specific to chat-family events only -- decoded
+		// locally rather than carried on the shared CommonData struct.
+		var extra struct {
+			ChatID uuid.UUID `json:"chat_id"`
+		}
+		_ = json.Unmarshal(raw, &extra)
+
+		chatID := extra.ChatID
 		if chatID == uuid.Nil {
 			chatID = d.ID
 		}
@@ -214,12 +230,18 @@ func (h *subscribeHandler) createTopics(ctx context.Context, messageType string,
 		// POST /webchat_sessions time, before any message exists) can
 		// subscribe to it -- mirrors the aimessage case's "scope by
 		// stable parent id, not the not-yet-known child id" pattern
-		// above. For webchat_message_created, d.SessionID (the
-		// message's own session_id field) is the session id; for
+		// above. For webchat_message_created, session_id (the
+		// message's own session_id field, decoded locally, specific to
+		// this event type) is the session id; for
 		// webchat_session_ended, the event's own d.ID (the Session's
 		// Identity.ID) IS the session id -- there is no separate
 		// SessionID field on a Session's own webhook payload. VOIP-1265.
-		sessionID := d.SessionID
+		var extra struct {
+			SessionID uuid.UUID `json:"session_id"`
+		}
+		_ = json.Unmarshal(raw, &extra)
+
+		sessionID := extra.SessionID
 		if sessionID == uuid.Nil {
 			sessionID = d.ID
 		}

--- a/bin-api-manager/pkg/subscribehandler/webhookmanager.go
+++ b/bin-api-manager/pkg/subscribehandler/webhookmanager.go
@@ -17,8 +17,9 @@ import (
 type commonWebhookData struct {
 	commonidentity.Identity
 	commonidentity.Owner
-	AIcallID uuid.UUID `json:"aicall_id,omitempty"`
-	ChatID   uuid.UUID `json:"chat_id,omitempty"`
+	AIcallID  uuid.UUID `json:"aicall_id,omitempty"`
+	ChatID    uuid.UUID `json:"chat_id,omitempty"`
+	SessionID uuid.UUID `json:"session_id,omitempty"`
 }
 
 // getServiceNamespace maps RabbitMQ publisher name to topic namespace
@@ -203,6 +204,27 @@ func (h *subscribeHandler) createTopics(ctx context.Context, messageType string,
 					res = append(res, fmt.Sprintf("agent_id:%s:%s:%s:%s", p.OwnerID, service, messageType, d.ID))
 				}
 			}
+		}
+
+	case "webchat":
+		// Both webchat_message_created and webchat_session_ended land
+		// here (both split to "webchat" as tmps[0]). Scope the topic by
+		// SESSION id, not message/session-row id, so a visitor's
+		// direct-scope JWT (which only learns the session id at
+		// POST /webchat_sessions time, before any message exists) can
+		// subscribe to it -- mirrors the aimessage case's "scope by
+		// stable parent id, not the not-yet-known child id" pattern
+		// above. For webchat_message_created, d.SessionID (the
+		// message's own session_id field) is the session id; for
+		// webchat_session_ended, the event's own d.ID (the Session's
+		// Identity.ID) IS the session id -- there is no separate
+		// SessionID field on a Session's own webhook payload. VOIP-1265.
+		sessionID := d.SessionID
+		if sessionID == uuid.Nil {
+			sessionID = d.ID
+		}
+		if d.CustomerID != uuid.Nil && sessionID != uuid.Nil {
+			res = append(res, fmt.Sprintf("customer_id:%s:webchat_session:%s", d.CustomerID, sessionID))
 		}
 
 	default:

--- a/bin-api-manager/pkg/subscribehandler/webhookmanager_test.go
+++ b/bin-api-manager/pkg/subscribehandler/webhookmanager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
+	apiwebhook "monorepo/bin-api-manager/models/webhook"
 	"monorepo/bin-api-manager/pkg/zmqpubhandler"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/models/sock"
@@ -313,7 +314,12 @@ func Test_createTopics(t *testing.T) {
 		name string
 
 		messageType string
-		data        *commonWebhookData
+		data        *apiwebhook.CommonData
+		// raw is the original event payload bytes -- createTopics decodes
+		// resource-specific fields (aicall_id, chat_id, session_id, ...)
+		// from this locally, per switch case, rather than from a shared
+		// struct field. See apiwebhook.CommonData's doc comment.
+		raw json.RawMessage
 
 		// For chat events that need participant fan-out
 		chatID       uuid.UUID
@@ -328,7 +334,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "have id, customer_id",
 			messageType: "activeflow_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("d5d70d9d-85ad-4ffc-90c1-fdda37c046b0"),
 					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
@@ -345,7 +351,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "have id, customer_id, owner_id",
 			messageType: "chatroom_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("7b0966c0-da98-11ee-97df-1786497422fb"),
 					CustomerID: uuid.FromStringOrNil("7b6cc58a-da98-11ee-b114-3fb0f4ae9318"),
@@ -367,7 +373,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "have id, owner_id",
 			messageType: "task_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("8c0966c0-da98-11ee-97df-1786497422fb"),
 				},
@@ -386,13 +392,13 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "aimessage_created with aicall_id uses aicall topic",
 			messageType: "aimessage_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
 					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
 				},
-				AIcallID: uuid.FromStringOrNil("c3d4e5f6-a1b2-7890-abcd-1234567890ef"),
 			},
+			raw: json.RawMessage(`{"id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","customer_id":"5e4a0680-804e-11ec-8477-2fea5968d85b","aicall_id":"c3d4e5f6-a1b2-7890-abcd-1234567890ef"}`),
 			expectTopics: []string{
 				// Old format uses aicall_id
 				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:aicall:c3d4e5f6-a1b2-7890-abcd-1234567890ef",
@@ -404,13 +410,13 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "aimessage_intermediate with aicall_id uses aicall topic",
 			messageType: "aimessage_intermediate",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("b2c3d4e5-f6a1-7890-abcd-234567890ef1"),
 					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
 				},
-				AIcallID: uuid.FromStringOrNil("c3d4e5f6-a1b2-7890-abcd-1234567890ef"),
 			},
+			raw: json.RawMessage(`{"id":"b2c3d4e5-f6a1-7890-abcd-234567890ef1","customer_id":"5e4a0680-804e-11ec-8477-2fea5968d85b","aicall_id":"c3d4e5f6-a1b2-7890-abcd-1234567890ef"}`),
 			expectTopics: []string{
 				// Old format uses aicall_id
 				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:aicall:c3d4e5f6-a1b2-7890-abcd-1234567890ef",
@@ -422,13 +428,13 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "webchat_message_created uses webchat_session topic scoped by session_id",
 			messageType: "webchat_message_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("e1e1e1e1-1111-1111-1111-111111111111"),
 					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
 				},
-				SessionID: uuid.FromStringOrNil("f2f2f2f2-2222-2222-2222-222222222222"),
 			},
+			raw: json.RawMessage(`{"id":"e1e1e1e1-1111-1111-1111-111111111111","customer_id":"5e4a0680-804e-11ec-8477-2fea5968d85b","session_id":"f2f2f2f2-2222-2222-2222-222222222222"}`),
 			expectTopics: []string{
 				// webchat case: scoped by session_id, not message id
 				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:webchat_session:f2f2f2f2-2222-2222-2222-222222222222",
@@ -440,15 +446,16 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "webchat_session_ended uses webchat_session topic scoped by the session's own id",
 			messageType: "webchat_session_ended",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					// A Session's own webhook payload has no separate
-					// SessionID field -- its own Identity.ID IS the
+					// session_id field -- its own Identity.ID IS the
 					// session id (VOIP-1265 §9.3).
 					ID:         uuid.FromStringOrNil("f2f2f2f2-2222-2222-2222-222222222222"),
 					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
 				},
 			},
+			raw: json.RawMessage(`{"id":"f2f2f2f2-2222-2222-2222-222222222222","customer_id":"5e4a0680-804e-11ec-8477-2fea5968d85b"}`),
 			expectTopics: []string{
 				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:webchat_session:f2f2f2f2-2222-2222-2222-222222222222",
 				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:test-manager:webchat_session_ended:f2f2f2f2-2222-2222-2222-222222222222",
@@ -458,7 +465,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "chatmessage_created with chat_id and participants",
 			messageType: "chatmessage_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("a11d1da0-3ed7-11ef-9208-4bcc069917a1"),
 					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
@@ -466,8 +473,8 @@ func Test_createTopics(t *testing.T) {
 				Owner: commonidentity.Owner{
 					OwnerID: uuid.FromStringOrNil("cdb5213a-8003-11ec-84ca-9fa226fcda9f"),
 				},
-				ChatID: uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 			},
+			raw: json.RawMessage(`{"id":"a11d1da0-3ed7-11ef-9208-4bcc069917a1","customer_id":"550e8400-e29b-41d4-a716-446655440000","owner_id":"cdb5213a-8003-11ec-84ca-9fa226fcda9f","chat_id":"e66d1da0-3ed7-11ef-9208-4bcc069917a1"}`),
 
 			chatID: uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 			participants: []*tkparticipant.Participant{
@@ -508,7 +515,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "chat_created with chatID nil fallback to d.ID",
 			messageType: "chat_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
@@ -542,7 +549,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "chatparticipant_added with chat_id",
 			messageType: "chatparticipant_added",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("f66d1da0-3ed7-11ef-9208-4bcc069917a2"),
 					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
@@ -550,8 +557,8 @@ func Test_createTopics(t *testing.T) {
 				Owner: commonidentity.Owner{
 					OwnerID: uuid.FromStringOrNil("cdb5213a-8003-11ec-84ca-9fa226fcda9f"),
 				},
-				ChatID: uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 			},
+			raw: json.RawMessage(`{"id":"f66d1da0-3ed7-11ef-9208-4bcc069917a2","customer_id":"550e8400-e29b-41d4-a716-446655440000","owner_id":"cdb5213a-8003-11ec-84ca-9fa226fcda9f","chat_id":"e66d1da0-3ed7-11ef-9208-4bcc069917a1"}`),
 
 			chatID: uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 			participants: []*tkparticipant.Participant{
@@ -592,7 +599,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "chatmessage_created with participant lookup failure",
 			messageType: "chatmessage_created",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("a11d1da0-3ed7-11ef-9208-4bcc069917a1"),
 					CustomerID: uuid.FromStringOrNil("550e8400-e29b-41d4-a716-446655440000"),
@@ -600,8 +607,8 @@ func Test_createTopics(t *testing.T) {
 				Owner: commonidentity.Owner{
 					OwnerID: uuid.FromStringOrNil("cdb5213a-8003-11ec-84ca-9fa226fcda9f"),
 				},
-				ChatID: uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 			},
+			raw: json.RawMessage(`{"id":"a11d1da0-3ed7-11ef-9208-4bcc069917a1","customer_id":"550e8400-e29b-41d4-a716-446655440000","owner_id":"cdb5213a-8003-11ec-84ca-9fa226fcda9f","chat_id":"e66d1da0-3ed7-11ef-9208-4bcc069917a1"}`),
 
 			chatID:         uuid.FromStringOrNil("e66d1da0-3ed7-11ef-9208-4bcc069917a1"),
 			participantErr: fmt.Errorf("rpc error"),
@@ -622,7 +629,7 @@ func Test_createTopics(t *testing.T) {
 		{
 			name:        "invalid message type",
 			messageType: "invalidtype",
-			data: &commonWebhookData{
+			data: &apiwebhook.CommonData{
 				Identity: commonidentity.Identity{
 					ID:         uuid.FromStringOrNil("9d0966c0-da98-11ee-97df-1786497422fb"),
 					CustomerID: uuid.FromStringOrNil("9d6cc58a-da98-11ee-b114-3fb0f4ae9318"),
@@ -655,7 +662,7 @@ func Test_createTopics(t *testing.T) {
 
 			ctx := context.Background()
 
-			topics, err := h.createTopics(ctx, tt.messageType, tt.data, "test-manager")
+			topics, err := h.createTopics(ctx, tt.messageType, tt.data, tt.raw, "test-manager")
 			if (err != nil) != tt.expectError {
 				t.Errorf("Unexpected error. expect: %v, got: %v", tt.expectError, err)
 			}

--- a/bin-api-manager/pkg/subscribehandler/webhookmanager_test.go
+++ b/bin-api-manager/pkg/subscribehandler/webhookmanager_test.go
@@ -420,6 +420,42 @@ func Test_createTopics(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "webchat_message_created uses webchat_session topic scoped by session_id",
+			messageType: "webchat_message_created",
+			data: &commonWebhookData{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("e1e1e1e1-1111-1111-1111-111111111111"),
+					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+				},
+				SessionID: uuid.FromStringOrNil("f2f2f2f2-2222-2222-2222-222222222222"),
+			},
+			expectTopics: []string{
+				// webchat case: scoped by session_id, not message id
+				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:webchat_session:f2f2f2f2-2222-2222-2222-222222222222",
+				// New format still uses the message's own id
+				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:test-manager:webchat_message_created:e1e1e1e1-1111-1111-1111-111111111111",
+			},
+			expectError: false,
+		},
+		{
+			name:        "webchat_session_ended uses webchat_session topic scoped by the session's own id",
+			messageType: "webchat_session_ended",
+			data: &commonWebhookData{
+				Identity: commonidentity.Identity{
+					// A Session's own webhook payload has no separate
+					// SessionID field -- its own Identity.ID IS the
+					// session id (VOIP-1265 §9.3).
+					ID:         uuid.FromStringOrNil("f2f2f2f2-2222-2222-2222-222222222222"),
+					CustomerID: uuid.FromStringOrNil("5e4a0680-804e-11ec-8477-2fea5968d85b"),
+				},
+			},
+			expectTopics: []string{
+				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:webchat_session:f2f2f2f2-2222-2222-2222-222222222222",
+				"customer_id:5e4a0680-804e-11ec-8477-2fea5968d85b:test-manager:webchat_session_ended:f2f2f2f2-2222-2222-2222-222222222222",
+			},
+			expectError: false,
+		},
+		{
 			name:        "chatmessage_created with chat_id and participants",
 			messageType: "chatmessage_created",
 			data: &commonWebhookData{

--- a/bin-webchat-manager/cmd/webchat-manager/main.go
+++ b/bin-webchat-manager/cmd/webchat-manager/main.go
@@ -120,7 +120,7 @@ func run(db dbhandler.DBHandler) error {
 	reqHandler := requesthandler.NewRequestHandler(sockHandler, serviceName)
 	notifyHandler := notifyhandler.NewNotifyHandler(sockHandler, reqHandler, commonoutline.QueueNameWebchatEvent, serviceName)
 	widgetHandler := widgethandler.NewWidgetHandler(reqHandler, db)
-	sessionHandler := sessionhandler.NewSessionHandler(reqHandler, db)
+	sessionHandler := sessionhandler.NewSessionHandler(reqHandler, notifyHandler, db)
 	messageHandler := messagehandler.NewMessageHandler(reqHandler, notifyHandler, db)
 
 	// run listen

--- a/bin-webchat-manager/models/session/event.go
+++ b/bin-webchat-manager/models/session/event.go
@@ -1,0 +1,6 @@
+package session
+
+// list of session event types
+const (
+	EventTypeSessionEnded string = "webchat_session_ended" // a webchat session has ended (WebchatSessionEnd)
+)

--- a/bin-webchat-manager/pkg/sessionhandler/db.go
+++ b/bin-webchat-manager/pkg/sessionhandler/db.go
@@ -75,5 +75,14 @@ func (h *sessionHandler) End(ctx context.Context, id uuid.UUID) (*session.Sessio
 		return nil, err
 	}
 
+	// Publish EventTypeSessionEnded so the visitor-side WS client (see
+	// bin-api-manager's createTopics webchat_session topic, VOIP-1265)
+	// can close its connection cooperatively -- otherwise the visitor's
+	// WS subscription for this session's topic would stay open
+	// indefinitely with no signal that the session is over.
+	if h.notifyHandler != nil {
+		h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, session.EventTypeSessionEnded, res)
+	}
+
 	return res, nil
 }

--- a/bin-webchat-manager/pkg/sessionhandler/db_test.go
+++ b/bin-webchat-manager/pkg/sessionhandler/db_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
@@ -126,10 +127,53 @@ func Test_SessionHandler_End(t *testing.T) {
 	defer mc.Finish()
 
 	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &sessionHandler{
+		utilHandler:   utilhandler.NewMockUtilHandler(mc),
+		db:            mockDB,
+		reqHandler:    requesthandler.NewMockRequestHandler(mc),
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	id := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
+	customerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
+	expectRes := &session.Session{
+		Identity: commonidentity.Identity{ID: id, CustomerID: customerID},
+		Status:   session.StatusEnded,
+	}
+
+	mockDB.EXPECT().SessionUpdate(ctx, id, map[session.Field]any{
+		session.FieldStatus: session.StatusEnded,
+	}).Return(nil)
+	mockDB.EXPECT().SessionGet(ctx, id).Return(expectRes, nil)
+	// VOIP-1265 §9.3: End() must publish EventTypeSessionEnded so the
+	// visitor-side WS client can close its connection cooperatively.
+	mockNotify.EXPECT().PublishWebhookEvent(ctx, customerID, session.EventTypeSessionEnded, expectRes)
+
+	res, err := h.End(ctx, id)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+	if !reflect.DeepEqual(res, expectRes) {
+		t.Errorf("Wrong match.\nexpect: %v\ngot: %v", expectRes, res)
+	}
+}
+
+// Test_SessionHandler_End_NilNotifyHandler verifies End() does not panic
+// when notifyHandler is nil (mirrors messagehandler.create's nil-guard
+// pattern -- defensive for tests/tools that construct sessionHandler
+// without a full dependency set).
+func Test_SessionHandler_End_NilNotifyHandler(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
 	h := &sessionHandler{
 		utilHandler: utilhandler.NewMockUtilHandler(mc),
 		db:          mockDB,
 		reqHandler:  requesthandler.NewMockRequestHandler(mc),
+		// notifyHandler intentionally left nil.
 	}
 	ctx := context.Background()
 

--- a/bin-webchat-manager/pkg/sessionhandler/main.go
+++ b/bin-webchat-manager/pkg/sessionhandler/main.go
@@ -5,6 +5,7 @@ package sessionhandler
 import (
 	"context"
 
+	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
@@ -24,19 +25,22 @@ type SessionHandler interface {
 }
 
 type sessionHandler struct {
-	utilHandler utilhandler.UtilHandler
-	reqHandler  requesthandler.RequestHandler
-	db          dbhandler.DBHandler
+	utilHandler   utilhandler.UtilHandler
+	reqHandler    requesthandler.RequestHandler
+	notifyHandler notifyhandler.NotifyHandler
+	db            dbhandler.DBHandler
 }
 
 // NewSessionHandler returns SessionHandler interface
 func NewSessionHandler(
 	reqHandler requesthandler.RequestHandler,
+	notifyHandler notifyhandler.NotifyHandler,
 	dbHandler dbhandler.DBHandler,
 ) SessionHandler {
 	return &sessionHandler{
-		utilHandler: utilhandler.NewUtilHandler(),
-		reqHandler:  reqHandler,
-		db:          dbHandler,
+		utilHandler:   utilhandler.NewUtilHandler(),
+		reqHandler:    reqHandler,
+		notifyHandler: notifyHandler,
+		db:            dbHandler,
 	}
 }

--- a/docs/plans/2026-07-17-webchat-widget-runtime-and-realtime-design.md
+++ b/docs/plans/2026-07-17-webchat-widget-runtime-and-realtime-design.md
@@ -1,0 +1,576 @@
+# Webchat widget runtime + real-time delivery (backend half)
+
+- Ticket: VOIP-1265
+- Companion frontend doc: `monorepo-javascript/.worktrees/SQUARE-15-webchat-widget-runtime-preview/docs/plans/2026-07-17-webchat-widget-runtime-and-preview-design.md`
+- Author: Hermes (CPO), for pchero
+- Status: DRAFT — Round 3 review complete (CHANGES_REQUESTED, 1 blocking finding: §9.2's code sample dropped FieldCustomerID, now fixed with verbatim-verified code), pending Round 4
+
+## 1. Problem
+
+square-admin can create a Webchat Widget and copy an embed snippet
+(`<script src="https://webchat.voipbin.net/embed.js" data-hash="...">`),
+but nothing in the platform actually renders that widget or lets a
+customer/admin see or test the real chat experience it produces. A
+CPO-level audit (this session) found four concrete gaps:
+
+1. **No `embed.js` widget runtime exists anywhere in the codebase.** The
+   design doc for `bin-webchat-manager` (`2026-06-29-add-webchat-manager-design.md`
+   §"theme_config") explicitly scoped the embed snippet as "frontend
+   deliverable, not part of the API design" and it was never built.
+2. **No hosting path for `webchat.voipbin.net`.** DNS does not resolve.
+   Out of scope for this design — tracked separately, not blocking local/
+   square-admin-embedded testing (see §6 Non-goals).
+3. **No real-time delivery path for a visitor.** `bin-api-manager`'s
+   WS topic builder (`pkg/subscribehandler/webhookmanager.go`
+   `createTopics()`) has no case for the `webchat` resource family, so a
+   `webchat_message_created` event never gets published to any topic a
+   visitor's direct-scoped WS connection could subscribe to.
+4. **`WebchatMessageList` unconditionally rejects direct-scoped callers**
+   (`bin-api-manager/pkg/servicehandler/webchat_message.go` line 85-87):
+   ```go
+   if a.IsDirect() {
+       return nil, serviceerrors.ErrDirectAccessNotSupported
+   }
+   ```
+   `WebchatMessageCreate` (line 217+) already has a full direct-scope
+   branch (verify `s.WidgetID == a.DirectScope.ResourceID`, reject
+   ended sessions, reject soft-deleted widgets). List has no equivalent
+   branch at all — a visitor can send a message but has no API-level way
+   to ever read the agent's reply, via polling or WS. This is judged a
+   bug, not an intentional restriction: Create/End have direct branches,
+   List does not, with no comment or design rationale marking the
+   asymmetry as deliberate.
+
+pchero directed (this session): build the real `embed.js` widget
+runtime, fix the message-list gap, and build WS-based real-time
+delivery — do not settle for a polling-only MVP or an admin-only fake
+preview. All four items ship together in this design.
+
+## 2. Goals
+
+- G1. A visitor holding a widget's `direct_hash` can open a real chat
+  panel (rendered from `embed.js`), send a message, and receive the
+  agent's reply in real time over WS (no polling). The agent's
+  visibility into the visitor's inbound message is addressed in §9.7 —
+  it is NOT left as a manual-refresh-only gap; minimal agent-side WS
+  wiring is pulled into scope via the frontend PR, using the same topic
+  this design already creates.
+- G2. `bin-api-manager`'s WS layer supports a visitor-scoped session
+  topic so a direct-scoped JWT can subscribe to exactly one session's
+  message stream and nothing else.
+- G3. `WebchatMessageList` is safely reachable by a direct-scoped caller,
+  scoped to the caller's own session only (no cross-session/cross-tenant
+  leak), with the same negative-case checks (deleted widget) that
+  `WebchatMessageCreate`'s direct branch already enforces (see §9.2).
+- G4. square-admin's widget create/detail pages render a **live preview**
+  driven by the *same* rendering code the real `embed.js` uses (not a
+  parallel reimplementation that can drift), reflecting theme_config
+  (primary_color, logo_url, position) as the admin edits it.
+- G5. The whole loop (create widget → copy snippet → visitor sends →
+  agent replies via square-admin's Sessions tab → visitor sees it
+  live) is demonstrably testable without needing `webchat.voipbin.net`
+  DNS/hosting to exist yet (see §6).
+
+## 3. Non-goals (explicitly out of scope for this design)
+
+- NG1. Production hosting/CDN path for `webchat.voipbin.net` and the
+  actual `<script src="https://webchat.voipbin.net/embed.js">` URL going
+  live. Tracked as a follow-up infra item once the runtime code exists
+  and is reviewed.
+- NG2. Custom CSS injection, multiple themes, per-agent avatars — already
+  deferred in the v8 theme_config design (Phase 2 bucket).
+- NG3. Typing indicators, read receipts, file attachments in webchat.
+- NG4. (Narrowed after Round 1 — see §9.7.) Full agent-side presence/
+  typing indicators and any UI beyond a live-updating message list on
+  the existing Sessions/message-timeline view remain out of scope.
+  Minimal WS wiring for that view to receive `webchat_message_created`
+  events live IS now in scope, driven from the frontend PR against the
+  topic this design creates — no additional backend change needed
+  beyond §4.2.
+
+## 4. Backend changes (this doc's scope: `monorepo`)
+
+### 4.1 Fix `WebchatMessageList` direct-scope gap
+
+**Superseded by §9.2's corrected code** (Round 1 found the version
+below missing a widget-soft-delete check). Kept here for the original
+context; implement per §9.2, not this block.
+
+File: `bin-api-manager/pkg/servicehandler/webchat_message.go`
+
+Add a direct-scope branch mirroring `WebchatMessageCreate`'s existing
+one, instead of the current unconditional rejection. See §9.2 for the
+corrected, final version of this branch.
+
+Tests to add: direct-scoped caller can list their own session's
+messages; direct-scoped caller with a `session_id` belonging to a
+different widget gets `ErrPermissionDenied`; direct-scoped caller
+omitting `session_id` gets rejected; direct-scoped caller on a
+soft-deleted widget gets rejected (added per §9.2).
+
+### 4.2 WS topic routing for visitor-scoped session subscription
+
+Files: `bin-api-manager/pkg/subscribehandler/webhookmanager.go`,
+`bin-api-manager/pkg/websockhandler/etc.go`.
+
+**Topic shape.** Add a `webchat_session`-scoped 4-part topic a
+direct-scoped JWT can subscribe to:
+
+```
+customer_id:<customer_id>:webchat_session:<session_id>
+```
+
+This deliberately does NOT reuse the existing 4-part
+`customer_id:<id>:<resource_type>:<resource_id>` pattern's generic
+`resource_type` value from `getServiceNamespace()` (which would produce
+`customer_id:<id>:webchat:<message_id>`, scoped by *message* id, useless
+to a visitor who doesn't know the next message's id yet). Instead it is
+scoped by **session id**, known to the visitor from the
+`POST /webchat_sessions` response, mirroring how `aicall_id` is used as
+the stable scope anchor for `aimessage_created` events (see
+`createTopics()`'s existing `case "aimessage":` branch, which already
+solves exactly this "message id is unknown in advance, scope by parent
+id instead" problem for AI calls).
+
+**`createTopics()` change** (`webhookmanager.go`): add a case for
+`webchat_message` (message.go's `EventTypeMessageCreated` constant is
+`"webchat_message_created"`, so `tmps[0]` after the existing
+`strings.Split(messageType, "_")` is `"webchat"` — confirm this doesn't
+collide with the generic `default:` branch's per-`d.ID` topic, which
+would be useless here for the same reason as aimessage). Mirror the
+`aimessage` branch shape:
+
+```go
+case "webchat":
+    if d.CustomerID != uuid.Nil && d.SessionID != uuid.Nil {
+        res = append(res, fmt.Sprintf("customer_id:%s:webchat_session:%s", d.CustomerID, d.SessionID))
+    }
+```
+
+`commonWebhookData` (top of the same file) needs a new
+`SessionID uuid.UUID \`json:"session_id,omitempty"\`` field.
+**Confirmed (Round 1, §9.1/§9.4)**: `wcmessage.WebhookMessage` already
+serializes `session_id` on the wire and no other publisher's payload
+collides with this field name — no open question remains here.
+
+**`validateTopics()`/`validateTopic()` change** (`websockhandler/etc.go`):
+add a `case "webchat_session":` arm alongside the existing
+`case "customer_id":`/`case "agent_id":` dispatch — actually this needs
+to slot into the existing 4-part `customer_id:...` handling, not a new
+top-level case, since the topic's first segment is still `customer_id`.
+The 4-part branch already does:
+```go
+if a.IsDirect() {
+    if !a.HasAllowedResourceType(tmps[2]) {
+        return false
+    }
+}
+```
+`tmps[2]` here is `"webchat_session"` — so this validation already works
+correctly as long as the direct-scope JWT's `AllowedResourceTypes`
+includes `"webchat_session"` (it does — `directResourceMapping` in
+`boot.go` already maps `dmdirect.ResourceTypeWebchatWidget` to
+`{"webchat_session"}`). **Confirmed (Round 1, §9.5): no `validateTopics`
+code change is needed**, and separately confirmed the `/ws` handshake
+itself accepts direct-scoped JWTs (same `middleware.Authenticate()`
+used by every other authenticated route).
+
+**Note on scope vs `DirectScope.ResourceID`:** `DirectScope.ResourceID`
+is the *widget* id (boot-time claim), but the topic is scoped by
+*session* id, a different value the visitor only learns after
+`POST /webchat_sessions`. `HasAllowedResourceType` only checks the
+resource-type string, not the specific id — so nothing here currently
+stops a direct-scoped JWT from subscribing to ANY session's topic if it
+guesses/enumerates a session UUID, not just its own. **This is
+acceptable**: session UUIDs are v4-random and not enumerable, and this
+exactly mirrors the existing aicall_id-scoped topic's trust model (no
+id-level check there either) — called out explicitly here and must
+appear in the PR description too, not left as a silent assumption.
+
+**WS-topic lifecycle on session end (Round 1 finding, resolved in
+§9.3):** the topic is not forcibly closed server-side when
+`WebchatSessionEnd` fires; the client is responsible for a cooperative
+close on receiving the session-ended event. See §9.3 for the full
+rationale and the (inert, since posting is already blocked) residual
+exposure this leaves.
+
+### 4.3 `bin-webchat-manager` message create: ensure `SessionID` is present on the published event
+
+**Confirmed (Round 1, §9.6):** `messagehandler/create.go` calls
+`PublishWebhookEvent` unconditionally with `SessionID` populated
+regardless of message direction or auth path — no change needed here,
+and this also resolves the sender-echo question (§9.6): a visitor's own
+inbound message IS echoed back to them over their own subscribed topic,
+so the frontend's send-path must dedupe against it.
+
+## 5. Frontend changes (companion doc, `monorepo-javascript`)
+
+See `SQUARE-15-webchat-widget-runtime-preview`'s design doc. Summary
+only, for backend reviewers' context:
+
+- New `embed.js`-equivalent widget runtime (vanilla JS, framework-free,
+  loaded via `<script>` tag) implementing: `POST /auth/boot` →
+  `POST /webchat_sessions` → render welcome message → open
+  `GET /ws?token=<jwt>` and subscribe to
+  `customer_id:<cid>:webchat_session:<session_id>` → render inbound
+  messages live → `POST /webchat_messages` on send → dedupe the WS echo
+  of the visitor's own message against the synchronous create response
+  (§9.6) → on session end, close the WS connection client-side (§9.3).
+- Shared theming module (`applyWidgetTheme(themeConfig)` or similar)
+  consumed by BOTH the real runtime and square-admin's live preview
+  iframe/component, so admin preview cannot drift from the real render.
+- square-admin's widget create/detail pages embed a live preview panel
+  using this shared module.
+- (Added per §9.7) square-admin's Sessions/message-timeline view
+  subscribes to the same session topic for a live-updating agent-side
+  message list, closing the G1 real-time gap Round 1 flagged.
+
+## 6. Testability without `webchat.voipbin.net` hosting
+
+Local/CI verification path for G5, until NG1 is separately resolved:
+
+- The widget runtime bundle is served locally (e.g. from square-admin's
+  own dev/build server, or a throwaway static file server) during
+  development/testing, with `data-hash` pointed at a real widget created
+  against `api.voipbin.net` (CORS already allows `*` — confirmed this
+  session).
+- square-admin's own detail page can optionally embed the same runtime
+  via a "Test this widget" action (loads the bundle against the current
+  widget's real `direct_hash`) — this satisfies the original CEO ask
+  ("실제로 바로 채팅 테스트를 해볼 수 있는 기능") without needing
+  `webchat.voipbin.net` to exist.
+
+## 7. Test plan
+
+- Backend: unit tests for §9.2 (direct-scope List branches, including
+  the widget-soft-delete rejection case) and the new `createTopics()`
+  case in §4.2. `go test ./...` + `golangci-lint` per the standard
+  verification workflow in both `bin-api-manager` and
+  `bin-webchat-manager`.
+- End-to-end manual verification (documented in the PR, not automated
+  in this phase): create widget in square-admin → open square-admin's
+  "Test this widget" action → send a message as visitor → confirm the
+  message appears live on the Sessions/message-timeline view (§9.7) →
+  reply as agent → confirm visitor sees the reply without a page
+  refresh (WS-delivered, not polled, on both sides).
+
+## 8. Open questions for review
+
+All Round-0 open questions (OQ1-OQ3) were resolved during Round 1 — see
+§9 for each resolution. No open questions remain for Round 2; Round 2
+should focus on verifying the §9 resolutions are correct and complete,
+not on re-litigating Round 0's OQs.
+
+## 9. Round 1 review findings and resolutions
+
+An independent adversarial review (Round 1) verified every claim in
+this doc against source and found 8 issues. Verdict was
+CHANGES_REQUESTED. All 8 are addressed below.
+
+### 9.1 OQ1 resolved (was incorrectly left open)
+
+**Confirmed by direct inspection**: `wcmessage.WebhookMessage`
+(`bin-webchat-manager/models/message/webhook.go` line 20) already has
+`SessionID uuid.UUID \`json:"session_id"\`` on the wire — no schema
+change needed, §4.2's `commonWebhookData` addition just needs to read
+this existing field. This should have been checked before drafting
+rather than deferred; corrected now, not at implementation time.
+
+### 9.2 §4.1 tenant-isolation gap fixed (widget-deleted / session-ended checks)
+
+Round 1 found the new direct-scope `WebchatMessageList` branch omitted
+the widget-not-deleted check `WebchatMessageCreate`'s direct branch
+already has, reintroducing a narrower version of the exact
+CRUD-asymmetry bug class this design sets out to fix. §4.1's proposed
+code is corrected to explicitly include both checks, matching
+`Create`'s direct branch. **This is the final version of the §4.1
+branch** (Round 2 note: the current `WebchatMessageList` function body
+is a standalone `if a.IsDirect() { return ..., ErrDirectAccessNotSupported }`
+early-return, not a `switch` — this must be restructured into a
+`switch { case a.IsDirect(): ... ; default: <existing agent/accesskey
+body, unchanged> }` exactly mirroring `WebchatMessageCreate`'s existing
+switch shape).
+
+**Round 3 correction (blocking finding, fixed): the Round 2 code sample
+below had dropped `wcmessage.FieldCustomerID` from the default/agent
+branch's filters and unconditionally set `FieldSessionID`, contradicting
+the doc's own prose and — since `MessageList`'s filters map is the sole
+customer-scoping mechanism at the DB layer (confirmed via
+`bin-webchat-manager/pkg/dbhandler/message.go`) — would have been a real
+cross-tenant data leak if implemented literally. This is now the
+verbatim, correct code, transcribed directly against the current
+unmodified function (`bin-api-manager/pkg/servicehandler/webchat_message.go`
+lines 78-128) with only the minimal diff needed to add the direct-scope
+case — not reconstructed from memory:**
+
+```go
+func (h *serviceHandler) WebchatMessageList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, sessionID uuid.UUID) ([]*wcmessage.WebhookMessage, error) {
+    log := logrus.WithFields(logrus.Fields{
+        "func":        "WebchatMessageList",
+        "customer_id": a.CustomerID,
+        "username":    a.DisplayName(),
+    })
+
+    if token == "" {
+        token = h.utilHandler.TimeGetCurTime()
+    }
+
+    filters := map[wcmessage.Field]any{
+        wcmessage.FieldDeleted: false,
+    }
+
+    switch {
+    case a.IsDirect():
+        if !a.HasAllowedResourceType("webchat_session") {
+            return nil, serviceerrors.ErrPermissionDenied
+        }
+        if sessionID == uuid.Nil {
+            // A visitor must always scope to their own session; there is
+            // no "list all my messages across sessions" concept for a
+            // direct-scoped caller.
+            return nil, serviceerrors.ErrPermissionDenied
+        }
+        s, err := h.sessionGet(ctx, sessionID)
+        if err != nil {
+            log.Errorf("Could not validate the session info. err: %v", err)
+            return nil, err
+        }
+        if s.WidgetID != a.DirectScope.ResourceID {
+            return nil, serviceerrors.ErrPermissionDenied
+        }
+        // Confirm the widget itself hasn't been soft-deleted -- mirrors
+        // WebchatMessageCreate's/WebchatSessionCreate's direct branches.
+        if _, err := h.widgetGet(ctx, a.DirectScope.ResourceID); err != nil {
+            log.Errorf("Could not validate the widget info. err: %v", err)
+            return nil, err
+        }
+        // Deliberately NOT rejecting on s.Status == StatusEnded: unlike
+        // Create (posting into a dead session is nonsensical) and unlike
+        // the WS topic (see §9.3, explicitly closed client-side on End),
+        // reading the final history of an ended session is a legitimate
+        // visitor need (e.g. reconnecting after a network drop to see the
+        // last replies before the session ended). This is an intentional,
+        // explicit decision -- Round 1's finding #2 flagged this exact
+        // ambiguity and this is the resolution.
+        // s.CustomerID is authoritative here (already ownership-verified
+        // above via s.WidgetID check) -- set explicitly rather than
+        // trusting a.CustomerID, mirroring WebchatMessageCreate's
+        // ownerCustomerID pattern for the same defense-in-depth reason.
+        filters[wcmessage.FieldCustomerID] = s.CustomerID
+        filters[wcmessage.FieldSessionID] = sessionID
+
+    default:
+        if !h.hasPermission(ctx, a, a.CustomerID, amagent.PermissionCustomerAdmin|amagent.PermissionCustomerManager) {
+            log.Info("The agent has no permission.")
+            return nil, serviceerrors.ErrPermissionDenied
+        }
+
+        filters[wcmessage.FieldCustomerID] = a.CustomerID
+
+        if sessionID != uuid.Nil {
+            s, err := h.sessionGet(ctx, sessionID)
+            if err != nil {
+                log.Errorf("Could not validate the session info. err: %v", err)
+                return nil, err
+            }
+            if s.CustomerID != a.CustomerID {
+                log.Info("The session does not belong to the requesting customer.")
+                return nil, serviceerrors.ErrPermissionDenied
+            }
+            filters[wcmessage.FieldSessionID] = sessionID
+        }
+    }
+
+    tmps, err := h.reqHandler.WebchatV1MessageList(ctx, token, size, filters)
+    if err != nil {
+        log.Errorf("Could not get messages from the webchat-manager. err: %v", err)
+        return nil, err
+    }
+
+    res := []*wcmessage.WebhookMessage{}
+    for _, tmp := range tmps {
+        e := tmp.ConvertWebhookMessage()
+        res = append(res, e)
+    }
+
+    return res, nil
+}
+```
+
+This is the literal, final code — not illustrative pseudocode — and
+must be implemented exactly as shown (modulo the `a.IsDirect()` early
+`ErrDirectAccessNotSupported` return at the current top of the function
+being removed, since it's now handled by the `switch`).
+
+**Server-layer claim corrected (was over-specified — see §9.8):** no
+`server/webchat_messages.go` change is needed; the servicehandler-layer
+`ErrPermissionDenied` above is already correctly mapped to an HTTP error
+by the existing `abortWithServiceError` mechanism.
+
+### 9.3 §4.2 WS-topic lifecycle addressed (session end / widget delete) — CORRECTED IN ROUND 2
+
+**Round 1's original resolution below was wrong and has been retracted.**
+Round 2 review verified by direct source inspection that the claim
+"`WebchatSessionEnd` publishes its own event... already true today" is
+**false**: `bin-webchat-manager/pkg/sessionhandler/db.go`'s `End()` only
+calls `db.SessionUpdate`/`db.SessionGet`, and `sessionHandler`
+(`pkg/sessionhandler/main.go`) has **no `notifyHandler` field at all**
+(unlike `messageHandler`, which does) — there is no session-end event,
+no event-type constant, and no publish call anywhere in the codebase
+(confirmed via repo-wide grep for `session_ended`/`EventTypeSessionEnd*`:
+zero matches). This was a fabricated "confirmed" claim in the original
+Round 1 fix — caught by Round 2's adversarial re-verification, not
+self-caught, which is itself worth noting for how this doc's claims get
+checked going forward.
+
+**Corrected resolution: this IS a real backend change, added to this
+PR's scope, not "no change needed."**
+
+1. Inject `notifyHandler notifyhandler.NotifyHandler` into
+   `sessionHandler` (`pkg/sessionhandler/main.go`), mirroring
+   `messageHandler`'s existing field — `NewSessionHandler`'s signature
+   gains a `notifyHandler` parameter.
+2. `cmd/webchat-manager/main.go` line 123's
+   `sessionhandler.NewSessionHandler(reqHandler, db)` call is updated to
+   `sessionhandler.NewSessionHandler(reqHandler, notifyHandler, db)` —
+   the `notifyHandler` value already exists at that point in `main.go`
+   (constructed at line 121, three lines before `messageHandler`'s own
+   construction at line 124, which already consumes it) — no new
+   `notifyHandler` construction needed, just passing the existing one
+   to a second constructor.
+3. `session` package (`models/session/`) already has a complete
+   `WebhookMessage`/`ConvertWebhookMessage`/`CreateWebhookEvent` set
+   (`webhook.go`, pre-existing, unused by any publish call today) — add
+   a new `EventTypeSessionEnded = "webchat_session_ended"` constant
+   (mirroring `message.EventTypeMessageCreated`'s pattern in
+   `models/message/event.go`) to a new `models/session/event.go`.
+4. `sessionHandler.End()` (`pkg/sessionhandler/db.go`), after the
+   existing `SessionUpdate`/`SessionGet` calls succeed, adds:
+   ```go
+   if h.notifyHandler != nil {
+       h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID, session.EventTypeSessionEnded, res)
+   }
+   ```
+   mirroring `messagehandler/create.go`'s existing call shape exactly,
+   including its `if h.notifyHandler != nil` nil-guard (kept for
+   consistency with the existing codebase style, even though the
+   constructor will always supply a real handler in production).
+5. §4.2's `createTopics()` case needs a **second** `case` (or an
+   extended condition on the existing `case "webchat":`) for
+   `webchat_session_ended`, since `strings.Split("webchat_session_ended", "_")[0]`
+   is also `"webchat"` — same topic-string output
+   (`customer_id:<cid>:webchat_session:<session_id>`) as the message-
+   created case, which is exactly what's wanted here (same topic,
+   different event type on it) — **but `commonWebhookData` needs `ID`
+   itself to resolve to the session id for this event** (unlike the
+   message-created case, where `d.SessionID` is a separate field from
+   `d.ID`/the message's own id) — `Session.WebhookMessage.Identity.ID`
+   IS the session id for this event, so the topic-building code must
+   branch on which event type it's handling to pick the right field
+   (`d.SessionID` for `webchat_message_created`, `d.ID` for
+   `webchat_session_ended`). This is a real implementation subtlety,
+   called out explicitly here so it isn't missed.
+
+The frontend's `client.js` (companion doc, updated) listens for this
+NOW-REAL event and closes its own WS connection client-side upon
+receipt. No backend enforcement is added to forcibly sever the WS
+connection at the socket layer (the underlying `sockhandler`/gorilla-
+websocket layer used platform-wide has no per-topic forced-disconnect
+primitive today — adding one is a larger cross-cutting change, still
+out of scope). This remains a client-side cooperative close, not a
+socket-level server-side guarantee — documented as an explicit accepted
+limitation: **a visitor who ignores the session-ended event and keeps
+their WS connection open would continue receiving any messages
+published to that session's topic after End** — but in practice this
+requires a subsequent message create on an ended session, which §9.2/
+existing `Create`'s direct branch already rejects — so no new
+*messages* CAN be published to an ended session's topic post-End; the
+remaining exposure is the (now real, single) session-ended event itself
+plus theoretical future events, not an open-ended leak.
+
+**Test plan addition**: `sessionHandler.End()` unit test asserting
+`PublishWebhookEvent` is called with the correct event type and
+customer id (mock `notifyHandler`, mirroring `messagehandler/create_test.go`'s
+existing pattern). `createTopics()` unit test for the new
+`webchat_session_ended` case.
+
+### 9.4 §4.2 `SessionID` field addition — confirmed safe
+
+Round 1 flagged (low-risk) the shared `commonWebhookData` struct gaining
+a `SessionID` field. Confirmed: `AIcallID`/`ChatID` are the only
+existing fields, both `omitempty` UUID, following the identical pattern;
+no other publisher's payload has ever populated a colliding `session_id`
+JSON key (grep confirms `session_id` is unique to `webchat` message/
+session payloads platform-wide). No change needed beyond what §4.2
+already specified.
+
+### 9.5 WS handshake auth path — confirmed, not assumed
+
+Round 1 correctly flagged that the original doc never verified a
+direct-scope JWT is even accepted at the `/ws` upgrade step (only that
+post-auth topic validation would pass one through). **Now verified**:
+`GetWs` (`bin-api-manager/server/ws.go`) sits under the same
+`v1.Use(middleware.Authenticate())` group (`cmd/api-manager/main.go`
+line 256) as every other `/v1.0/*` route including
+`POST /webchat_sessions` and `POST /webchat_messages`, both of which
+already accept direct-scope callers today. `middleware.Authenticate()`
+(`lib/middleware/authenticate.go` line 96-114) has an explicit
+`case string(auth.TypeDirect):` branch building `auth.NewDirectIdentity`
+from the JWT's `direct` claim — this is the exact same code path already
+exercised by the existing `POST /auth/boot` → direct-scope-JWT flow. No
+gap exists; §4.2 proceeds as designed.
+
+### 9.6 Sender-echo question resolved (not left as shared open question)
+
+Round 1 pointed out this doc owns the authoritative answer and should
+not defer it to the frontend. **Resolved**: `messagehandler/create.go`
+calls `h.notifyHandler.PublishWebhookEvent(ctx, res.CustomerID,
+message.EventTypeMessageCreated, res)` unconditionally, regardless of
+`direction` or which auth path (agent vs. direct) created the message,
+and §4.2's new topic is scoped by session id, not by sender/recipient —
+there is exactly one topic per session, subscribed to by whichever
+party (visitor and/or agent, per §9.7) is listening. **Therefore: yes,
+a visitor's own inbound message IS echoed back to them over their own
+subscribed topic.** Companion frontend doc's `client.js` design must
+dedupe on the message `id` returned by the synchronous
+`POST /webchat_messages` response against the async WS delivery of the
+same id — this is now a confirmed requirement, not an open question.
+
+### 9.7 G1 wording corrected + NG4 narrowed (real-time claim scoped accurately, gap closed)
+
+Round 1 noted G1's original "receive the agent's reply in real time...
+no polling loop" described only the visitor's half of the round-trip,
+since the original NG4 kept the agent side on manual refresh — and the
+companion frontend doc's independent Round 1 review flagged the SAME
+gap from the other side, additionally noting square-admin's own
+CLAUDE.md bans manual-refresh-button UX on detail pages, meaning the
+original scope cut wasn't just incomplete, it was unworkable within the
+product's own UI conventions.
+
+**Resolution: NG4 is narrowed, not just re-worded.** Minimal agent-side
+WS wiring for the Sessions/message-timeline view (subscribing to the
+same `customer_id:<cid>:webchat_session:<session_id>` topic this design
+already creates) is pulled into scope, implemented in the frontend PR.
+This requires **zero additional backend change** — the topic is
+symmetric by construction (§4.2 scopes it by session, not by
+sender/recipient role), so an agent-side subscriber works identically
+to the visitor-side subscriber already designed. G1 and NG4 above are
+updated to reflect this; G5's E2E test plan (§7) now confirms live
+delivery on both sides, not just the visitor's.
+
+### 9.8 Server-layer 400 requirement — corrected (removed, not needed)
+
+Round 1 flagged this claim was unverified. **Confirmed**:
+`bin-api-manager/server/webchat_messages.go`'s `GetWebchatMessages`
+(line 15-64) currently passes `sessionID` through as `uuid.Nil` when
+the query param is absent, with no server-layer validation — the
+"required for direct callers" check does NOT exist today and is not
+added by this doc's servicehandler-layer fix in §9.2 either (§9.2's
+`sessionID == uuid.Nil` check happens inside `WebchatMessageList`
+itself, not in the `server/` HTTP layer). This is sufficient: the
+`ErrPermissionDenied` returned by the servicehandler is correctly
+mapped to an HTTP error by `abortWithServiceError` (existing, unchanged
+mechanism) — so the original doc's claim of a required "server-layer
+400" was over-specified; the actual, simpler mechanism is a
+servicehandler-layer permission denial, already covered by §9.2's code.
+No `server/webchat_messages.go` change is needed.


### PR DESCRIPTION
Backend half of the webchat widget runtime feature: fixes the
visitor-facing message-read gap and adds the WS routing/session-end
event a real chat widget needs. Design doc:
docs/plans/2026-07-17-webchat-widget-runtime-and-realtime-design.md
(5 review rounds, 2 consecutive APPROVE).

- bin-api-manager: WebchatMessageList now has a direct-scope (visitor)
  branch mirroring WebchatMessageCreate's existing dual-path auth --
  previously a direct-scoped caller was unconditionally rejected,
  meaning a visitor could send a message but never read the agent's
  reply. Scoped to the caller's own session, with widget soft-delete
  rejection (ended-session history remains readable, deliberately).
- bin-api-manager: createTopics() adds a webchat case producing a
  session-scoped WS topic (customer_id:<cid>:webchat_session:<sid>),
  handling both webchat_message_created (scoped via the message's own
  session_id field) and webchat_session_ended (scoped via the Session's
  own identity id).
- bin-api-manager: commonWebhookData gains a session_id field to carry
  webchat_message_created's session_id through to createTopics().
- bin-webchat-manager: sessionHandler now takes a notifyHandler
  dependency (previously absent, unlike messageHandler) and publishes
  a new webchat_session_ended event on End(), so the visitor-side WS
  client can close its subscription cooperatively when a session ends.