### PR TITLE
VOIP-1267-webchat-session-flow-conversation-variables

### DIFF
--- a/bin-conversation-manager/cmd/conversation-control/main.go
+++ b/bin-conversation-manager/cmd/conversation-control/main.go
@@ -75,7 +75,7 @@ func initConversationHandlers(sqlDB *sql.DB, cache cachehandler.CacheHandler, re
 	whatsAppHandler := whatsapphandler.NewWhatsAppHandler(reqHandler)
 	accountHandler := accounthandler.NewAccountHandler(db, reqHandler, notifyHandler, lineHandler, whatsAppHandler)
 	smsHandler := smshandler.NewSMSHandler(reqHandler, accountHandler)
-	messageHandler := messagehandler.NewMessageHandler(db, notifyHandler, accountHandler, lineHandler, smsHandler, whatsAppHandler)
+	messageHandler := messagehandler.NewMessageHandler(db, notifyHandler, reqHandler, accountHandler, lineHandler, smsHandler, whatsAppHandler)
 	conversationHandler := conversationhandler.NewConversationHandler(db, notifyHandler, reqHandler, accountHandler, messageHandler, lineHandler, smsHandler, whatsAppHandler)
 
 	return conversationHandler, accountHandler, messageHandler, nil

--- a/bin-conversation-manager/cmd/conversation-manager/main.go
+++ b/bin-conversation-manager/cmd/conversation-manager/main.go
@@ -127,7 +127,7 @@ func run(sqlDB *sql.DB, cache cachehandler.CacheHandler, cfg *config.Config) err
 	accountHandler := accounthandler.NewAccountHandler(db, reqHandler, notifyHandler, lineHandler, whatsAppHandler)
 	smsHandler := smshandler.NewSMSHandler(reqHandler, accountHandler)
 
-	messageHandler := messagehandler.NewMessageHandler(db, notifyHandler, accountHandler, lineHandler, smsHandler, whatsAppHandler)
+	messageHandler := messagehandler.NewMessageHandler(db, notifyHandler, reqHandler, accountHandler, lineHandler, smsHandler, whatsAppHandler)
 	conversationHandler := conversationhandler.NewConversationHandler(db, notifyHandler, reqHandler, accountHandler, messageHandler, lineHandler, smsHandler, whatsAppHandler)
 
 	// run listen

--- a/bin-conversation-manager/pkg/conversationhandler/create_and_execute_flow.go
+++ b/bin-conversation-manager/pkg/conversationhandler/create_and_execute_flow.go
@@ -112,6 +112,17 @@ func (h *conversationHandler) CreateAndExecuteFlow(
 	}
 	log.WithField("activeflow_id", af.ID).Debug("Created activeflow.")
 
+	// Set voipbin.conversation.* flow variables before executing --
+	// unlike executeActiveflow (message.go), there is no Message yet
+	// at webchat session-start time, so only the conversation variables
+	// are set here. Best-effort: a variable-set failure must not fail
+	// the visitor-facing session-creation response, same framing as the
+	// activeflow create/execute failures below.
+	if errVariable := h.setVariablesConversation(ctx, af.ID, res); errVariable != nil {
+		log.Errorf("Could not set conversation variables. activeflow_id: %s, err: %v", af.ID, errVariable)
+		return res, nil
+	}
+
 	if errExecute := h.reqHandler.FlowV1ActiveflowExecute(ctx, af.ID); errExecute != nil {
 		log.Errorf("Could not execute activeflow. activeflow_id: %s, err: %v", af.ID, errExecute)
 		return res, nil

--- a/bin-conversation-manager/pkg/conversationhandler/create_and_execute_flow_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/create_and_execute_flow_test.go
@@ -74,6 +74,7 @@ func Test_CreateAndExecuteFlow_Normal(t *testing.T) {
 	).Return(&fmactiveflow.Activeflow{
 		Identity: commonidentity.Identity{ID: activeflowID},
 	}, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(nil)
 	mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
 
 	res, err := h.CreateAndExecuteFlow(ctx, customerID, flowID, conversation.TypeWebchat, "", self, peer)
@@ -176,6 +177,65 @@ func Test_CreateAndExecuteFlow_ActiveflowCreateFails(t *testing.T) {
 	mockReq.EXPECT().FlowV1ActiveflowCreate(
 		ctx, uuid.Nil, customerID, flowID, fmactiveflow.ReferenceTypeConversation, conversationID, uuid.Nil, nil, "", fmactiveflow.WebhookMethodNone,
 	).Return(nil, context.DeadlineExceeded)
+
+	res, err := h.CreateAndExecuteFlow(ctx, customerID, flowID, conversation.TypeWebchat, "", self, peer)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok (best-effort), got: %v", err)
+	}
+	if res.ID != conversationID {
+		t.Errorf("Wrong match. expect: %s, got: %s", conversationID, res.ID)
+	}
+}
+
+// Test_CreateAndExecuteFlow_SetVariablesFails verifies the Conversation
+// is still returned (best-effort) when setting the voipbin.conversation.*
+// flow variables fails, and that FlowV1ActiveflowExecute is never called
+// in that case (variables must be set before execution starts).
+func Test_CreateAndExecuteFlow_SetVariablesFails(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	h := &conversationHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("c1b2c3d4-0000-0000-0000-000000000001")
+	flowID := uuid.FromStringOrNil("2b5bc824-2066-11f0-81b0-672de53dec30")
+	conversationID := uuid.FromStringOrNil("44ebbd2e-82d8-11eb-8a4e-f7957fea9f50")
+	activeflowID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+
+	self := commonaddress.Address{Type: commonaddress.TypeWebchat, Target: "widget-id"}
+	peer := commonaddress.Address{Type: commonaddress.TypeWebchat, Target: "session-id"}
+
+	cv := &conversation.Conversation{
+		Identity: commonidentity.Identity{ID: conversationID, CustomerID: customerID},
+		Type:     conversation.TypeWebchat,
+		Self:     self,
+		Peer:     peer,
+	}
+
+	mockUtil.EXPECT().UUIDCreate().Return(conversationID)
+	mockDB.EXPECT().ConversationCreate(ctx, gomock.Any()).Return(nil)
+	mockDB.EXPECT().ConversationGet(ctx, conversationID).Return(cv, nil)
+	mockNotify.EXPECT().PublishWebhookEvent(ctx, customerID, conversation.EventTypeConversationCreated, cv)
+
+	mockReq.EXPECT().FlowV1ActiveflowCreate(
+		ctx, uuid.Nil, customerID, flowID, fmactiveflow.ReferenceTypeConversation, conversationID, uuid.Nil, nil, "", fmactiveflow.WebhookMethodNone,
+	).Return(&fmactiveflow.Activeflow{
+		Identity: commonidentity.Identity{ID: activeflowID},
+	}, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(context.DeadlineExceeded)
+	// FlowV1ActiveflowExecute must NOT be called -- its absence from the
+	// mock is enforced by gomock failing on any unexpected call.
 
 	res, err := h.CreateAndExecuteFlow(ctx, customerID, flowID, conversation.TypeWebchat, "", self, peer)
 	if err != nil {

--- a/bin-conversation-manager/pkg/conversationhandler/create_and_execute_flow_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/create_and_execute_flow_test.go
@@ -60,7 +60,24 @@ func Test_CreateAndExecuteFlow_Normal(t *testing.T) {
 	mockDB.EXPECT().ConversationGet(ctx, conversationID).Return(cv, nil)
 	mockNotify.EXPECT().PublishWebhookEvent(ctx, customerID, conversation.EventTypeConversationCreated, cv)
 
-	mockReq.EXPECT().FlowV1ActiveflowCreate(
+	expectVariables := map[string]string{
+		variableConversationSelfName:       cv.Self.Name,
+		variableConversationSelfDetail:     cv.Self.Detail,
+		variableConversationSelfTarget:     cv.Self.Target,
+		variableConversationSelfTargetName: cv.Self.TargetName,
+		variableConversationSelfType:       string(cv.Self.Type),
+
+		variableConversationPeerName:       cv.Peer.Name,
+		variableConversationPeerDetail:     cv.Peer.Detail,
+		variableConversationPeerTarget:     cv.Peer.Target,
+		variableConversationPeerTargetName: cv.Peer.TargetName,
+		variableConversationPeerType:       string(cv.Peer.Type),
+
+		variableConversationID:      cv.ID.String(),
+		variableConversationOwnerID: cv.OwnerID.String(),
+	}
+
+	callCreate := mockReq.EXPECT().FlowV1ActiveflowCreate(
 		ctx,
 		uuid.Nil,
 		customerID,
@@ -74,8 +91,9 @@ func Test_CreateAndExecuteFlow_Normal(t *testing.T) {
 	).Return(&fmactiveflow.Activeflow{
 		Identity: commonidentity.Identity{ID: activeflowID},
 	}, nil)
-	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(nil)
-	mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
+	callSetVariable := mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, expectVariables).Return(nil)
+	callExecute := mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
+	gomock.InOrder(callCreate, callSetVariable, callExecute)
 
 	res, err := h.CreateAndExecuteFlow(ctx, customerID, flowID, conversation.TypeWebchat, "", self, peer)
 	if err != nil {
@@ -228,12 +246,13 @@ func Test_CreateAndExecuteFlow_SetVariablesFails(t *testing.T) {
 	mockDB.EXPECT().ConversationGet(ctx, conversationID).Return(cv, nil)
 	mockNotify.EXPECT().PublishWebhookEvent(ctx, customerID, conversation.EventTypeConversationCreated, cv)
 
-	mockReq.EXPECT().FlowV1ActiveflowCreate(
+	callCreate := mockReq.EXPECT().FlowV1ActiveflowCreate(
 		ctx, uuid.Nil, customerID, flowID, fmactiveflow.ReferenceTypeConversation, conversationID, uuid.Nil, nil, "", fmactiveflow.WebhookMethodNone,
 	).Return(&fmactiveflow.Activeflow{
 		Identity: commonidentity.Identity{ID: activeflowID},
 	}, nil)
-	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(context.DeadlineExceeded)
+	callSetVariable := mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(context.DeadlineExceeded)
+	gomock.InOrder(callCreate, callSetVariable)
 	// FlowV1ActiveflowExecute must NOT be called -- its absence from the
 	// mock is enforced by gomock failing on any unexpected call.
 

--- a/bin-conversation-manager/pkg/conversationhandler/execute_mode_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/execute_mode_test.go
@@ -131,10 +131,10 @@ func Test_runExecuteModeFlowLine(t *testing.T) {
 					gomock.Any(), uuid.Nil, custID, flowID,
 					fmactiveflow.ReferenceTypeConversation, convID, uuid.Nil,
 					nil,
-				gomock.Any(),
-				gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
 				).Return(&fmactiveflow.Activeflow{Identity: commonidentity.Identity{ID: afID}}, nil)
-				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Return(nil)
+				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Times(2).Return(nil)
 				mockReq.EXPECT().FlowV1ActiveflowExecute(gomock.Any(), afID).Return(nil)
 			},
 			wantErr: false,
@@ -254,10 +254,10 @@ func Test_runExecuteModeFlowMessage(t *testing.T) {
 					gomock.Any(), uuid.Nil, custID, flowID,
 					fmactiveflow.ReferenceTypeConversation, convID, uuid.Nil,
 					nil,
-				gomock.Any(),
-				gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
 				).Return(&fmactiveflow.Activeflow{Identity: commonidentity.Identity{ID: afID}}, nil)
-				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Return(nil)
+				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Times(2).Return(nil)
 				mockReq.EXPECT().FlowV1ActiveflowExecute(gomock.Any(), afID).Return(nil)
 			},
 			wantErr: false,
@@ -377,10 +377,10 @@ func Test_runExecuteModeFlowWhatsApp(t *testing.T) {
 					gomock.Any(), uuid.Nil, custID, flowID,
 					fmactiveflow.ReferenceTypeConversation, convID, uuid.Nil,
 					nil,
-				gomock.Any(),
-				gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
 				).Return(&fmactiveflow.Activeflow{Identity: commonidentity.Identity{ID: afID}}, nil)
-				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Return(nil)
+				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Times(2).Return(nil)
 				mockReq.EXPECT().FlowV1ActiveflowExecute(gomock.Any(), afID).Return(nil)
 			},
 			wantErr: false,

--- a/bin-conversation-manager/pkg/conversationhandler/hook_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/hook_test.go
@@ -475,8 +475,8 @@ func Test_hookLine(t *testing.T) {
 					r.Message.ConversationID,
 					uuid.Nil,
 					nil,
-				gomock.Any(),
-				gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
 				).Return(nil, fmt.Errorf("activeflow create failed"))
 			} else if tt.expectActiveflowCalls > 0 {
 				for _, r := range flowResults {
@@ -490,10 +490,10 @@ func Test_hookLine(t *testing.T) {
 						r.Message.ConversationID,
 						uuid.Nil,
 						nil,
-					gomock.Any(),
-					gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
 					).Return(tt.responseActiveflow, nil)
-					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Return(nil)
+					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Times(2).Return(nil)
 					mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
 				}
 			}

--- a/bin-conversation-manager/pkg/conversationhandler/message_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/message_test.go
@@ -265,8 +265,8 @@ func Test_executeActiveflow(t *testing.T) {
 						tt.message.ConversationID,
 						uuid.Nil,
 						nil,
-					gomock.Any(),
-					gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
 					).Return(nil, fmt.Errorf("create failed"))
 
 				case "variable":
@@ -279,8 +279,8 @@ func Test_executeActiveflow(t *testing.T) {
 						tt.message.ConversationID,
 						uuid.Nil,
 						nil,
-					gomock.Any(),
-					gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
 					).Return(tt.responseActiveflow, nil)
 					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.responseActiveflow.ID, gomock.Any()).Return(fmt.Errorf("variable failed"))
 
@@ -294,10 +294,10 @@ func Test_executeActiveflow(t *testing.T) {
 						tt.message.ConversationID,
 						uuid.Nil,
 						nil,
-					gomock.Any(),
-					gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
 					).Return(tt.responseActiveflow, nil)
-					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.responseActiveflow.ID, gomock.Any()).Return(nil)
+					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.responseActiveflow.ID, gomock.Any()).Times(2).Return(nil)
 					mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, tt.responseActiveflow.ID).Return(fmt.Errorf("execute failed"))
 
 				default:
@@ -311,10 +311,10 @@ func Test_executeActiveflow(t *testing.T) {
 						tt.message.ConversationID,
 						uuid.Nil,
 						nil,
-					gomock.Any(),
-					gomock.Any(),
+						gomock.Any(),
+						gomock.Any(),
 					).Return(tt.responseActiveflow, nil)
-					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.responseActiveflow.ID, gomock.Any()).Return(nil)
+					mockReq.EXPECT().FlowV1VariableSetVariable(ctx, tt.responseActiveflow.ID, gomock.Any()).Times(2).Return(nil)
 					mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, tt.responseActiveflow.ID).Return(nil)
 				}
 			}

--- a/bin-conversation-manager/pkg/conversationhandler/variable.go
+++ b/bin-conversation-manager/pkg/conversationhandler/variable.go
@@ -9,8 +9,26 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-// setVariables sets the variables
+// setVariables sets both the conversation and message variables.
+// Kept for the message-triggered path (executeActiveflow) where both
+// a Conversation and a Message are always available.
 func (h *conversationHandler) setVariables(ctx context.Context, activeflowID uuid.UUID, cv *conversation.Conversation, m *message.Message) error {
+	if errSet := h.setVariablesConversation(ctx, activeflowID, cv); errSet != nil {
+		return errSet
+	}
+
+	if errSet := h.setVariablesMessage(ctx, activeflowID, m); errSet != nil {
+		return errSet
+	}
+
+	return nil
+}
+
+// setVariablesConversation sets the voipbin.conversation.* variables.
+// Usable on its own for flow-trigger paths that have a Conversation but
+// no Message yet (e.g. CreateAndExecuteFlow's webchat session-start
+// trigger, which runs before any Message exists).
+func (h *conversationHandler) setVariablesConversation(ctx context.Context, activeflowID uuid.UUID, cv *conversation.Conversation) error {
 
 	variables := map[string]string{
 
@@ -28,14 +46,26 @@ func (h *conversationHandler) setVariables(ctx context.Context, activeflowID uui
 
 		variableConversationID:      cv.ID.String(),
 		variableConversationOwnerID: cv.OwnerID.String(),
+	}
 
+	if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, activeflowID, variables); errSet != nil {
+		return fmt.Errorf("could not set the conversation variable. variables: %s, err: %v", variables, errSet)
+	}
+
+	return nil
+}
+
+// setVariablesMessage sets the voipbin.conversation_message.* variables.
+func (h *conversationHandler) setVariablesMessage(ctx context.Context, activeflowID uuid.UUID, m *message.Message) error {
+
+	variables := map[string]string{
 		variableConversationMessageID:        m.ID.String(),
 		variableConversationMessageText:      string(m.Text),
 		variableConversationMessageDirection: string(m.Direction),
 	}
 
 	if errSet := h.reqHandler.FlowV1VariableSetVariable(ctx, activeflowID, variables); errSet != nil {
-		return fmt.Errorf("could not set the variable. variables: %s, err: %v", variables, errSet)
+		return fmt.Errorf("could not set the message variable. variables: %s, err: %v", variables, errSet)
 	}
 
 	return nil

--- a/bin-conversation-manager/pkg/messagehandler/main.go
+++ b/bin-conversation-manager/pkg/messagehandler/main.go
@@ -7,6 +7,7 @@ import (
 
 	commonaddress "monorepo/bin-common-handler/models/address"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
@@ -91,6 +92,7 @@ type messageHandler struct {
 	utilHandler   utilhandler.UtilHandler
 	db            dbhandler.DBHandler
 	notifyHandler notifyhandler.NotifyHandler
+	reqHandler    requesthandler.RequestHandler
 
 	accountHandler  accounthandler.AccountHandler
 	lineHandler     linehandler.LineHandler
@@ -102,6 +104,7 @@ type messageHandler struct {
 func NewMessageHandler(
 	db dbhandler.DBHandler,
 	notifyHandler notifyhandler.NotifyHandler,
+	reqHandler requesthandler.RequestHandler,
 	accountHandler accounthandler.AccountHandler,
 	lineHandler linehandler.LineHandler,
 	smsHandler smshandler.SMSHandler,
@@ -111,6 +114,7 @@ func NewMessageHandler(
 		utilHandler:   utilhandler.NewUtilHandler(),
 		db:            db,
 		notifyHandler: notifyHandler,
+		reqHandler:    reqHandler,
 
 		accountHandler:  accountHandler,
 		lineHandler:     lineHandler,

--- a/bin-conversation-manager/pkg/messagehandler/send.go
+++ b/bin-conversation-manager/pkg/messagehandler/send.go
@@ -11,6 +11,8 @@ import (
 	"monorepo/bin-conversation-manager/models/conversation"
 	"monorepo/bin-conversation-manager/models/media"
 	"monorepo/bin-conversation-manager/models/message"
+
+	wcmessage "monorepo/bin-webchat-manager/models/message"
 )
 
 // Send sends the message to the given conversation
@@ -32,6 +34,9 @@ func (h *messageHandler) Send(ctx context.Context, cv *conversation.Conversation
 
 	case conversation.TypeWhatsApp:
 		return h.sendWhatsApp(ctx, cv, text)
+
+	case conversation.TypeWebchat:
+		return h.sendWebchat(ctx, cv, text)
 
 	default:
 		log.Errorf("Unsupported reference type. reference_type: %s", cv.Type)
@@ -129,6 +134,56 @@ func (h *messageHandler) sendWhatsApp(ctx context.Context, cv *conversation.Conv
 	}
 
 	log.Debugf("Sent WhatsApp message. wamid: %s", wamid)
+	return res, nil
+}
+
+// sendWebchat sends the message to the webchat type of conversation, via
+// bin-webchat-manager (the sole owner of the webchat Session/Message
+// thread). cv.Peer.Target holds the webchat Session ID (see
+// conversationhandler.eventWebchat's Self=Widget/Peer=Session convention).
+// The message is persisted immediately here (ID = webchat-manager's own
+// returned message ID) so the flow-manager caller gets a durable response
+// right away; the later webchat_message_created (outbound) subscribed
+// event -- handled by messageEventSentWebchat -- finds this same ID
+// already present and only updates its status, so no duplicate row is
+// created.
+func (h *messageHandler) sendWebchat(ctx context.Context, cv *conversation.Conversation, text string) (*message.Message, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":         "sendWebchat",
+		"conversation": cv,
+		"text":         text,
+	})
+
+	sessionID, err := uuid.FromString(cv.Peer.Target)
+	if err != nil {
+		log.Errorf("Could not parse the session id. err: %v", err)
+		return nil, errors.Wrapf(err, "could not parse the session id. target: %s", cv.Peer.Target)
+	}
+
+	wm, err := h.reqHandler.WebchatV1MessageCreate(ctx, cv.CustomerID, sessionID, wcmessage.DirectionOutbound, uuid.Nil, text)
+	if err != nil {
+		log.Errorf("Could not send the webchat message. err: %v", err)
+		return nil, err
+	}
+
+	source, destination := DeriveEndpoints(cv, message.DirectionOutgoing)
+	res, err := h.Create(ctx, MessageCreateArgs{
+		ID:             wm.ID,
+		CustomerID:     cv.CustomerID,
+		ConversationID: cv.ID,
+		Direction:      message.DirectionOutgoing,
+		Status:         message.StatusDone,
+		ReferenceType:  message.ReferenceTypeWebchat,
+		ReferenceID:    wm.ID,
+		Text:           text,
+		Source:         source,
+		Destination:    destination,
+	})
+	if err != nil {
+		log.Errorf("Could not create a message. err: %v", err)
+		return nil, err
+	}
+
 	return res, nil
 }
 

--- a/bin-conversation-manager/pkg/messagehandler/send.go
+++ b/bin-conversation-manager/pkg/messagehandler/send.go
@@ -3,6 +3,7 @@ package messagehandler
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
@@ -141,12 +142,19 @@ func (h *messageHandler) sendWhatsApp(ctx context.Context, cv *conversation.Conv
 // bin-webchat-manager (the sole owner of the webchat Session/Message
 // thread). cv.Peer.Target holds the webchat Session ID (see
 // conversationhandler.eventWebchat's Self=Widget/Peer=Session convention).
-// The message is persisted immediately here (ID = webchat-manager's own
+// The message is persisted locally here (ID = webchat-manager's own
 // returned message ID) so the flow-manager caller gets a durable response
-// right away; the later webchat_message_created (outbound) subscribed
-// event -- handled by messageEventSentWebchat -- finds this same ID
-// already present and only updates its status, so no duplicate row is
-// created.
+// right away.
+//
+// Idempotency note: bin-webchat-manager fires the corresponding
+// webchat_message_created (outbound) event asynchronously, which
+// conversation-manager's own subscribeHandler processes via
+// messageEventSentWebchat -- and that path can race this one and win,
+// persisting the same wm.ID first. Guard both directions of the race: if
+// the row is already there (event handler won), return it instead of
+// erroring on a duplicate-key insert; if h.db.MessageCreate itself hits a
+// duplicate-key error (race lost mid-call), fall back to a Get rather than
+// surfacing an error for a message that was, in fact, delivered.
 func (h *messageHandler) sendWebchat(ctx context.Context, cv *conversation.Conversation, text string) (*message.Message, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":         "sendWebchat",
@@ -166,6 +174,13 @@ func (h *messageHandler) sendWebchat(ctx context.Context, cv *conversation.Conve
 		return nil, err
 	}
 
+	// The subscribed webchat_message_created (outbound) event may have
+	// already persisted this same wm.ID via messageEventSentWebchat --
+	// check first so we don't attempt a doomed duplicate insert.
+	if existing, errGet := h.Get(ctx, wm.ID); errGet == nil {
+		return existing, nil
+	}
+
 	source, destination := DeriveEndpoints(cv, message.DirectionOutgoing)
 	res, err := h.Create(ctx, MessageCreateArgs{
 		ID:             wm.ID,
@@ -180,6 +195,15 @@ func (h *messageHandler) sendWebchat(ctx context.Context, cv *conversation.Conve
 		Destination:    destination,
 	})
 	if err != nil {
+		// The event handler may have won the race between our Get
+		// above and this Create -- if so, the failure is a
+		// duplicate-key insert for a message that was, in fact,
+		// delivered. Fall back to a re-Get instead of erroring out.
+		if strings.Contains(err.Error(), "Duplicate entry") || strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			if existing, errGet := h.Get(ctx, wm.ID); errGet == nil {
+				return existing, nil
+			}
+		}
 		log.Errorf("Could not create a message. err: %v", err)
 		return nil, err
 	}

--- a/bin-conversation-manager/pkg/messagehandler/send_test.go
+++ b/bin-conversation-manager/pkg/messagehandler/send_test.go
@@ -8,6 +8,7 @@ import (
 	commonaddress "monorepo/bin-common-handler/models/address"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
@@ -22,6 +23,8 @@ import (
 	"monorepo/bin-conversation-manager/pkg/linehandler"
 	"monorepo/bin-conversation-manager/pkg/smshandler"
 	"monorepo/bin-conversation-manager/pkg/whatsapphandler"
+
+	wcmessage "monorepo/bin-webchat-manager/models/message"
 )
 
 func Test_Send_sendLine(t *testing.T) {
@@ -124,6 +127,105 @@ func Test_Send_sendLine(t *testing.T) {
 			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.expectMessage.CustomerID, message.EventTypeMessageUpdated, tt.expectMessage)
 
 			res, err := h.Send(ctx, tt.conversation, tt.text, tt.medias)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectMessage) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectMessage, res)
+			}
+		})
+	}
+}
+
+func Test_Send_sendWebchat(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		conversation *conversation.Conversation
+		text         string
+
+		responseWebchatMessage *wcmessage.Message
+
+		expectSessionID uuid.UUID
+		expectMessage   *message.Message
+	}{
+		{
+			name: "webchat text type",
+
+			conversation: &conversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c1a9c2d0-1234-11f0-aaaa-aaaaaaaaaaaa"),
+					CustomerID: uuid.FromStringOrNil("c2b0c3d1-1234-11f0-bbbb-bbbbbbbbbbbb"),
+				},
+				Type: conversation.TypeWebchat,
+				Self: commonaddress.Address{
+					Type:   commonaddress.TypeWebchat,
+					Target: "widget-id",
+				},
+				Peer: commonaddress.Address{
+					Type:   commonaddress.TypeWebchat,
+					Target: "c3d1e4f2-1234-11f0-cccc-cccccccccccc",
+				},
+			},
+			text: "Hello, welcome to voipbin world!",
+
+			responseWebchatMessage: &wcmessage.Message{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("c4e2f5a3-1234-11f0-dddd-dddddddddddd"),
+				},
+			},
+
+			expectSessionID: uuid.FromStringOrNil("c3d1e4f2-1234-11f0-cccc-cccccccccccc"),
+			expectMessage: &message.Message{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("c4e2f5a3-1234-11f0-dddd-dddddddddddd"),
+					CustomerID: uuid.FromStringOrNil("c2b0c3d1-1234-11f0-bbbb-bbbbbbbbbbbb"),
+				},
+				ConversationID: uuid.FromStringOrNil("c1a9c2d0-1234-11f0-aaaa-aaaaaaaaaaaa"),
+				Direction:      message.DirectionOutgoing,
+				Status:         message.StatusDone,
+				ReferenceType:  message.ReferenceTypeWebchat,
+				ReferenceID:    uuid.FromStringOrNil("c4e2f5a3-1234-11f0-dddd-dddddddddddd"),
+				Text:           "Hello, welcome to voipbin world!",
+				// outbound: source = Self, destination = Peer.
+				Source: commonaddress.Address{
+					Type:   commonaddress.TypeWebchat,
+					Target: "widget-id",
+				},
+				Destination: commonaddress.Address{
+					Type:   commonaddress.TypeWebchat,
+					Target: "c3d1e4f2-1234-11f0-cccc-cccccccccccc",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &messageHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+			}
+			ctx := context.Background()
+
+			mockReq.EXPECT().WebchatV1MessageCreate(ctx, tt.conversation.CustomerID, tt.expectSessionID, wcmessage.DirectionOutbound, uuid.Nil, tt.text).Return(tt.responseWebchatMessage, nil)
+
+			mockDB.EXPECT().MessageCreate(ctx, tt.expectMessage).Return(nil)
+			mockDB.EXPECT().MessageGet(ctx, tt.expectMessage.ID).Return(tt.expectMessage, nil)
+			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.expectMessage.CustomerID, message.EventTypeMessageCreated, tt.expectMessage)
+
+			res, err := h.Send(ctx, tt.conversation, tt.text, nil)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
@@ -374,5 +476,37 @@ func Test_Send_sendWhatsApp(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectMessage, res)
 			}
 		})
+	}
+}
+
+func Test_Send_sendWebchat_InvalidSessionID(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	h := &messageHandler{}
+	ctx := context.Background()
+
+	cv := &conversation.Conversation{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("d1a9c2d0-1234-11f0-aaaa-aaaaaaaaaaaa"),
+			CustomerID: uuid.FromStringOrNil("d2b0c3d1-1234-11f0-bbbb-bbbbbbbbbbbb"),
+		},
+		Type: conversation.TypeWebchat,
+		Self: commonaddress.Address{
+			Type:   commonaddress.TypeWebchat,
+			Target: "widget-id",
+		},
+		Peer: commonaddress.Address{
+			Type:   commonaddress.TypeWebchat,
+			Target: "not-a-valid-uuid",
+		},
+	}
+
+	// WebchatV1MessageCreate must NOT be called -- the session id parse
+	// failure must short-circuit before any RPC is attempted. Absence
+	// enforced by a nil reqHandler: a call would panic on nil deref.
+	res, err := h.Send(ctx, cv, "hello", nil)
+	if err == nil {
+		t.Fatalf("Wrong match. expect: error, got: ok (res: %v)", res)
 	}
 }

--- a/bin-conversation-manager/pkg/messagehandler/send_test.go
+++ b/bin-conversation-manager/pkg/messagehandler/send_test.go
@@ -221,6 +221,10 @@ func Test_Send_sendWebchat(t *testing.T) {
 
 			mockReq.EXPECT().WebchatV1MessageCreate(ctx, tt.conversation.CustomerID, tt.expectSessionID, wcmessage.DirectionOutbound, uuid.Nil, tt.text).Return(tt.responseWebchatMessage, nil)
 
+			// sendWebchat's race-guard Get: no row yet (event handler
+			// hasn't won the race), proceed to Create below.
+			mockDB.EXPECT().MessageGet(ctx, tt.responseWebchatMessage.ID).Return(nil, dbhandler.ErrNotFound)
+
 			mockDB.EXPECT().MessageCreate(ctx, tt.expectMessage).Return(nil)
 			mockDB.EXPECT().MessageGet(ctx, tt.expectMessage.ID).Return(tt.expectMessage, nil)
 			mockNotify.EXPECT().PublishWebhookEvent(ctx, tt.expectMessage.CustomerID, message.EventTypeMessageCreated, tt.expectMessage)
@@ -508,5 +512,72 @@ func Test_Send_sendWebchat_InvalidSessionID(t *testing.T) {
 	res, err := h.Send(ctx, cv, "hello", nil)
 	if err == nil {
 		t.Fatalf("Wrong match. expect: error, got: ok (res: %v)", res)
+	}
+}
+
+// Test_Send_sendWebchat_RaceEventHandlerWon simulates the
+// messageEventSentWebchat subscribed-event path winning the race and
+// persisting the same wm.ID before sendWebchat's own Create runs.
+// sendWebchat's post-RPC Get must find that row and return it, rather
+// than attempting -- and failing -- a duplicate insert.
+func Test_Send_sendWebchat_RaceEventHandlerWon(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &messageHandler{
+		db:         mockDB,
+		reqHandler: mockReq,
+	}
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("e2b0c3d1-1234-11f0-bbbb-bbbbbbbbbbbb")
+	sessionID := uuid.FromStringOrNil("e3d1e4f2-1234-11f0-cccc-cccccccccccc")
+	messageID := uuid.FromStringOrNil("e4e2f5a3-1234-11f0-dddd-dddddddddddd")
+
+	cv := &conversation.Conversation{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("e1a9c2d0-1234-11f0-aaaa-aaaaaaaaaaaa"),
+			CustomerID: customerID,
+		},
+		Type: conversation.TypeWebchat,
+		Self: commonaddress.Address{
+			Type:   commonaddress.TypeWebchat,
+			Target: "widget-id",
+		},
+		Peer: commonaddress.Address{
+			Type:   commonaddress.TypeWebchat,
+			Target: sessionID.String(),
+		},
+	}
+
+	existing := &message.Message{
+		Identity: commonidentity.Identity{
+			ID:         messageID,
+			CustomerID: customerID,
+		},
+		ConversationID: cv.ID,
+		Direction:      message.DirectionOutgoing,
+		Status:         message.StatusDone,
+		ReferenceType:  message.ReferenceTypeWebchat,
+		ReferenceID:    messageID,
+		Text:           "hello",
+	}
+
+	mockReq.EXPECT().WebchatV1MessageCreate(ctx, customerID, sessionID, wcmessage.DirectionOutbound, uuid.Nil, "hello").Return(&wcmessage.Message{
+		Identity: commonidentity.Identity{ID: messageID},
+	}, nil)
+
+	// The event handler already won the race and persisted this row --
+	// sendWebchat's guard Get finds it and must NOT attempt Create.
+	mockDB.EXPECT().MessageGet(ctx, messageID).Return(existing, nil)
+
+	res, err := h.Send(ctx, cv, "hello", nil)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if !reflect.DeepEqual(res, existing) {
+		t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", existing, res)
 	}
 }


### PR DESCRIPTION
Fix bin-conversation-manager's webchat session-start flow trigger
(CreateAndExecuteFlow) so voipbin.conversation.* flow variables are
set before the activeflow executes, matching the message-triggered
path's behavior.

- bin-conversation-manager: Split setVariables into setVariablesConversation and setVariablesMessage so the conversation-only variables can be set without requiring a Message
- bin-conversation-manager: Call setVariablesConversation from CreateAndExecuteFlow before FlowV1ActiveflowExecute, best-effort framing matching the existing activeflow create/execute failure handling
- bin-conversation-manager: Update existing executeActiveflow/hookLine/runExecuteModeFlow* tests for the now-split FlowV1VariableSetVariable calls, add a new test covering the conversation-variable-set failure path