### PR TITLE
NOJIRA-Webchat-message-flow-owner-migration

### DIFF
--- a/bin-conversation-manager/pkg/conversationhandler/event_webchat.go
+++ b/bin-conversation-manager/pkg/conversationhandler/event_webchat.go
@@ -121,13 +121,15 @@ func (h *conversationHandler) messageEventReceivedWebchat(ctx context.Context, w
 	}
 	log.WithField("message", convMsg).Debugf("Create a message. message_id: %s", convMsg.ID)
 
-	// B안 (confirmed, design doc §16.5): webchat-manager alone owns the
-	// real-time Flow trigger on Widget.FlowID. This subscriber path must
-	// NEVER trigger a Flow of its own. getExecuteMode/runExecuteModeFlow
-	// already default-case no-op on an unrecognized/unconfigured
-	// Account for TypeWebchat (no Account is ever created for webchat --
-	// see GetOrCreateBySelfAndPeer's Account-less resolution above), so
-	// this is enforced structurally, not by an explicit skip here.
+	// MessageFlowID's Flow-trigger (design doc
+	// 2026-07-18-webchat-message-flow-owner-migration-design.md):
+	// this subscriber path NOW owns the Flow trigger for TypeWebchat
+	// conversations, via ExecuteModeFlow -> runExecuteModeFlowWebchat,
+	// exactly mirroring SMS/LINE/WhatsApp's own inbound path. This
+	// reverses the prior "B안" behavior (webchat-manager alone owned
+	// the trigger) -- webchat-manager no longer triggers any
+	// activeflow of its own; this event handler is now the SOLE
+	// trigger point for MessageFlowID.
 	mode := h.getExecuteMode(cv)
 	switch mode {
 	case ExecuteModeAgent:
@@ -135,12 +137,6 @@ func (h *conversationHandler) messageEventReceivedWebchat(ctx context.Context, w
 			return errors.Wrapf(errAgent, "could not run agent mode. message_id: %s", convMsg.ID)
 		}
 	case ExecuteModeFlow:
-		// Structurally unreachable for TypeWebchat conversations today
-		// (no Account, hence no Account.MessageFlowID, hence
-		// getExecuteMode never returns ExecuteModeFlow here) -- kept for
-		// interface completeness / future-proofing against
-		// getExecuteMode's own evolution, exactly mirroring eventSMS's
-		// switch shape.
 		if errFlow := h.runExecuteModeFlow(ctx, cv, convMsg); errFlow != nil {
 			return errors.Wrapf(errFlow, "could not run flow mode. message_id: %s", convMsg.ID)
 		}

--- a/bin-conversation-manager/pkg/conversationhandler/event_webchat_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/event_webchat_test.go
@@ -17,15 +17,127 @@ import (
 	"monorepo/bin-conversation-manager/models/message"
 	"monorepo/bin-conversation-manager/pkg/dbhandler"
 	"monorepo/bin-conversation-manager/pkg/messagehandler"
+	fmactiveflow "monorepo/bin-flow-manager/models/activeflow"
+	wcwidget "monorepo/bin-webchat-manager/models/widget"
 )
 
-// Test_EventWebchat_Inbound verifies an inbound webchat_message_created
-// event resolves/creates a Conversation with Self=Widget address,
-// Peer=Session address (both commonaddress.TypeWebchat, no Account
-// created anywhere in this path), creates the mirrored message with
-// ReferenceType=webchat, and does NOT trigger any Flow -- runExecuteModeFlow's
-// default case is a structural no-op for conversation.TypeWebchat.
-func Test_EventWebchat_Inbound(t *testing.T) {
+// Test_EventWebchat_Inbound_MessageFlowConfigured verifies an inbound
+// webchat_message_created event resolves/creates a Conversation with
+// Self=Widget address, Peer=Session address (both
+// commonaddress.TypeWebchat, no Account created anywhere in this
+// path), creates the mirrored message with ReferenceType=webchat, and
+// -- per the message-flow-owner-migration design -- DOES trigger a
+// Flow via runExecuteModeFlowWebchat when the Widget has
+// MessageFlowID configured, with ReferenceType=ReferenceTypeConversation
+// (not ReferenceTypeWebchat) and ReferenceID=cv.ID.
+func Test_EventWebchat_Inbound_MessageFlowConfigured(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+
+	h := &conversationHandler{
+		db:            mockDB,
+		notifyHandler: mockNotify,
+		reqHandler:    mockReq,
+
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	customerID := uuid.FromStringOrNil("c1b2c3d4-0000-0000-0000-000000000001")
+	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
+	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
+	msgID := uuid.FromStringOrNil("db596422-07f5-11f0-9afe-e7cd6b75aeac")
+	convID := uuid.FromStringOrNil("44ebbd2e-82d8-11eb-8a4e-f7957fea9f50")
+	messageFlowID := uuid.FromStringOrNil("2b5bc824-2066-11f0-81b0-672de53dec30")
+	activeflowID := uuid.FromStringOrNil("55555555-5555-5555-5555-555555555555")
+
+	wm := webchatMessage{
+		ID:         msgID,
+		CustomerID: customerID,
+		WidgetID:   widgetID,
+		SessionID:  sessionID,
+		Direction:  webchatDirectionInbound,
+		Text:       "hello there",
+	}
+	data, errMarshal := json.Marshal(wm)
+	if errMarshal != nil {
+		t.Fatalf("could not marshal test fixture: %v", errMarshal)
+	}
+
+	expectSelf := commonaddress.Address{Type: commonaddress.TypeWebchat, Target: widgetID.String()}
+	expectPeer := commonaddress.Address{Type: commonaddress.TypeWebchat, Target: sessionID.String()}
+
+	cv := &conversation.Conversation{
+		Identity: commonidentity.Identity{ID: convID, CustomerID: customerID},
+		Type:     conversation.TypeWebchat,
+		Self:     expectSelf,
+		Peer:     expectPeer,
+		// OwnerType/OwnerID zero-value -> getExecuteMode returns
+		// ExecuteModeFlow, which is the branch under test here.
+	}
+
+	convMsg := &message.Message{
+		Identity:       commonidentity.Identity{ID: msgID, CustomerID: customerID},
+		ConversationID: convID,
+		Direction:      message.DirectionIncoming,
+		ReferenceType:  message.ReferenceTypeWebchat,
+		Text:           "hello there",
+	}
+
+	mockDB.EXPECT().ConversationGetBySelfAndPeer(ctx, expectSelf, expectPeer).Return(cv, nil)
+	mockMessage.EXPECT().Create(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, args messagehandler.MessageCreateArgs) (*message.Message, error) {
+			if args.ReferenceType != message.ReferenceTypeWebchat {
+				t.Errorf("expected ReferenceType=webchat, got: %v", args.ReferenceType)
+			}
+			if args.Direction != message.DirectionIncoming {
+				t.Errorf("expected Direction=incoming, got: %v", args.Direction)
+			}
+			return convMsg, nil
+		},
+	)
+
+	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(&wcwidget.Widget{
+		Identity:      commonidentity.Identity{ID: widgetID, CustomerID: customerID},
+		MessageFlowID: messageFlowID,
+	}, nil)
+
+	// CRITICAL assertion for the message-flow-owner-migration design:
+	// ReferenceType=ReferenceTypeConversation (NOT ReferenceTypeWebchat),
+	// ReferenceID=cv.ID (NOT sessionID) -- this is the key behavioral
+	// change from the prior "B안" design.
+	mockReq.EXPECT().FlowV1ActiveflowCreate(
+		ctx,
+		uuid.Nil,
+		convMsg.CustomerID,
+		messageFlowID,
+		fmactiveflow.ReferenceTypeConversation,
+		convID,
+		uuid.Nil,
+		nil,
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&fmactiveflow.Activeflow{Identity: commonidentity.Identity{ID: activeflowID}}, nil)
+	mockReq.EXPECT().FlowV1VariableSetVariable(ctx, activeflowID, gomock.Any()).Times(2).Return(nil)
+	mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
+
+	if err := h.eventWebchat(ctx, data); err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+}
+
+// Test_EventWebchat_Inbound_NoMessageFlowConfigured verifies an inbound
+// webchat_message_created event on a Widget with NO MessageFlowID
+// configured resolves/creates the Conversation and Message as usual,
+// but triggers no Flow -- executeActiveflow's own no-op-on-uuid.Nil
+// behavior, reached via runExecuteModeFlowWebchat.
+func Test_EventWebchat_Inbound_NoMessageFlowConfigured(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
@@ -71,10 +183,6 @@ func Test_EventWebchat_Inbound(t *testing.T) {
 		Type:     conversation.TypeWebchat,
 		Self:     expectSelf,
 		Peer:     expectPeer,
-		// OwnerType/OwnerID zero-value -> getExecuteMode returns
-		// ExecuteModeFlow, which is the branch under test here (proves
-		// the flow-trigger path is a structural no-op, not merely
-		// "untested").
 	}
 
 	convMsg := &message.Message{
@@ -86,22 +194,15 @@ func Test_EventWebchat_Inbound(t *testing.T) {
 	}
 
 	mockDB.EXPECT().ConversationGetBySelfAndPeer(ctx, expectSelf, expectPeer).Return(cv, nil)
-	mockMessage.EXPECT().Create(ctx, gomock.Any()).DoAndReturn(
-		func(_ context.Context, args messagehandler.MessageCreateArgs) (*message.Message, error) {
-			if args.ReferenceType != message.ReferenceTypeWebchat {
-				t.Errorf("expected ReferenceType=webchat, got: %v", args.ReferenceType)
-			}
-			if args.Direction != message.DirectionIncoming {
-				t.Errorf("expected Direction=incoming, got: %v", args.Direction)
-			}
-			return convMsg, nil
-		},
-	)
+	mockMessage.EXPECT().Create(ctx, gomock.Any()).Return(convMsg, nil)
 
-	// CRITICAL assertion for B안 (design doc §16.5): no FlowV1ActiveflowCreate
-	// call is expected on the mockReq. If runExecuteModeFlow's default case
-	// ever stops being a no-op for TypeWebchat, gomock fails this test with
-	// "unexpected call" the moment that RPC fires.
+	mockReq.EXPECT().WebchatV1WidgetGet(ctx, widgetID).Return(&wcwidget.Widget{
+		Identity:      commonidentity.Identity{ID: widgetID, CustomerID: customerID},
+		MessageFlowID: uuid.Nil,
+	}, nil)
+
+	// No FlowV1ActiveflowCreate/Execute expected -- executeActiveflow
+	// no-ops when flowID == uuid.Nil.
 
 	if err := h.eventWebchat(ctx, data); err != nil {
 		t.Fatalf("Wrong match. expect: ok, got: %v", err)

--- a/bin-conversation-manager/pkg/conversationhandler/execute_mode.go
+++ b/bin-conversation-manager/pkg/conversationhandler/execute_mode.go
@@ -58,7 +58,7 @@ func (h *conversationHandler) runExecuteModeAgent(ctx context.Context, cv *conve
 }
 
 // runExecuteModeFlow dispatches by conversation type. Each per-type runner fetches the type-specific
-// flow source (account for LINE/WhatsApp, number for SMS) and calls executeActiveflow with the resolved flow id.
+// flow source (account for LINE/WhatsApp, number for SMS, widget for Webchat) and calls executeActiveflow with the resolved flow id.
 func (h *conversationHandler) runExecuteModeFlow(ctx context.Context, cv *conversation.Conversation, m *message.Message) error {
 	switch cv.Type {
 	case conversation.TypeLine:
@@ -67,6 +67,8 @@ func (h *conversationHandler) runExecuteModeFlow(ctx context.Context, cv *conver
 		return h.runExecuteModeFlowMessage(ctx, cv, m)
 	case conversation.TypeWhatsApp:
 		return h.runExecuteModeFlowWhatsApp(ctx, cv, m)
+	case conversation.TypeWebchat:
+		return h.runExecuteModeFlowWebchat(ctx, cv, m)
 	default:
 		logrus.WithFields(logrus.Fields{
 			"func":            "runExecuteModeFlow",
@@ -118,6 +120,31 @@ func (h *conversationHandler) runExecuteModeFlowWhatsApp(ctx context.Context, cv
 	}
 	if errExecute := h.executeActiveflow(ctx, cv, m, ac.MessageFlowID); errExecute != nil {
 		return errors.Wrapf(errExecute, "could not execute activeflow. account_id: %s", ac.ID)
+	}
+	return nil
+}
+
+// runExecuteModeFlowWebchat fetches the Widget by cv.Self.Target (the
+// Widget's own UUID, per messageEventReceivedWebchat's Self=Widget.ID
+// address construction) and triggers an activeflow using
+// Widget.MessageFlowID. Mirrors runExecuteModeFlowLine/WhatsApp's shape
+// exactly, except the flow source is a Widget (via WebchatV1WidgetGet)
+// rather than an Account -- webchat conversations never have an
+// AccountID. See design doc
+// 2026-07-18-webchat-message-flow-owner-migration-design.md §3: this
+// moves MessageFlowID's Flow-trigger ownership here from
+// bin-webchat-manager, matching every other channel.
+func (h *conversationHandler) runExecuteModeFlowWebchat(ctx context.Context, cv *conversation.Conversation, m *message.Message) error {
+	widgetID, errParse := uuid.FromString(cv.Self.Target)
+	if errParse != nil {
+		return errors.Wrapf(errParse, "invalid widget id in conversation self target: %s", cv.Self.Target)
+	}
+	w, errGet := h.reqHandler.WebchatV1WidgetGet(ctx, widgetID)
+	if errGet != nil {
+		return errors.Wrapf(errGet, "could not get widget. widget_id: %s", widgetID)
+	}
+	if errExecute := h.executeActiveflow(ctx, cv, m, w.MessageFlowID); errExecute != nil {
+		return errors.Wrapf(errExecute, "could not execute activeflow. widget_id: %s", w.ID)
 	}
 	return nil
 }

--- a/bin-conversation-manager/pkg/conversationhandler/execute_mode_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/execute_mode_test.go
@@ -18,6 +18,7 @@ import (
 	"monorepo/bin-conversation-manager/pkg/accounthandler"
 	fmactiveflow "monorepo/bin-flow-manager/models/activeflow"
 	nmnumber "monorepo/bin-number-manager/models/number"
+	wcwidget "monorepo/bin-webchat-manager/models/widget"
 )
 
 func Test_getExecuteMode(t *testing.T) {
@@ -450,6 +451,119 @@ func Test_runExecuteModeFlowWhatsApp(t *testing.T) {
 			tt.setup(mockAccount, mockReq)
 
 			err := h.runExecuteModeFlowWhatsApp(context.Background(), tt.cv, tt.m)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_runExecuteModeFlowWebchat(t *testing.T) {
+	widgetID := uuid.FromStringOrNil("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	flowID := uuid.FromStringOrNil("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	convID := uuid.FromStringOrNil("cccccccc-cccc-cccc-cccc-cccccccccccc")
+	custID := uuid.FromStringOrNil("dddddddd-dddd-dddd-dddd-dddddddddddd")
+	msgID := uuid.FromStringOrNil("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+	afID := uuid.FromStringOrNil("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+	tests := []struct {
+		name    string
+		cv      *conversation.Conversation
+		m       *message.Message
+		setup   func(mockReq *requesthandler.MockRequestHandler)
+		wantErr bool
+	}{
+		{
+			name: "valid webchat conversation with flow id -> executeActiveflow called",
+			cv: &conversation.Conversation{
+				Identity: commonidentity.Identity{ID: convID, CustomerID: custID},
+				Type:     conversation.TypeWebchat,
+				Self:     commonaddress.Address{Type: commonaddress.TypeWebchat, Target: widgetID.String()},
+			},
+			m: &message.Message{
+				Identity:       commonidentity.Identity{ID: msgID, CustomerID: custID},
+				ConversationID: convID,
+			},
+			setup: func(mockReq *requesthandler.MockRequestHandler) {
+				mockReq.EXPECT().WebchatV1WidgetGet(gomock.Any(), widgetID).Return(&wcwidget.Widget{
+					Identity:      commonidentity.Identity{ID: widgetID, CustomerID: custID},
+					MessageFlowID: flowID,
+				}, nil)
+				mockReq.EXPECT().FlowV1ActiveflowCreate(
+					gomock.Any(), uuid.Nil, custID, flowID,
+					fmactiveflow.ReferenceTypeConversation, convID, uuid.Nil,
+					nil,
+					gomock.Any(),
+					gomock.Any(),
+				).Return(&fmactiveflow.Activeflow{Identity: commonidentity.Identity{ID: afID}}, nil)
+				mockReq.EXPECT().FlowV1VariableSetVariable(gomock.Any(), afID, gomock.Any()).Times(2).Return(nil)
+				mockReq.EXPECT().FlowV1ActiveflowExecute(gomock.Any(), afID).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "webchat conversation, widget fetch fails -> error wrapped and returned",
+			cv: &conversation.Conversation{
+				Identity: commonidentity.Identity{ID: convID, CustomerID: custID},
+				Type:     conversation.TypeWebchat,
+				Self:     commonaddress.Address{Type: commonaddress.TypeWebchat, Target: widgetID.String()},
+			},
+			m: &message.Message{
+				Identity:       commonidentity.Identity{ID: msgID, CustomerID: custID},
+				ConversationID: convID,
+			},
+			setup: func(mockReq *requesthandler.MockRequestHandler) {
+				mockReq.EXPECT().WebchatV1WidgetGet(gomock.Any(), widgetID).Return(nil, errors.New("widget-manager down"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "webchat conversation, widget has no flow id -> no activeflow created, no error",
+			cv: &conversation.Conversation{
+				Identity: commonidentity.Identity{ID: convID, CustomerID: custID},
+				Type:     conversation.TypeWebchat,
+				Self:     commonaddress.Address{Type: commonaddress.TypeWebchat, Target: widgetID.String()},
+			},
+			m: &message.Message{
+				Identity:       commonidentity.Identity{ID: msgID, CustomerID: custID},
+				ConversationID: convID,
+			},
+			setup: func(mockReq *requesthandler.MockRequestHandler) {
+				mockReq.EXPECT().WebchatV1WidgetGet(gomock.Any(), widgetID).Return(&wcwidget.Widget{
+					Identity:      commonidentity.Identity{ID: widgetID, CustomerID: custID},
+					MessageFlowID: uuid.Nil,
+				}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "webchat conversation, malformed self target -> error, no RPC calls",
+			cv: &conversation.Conversation{
+				Identity: commonidentity.Identity{ID: convID, CustomerID: custID},
+				Type:     conversation.TypeWebchat,
+				Self:     commonaddress.Address{Type: commonaddress.TypeWebchat, Target: "not-a-uuid"},
+			},
+			m: &message.Message{
+				Identity:       commonidentity.Identity{ID: msgID, CustomerID: custID},
+				ConversationID: convID,
+			},
+			setup:   func(mockReq *requesthandler.MockRequestHandler) {},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &conversationHandler{
+				reqHandler: mockReq,
+			}
+			tt.setup(mockReq)
+
+			err := h.runExecuteModeFlowWebchat(context.Background(), tt.cv, tt.m)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/bin-flow-manager/models/activeflow/activeflow.go
+++ b/bin-flow-manager/models/activeflow/activeflow.go
@@ -85,7 +85,12 @@ const (
 	ReferenceTypeConversation ReferenceType = "conversation" // conversation
 	ReferenceTypeTranscribe   ReferenceType = "transcribe"   // transcribe
 	ReferenceTypeRecording    ReferenceType = "recording"    // recording
-	ReferenceTypeWebchat      ReferenceType = "webchat"      // webchat
+	// ReferenceTypeWebchat is no longer produced by any current code
+	// path (webchat's MessageFlowID trigger moved to
+	// bin-conversation-manager, using ReferenceTypeConversation instead
+	// -- see docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md).
+	// Retained for historical activeflow rows only.
+	ReferenceTypeWebchat ReferenceType = "webchat" // webchat
 )
 
 // Matches return true if the given items are the same

--- a/bin-webchat-manager/go.mod
+++ b/bin-webchat-manager/go.mod
@@ -79,7 +79,6 @@ require (
 	monorepo/bin-common-handler v0.0.0-20240408033155-50f0cd082334
 	monorepo/bin-conversation-manager v0.0.0-20231117134833-7918f76572d4
 	monorepo/bin-direct-manager v0.0.0-00010101000000-000000000000
-	monorepo/bin-flow-manager v0.0.0-20240403034140-ce82222fe7f4
 )
 
 require (
@@ -123,6 +122,7 @@ require (
 	monorepo/bin-contact-manager v0.0.0-00010101000000-000000000000 // indirect
 	monorepo/bin-customer-manager v0.0.0-20240408042746-c45b2b5aa984 // indirect
 	monorepo/bin-email-manager v0.0.0-00010101000000-000000000000 // indirect
+	monorepo/bin-flow-manager v0.0.0-20240403034140-ce82222fe7f4 // indirect
 	monorepo/bin-hook-manager v0.0.0-20240313052650-d3e4c79af4c0 // indirect
 	monorepo/bin-message-manager v0.0.0-20240328053936-9008e28c2268 // indirect
 	monorepo/bin-number-manager v0.0.0-20240328055052-ec1c723aa183 // indirect

--- a/bin-webchat-manager/pkg/messagehandler/create.go
+++ b/bin-webchat-manager/pkg/messagehandler/create.go
@@ -4,37 +4,25 @@ import (
 	"context"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
-	fmactiveflow "monorepo/bin-flow-manager/models/activeflow"
 
 	"github.com/gofrs/uuid"
 	"github.com/sirupsen/logrus"
 
 	"monorepo/bin-webchat-manager/models/message"
-	"monorepo/bin-webchat-manager/models/widget"
 )
 
-// Create creates a new message. If this is an INBOUND message AND the
-// owning Widget has a MessageFlowID configured, this also triggers a
-// brand-new, independent activeflow for THIS message -- unconditionally,
-// on every inbound message, with no "already triggered" gate and no
-// per-session lock. This mirrors bin-conversation-manager's existing
-// Account.MessageFlowID/Number.MessageFlowID pattern (SMS/LINE/WhatsApp)
-// exactly. See design doc
-// 2026-07-17-webchat-widget-session-message-flow-split-design.md §2.3, §5.
+// Create creates a new message. Flow-triggering for inbound messages
+// (MessageFlowID) is no longer this function's concern -- that is now
+// owned entirely by bin-conversation-manager's runExecuteModeFlowWebchat,
+// triggered asynchronously off the existing webchat_message_created
+// event this function already publishes (via h.create below). See
+// design doc 2026-07-18-webchat-message-flow-owner-migration-design.md.
 //
 // SessionFlowID's trigger (fires once per Session, at session-create
-// time) is NOT this function's concern -- that is owned by
+// time) is likewise not this function's concern -- that is owned by
 // bin-conversation-manager's CreateAndExecuteFlow, called from
-// bin-webchat-manager's sessionhandler.Create. See design doc §3.
-//
-// Accepted risk (design doc §4): with no per-session lock, rapid
-// consecutive inbound messages can each trigger their own concurrent
-// activeflow. This is the same shape of risk
-// bin-conversation-manager's SMS/LINE/WhatsApp executeActiveflow
-// already lives with (no per-conversation lock there either) --
-// applying an existing, already-accepted platform risk to a channel
-// with a higher realistic message frequency, not introducing a new
-// class of risk.
+// bin-webchat-manager's sessionhandler.Create. See design doc
+// 2026-07-17-webchat-widget-session-message-flow-split-design.md §3.
 func (h *messageHandler) Create(
 	ctx context.Context,
 	customerID uuid.UUID,
@@ -62,33 +50,6 @@ func (h *messageHandler) Create(
 		return nil, err
 	}
 
-	// Only inbound (visitor -> VoIPbin) messages can trigger
-	// MessageFlowID. Outbound (VoIPbin -> visitor, e.g. an agent reply
-	// or a Flow-delivered response) never does -- matches
-	// conversation-manager's MessageEventSent never calling
-	// runExecuteModeFlow.
-	if direction != message.DirectionInbound {
-		return res, nil
-	}
-
-	w, err := h.db.WidgetGet(ctx, sess.WidgetID)
-	if err != nil {
-		log.Errorf("Could not get widget. widget_id: %s, err: %v", sess.WidgetID, err)
-		// The message itself was already created successfully; a Flow-
-		// trigger failure must not fail the visitor-facing send.
-		return res, nil
-	}
-
-	if w.MessageFlowID == uuid.Nil {
-		log.Debugf("Widget has no message flow configured. Skipping activeflow. widget_id: %s", w.ID)
-		return res, nil
-	}
-
-	if errFlow := h.triggerMessageFlow(ctx, customerID, sessionID, w, res); errFlow != nil {
-		log.Errorf("Could not trigger the message activeflow. err: %v", errFlow)
-		// Best-effort: the message send itself already succeeded.
-	}
-
 	return res, nil
 }
 
@@ -97,7 +58,9 @@ func (h *messageHandler) Create(
 // Publishes EventTypeMessageCreated to both the webhook and event queue
 // on every successful create (design doc §16: conversation-manager
 // subscribes to this event to build its own independent
-// Conversation/Message records, message-manager pattern).
+// Conversation/Message records, message-manager pattern, AND -- as of
+// the message-flow-owner-migration design -- to trigger MessageFlowID's
+// activeflow for inbound messages).
 func (h *messageHandler) create(
 	ctx context.Context,
 	customerID uuid.UUID,
@@ -138,54 +101,4 @@ func (h *messageHandler) create(
 	}
 
 	return res, nil
-}
-
-// triggerMessageFlow creates and executes a brand-new activeflow for
-// THIS inbound message, unconditionally -- no "already triggered"
-// bookkeeping, no cross-message state. Mirrors
-// bin-conversation-manager's executeActiveflow for SMS/LINE/WhatsApp's
-// MessageFlowID exactly.
-func (h *messageHandler) triggerMessageFlow(
-	ctx context.Context,
-	customerID uuid.UUID,
-	sessionID uuid.UUID,
-	w *widget.Widget,
-	m *message.Message,
-) error {
-	log := logrus.WithFields(logrus.Fields{
-		"func":            "triggerMessageFlow",
-		"session_id":      sessionID,
-		"widget_id":       w.ID,
-		"message_flow_id": w.MessageFlowID,
-	})
-
-	variables := map[string]string{
-		"voipbin.webchat.session.id":        sessionID.String(),
-		"voipbin.webchat.session.widget_id": w.ID.String(),
-		"voipbin.webchat.message.text":      m.Text,
-	}
-
-	af, err := h.reqHandler.FlowV1ActiveflowCreate(
-		ctx,
-		uuid.Nil,
-		customerID,
-		w.MessageFlowID,
-		fmactiveflow.ReferenceTypeWebchat,
-		sessionID,
-		uuid.Nil,
-		variables,
-		"",
-		fmactiveflow.WebhookMethodNone,
-	)
-	if err != nil {
-		return err
-	}
-	log.WithField("activeflow_id", af.ID).Debug("Created activeflow.")
-
-	if err := h.reqHandler.FlowV1ActiveflowExecute(ctx, af.ID); err != nil {
-		return err
-	}
-	log.Debug("Executed activeflow.")
-
-	return nil
 }

--- a/bin-webchat-manager/pkg/messagehandler/create_test.go
+++ b/bin-webchat-manager/pkg/messagehandler/create_test.go
@@ -10,14 +10,11 @@ import (
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
-	fmactiveflow "monorepo/bin-flow-manager/models/activeflow"
-
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
 	"monorepo/bin-webchat-manager/models/message"
 	"monorepo/bin-webchat-manager/models/session"
-	"monorepo/bin-webchat-manager/models/widget"
 	"monorepo/bin-webchat-manager/pkg/dbhandler"
 )
 
@@ -38,151 +35,15 @@ func newTestMessageHandler(mc *gomock.Controller) (*messageHandler, *utilhandler
 	return h, mockUtil, mockReq, mockDB
 }
 
-// Test_Create_Inbound_MessageFlowConfigured_TriggersFlow verifies EVERY
-// inbound message on a Widget with MessageFlowID configured triggers
-// its own independent activeflow -- unconditionally, with no
-// "already triggered" gate.
-func Test_Create_Inbound_MessageFlowConfigured_TriggersFlow(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	h, mockUtil, mockReq, mockDB := newTestMessageHandler(mc)
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("c1b2c3d4-0000-0000-0000-000000000001")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	messageFlowID := uuid.FromStringOrNil("2b5bc824-2066-11f0-81b0-672de53dec30")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9afe-e7cd6b75aeac")
-	activeflowID := uuid.FromStringOrNil("44ebbd2e-82d8-11eb-8a4e-f7957fea9f50")
-
-	sess := &session.Session{
-		Identity: commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID: widgetID,
-		Status:   session.StatusActive,
-	}
-
-	w := &widget.Widget{
-		Identity:      commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-		MessageFlowID: messageFlowID,
-	}
-
-	msg := &message.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		SessionID: sessionID,
-		Direction: message.DirectionInbound,
-		Status:    message.StatusSent,
-		Text:      "hello",
-	}
-
-	mockDB.EXPECT().SessionGet(ctx, sessionID).Return(sess, nil)
-	mockUtil.EXPECT().UUIDCreate().Return(messageID)
-	mockDB.EXPECT().MessageCreate(ctx, gomock.Any()).Return(nil)
-	mockDB.EXPECT().MessageGet(ctx, messageID).Return(msg, nil)
-	mockDB.EXPECT().WidgetGet(ctx, widgetID).Return(w, nil)
-
-	mockReq.EXPECT().FlowV1ActiveflowCreate(
-		ctx,
-		uuid.Nil,
-		customerID,
-		messageFlowID,
-		fmactiveflow.ReferenceTypeWebchat,
-		sessionID,
-		uuid.Nil,
-		gomock.Any(),
-		"",
-		fmactiveflow.WebhookMethodNone,
-	).Return(&fmactiveflow.Activeflow{
-		Identity: commonidentity.Identity{ID: activeflowID},
-	}, nil)
-
-	mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
-
-	res, err := h.Create(ctx, customerID, sessionID, message.DirectionInbound, uuid.Nil, "hello")
-	if err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-	if !reflect.DeepEqual(res, msg) {
-		t.Errorf("Wrong match.\nexpect: %v\ngot: %v", msg, res)
-	}
-}
-
-// Test_Create_Inbound_MessageFlowConfigured_TriggersFlowEveryTime
-// verifies a SECOND inbound message on the same Session ALSO triggers
-// its own independent activeflow -- MessageFlowID never gates on prior
-// messages, unlike the old FlowID-on-first-message behavior.
-func Test_Create_Inbound_MessageFlowConfigured_TriggersFlowEveryTime(t *testing.T) {
-	mc := gomock.NewController(t)
-	defer mc.Finish()
-
-	h, mockUtil, mockReq, mockDB := newTestMessageHandler(mc)
-	ctx := context.Background()
-
-	customerID := uuid.FromStringOrNil("c1b2c3d4-0000-0000-0000-000000000001")
-	sessionID := uuid.FromStringOrNil("876defde-ad5e-11ed-a8c3-7bc19647b03f")
-	widgetID := uuid.FromStringOrNil("aa847807-6cc4-4713-9dec-53a42840e74c")
-	messageFlowID := uuid.FromStringOrNil("2b5bc824-2066-11f0-81b0-672de53dec30")
-	messageID := uuid.FromStringOrNil("db596422-07f5-11f0-9afe-e7cd6b75aeac")
-	activeflowID := uuid.FromStringOrNil("44ebbd2e-82d8-11eb-8a4e-f7957fea9f50")
-
-	// ActiveflowID is already set on the Session (from a prior
-	// SessionFlowID trigger at session-create time, or a prior
-	// MessageFlowID trigger) -- this must NOT gate MessageFlowID at all.
-	sess := &session.Session{
-		Identity:     commonidentity.Identity{ID: sessionID, CustomerID: customerID},
-		WidgetID:     widgetID,
-		Status:       session.StatusActive,
-		ActiveflowID: uuid.FromStringOrNil("11111111-0000-0000-0000-000000000001"),
-	}
-
-	w := &widget.Widget{
-		Identity:      commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-		MessageFlowID: messageFlowID,
-	}
-
-	msg := &message.Message{
-		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
-		SessionID: sessionID,
-		Direction: message.DirectionInbound,
-		Status:    message.StatusSent,
-		Text:      "follow-up",
-	}
-
-	mockDB.EXPECT().SessionGet(ctx, sessionID).Return(sess, nil)
-	mockUtil.EXPECT().UUIDCreate().Return(messageID)
-	mockDB.EXPECT().MessageCreate(ctx, gomock.Any()).Return(nil)
-	mockDB.EXPECT().MessageGet(ctx, messageID).Return(msg, nil)
-	mockDB.EXPECT().WidgetGet(ctx, widgetID).Return(w, nil)
-
-	mockReq.EXPECT().FlowV1ActiveflowCreate(
-		ctx,
-		uuid.Nil,
-		customerID,
-		messageFlowID,
-		fmactiveflow.ReferenceTypeWebchat,
-		sessionID,
-		uuid.Nil,
-		gomock.Any(),
-		"",
-		fmactiveflow.WebhookMethodNone,
-	).Return(&fmactiveflow.Activeflow{
-		Identity: commonidentity.Identity{ID: activeflowID},
-	}, nil)
-
-	mockReq.EXPECT().FlowV1ActiveflowExecute(ctx, activeflowID).Return(nil)
-
-	res, err := h.Create(ctx, customerID, sessionID, message.DirectionInbound, uuid.Nil, "follow-up")
-	if err != nil {
-		t.Fatalf("Wrong match. expect: ok, got: %v", err)
-	}
-	if !reflect.DeepEqual(res, msg) {
-		t.Errorf("Wrong match.\nexpect: %v\ngot: %v", msg, res)
-	}
-}
-
-// Test_Create_Inbound_NoMessageFlowConfigured verifies a Widget with no
-// MessageFlowID never triggers an activeflow.
-func Test_Create_Inbound_NoMessageFlowConfigured(t *testing.T) {
+// Test_Create_Inbound_NeverFetchesWidgetOrTriggersFlow verifies an
+// inbound message never fetches the Widget and never calls any
+// FlowV1* RPC -- MessageFlowID's Flow-trigger is no longer this
+// package's concern (moved to bin-conversation-manager's
+// runExecuteModeFlowWebchat, triggered async off the
+// webchat_message_created event this Create already publishes). Any
+// unexpected WidgetGet/FlowV1* call on mockDB/mockReq fails this test
+// via gomock.
+func Test_Create_Inbound_NeverFetchesWidgetOrTriggersFlow(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
@@ -200,11 +61,6 @@ func Test_Create_Inbound_NoMessageFlowConfigured(t *testing.T) {
 		Status:   session.StatusActive,
 	}
 
-	w := &widget.Widget{
-		Identity:      commonidentity.Identity{ID: widgetID, CustomerID: customerID},
-		MessageFlowID: uuid.Nil, // no message flow configured
-	}
-
 	msg := &message.Message{
 		Identity:  commonidentity.Identity{ID: messageID, CustomerID: customerID},
 		SessionID: sessionID,
@@ -217,10 +73,10 @@ func Test_Create_Inbound_NoMessageFlowConfigured(t *testing.T) {
 	mockUtil.EXPECT().UUIDCreate().Return(messageID)
 	mockDB.EXPECT().MessageCreate(ctx, gomock.Any()).Return(nil)
 	mockDB.EXPECT().MessageGet(ctx, messageID).Return(msg, nil)
-	mockDB.EXPECT().WidgetGet(ctx, widgetID).Return(w, nil)
 
-	// No FlowV1ActiveflowCreate/Execute expected -- their absence from
-	// the mock is enforced by gomock failing on any unexpected call.
+	// No WidgetGet, no FlowV1ActiveflowCreate/Execute expected -- their
+	// absence from the mock is enforced by gomock failing on any
+	// unexpected call.
 
 	res, err := h.Create(ctx, customerID, sessionID, message.DirectionInbound, uuid.Nil, "hello")
 	if err != nil {
@@ -231,11 +87,10 @@ func Test_Create_Inbound_NoMessageFlowConfigured(t *testing.T) {
 	}
 }
 
-// Test_Create_Outbound_NeverTriggersFlow verifies an outbound message
-// (agent reply or Flow-delivered response) never checks/triggers
-// MessageFlowID -- matches conversation-manager's MessageEventSent
-// never calling runExecuteModeFlow.
-func Test_Create_Outbound_NeverTriggersFlow(t *testing.T) {
+// Test_Create_Outbound_NeverFetchesWidgetOrTriggersFlow verifies an
+// outbound message (agent reply or Flow-delivered response) likewise
+// never fetches the Widget or triggers a Flow.
+func Test_Create_Outbound_NeverFetchesWidgetOrTriggersFlow(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 

--- a/docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md
+++ b/docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md
@@ -227,11 +227,10 @@ activeflow rows only`.
 
 `bin-webchat-manager` and `bin-conversation-manager` are two
 independently deployed services (separate k8s rolling deploys). This
-design is NOT a single atomic commit across both — it is two
-service-level diffs (§4) landing as separate PRs/deploys. Because of
-this, the deploy ORDER between the two creates two distinct
-transitional-window risks that must be handled explicitly, not left
-implicit:
+design is NOT a single atomic commit across both in effect — deploying
+one service's change does not deploy the other's. Because of this, the
+deploy ORDER between the two creates two distinct transitional-window
+risks that must be handled explicitly, not left implicit:
 
 1. **conversation-manager's new trigger deploys BEFORE
    webchat-manager's old trigger is removed** → during the window where
@@ -245,19 +244,38 @@ implicit:
    gap — no error, just a missing Flow execution for any customer with
    `MessageFlowID` configured).
 
-**Resolution: land and deploy conversation-manager's `execute_mode.go`
-change FIRST, verify it in production, THEN land and deploy the
-webchat-manager `triggerMessageFlow` removal as a separate, later PR.**
+**Resolution: land BOTH service-level diffs (§4) in a single PR/commit
+(simpler review, simpler squash-merge history), but deploy them
+sequentially using this repo's existing CI/CD sequencing mechanism —
+`bin-conversation-manager`'s change deploys FIRST, is verified in
+production, THEN `bin-webchat-manager`'s trigger removal deploys
+second.** This is enforced via `.circleci/config.yml`'s
+`path-filtering` orb (triggers one independent pipeline per changed
+`bin-*-manager/` directory) combined with each service pipeline's own
+manual `build-approval` gate (`type: approval`, gating
+`<service>-test`/`-build`/`-release` in `config_work.yml`) — merging
+this single PR triggers BOTH the `bin-conversation-manager` and
+`bin-webchat-manager` pipelines, but neither proceeds past its
+`build-approval` step without an explicit manual click. The rollout
+operator approves `bin-conversation-manager`'s gate first, verifies in
+production (the REDUCED criterion below), THEN approves
+`bin-webchat-manager`'s gate. No code-level PR split is needed — the
+existing per-service approval gate already provides the sequencing
+control this design requires. (An earlier draft of this design
+required splitting this migration into two separate PRs; that
+requirement is superseded by this section once the CI/CD mechanism
+above was verified to already provide equivalent sequencing control
+without a PR split.)
+
 This accepts window (1) — a bounded period of double-triggering — over
 window (2) — a silent gap — because a double bot-reply/duplicate Case
 is visibly wrong and immediately noticeable (customer complaint, log
 volume spike), whereas a silent no-trigger gap can go unnoticed for an
 arbitrary period. Concretely:
 
-- PR/deploy 1 (`bin-conversation-manager`): add
-  `runExecuteModeFlowWebchat`, wire the switch case, update the stale
-  §16.5 comment (§4). Deploy. **Verification at this stage is NOT the
-  full §5 smoke test** — §5's "exactly ONE activeflow, not two" success
+- Approval 1 (`bin-conversation-manager`'s `build-approval` gate):
+  approve first. Deploy. **Verification at this stage is NOT the full
+  §5 smoke test** — §5's "exactly ONE activeflow, not two" success
   criterion only holds once BOTH deploys have landed. At this
   intermediate stage, the correct (and only) check is a REDUCED
   criterion: confirm that a fresh inbound webchat message with
@@ -276,12 +294,12 @@ arbitrary period. Concretely:
   guidance below; that guidance is aimed at customer-facing widget
   configuration during the window, not at this design's own required
   verification step.
-- PR/deploy 2 (`bin-webchat-manager`): remove `triggerMessageFlow` and
-  its callers (§4). Deploy. Double-triggering ends; only the
-  `conversation`-typed activeflow is produced from this point forward.
-  **§5's full smoke test ("exactly ONE activeflow, not two") is the
-  correct and only point to run it — it is deploy-2's acceptance
-  criterion, not deploy-1's.**
+- Approval 2 (`bin-webchat-manager`'s `build-approval` gate): approve
+  only after Approval 1's verification has passed. Deploy.
+  Double-triggering ends; only the `conversation`-typed activeflow is
+  produced from this point forward. **§5's full smoke test ("exactly
+  ONE activeflow, not two") is the correct and only point to run it —
+  it is Approval-2's acceptance criterion, not Approval-1's.**
 - Between the two deploys, avoid configuring NEW customer-facing
   widgets with `MessageFlowID` if practical (existing widgets with it
   already set will double-trigger for the duration of the window
@@ -293,13 +311,13 @@ arbitrary period. Concretely:
   complexity for this migration, on the following honestly-stated
   basis (correcting an earlier draft of this section that understated
   the window): the double-trigger window is NOT bounded merely by
-  ordinary single-PR merge-to-deploy latency — it spans deploy 1's
+  ordinary single-PR merge-to-deploy latency — it spans Approval 1's
   rollout, an UNBOUNDED production-verification step this design itself
-  requires before starting deploy 2's PR, and deploy 2's own
-  merge-to-deploy latency. This window could plausibly span hours to a
-  few days if verification is not prioritized promptly, not merely
-  minutes. The rejection of a feature flag stands anyway, because blast
-  radius (not window duration) is the controlling factor here: query
+  requires before clicking Approval 2's gate, and Approval 2's own
+  rollout. This window could plausibly span hours to a few days if
+  verification is not prioritized promptly, not merely minutes. The
+  rejection of a feature flag stands anyway, because blast radius (not
+  window duration) is the controlling factor here: query
   `bin-webchat-manager`'s `webchat_widgets` table for `COUNT(*) WHERE
   message_flow_id IS NOT NULL` before starting the rollout to confirm
   the actual number of exposed customers (expected to be zero or

--- a/docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md
+++ b/docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md
@@ -254,8 +254,12 @@ second.** This is enforced via `.circleci/config.yml`'s
 `bin-*-manager/` directory) combined with each service pipeline's own
 manual `build-approval` gate (`type: approval`, gating
 `<service>-test`/`-build`/`-release` in `config_work.yml`) — merging
-this single PR triggers BOTH the `bin-conversation-manager` and
-`bin-webchat-manager` pipelines, but neither proceeds past its
+this single PR triggers the `bin-conversation-manager` and
+`bin-webchat-manager` pipelines (and, incidentally, `bin-flow-manager`'s
+pipeline too, for the comment-only change in §4 — that pipeline's
+approval can be clicked at any time, since it carries no behavioral
+change and has no sequencing dependency on the other two), but neither
+of the two SEQUENCING-RELEVANT pipelines proceeds past its
 `build-approval` step without an explicit manual click. The rollout
 operator approves `bin-conversation-manager`'s gate first, verifies in
 production (the REDUCED criterion below), THEN approves

--- a/docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md
+++ b/docs/plans/2026-07-18-webchat-message-flow-owner-migration-design.md
@@ -1,0 +1,310 @@
+# Webchat MessageFlowID: move Flow-trigger ownership from webchat-manager to conversation-manager
+
+- Ticket: NOJIRA
+- Author: Hermes (CPO), for pchero (CEO/CTO)
+- Status: DRAFT — first pass, not yet reviewed
+- Supersedes: the `MessageFlowID` half of
+  `2026-07-17-webchat-widget-session-message-flow-split-design.md` (§2.3,
+  §3.2 step 4, §5.5). That design's `SessionFlowID` half (§3, §3.3) is
+  UNCHANGED by this doc — this is a narrower follow-up correcting only
+  the remaining asymmetry it left in place.
+
+## 1. Problem
+
+The 2026-07-17 design split Widget's single `FlowID` into
+`SessionFlowID` (session-create-time trigger, owned by
+`bin-conversation-manager` via `ConversationV1ConversationCreateAndExecuteFlow`)
+and `MessageFlowID` (per-message trigger, deliberately left owned by
+`bin-webchat-manager` itself, for zero-added-latency reasons — see that
+doc's §2.3, §3.1).
+
+This left webchat as the *only* channel whose per-message Flow-trigger
+does not go through `bin-conversation-manager`. SMS (`Number.MessageFlowID`),
+LINE and WhatsApp (`Account.MessageFlowID`) all resolve their flow
+source and call `executeActiveflow` from inside
+`bin-conversation-manager`'s `execute_mode.go`
+(`runExecuteModeFlowLine/Message/WhatsApp`). Every activeflow they
+trigger carries `ReferenceType=ReferenceTypeConversation`,
+`ReferenceID=Conversation.ID`.
+
+Webchat's `MessageFlowID` trigger, by contrast, still runs inside
+`bin-webchat-manager`'s `messagehandler.Create` → `triggerMessageFlow`,
+producing `ReferenceType=ReferenceTypeWebchat`, `ReferenceID=Session.ID`.
+
+This asymmetry has a real, confirmed cost: `bin-flow-manager` branches
+on `activeflow.ReferenceType` in three places
+(`variablehandler/substitute.go`'s `{{voipbin.reference_data}}`
+resolution, `activeflowhandler/actionhandle.go`'s `actionHandleAITalk`
+AI-reference-type mapping, and `actionHandleCaseCreate`'s Case-peer
+derivation) and all three only recognize `ReferenceTypeCall` and
+`ReferenceTypeConversation`. A Flow triggered by webchat's
+`MessageFlowID` silently gets none of: `reference_data` variable
+substitution, correct AI reference-type propagation (it currently
+falls through to `ReferenceTypeCall`, which is wrong), or Case
+auto-creation (falls into `actionHandleCaseCreate`'s explicit
+"not supported" warning branch, no Case is ever created).
+
+pchero's directive (this session): there is no reason for webchat to be
+the one exception. Move `MessageFlowID`'s trigger to
+`bin-conversation-manager`, matching every other channel. Channel
+parity and code consistency are the priority; §2 shows this also
+happens to improve, not worsen, the visitor-facing latency profile, so
+there is no tradeoff to accept here after all — see §2 for the
+corrected analysis (the 2026-07-17 design's original "zero added
+latency" framing for keeping this trigger in webchat-manager assumed a
+tradeoff that turns out not to exist once the synchronous-vs-async
+distinction is worked through properly).
+
+## 2. Decision
+
+`bin-webchat-manager` no longer triggers any activeflow of its own.
+`bin-conversation-manager`'s existing `messageEventReceivedWebchat`
+(the async subscriber on `webchat_message_created`, inbound direction)
+gains a real `runExecuteModeFlowWebchat`, following the exact same
+shape as `runExecuteModeFlowMessage`/`Line`/`WhatsApp`: resolve the
+channel-specific flow source, then call the existing `executeActiveflow`
+(unchanged — always uses `ReferenceType=ReferenceTypeConversation`,
+`ReferenceID=cv.ID` internally).
+
+This means, after this change:
+
+- `ReferenceTypeWebchat` (in `bin-flow-manager/models/activeflow`) is no
+  longer produced by any code path. It is NOT removed from the enum —
+  historical activeflow rows already created with this value must
+  remain readable/queryable — but no new activeflow will ever carry it.
+  A comment is added at the constant noting this.
+- The flow-manager reference_type gaps described in §1 close themselves
+  automatically; no changes needed inside `bin-flow-manager` at all.
+- Latency shape changes, in one direction only (no tradeoff, despite
+  how the 2026-07-17 design's original wording might suggest): today,
+  `bin-webchat-manager`'s synchronous message-create path blocks on
+  `FlowV1ActiveflowCreate`+`Execute` before returning to the visitor
+  (`triggerMessageFlow` is called inline inside `Create`, best-effort
+  but still on the request path). After this change, webchat-manager's
+  message-create response no longer waits on any Flow RPC at all — Flow
+  triggering moves fully off the synchronous path and becomes
+  event-driven (via the existing `webchat_message_created` event → the
+  async `messageEventReceivedWebchat` subscriber), exactly matching
+  SMS/LINE/WhatsApp's existing profile. The visitor-facing send
+  response gets faster; the Flow's own effects (e.g. an immediate bot
+  reply) start slightly later, bounded by event-publish +
+  subscriber-pickup latency — the same latency profile SMS/LINE/WhatsApp
+  already live with today, not a new one introduced by this design.
+
+## 3. Flow source resolution: how conversation-manager gets `MessageFlowID`
+
+Unlike SMS (`Number.MessageFlowID` via `cv.Self.Target`) and LINE/WhatsApp
+(`Account.MessageFlowID` via `cv.AccountID`), webchat conversations have
+no `AccountID` and `cv.Self.Target` is the Widget's UUID string (not a
+number). The flow source is `Widget.MessageFlowID`, fetched via the
+already-existing `WebchatV1WidgetGet(ctx, widgetID)` RPC
+(`bin-common-handler/pkg/requesthandler/webchat_widget.go:56`) — no new
+RPC needed.
+
+```go
+// execute_mode.go, new function, mirrors runExecuteModeFlowLine's shape
+func (h *conversationHandler) runExecuteModeFlowWebchat(ctx context.Context, cv *conversation.Conversation, m *message.Message) error {
+	widgetID, errParse := uuid.FromString(cv.Self.Target)
+	if errParse != nil {
+		return errors.Wrapf(errParse, "invalid widget id in conversation self target: %s", cv.Self.Target)
+	}
+	w, errGet := h.reqHandler.WebchatV1WidgetGet(ctx, widgetID)
+	if errGet != nil {
+		return errors.Wrapf(errGet, "could not get widget. widget_id: %s", widgetID)
+	}
+	if errExecute := h.executeActiveflow(ctx, cv, m, w.MessageFlowID); errExecute != nil {
+		return errors.Wrapf(errExecute, "could not execute activeflow. widget_id: %s", w.ID)
+	}
+	return nil
+}
+```
+
+`runExecuteModeFlow`'s switch gains `case conversation.TypeWebchat:
+return h.runExecuteModeFlowWebchat(ctx, cv, m)` — no longer falls
+through to the `default` no-op branch.
+
+`executeActiveflow` itself is unchanged: it already no-ops cleanly when
+`flowID == uuid.Nil` (`Widget.MessageFlowID` unset), exactly matching
+SMS/LINE/WhatsApp's existing "no flow source configured" behavior.
+
+## 4. Code changes
+
+### bin-webchat-manager
+
+1. `pkg/messagehandler/create.go`: **remove** `triggerMessageFlow`
+   entirely. **Remove** the `w, err := h.db.WidgetGet(...)` call and the
+   `w.MessageFlowID == uuid.Nil` gate inside `Create` — nothing in this
+   function needs Widget any more once the trigger call is gone.
+   `Create` becomes: persist the message (`h.create(...)`), publish the
+   event (already inside `h.create`), return. No Flow-related code
+   remains in this file.
+2. `pkg/messagehandler/create_test.go`: remove/rewrite the
+   `triggerMessageFlow`-related test cases (the ones asserting
+   `FlowV1ActiveflowCreate`/`FlowV1ActiveflowExecute` calls from this
+   package) — webchat-manager itself never calls these RPCs again for
+   the message-trigger path. Replace with an assertion that `Create`
+   does NOT call `WidgetGet` or any `FlowV1*` RPC on the inbound path
+   any more (a negative test, mirroring `Test_EventWebchat_Inbound`'s own
+   negative-assertion style on the conversation-manager side, updated to
+   its NEW meaning — see §5 below).
+3. Confirm no other caller of `triggerMessageFlow`/the removed
+   `WidgetGet` call exists before deleting (grep first).
+
+### bin-conversation-manager
+
+1. `pkg/conversationhandler/execute_mode.go`: add
+   `runExecuteModeFlowWebchat` (§3). Add `case conversation.TypeWebchat`
+   to `runExecuteModeFlow`'s switch.
+2. `pkg/conversationhandler/event_webchat.go`: update the stale comment
+   block in `messageEventReceivedWebchat` (currently lines 124-130,
+   "B안 (confirmed, design doc §16.5): webchat-manager alone owns the
+   real-time Flow trigger... This subscriber path must NEVER trigger a
+   Flow of its own") — this is now FALSE and must be corrected to
+   describe the new reality: this subscriber path DOES trigger
+   `MessageFlowID`'s Flow now, via `ExecuteModeFlow` →
+   `runExecuteModeFlowWebchat`, exactly like every other channel. Do
+   not leave a comment describing the old, now-incorrect behavior next
+   to code that behaves differently (the exact drift trap called out in
+   the `new-channel-conv-mgr-integration.md` skill reference for this
+   same file).
+3. `pkg/conversationhandler/event_webchat_test.go`:
+   `Test_EventWebchat_Inbound` currently asserts the ABSENCE of any
+   `FlowV1ActiveflowCreate` call — this assertion is now WRONG and must
+   be rewritten to assert the OPPOSITE: given a `Widget.MessageFlowID !=
+   uuid.Nil` fixture, `FlowV1ActiveflowCreate` IS called with
+   `ReferenceType=ReferenceTypeConversation`, `ReferenceID=cv.ID`
+   (mirroring `Test_runExecuteModeFlowLine`'s assertion shape in
+   `execute_mode_test.go`). Add a second case: `Widget.MessageFlowID ==
+   uuid.Nil` → no RPC call, no error (the existing no-flow-configured
+   no-op path). Add a `WebchatV1WidgetGet` mock expectation to both.
+4. `pkg/conversationhandler/execute_mode_test.go`: add
+   `Test_runExecuteModeFlowWebchat` mirroring
+   `Test_runExecuteModeFlowLine`/`Test_runExecuteModeFlowMessage`'s
+   existing table-driven shape exactly (happy path with flow id set;
+   `WebchatV1WidgetGet` fetch failure → error wrapped and returned;
+   Widget has no flow id → no activeflow created, no error; malformed
+   `cv.Self.Target` → error, no RPC calls).
+
+### bin-flow-manager
+
+No code changes. `ReferenceTypeWebchat` constant stays (historical
+data), gains a one-line comment: `// no longer produced by any current
+code path (webchat's MessageFlowID trigger moved to
+bin-conversation-manager, 2026-07-18) — retained for historical
+activeflow rows only`.
+
+## 5. Test plan
+
+- `bin-webchat-manager`: rewritten `create_test.go` cases per §4.
+  Full verification workflow.
+- `bin-conversation-manager`: rewritten `Test_EventWebchat_Inbound`,
+  new `Test_runExecuteModeFlowWebchat` per §4. `Test_EventWebchat_Outbound`
+  and `Test_EventWebchat_UnknownDirection` are unaffected (outbound
+  never triggers a Flow regardless of channel; this doc does not touch
+  that). Full verification workflow.
+- Manual/integration smoke: create a widget with `MessageFlowID` set,
+  send an inbound webchat message via the existing dogfood/sandbox path,
+  confirm exactly ONE activeflow is created with
+  `ReferenceType=conversation` (query `bin-flow-manager`'s activeflow
+  list, filter by the conversation's ID) — not two, not
+  `ReferenceType=webchat`.
+
+## 6. Non-goals
+
+- `SessionFlowID`'s trigger path (`ConversationV1ConversationCreateAndExecuteFlow`,
+  owned by conversation-manager since the 2026-07-17 design) is
+  unchanged — already on the conversation-manager side, already uses
+  `ReferenceType=conversation`.
+- No change to `bin-api-manager`, OpenAPI schemas, or any DB migration —
+  `Widget.MessageFlowID` itself is unchanged; only which service reads
+  it and triggers against it moves.
+- No change to the accepted-risk note in the 2026-07-17 design (§4,
+  concurrent overlapping MessageFlowID executions with no lock) — this
+  doc does not add or remove that risk, it only relocates which service
+  the (already-accepted) risk lives in.
+
+## 7. Rollout sequencing (deploy-order double-trigger / no-trigger window)
+
+`bin-webchat-manager` and `bin-conversation-manager` are two
+independently deployed services (separate k8s rolling deploys). This
+design is NOT a single atomic commit across both — it is two
+service-level diffs (§4) landing as separate PRs/deploys. Because of
+this, the deploy ORDER between the two creates two distinct
+transitional-window risks that must be handled explicitly, not left
+implicit:
+
+1. **conversation-manager's new trigger deploys BEFORE
+   webchat-manager's old trigger is removed** → during the window where
+   both are live, every inbound webchat message with `MessageFlowID`
+   set triggers **two independent activeflows** — one from each
+   service (double bot reply, double AI session start, duplicate
+   `Case` creation attempts).
+2. **webchat-manager's old trigger is removed BEFORE
+   conversation-manager's new trigger deploys** → during that window,
+   inbound webchat messages trigger **no activeflow at all** (silent
+   gap — no error, just a missing Flow execution for any customer with
+   `MessageFlowID` configured).
+
+**Resolution: land and deploy conversation-manager's `execute_mode.go`
+change FIRST, verify it in production, THEN land and deploy the
+webchat-manager `triggerMessageFlow` removal as a separate, later PR.**
+This accepts window (1) — a bounded period of double-triggering — over
+window (2) — a silent gap — because a double bot-reply/duplicate Case
+is visibly wrong and immediately noticeable (customer complaint, log
+volume spike), whereas a silent no-trigger gap can go unnoticed for an
+arbitrary period. Concretely:
+
+- PR/deploy 1 (`bin-conversation-manager`): add
+  `runExecuteModeFlowWebchat`, wire the switch case, update the stale
+  §16.5 comment (§4). Deploy. **Verification at this stage is NOT the
+  full §5 smoke test** — §5's "exactly ONE activeflow, not two" success
+  criterion only holds once BOTH deploys have landed. At this
+  intermediate stage, the correct (and only) check is a REDUCED
+  criterion: confirm that a fresh inbound webchat message with
+  `MessageFlowID` set now ALSO produces a `ReferenceType=conversation`
+  activeflow (existence check only) — seeing a `ReferenceType=webchat`
+  activeflow ALONGSIDE it at this point is the expected, accepted
+  transitional state, not a failure. Do not run §5's full pass/fail
+  smoke test until after deploy 2; running it here would misclassify
+  the correct transitional double-trigger state as a regression and
+  risk triggering an unnecessary rollback. Because
+  `MessageFlowID` has no existing production adopters at design time
+  (see below), this existence check requires standing up ONE dedicated
+  test widget with `MessageFlowID` set for the duration of the
+  verification step — this is the one deliberate, intentional
+  exception to the "avoid configuring new widgets with `MessageFlowID`"
+  guidance below; that guidance is aimed at customer-facing widget
+  configuration during the window, not at this design's own required
+  verification step.
+- PR/deploy 2 (`bin-webchat-manager`): remove `triggerMessageFlow` and
+  its callers (§4). Deploy. Double-triggering ends; only the
+  `conversation`-typed activeflow is produced from this point forward.
+  **§5's full smoke test ("exactly ONE activeflow, not two") is the
+  correct and only point to run it — it is deploy-2's acceptance
+  criterion, not deploy-1's.**
+- Between the two deploys, avoid configuring NEW customer-facing
+  widgets with `MessageFlowID` if practical (existing widgets with it
+  already set will double-trigger for the duration of the window
+  regardless — this is accepted, not preventable without a feature
+  flag, which is explicitly out of scope below). This does not apply to
+  the single dedicated verification widget above.
+- Feature-flag-gated sequential cutover (mentioned as an alternative
+  during design review) is explicitly REJECTED as unnecessary
+  complexity for this migration, on the following honestly-stated
+  basis (correcting an earlier draft of this section that understated
+  the window): the double-trigger window is NOT bounded merely by
+  ordinary single-PR merge-to-deploy latency — it spans deploy 1's
+  rollout, an UNBOUNDED production-verification step this design itself
+  requires before starting deploy 2's PR, and deploy 2's own
+  merge-to-deploy latency. This window could plausibly span hours to a
+  few days if verification is not prioritized promptly, not merely
+  minutes. The rejection of a feature flag stands anyway, because blast
+  radius (not window duration) is the controlling factor here: query
+  `bin-webchat-manager`'s `webchat_widgets` table for `COUNT(*) WHERE
+  message_flow_id IS NOT NULL` before starting the rollout to confirm
+  the actual number of exposed customers (expected to be zero or
+  near-zero, since `MessageFlowID` is a brand-new opt-in field with no
+  existing adopters at the time of this design — verify this count
+  explicitly rather than assuming it). If that count is non-trivial by
+  the time this rollout actually happens, re-open the feature-flag
+  question rather than proceeding on this design's original assumption.


### PR DESCRIPTION
Webchat's per-message MessageFlowID Flow-trigger moves from bin-webchat-manager to bin-conversation-manager, matching every other channel's (SMS/LINE/WhatsApp) existing pattern. Activeflows triggered from an inbound webchat message now carry ReferenceType=conversation instead of ReferenceType=webchat, closing three previously-silent gaps in bin-flow-manager (reference_data variable substitution, AI reference-type propagation, and Case auto-creation), with zero code changes required in bin-flow-manager itself.

- bin-webchat-manager: Remove triggerMessageFlow and its callers from messagehandler.Create; the inbound message path no longer fetches the Widget or calls any FlowV1* RPC.
- bin-conversation-manager: Add runExecuteModeFlowWebchat, mirroring runExecuteModeFlowLine/Message/WhatsApp's shape, resolving the flow source via WebchatV1WidgetGet and Widget.MessageFlowID. Wire the new case into runExecuteModeFlow's switch. Correct the stale event_webchat.go comment describing the prior webchat-manager-owns-the-trigger design.
- bin-flow-manager: Annotate ReferenceTypeWebchat as no longer produced by any current code path, retained for historical activeflow rows only.
- docs: Add design doc for this migration (5 rounds of adversarial design review, 2 consecutive APPROVED), including rollout-sequencing guidance (conversation-manager deploys first, webchat-manager's trigger removal deploys second, to avoid a silent no-trigger gap).