### PR TITLE
NOJIRA-Fix-zmqsub-unsubscribe-slice-panic

### DIFF
--- a/bin-api-manager/pkg/zmqsubhandler/subscribe.go
+++ b/bin-api-manager/pkg/zmqsubhandler/subscribe.go
@@ -72,7 +72,7 @@ func (h *zmqSubHandler) Unsubscribe(topic string) error {
 		// nothing to unsubscribe
 		return nil
 	}
-	h.topics = slices.Delete(h.topics, idx, 1)
+	h.topics = slices.Delete(h.topics, idx, idx+1)
 
 	if errSub := h.sock.Unsubscribe(topic); errSub != nil {
 		log.Errorf("Could not unsubscribe the topic. err: %v", errSub)

--- a/bin-api-manager/pkg/zmqsubhandler/subscribe_test.go
+++ b/bin-api-manager/pkg/zmqsubhandler/subscribe_test.go
@@ -221,6 +221,29 @@ func Test_Unsubscribe(t *testing.T) {
 				"topic4",
 			},
 		},
+		{
+			// Regression test for the idx == 1 boundary. Under the old buggy code,
+			// slices.Delete(s, 1, 1) is a VALID but EMPTY range -- it does not panic,
+			// it silently deletes nothing. That means unsubscribing the topic at
+			// index 1 used to leave it in h.topics forever (a silent local-state
+			// leak/correctness bug distinct from the panic at idx >= 2, caught during
+			// PR #1119 review). The fixed slices.Delete(s, 1, 2) must actually remove
+			// the element at index 1.
+			"unsubscribe the topic at index 1 (regression: old code silently deleted nothing here)",
+
+			[]string{
+				"topic0",
+				"topic1",
+				"topic2",
+			},
+
+			"topic1",
+
+			[]string{
+				"topic0",
+				"topic2",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-api-manager/pkg/zmqsubhandler/subscribe_test.go
+++ b/bin-api-manager/pkg/zmqsubhandler/subscribe_test.go
@@ -175,6 +175,52 @@ func Test_Unsubscribe(t *testing.T) {
 				"world",
 			},
 		},
+		{
+			// Regression test for a production panic (prod api-manager crash-loop,
+			// 2026-07-18): slices.Delete(s, idx, 1) is only valid when idx <= 1, because
+			// the second argument is an end-index, not a count. Unsubscribing a topic
+			// held at index >= 2 previously panicked with
+			// "slice bounds out of range [idx:1]". This case deletes the topic at
+			// index 4 (5 topics total) to guard against that regression.
+			"unsubscribe a topic beyond index 1 (regression: slices.Delete end-index bug)",
+
+			[]string{
+				"topic0",
+				"topic1",
+				"topic2",
+				"topic3",
+				"topic4",
+			},
+
+			"topic4",
+
+			[]string{
+				"topic0",
+				"topic1",
+				"topic2",
+				"topic3",
+			},
+		},
+		{
+			"unsubscribe a topic in the middle of a longer list",
+
+			[]string{
+				"topic0",
+				"topic1",
+				"topic2",
+				"topic3",
+				"topic4",
+			},
+
+			"topic2",
+
+			[]string{
+				"topic0",
+				"topic1",
+				"topic3",
+				"topic4",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix a production panic that was crash-looping both api-manager pods (Running, RESTARTS climbing, readiness probe failures on :443/ping).

zmqsubhandler.Unsubscribe called slices.Delete(h.topics, idx, 1) to remove a single topic at index idx. golang.org/x/exp/slices.Delete(s, i, j) takes an end-index j, not a count -- the call is only valid when idx <= 1. Any client unsubscribing a topic held at index >= 2 in the local topic slice hit 'panic: runtime error: slice bounds out of range [idx:1]', killing the RPC/websocket goroutine and crash-looping the pod. Confirmed live in prod via kubectl logs deploy/api-manager --previous, triggered by a normal webchat widget test session's subscribe/unsubscribe flow -- not an edge case.

- bin-api-manager: Fix slices.Delete end-index bug in zmqsubhandler.Unsubscribe (idx, 1 -> idx, idx+1)
- bin-api-manager: Add regression tests for unsubscribe at index >= 2 and mid-list positions; confirmed the new test reproduces the exact prod panic signature against the pre-fix code, then passes against the fix