### PR TITLE
NOJIRA-fix-flaky-receive-message-context-canceled-test

### DIFF
--- a/bin-api-manager/pkg/zmqsubhandler/run.go
+++ b/bin-api-manager/pkg/zmqsubhandler/run.go
@@ -81,8 +81,21 @@ func (h *zmqSubHandler) receiveMessage(ctx context.Context) (string, string, err
 		if err != nil {
 			if err.Error() == syscall.EAGAIN.Error() {
 				// no received message
-				// wait for 1 second and try again
-				time.Sleep(time.Millisecond * 1000)
+				// wait for 1 second and try again, but return immediately if the
+				// context gets canceled while waiting. Without this, a canceled
+				// context could go unnoticed for up to 1 second, which races with
+				// callers that close/terminate the socket shortly after cancel()
+				// (this was the root cause of the flaky
+				// Test_recevieMessage_context_canceled test: -race detected a
+				// concurrent Close()/RecvMessage() when the goroutine was still
+				// asleep past the point where the test canceled the context and
+				// terminated the socket).
+				select {
+				case <-ctx.Done():
+					log.Infof("The context is canceled while waiting to retry. err: %v", ctx.Err())
+					return "", "", ctx.Err()
+				case <-time.After(time.Millisecond * 1000):
+				}
 				continue
 			}
 

--- a/bin-api-manager/pkg/zmqsubhandler/run_test.go
+++ b/bin-api-manager/pkg/zmqsubhandler/run_test.go
@@ -196,7 +196,10 @@ func Test_recevieMessage_context_canceled(t *testing.T) {
 			}
 
 			t.Logf("Receiving the message.")
+			done := make(chan struct{})
 			go func() {
+				defer close(done)
+
 				t.Logf("Receiving message")
 				time.Sleep(time.Millisecond * 1000)
 
@@ -230,7 +233,18 @@ func Test_recevieMessage_context_canceled(t *testing.T) {
 			t.Logf("Closing the socket.")
 			cancel()
 
-			time.Sleep(time.Millisecond * 1000)
+			// wait for the receiveMessage goroutine to actually observe the
+			// cancellation and return before the deferred sockSub.Terminate()
+			// closes the socket underneath it. Without this synchronization, the
+			// goroutine could still be inside sock.ReceiveNoBlock() when the
+			// socket gets terminated, racing Close() against RecvMessage()
+			// (caught by go test -race; this was the root cause of the flaky
+			// Test_recevieMessage_context_canceled failures).
+			select {
+			case <-done:
+			case <-time.After(time.Second * 5):
+				t.Errorf("Timed out waiting for receiveMessage to return after context cancellation")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fix a data race in zmqsubhandler.receiveMessage that made Test_recevieMessage_context_canceled fail intermittently under go test -race (and occasionally without -race, when scheduling happened to line up the same way).

- bin-api-manager: receiveMessage now selects on ctx.Done() while waiting to retry after EAGAIN, instead of an unconditional time.Sleep(1s). Previously a canceled context could go unnoticed for up to 1 second, racing with callers that Terminate() the zmq socket shortly after cancel().
- bin-api-manager: Test_recevieMessage_context_canceled now waits on a done channel for the receiveMessage goroutine to actually return after cancel(), instead of a fixed 1s sleep, before the deferred sockSub.Terminate() runs.