### PR TITLE
SQUARE-23-Insight-AI-one-per-customer

### DIFF
--- a/bin-ai-manager/pkg/aihandler/chatbot.go
+++ b/bin-ai-manager/pkg/aihandler/chatbot.go
@@ -174,6 +174,13 @@ func (h *aiHandler) Update(
 			ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
 		fields[ai.FieldCurrentPromptHistoryID] = historyID
 		if err := h.db.AIUpdate(ctx, id, fields); err != nil {
+			if dbhandler.IsErrDuplicate(err) {
+				return nil, cerrors.AlreadyExists(
+					commonoutline.ServiceNameAIManager,
+					"AI_INSIGHT_ALREADY_EXISTS",
+					"This customer already has an active Insight AI. Delete it before creating another.",
+				).Wrap(err)
+			}
 			return nil, errors.Wrapf(err, "could not update ai")
 		}
 		res, err := h.db.AIGet(ctx, id)
@@ -198,6 +205,13 @@ func (h *aiHandler) Update(
 			ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
 		fields[ai.FieldCurrentPromptHistoryID] = uuid.Nil
 		if err := h.db.AIUpdate(ctx, id, fields); err != nil {
+			if dbhandler.IsErrDuplicate(err) {
+				return nil, cerrors.AlreadyExists(
+					commonoutline.ServiceNameAIManager,
+					"AI_INSIGHT_ALREADY_EXISTS",
+					"This customer already has an active Insight AI. Delete it before creating another.",
+				).Wrap(err)
+			}
 			return nil, errors.Wrapf(err, "could not update ai (clear prompt)")
 		}
 		res, err := h.db.AIGet(ctx, id)

--- a/bin-ai-manager/pkg/aihandler/chatbot.go
+++ b/bin-ai-manager/pkg/aihandler/chatbot.go
@@ -12,7 +12,6 @@ import (
 	"monorepo/bin-ai-manager/models/ai"
 	"monorepo/bin-ai-manager/models/aiprompthistory"
 	"monorepo/bin-ai-manager/models/tool"
-	"monorepo/bin-ai-manager/pkg/dbhandler"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
 	commonoutline "monorepo/bin-common-handler/models/outline"
@@ -76,12 +75,8 @@ func (h *aiHandler) Create(
 		initPrompt, ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled,
 		autoAICallAuditEnabled, currentPromptHistoryID)
 	if err != nil {
-		if dbhandler.IsErrDuplicate(err) {
-			return nil, cerrors.AlreadyExists(
-				commonoutline.ServiceNameAIManager,
-				"AI_INSIGHT_ALREADY_EXISTS",
-				"This customer already has an active Insight AI. Delete it before creating another.",
-			).Wrap(err)
+		if dupErr := aiInsightDuplicateErr(err); dupErr != nil {
+			return nil, dupErr
 		}
 		return nil, errors.Wrapf(err, "could not create ai")
 	}
@@ -174,12 +169,8 @@ func (h *aiHandler) Update(
 			ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
 		fields[ai.FieldCurrentPromptHistoryID] = historyID
 		if err := h.db.AIUpdate(ctx, id, fields); err != nil {
-			if dbhandler.IsErrDuplicate(err) {
-				return nil, cerrors.AlreadyExists(
-					commonoutline.ServiceNameAIManager,
-					"AI_INSIGHT_ALREADY_EXISTS",
-					"This customer already has an active Insight AI. Delete it before creating another.",
-				).Wrap(err)
+			if dupErr := aiInsightDuplicateErr(err); dupErr != nil {
+				return nil, dupErr
 			}
 			return nil, errors.Wrapf(err, "could not update ai")
 		}
@@ -205,12 +196,8 @@ func (h *aiHandler) Update(
 			ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
 		fields[ai.FieldCurrentPromptHistoryID] = uuid.Nil
 		if err := h.db.AIUpdate(ctx, id, fields); err != nil {
-			if dbhandler.IsErrDuplicate(err) {
-				return nil, cerrors.AlreadyExists(
-					commonoutline.ServiceNameAIManager,
-					"AI_INSIGHT_ALREADY_EXISTS",
-					"This customer already has an active Insight AI. Delete it before creating another.",
-				).Wrap(err)
+			if dupErr := aiInsightDuplicateErr(err); dupErr != nil {
+				return nil, dupErr
 			}
 			return nil, errors.Wrapf(err, "could not update ai (clear prompt)")
 		}

--- a/bin-ai-manager/pkg/aihandler/chatbot.go
+++ b/bin-ai-manager/pkg/aihandler/chatbot.go
@@ -12,6 +12,7 @@ import (
 	"monorepo/bin-ai-manager/models/ai"
 	"monorepo/bin-ai-manager/models/aiprompthistory"
 	"monorepo/bin-ai-manager/models/tool"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
 	commonoutline "monorepo/bin-common-handler/models/outline"
@@ -75,6 +76,13 @@ func (h *aiHandler) Create(
 		initPrompt, ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled,
 		autoAICallAuditEnabled, currentPromptHistoryID)
 	if err != nil {
+		if dbhandler.IsErrDuplicate(err) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameAIManager,
+				"AI_INSIGHT_ALREADY_EXISTS",
+				"This customer already has an active Insight AI. Delete it before creating another.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not create ai")
 	}
 

--- a/bin-ai-manager/pkg/aihandler/chatbot_test.go
+++ b/bin-ai-manager/pkg/aihandler/chatbot_test.go
@@ -1210,6 +1210,107 @@ func TestCreate_RejectsDuplicateInsightAI(t *testing.T) {
 	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
 }
 
+// SQUARE-23: Update's promptChanged branch (chatbot.go) must translate a
+// duplicate-key failure the same way Create does.
+func TestUpdate_promptChanged_RejectsDuplicateInsightAI(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	aiID := uuid.Must(uuid.NewV4())
+	existing := &ai.AI{Type: ai.TypeNormal, InitPrompt: "old prompt"}
+	existing.ID = aiID
+	existing.CustomerID = uuid.Must(uuid.NewV4())
+
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.Must(uuid.NewV4())).Times(1)
+	mockDB.EXPECT().AIGet(gomock.Any(), aiID).Return(existing, nil).Times(1) // pre-fetch
+	mockDB.EXPECT().AIUpdate(gomock.Any(), aiID, gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+	_, err := h.Update(context.Background(), aiID, "name", "", ai.TypeInsight, ai.EngineModelOpenaiGPT5, nil, "", uuid.Nil,
+		"new prompt", ai.TTSTypeNone, "", ai.STTTypeNone, "", nil, nil, false, false)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+
+// SQUARE-23: Update's promptCleared branch must also translate a
+// duplicate-key failure — clearing the prompt and changing type to
+// insight in the same request is a valid combination.
+func TestUpdate_promptCleared_RejectsDuplicateInsightAI(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	aiID := uuid.Must(uuid.NewV4())
+	existing := &ai.AI{Type: ai.TypeNormal, InitPrompt: "old prompt"}
+	existing.ID = aiID
+	existing.CustomerID = uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().AIGet(gomock.Any(), aiID).Return(existing, nil).Times(1) // pre-fetch
+	mockDB.EXPECT().AIUpdate(gomock.Any(), aiID, gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+	// initPrompt == "" clears the prompt; type changes to insight in the same call
+	_, err := h.Update(context.Background(), aiID, "name", "", ai.TypeInsight, ai.EngineModelOpenaiGPT5, nil, "", uuid.Nil,
+		"", ai.TTSTypeNone, "", ai.STTTypeNone, "", nil, nil, false, false)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+
+// SQUARE-23: Update's default ("prompt unchanged") branch routes through
+// dbUpdate() in db.go, a different file than the other two branches — the
+// translation must live there too.
+func TestUpdate_promptUnchanged_RejectsDuplicateInsightAI(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	aiID := uuid.Must(uuid.NewV4())
+	same := "same prompt"
+	existing := &ai.AI{Type: ai.TypeNormal, InitPrompt: same}
+	existing.ID = aiID
+	existing.CustomerID = uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().AIGet(gomock.Any(), aiID).Return(existing, nil).Times(1) // pre-fetch
+	mockDB.EXPECT().AIUpdate(gomock.Any(), aiID, gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+	_, err := h.Update(context.Background(), aiID, "name", "", ai.TypeInsight, ai.EngineModelOpenaiGPT5, nil, "", uuid.Nil,
+		same, ai.TTSTypeNone, "", ai.STTTypeNone, "", nil, nil, false, false)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+
 func TestUpdate_RejectsInsightAIWithNormalTools(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/bin-ai-manager/pkg/aihandler/chatbot_test.go
+++ b/bin-ai-manager/pkg/aihandler/chatbot_test.go
@@ -1141,6 +1141,75 @@ func TestCreate_AllowsValidInsightAI(t *testing.T) {
 	}
 }
 
+// assertAlreadyExists fails the test unless err is a *cerrors.VoipbinError
+// with Status == cerrors.StatusAlreadyExists and the given Reason, per
+// SQUARE-23's design (a duplicate-key failure on ai_ais.active_insight_key
+// must be translated to a 409 ALREADY_EXISTS, not a raw SQL error).
+func assertAlreadyExists(t *testing.T, err error, wantReason string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var ve *cerrors.VoipbinError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected a *cerrors.VoipbinError, got: %v (%T)", err, err)
+	}
+	if ve.Status != cerrors.StatusAlreadyExists {
+		t.Errorf("expected Status=%v, got %v (err: %v)", cerrors.StatusAlreadyExists, ve.Status, err)
+	}
+	if ve.Reason != wantReason {
+		t.Errorf("expected Reason=%v, got %v (err: %v)", wantReason, ve.Reason, err)
+	}
+}
+
+// SQUARE-23: Create must translate a duplicate-key failure on
+// ai_ais.active_insight_key into cerrors.AlreadyExists (HTTP 409), not a
+// raw wrapped SQL error.
+func TestCreate_RejectsDuplicateInsightAI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+
+	mockReq.EXPECT().DirectV1DirectCreate(gomock.Any(), gomock.Any(), dmdirect.ResourceTypeAI, gomock.Any()).
+		Return(&dmdirect.Direct{Hash: "a1b2c3d4e5f6"}, nil).Times(1)
+	mockDB.EXPECT().AICreate(gomock.Any(), gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+	mockReq.EXPECT().DirectV1DirectDelete(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   utilhandler.NewUtilHandler(),
+	}
+
+	_, err := h.Create(
+		context.Background(),
+		uuid.Must(uuid.NewV4()),
+		"Insight AI",
+		"",
+		ai.TypeInsight,
+		ai.EngineModelOpenaiGPT5,
+		nil,
+		"test-key",
+		uuid.Nil,
+		"",
+		ai.TTSTypeNone,
+		"",
+		ai.STTTypeNone,
+		"",
+		[]tool.ToolName{},
+		nil,
+		false,
+		false,
+	)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+
 func TestUpdate_RejectsInsightAIWithNormalTools(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/bin-ai-manager/pkg/aihandler/db.go
+++ b/bin-ai-manager/pkg/aihandler/db.go
@@ -194,6 +194,13 @@ func (h *aiHandler) dbUpdate(
 		ttsType, ttsVoice, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
 
 	if err := h.db.AIUpdate(ctx, id, fields); err != nil {
+		if dbhandler.IsErrDuplicate(err) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameAIManager,
+				"AI_INSIGHT_ALREADY_EXISTS",
+				"This customer already has an active Insight AI. Delete it before creating another.",
+			).Wrap(err)
+		}
 		return nil, errors.Wrapf(err, "could not update ai")
 	}
 

--- a/bin-ai-manager/pkg/aihandler/db.go
+++ b/bin-ai-manager/pkg/aihandler/db.go
@@ -20,6 +20,21 @@ import (
 	"monorepo/bin-ai-manager/pkg/dbhandler"
 )
 
+// aiInsightDuplicateErr translates a duplicate-key failure on
+// ai_ais.active_insight_key into a customer-facing 409 AlreadyExists
+// error. Returns nil if err is not a duplicate-key error, signaling the
+// caller should fall through to its own generic wrap.
+func aiInsightDuplicateErr(err error) error {
+	if !dbhandler.IsErrDuplicate(err) {
+		return nil
+	}
+	return cerrors.AlreadyExists(
+		commonoutline.ServiceNameAIManager,
+		"AI_INSIGHT_ALREADY_EXISTS",
+		"This customer already has an active Insight AI. Delete it before creating another.",
+	).Wrap(err)
+}
+
 // Create creates a new ai record.
 func (h *aiHandler) dbCreate(
 	ctx context.Context,
@@ -194,12 +209,8 @@ func (h *aiHandler) dbUpdate(
 		ttsType, ttsVoice, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
 
 	if err := h.db.AIUpdate(ctx, id, fields); err != nil {
-		if dbhandler.IsErrDuplicate(err) {
-			return nil, cerrors.AlreadyExists(
-				commonoutline.ServiceNameAIManager,
-				"AI_INSIGHT_ALREADY_EXISTS",
-				"This customer already has an active Insight AI. Delete it before creating another.",
-			).Wrap(err)
+		if dupErr := aiInsightDuplicateErr(err); dupErr != nil {
+			return nil, dupErr
 		}
 		return nil, errors.Wrapf(err, "could not update ai")
 	}

--- a/bin-ai-manager/pkg/dbhandler/ai_test.go
+++ b/bin-ai-manager/pkg/dbhandler/ai_test.go
@@ -423,3 +423,88 @@ func Test_AIUpdate(t *testing.T) {
 		})
 	}
 }
+
+func Test_AICreate_InsightUniquePerCustomer(t *testing.T) {
+	ctx := context.Background()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().AISet(ctx, gomock.Any()).AnyTimes()
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	customerID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000001")
+
+	// first insight AI for the customer succeeds
+	firstID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000002")
+	t1 := time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t1)
+	first := &ai.AI{
+		Identity: identity.Identity{ID: firstID, CustomerID: customerID},
+		Type:     ai.TypeInsight,
+	}
+	if err := h.AICreate(ctx, first); err != nil {
+		t.Fatalf("first insight AICreate: expected ok, got: %v", err)
+	}
+
+	// second insight AI for the SAME customer must be rejected
+	secondID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000003")
+	t2 := time.Date(2026, 7, 29, 0, 0, 1, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t2)
+	second := &ai.AI{
+		Identity: identity.Identity{ID: secondID, CustomerID: customerID},
+		Type:     ai.TypeInsight,
+	}
+	err := h.AICreate(ctx, second)
+	if err == nil {
+		t.Fatal("second insight AICreate: expected an error, got nil")
+	}
+	if !IsErrDuplicate(err) {
+		t.Errorf("second insight AICreate: expected IsErrDuplicate(err)=true, got err: %v", err)
+	}
+
+	// a normal-type AI for the same customer is NOT affected by the constraint
+	normalID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000004")
+	t3 := time.Date(2026, 7, 29, 0, 0, 2, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t3)
+	normal := &ai.AI{
+		Identity: identity.Identity{ID: normalID, CustomerID: customerID},
+		Type:     ai.TypeNormal,
+	}
+	if err := h.AICreate(ctx, normal); err != nil {
+		t.Errorf("normal-type AICreate for same customer: expected ok, got: %v", err)
+	}
+
+	// soft-delete the first insight AI, freeing the slot.
+	// AIDelete's real cache interaction is TimeNow + aiUpdateToCache (which
+	// reads back via a DB query, not cache.AIGet, then calls cache.AISet) —
+	// see bin-ai-manager/pkg/dbhandler/ai.go's AIDelete and aiUpdateToCache.
+	// The AISet call is already covered by the mockCache.EXPECT().AISet(...).AnyTimes()
+	// set up above; AIDelete never calls cache.AIGet, so no such expectation
+	// is set here (unlike the separate, subsequent h.AIGet call pattern used
+	// in the existing Test_AIDelete test, which does call cache.AIGet).
+	t4 := time.Date(2026, 7, 29, 0, 0, 3, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t4)
+	if err := h.AIDelete(ctx, firstID); err != nil {
+		t.Fatalf("AIDelete(first): expected ok, got: %v", err)
+	}
+
+	// a new insight AI for the same customer now succeeds
+	thirdID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000005")
+	t5 := time.Date(2026, 7, 29, 0, 0, 4, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t5)
+	third := &ai.AI{
+		Identity: identity.Identity{ID: thirdID, CustomerID: customerID},
+		Type:     ai.TypeInsight,
+	}
+	if err := h.AICreate(ctx, third); err != nil {
+		t.Errorf("insight AICreate after soft-delete: expected ok, got: %v", err)
+	}
+}

--- a/bin-ai-manager/scripts/database_scripts_test/table_ai_ais.sql
+++ b/bin-ai-manager/scripts/database_scripts_test/table_ai_ais.sql
@@ -41,8 +41,23 @@ create table ai_ais(
   tm_update datetime(6),  --
   tm_delete datetime(6),  --
 
+  -- SQLite-compatible stand-in for the MySQL STORED generated column
+  -- active_insight_key (BINARY(16), see bin-dbscheme-manager migration
+  -- for SQUARE-23, mirroring the active_reference_key pattern in
+  -- table_ai_aicalls.sql). Computes customer_id only when type='insight'
+  -- and the row is not soft-deleted; NULL otherwise (any number of NULLs
+  -- may coexist under UNIQUE), enforcing "at most one active Insight AI
+  -- per customer" without affecting type='normal' rows.
+  active_insight_key varchar(255) GENERATED ALWAYS AS (
+    CASE WHEN type = 'insight' AND tm_delete IS NULL
+      THEN customer_id
+      ELSE NULL
+    END
+  ) STORED,
+
   primary key(id)
 );
 
 create index idx_ai_ais_create on ai_ais(tm_create);
 create index idx_ai_ais_customer_id on ai_ais(customer_id);
+create unique index uq_ai_active_insight_key on ai_ais(active_insight_key);

--- a/bin-dbscheme-manager/bin-manager/main/versions/f4c4c2407cee_ai_ais_add_active_insight_key_unique.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/f4c4c2407cee_ai_ais_add_active_insight_key_unique.py
@@ -1,0 +1,85 @@
+"""ai_ais_add_active_insight_key_unique
+
+Revision ID: f4c4c2407cee
+Revises: d8b04ef3ddd0
+Create Date: 2026-07-29 04:14:32.140037
+
+SQUARE-23: adds active_insight_key to ai_ais as a STORED generated column
+to enforce "at most one active (non-deleted) type=insight AI per
+customer" at the DB level, mirroring the ai_aicalls.active_reference_key
+pattern (a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py, VOIP-1234).
+
+active_insight_key carries customer_id only when type='insight' AND
+tm_delete IS NULL; all other rows (type='normal', or soft-deleted
+type='insight' rows) compute NULL, which MySQL treats as distinct under
+UNIQUE, so any number of such rows may coexist while at most one
+genuinely-active Insight AI may exist per customer.
+
+Before applying this migration to any non-local environment: confirm no
+customer currently has 2+ non-deleted type='insight' AIs (see SQUARE-23
+design doc docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
+section 3 for the audit query and cleanup approach -- extras must be
+removed via the existing DELETE /ais/{id} API, not raw SQL, before this
+migration's CREATE UNIQUE INDEX can succeed), and confirm ai_ais's row
+count / the expected ALTER TABLE ... ADD COLUMN ... STORED rewrite
+duration are acceptable for an in-place lock, per the precedent's
+documented incident (see design doc section 1 "Operational cost").
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f4c4c2407cee'
+down_revision = 'd8b04ef3ddd0'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table, column):
+    result = conn.execute(sa.text(
+        "SELECT COUNT(*) FROM information_schema.columns "
+        "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :col"
+    ), {'table': table, 'col': column})
+    return result.scalar() > 0
+
+
+def _index_exists(conn, table, index):
+    result = conn.execute(sa.text(
+        "SELECT COUNT(*) FROM information_schema.statistics "
+        "WHERE table_schema = DATABASE() AND table_name = :table AND index_name = :idx"
+    ), {'table': table, 'idx': index})
+    return result.scalar() > 0
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _column_exists(conn, 'ai_ais', 'active_insight_key'):
+        op.execute("""
+            ALTER TABLE ai_ais
+            ADD COLUMN active_insight_key BINARY(16) GENERATED ALWAYS AS (
+                IF(type = 'insight' AND tm_delete IS NULL, customer_id, NULL)
+            ) STORED
+        """)
+
+    if not _index_exists(conn, 'ai_ais', 'uq_ai_active_insight_key'):
+        op.execute("""
+            CREATE UNIQUE INDEX uq_ai_active_insight_key
+            ON ai_ais(active_insight_key)
+        """)
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _index_exists(conn, 'ai_ais', 'uq_ai_active_insight_key'):
+        op.execute("""
+            DROP INDEX uq_ai_active_insight_key ON ai_ais
+        """)
+
+    if _column_exists(conn, 'ai_ais', 'active_insight_key'):
+        op.execute("""
+            ALTER TABLE ai_ais
+            DROP COLUMN active_insight_key
+        """)

--- a/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
+++ b/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
@@ -89,11 +89,44 @@ if err != nil {
 `HTTPStatusFor` table (`bin-common-handler/models/errors/rpc.go`) — no new
 status code or mapping needed.
 
-The same translation is added at the two duplicate-key-reachable exit
-points in `aihandler.Update` (the `promptChanged` and default/"prompt
-unchanged" branches both call into `h.db.AIUpdate`; `promptCleared` cannot
-change `type`, since clearing the prompt is orthogonal to type, but the
-helper call is added generically so it also covers that branch defensively).
+**Limitation (inherited, not new):** `dbhandler.IsErrDuplicate`
+(`bin-ai-manager/pkg/dbhandler/main.go`) does a blunt substring match on
+`"Duplicate entry"` with no index-name scoping. Once `uq_ai_active_insight_key`
+exists on `ai_ais`, any duplicate-key error on that table — e.g. an
+extremely unlikely `id`/PK collision — would also get mapped to
+`AI_INSIGHT_ALREADY_EXISTS`, which would be a misleading message for that
+case. This weakness pre-dates this design (it already applies to the sole
+prior caller, `aicallhandler/start.go`'s internal race-detection check),
+but it now backs a customer-facing error message rather than an internal
+check, so the risk surface is different. Not fixed as part of this change;
+noted here so a future index-scoped refinement (e.g. matching the index
+name in the error text) can be tracked if it becomes a real issue.
+
+`Update` resolves `aiType` once, before the prompt-state branching
+(`pkg/aihandler/chatbot.go`, the `aiType == ai.TypeNone` fallback block),
+and passes that same resolved `aiType` into `buildUpdateFields` in all
+three branches of the `switch`. So a caller can clear the prompt **and**
+change `type` from `normal` to `insight` in the same request — the
+`promptCleared` branch's `h.db.AIUpdate` call is exactly as
+duplicate-key-reachable as the other two, not "orthogonal to type" as the
+branch name might suggest. All three branches need the translation:
+
+1. `promptChanged` — inline `h.db.AIUpdate` call in `chatbot.go`.
+2. `promptCleared` — inline `h.db.AIUpdate` call in `chatbot.go` (the
+   type-change-while-clearing-prompt case above).
+3. `default` ("prompt unchanged") — `chatbot.go` does not call
+   `h.db.AIUpdate` directly here; it returns `h.dbUpdate(ctx, ...)`, and
+   `dbUpdate` (`pkg/aihandler/db.go`) is the one that calls `h.db.AIUpdate`
+   and returns its error unwrapped. The `IsErrDuplicate` translation for
+   this branch must therefore live inside `dbUpdate` in `db.go`, not in
+   `chatbot.go`. An implementation that only edits `chatbot.go` will leave
+   this branch's duplicate-key errors as raw wrapped SQL errors, missing
+   the AC's rejection guarantee for the most common update path (type
+   unchanged, prompt unchanged).
+
+Concretely: add the `IsErrDuplicate` check around the `h.db.AIUpdate` call
+in each of `chatbot.go`'s `promptChanged` and `promptCleared` branches, and
+around the `h.db.AIUpdate` call inside `dbUpdate` in `db.go`.
 
 ### 3. Existing duplicates (AC: migration/cleanup review)
 
@@ -127,7 +160,18 @@ prohibits AI-run schema/data changes against non-local databases):
 - `aihandler`: `Create` and `Update` unit tests asserting the duplicate-key
   path returns a `cerrors.VoipbinError` with `StatusAlreadyExists` and
   reason `AI_INSIGHT_ALREADY_EXISTS`, using a mock `dbhandler` that returns
-  an error matching `IsErrDuplicate`.
+  an error matching `IsErrDuplicate`. `Update` needs one case per branch
+  that reaches `h.db.AIUpdate`, since each has a separate code path for
+  the translation (see §2):
+  - `promptChanged` with a `type` change to `insight` (duplicate exists).
+  - `promptCleared` with a `type` change to `insight` (duplicate exists)
+    — regression test for the case where clearing the prompt and changing
+    `type` happen in the same request; this is the scenario the original
+    "`promptCleared` cannot change `type`" description would have caused
+    an implementer to skip.
+  - `default` ("prompt unchanged") with a `type` change to `insight`
+    (duplicate exists) — exercises the translation inside `dbUpdate`
+    (`db.go`), not `chatbot.go`.
 
 ## Open items for the ticket's AC
 

--- a/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
+++ b/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
@@ -141,13 +141,19 @@ branch name might suggest. All three branches need the translation:
    type-change-while-clearing-prompt case above).
 3. `default` ("prompt unchanged") — `chatbot.go` does not call
    `h.db.AIUpdate` directly here; it returns `h.dbUpdate(ctx, ...)`, and
-   `dbUpdate` (`pkg/aihandler/db.go`) is the one that calls `h.db.AIUpdate`
-   and returns its error unwrapped. The `IsErrDuplicate` translation for
-   this branch must therefore live inside `dbUpdate` in `db.go`, not in
-   `chatbot.go`. An implementation that only edits `chatbot.go` will leave
-   this branch's duplicate-key errors as raw wrapped SQL errors, missing
-   the AC's rejection guarantee for the most common update path (type
-   unchanged, prompt unchanged).
+   `dbUpdate` (`pkg/aihandler/db.go`) is the one that calls `h.db.AIUpdate`.
+   `dbUpdate` does not return that error unwrapped, though: it wraps it via
+   `errors.Wrapf(err, "could not update ai")` (`pkg/errors`, i.e. github.com
+   /pkg/errors) before returning. That wrapping does not defeat
+   `IsErrDuplicate` — it does a substring match on `err.Error()`, and
+   `pkg/errors` wrapping preserves the original message text in `Error()`
+   — but it does mean the sentinel/type is not preserved as-is, only the
+   message text is. The `IsErrDuplicate` translation for this branch must
+   therefore live inside `dbUpdate` in `db.go`, not in `chatbot.go`. An
+   implementation that only edits `chatbot.go` will leave this branch's
+   duplicate-key errors as raw wrapped SQL errors, missing the AC's
+   rejection guarantee for the most common update path (type unchanged,
+   prompt unchanged).
 
 Concretely: add the `IsErrDuplicate` check around the `h.db.AIUpdate` call
 in each of `chatbot.go`'s `promptChanged` and `promptCleared` branches, and
@@ -176,6 +182,41 @@ prohibits AI-run schema/data changes against non-local databases):
    the migration's `CREATE UNIQUE INDEX` get applied.
 
 ### 4. Testing
+
+**Prerequisite — SQLite test-schema stand-in.** `bin-ai-manager`'s
+`dbhandler` tests (`pkg/dbhandler/main_test.go`) run against an in-memory
+SQLite database (`go-sqlite3`), loading table DDL from
+`scripts/database_scripts_test/*.sql` — they do **not** exercise the
+Alembic/MySQL migration at all. The precedent this design cites needed its
+own SQLite-compatible stand-in for exactly this reason:
+`scripts/database_scripts_test/table_ai_aicalls.sql` defines
+`active_reference_key` using `CASE WHEN` + string concatenation instead of
+MySQL's `IF(...)`, with an inline comment explaining it is a SQLite
+substitute for the real `STORED` generated column. MySQL's `IF(...)` is not
+valid SQLite syntax, so a literal copy of this design's migration DDL into
+a test script would not apply.
+
+Before the dbhandler tests below can pass, `scripts/database_scripts_test/table_ai_ais.sql`
+must be updated with an equivalent SQLite stand-in, e.g.:
+
+```sql
+active_insight_key varchar(255) GENERATED ALWAYS AS (
+  CASE WHEN type = 'insight' AND tm_delete IS NULL
+    THEN customer_id
+    ELSE NULL
+  END
+) STORED,
+```
+
+```sql
+create unique index uq_ai_active_insight_key on ai_ais(active_insight_key);
+```
+
+added alongside the existing `create table ai_ais(...)` block, mirroring
+`table_ai_aicalls.sql`'s pattern (`customer_id` is already `binary(16)`
+here, so — unlike the precedent's hash-based key — no `X'...'` hex-literal
+handling is needed). This file update is in scope for this change, not a
+follow-up; without it the test plan below is unexecutable as described.
 
 - `dbhandler`: table-driven test creating two `type=insight` AIs for the
   same `customer_id` — the first `AICreate` succeeds, the second must

--- a/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
+++ b/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
@@ -1,0 +1,138 @@
+# Insight AI: enforce one per customer (SQUARE-23)
+
+**Date:** 2026-07-29
+**Ticket:** [SQUARE-23](https://voipbin.atlassian.net/browse/SQUARE-23)
+**Service:** `bin-ai-manager`
+
+## Problem
+
+`type=insight` AI records are currently unbounded per customer. square-admin's
+Case detail Insight Assistant panel assumes "one Insight AI per customer" and
+auto-selects a single AI to drive the panel; today it falls back to "most
+recently created" when it finds more than one. That fallback masks operator
+mistakes (accidentally creating a second Insight AI) instead of preventing
+them.
+
+This change adds a database-level constraint so a customer can never have
+more than one non-deleted `type=insight` AI, and returns a clear API error
+when a create or update would violate it.
+
+## Non-goals
+
+- Enforcing any cap on `type=normal` AIs (unaffected by this change).
+- Removing square-admin's existing "most recent wins" fallback — it remains
+  as a defensive read-path safeguard even after this constraint lands.
+- Automating cleanup of pre-existing duplicate customers as part of the
+  schema migration (see "Existing duplicates" below — handled out of band,
+  before the migration runs).
+
+## Design
+
+### 1. Schema: generated column + unique index
+
+MySQL has no partial unique index. Follow the existing precedent in this
+same table family — `ai_aicalls.active_reference_key`
+(`a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py`, VOIP-1234) — which
+solves an equivalent "at most one active X per customer" constraint with a
+`STORED` generated column plus a `UNIQUE INDEX`.
+
+```sql
+ALTER TABLE ai_ais
+ADD COLUMN active_insight_key BINARY(16) GENERATED ALWAYS AS (
+  IF(type = 'insight' AND tm_delete IS NULL, customer_id, NULL)
+) STORED;
+
+CREATE UNIQUE INDEX uq_ai_active_insight_key ON ai_ais(active_insight_key);
+```
+
+Behavior:
+- `type != 'insight'` → column computes `NULL` → any number of rows may
+  share the same `NULL` (MySQL treats `NULL` as distinct in a `UNIQUE`
+  index), so `normal` AIs are entirely unaffected.
+- `type = 'insight'` and `tm_delete IS NULL` (not soft-deleted) → column
+  computes `customer_id` → at most one such row per customer.
+- `type = 'insight'` and soft-deleted (`tm_delete IS NOT NULL`) → `NULL` →
+  a customer may freely create a new Insight AI after deleting the old one.
+
+Migration file: created via `alembic revision` in `bin-dbscheme-manager`
+(never hand-authored — see that service's `CLAUDE.md`), following the
+`_column_exists` / `_index_exists` idempotency-guard pattern already used in
+`a5a40c93d3e6_...` so a partially-applied migration can be safely re-run.
+
+### 2. API-level error handling
+
+Both `aihandler.Create` and `aihandler.Update` (`bin-ai-manager/pkg/aihandler`)
+must translate a duplicate-key failure on `active_insight_key` into a clear
+error, not a raw SQL error. `Update` is in scope too: a `normal → insight`
+type change on an existing AI hits the same constraint and needs the same
+translation.
+
+Reuse the existing `dbhandler.IsErrDuplicate(err)` helper
+(`bin-ai-manager/pkg/dbhandler/main.go`), already used for the same purpose
+in `aicallhandler/start.go` (`startReferenceTypeContactCase`):
+
+```go
+res, err := h.dbCreate(ctx, ...)
+if err != nil {
+    if dbhandler.IsErrDuplicate(err) {
+        return nil, cerrors.AlreadyExists(
+            commonoutline.ServiceNameAIManager,
+            "AI_INSIGHT_ALREADY_EXISTS",
+            "This customer already has an Insight AI. Delete the existing one before creating another.",
+        ).Wrap(err)
+    }
+    return nil, errors.Wrapf(err, "could not create ai")
+}
+```
+
+`cerrors.StatusAlreadyExists` maps to HTTP 409 via the existing
+`HTTPStatusFor` table (`bin-common-handler/models/errors/rpc.go`) — no new
+status code or mapping needed.
+
+The same translation is added at the two duplicate-key-reachable exit
+points in `aihandler.Update` (the `promptChanged` and default/"prompt
+unchanged" branches both call into `h.db.AIUpdate`; `promptCleared` cannot
+change `type`, since clearing the prompt is orthogonal to type, but the
+helper call is added generically so it also covers that branch defensively).
+
+### 3. Existing duplicates (AC: migration/cleanup review)
+
+`CREATE UNIQUE INDEX` fails with a 1062 if any customer already has 2+
+non-deleted Insight AIs at migration time — the exact failure mode already
+hit once in production by the `ai_aicalls` migration this design mirrors.
+Handled as a pre-migration, out-of-band step (not part of the migration
+file, and not raw SQL against production — `bin-dbscheme-manager/CLAUDE.md`
+prohibits AI-run schema/data changes against non-local databases):
+
+1. **Audit (read-only):** run a `SELECT customer_id, COUNT(*) FROM ai_ais
+   WHERE type = 'insight' AND tm_delete IS NULL GROUP BY customer_id HAVING
+   COUNT(*) > 1` against a read replica or via an ops-approved read path,
+   and report the affected customer list.
+2. **Resolution (product decision, human-approved):** default proposal is
+   "keep the most recently created Insight AI per customer" — matching
+   square-admin's existing fallback exactly, so no customer's active
+   assistant changes. Extras are removed via the existing `DELETE /ais/{id}`
+   endpoint (soft delete, goes through `aiHandler.Delete`, cache
+   invalidation included) — not a raw SQL `UPDATE`/`DELETE`.
+3. Only after step 2 confirms zero customers with 2+ active Insight AIs does
+   the migration's `CREATE UNIQUE INDEX` get applied.
+
+### 4. Testing
+
+- `dbhandler`: table-driven test creating two `type=insight` AIs for the
+  same `customer_id` — second `AICreate` must return an error satisfying
+  `IsErrDuplicate`. A third AI after soft-deleting the first two must
+  succeed. A second `type=normal` AI for the same customer must always
+  succeed (regression guard for the non-goal).
+- `aihandler`: `Create` and `Update` unit tests asserting the duplicate-key
+  path returns a `cerrors.VoipbinError` with `StatusAlreadyExists` and
+  reason `AI_INSIGHT_ALREADY_EXISTS`, using a mock `dbhandler` that returns
+  an error matching `IsErrDuplicate`.
+
+## Open items for the ticket's AC
+
+Ticket AC line 2 ("검토") is satisfied by §3 above — audit query defined,
+resolution approach proposed (human-approved before execution, no schema
+change until clear). Actual execution of the audit and any cleanup is
+tracked as a follow-up step before the migration merges, not part of this
+design.

--- a/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
+++ b/docs/plans/2026-07-29-insight-ai-one-per-customer-design.md
@@ -59,6 +59,31 @@ Migration file: created via `alembic revision` in `bin-dbscheme-manager`
 `_column_exists` / `_index_exists` idempotency-guard pattern already used in
 `a5a40c93d3e6_...` so a partially-applied migration can be safely re-run.
 
+**Operational cost (inherited from the precedent, not new):** the cited
+`a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py` migration's own
+history documents that `ADD COLUMN ... STORED` on a populated table forces
+MySQL to rewrite the entire table in place, holding a metadata/table lock
+for the duration; that migration is the exact incident this design mirrors,
+including partial-failure retries against a stale generated-column
+definition (which is why the `_column_exists`/`_index_exists` idempotency
+guards exist at all). This design inherits the same risk class on `ai_ais`.
+Before the migration is applied to any non-local environment:
+- Confirm `ai_ais`'s current row count and expected rewrite duration are
+  acceptable for an in-place `ALTER`; if the table is large enough that the
+  lock duration would be customer-visible, use the same mitigation the
+  precedent's follow-up used (a maintenance window) or an online schema
+  tool (`pt-online-schema-change` / `gh-ost`) instead of a bare `ALTER
+  TABLE`.
+- This decision is an ops call at apply time, not something this design
+  file fixes in advance; it is called out here so it isn't missed the way
+  it was on the precedent.
+
+**Downgrade:** mirrors the precedent 1:1 — `DROP INDEX
+uq_ai_active_insight_key ON ai_ais` followed by `ALTER TABLE ai_ais DROP
+COLUMN active_insight_key`, guarded by the same `_index_exists` /
+`_column_exists` checks used on the way up so the downgrade is also safe to
+re-run against a partially-applied state.
+
 ### 2. API-level error handling
 
 Both `aihandler.Create` and `aihandler.Update` (`bin-ai-manager/pkg/aihandler`)
@@ -153,10 +178,13 @@ prohibits AI-run schema/data changes against non-local databases):
 ### 4. Testing
 
 - `dbhandler`: table-driven test creating two `type=insight` AIs for the
-  same `customer_id` — second `AICreate` must return an error satisfying
-  `IsErrDuplicate`. A third AI after soft-deleting the first two must
-  succeed. A second `type=normal` AI for the same customer must always
-  succeed (regression guard for the non-goal).
+  same `customer_id` — the first `AICreate` succeeds, the second must
+  return an error satisfying `IsErrDuplicate` (no second row is ever
+  persisted, since the unique index rejects it at insert time). A second
+  `AICreate` attempt after soft-deleting the first must then succeed,
+  proving the generated column frees the slot once the original row's
+  `tm_delete` is set. A second `type=normal` AI for the same customer must
+  always succeed (regression guard for the non-goal).
 - `aihandler`: `Create` and `Update` unit tests asserting the duplicate-key
   path returns a `cerrors.VoipbinError` with `StatusAlreadyExists` and
   reason `AI_INSIGHT_ALREADY_EXISTS`, using a mock `dbhandler` that returns

--- a/docs/plans/2026-07-29-insight-ai-one-per-customer-plan.md
+++ b/docs/plans/2026-07-29-insight-ai-one-per-customer-plan.md
@@ -1,0 +1,770 @@
+# Insight AI: enforce one per customer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce "at most one non-deleted `type=insight` AI per customer" at the DB level in `bin-ai-manager`, with a clear 409 API error on violation, per [SQUARE-23](https://voipbin.atlassian.net/browse/SQUARE-23).
+
+**Architecture:** A `STORED` generated column (`active_insight_key`) plus a `UNIQUE INDEX` on `ai_ais`, mirroring the existing `ai_aicalls.active_reference_key` precedent (VOIP-1234). `aihandler.Create`/`Update` translate the resulting duplicate-key DB error into `cerrors.AlreadyExists` (HTTP 409) via the existing `dbhandler.IsErrDuplicate` helper.
+
+**Tech Stack:** Go, MySQL (production) / SQLite (`go-sqlite3`, dbhandler unit tests), Alembic (`bin-dbscheme-manager`), gomock.
+
+**Design doc:** [docs/plans/2026-07-29-insight-ai-one-per-customer-design.md](2026-07-29-insight-ai-one-per-customer-design.md)
+
+---
+
+## Task 1: SQLite test schema + dbhandler regression tests
+
+**Files:**
+- Modify: `bin-ai-manager/scripts/database_scripts_test/table_ai_ais.sql`
+- Modify: `bin-ai-manager/pkg/dbhandler/ai_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the end of `bin-ai-manager/pkg/dbhandler/ai_test.go` (after the existing `Test_AIDelete` function — check the file's last line number first with `tail -5 bin-ai-manager/pkg/dbhandler/ai_test.go` and append after it):
+
+```go
+func Test_AICreate_InsightUniquePerCustomer(t *testing.T) {
+	ctx := context.Background()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().AISet(ctx, gomock.Any()).AnyTimes()
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+
+	customerID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000001")
+
+	// first insight AI for the customer succeeds
+	firstID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000002")
+	t1 := time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t1)
+	first := &ai.AI{
+		Identity: identity.Identity{ID: firstID, CustomerID: customerID},
+		Type:     ai.TypeInsight,
+	}
+	if err := h.AICreate(ctx, first); err != nil {
+		t.Fatalf("first insight AICreate: expected ok, got: %v", err)
+	}
+
+	// second insight AI for the SAME customer must be rejected
+	secondID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000003")
+	t2 := time.Date(2026, 7, 29, 0, 0, 1, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t2)
+	second := &ai.AI{
+		Identity: identity.Identity{ID: secondID, CustomerID: customerID},
+		Type:     ai.TypeInsight,
+	}
+	err := h.AICreate(ctx, second)
+	if err == nil {
+		t.Fatal("second insight AICreate: expected an error, got nil")
+	}
+	if !IsErrDuplicate(err) {
+		t.Errorf("second insight AICreate: expected IsErrDuplicate(err)=true, got err: %v", err)
+	}
+
+	// a normal-type AI for the same customer is NOT affected by the constraint
+	normalID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000004")
+	t3 := time.Date(2026, 7, 29, 0, 0, 2, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t3)
+	normal := &ai.AI{
+		Identity: identity.Identity{ID: normalID, CustomerID: customerID},
+		Type:     ai.TypeNormal,
+	}
+	if err := h.AICreate(ctx, normal); err != nil {
+		t.Errorf("normal-type AICreate for same customer: expected ok, got: %v", err)
+	}
+
+	// soft-delete the first insight AI, freeing the slot
+	t4 := time.Date(2026, 7, 29, 0, 0, 3, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t4)
+	mockCache.EXPECT().AIGet(ctx, firstID).Return(nil, fmt.Errorf(""))
+	mockCache.EXPECT().AISet(ctx, gomock.Any())
+	if err := h.AIDelete(ctx, firstID); err != nil {
+		t.Fatalf("AIDelete(first): expected ok, got: %v", err)
+	}
+
+	// a new insight AI for the same customer now succeeds
+	thirdID := uuid.FromStringOrNil("a1a1a1a1-0000-0000-0000-000000000005")
+	t5 := time.Date(2026, 7, 29, 0, 0, 4, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&t5)
+	third := &ai.AI{
+		Identity: identity.Identity{ID: thirdID, CustomerID: customerID},
+		Type:     ai.TypeInsight,
+	}
+	if err := h.AICreate(ctx, third); err != nil {
+		t.Errorf("insight AICreate after soft-delete: expected ok, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd bin-ai-manager && go test ./pkg/dbhandler/... -run Test_AICreate_InsightUniquePerCustomer -v`
+Expected: FAIL at the `if !IsErrDuplicate(err)` check — `ai_ais` has no uniqueness constraint yet, so the second insight `AICreate` currently succeeds and `err` is `nil` on the "expected an error, got nil" line.
+
+- [ ] **Step 3: Add the SQLite stand-in generated column + unique index**
+
+Edit `bin-ai-manager/scripts/database_scripts_test/table_ai_ais.sql`. Insert the new generated column right before `primary key(id)`, and add the unique index alongside the other `create index` statements at the bottom:
+
+```sql
+create table ai_ais(
+  -- identity
+  id            binary(16),   -- id
+  customer_id   binary(16),   -- customer id
+
+  -- info
+  name        varchar(255),   -- name
+  detail      text,           -- detail description
+
+  engine_type   varchar(255),
+  engine_model  varchar(255),
+  parameter     json,
+  engine_key    varchar(255),
+  rag_id        binary(16),
+
+  init_prompt   text,           -- initial prompt
+
+  tts_type      varchar(255),
+  tts_voice_id  varchar(255),
+
+  stt_type      varchar(255),
+  stt_language  varchar(255),
+
+  vad_config  json,           -- VAD configuration
+
+  smart_turn_enabled  boolean not null default 0,      -- smart turn detection enabled
+
+  auto_aicall_audit_enabled  boolean not null default 0,   -- auto aicall audit enabled
+
+  type  varchar(255) not null default 'normal',   -- ai type: normal, insight
+
+  tool_names  json,           -- enabled tools for this AI
+
+  current_prompt_history_id  binary(16),   -- current prompt history id
+
+  direct_id     binary(16),     -- direct id
+  direct_hash   varchar(255),   -- direct hash
+
+  -- timestamps
+  tm_create datetime(6),  --
+  tm_update datetime(6),  --
+  tm_delete datetime(6),  --
+
+  -- SQLite-compatible stand-in for the MySQL STORED generated column
+  -- active_insight_key (BINARY(16), see bin-dbscheme-manager migration
+  -- for SQUARE-23, mirroring the active_reference_key pattern in
+  -- table_ai_aicalls.sql / a5a40c93d3e6). Computes customer_id only when
+  -- type='insight' and the row is not soft-deleted; NULL otherwise (any
+  -- number of NULLs may coexist under UNIQUE), enforcing "at most one
+  -- active Insight AI per customer" without affecting type='normal' rows.
+  active_insight_key varchar(255) GENERATED ALWAYS AS (
+    CASE WHEN type = 'insight' AND tm_delete IS NULL
+      THEN customer_id
+      ELSE NULL
+    END
+  ) STORED,
+
+  primary key(id)
+);
+
+create index idx_ai_ais_create on ai_ais(tm_create);
+create index idx_ai_ais_customer_id on ai_ais(customer_id);
+create unique index uq_ai_active_insight_key on ai_ais(active_insight_key);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd bin-ai-manager && go test ./pkg/dbhandler/... -run Test_AICreate_InsightUniquePerCustomer -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full dbhandler package tests to check for regressions**
+
+Run: `cd bin-ai-manager && go test ./pkg/dbhandler/... -v`
+Expected: PASS (all existing `ai_ais`-related tests, e.g. `Test_AICreate`, `Test_AIDelete`, still pass — they use `type=""`/default, which computes `NULL` and is unaffected)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd bin-ai-manager
+git add scripts/database_scripts_test/table_ai_ais.sql pkg/dbhandler/ai_test.go
+git commit -m "$(cat <<'EOF'
+SQUARE-23-Insight-AI-one-per-customer
+
+- bin-ai-manager: Add active_insight_key SQLite test-schema stand-in and regression test for one-insight-AI-per-customer
+EOF
+)"
+```
+
+---
+
+## Task 2: Production Alembic migration
+
+**Files:**
+- Create: `bin-dbscheme-manager/bin-manager/main/versions/<generated>_ai_ais_add_active_insight_key_.py`
+
+- [ ] **Step 1: Check the current migration head**
+
+Run: `cd bin-dbscheme-manager/bin-manager && alembic -c alembic.ini heads`
+Expected: exactly one head revision printed (note its ID — `alembic revision` will chain `down_revision` to it automatically).
+
+If `alembic.ini` does not exist yet in this worktree, copy it first: `cp alembic.ini.sample alembic.ini`, then edit `sqlalchemy.url` to point at a local database before running any Alembic command (per `bin-dbscheme-manager/CLAUDE.md`). Do not point it at staging or production.
+
+- [ ] **Step 2: Generate the migration file**
+
+Run: `cd bin-dbscheme-manager/bin-manager && alembic -c alembic.ini revision -m "ai_ais_add_active_insight_key_unique"`
+Expected: a new file appears in `bin-dbscheme-manager/bin-manager/main/versions/`, e.g. `<hash>_ai_ais_add_active_insight_key_unique.py`, with `down_revision` already set to the head from Step 1.
+
+Never hand-author this file's `revision`/`down_revision` IDs — always generate via this command (`bin-dbscheme-manager/CLAUDE.md`).
+
+- [ ] **Step 3: Fill in `upgrade()` / `downgrade()`**
+
+Edit the generated file. Replace its body with (keep the auto-generated `revision`/`down_revision`/`branch_labels`/`depends_on` values at the top exactly as generated — do not edit those):
+
+```python
+"""ai_ais_add_active_insight_key_unique
+
+SQUARE-23: adds active_insight_key to ai_ais as a STORED generated column
+to enforce "at most one active (non-deleted) type=insight AI per
+customer" at the DB level, mirroring the ai_aicalls.active_reference_key
+pattern (a5a40c93d3e6_ai_aicalls_add_active_reference_key_.py, VOIP-1234).
+
+active_insight_key carries customer_id only when type='insight' AND
+tm_delete IS NULL; all other rows (type='normal', or soft-deleted
+type='insight' rows) compute NULL, which MySQL treats as distinct under
+UNIQUE, so any number of such rows may coexist while at most one
+genuinely-active Insight AI may exist per customer.
+
+Before applying this migration to any non-local environment: confirm no
+customer currently has 2+ non-deleted type='insight' AIs (see SQUARE-23
+design doc §3 for the audit query and cleanup approach — extras must be
+removed via the existing DELETE /ais/{id} API, not raw SQL, before this
+migration's CREATE UNIQUE INDEX can succeed), and confirm ai_ais's row
+count / the expected ALTER TABLE ... ADD COLUMN ... STORED rewrite
+duration are acceptable for an in-place lock, per the precedent's
+documented incident (see design doc §1 "Operational cost").
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '<KEEP THE AUTO-GENERATED VALUE>'
+down_revision = '<KEEP THE AUTO-GENERATED VALUE>'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table, column):
+    result = conn.execute(sa.text(
+        "SELECT COUNT(*) FROM information_schema.columns "
+        "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :col"
+    ), {'table': table, 'col': column})
+    return result.scalar() > 0
+
+
+def _index_exists(conn, table, index):
+    result = conn.execute(sa.text(
+        "SELECT COUNT(*) FROM information_schema.statistics "
+        "WHERE table_schema = DATABASE() AND table_name = :table AND index_name = :idx"
+    ), {'table': table, 'idx': index})
+    return result.scalar() > 0
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not _column_exists(conn, 'ai_ais', 'active_insight_key'):
+        op.execute("""
+            ALTER TABLE ai_ais
+            ADD COLUMN active_insight_key BINARY(16) GENERATED ALWAYS AS (
+                IF(type = 'insight' AND tm_delete IS NULL, customer_id, NULL)
+            ) STORED
+        """)
+
+    if not _index_exists(conn, 'ai_ais', 'uq_ai_active_insight_key'):
+        op.execute("""
+            CREATE UNIQUE INDEX uq_ai_active_insight_key
+            ON ai_ais(active_insight_key)
+        """)
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if _index_exists(conn, 'ai_ais', 'uq_ai_active_insight_key'):
+        op.execute("""
+            DROP INDEX uq_ai_active_insight_key ON ai_ais
+        """)
+
+    if _column_exists(conn, 'ai_ais', 'active_insight_key'):
+        op.execute("""
+            ALTER TABLE ai_ais
+            DROP COLUMN active_insight_key
+        """)
+```
+
+Keep the `revision`/`down_revision` values exactly as `alembic revision` generated them in Step 2 — do not paste over them with the placeholder text shown above.
+
+- [ ] **Step 4: Verify exactly one head remains**
+
+Run: `cd bin-dbscheme-manager/bin-manager && alembic -c alembic.ini heads`
+Expected: exactly one head — the newly created revision.
+
+Do **not** run `alembic upgrade` or `alembic downgrade` against anything but a local throwaway database (per `bin-dbscheme-manager/CLAUDE.md`). Applying this migration to staging/production is a separate, human-authorized step outside this plan.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd bin-dbscheme-manager
+git add bin-manager/main/versions/*ai_ais_add_active_insight_key_unique.py
+git commit -m "$(cat <<'EOF'
+SQUARE-23-Insight-AI-one-per-customer
+
+- bin-dbscheme-manager: Add ai_ais.active_insight_key migration enforcing one active Insight AI per customer
+EOF
+)"
+```
+
+---
+
+## Task 3: `aihandler.Create` — translate duplicate-key error
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/aihandler/chatbot.go:1-18` (imports), `:74-79` (error check)
+- Test: `bin-ai-manager/pkg/aihandler/chatbot_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `bin-ai-manager/pkg/aihandler/chatbot_test.go`, near `TestCreate_AllowsValidInsightAI` (around line 1088 — append after that function, before `TestUpdate_RejectsInsightAIWithNormalTools`):
+
+```go
+// assertAlreadyExists fails the test unless err is a *cerrors.VoipbinError
+// with Status == cerrors.StatusAlreadyExists and the given Reason, per
+// SQUARE-23's design (a duplicate-key failure on ai_ais.active_insight_key
+// must be translated to a 409 ALREADY_EXISTS, not a raw SQL error).
+func assertAlreadyExists(t *testing.T, err error, wantReason string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	var ve *cerrors.VoipbinError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected a *cerrors.VoipbinError, got: %v (%T)", err, err)
+	}
+	if ve.Status != cerrors.StatusAlreadyExists {
+		t.Errorf("expected Status=%v, got %v (err: %v)", cerrors.StatusAlreadyExists, ve.Status, err)
+	}
+	if ve.Reason != wantReason {
+		t.Errorf("expected Reason=%v, got %v (err: %v)", wantReason, ve.Reason, err)
+	}
+}
+
+// SQUARE-23: Create must translate a duplicate-key failure on
+// ai_ais.active_insight_key into cerrors.AlreadyExists (HTTP 409), not a
+// raw wrapped SQL error.
+func TestCreate_RejectsDuplicateInsightAI(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(ctrl)
+	mockReq := requesthandler.NewMockRequestHandler(ctrl)
+	mockNotify := notifyhandler.NewMockNotifyHandler(ctrl)
+
+	mockReq.EXPECT().DirectV1DirectCreate(gomock.Any(), gomock.Any(), dmdirect.ResourceTypeAI, gomock.Any()).
+		Return(&dmdirect.Direct{Hash: "a1b2c3d4e5f6"}, nil).Times(1)
+	mockDB.EXPECT().AICreate(gomock.Any(), gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+	mockReq.EXPECT().DirectV1DirectDelete(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   utilhandler.NewUtilHandler(),
+	}
+
+	_, err := h.Create(
+		context.Background(),
+		uuid.Must(uuid.NewV4()),
+		"Insight AI",
+		"",
+		ai.TypeInsight,
+		ai.EngineModelOpenaiGPT5,
+		nil,
+		"test-key",
+		uuid.Nil,
+		"",
+		ai.TTSTypeNone,
+		"",
+		ai.STTTypeNone,
+		"",
+		[]tool.ToolName{},
+		nil,
+		false,
+		false,
+	)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestCreate_RejectsDuplicateInsightAI -v`
+Expected: FAIL — `Create` currently returns a plain wrapped error ("could not create ai: ..."), not a `*cerrors.VoipbinError`, so `errors.As(err, &ve)` fails the test at "expected a `*cerrors.VoipbinError`".
+
+- [ ] **Step 3: Add the `dbhandler` import**
+
+In `bin-ai-manager/pkg/aihandler/chatbot.go`, update the import block (currently lines 1-18):
+
+```go
+package aihandler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-ai-manager/models/ai"
+	"monorepo/bin-ai-manager/models/aiprompthistory"
+	"monorepo/bin-ai-manager/models/tool"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	"monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+)
+```
+
+- [ ] **Step 4: Translate the duplicate-key error in `Create`**
+
+In the same file, replace the `h.dbCreate` error check (currently lines 74-79):
+
+```go
+	res, err := h.dbCreate(ctx, customerID, name, detail, aiType, engineModel, parameter, engineKey, ragID,
+		initPrompt, ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled,
+		autoAICallAuditEnabled, currentPromptHistoryID)
+	if err != nil {
+		if dbhandler.IsErrDuplicate(err) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameAIManager,
+				"AI_INSIGHT_ALREADY_EXISTS",
+				"This customer already has an active Insight AI. Delete it before creating another.",
+			).Wrap(err)
+		}
+		return nil, errors.Wrapf(err, "could not create ai")
+	}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestCreate_RejectsDuplicateInsightAI -v`
+Expected: PASS
+
+- [ ] **Step 6: Run the full aihandler package tests to check for regressions**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -v`
+Expected: PASS (in particular `TestCreate`'s `"handles_database_error"` case, which returns a generic non-duplicate error and must still hit the `errors.Wrapf(err, "could not create ai")` fallback, not the new branch)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd bin-ai-manager
+git add pkg/aihandler/chatbot.go pkg/aihandler/chatbot_test.go
+git commit -m "$(cat <<'EOF'
+SQUARE-23-Insight-AI-one-per-customer
+
+- bin-ai-manager: Translate ai_ais duplicate-key error into AI_INSIGHT_ALREADY_EXISTS (409) in Create
+EOF
+)"
+```
+
+---
+
+## Task 4: `aihandler.Update` — translate duplicate-key error in all three branches
+
+**Files:**
+- Modify: `bin-ai-manager/pkg/aihandler/chatbot.go:162-201` (`promptChanged`, `promptCleared` branches)
+- Modify: `bin-ai-manager/pkg/aihandler/db.go:1-21` (imports — none needed, `dbhandler`/`cerrors`/`commonoutline` already imported), `:193-198` (`dbUpdate`)
+- Test: `bin-ai-manager/pkg/aihandler/chatbot_test.go`
+
+This task has three sub-parts, one per branch identified in the design doc §2. Do them in order; each is independently testable.
+
+### 4a. `promptChanged` branch (`chatbot.go`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `bin-ai-manager/pkg/aihandler/chatbot_test.go`, after `TestCreate_RejectsDuplicateInsightAI` (added in Task 3):
+
+```go
+// SQUARE-23: Update's promptChanged branch (chatbot.go) must translate a
+// duplicate-key failure the same way Create does.
+func TestUpdate_promptChanged_RejectsDuplicateInsightAI(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	aiID := uuid.Must(uuid.NewV4())
+	existing := &ai.AI{Type: ai.TypeNormal, InitPrompt: "old prompt"}
+	existing.ID = aiID
+	existing.CustomerID = uuid.Must(uuid.NewV4())
+
+	mockUtil.EXPECT().UUIDCreate().Return(uuid.Must(uuid.NewV4())).Times(1)
+	mockDB.EXPECT().AIGet(gomock.Any(), aiID).Return(existing, nil).Times(1) // pre-fetch
+	mockDB.EXPECT().AIUpdate(gomock.Any(), aiID, gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+	_, err := h.Update(context.Background(), aiID, "name", "", ai.TypeInsight, ai.EngineModelOpenaiGPT5, nil, "", uuid.Nil,
+		"new prompt", ai.TTSTypeNone, "", ai.STTTypeNone, "", nil, nil, false, false)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestUpdate_promptChanged_RejectsDuplicateInsightAI -v`
+Expected: FAIL — same reason as Task 3 Step 2 (plain wrapped error, not `*cerrors.VoipbinError`).
+
+- [ ] **Step 3: Translate the duplicate-key error in the `promptChanged` branch**
+
+In `bin-ai-manager/pkg/aihandler/chatbot.go`, inside `Update`'s `switch`, replace the `promptChanged` case's `h.db.AIUpdate` check (currently around lines 163-170):
+
+```go
+	case promptChanged:
+		historyID := h.utilHandler.UUIDCreate()
+		fields := h.buildUpdateFields(name, detail, aiType, engineModel, parameter, engineKey, ragID, initPrompt,
+			ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
+		fields[ai.FieldCurrentPromptHistoryID] = historyID
+		if err := h.db.AIUpdate(ctx, id, fields); err != nil {
+			if dbhandler.IsErrDuplicate(err) {
+				return nil, cerrors.AlreadyExists(
+					commonoutline.ServiceNameAIManager,
+					"AI_INSIGHT_ALREADY_EXISTS",
+					"This customer already has an active Insight AI. Delete it before creating another.",
+				).Wrap(err)
+			}
+			return nil, errors.Wrapf(err, "could not update ai")
+		}
+```
+
+(The rest of the `promptChanged` case — fetching the updated AI, publishing the webhook event, recording prompt history — is unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestUpdate_promptChanged_RejectsDuplicateInsightAI -v`
+Expected: PASS
+
+### 4b. `promptCleared` branch (`chatbot.go`)
+
+- [ ] **Step 5: Write the failing test**
+
+Add to `chatbot_test.go`, after the test from 4a:
+
+```go
+// SQUARE-23: Update's promptCleared branch must also translate a
+// duplicate-key failure — clearing the prompt and changing type to
+// insight in the same request is a valid combination (see design doc §2).
+func TestUpdate_promptCleared_RejectsDuplicateInsightAI(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	aiID := uuid.Must(uuid.NewV4())
+	existing := &ai.AI{Type: ai.TypeNormal, InitPrompt: "old prompt"}
+	existing.ID = aiID
+	existing.CustomerID = uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().AIGet(gomock.Any(), aiID).Return(existing, nil).Times(1) // pre-fetch
+	mockDB.EXPECT().AIUpdate(gomock.Any(), aiID, gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+	// initPrompt == "" clears the prompt; type changes to insight in the same call
+	_, err := h.Update(context.Background(), aiID, "name", "", ai.TypeInsight, ai.EngineModelOpenaiGPT5, nil, "", uuid.Nil,
+		"", ai.TTSTypeNone, "", ai.STTTypeNone, "", nil, nil, false, false)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestUpdate_promptCleared_RejectsDuplicateInsightAI -v`
+Expected: FAIL, same reason as Step 2.
+
+- [ ] **Step 7: Translate the duplicate-key error in the `promptCleared` branch**
+
+In `chatbot.go`, replace the `promptCleared` case's `h.db.AIUpdate` check (currently around lines 189-194):
+
+```go
+	case promptCleared:
+		fields := h.buildUpdateFields(name, detail, aiType, engineModel, parameter, engineKey, ragID, "",
+			ttsType, ttsVoiceID, sttType, sttLanguage, toolNames, vadConfig, smartTurnEnabled, autoAICallAuditEnabled)
+		fields[ai.FieldCurrentPromptHistoryID] = uuid.Nil
+		if err := h.db.AIUpdate(ctx, id, fields); err != nil {
+			if dbhandler.IsErrDuplicate(err) {
+				return nil, cerrors.AlreadyExists(
+					commonoutline.ServiceNameAIManager,
+					"AI_INSIGHT_ALREADY_EXISTS",
+					"This customer already has an active Insight AI. Delete it before creating another.",
+				).Wrap(err)
+			}
+			return nil, errors.Wrapf(err, "could not update ai (clear prompt)")
+		}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestUpdate_promptCleared_RejectsDuplicateInsightAI -v`
+Expected: PASS
+
+### 4c. `default` branch (`dbUpdate` in `db.go`)
+
+- [ ] **Step 9: Write the failing test**
+
+Add to `chatbot_test.go`, after the test from 4b:
+
+```go
+// SQUARE-23: Update's default ("prompt unchanged") branch routes through
+// dbUpdate() in db.go, a different file than the other two branches — the
+// translation must live there too (design doc §2, point 3).
+func TestUpdate_promptUnchanged_RejectsDuplicateInsightAI(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	aiID := uuid.Must(uuid.NewV4())
+	same := "same prompt"
+	existing := &ai.AI{Type: ai.TypeNormal, InitPrompt: same}
+	existing.ID = aiID
+	existing.CustomerID = uuid.Must(uuid.NewV4())
+
+	mockDB.EXPECT().AIGet(gomock.Any(), aiID).Return(existing, nil).Times(1) // pre-fetch
+	mockDB.EXPECT().AIUpdate(gomock.Any(), aiID, gomock.Any()).
+		Return(fmt.Errorf("Error 1062: Duplicate entry 'x' for key 'uq_ai_active_insight_key'")).Times(1)
+
+	h := &aiHandler{
+		db:            mockDB,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		utilHandler:   mockUtil,
+	}
+	_, err := h.Update(context.Background(), aiID, "name", "", ai.TypeInsight, ai.EngineModelOpenaiGPT5, nil, "", uuid.Nil,
+		same, ai.TTSTypeNone, "", ai.STTTypeNone, "", nil, nil, false, false)
+
+	assertAlreadyExists(t, err, "AI_INSIGHT_ALREADY_EXISTS")
+}
+```
+
+- [ ] **Step 10: Run test to verify it fails**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestUpdate_promptUnchanged_RejectsDuplicateInsightAI -v`
+Expected: FAIL, same reason as Step 2.
+
+- [ ] **Step 11: Translate the duplicate-key error inside `dbUpdate` (`db.go`)**
+
+In `bin-ai-manager/pkg/aihandler/db.go`, replace the `h.db.AIUpdate` check inside `dbUpdate` (currently lines 196-198; `cerrors`, `commonoutline`, and `dbhandler` are already imported in this file — no import changes needed):
+
+```go
+	if err := h.db.AIUpdate(ctx, id, fields); err != nil {
+		if dbhandler.IsErrDuplicate(err) {
+			return nil, cerrors.AlreadyExists(
+				commonoutline.ServiceNameAIManager,
+				"AI_INSIGHT_ALREADY_EXISTS",
+				"This customer already has an active Insight AI. Delete it before creating another.",
+			).Wrap(err)
+		}
+		return nil, errors.Wrapf(err, "could not update ai")
+	}
+```
+
+- [ ] **Step 12: Run test to verify it passes**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -run TestUpdate_promptUnchanged_RejectsDuplicateInsightAI -v`
+Expected: PASS
+
+- [ ] **Step 13: Run the full aihandler package tests to check for regressions**
+
+Run: `cd bin-ai-manager && go test ./pkg/aihandler/... -v`
+Expected: PASS — in particular the pre-existing `TestUpdate_promptChangedCreatesHistoryAndSetsID`, `TestUpdate_promptClearedResetsID`, and `TestUpdate_promptUnchangedDoesNotCreateHistory` (Task 4's new duplicate-key branches must not affect the non-error path those tests cover).
+
+- [ ] **Step 14: Commit**
+
+```bash
+cd bin-ai-manager
+git add pkg/aihandler/chatbot.go pkg/aihandler/db.go pkg/aihandler/chatbot_test.go
+git commit -m "$(cat <<'EOF'
+SQUARE-23-Insight-AI-one-per-customer
+
+- bin-ai-manager: Translate ai_ais duplicate-key error into AI_INSIGHT_ALREADY_EXISTS (409) in all three Update branches
+EOF
+)"
+```
+
+---
+
+## Task 5: Full verification workflow
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the mandatory `bin-ai-manager` verification workflow**
+
+Run:
+```bash
+cd bin-ai-manager
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test ./... && \
+golangci-lint run -v --timeout 5m
+```
+Expected: all five steps succeed with no errors. `go mod tidy`/`go mod vendor` should produce no diff (no new dependencies were added — this change only uses existing stdlib/`pkg/errors`/`cerrors`/`dbhandler` symbols).
+
+If `go mod tidy` or `go mod vendor` change `go.mod`/`go.sum`, commit those alongside (per root `CLAUDE.md`'s verification rule) — do not skip.
+
+- [ ] **Step 2: Confirm no unintended changes outside `bin-ai-manager` / `bin-dbscheme-manager`**
+
+Run: `git status --short` from the worktree root (`~/gitvoipbin/monorepo/.worktrees/SQUARE-23-Insight-AI-one-per-customer`)
+Expected: clean (everything already committed in Tasks 1-4), or only `vendor/`-adjacent files that are gitignored.
+
+- [ ] **Step 3: Re-confirm the ticket's AC against the finished state**
+
+- [ ] A customer with an existing `type=insight` AI gets a clear 409 `AI_INSIGHT_ALREADY_EXISTS` error creating (Task 3) or updating-into (Task 4) a second one — verified by `TestCreate_RejectsDuplicateInsightAI`, `TestUpdate_promptChanged_RejectsDuplicateInsightAI`, `TestUpdate_promptCleared_RejectsDuplicateInsightAI`, `TestUpdate_promptUnchanged_RejectsDuplicateInsightAI`, and the DB-level `Test_AICreate_InsightUniquePerCustomer`.
+- [ ] Migration/cleanup for pre-existing duplicate customers is reviewed — Task 2's migration docstring plus design doc §3 (audit query + human-approved cleanup via the existing `DELETE /ais/{id}` API, executed before this migration is applied to any shared environment — tracked as a follow-up outside this plan, per `bin-dbscheme-manager/CLAUDE.md`'s prohibition on AI-run schema/data changes against non-local databases).
+- [ ] `type=normal` AIs are unaffected — verified by `Test_AICreate_InsightUniquePerCustomer`'s normal-type sub-case and the untouched pre-existing `Test_AICreate`/aihandler test suite.
+
+No further code changes needed for this step — it's a checklist confirmation, not new work.

--- a/docs/plans/2026-07-29-insight-ai-one-per-customer-plan.md
+++ b/docs/plans/2026-07-29-insight-ai-one-per-customer-plan.md
@@ -81,11 +81,17 @@ func Test_AICreate_InsightUniquePerCustomer(t *testing.T) {
 		t.Errorf("normal-type AICreate for same customer: expected ok, got: %v", err)
 	}
 
-	// soft-delete the first insight AI, freeing the slot
+	// soft-delete the first insight AI, freeing the slot.
+	// AIDelete's real cache interaction is TimeNow + aiUpdateToCache (which
+	// reads back via a DB query, not cache.AIGet, then calls cache.AISet) —
+	// see bin-ai-manager/pkg/dbhandler/ai.go:128-151 and the aiUpdateToCache
+	// helper at ai.go:87-98. The AISet call is already covered by the
+	// mockCache.EXPECT().AISet(ctx, gomock.Any()).AnyTimes() set up above;
+	// AIDelete never calls cache.AIGet, so no such expectation is set here
+	// (unlike the separate, subsequent h.AIGet call in the Test_AIDelete
+	// precedent at ai_test.go:186-192, which does call cache.AIGet).
 	t4 := time.Date(2026, 7, 29, 0, 0, 3, 0, time.UTC)
 	mockUtil.EXPECT().TimeNow().Return(&t4)
-	mockCache.EXPECT().AIGet(ctx, firstID).Return(nil, fmt.Errorf(""))
-	mockCache.EXPECT().AISet(ctx, gomock.Any())
 	if err := h.AIDelete(ctx, firstID); err != nil {
 		t.Fatalf("AIDelete(first): expected ok, got: %v", err)
 	}
@@ -225,7 +231,7 @@ Never hand-author this file's `revision`/`down_revision` IDs — always generate
 
 - [ ] **Step 3: Fill in `upgrade()` / `downgrade()`**
 
-Edit the generated file. Replace its body with (keep the auto-generated `revision`/`down_revision`/`branch_labels`/`depends_on` values at the top exactly as generated — do not edit those):
+Edit the generated file. **Do not touch the `revision`/`down_revision`/`branch_labels`/`depends_on` block that `alembic revision` already wrote at the top of the file — leave those four lines exactly as generated.** Replace everything else (the docstring and the `upgrade()`/`downgrade()` bodies) with the content below. The `revision = ...` / `down_revision = ...` lines shown in this snippet are illustrative only, marking where that existing block sits in the file — do not copy them over the real generated values:
 
 ```python
 """ai_ais_add_active_insight_key_unique
@@ -254,11 +260,12 @@ from alembic import op
 import sqlalchemy as sa
 
 
-# revision identifiers, used by Alembic.
-revision = '<KEEP THE AUTO-GENERATED VALUE>'
-down_revision = '<KEEP THE AUTO-GENERATED VALUE>'
-branch_labels = None
-depends_on = None
+# --- revision identifiers, used by Alembic. -------------------------------
+# DO NOT COPY/PASTE this block. `alembic revision` (Step 2) already wrote the
+# real `revision`, `down_revision`, `branch_labels`, and `depends_on` values
+# at the top of the generated file — leave those four lines untouched and
+# skip straight to the `def _column_exists(...)` line below when editing.
+# ---------------------------------------------------------------------------
 
 
 def _column_exists(conn, table, column):
@@ -310,7 +317,7 @@ def downgrade():
         """)
 ```
 
-Keep the `revision`/`down_revision` values exactly as `alembic revision` generated them in Step 2 — do not paste over them with the placeholder text shown above.
+Reminder: the `revision`/`down_revision`/`branch_labels`/`depends_on` block is not part of the snippet above — it must stay exactly as `alembic revision` generated it in Step 2.
 
 - [ ] **Step 4: Verify exactly one head remains**
 


### PR DESCRIPTION
Enforces at most one active (non-deleted) type=insight AI per customer at the DB level, with a clear 409 API error on violation, per SQUARE-23. A generated column plus unique index on ai_ais mirrors the existing ai_aicalls.active_reference_key precedent (VOIP-1234); aihandler translates the resulting duplicate-key error into cerrors.AlreadyExists across every reachable Create/Update path.

- bin-ai-manager: Add active_insight_key SQLite test-schema stand-in and regression test for one-insight-AI-per-customer
- bin-ai-manager: Translate ai_ais duplicate-key error into AI_INSIGHT_ALREADY_EXISTS (409) in Create
- bin-ai-manager: Translate ai_ais duplicate-key error into AI_INSIGHT_ALREADY_EXISTS (409) in all three Update branches
- bin-ai-manager: Extract shared aiInsightDuplicateErr helper for AI_INSIGHT_ALREADY_EXISTS translation, eliminating 4-way duplication
- bin-dbscheme-manager: Add ai_ais.active_insight_key migration enforcing one active Insight AI per customer

Migration is not applied to any shared environment by this PR. Before it is applied, customers with 2+ existing active Insight AIs must be identified via a read-only audit query and resolved (default proposal: keep the most recently created, matching square-admin's existing fallback) via the existing DELETE /ais/{id} API — see docs/plans/2026-07-29-insight-ai-one-per-customer-design.md section 3 for the full audit/cleanup approach.