### PR TITLE
NOJIRA-Insight-tool-expansion-design

### DIFF
--- a/bin-ai-manager/models/ai/allowed_tools_test.go
+++ b/bin-ai-manager/models/ai/allowed_tools_test.go
@@ -1,0 +1,106 @@
+package ai
+
+import (
+	"testing"
+
+	"monorepo/bin-ai-manager/models/tool"
+)
+
+func TestAllowedToolNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		aiType Type
+
+		wantAllowed    []tool.ToolName
+		wantDisallowed []tool.ToolName
+	}{
+		{
+			name:           "normal_allows_normal_tools_only",
+			aiType:         TypeNormal,
+			wantAllowed:    tool.AllToolNames,
+			wantDisallowed: tool.AllInsightToolNames,
+		},
+		{
+			name:           "insight_allows_insight_tools_only",
+			aiType:         TypeInsight,
+			wantAllowed:    tool.AllInsightToolNames,
+			wantDisallowed: tool.AllToolNames,
+		},
+		{
+			name:           "unknown_type_denies_everything",
+			aiType:         Type("some_future_type"),
+			wantDisallowed: append(append([]tool.ToolName{}, tool.AllToolNames...), tool.AllInsightToolNames...),
+		},
+		{
+			name:           "type_none_denies_everything",
+			aiType:         TypeNone,
+			wantDisallowed: append(append([]tool.ToolName{}, tool.AllToolNames...), tool.AllInsightToolNames...),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed := AllowedToolNames(tt.aiType)
+
+			for _, n := range tt.wantAllowed {
+				if !allowed[n] {
+					t.Errorf("AllowedToolNames(%v)[%v] = false, want true", tt.aiType, n)
+				}
+			}
+			for _, n := range tt.wantDisallowed {
+				if allowed[n] {
+					t.Errorf("AllowedToolNames(%v)[%v] = true, want false", tt.aiType, n)
+				}
+			}
+
+			// "all" is a selector, never itself a member of the whitelist.
+			if allowed[tool.ToolNameAll] {
+				t.Errorf("AllowedToolNames(%v)[ToolNameAll] = true, want false (all is a selector, not a concrete tool name)", tt.aiType)
+			}
+		})
+	}
+}
+
+// TestAllInsightToolNamesAreReadOnly is the recommended (design §2.6) cheap
+// regression guard: every entry in tool.AllInsightToolNames must be a
+// read-only tool, since the "all" selector automatically grants any future
+// addition to every Insight AI already storing tool_names=["all"], with no
+// re-consent step. This is a hardcoded allowlist of known-read-only names
+// (not a structural Tool metadata flag -- deferred per design §2.6/non-goals)
+// so adding a write-capable tool to AllInsightToolNames without updating
+// this test fails loudly here rather than silently shipping.
+func TestAllInsightToolNamesAreReadOnly(t *testing.T) {
+	knownReadOnly := map[tool.ToolName]bool{
+		tool.ToolNameGetContactInteractions: true,
+		tool.ToolNameGetConversationContent: true,
+		tool.ToolNameGetRelatedCases:        true,
+		tool.ToolNameGetCaseNotes:           true,
+	}
+
+	for _, n := range tool.AllInsightToolNames {
+		if !knownReadOnly[n] {
+			t.Errorf("tool.AllInsightToolNames contains %q, which is not in this test's known-read-only allowlist -- "+
+				"verify it has no side effects, then add it to knownReadOnly in this test", n)
+		}
+	}
+}
+
+// TestValidateToolNames_WriteToolNeverAllowedForInsight guards against a
+// write-capable Normal-only tool ever being smuggled into
+// tool.AllInsightToolNames: every tool.AllToolNames entry that is NOT also
+// in tool.AllInsightToolNames must be rejected for TypeInsight.
+func TestValidateToolNames_WriteToolNeverAllowedForInsight(t *testing.T) {
+	insightAllowed := toSet(tool.AllInsightToolNames)
+
+	for _, writeTool := range tool.AllToolNames {
+		if insightAllowed[writeTool] {
+			continue
+		}
+		t.Run(string(writeTool), func(t *testing.T) {
+			if err := ValidateToolNames(TypeInsight, []tool.ToolName{writeTool}); err == nil {
+				t.Errorf("ValidateToolNames(TypeInsight, [%q]) = nil error, want rejection -- "+
+					"write-capable tool must never be allowed for Insight AI", writeTool)
+			}
+		})
+	}
+}

--- a/bin-ai-manager/models/ai/metrics.go
+++ b/bin-ai-manager/models/ai/metrics.go
@@ -1,0 +1,30 @@
+package ai
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// metricsNamespace matches the namespace used by pkg/aicallhandler's
+// Prometheus metrics (ai_manager_*) so this counter surfaces alongside the
+// rest of the service's metrics.
+const metricsNamespace = "ai_manager"
+
+// UnknownAITypeToolDenialTotal counts AllowedToolNames calls that hit the
+// deny-by-default branch (an AI Type that is neither TypeNormal nor
+// TypeInsight). This should never fire in production -- Create/Update
+// resolve TypeNone to TypeNormal before persisting (see pkg/aihandler/
+// chatbot.go), so every persisted AI record already has a known Type. A
+// non-zero count means either a new Type was added without updating
+// AllowedToolNames, or a record reached this path with a corrupted/unknown
+// Type value -- either way, tool access was correctly denied rather than
+// silently falling back to the widest (Normal, write-capable) set. See
+// docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md §2.2.
+var UnknownAITypeToolDenialTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Name:      "unknown_ai_type_tool_denial_total",
+		Help:      "Counter of AllowedToolNames resolutions that denied all tools due to an unknown/unhandled AI Type.",
+	},
+)
+
+func init() {
+	prometheus.MustRegister(UnknownAITypeToolDenialTotal)
+}

--- a/bin-ai-manager/models/ai/tool_validation.go
+++ b/bin-ai-manager/models/ai/tool_validation.go
@@ -2,60 +2,87 @@ package ai
 
 import (
 	"fmt"
-	"strings"
 
 	"monorepo/bin-ai-manager/models/tool"
+
+	"github.com/sirupsen/logrus"
 )
+
+// toSet converts a slice of tool names into a lookup set.
+func toSet(names []tool.ToolName) map[tool.ToolName]bool {
+	set := make(map[tool.ToolName]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return set
+}
+
+// AllowedToolNames returns the tool whitelist for a given AI type -- the
+// single source of truth consumed by both ValidateToolNames (save-time
+// validation, this package) and bin-pipecat-manager's runtime tool
+// expansion (GetByNames). Unknown/future types deny-by-default (empty set)
+// rather than falling back to the widest (Normal, write-capable) set.
+//
+// tool.ToolNameAll ("all") is a SELECTOR, not a concrete tool name --
+// tool.AllToolNames / tool.AllInsightToolNames correctly do not contain it.
+// AllowedToolNames only ever answers "is this concrete tool name allowed
+// for type t"; it is never asked whether "all" itself is a member.
+//
+// See docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md
+// §2.2 for the full rationale, including why this is keyed on the Type enum
+// (in models/ai) rather than a bool in models/tool: a bool collapses any
+// future third AIType into "Normal" (the write-capable set) by
+// construction, which is the opposite of deny-by-default.
+func AllowedToolNames(t Type) map[tool.ToolName]bool {
+	switch t {
+	case TypeNormal:
+		return toSet(tool.AllToolNames)
+	case TypeInsight:
+		return toSet(tool.AllInsightToolNames)
+	default:
+		logrus.WithField("ai_type", t).Warnf("unknown AI type encountered in tool whitelist resolution, denying all tools")
+		UnknownAITypeToolDenialTotal.Inc()
+		return map[tool.ToolName]bool{}
+	}
+}
 
 // ValidateToolNames returns an error if any name in toolNames is not
 // permitted for the given (already-resolved) Type. See
 // docs/plans/2026-07-14-insight-ai-tool-name-validation-design.md for the
-// full rationale (VOIP-1257).
+// original rationale (VOIP-1257) and
+// docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md §2.2
+// for the AllowedToolNames-based refactor that also grants Insight AI the
+// ability to store tool_names=["all"].
 //
 // Rules:
-//   - Type = TypeInsight: every name must be a member of
-//     tool.AllInsightToolNames. tool.ToolNameAll is rejected (it currently
-//     means "all Normal tools", which has no sensible meaning for an
-//     Insight AI).
-//   - Type = TypeNormal (or resolved default): every name must be a member
-//     of tool.AllToolNames, or be tool.ToolNameAll.
-//   - Any name that is neither a known AllToolNames member, a known
-//     AllInsightToolNames member, nor ToolNameAll is rejected regardless of
-//     Type (closes a pre-existing "unknown tool name silently accepted"
-//     gap).
+//   - tool.ToolNameAll is always structurally valid input, for either Type --
+//     it is a selector expanded at runtime by bin-pipecat-manager's
+//     GetByNames against AllowedToolNames(t), never a concrete tool name
+//     checked for set membership here.
+//   - Every other name must be a member of AllowedToolNames(t) for the
+//     given Type. A name that is neither a known tool for this Type nor
+//     ToolNameAll is rejected (closes a pre-existing "unknown tool name
+//     silently accepted" gap).
 //   - nil/empty toolNames is always valid for either Type.
 //
 // The whole toolNames slice is checked (not short-circuited on the first
 // valid or invalid element), so a mixed list such as
-// ["all", "get_contact_interactions"] for an Insight AI is rejected because
-// "all" alone is invalid for Insight, and ["all", "bogus_tool"] for a
-// Normal AI is rejected because "bogus_tool" is invalid even though "all"
-// is valid.
+// ["all", "bogus_tool"] is rejected because "bogus_tool" is invalid even
+// though "all" is valid.
 func ValidateToolNames(t Type, toolNames []tool.ToolName) error {
 	if len(toolNames) == 0 {
 		return nil
 	}
 
-	allowedNormal := make(map[tool.ToolName]bool, len(tool.AllToolNames))
-	for _, n := range tool.AllToolNames {
-		allowedNormal[n] = true
-	}
-	allowedInsight := make(map[tool.ToolName]bool, len(tool.AllInsightToolNames))
-	for _, n := range tool.AllInsightToolNames {
-		allowedInsight[n] = true
-	}
+	allowed := AllowedToolNames(t)
 
-	var invalid []string
+	var invalid []tool.ToolName
 	for _, name := range toolNames {
-		switch t {
-		case TypeInsight:
-			if !allowedInsight[name] {
-				invalid = append(invalid, string(name))
-			}
-		default: // TypeNormal and any other resolved value
-			if name != tool.ToolNameAll && !allowedNormal[name] {
-				invalid = append(invalid, string(name))
-			}
+		if name == tool.ToolNameAll {
+			continue
+		}
+		if !allowed[name] {
+			invalid = append(invalid, name)
 		}
 	}
 
@@ -63,24 +90,5 @@ func ValidateToolNames(t Type, toolNames []tool.ToolName) error {
 		return nil
 	}
 
-	if t == TypeInsight {
-		valid := make([]string, 0, len(tool.AllInsightToolNames))
-		for _, n := range tool.AllInsightToolNames {
-			valid = append(valid, string(n))
-		}
-		return fmt.Errorf(
-			"invalid tool_names for type=insight: %q is not an Insight tool (valid: %s)",
-			strings.Join(invalid, ", "), strings.Join(valid, ", "),
-		)
-	}
-
-	valid := make([]string, 0, len(tool.AllToolNames)+1)
-	valid = append(valid, string(tool.ToolNameAll))
-	for _, n := range tool.AllToolNames {
-		valid = append(valid, string(n))
-	}
-	return fmt.Errorf(
-		"invalid tool_names for type=normal: %q is not a Normal tool (valid: %s)",
-		strings.Join(invalid, ", "), strings.Join(valid, ", "),
-	)
+	return fmt.Errorf("invalid tool_names for type=%s: %v is not allowed", t, invalid)
 }

--- a/bin-ai-manager/models/ai/tool_validation_test.go
+++ b/bin-ai-manager/models/ai/tool_validation_test.go
@@ -44,10 +44,10 @@ func TestValidateToolNames(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name:      "insight_with_all_rejected",
+			name:      "insight_with_all_ok",
 			aiType:    TypeInsight,
 			toolNames: []tool.ToolName{tool.ToolNameAll},
-			wantError: true,
+			wantError: false,
 		},
 		{
 			name:      "insight_with_normal_tool_rejected",
@@ -80,10 +80,22 @@ func TestValidateToolNames(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name:      "insight_all_mixed_with_insight_tool_rejected",
+			name:      "insight_all_mixed_with_insight_tool_ok",
 			aiType:    TypeInsight,
 			toolNames: []tool.ToolName{tool.ToolNameAll, tool.ToolNameGetContactInteractions},
+			wantError: false,
+		},
+		{
+			name:      "insight_all_mixed_with_unknown_rejected",
+			aiType:    TypeInsight,
+			toolNames: []tool.ToolName{tool.ToolNameAll, "bogus_tool"},
 			wantError: true,
+		},
+		{
+			name:      "insight_with_new_related_cases_tool_ok",
+			aiType:    TypeInsight,
+			toolNames: []tool.ToolName{tool.ToolNameGetRelatedCases, tool.ToolNameGetCaseNotes},
+			wantError: false,
 		},
 		{
 			name:      "normal_all_mixed_with_unknown_rejected",

--- a/bin-ai-manager/models/message/tool.go
+++ b/bin-ai-manager/models/message/tool.go
@@ -45,4 +45,6 @@ const (
 
 	FunctionCallNameGetContactInteractions FunctionCallName = "get_contact_interactions"
 	FunctionCallNameGetConversationContent FunctionCallName = "get_conversation_content"
+	FunctionCallNameGetRelatedCases        FunctionCallName = "get_related_cases"
+	FunctionCallNameGetCaseNotes           FunctionCallName = "get_case_notes"
 )

--- a/bin-ai-manager/models/tool/main.go
+++ b/bin-ai-manager/models/tool/main.go
@@ -25,6 +25,11 @@ const (
 	// Insight AI tool set (VOIP-1234).
 	ToolNameGetContactInteractions ToolName = "get_contact_interactions"
 	ToolNameGetConversationContent ToolName = "get_conversation_content"
+
+	// Insight AI tool set expansion (NOJIRA, docs/plans/
+	// 2026-07-30-case-insight-assistant-tool-expansion-design.md §1).
+	ToolNameGetRelatedCases ToolName = "get_related_cases"
+	ToolNameGetCaseNotes    ToolName = "get_case_notes"
 )
 
 // AllToolNames returns all available tool names (excluding "all")
@@ -47,9 +52,13 @@ var AllToolNames = []ToolName{
 }
 
 // AllInsightToolNames defines the tool set available to ai.TypeInsight AIs.
+// Every entry MUST be read-only (no side effects) -- see
+// docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md §2.6.
 var AllInsightToolNames = []ToolName{
 	ToolNameGetContactInteractions,
 	ToolNameGetConversationContent,
+	ToolNameGetRelatedCases,
+	ToolNameGetCaseNotes,
 }
 
 // Tool defines a tool with its schema for LLM function calling.

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -69,6 +69,8 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		message.FunctionCallNameCaseCreate:             h.toolHandleCaseCreate,
 		message.FunctionCallNameGetContactInteractions: h.toolHandleGetContactInteractions,
 		message.FunctionCallNameGetConversationContent: h.toolHandleGetConversationContent,
+		message.FunctionCallNameGetRelatedCases:        h.toolHandleGetRelatedCases,
+		message.FunctionCallNameGetCaseNotes:           h.toolHandleGetCaseNotes,
 	}
 
 	promAIcallToolExecuteTotal.WithLabelValues(string(tool.Function.Name)).Inc()

--- a/bin-ai-manager/pkg/aicallhandler/tool_insight.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_insight.go
@@ -11,6 +11,7 @@ import (
 	"monorepo/bin-ai-manager/models/message"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/pkg/requesthandler"
+	kmkase "monorepo/bin-contact-manager/models/kase"
 	cvmessage "monorepo/bin-conversation-manager/models/message"
 	tmpeerevent "monorepo/bin-timeline-manager/models/peerevent"
 
@@ -242,5 +243,195 @@ func (h *aicallHandler) toolHandleGetConversationContent(ctx context.Context, c 
 
 	body := renderBodyLines("", lines, uint64(len(msgs)) >= limit, "messages")
 	fillSuccess(res, "conversation_content", args.ReferenceID, body)
+	return res
+}
+
+// toolHandleGetRelatedCases lists OTHER cases belonging to the same contact
+// as the current Insight AIcall's Case -- metadata only (id/title/status/
+// created_at), never case body or notes. Design docs/plans/
+// 2026-07-30-case-insight-assistant-tool-expansion-design.md §1.1.
+//
+// The nil/zero-UUID ContactID branch below is NOT an optional nicety: this
+// codebase's ContactV1CaseList silently DROPS its contact_id filter when
+// given uuid.Nil (bin-common-handler/pkg/requesthandler/contact_cases.go,
+// `if contactID != uuid.Nil { ... }`), which would otherwise return every
+// case for the tenant instead of "no related contact". The RPC must never
+// be reached in that case.
+func (h *aicallHandler) toolHandleGetRelatedCases(ctx context.Context, c *aicall.AIcall, tc *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleGetRelatedCases",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool get_related_cases.")
+
+	res := newToolResult(tc.ID)
+
+	if c.ReferenceType != aicall.ReferenceTypeContactCase {
+		fillFailed(res, fmt.Errorf("get_related_cases is only supported for contact_case reference type"))
+		return res
+	}
+
+	kase, err := h.reqHandler.ContactV1CaseGet(ctx, c.CustomerID, c.ReferenceID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			fillSuccess(res, "related_case_list", c.ReferenceID.String(), msgResourceNotFound)
+			return res
+		}
+		log.Errorf("Could not get the case. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+	if kase.CustomerID != c.CustomerID || kase.CustomerID == uuid.Nil {
+		// Defensive: tenant is already embedded in the RPC, but fail closed
+		// on any mismatch rather than trust a foreign response shape.
+		log.Warnf("Cross-customer case access blocked. case_customer_id: %s", kase.CustomerID)
+		fillSuccess(res, "related_case_list", c.ReferenceID.String(), msgResourceNotFound)
+		return res
+	}
+
+	if kase.ContactID == nil || *kase.ContactID == uuid.Nil {
+		// Legitimate outcome (no linked contact) -- not a denial, no audit
+		// log needed. Never reach ContactV1CaseList with a nil contact id.
+		fillSuccess(res, "related_case_list", c.ReferenceID.String(), "no related cases found")
+		return res
+	}
+
+	// The pagination token is intentionally discarded: this tool always
+	// fetches a single bounded page (insightMaxListLimit) and reports
+	// truncation via the "pagedOut" flag below rather than paging through
+	// the full history -- an Insight tool call is a single LLM function
+	// invocation, not a paginated list endpoint.
+	cases, _, err := h.reqHandler.ContactV1CaseList(
+		ctx, c.CustomerID, "", "", uuid.Nil, *kase.ContactID, insightMaxListLimit, "", "")
+	if err != nil {
+		if isNotFoundErr(err) {
+			fillSuccess(res, "related_case_list", c.ReferenceID.String(), "no related cases found")
+			return res
+		}
+		log.Errorf("Could not list related cases. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+
+	// The truncation flag must reflect whether the RAW fetch (pre-exclusion)
+	// hit the page size cap -- that's the only reliable signal that more
+	// rows may exist beyond this page. Computing it from the post-exclusion
+	// count under-reports: if the raw page was exactly insightMaxListLimit
+	// rows and one of them happened to be the current case, the excluded
+	// count would fall one short of the limit and "truncated" would go
+	// unset even though further related cases may exist beyond this page.
+	// (Round-2 code review finding; supersedes the design doc's original
+	// "exclude first" framing in design §1.1 row 6, which named the right
+	// ordering for exclusion but the wrong basis for the truncation flag.)
+	pagedOut := uint64(len(cases)) >= insightMaxListLimit
+
+	filtered := make([]*kmkase.Case, 0, len(cases))
+	for _, cs := range cases {
+		if cs.ID == c.ReferenceID {
+			continue
+		}
+		filtered = append(filtered, cs)
+	}
+
+	if len(filtered) == 0 {
+		fillSuccess(res, "related_case_list", c.ReferenceID.String(), "no related cases found")
+		return res
+	}
+
+	lines := make([]string, 0, len(filtered))
+	for _, cs := range filtered {
+		ts := "unknown"
+		if cs.TMCreate != nil {
+			ts = cs.TMCreate.UTC().Format(time.RFC3339)
+		}
+		lines = append(lines, fmt.Sprintf("[%s] case_id=%s title=%q status=%s", ts, cs.ID, cs.Name, cs.Status))
+	}
+
+	body := renderBodyLines("", lines, pagedOut, "related cases")
+	fillSuccess(res, "related_case_list", c.ReferenceID.String(), body)
+	return res
+}
+
+// toolHandleGetCaseNotes returns internal agent notes on the CURRENT case
+// (not other cases) -- useful for handoffs between agents. Design
+// docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md §1.2.
+func (h *aicallHandler) toolHandleGetCaseNotes(ctx context.Context, c *aicall.AIcall, tc *message.ToolCall) *messageContent {
+	log := logrus.WithFields(logrus.Fields{
+		"func":      "toolHandleGetCaseNotes",
+		"aicall_id": c.ID,
+	})
+	log.Debugf("handling tool get_case_notes.")
+
+	res := newToolResult(tc.ID)
+
+	var args struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		fillFailed(res, errors.Wrap(err, "invalid arguments"))
+		return res
+	}
+	limit := resolveInsightListLimit(args.Limit)
+
+	if c.ReferenceType != aicall.ReferenceTypeContactCase {
+		fillFailed(res, fmt.Errorf("get_case_notes is only supported for contact_case reference type"))
+		return res
+	}
+
+	kase, err := h.reqHandler.ContactV1CaseGet(ctx, c.CustomerID, c.ReferenceID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			fillSuccess(res, "case_note_list", c.ReferenceID.String(), msgResourceNotFound)
+			return res
+		}
+		log.Errorf("Could not get the case. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+	if kase.CustomerID != c.CustomerID || kase.CustomerID == uuid.Nil {
+		log.Warnf("Cross-customer case access blocked. case_customer_id: %s", kase.CustomerID)
+		fillSuccess(res, "case_note_list", c.ReferenceID.String(), msgResourceNotFound)
+		return res
+	}
+
+	// ContactV1CaseNoteList takes no size/token args (unlike ContactV1CaseList
+	// above); the caller-side clamp is the only limit enforcement here.
+	notes, err := h.reqHandler.ContactV1CaseNoteList(ctx, c.CustomerID, c.ReferenceID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			fillSuccess(res, "case_note_list", c.ReferenceID.String(), "no notes found")
+			return res
+		}
+		log.Errorf("Could not list case notes. err: %v", err)
+		fillFailed(res, fmt.Errorf("resource lookup failed"))
+		return res
+	}
+
+	if len(notes) == 0 {
+		fillSuccess(res, "case_note_list", c.ReferenceID.String(), "no notes found")
+		return res
+	}
+
+	// CaseNoteListByCase (bin-contact-manager/pkg/dbhandler/casenote.go)
+	// orders notes by tm_create ASC (oldest first). "Most recent N" is
+	// therefore the TAIL of this slice, not the head.
+	truncated := uint64(len(notes)) > limit
+	start := 0
+	if truncated {
+		start = len(notes) - int(limit)
+	}
+	recent := notes[start:]
+
+	lines := make([]string, 0, len(recent))
+	for _, n := range recent {
+		ts := "unknown"
+		if n.TMCreate != nil {
+			ts = n.TMCreate.UTC().Format(time.RFC3339)
+		}
+		lines = append(lines, fmt.Sprintf("[%s] author_type=%s: %s", ts, n.AuthorType, n.Text))
+	}
+
+	body := renderBodyLines("", lines, truncated, "notes")
+	fillSuccess(res, "case_note_list", c.ReferenceID.String(), body)
 	return res
 }

--- a/bin-ai-manager/pkg/aicallhandler/tool_insight_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_insight_test.go
@@ -2,6 +2,8 @@ package aicallhandler
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 
+	cmcasenote "monorepo/bin-contact-manager/models/casenote"
 	kmkase "monorepo/bin-contact-manager/models/kase"
 	cvmessage "monorepo/bin-conversation-manager/models/message"
 	tmpeerevent "monorepo/bin-timeline-manager/models/peerevent"
@@ -68,7 +71,7 @@ func Test_toolHandleGetContactInteractions(t *testing.T) {
 				ID:         caseID,
 				CustomerID: customerID,
 				ContactID:  &contactID,
-				Peer: commonaddress.Address{Type: "tel", Target: "+15551500001"},
+				Peer:       commonaddress.Address{Type: "tel", Target: "+15551500001"},
 			},
 			responseInteraction: []*tmpeerevent.PeerEvent{
 				{
@@ -87,7 +90,7 @@ func Test_toolHandleGetContactInteractions(t *testing.T) {
 			responseCase: &kmkase.Case{
 				ID:         caseID,
 				CustomerID: customerID,
-				Peer: commonaddress.Address{Type: "tel", Target: "+15551500002"},
+				Peer:       commonaddress.Address{Type: "tel", Target: "+15551500002"},
 			},
 			responseInteraction: []*tmpeerevent.PeerEvent{
 				{
@@ -105,7 +108,7 @@ func Test_toolHandleGetContactInteractions(t *testing.T) {
 			responseCase: &kmkase.Case{
 				ID:         caseID,
 				CustomerID: customerID,
-				Peer: commonaddress.Address{Type: "tel", Target: "+15551500003"},
+				Peer:       commonaddress.Address{Type: "tel", Target: "+15551500003"},
 			},
 			responseInteraction: []*tmpeerevent.PeerEvent{},
 			expectContactFilter: false,
@@ -136,7 +139,7 @@ func Test_toolHandleGetContactInteractions(t *testing.T) {
 				ID:         caseID,
 				CustomerID: customerID,
 				ContactID:  &contactID,
-				Peer: commonaddress.Address{Type: "tel", Target: "+15551500004"},
+				Peer:       commonaddress.Address{Type: "tel", Target: "+15551500004"},
 			},
 			responseListErr:     cerrors.NotFound(commonoutline.ServiceNameContactManager, "CONTACT_NOT_FOUND", "The contact was not found."),
 			expectContactFilter: true,
@@ -346,6 +349,354 @@ func Test_toolHandleGetConversationContent(t *testing.T) {
 
 func timePtr(t time.Time) *time.Time {
 	return &t
+}
+
+// Test_toolHandleGetRelatedCases covers design docs/plans/
+// 2026-07-30-case-insight-assistant-tool-expansion-design.md §1.1: nil/zero
+// ContactID short-circuit (never reach ContactV1CaseList with uuid.Nil),
+// self-exclusion (current case never in its own related-case list), ownership
+// masking, and honest failure on RPC error.
+func Test_toolHandleGetRelatedCases(t *testing.T) {
+	customerID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000002")
+	caseID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000003")
+	contactID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000004")
+	otherCaseID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000005")
+	toolCallID := "7a1f2c10-c001-11f0-9000-000000000006"
+
+	tc := &message.ToolCall{
+		ID:   toolCallID,
+		Type: message.ToolTypeFunction,
+		Function: message.FunctionCall{
+			Name:      message.FunctionCallNameGetRelatedCases,
+			Arguments: `{}`,
+		},
+	}
+
+	tests := []struct {
+		name string
+
+		responseCase       *kmkase.Case
+		responseCaseErr    error
+		expectCaseListCall bool
+		responseCases      []*kmkase.Case
+		responseCasesErr   error
+
+		expectResult       string
+		expectMessage      string
+		expectMessageEmpty bool
+	}{
+		{
+			name:            "case not found -> masked, not failed",
+			responseCaseErr: requesthandler.ErrNotFound,
+			expectResult:    "success",
+			expectMessage:   msgResourceNotFound,
+		},
+		{
+			name: "cross-customer case -> masked",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-0000000000ff"),
+			},
+			expectResult:  "success",
+			expectMessage: msgResourceNotFound,
+		},
+		{
+			name:            "case RPC transient failure -> honest failure",
+			responseCaseErr: errTest,
+			expectResult:    "failed",
+		},
+		{
+			name: "nil ContactID -> success empty, RPC never called",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  nil,
+			},
+			expectCaseListCall: false,
+			expectResult:       "success",
+			expectMessage:      "no related cases found",
+		},
+		{
+			name: "zero-UUID ContactID -> success empty, RPC never called",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  &uuid.Nil,
+			},
+			expectCaseListCall: false,
+			expectResult:       "success",
+			expectMessage:      "no related cases found",
+		},
+		{
+			name: "self-exclusion: current case removed from results",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  &contactID,
+			},
+			expectCaseListCall: true,
+			responseCases: []*kmkase.Case{
+				{ID: caseID, CustomerID: customerID, Name: "current case"},
+			},
+			expectResult:  "success",
+			expectMessage: "no related cases found",
+		},
+		{
+			name: "other case present -> returned",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  &contactID,
+			},
+			expectCaseListCall: true,
+			responseCases: []*kmkase.Case{
+				{ID: caseID, CustomerID: customerID, Name: "current case"},
+				{ID: otherCaseID, CustomerID: customerID, Name: "other case", Status: kmkase.StatusOpen},
+			},
+			expectResult: "success",
+		},
+		{
+			name: "case list RPC error -> honest failure",
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: customerID,
+				ContactID:  &contactID,
+			},
+			expectCaseListCall: true,
+			responseCasesErr:   errTest,
+			expectResult:       "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq}
+			ctx := context.Background()
+			c := testAIcallForCase(customerID, caseID)
+
+			mockReq.EXPECT().ContactV1CaseGet(ctx, customerID, caseID).Return(tt.responseCase, tt.responseCaseErr)
+
+			if tt.expectCaseListCall {
+				mockReq.EXPECT().ContactV1CaseList(
+					ctx, customerID, "", "", uuid.Nil, contactID, uint64(insightMaxListLimit), "", "",
+				).Return(tt.responseCases, "", tt.responseCasesErr)
+			}
+
+			res := h.toolHandleGetRelatedCases(ctx, c, tc)
+
+			if res.Result != tt.expectResult {
+				t.Fatalf("Result = %q, want %q (message: %s)", res.Result, tt.expectResult, res.Message)
+			}
+			if tt.expectMessage != "" && res.Message != tt.expectMessage {
+				t.Errorf("Message = %q, want %q", res.Message, tt.expectMessage)
+			}
+		})
+	}
+}
+
+// Test_toolHandleGetRelatedCases_TruncationUsesRawPageSize is a regression
+// test (round-2 code review finding) for a bug where the truncation flag was
+// computed from the POST-exclusion count against the page-size limit: if the
+// raw fetch returned exactly insightMaxListLimit rows and one of them was the
+// current case (excluded from the result), the post-exclusion count fell one
+// short of the limit and the truncation marker was incorrectly omitted even
+// though further related cases could exist beyond this page. The flag must
+// be derived from the RAW (pre-exclusion) row count instead.
+func Test_toolHandleGetRelatedCases_TruncationUsesRawPageSize(t *testing.T) {
+	customerID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000102")
+	caseID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000103")
+	contactID := uuid.FromStringOrNil("7a1f2c10-c001-11f0-9000-000000000104")
+	toolCallID := "7a1f2c10-c001-11f0-9000-000000000106"
+
+	tc := &message.ToolCall{
+		ID:   toolCallID,
+		Type: message.ToolTypeFunction,
+		Function: message.FunctionCall{
+			Name:      message.FunctionCallNameGetRelatedCases,
+			Arguments: `{}`,
+		},
+	}
+
+	// Build exactly insightMaxListLimit raw rows, with the CURRENT case as
+	// one of them -- so the post-exclusion count is insightMaxListLimit-1,
+	// while the raw fetch count that must drive the truncation flag is
+	// exactly insightMaxListLimit.
+	rawCases := make([]*kmkase.Case, 0, insightMaxListLimit)
+	rawCases = append(rawCases, &kmkase.Case{ID: caseID, CustomerID: customerID, Name: "current case"})
+	for i := 1; i < insightMaxListLimit; i++ {
+		rawCases = append(rawCases, &kmkase.Case{
+			ID:         uuid.Must(uuid.NewV4()),
+			CustomerID: customerID,
+			Name:       fmt.Sprintf("other case %d", i),
+			Status:     kmkase.StatusOpen,
+		})
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &aicallHandler{reqHandler: mockReq}
+	ctx := context.Background()
+	c := testAIcallForCase(customerID, caseID)
+
+	mockReq.EXPECT().ContactV1CaseGet(ctx, customerID, caseID).Return(
+		&kmkase.Case{ID: caseID, CustomerID: customerID, ContactID: &contactID}, nil,
+	)
+	mockReq.EXPECT().ContactV1CaseList(
+		ctx, customerID, "", "", uuid.Nil, contactID, uint64(insightMaxListLimit), "", "",
+	).Return(rawCases, "", nil)
+
+	res := h.toolHandleGetRelatedCases(ctx, c, tc)
+
+	if res.Result != "success" {
+		t.Fatalf("Result = %q, want success (message: %s)", res.Result, res.Message)
+	}
+	if !strings.Contains(res.Message, "showing the most recent") {
+		t.Errorf("expected truncation marker in message when raw fetch hit the page cap, got: %s", res.Message)
+	}
+}
+
+// Test_toolHandleGetCaseNotes covers design §1.2: ownership masking and the
+// "most recent N" truncation, which requires slicing from the TAIL of the
+// ascending (tm_create asc) note list, not the head.
+func Test_toolHandleGetCaseNotes(t *testing.T) {
+	customerID := uuid.FromStringOrNil("7b1f2c10-c001-11f0-9000-000000000002")
+	caseID := uuid.FromStringOrNil("7b1f2c10-c001-11f0-9000-000000000003")
+	toolCallID := "7b1f2c10-c001-11f0-9000-000000000004"
+
+	baseCase := &kmkase.Case{ID: caseID, CustomerID: customerID}
+
+	makeNotes := func(n int) []*cmcasenote.CaseNote {
+		notes := make([]*cmcasenote.CaseNote, 0, n)
+		base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+		for i := 0; i < n; i++ {
+			ts := base.Add(time.Duration(i) * time.Minute)
+			notes = append(notes, &cmcasenote.CaseNote{
+				ID:         uuid.Must(uuid.NewV4()),
+				CustomerID: customerID,
+				CaseID:     caseID,
+				AuthorType: cmcasenote.AuthorTypeAgent,
+				Text:       fmt.Sprintf("note-%d", i),
+				TMCreate:   timePtr(ts),
+			})
+		}
+		return notes
+	}
+
+	tests := []struct {
+		name string
+
+		args string
+
+		responseCase    *kmkase.Case
+		responseCaseErr error
+		responseNotes   []*cmcasenote.CaseNote
+		responseNoteErr error
+
+		expectResult  string
+		expectMessage string
+	}{
+		{
+			name:            "case not found -> masked",
+			args:            `{}`,
+			responseCaseErr: requesthandler.ErrNotFound,
+			expectResult:    "success",
+			expectMessage:   msgResourceNotFound,
+		},
+		{
+			name: "cross-customer case -> masked",
+			args: `{}`,
+			responseCase: &kmkase.Case{
+				ID:         caseID,
+				CustomerID: uuid.FromStringOrNil("7b1f2c10-c001-11f0-9000-0000000000ff"),
+			},
+			expectResult:  "success",
+			expectMessage: msgResourceNotFound,
+		},
+		{
+			name:            "case RPC transient failure -> honest failure",
+			args:            `{}`,
+			responseCaseErr: errTest,
+			expectResult:    "failed",
+		},
+		{
+			name:          "empty notes -> success empty",
+			args:          `{}`,
+			responseCase:  baseCase,
+			responseNotes: []*cmcasenote.CaseNote{},
+			expectResult:  "success",
+			expectMessage: "no notes found",
+		},
+		{
+			name:          "notes within limit -> all returned, no truncation",
+			args:          `{"limit":20}`,
+			responseCase:  baseCase,
+			responseNotes: makeNotes(3),
+			expectResult:  "success",
+		},
+		{
+			name:          "notes exceed limit -> keeps the MOST RECENT (tail), not the head",
+			args:          `{"limit":2}`,
+			responseCase:  baseCase,
+			responseNotes: makeNotes(5), // note-0 .. note-4, ascending tm_create
+			expectResult:  "success",
+		},
+		{
+			name:            "note list RPC error -> honest failure",
+			args:            `{}`,
+			responseCase:    baseCase,
+			responseNoteErr: errTest,
+			expectResult:    "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &aicallHandler{reqHandler: mockReq}
+			ctx := context.Background()
+			c := testAIcallForCase(customerID, caseID)
+
+			tc := &message.ToolCall{
+				ID:   toolCallID,
+				Type: message.ToolTypeFunction,
+				Function: message.FunctionCall{
+					Name:      message.FunctionCallNameGetCaseNotes,
+					Arguments: tt.args,
+				},
+			}
+
+			mockReq.EXPECT().ContactV1CaseGet(ctx, customerID, caseID).Return(tt.responseCase, tt.responseCaseErr)
+
+			if tt.responseCaseErr == nil && tt.responseCase != nil && tt.responseCase.CustomerID == customerID {
+				mockReq.EXPECT().ContactV1CaseNoteList(ctx, customerID, caseID).Return(tt.responseNotes, tt.responseNoteErr)
+			}
+
+			res := h.toolHandleGetCaseNotes(ctx, c, tc)
+
+			if res.Result != tt.expectResult {
+				t.Fatalf("Result = %q, want %q (message: %s)", res.Result, tt.expectResult, res.Message)
+			}
+			if tt.expectMessage != "" && res.Message != tt.expectMessage {
+				t.Errorf("Message = %q, want %q", res.Message, tt.expectMessage)
+			}
+			if tt.name == "notes exceed limit -> keeps the MOST RECENT (tail), not the head" {
+				if !strings.Contains(res.Message, "note-4") || strings.Contains(res.Message, "note-0") {
+					t.Errorf("expected the most recent notes (tail) to be kept, got: %s", res.Message)
+				}
+			}
+		})
+	}
 }
 
 // Test_isNotFoundErr covers both error shapes this codebase's downstream

--- a/bin-ai-manager/pkg/toolhandler/definitions.go
+++ b/bin-ai-manager/pkg/toolhandler/definitions.go
@@ -820,4 +820,59 @@ run_llm: Set true to reason about the retrieved conversation content.`,
 			"required": []string{"reference_id"},
 		},
 	},
+	{
+		Name:   tool.ToolNameGetRelatedCases,
+		RunLLM: true,
+		Description: `Lists OTHER cases belonging to the same contact as the current Case (metadata only: id/title/status/date -- never the case body or internal notes).
+
+WHEN TO USE:
+- Answering "has this contact had other cases before" / "what other issues has this customer raised".
+
+WHEN NOT TO USE:
+- You need the notes on the CURRENT case (use get_case_notes instead).
+
+Always scoped to the current Case's contact; there is no argument to target a different contact. The current case itself is never included in the results.
+
+run_llm: Set true to reason about the returned related-case history.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to reason about the retrieved related-case history.",
+					"default":     true,
+				},
+			},
+		},
+	},
+	{
+		Name:   tool.ToolNameGetCaseNotes,
+		RunLLM: true,
+		Description: `Returns the internal agent notes on the CURRENT Case -- useful for picking up context left by a previous agent.
+
+WHEN TO USE:
+- Answering "what did the last agent note about this case" / handing off between agents.
+
+WHEN NOT TO USE:
+- You need notes from a DIFFERENT case (not supported -- notes are always scoped to the current Case).
+
+Always scoped to the current Case; there is no argument to target a different Case.
+
+run_llm: Set true to reason about the retrieved notes.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"run_llm": map[string]any{
+					"type":        "boolean",
+					"description": "Set true to reason about the retrieved case notes.",
+					"default":     true,
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Maximum number of most-recent notes to return (default 20, max 50).",
+					"default":     20,
+				},
+			},
+		},
+	},
 }

--- a/bin-pipecat-manager/docs/operations.md
+++ b/bin-pipecat-manager/docs/operations.md
@@ -36,7 +36,7 @@ Exposed at `PROMETHEUS_LISTEN_ADDRESS/PROMETHEUS_ENDPOINT` (default `:2112/metri
 | `pipecat_manager_llm_flush_exit_total` | Counter | — | LLM flush operations that exited cleanly |
 | `pipecat_manager_llm_flush_finalize_outcome_total` | Counter | `outcome` | LLM flush finalization outcomes |
 | `pipecat_manager_llm_idle_watchdog_fired_total` | Counter | — | Idle watchdog triggers |
-| `pipecat_manager_tool_resolve_fallback_total` | Counter | — | runnerStartScript fell back to all tools (GetAll()) after an AI lookup failure. Intentionally fail-open (VOIP-1234 §6); a sustained non-zero rate should be investigated and alerted on, since it means sessions are running with an over-broad tool set instead of the AI's configured whitelist |
+| `pipecat_manager_tool_resolve_fallback_total` | Counter | — | runnerStartScript failed CLOSED to an empty tool list after an AI lookup failure. Fail-closed by design (docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md §2.4; this reverses the prior fail-open VOIP-1234 §6 v4 decision) since tool-access control must favor least-privilege over availability. A sustained non-zero rate should still be investigated and alerted on, since it means sessions are running with NO tools instead of the AI's configured whitelist |
 | `receive_request_process_time` | Histogram | `type`, `method` | RPC request latency |
 
 Circuit-breaker metrics from `bin-common-handler/pkg/requesthandler` are also registered under the `pipecat_manager_*` namespace. See [docs/patterns/circuit-breaker.md](../../docs/patterns/circuit-breaker.md).

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go
@@ -34,17 +34,20 @@ var (
 	)
 
 	// metricsToolResolveFallbackTotal counts occurrences of the runnerStartScript
-	// fail-open path where resolveAIFromAIcall fails and the session falls back
-	// to GetAll() (all tools, over-broad exposure) instead of the AI's configured
-	// tool whitelist. This path is intentionally fail-open (VOIP-1234 §6 v4) since
-	// it cannot be scoped to Insight-typed AIs specifically and no incident has
-	// been observed to justify a fail-closed change affecting all AICall-backed
-	// sessions. This counter (paired with the Errorf log at the call site) exists
-	// so a real-world spike is observable and can trigger a design revisit.
+	// fail-CLOSED path where resolveAIFromAIcall fails and the session falls
+	// back to an empty tool list instead of the AI's configured tool
+	// whitelist. This was originally a fail-OPEN path (falling back to
+	// GetAll(), VOIP-1234 §6 v4); that decision was reversed (design
+	// docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md
+	// §2.4) because tool-access control is a case where least-privilege must
+	// outweigh availability -- a degraded (tool-less) session is acceptable,
+	// silently granting write-capable tools to a session whose type couldn't
+	// be determined is not. This counter (paired with the Errorf log at the
+	// call site) exists so a real-world spike in this path is observable.
 	metricsToolResolveFallbackTotal = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "pipecat_manager_tool_resolve_fallback_total",
-			Help: "Counter of runnerStartScript falling back to GetAll() (all tools) after an AI lookup failure.",
+			Help: "Counter of runnerStartScript failing closed to an empty tool list after an AI lookup failure.",
 		},
 	)
 )

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run.go
@@ -175,7 +175,7 @@ func (h *pipecatcallHandler) resolveTeamForPython(
 		}
 		logrus.WithField("ai", ai).Debugf("Retrieved AI info for member. member_id: %s, ai_id: %s", m.ID, m.AIID)
 
-		tools := h.toolHandler.GetByNames(ai.ToolNames)
+		tools := h.toolHandler.GetByNames(ai.Type, ai.ToolNames)
 
 		// filter out search_knowledge if no RAG is configured
 		if ai.RagID == uuid.Nil {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go
@@ -476,6 +476,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					Identity: commonidentity.Identity{
 						ID: ai1ID,
 					},
+					Type:        amai.TypeNormal,
 					EngineModel: amai.EngineModelOpenaiGPT5,
 					EngineKey:   "key-1",
 					InitPrompt:  "You are a greeter",
@@ -490,6 +491,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					Identity: commonidentity.Identity{
 						ID: ai2ID,
 					},
+					Type:        amai.TypeNormal,
 					EngineModel: amai.EngineModelOpenaiGPT5Mini,
 					EngineKey:   "key-2",
 					InitPrompt:  "You are support",
@@ -499,7 +501,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					ToolNames:   []aitool.ToolName{aitool.ToolNameSendEmail},
 				}, nil)
 
-				mockTool.EXPECT().GetByNames([]aitool.ToolName{aitool.ToolNameConnectCall}).Return([]aitool.Tool{
+				mockTool.EXPECT().GetByNames(amai.TypeNormal, []aitool.ToolName{aitool.ToolNameConnectCall}).Return([]aitool.Tool{
 					{
 						Name:        aitool.ToolNameConnectCall,
 						Description: "Connect a call",
@@ -507,7 +509,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					},
 				})
 
-				mockTool.EXPECT().GetByNames([]aitool.ToolName{aitool.ToolNameSendEmail}).Return([]aitool.Tool{
+				mockTool.EXPECT().GetByNames(amai.TypeNormal, []aitool.ToolName{aitool.ToolNameSendEmail}).Return([]aitool.Tool{
 					{
 						Name:        aitool.ToolNameSendEmail,
 						Description: "Send an email",
@@ -674,7 +676,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					TTSType:     amai.TTSTypeCartesia,
 					STTType:     amai.STTTypeDeepgram,
 				}, nil)
-				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{})
+				mockTool.EXPECT().GetByNames(gomock.Any(), gomock.Any()).Return([]aitool.Tool{})
 			},
 
 			validate: func(t *testing.T, result *resolvedTeamData) {
@@ -720,7 +722,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					EngineKey:   "key-2",
 					InitPrompt:  "You are support",
 				}, nil)
-				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{}).Times(2)
+				mockTool.EXPECT().GetByNames(gomock.Any(), gomock.Any()).Return([]aitool.Tool{}).Times(2)
 			},
 
 			validate: func(t *testing.T, result *resolvedTeamData) {
@@ -752,7 +754,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					EngineKey:   "key-1",
 					InitPrompt:  "You are a greeter",
 				}, nil)
-				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{})
+				mockTool.EXPECT().GetByNames(gomock.Any(), gomock.Any()).Return([]aitool.Tool{})
 			},
 
 			validate: func(t *testing.T, result *resolvedTeamData) {
@@ -784,7 +786,7 @@ func Test_resolveTeamForPython(t *testing.T) {
 					EngineKey:   "key-1",
 					InitPrompt:  "You are a greeter",
 				}, nil)
-				mockTool.EXPECT().GetByNames(gomock.Any()).Return([]aitool.Tool{})
+				mockTool.EXPECT().GetByNames(gomock.Any(), gomock.Any()).Return([]aitool.Tool{})
 			},
 
 			validate: func(t *testing.T, result *resolvedTeamData) {

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner.go
@@ -130,22 +130,24 @@ func (h *pipecatcallHandler) runnerStartScript(pc *pipecatcall.Pipecatcall, se *
 			// Single AI: resolve tools from the AI's configuration
 			ai, errAI := h.resolveAIFromAIcall(se.Ctx, aicall)
 			if errAI != nil {
-				// Fail-open by design (VOIP-1234 §6 v4): this AI lookup failure
-				// cannot be scoped to Insight-typed AIs specifically (pipecatcall.ReferenceType
-				// only distinguishes ReferenceTypeCall/ReferenceTypeAICall, not AI.Type), and
-				// there is no observed incident motivating a fail-closed change that would
-				// affect every AICall-backed session (not just Insight). Falling back to
-				// GetAll() keeps the session usable at the cost of over-broad tool exposure
-				// on this rare error path. Metric + alert-worthy log below give operators
-				// visibility so a real incident can be detected and this decision revisited.
+				// Fail-CLOSED by design (docs/plans/
+				// 2026-07-30-case-insight-assistant-tool-expansion-design.md
+				// §2.4 -- this is an explicit reversal of the prior fail-open
+				// policy, VOIP-1234 §6 v4). Tool-access control is a case
+				// where least-privilege must outweigh availability: a
+				// degraded (tool-less) session is an acceptable outcome;
+				// silently granting write-capable tools to a session whose
+				// AI type couldn't even be determined is not. The metric +
+				// error log below give operators visibility into how often
+				// this path is hit.
 				metricsToolResolveFallbackTotal.Inc()
 				log.WithFields(logrus.Fields{
 					"aicall_id":     aicall.ID,
 					"assistance_id": aicall.AssistanceID,
-				}).WithError(errAI).Errorf("Could not resolve AI for pipecat session %s; falling back to all tools (fail-open, over-broad tool exposure)", pc.ID)
-				tools = h.toolHandler.GetAll()
+				}).WithError(errAI).Errorf("Could not resolve AI for pipecat session %s; failing closed to no tools (least-privilege over availability)", pc.ID)
+				tools = []aitool.Tool{}
 			} else {
-				tools = h.toolHandler.GetByNames(ai.ToolNames)
+				tools = h.toolHandler.GetByNames(ai.Type, ai.ToolNames)
 
 				// filter out search_knowledge if no RAG is configured
 				if ai.RagID == uuid.Nil {
@@ -160,7 +162,11 @@ func (h *pipecatcallHandler) runnerStartScript(pc *pipecatcall.Pipecatcall, se *
 			}
 		}
 	} else {
-		tools = h.toolHandler.GetAll()
+		// Non-AICall reference types are provably Normal-only by code
+		// inspection today (design §2.1) -- go through GetByNames so the
+		// AIType whitelist is still enforced rather than calling an
+		// unfiltered GetAll().
+		tools = h.toolHandler.GetByNames(amai.TypeNormal, []aitool.ToolName{aitool.ToolNameAll})
 	}
 	log.WithField("tool_count", len(tools)).Debugf("Retrieved tools for pipecat call")
 

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/runner_toolfallback_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/runner_toolfallback_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	amaicall "monorepo/bin-ai-manager/models/aicall"
-	aitool "monorepo/bin-ai-manager/models/tool"
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-pipecat-manager/models/pipecatcall"
@@ -17,12 +16,13 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-// Test_runnerStartScript_toolResolveFallback verifies the VOIP-1234 subtask 4
-// fail-open path: when resolveAIFromAIcall fails for a non-team AICall-backed
-// session, runnerStartScript falls back to toolHandler.GetAll() (unchanged
-// behavior) AND now increments metricsToolResolveFallbackTotal so the fallback
-// is observable (see runner.go / metrics.go for the design rationale — this
-// path stays fail-open by design, but must be alertable).
+// Test_runnerStartScript_toolResolveFallback verifies the fail-CLOSED policy
+// (docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md
+// §2.4, reversing the prior fail-open VOIP-1234 §6 v4 decision): when
+// resolveAIFromAIcall fails for a non-team AICall-backed session,
+// runnerStartScript now falls back to an EMPTY tool list (never GetByNames /
+// GetAll) AND still increments metricsToolResolveFallbackTotal so the
+// fallback stays observable.
 func Test_runnerStartScript_toolResolveFallback(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
@@ -64,7 +64,8 @@ func Test_runnerStartScript_toolResolveFallback(t *testing.T) {
 	// fail so runnerStartScript takes the fallback branch under test.
 	mockReq.EXPECT().AIV1AIGet(gomock.Any(), assistanceID).Return(nil, errors.New("boom"))
 
-	mockTool.EXPECT().GetAll().Return([]aitool.Tool{})
+	// Fail-closed: no GetByNames/GetAll call at all -- runnerStartScript must
+	// use an empty tool list directly rather than resolving any tool set.
 
 	mockPython.EXPECT().Start(
 		gomock.Any(), pc.ID, gomock.Any(), gomock.Any(), gomock.Any(),

--- a/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
+++ b/bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go
@@ -108,7 +108,7 @@ func Test_startReferenceTypeCall_externalMediaFailure(t *testing.T) {
 	).Return(nil, fmt.Errorf("external media creation failed"))
 
 	// RunnerStart goroutine may call these before context is cancelled
-	mockTool.EXPECT().GetAll().AnyTimes()
+	mockTool.EXPECT().GetByNames(gomock.Any(), gomock.Any()).AnyTimes()
 	mockPythonRunner.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -232,7 +232,7 @@ func Test_startReferenceTypeCall_websocketDialFailure(t *testing.T) {
 		Return(&cmexternalmedia.ExternalMedia{ID: emID}, nil)
 
 	// RunnerStart goroutine may call these before context is cancelled
-	mockTool.EXPECT().GetAll().AnyTimes()
+	mockTool.EXPECT().GetByNames(gomock.Any(), gomock.Any()).AnyTimes()
 	mockPythonRunner.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()

--- a/bin-pipecat-manager/pkg/toolhandler/main.go
+++ b/bin-pipecat-manager/pkg/toolhandler/main.go
@@ -9,22 +9,32 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	amai "monorepo/bin-ai-manager/models/ai"
 	aitool "monorepo/bin-ai-manager/models/tool"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 )
 
-// ToolHandler manages fetching and caching tool definitions from ai-manager
+// ToolHandler manages fetching and caching tool definitions from ai-manager.
+//
+// GetAll (all cached tools, no type filtering) is intentionally NOT part of
+// this interface -- see docs/plans/
+// 2026-07-30-case-insight-assistant-tool-expansion-design.md §2.4. Every
+// caller must go through GetByNames so the AIType whitelist (models/ai.
+// AllowedToolNames) is re-applied at expansion time regardless of what a
+// stored tool_names value claims, closing both the "Normal `all` leaks
+// Insight tools" bug and a fail-open path a future caller could otherwise
+// silently reintroduce by calling an unfiltered GetAll() directly.
 type ToolHandler interface {
 	// FetchTools fetches all tools from ai-manager and caches them
 	FetchTools(ctx context.Context) error
 
-	// GetAll returns all cached tools
-	GetAll() []aitool.Tool
-
-	// GetByNames returns tools filtered by the given tool names
-	// If names contains "all", returns all tools
-	// If names is empty or nil, returns empty slice
-	GetByNames(names []aitool.ToolName) []aitool.Tool
+	// GetByNames returns the cached tools matching names, filtered through
+	// amai.AllowedToolNames(aiType) first -- a tool is only ever returned if
+	// it is both a member of the AIType's whitelist AND requested (directly
+	// by name, or via the "all" selector in names). aiType is resolved
+	// fresh by the caller from the AI record already in hand on every call,
+	// never cached across calls.
+	GetByNames(aiType amai.Type, names []aitool.ToolName) []aitool.Tool
 }
 
 type toolHandler struct {
@@ -60,42 +70,38 @@ func (h *toolHandler) FetchTools(ctx context.Context) error {
 	return nil
 }
 
-// GetAll returns all cached tools
-func (h *toolHandler) GetAll() []aitool.Tool {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	result := make([]aitool.Tool, len(h.tools))
-	copy(result, h.tools)
-	return result
-}
-
-// GetByNames returns tools filtered by the given tool names
-func (h *toolHandler) GetByNames(names []aitool.ToolName) []aitool.Tool {
-	if len(names) == 0 {
-		return []aitool.Tool{}
-	}
-
-	// Check if "all" is in the names
-	for _, name := range names {
-		if name == aitool.ToolNameAll {
-			return h.GetAll()
+// containsName reports whether target is present in names.
+func containsName(names []aitool.ToolName, target aitool.ToolName) bool {
+	for _, n := range names {
+		if n == target {
+			return true
 		}
 	}
+	return false
+}
 
-	// Create a set of requested names for O(1) lookup
-	nameSet := make(map[aitool.ToolName]bool, len(names))
-	for _, name := range names {
-		nameSet[name] = true
-	}
+// GetByNames returns tools filtered by the given tool names, with the
+// AIType whitelist re-applied at expansion time regardless of what names
+// contains (defense-in-depth, design §2.3): whether names is an explicit
+// list or contains the "all" selector, every returned tool must first be a
+// member of amai.AllowedToolNames(aiType). This closes the pre-existing gap
+// where Normal AI's tool_names=["all"] returned Insight-only tools
+// alongside every Normal tool -- the type separation ValidateToolNames
+// enforces at save time was not previously re-checked here.
+func (h *toolHandler) GetByNames(aiType amai.Type, names []aitool.ToolName) []aitool.Tool {
+	allowed := amai.AllowedToolNames(aiType)
+	hasAll := containsName(names, aitool.ToolNameAll)
 
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	result := make([]aitool.Tool, 0, len(names))
-	for _, tool := range h.tools {
-		if nameSet[tool.Name] {
-			result = append(result, tool)
+	result := make([]aitool.Tool, 0, len(h.tools))
+	for _, t := range h.tools {
+		if !allowed[t.Name] {
+			continue // concrete-name check only; "all" is never itself checked for set membership
+		}
+		if hasAll || containsName(names, t.Name) {
+			result = append(result, t)
 		}
 	}
 

--- a/bin-pipecat-manager/pkg/toolhandler/main_test.go
+++ b/bin-pipecat-manager/pkg/toolhandler/main_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	amai "monorepo/bin-ai-manager/models/ai"
 	aitool "monorepo/bin-ai-manager/models/tool"
 	"monorepo/bin-common-handler/pkg/requesthandler"
 
@@ -81,68 +82,13 @@ func TestToolHandler_FetchTools(t *testing.T) {
 				return
 			}
 
-			// Verify tools were cached
-			got := h.GetAll()
-			if !reflect.DeepEqual(got, tt.responseTools) {
-				t.Errorf("GetAll() = %v, want %v", got, tt.responseTools)
-			}
-		})
-	}
-}
-
-func TestToolHandler_GetAll(t *testing.T) {
-	tests := []struct {
-		name string
-
-		cachedTools []aitool.Tool
-		want        []aitool.Tool
-	}{
-		{
-			name: "returns all cached tools",
-
-			cachedTools: []aitool.Tool{
-				{
-					Name:        aitool.ToolNameConnectCall,
-					Description: "Connects to another endpoint",
-				},
-				{
-					Name:        aitool.ToolNameSendEmail,
-					Description: "Sends an email",
-				},
-			},
-			want: []aitool.Tool{
-				{
-					Name:        aitool.ToolNameConnectCall,
-					Description: "Connects to another endpoint",
-				},
-				{
-					Name:        aitool.ToolNameSendEmail,
-					Description: "Sends an email",
-				},
-			},
-		},
-		{
-			name: "empty cache returns empty slice",
-
-			cachedTools: []aitool.Tool{},
-			want:        []aitool.Tool{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mc := gomock.NewController(t)
-			defer mc.Finish()
-
-			mockRequest := requesthandler.NewMockRequestHandler(mc)
-			h := &toolHandler{
-				requestHandler: mockRequest,
-				tools:          tt.cachedTools,
-			}
-
-			got := h.GetAll()
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAll() = %v, want %v", got, tt.want)
+			// Verify tools were cached: GetByNames(TypeNormal, ["all"]) returns
+			// everything cached that is also Normal-whitelisted. Both fixture
+			// tools here are in tool.AllToolNames, so this is equivalent to the
+			// old GetAll() check.
+			got := h.GetByNames(amai.TypeNormal, []aitool.ToolName{aitool.ToolNameAll})
+			if len(got) != len(tt.responseTools) {
+				t.Errorf("GetByNames(TypeNormal, [\"all\"]) returned %d tools, want %d", len(got), len(tt.responseTools))
 			}
 		})
 	}
@@ -154,12 +100,15 @@ func TestToolHandler_GetByNames(t *testing.T) {
 		{Name: aitool.ToolNameSendEmail, Description: "Send email"},
 		{Name: aitool.ToolNameSendMessage, Description: "Send message"},
 		{Name: aitool.ToolNameSetVariables, Description: "Set variables"},
+		{Name: aitool.ToolNameGetContactInteractions, Description: "Get contact interactions"},
+		{Name: aitool.ToolNameGetConversationContent, Description: "Get conversation content"},
 	}
 
 	tests := []struct {
 		name string
 
 		cachedTools []aitool.Tool
+		aiType      amai.Type
 		names       []aitool.ToolName
 
 		wantCount int
@@ -169,6 +118,7 @@ func TestToolHandler_GetByNames(t *testing.T) {
 			name: "empty names returns empty slice",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       []aitool.ToolName{},
 
 			wantCount: 0,
@@ -178,24 +128,42 @@ func TestToolHandler_GetByNames(t *testing.T) {
 			name: "nil names returns empty slice",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       nil,
 
 			wantCount: 0,
 			wantNames: nil,
 		},
 		{
-			name: "all returns all tools",
+			name: "normal all returns all normal tools, not insight tools",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       []aitool.ToolName{aitool.ToolNameAll},
 
 			wantCount: 4,
-			wantNames: nil, // Don't check specific names, just count
+			wantNames: []aitool.ToolName{
+				aitool.ToolNameConnectCall, aitool.ToolNameSendEmail,
+				aitool.ToolNameSendMessage, aitool.ToolNameSetVariables,
+			},
+		},
+		{
+			name: "insight all returns only insight tools, never normal tools (leak regression guard)",
+
+			cachedTools: cachedTools,
+			aiType:      amai.TypeInsight,
+			names:       []aitool.ToolName{aitool.ToolNameAll},
+
+			wantCount: 2,
+			wantNames: []aitool.ToolName{
+				aitool.ToolNameGetContactInteractions, aitool.ToolNameGetConversationContent,
+			},
 		},
 		{
 			name: "single tool name",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       []aitool.ToolName{aitool.ToolNameConnectCall},
 
 			wantCount: 1,
@@ -205,25 +173,61 @@ func TestToolHandler_GetByNames(t *testing.T) {
 			name: "multiple tool names",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       []aitool.ToolName{aitool.ToolNameConnectCall, aitool.ToolNameSendEmail},
 
 			wantCount: 2,
 			wantNames: []aitool.ToolName{aitool.ToolNameConnectCall, aitool.ToolNameSendEmail},
 		},
 		{
-			name: "all with other names returns all",
+			name: "all with other names returns all (of the allowed type)",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       []aitool.ToolName{aitool.ToolNameConnectCall, aitool.ToolNameAll},
 
 			wantCount: 4,
-			wantNames: nil, // Don't check specific names, just count
+			wantNames: []aitool.ToolName{
+				aitool.ToolNameConnectCall, aitool.ToolNameSendEmail,
+				aitool.ToolNameSendMessage, aitool.ToolNameSetVariables,
+			},
 		},
 		{
 			name: "non-existent tool name returns empty",
 
 			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
 			names:       []aitool.ToolName{"non_existent_tool"},
+
+			wantCount: 0,
+			wantNames: nil,
+		},
+		{
+			name: "defense-in-depth: normal AI explicitly requesting an insight-only tool by name is denied",
+
+			cachedTools: cachedTools,
+			aiType:      amai.TypeNormal,
+			names:       []aitool.ToolName{aitool.ToolNameGetContactInteractions},
+
+			wantCount: 0,
+			wantNames: nil,
+		},
+		{
+			name: "defense-in-depth: insight AI explicitly requesting a normal-only tool by name is denied",
+
+			cachedTools: cachedTools,
+			aiType:      amai.TypeInsight,
+			names:       []aitool.ToolName{aitool.ToolNameConnectCall},
+
+			wantCount: 0,
+			wantNames: nil,
+		},
+		{
+			name: "unknown AI type denies everything, even with explicit names",
+
+			cachedTools: cachedTools,
+			aiType:      amai.Type("some_future_type"),
+			names:       []aitool.ToolName{aitool.ToolNameAll},
 
 			wantCount: 0,
 			wantNames: nil,
@@ -241,7 +245,7 @@ func TestToolHandler_GetByNames(t *testing.T) {
 				tools:          tt.cachedTools,
 			}
 
-			got := h.GetByNames(tt.names)
+			got := h.GetByNames(tt.aiType, tt.names)
 
 			if len(got) != tt.wantCount {
 				t.Errorf("GetByNames() returned %d tools, want %d", len(got), tt.wantCount)

--- a/bin-pipecat-manager/pkg/toolhandler/mock_main.go
+++ b/bin-pipecat-manager/pkg/toolhandler/mock_main.go
@@ -11,6 +11,7 @@ package toolhandler
 
 import (
 	context "context"
+	ai "monorepo/bin-ai-manager/models/ai"
 	tool "monorepo/bin-ai-manager/models/tool"
 	reflect "reflect"
 
@@ -55,30 +56,16 @@ func (mr *MockToolHandlerMockRecorder) FetchTools(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchTools", reflect.TypeOf((*MockToolHandler)(nil).FetchTools), ctx)
 }
 
-// GetAll mocks base method.
-func (m *MockToolHandler) GetAll() []tool.Tool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAll")
-	ret0, _ := ret[0].([]tool.Tool)
-	return ret0
-}
-
-// GetAll indicates an expected call of GetAll.
-func (mr *MockToolHandlerMockRecorder) GetAll() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockToolHandler)(nil).GetAll))
-}
-
 // GetByNames mocks base method.
-func (m *MockToolHandler) GetByNames(names []tool.ToolName) []tool.Tool {
+func (m *MockToolHandler) GetByNames(aiType ai.Type, names []tool.ToolName) []tool.Tool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByNames", names)
+	ret := m.ctrl.Call(m, "GetByNames", aiType, names)
 	ret0, _ := ret[0].([]tool.Tool)
 	return ret0
 }
 
 // GetByNames indicates an expected call of GetByNames.
-func (mr *MockToolHandlerMockRecorder) GetByNames(names any) *gomock.Call {
+func (mr *MockToolHandlerMockRecorder) GetByNames(aiType, names any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByNames", reflect.TypeOf((*MockToolHandler)(nil).GetByNames), names)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByNames", reflect.TypeOf((*MockToolHandler)(nil).GetByNames), aiType, names)
 }

--- a/docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md
+++ b/docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md
@@ -1,0 +1,390 @@
+# Case Insight Assistant: tool whitelist expansion + "all" support (NOJIRA)
+
+**Date:** 2026-07-30
+**Ticket:** none (NOJIRA)
+**Services:** `bin-ai-manager`, `bin-pipecat-manager`, `square-admin` (frontend)
+**Status:** Design reviewed (5 rounds each, 2 consecutive approvals) for both parts below. Not yet implemented.
+
+## Problem
+
+Case Insight Assistant (`type=insight` AI, `bin-ai-manager`) currently exposes
+exactly two tools to the LLM: `get_contact_interactions` and
+`get_conversation_content` (`tool.AllInsightToolNames`,
+`bin-ai-manager/models/tool/main.go:50`). Two separate gaps were raised in
+this design pass:
+
+1. **The whitelist is too narrow.** Agents want the assistant to answer "has
+   this contact had other cases?" and "what did the last agent write in their
+   notes?" — neither is answerable today.
+2. **Insight AI cannot use `tool_names=["all"]`.** Normal AI supports this
+   shorthand in square-admin's AI editor ("Enable All Tools"); Insight AI's
+   editor has no equivalent, and the backend rejects `"all"` for
+   `type=insight` outright.
+
+Investigating (2) surfaced a pre-existing production gap unrelated to the
+original ask: the *actual* runtime tool-expansion code lives in
+`bin-pipecat-manager`, not `bin-ai-manager`, and it has no `AIType` awareness
+at all — see §2 below. Fixing that is a prerequisite for shipping "all"
+support safely, so it's included in this design.
+
+## Non-goals
+
+- **Tier 2/3 candidate tools** surveyed during requirements discussion
+  (`get_call_transcript`, `get_call_history`, `get_message_history`,
+  `get_queue_wait_status`, `get_campaign_membership`, `get_contact_profile`,
+  `get_billing_status`, `get_customer_profile`) — deferred. Most depend on
+  filter-map RPCs (`CallV1CallList`, `TranscribeV1*List`, etc.) that have no
+  server-enforced tenant filter; they need a shared scope-verification
+  helper before they're safe to whitelist. Not designed here.
+- **`get_case_tags`** — deferred. Depends on `TagV1TagList`, a free-form
+  filter API with no `customer_id` parameter; needs its own
+  ownership-reverification design.
+- **`get_ai_summary_history`** — deferred, and currently **not viable as
+  specified**: `summary.ReferenceType` (`bin-ai-manager/models/summary/main.go:32-36`)
+  only covers `call/conference/transcribe/recording`, not `contact_case`, so
+  a naive `reference_id=c.ReferenceID` filter always returns empty. Needs a
+  multi-hop design (Case → interaction → call/transcribe reference) before
+  reconsideration.
+- **Rate limiting / automated repeated-attempt detection** on tool calls —
+  out of scope for this change; audit logging (§1.3) is the only control
+  landing now. Tracked as a follow-up.
+- **Automated read-only enforcement** on future `AllInsightToolNames`
+  entries — this design documents the requirement and recommends one cheap
+  unit test (§2.6); a structural guard (e.g. a `Tool` metadata flag) is a
+  follow-up, not required to ship.
+
+## Part 1 — Two new Insight tools
+
+### 1.1 `get_related_cases`
+
+Returns metadata (not full body) for other cases belonging to the same
+contact as the current case, so the assistant can answer "has this contact
+had other cases?" without exposing unrelated case content.
+
+**Decision matrix** (mirrors the existing `get_contact_interactions` pattern
+in `bin-ai-manager/pkg/aicallhandler/tool_insight.go`):
+
+| # | Condition | Result |
+|---|---|---|
+| 1 | `c.ReferenceType != aicall.ReferenceTypeContactCase` | tool failure (entry guard, shared with `get_case_notes`) |
+| 2 | `ContactV1CaseGet(case_id=c.ReferenceID)` RPC errors/times out | tool failure — **never** silently treated as "no data" |
+| 3 | CaseGet succeeds, case not found | success, empty result (not-found) |
+| 4 | CaseGet succeeds, `kase.CustomerID != c.CustomerID` | mask as not-found (empty result) + `log.Warnf` audit (actor/customer_id/case_id/reason/timestamp) — cross-tenant attempt |
+| 5 | CaseGet succeeds, ownership confirmed, `kase.ContactID == nil` **or** `*kase.ContactID == uuid.Nil` | success, empty result (legitimate: no linked contact) — no audit needed, not a denial |
+| 6 | CaseGet succeeds, ownership confirmed, `ContactID` present and non-nil-UUID | `ContactV1CaseList(ctx, customerID=c.CustomerID, status="", ownerType="", ownerID=uuid.Nil, contactID=*kase.ContactID, size=insightMaxListLimit, token="", referenceID="")`. RPC error → tool failure. Success → map to `{case_id, title, status, created_at}` only (no body/notes), **exclude `case_id == c.ReferenceID`** (the current case itself) from the result, apply `insightMaxListLimit` **after** exclusion (so the truncation flag reflects the post-exclusion count, not a stale pre-exclusion count) |
+
+Step 5's nil-`ContactID` handling exists specifically to close a real bug
+found in review: `ContactV1CaseList`'s underlying query
+(`bin-common-handler/pkg/requesthandler/contact_cases.go:103`,
+`if contactID != uuid.Nil { ... }`) silently *drops* the `contact_id` filter
+when given `uuid.Nil` — calling it with a zero-value UUID would return every
+case for the tenant, not "no related contact." Step 5 must never reach the
+RPC in that case.
+
+**Accepted residual risk (documented, not IDOR):** the assistant can see
+metadata (title/status/date, not body) of other cases from the *same*
+contact, even if unrelated to the current conversation topic. This is
+same-tenant, same-contact data, not a cross-customer leak, but is a
+deliberate minimum-privilege trade-off — recorded here per review
+requirement rather than silently accepted.
+
+### 1.2 `get_case_notes`
+
+Returns internal agent notes on the *current* case (not other cases) —
+useful for handoffs between agents.
+
+Same guard (row 1) and CaseGet ownership check (rows 2-4) as
+`get_related_cases`. On ownership confirmed:
+`ContactV1CaseNoteList(ctx, customerID=c.CustomerID, caseID=c.ReferenceID)`
+(`bin-common-handler/pkg/requesthandler/contact_cases.go:314` — this RPC
+takes no `size`/`token` args, unlike the case list one above). RPC error →
+tool failure. Success → truncate client-side to `resolveInsightListLimit(args.Limit)`
+(the same clamp-and-truncate helper the two existing tools already use,
+**not** a new hardcoded constant), keeping the **most recent** N notes and
+using the existing `renderBodyLines` "showing the most recent N" truncation
+marker — confirm note sort order (`tm_create` asc/desc) before slicing so
+the marker's claim ("most recent") is actually true.
+
+### 1.3 Cross-cutting for both tools
+
+- Response list size: reuse `insightMaxListLimit` (case list) /
+  `resolveInsightListLimit` (case notes) — no new constants.
+- Audit log fields (row 4 in both): actor (AI session/aicall id),
+  customer_id, case_id, denial reason, timestamp — matches the existing
+  `log.Warnf("Cross-customer ... access blocked")` convention in
+  `tool_insight.go`.
+- Registration work (not just the whitelist): `tool.AllInsightToolNames`
+  (`models/tool/main.go:50`) entries, `toolDefinitions` schema entries in
+  `bin-ai-manager/pkg/toolhandler/definitions.go`, dispatch branches in
+  `tool_insight.go`, and a `ValidateToolNames` unit test asserting no
+  write-capable tool name can ever be added to `AllInsightToolNames`.
+
+## Part 2 — Insight AI `"all"` support (and the pipecat fail-open fix it depends on)
+
+### 2.1 Why this isn't a one-line change
+
+The obvious fix — allow `"all"` in `bin-ai-manager`'s
+`ValidateToolNames` — is necessary but not sufficient. The actual runtime
+tool-list expansion for a live LLM session happens in a **different
+service**, `bin-pipecat-manager`, whose `GetByNames` has no `AIType`
+parameter at all today:
+
+```go
+// bin-pipecat-manager/pkg/toolhandler/main.go:74-103 (current, unmodified)
+func (h *toolHandler) GetByNames(names []aitool.ToolName) []aitool.Tool {
+    if len(names) == 0 { return []aitool.Tool{} }
+    for _, name := range names {
+        if name == aitool.ToolNameAll {
+            return h.GetAll() // no type check — returns all 17 cached tools
+        }
+    }
+    // ... else: return cached tools whose name is in `names`, again no type check
+}
+```
+
+`h.tools` is a flat, untyped cache of all 17 tool definitions (Normal +
+Insight combined) fetched once via `AIV1ToolList`
+(`bin-ai-manager/pkg/listenhandler/v1_tools.go:12`, itself untyped —
+`toolDefinitions` in `definitions.go` has no type tag).
+
+**Confirmed pre-existing bugs this surfaces, independent of the "all"
+feature request:**
+
+- Normal AI's existing `tool_names=["all"]` already returns the two
+  Insight-only tools alongside all 15 Normal tools — the type separation
+  `ValidateToolNames` enforces at save time is not re-checked at pipecat's
+  expansion time.
+- `bin-pipecat-manager/pkg/pipecatcallhandler/runner.go`'s
+  `resolveAIFromAIcall` failure branch falls back to `GetAll()` —
+  **every** tool, including write-capable ones (`create_call`,
+  `send_email`, ...), whenever the AI record lookup fails for *any*
+  reason, regardless of the AI's actual type. This is a documented,
+  intentional decision (VOIP-1234 §6 v4) that predates this design and is
+  being revisited here because it directly contradicts the
+  defense-in-depth this change introduces.
+- A second `GetAll()` call site (non-`AICall` reference types,
+  `runner.go`) is provably Normal-only by code inspection but doesn't say
+  so — it just happens to never be reached by Insight sessions today.
+
+### 2.2 Single source of truth for the whitelist
+
+Add to `bin-ai-manager/models/ai` (not `models/tool`, to key on the real
+`Type` enum rather than a boolean — see rationale below):
+
+```go
+// AllowedToolNames returns the tool whitelist for a given AI type.
+// Unknown/future types deny-by-default (empty set) rather than falling
+// back to the widest (Normal, write-capable) set.
+func AllowedToolNames(t Type) map[tool.ToolName]bool {
+    switch t {
+    case TypeNormal:
+        return toSet(tool.AllToolNames)
+    case TypeInsight:
+        return toSet(tool.AllInsightToolNames)
+    default:
+        log.Warnf("unknown AI type %v encountered in tool whitelist resolution, denying all tools", t)
+        metrics.UnknownAITypeToolDenialTotal.Inc() // new counter
+        return map[tool.ToolName]bool{}
+    }
+}
+```
+
+`models/ai` already imports `models/tool` (for `ValidateToolNames`), so this
+has no import cycle. A `bool isInsight` parameter was considered and
+rejected: it collapses any future third `AIType` into "Normal" (the
+write-capable set) by construction, which is the opposite of
+deny-by-default.
+
+**Important semantic note** (this caused confusion across review rounds and
+must be stated explicitly): `tool.ToolNameAll` (`"all"`) is a **selector**,
+not a concrete tool name — `tool.AllToolNames` / `tool.AllInsightToolNames`
+correctly do **not** contain it. `AllowedToolNames(t)` only ever answers
+"is this concrete tool name allowed for type t"; it is never asked whether
+`"all"` itself is a member.
+
+`ValidateToolNames` (`bin-ai-manager/models/ai/tool_validation.go`) is
+refactored to consume this same helper instead of building its own inline
+sets:
+
+```go
+func ValidateToolNames(t Type, toolNames []tool.ToolName) error {
+    allowed := AllowedToolNames(t)
+    for _, name := range toolNames {
+        if name == tool.ToolNameAll {
+            continue // selector: structurally valid input for any type that supports "all"
+        }
+        if !allowed[name] {
+            return fmt.Errorf("invalid tool_names for type=%s: %q is not allowed", t, name)
+        }
+    }
+    return nil
+}
+```
+
+This is what actually grants Insight AI the ability to save `["all"]` —
+today `case TypeInsight:` rejects it outright.
+
+### 2.3 Pipecat-side defense-in-depth
+
+```go
+// bin-pipecat-manager/pkg/toolhandler/main.go
+func (h *toolHandler) GetByNames(aiType amai.Type, names []aitool.ToolName) []aitool.Tool {
+    allowed := amai.AllowedToolNames(aiType) // re-resolved every call, never cached across calls
+    hasAll := containsName(names, aitool.ToolNameAll)
+    h.mu.RLock()
+    defer h.mu.RUnlock()
+    result := make([]aitool.Tool, 0, len(h.tools))
+    for _, t := range h.tools {
+        if !allowed[t.Name] {
+            continue // concrete-name check only; "all" is never itself checked for set membership
+        }
+        if hasAll || containsName(names, t.Name) {
+            result = append(result, t)
+        }
+    }
+    return result
+}
+```
+
+Whether `names` contains `"all"` or an explicit list, every returned tool
+must first be a member of `allowed`. This closes both the "Normal `all`
+leaks Insight tools" bug and the "`ValidateToolNames` bypassed via direct
+DB write" gap — the type check is re-applied at expansion time regardless
+of what's stored.
+
+`aiType` is derived **fresh** at each call site from the AI record already
+in hand (`run.go:178`'s `resolveTeamForPython`, `runner.go:148`) —
+`ai.Type == amai.TypeInsight` — not threaded through as a long-lived
+cached value. This mirrors the existing pattern one line away, where the
+same functions already read `ai.RagID` to conditionally include
+`search_knowledge`.
+
+### 2.4 Fail-open → fail-closed policy change
+
+`runner.go`'s `resolveAIFromAIcall` failure branch currently does:
+
+```go
+// current: "Could not resolve AI, returning all tools"
+tools = h.toolHandler.GetAll()
+```
+
+This is changed to fail-closed: on AI-lookup failure, return `[]aitool.Tool{}`
+(no tools) rather than every tool. This is an explicit policy reversal of
+VOIP-1234 §6 v4's original fail-open decision, made because tool-access
+control is a case where least-privilege must outweigh availability — a
+degraded (tool-less) session is an acceptable outcome; silently granting
+write-capable tools to a session whose type couldn't even be determined is
+not. The trade-off (a transient AI-lookup RPC failure now produces a
+tool-less session instead of a fully-capable one) is accepted as-is;
+retry-before-fail-closed was considered and explicitly rejected as
+unnecessary scope for this change.
+
+The second call site, `runner.go`'s non-`AICall` reference-type branch
+(provably Normal-only), becomes `GetByNames(amai.TypeNormal, []aitool.ToolName{aitool.ToolNameAll})`
+instead of raw `GetAll()`.
+
+`ToolHandler.GetAll()` is removed from the exported interface entirely (or
+unexported to an internal `getAll()` helper used only inside `GetByNames`'s
+own implementation) once both call sites above are migrated, so a future
+caller cannot silently reintroduce a fail-open path by calling it directly.
+This does **not** affect the unrelated, same-named
+`bin-ai-manager/pkg/toolhandler.GetAll()` (different package, different
+purpose — backs the admin-facing `AIV1ToolList` RPC, not runtime
+expansion).
+
+### 2.5 Mechanical follow-through (implementation checklist, not exhaustive)
+
+- `bin-pipecat-manager/pkg/toolhandler/mock_main.go` — regenerate for the
+  new `GetByNames` signature.
+- `bin-pipecat-manager/pkg/toolhandler/main_test.go` (`TestToolHandler_GetByNames`
+  and `TestToolHandler_GetAll`, if `GetAll` is removed) — update.
+- `bin-pipecat-manager/pkg/pipecatcallhandler/run_test.go` (lines using
+  single-arg `GetByNames(gomock.Any())`) — update to 2-arg form.
+- `bin-pipecat-manager/pkg/pipecatcallhandler/runner_toolfallback_test.go` —
+  currently asserts the fail-open fallback (`mockTool.EXPECT().GetAll().Return(...)`);
+  invert to assert fail-closed (empty tool list), and add
+  `TestToolResolve_AIResolveFailure_FailsClosed` (name indicative) pinning
+  the new behavior.
+- `bin-pipecat-manager/pkg/pipecatcallhandler/start_test.go` (`GetAll().AnyTimes()`
+  expectations) — audit and update now that the non-AICall path calls
+  `GetByNames` instead.
+- `bin-pipecat-manager/pkg/pipecatcallhandler/metrics.go` and
+  `docs/operations.md` — both currently document the fallback as
+  intentional fail-open (VOIP-1234 §6); update to describe the fail-closed
+  policy and add a superseding note on the original VOIP-1234 §6 v4 design
+  doc.
+
+### 2.6 Live-whitelist policy (explicit decision record)
+
+`tool_names=["all"]` is stored as the literal string, re-expanded via
+`AllowedToolNames(t)` at every call. This means any future addition to
+`tool.AllInsightToolNames` (e.g. Part 1's `get_related_cases`/
+`get_case_notes` once merged) is **automatically** granted to every
+existing Insight AI already storing `["all"]`, with no re-consent step.
+
+This is accepted as the intended model: Insight AI's whitelist is
+constructed to only ever contain read-only tools, so scope growth carries
+low risk. This assumption must hold going forward — **recommended (not
+blocking) for the implementation PR:** add one unit test asserting every
+entry in `tool.AllInsightToolNames` maps to a tool definition with no
+side effects (however "read-only" is representable in the `Tool`
+struct/definition — introduce a metadata flag if none exists). Automating
+this via a structural guard (vs. a single assertion test) is a follow-up,
+not a requirement to ship.
+
+### 2.7 Frontend (`square-admin`)
+
+- `src/views/ais/AIEngineFields.js`: extend the "Enable All Tools" checkbox
+  (currently rendered only for `aiType === 'normal'`) to also render for
+  `'insight'`. The underlying state (`enableAllTools`, `selectedTools`) and
+  save/load logic in `ais_create.js` / `ais_detail.js` (`toolNamesValue =
+  enableAllTools ? ['all'] : selectedTools`, and the reverse mapping on
+  load) is already type-agnostic and needs no change.
+- `ais_create.js` / `ais_detail.js`: both currently force
+  `setEnableAllTools(false)` on switching `aiType` to `'insight'` — this
+  reset logic must be removed (or made conditional) now that Insight
+  supports the flag.
+- `src/views/ais/constants.js`: update the comment documenting that
+  Insight rejects `"all"` (no longer true).
+- `AIEngineFields.test.js`: update the existing assertions that Insight has
+  no "Enable All" checkbox.
+
+## Review history (condensed)
+
+Both parts went through 5 rounds of independent architecture + security
+review (parallel reviewers each round, `Agent` tool, `architect` +
+`security-reviewer` subagent types) before reaching 2 consecutive
+approvals, per this repo's mandatory review-loop policy. Substantive
+findings that changed the design, in order:
+
+**Part 1** (new tools): tier misclassification (two "safe" candidates
+actually shared Tier 2's IDOR risk) → batch size cut from 10 candidates to
+2 → `get_ai_summary_history` found non-viable by code inspection (dropped)
+→ `get_customer_cases` scope cut from tenant-wide to same-contact,
+renamed `get_related_cases` → fail-open bug found in the nil-`ContactID`
+path (§1.1 row 5) → fail-closed semantics for RPC errors vs. not-found
+clarified (§1.1 row 2 vs. 3) → self-inclusion bug found (current case
+appearing in its own "related cases" list, §1.1 row 6).
+
+**Part 2** (`"all"` support): initial design targeted dead code
+(`bin-ai-manager`'s unused `GetByNames`) — real expansion logic in
+`bin-pipecat-manager` found by the first review round → surfaced the
+pre-existing Normal/Insight leak and the `resolveAIFromAIcall` fail-open
+bug (§2.1) → whitelist helper relocated from a `bool` in `models/tool` to
+a `Type`-keyed function in `models/ai` for deny-by-default safety on future
+types → fail-open→fail-closed policy change proposed and reviewed
+specifically for its availability trade-off → missing test/mock/doc call
+sites found by direct grep in round 3.
+
+## Open questions for the next stage (implementation plan)
+
+1. Should Part 1 and Part 2 ship as one PR or two? They touch different
+   services (`bin-ai-manager` models/tools vs. `bin-pipecat-manager`
+   runtime) and are independently valuable; splitting reduces review
+   surface per PR but Part 2's whitelist refactor (`AllowedToolNames`) is
+   a clean dependency Part 1's new tools should register against either
+   way.
+2. Confirm current sort order of `ContactV1CaseNoteList` results before
+   implementing the "most recent N" truncation in `get_case_notes`
+   (§1.2) — flagged by review as needing code-level verification, not
+   assumed here.


### PR DESCRIPTION
Expand Case Insight Assistant's tool whitelist with two new read-only
tools and let Insight AIs use the "all" tool shorthand, closing a
pre-existing production gap discovered while investigating the latter:
tool-list expansion had no AIType awareness and would fail open on AI
lookup failure. Design doc: docs/plans/2026-07-30-case-insight-assistant-tool-expansion-design.md
(5 rounds of independent architecture + security review, 2 consecutive
approvals). Frontend counterpart: voipbin/monorepo-javascript#408.

- bin-ai-manager: add get_related_cases and get_case_notes tools, both
  scoped to the current case's CustomerID with fail-closed ownership
  checks and audit logging on cross-customer access attempts
- bin-ai-manager: add AllowedToolNames(Type) as the single source of
  truth for the tool whitelist (deny-by-default for unknown types);
  refactor ValidateToolNames to use it and accept "all" for type=insight
- bin-pipecat-manager: make GetByNames AIType-aware so it re-applies the
  whitelist at tool-expansion time regardless of what tool_names stores,
  closing a defense-in-depth gap (Normal AI's "all" was leaking the two
  Insight-only tools)
- bin-pipecat-manager: change the AI-lookup-failure fallback from
  fail-open (GetAll(), every tool including write-capable ones) to
  fail-closed (no tools), reversing a prior VOIP-1234 decision now that
  tool access is enforced per-type; remove GetAll() from the
  ToolHandler interface entirely so this can't be silently reintroduced
- bin-pipecat-manager: update docs/operations.md and metrics to reflect
  the fail-closed policy