### PR TITLE
VOIP-1277-All-services-static-build-distroless

### DIFF
--- a/bin-agent-manager/Dockerfile
+++ b/bin-agent-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-agent-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-agent-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-ai-manager/Dockerfile
+++ b/bin-ai-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-ai-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-ai-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-api-manager/Dockerfile
+++ b/bin-api-manager/Dockerfile
@@ -1,8 +1,5 @@
-# base
-FROM public.ecr.aws/docker/library/golang:1.25-bookworm AS base
-
 # build
-FROM base AS build
+FROM public.ecr.aws/docker/library/golang:1.25-alpine AS build
 
 WORKDIR /app
 COPY ./ .

--- a/bin-api-manager/Dockerfile
+++ b/bin-api-manager/Dockerfile
@@ -7,12 +7,12 @@ FROM base AS build
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-api-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-api-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM base
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin
-COPY --from=build /app/bin-api-manager/docsdev /app/bin/docsdev
+COPY --from=build /app/bin-api-manager/docsdev/build/html /app/bin/docsdev/build/html
 COPY --from=build /app/bin-api-manager/gens/openapi_redoc /app/bin/gens/openapi_redoc

--- a/bin-billing-manager/Dockerfile
+++ b/bin-billing-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-billing-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-billing-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-call-manager/Dockerfile
+++ b/bin-call-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-call-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-call-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-campaign-manager/Dockerfile
+++ b/bin-campaign-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-campaign-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-campaign-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-conference-manager/Dockerfile
+++ b/bin-conference-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-conference-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-conference-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-contact-manager/Dockerfile
+++ b/bin-contact-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-contact-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-contact-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-conversation-manager/Dockerfile
+++ b/bin-conversation-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-conversation-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-conversation-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-customer-manager/Dockerfile
+++ b/bin-customer-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-customer-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-customer-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-direct-manager/Dockerfile
+++ b/bin-direct-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-direct-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-direct-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-email-manager/Dockerfile
+++ b/bin-email-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-email-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-email-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-flow-manager/Dockerfile
+++ b/bin-flow-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-flow-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-flow-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-hook-manager/Dockerfile
+++ b/bin-hook-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-hook-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-hook-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-message-manager/Dockerfile
+++ b/bin-message-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-message-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-message-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-number-manager/Dockerfile
+++ b/bin-number-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-number-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-number-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-outdial-manager/Dockerfile
+++ b/bin-outdial-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-outdial-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-outdial-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-queue-manager/Dockerfile
+++ b/bin-queue-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-queue-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-queue-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-rag-manager/Dockerfile
+++ b/bin-rag-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-rag-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-rag-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-registrar-manager/Dockerfile
+++ b/bin-registrar-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-registrar-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-registrar-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-route-manager/Dockerfile
+++ b/bin-route-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-route-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-route-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-sentinel-manager/Dockerfile
+++ b/bin-sentinel-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-sentinel-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-sentinel-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-storage-manager/Dockerfile
+++ b/bin-storage-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-storage-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-storage-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-tag-manager/Dockerfile
+++ b/bin-tag-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-tag-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-tag-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-talk-manager/Dockerfile
+++ b/bin-talk-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-talk-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-talk-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-timeline-manager/Dockerfile
+++ b/bin-timeline-manager/Dockerfile
@@ -4,11 +4,10 @@ FROM public.ecr.aws/docker/library/golang:1.25-alpine AS build
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-timeline-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-timeline-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM gcr.io/distroless/static-debian12
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin
 COPY --from=build /app/bin-timeline-manager/migrations /app/bin/migrations

--- a/bin-transcribe-manager/Dockerfile
+++ b/bin-transcribe-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-transcribe-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-transcribe-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-transfer-manager/Dockerfile
+++ b/bin-transfer-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-transfer-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-transfer-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-trigger-sender/Dockerfile
+++ b/bin-trigger-sender/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-trigger-sender && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-trigger-sender && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-tts-manager/Dockerfile
+++ b/bin-tts-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-tts-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-tts-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-webchat-manager/Dockerfile
+++ b/bin-webchat-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-webchat-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-webchat-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-webhook-manager/Dockerfile
+++ b/bin-webhook-manager/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd bin-webhook-manager && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd bin-webhook-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/docs/plans/2026-07-31-api-manager-static-build-distroless-design.md
+++ b/docs/plans/2026-07-31-api-manager-static-build-distroless-design.md
@@ -1,0 +1,93 @@
+# api-manager 정적 빌드 + distroless 런타임 파일럿 (VOIP-1277)
+
+날짜: 2026-07-31
+상태: 디자인 리뷰 루프 완료 (R1 Request Changes → R2 Approve → R3 Approve, 2연속 Approval)
+선행: VOIP-1276 (ZeroMQ/cgo 제거, PR #1150 머지 완료)
+
+## 1. 목표
+
+VOIP-1277의 파일럿으로 `bin-api-manager` 하나만 `CGO_ENABLED=0` 정적 빌드 + 최소 런타임 이미지(distroless)로 전환한다. 패턴이 검증되면 나머지 서비스에 일괄 적용한다(별도 작업).
+
+## 2. 사전 조사 결과 (실측 기반)
+
+### 2.1 실행 환경 제약
+
+| 환경 | 실행 방식 | 셸 필요 여부 | 영향 |
+|---|---|---|---|
+| GKE (`bin-api-manager/k8s/deployment.yml`) | `command: ['./api-manager']` (exec form), probe는 `httpGet /ping :443 HTTPS` | 불필요 | 변경 없음. distroless 호환 |
+| sandbox (`~/gitvoipbin/sandbox/docker-compose.yml`) | `command: ./api-manager` (compose 문자열은 shlex 분해되어 exec form으로 실행, 셸 불필요) | command는 불필요. 단 **healthcheck가 `wget` 사용** → distroless에 없음 | sandbox가 새 이미지 digest로 lock 갱신하는 시점에 healthcheck 교체 필요 (sandbox 저장소, 별도 PR) |
+| CircleCI (`docker-build` command) | repo 루트 컨텍스트로 `docker build -f bin-api-manager/Dockerfile .` 후 push | 무관 | Dockerfile 변경만으로 충분, CI 수정 불필요 |
+
+### 2.2 런타임 요구사항 vs distroless/static-debian12 (이미지 실측: docker export로 확인)
+
+| 요구 | 근거 | distroless/static 충족 여부 |
+|---|---|---|
+| `/tmp` 쓰기 | `cmd/api-manager/main.go`가 `/tmp/ssl_privkey.pem`, `/tmp/ssl_cert.pem` 기록 | ✓ `/tmp` 존재, `drwxrwxrwt` |
+| CA 인증서 | GCS 접근, 외부 HTTPS 호출 | ✓ `/etc/ssl/certs/ca-certificates.crt` 포함 |
+| tzdata | Go `time.LoadLocation` 사용처 없음(비-vendor 코드 grep 0건). 있어도 무방 | ✓ zoneinfo 1,308개 파일 포함 |
+| 정적 자산 서빙 | `docsdev/` HTML, `gens/openapi_redoc` — 바이너리가 `WORKDIR /app/bin` 기준 상대 경로로 서빙 | COPY로 동일 레이아웃 유지 |
+| 포트 443 바인딩 | HTTPS 리스너가 443 사용 | distroless/static 기본 태그는 root 실행이므로 가능. `:nonroot` 태그는 443 바인딩 불가 → 이번 파일럿에서는 기본(root) 유지 |
+| cgo 미필요 | VOIP-1276에서 `CGO_ENABLED=0 go build ./cmd/...` 성공 실증 | ✓ |
+| DNS resolve | RabbitMQ/MySQL/Redis/GCS 호스트명 해석. `CGO_ENABLED=0`이면 glibc `getaddrinfo` 대신 **pure-Go resolver**가 `/etc/resolv.conf`, `/etc/hosts`, `/etc/nsswitch.conf`를 직접 파싱한다(모두 distroless/static에 존재). 이미지 교체가 아닌 **런타임 동작 변화**이므로 스모크 테스트에서 의존 호스트명 해석을 명시 확인 | ✓ (단, §5 리스크에 기재) |
+
+### 2.3 현행 Dockerfile 문제
+
+- 런타임 스테이지가 `FROM base`(= golang:1.25-bookworm, 약 800MB+)를 그대로 사용. 컴파일러 툴체인 전체가 프로덕션 컨테이너에 포함됨.
+- `CGO_ENABLED` 미명시 → 기본값(cgo 활성)으로 동적 링크 바이너리 생성.
+
+## 3. 설계
+
+### 3.1 Dockerfile 변경 (bin-api-manager만)
+
+```dockerfile
+# base
+FROM public.ecr.aws/docker/library/golang:1.25-bookworm AS base
+
+# build
+FROM base AS build
+WORKDIR /app
+COPY ./ .
+RUN mkdir -p /app/bin
+RUN cd bin-api-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
+
+# run
+FROM gcr.io/distroless/static-debian12
+WORKDIR /app/bin/
+COPY --from=build /app/bin /app/bin
+COPY --from=build /app/bin-api-manager/docsdev/build/html /app/bin/docsdev/build/html
+COPY --from=build /app/bin-api-manager/gens/openapi_redoc /app/bin/gens/openapi_redoc
+```
+
+결정 사항:
+- **런타임 베이스: `gcr.io/distroless/static-debian12` (기본/root 태그)**. `:nonroot`는 443 바인딩이 막히므로 이번 범위에서 제외. 비루트 전환은 포트 구성 변경(8443 + Service 매핑)과 함께 별도 검토.
+- **베이스 이미지 태그 정책**: `gcr.io/distroless/static-debian12`에서 `debian12`는 태그가 아니라 저장소 이름의 일부이며, 태그 미지정 시 해당 저장소의 `:latest`(가변 태그)를 pull한다. 저장소 이름으로 debian 세대 고정은 보장되지만 pull 자체가 불변인 것은 아니다. digest 고정은 하지 않는다. 현행 golang 베이스(`golang:1.25-bookworm`)도 동일한 수준의 가변 태그이므로 기준을 유지하는 것이다.
+- **docsdev COPY 축소**: 바이너리는 `docsdev/build/html`만 서빙한다(main.go의 gin Static 경로). RST 소스 등 비런타임 파일 약 5.4MB를 제외하고 `build/html`만 동일 상대 경로로 복사한다.
+- ENTRYPOINT/CMD는 기존과 동일하게 미지정 (k8s/compose가 command 제공).
+- **빌드 경로에 gcr.io 추가**: distroless pull은 익명 접근 가능하며 CI 수정이 불필요하다. 다만 모노레포 빌드 경로에 처음 추가되는 gcr.io 의존이다(빌드 타임 한정 — GKE/sandbox는 최종 이미지를 Docker Hub에서 pull하므로 런타임 gcr.io 의존은 없음).
+- 빌드 스테이지 구조(base→build)와 빌드 명령은 기존 유지, `CGO_ENABLED=0`만 추가.
+
+### 3.2 이번 범위에서 하지 않는 것
+
+- 다른 36개 서비스 전환 (파일럿 검증 후 별도 진행)
+- `:nonroot` 전환 (포트 구성 변경 필요)
+- sandbox healthcheck 교체 (sandbox 저장소 소관, 새 이미지 digest로 lock 갱신 시점에 `wget` → 다른 방식으로 교체. 후보: api-control 기반 CMD probe 또는 metrics 포트 노출 유지 방식 재검토)
+- k8s 매니페스트 변경 (변경 불필요함을 확인했으므로)
+
+## 4. 검증 계획
+
+1. **로컬 이미지 빌드**: repo 루트에서 `docker build -f bin-api-manager/Dockerfile -t api-manager-distroless-test .` 성공.
+2. **바이너리 정적 링크 확인**: 빌드 스테이지 산출물에 대해 `file`/`ldd`로 정적 바이너리 확인 (또는 `docker run` 기동으로 갈음).
+3. **컨테이너 기동 스모크 테스트**: 새 이미지를 `docker run` (RabbitMQ 등 없는 환경이므로 dependency 연결 실패로 종료하는 것까지가 정상 동작 확인 범위 — 바이너리가 exec되고 로그가 나오는지, "no such file"류 링킹/경로 오류가 없는지 확인). **DNS 해석 확인 포함**: 실패 로그가 "호스트명 해석 실패"가 아니라 "연결/인증 실패"인지 구분 확인(pure-Go resolver 검증). 가능하면 sandbox 스택에 이미지를 끼워 `/metrics` 응답과 docsdev/redoc 정적 서빙까지 확인.
+3b. **api-control 실행 확인**: `go build ./cmd/...`는 `api-manager`와 `api-control` 두 바이너리를 생성하며, sandbox healthcheck 교체 후보가 api-control이므로 distroless 이미지에서 api-control도 exec되는지 확인.
+4. **이미지 크기 비교**: 변경 전후 `docker images` 기록.
+5. 모노레포 검증 워크플로우는 Go 코드 무변경이므로 build/test만 재확인.
+6. **배포 후 검증** (머지 → CircleCI build-approval 수동 승인 → 프로덕션 배포 파이프라인. 스테이징 없음, 단 readinessProbe + 2 replica + maxUnavailable=0 구조라 기동 불능 이미지는 롤아웃이 정지될 뿐 장애로 이어지지 않음): `kubectl rollout status deploy/api-manager` 확인 후 `/ping`, `/docs`, `/redoc/index.html` 응답 확인.
+
+## 5. 리스크
+
+| 리스크 | 완화 |
+|---|---|
+| distroless에 없는 런타임 파일 의존 발견 | §2.2에서 알려진 요구사항 전수 실측 확인 완료. 스모크 테스트에서 기동 로그로 재확인 |
+| pure-Go resolver 동작 차이 (ndots 검색 도메인 확장, NSS 플러그인 부재 등) | GKE kube-dns 표준 구성에서는 동작 동일 범위. 스모크 테스트에서 의존 호스트명 해석 확인. 문제 시 이미지 롤백으로 즉시 복구 |
+| sandbox healthcheck 파손 | sandbox는 digest lock이라 이번 머지로 즉시 영향 없음. lock 갱신 PR에서 healthcheck 교체를 함께 진행 (§3.2에 명시) |
+| 프로덕션 롤백 | 이미지 태그 단위 롤백 가능 (이전 digest로 재배포). Go 코드 무변경이므로 이미지만 되돌리면 됨 |

--- a/docs/plans/2026-07-31-fleet-static-build-distroless-design.md
+++ b/docs/plans/2026-07-31-fleet-static-build-distroless-design.md
@@ -1,0 +1,72 @@
+# 전 서비스 정적 빌드 + distroless 런타임 전환 (VOIP-1277 플릿 롤아웃)
+
+날짜: 2026-07-31
+상태: 디자인 리뷰 루프 완료 (R1 RC → R2 A → R3 RC → R4 A → R5 A, 2연속 Approval)
+선행: [2026-07-31-api-manager-static-build-distroless-design.md](2026-07-31-api-manager-static-build-distroless-design.md) (파일럿, 설계/코드 리뷰 루프 통과, 이미지 1.08GB → 139MB 실증)
+
+## 1. 목표
+
+파일럿(bin-api-manager)에서 검증된 패턴을 모노레포 전체 Go 서비스로 확대한다. 단일 PR로 진행한다(파일럿 PR #1151은 본 PR로 대체).
+
+## 2. 전수 조사 결과 (37개 Dockerfile)
+
+### 2.1 현행 패턴
+
+- **표준 (30개)**: `golang:1.25-alpine` 빌드 → `alpine:latest` 런타임, `COPY --from=build /app/bin /app/bin`, CMD 없음(k8s가 exec-form command 제공).
+- **변형**: bin-timeline-manager(runtime `apk add ca-certificates` + `CMD ["./timeline-manager"]` + migrations COPY), bin-rag-manager(migrations COPY), voip-kamailio-proxy(exec-form ENTRYPOINT), bin-api-manager(파일럿에서 이미 전환).
+- **특수 (3개, 전환 제외)**: 아래 §3.2.
+
+### 2.2 안전성 확인 (전 서비스 실측)
+
+- **k8s `exec:` probe: 0건.** probe는 api-manager와 hook-manager의 `httpGet`(:443 HTTPS /ping) 2건뿐. initContainers/lifecycle hook 0건.
+- **k8s command: 100% exec-list form.** 셸 불필요. (tts-manager의 `sh -c` 사이드카는 별도 python 이미지, pipecat의 사이드카는 §3.2에서 제외 처리)
+- **voip 프록시 2종의 외부 소비자 검증(monorepo-voip 실측)**: voip-asterisk-proxy는 voip-asterisk-k8s-{call,conference,registrar}의 사이드카로 `command: ['./asterisk-proxy']` (exec form) 실행, probe 없음. voip-kamailio-proxy는 voip-kamailio-ansible의 docker-compose에서 command/healthcheck 없이 이미지 ENTRYPOINT(exec form, 본 전환에서 보존)로 실행되며 `cap_add: NET_RAW`는 프로세스 capability라 이미지 내용과 무관. 두 이미지를 `FROM`으로 파생하는 이미지는 monorepo-voip 전체에 없음. → 전환 안전.
+- **비-vendor Go 코드의 `os/exec` 사용: voip-rtpengine-proxy 1건뿐** (tcpdump, §3.2에서 제외).
+- **`time.LoadLocation`/`os/user` 사용: 0건.** tzdata/NSS 우려 없음.
+- **`mattn/go-sqlite3`는 `_test.go`에서만 import** → 프로덕션 빌드에 cgo 불필요 (pipecat 제외).
+- **`/tmp` 쓰기: 3건** — api-manager, hook-manager(TLS 인증서 파일), tts-control(`/tmp/tts-media` 기본값, CLI 바이너리). distroless/static의 `/tmp`는 world-writable, `readOnlyRootFilesystem` 미설정 → 동작.
+- **런타임 상대 경로 파일 의존**: api-manager(docsdev/redoc, 파일럿에서 처리), rag-manager(`./migrations`, 메인 프로세스가 기동 시 실행), timeline-manager(`file://migrations`, timeline-control) → migrations COPY 보존 필수.
+- **CA 인증서 일관성 확보**: 34개 alpine 런타임 중 timeline-manager 1개만 명시적으로 ca-certificates를 설치하며, 나머지는 alpine 베이스에 기본 포함된 `ca-certificates-bundle`에 암묵 의존. distroless/static은 CA 번들을 항상 포함하므로 명시/암묵 혼재가 단일 기준으로 정리됨.
+
+## 3. 설계
+
+### 3.1 전환 대상: 34개 (bin-* 32개 + voip-asterisk-proxy, voip-kamailio-proxy)
+
+표준 변환 규칙 (기존 파일 대비 최소 diff):
+
+1. 빌드 명령에 `CGO_ENABLED=0` 추가: `go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...`
+2. 런타임 스테이지: `FROM public.ecr.aws/docker/library/alpine:latest` (또는 `alpine:latest`) → `FROM gcr.io/distroless/static-debian12`
+3. 기존 LABEL, WORKDIR, COPY 구조 유지. migrations COPY(rag, timeline), CMD(timeline, exec form), ENTRYPOINT(kamailio-proxy, exec form) 그대로 보존.
+4. timeline-manager의 `RUN apk --no-cache add ca-certificates` 삭제 (distroless가 CA 번들 포함).
+5. bin-api-manager: 파일럿 상태 유지하되 빌드 베이스를 `golang:1.25-bookworm`(+무의미해진 base 스테이지)에서 표준 `golang:1.25-alpine` 단일 빌드 스테이지로 통일. (코드 리뷰 R3에서 vestigial base 스테이지로 지적된 항목의 해소이기도 함)
+
+### 3.2 전환 제외: 3개
+
+| 서비스 | 사유 | 처리 |
+|---|---|---|
+| bin-pipecat-manager | `github.com/zaf/resample`(libsoxr cgo) 필수 + 런타임이 Python 3.12(torch/ffmpeg) + 동일 이미지로 python 사이드카 실행 | 현행 유지. 별도 최적화는 독립 티켓 |
+| bin-dbscheme-manager | Go 서비스 아님 (python/alembic 빌더 → mysql:8.0 시드 이미지) | 현행 유지 |
+| voip-rtpengine-proxy | 런타임에 `tcpdump` 실행 파일 필요 (`exec.Command`, 동적 링크라 distroless/static 불가) | 현행(alpine) 유지. distroless/base+tcpdump 검토는 후속 |
+
+### 3.3 베이스 이미지 정책
+
+파일럿과 동일: `gcr.io/distroless/static-debian12` (저장소명으로 debian 세대 고정, 태그는 암묵 `:latest` 가변, digest 고정 없음 — 현행 `alpine:latest`와 동일한 가변성 수준이므로 후퇴 아님. digest 고정은 플릿 안정화 후 별도 검토).
+
+## 4. 검증 계획
+
+1. **전 서비스 `CGO_ENABLED=0 go build ./...`**: 34개 대상 서비스 전부 로컬 실행, 실패 0건 확인 (cgo 의존 잔존 검출).
+2. **전 서비스(34개) docker build 로컬 완주**: 변환된 모든 Dockerfile을 머지 전에 로컬에서 빌드해 실패 0건 확인. (readinessProbe가 없는 32개 서비스는 배포 시 안전망이 약하므로, 머지 전 컨테이너 수준 검증을 전수로 수행)
+3. **스모크 실행 샘플**: bin-call-manager(표준), bin-timeline-manager(migrations+CMD), voip-kamailio-proxy(ENTRYPOINT), bin-hook-manager(/tmp TLS+443), bin-rag-manager(기동 시 migrations 실행), bin-trigger-sender(CronJob 소비, 아래 §5 참고) 기동 확인(의존성 부재로 인한 연결 실패까지가 정상 범위).
+4. **이미지 크기 비교**: 표준 서비스 1종의 전후 크기 기록 (alpine 런타임은 원래 작으므로 api-manager만큼 극적이지 않음. 주된 이득은 셸/패키지매니저 제거와 CA 번들 일관성).
+5. Go 코드 무변경이므로 모노레포 검증 워크플로우는 원칙적으로 대상 외. 예외: voip-kamailio-proxy는 `go mod vendor`가 main에서 이미 깨져 있던 상태(x/sys 0.42.0 pin이 bin-common-handler의 0.45.0 요구와 불일치)라 go.mod/go.sum 동기화를 포함하며, 해당 서비스는 전체 검증 워크플로우(vendor/generate/build/test/lint)를 완주함.
+
+## 5. 리스크
+
+| 리스크 | 완화 |
+|---|---|
+| 특정 서비스의 미발견 런타임 의존 | §2.2 전수 조사(os/exec, 파일 경로, probe, tzdata)로 사전 배제. **전 서비스(34개) docker build를 머지 전 로컬 완주** + 전 서비스 CGO_ENABLED=0 빌드 + 샘플 스모크로 삼중 확인 |
+| **readinessProbe 부재 (32/34 서비스)** | probe가 있는 서비스는 api-manager, hook-manager 2개뿐. 나머지는 기동 직후 프로세스가 종료하는 유형의 실패(start-then-exit)가 발생하면 롤아웃이 정지되지 않고 기존 pod를 대체해버릴 수 있음(장애 가능). **완화: 배포는 서비스별 CircleCI approval 게이트로 1개씩 진행하며, 각 서비스 승인 후 `kubectl rollout status` + 기동 로그 확인을 마친 뒤 다음 서비스를 승인**. 문제 발생 시 이미지 태그 롤백. probe 일괄 추가는 별도 티켓으로 후속 (이번 변경과 독립적인 기존 격차) |
+| 배포 파이프라인 | 서비스별 CircleCI build-approval 수동 승인 구조 유지. 한 번에 전 서비스를 배포하지 않고 1개씩 승인·확인·진행 (위 readinessProbe 행의 절차). 이미지 태그 단위 롤백 가능 |
+| **bin-trigger-sender 예외 (CronJob 자동 반영)** | 이 서비스만 release 잡이 없고 CronJob이 `:latest` + `imagePullPolicy: Always`로 다음 스케줄 실행 때 자동으로 새 이미지를 사용. `kubectl rollout status` 절차가 적용 불가하며, 실패 시 "번호 갱신 잡의 조용한 실패"가 됨. **완화: build approval 후 `kubectl create job --from=cronjob/...`로 1회 수동 실행해 로그를 확인**. 롤백은 태그 재지정이 아니라 이전 이미지의 `:latest` 재푸시 |
+| sandbox healthcheck (wget/셸 기반) | sandbox는 digest lock이라 즉시 영향 없음. **단, 다음 lock 갱신 시 전 서비스 healthcheck가 일괄 영향을 받으므로**, sandbox 저장소에서 healthcheck 방식 교체(각 서비스 control 바이너리 또는 대체 방식)를 선행/동시 진행해야 함. 별도 sandbox PR로 처리 |
+| pure-Go resolver | 33개 alpine 빌드 서비스는 이미 사실상 pure-Go resolver로 운영 중임(golang:alpine 이미지에 C 컴파일러가 없어 Go 1.20+가 cgo를 자동 비활성화 → 현행 프로덕션 바이너리가 이미 정적/netgo). `CGO_ENABLED=0` 명시는 이 상태를 고정하는 것이지 동작 변경이 아님. 실질 전환은 api-manager(bookworm 빌드) 1개뿐이며 파일럿에서 /etc/hosts + DNS 쿼리 동작 실증 완료 |

--- a/voip-asterisk-proxy/Dockerfile
+++ b/voip-asterisk-proxy/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd voip-asterisk-proxy && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd voip-asterisk-proxy && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/voip-kamailio-proxy/Dockerfile
+++ b/voip-kamailio-proxy/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Sungtae Kim <pchero21@gmail.com>"
 WORKDIR /app
 COPY ./ .
 RUN mkdir -p /app/bin
-RUN cd voip-kamailio-proxy && go mod vendor && go build -o /app/bin/ ./cmd/...
+RUN cd voip-kamailio-proxy && go mod vendor && CGO_ENABLED=0 go build -o /app/bin/ ./cmd/...
 
 # run
-FROM public.ecr.aws/docker/library/alpine:latest
+FROM gcr.io/distroless/static-debian12
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/voip-kamailio-proxy/go.mod
+++ b/voip-kamailio-proxy/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/voip-kamailio-proxy/go.sum
+++ b/voip-kamailio-proxy/go.sum
@@ -856,8 +856,8 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=


### PR DESCRIPTION
Fleet rollout of VOIP-1277: convert all Go services to CGO_ENABLED=0 static builds with gcr.io/distroless/static-debian12 runtime images. Extends the bin-api-manager pilot (PR #1151, superseded by this PR) to 34 Dockerfiles. Production containers no longer contain a shell, package manager, or OS userland; CA certificates become uniformly bundled. Excluded with documented rationale: bin-pipecat-manager (mandatory cgo/libsoxr + Python runtime), bin-dbscheme-manager (non-Go mysql seed image), voip-rtpengine-proxy (needs tcpdump executable). Verified pre-merge: all 34 services build with CGO_ENABLED=0, all 34 docker images built locally with zero failures, 6 smoke samples (standard, TLS+/tmp, migrations-at-startup, CronJob binary, CMD, ENTRYPOINT) exec correctly in distroless, voip-kamailio-proxy full verification workflow green. Deployment is one-service-at-a-time via existing CircleCI approval gates per the design doc's rollout procedure. Jira: VOIP-1277.

- bin-api-manager: CGO_ENABLED=0 + distroless/static runtime, docsdev COPY narrowed to build/html, build stage unified to golang:1.25-alpine (1.08GB to 139MB)
- bin-agent-manager, bin-ai-manager, bin-billing-manager, bin-call-manager, bin-campaign-manager, bin-conference-manager, bin-contact-manager, bin-conversation-manager, bin-customer-manager, bin-direct-manager, bin-email-manager, bin-flow-manager, bin-hook-manager, bin-message-manager, bin-number-manager, bin-outdial-manager, bin-queue-manager, bin-registrar-manager, bin-route-manager, bin-sentinel-manager, bin-storage-manager, bin-tag-manager, bin-talk-manager, bin-transcribe-manager, bin-transfer-manager, bin-trigger-sender, bin-tts-manager, bin-webchat-manager, bin-webhook-manager: Convert to CGO_ENABLED=0 static build + distroless/static runtime
- bin-rag-manager: Convert to distroless/static runtime, migrations COPY preserved (startup migrations)
- bin-timeline-manager: Convert to distroless/static runtime, drop apk ca-certificates (bundled in distroless), CMD and migrations COPY preserved
- voip-asterisk-proxy: Convert to CGO_ENABLED=0 static build + distroless/static runtime
- voip-kamailio-proxy: Convert to distroless/static runtime, ENTRYPOINT preserved; fix stale x/sys go.mod pin that broke go mod vendor on main
- monorepo: Add fleet design document docs/plans/2026-07-31-fleet-static-build-distroless-design.md and pilot design document