### PR TITLE
VOIP-1279-Asterisk-proxy-fail-fast-listen-handler

### DIFF
--- a/docs/plans/2026-08-02-asterisk-proxy-fail-fast-design.md
+++ b/docs/plans/2026-08-02-asterisk-proxy-fail-fast-design.md
@@ -1,0 +1,363 @@
+# VOIP-1279: asterisk-proxy fail-fast on listen handler failure — Design
+
+Date: 2026-08-02
+Ticket: VOIP-1279
+Service: voip-asterisk-proxy
+
+## Problem
+
+When the proxy's RabbitMQ listen handler fails at startup (observed: queue declaration
+failed because the delayed-message exchange plugin was missing), the error is only
+logged and the process keeps running. The container stays Up, periodic Redis
+address-key updates continue, but the request queues (`asterisk.<id>.request`,
+`asterisk.call.request`, ...) have zero consumers. `restart: always` never fires
+because the process never exits. Call setup is silently broken until a manual
+restart.
+
+Root causes (two layers):
+
+1. `pkg/listenhandler/main.go` `Run()` does *all* work (queue declaration +
+   consumer startup) inside a goroutine and unconditionally returns `nil`.
+   Errors are logged and swallowed.
+2. `cmd/asterisk-proxy/main.go` startup error paths use `log.Errorf` + `return`,
+   which exits `main()` with **exit code 0**. Even if the error were propagated,
+   the process would not signal failure.
+
+   This is only partially addressed by this design: per the fatal-vs-soft
+   principle in Change 2, `getAsteriskIDAddress` and the listen-handler paths
+   move to `Fatalf`, but `setProxyInfoRedis` and `setProxyInfoAnnotation`
+   keep their `log.Errorf` + `return` (exit 0) paths. This is a deliberate
+   scoping choice, not an oversight, and it is harmless for the restart-heal
+   requirement in this ticket: both `restart: always` (docker-compose) and
+   Kubernetes' default `RestartPolicy: Always` restart on container exit
+   regardless of exit code, they don't require non-zero specifically. Exit
+   code correctness for those two paths is left as a smaller, separate
+   cleanup, not required for this ticket's acceptance criteria.
+
+Transient-loss analysis (revised after review): the shared
+`bin-common-handler/pkg/rabbitmqhandler` layer self-heals **connection**-level
+loss only (`reconnector` + `redeclareAll`, infinite 1s retry on `connect()`).
+Two narrower gaps exist above that layer and are explicitly scoped below:
+
+- Consumer **re-registration** after reconnect (`reconsumerAll`) is a
+  best-effort retry bounded at 3 attempts; on exhaustion it logs and gives up
+  permanently, leaving a live process with zero consumers on that queue. This
+  is the same symptom as the ticket, but triggered post-startup rather than at
+  startup, and fixing it means changing `bin-common-handler` (38-service blast
+  radius per its admission rule). **Out of scope for this ticket** — filed as
+  a follow-up (see Out of scope).
+- `redeclareAll` itself logs-and-continues on a failed `QueueDeclare`, which is
+  the upstream cause of the above. Same follow-up.
+
+This ticket's fix targets the **startup** failure path only, which is both
+what VOIP-1275 observed and what the acceptance criteria describe (the
+sandbox replay is a start/break/fix/recover sequence, not a live-reconnect
+sequence).
+
+## Deployment model check
+
+`docs/subsystems.md` documents two supported models: Kubernetes sidecar (proxy
+and Asterisk as separate containers in one pod) and single-container
+(Asterisk + proxy binary in one image). **This cannot be resolved from the
+monorepo alone** — there are no Kubernetes manifests here (infra lives in a
+separate repo), so which model production actually runs is not verifiable
+from source under review. Rather than assume sidecar, this design proceeds on
+a worse-case-safe basis:
+
+- The ticket's own "Fix direction" explicitly asks for fail-fast-and-exit —
+  this was written by the reporter after live-diagnosing the exact incident,
+  so the fail-fast behavior itself is a requirement, not a design choice up
+  for renegotiation here.
+- Under single-container, a proxy crash-loop would restart the co-located
+  Asterisk process and drop in-progress calls. This is a real, unverified
+  residual risk. It is called out explicitly in the PR description so
+  whoever deploys this can confirm the running topology before rollout, and
+  captured in `docs/subsystems.md` (see Documentation updates) so it isn't
+  lost. It is not something this design can mitigate in-process — no amount
+  of in-process retry changes the outcome once the process has decided to
+  exit, so gating on "confirm sidecar in production" (a deploy-time check,
+  not a code change) is the correct place for this risk, not a code
+  workaround.
+- **This risk is not confined to single-container.** `Fatalf` exits the whole
+  process, which also kills the ARI/AMI event pump managed by
+  `pkg/eventhandler` (`evtHandler.Run()`, launched at
+  `cmd/asterisk-proxy/main.go:125`, before the listen handler). Today, a
+  proxy stuck in the ticket's bug still relays ARI/AMI events (hangups, state
+  changes) for in-progress calls even though new RPC requests time out —
+  upstream services can at least see calls end and clean up/bill correctly.
+  After this fix, on `Fatalf`, event relay stops too, **in sidecar mode as
+  well as single-container**: in-progress calls lose their terminal-event
+  path until the restarted proxy reconnects to ARI/AMI. This is accepted as
+  an intentional trade-off — the ticket's explicit ask is "exit non-zero,
+  don't run in a half-working state" — but it is a real behavior change
+  beyond "new call setup fails faster," not a risk-free improvement, and
+  should be stated as such in the PR description rather than only "restart
+  policy heals it."
+- The observed trigger (a missing broker plugin) is a **broker-side,
+  fleet-correlated** condition: every asterisk-proxy pod hits the same
+  failure simultaneously, since they all declare against the same broker.
+  Combined with the point above, this fix turns "one proxy quietly stuck"
+  into "the whole Asterisk fleet's event plane going down at once" for the
+  duration of the outage — worse in aggregate blast radius than today's bug,
+  though also more visible (crash-looping pods vs. a silently-stuck fleet)
+  and self-healing once the broker-side issue is fixed, which today's
+  behavior is not. Net, this still matches the ticket's explicit ask
+  (visibility and self-healing over silent, unbounded outage), but it should
+  be understood as a trade of "quieter, unbounded breakage" for "louder,
+  bounded, fleet-wide breakage," not a strict improvement with no downside.
+- No in-process retry/backoff is added (see next paragraph for why) — a
+  crash-loop under sustained failure is accepted as intentional given the
+  ticket's explicit ask, with backoff timing left entirely to the container
+  runtime's restart policy (docker-compose / Kubernetes `RestartPolicy`),
+  which already implements backoff and is the correct layer for it.
+
+**Why no in-process retry:** an earlier revision of this design added a
+5s/60s in-process retry loop to avoid a "storm" on a brief broker blip. On
+review this didn't hold up: (a) connection-level loss is already retried
+unboundedly one layer down in `rabbitmqhandler.connect()`, so the new retry
+added nothing there; (b) the ticket's own trigger — a missing broker plugin —
+is deterministic, not transient, so retrying it for 60s only delays the
+correct fatal exit by 60s on every single restart attempt; (c) applying the
+retry to queue declaration but not consumer startup (`ConsumeRPC`) left the
+consumer path exposed to the exact same "storm" scenario the retry was meant
+to prevent, since `startConsumers` can fail on the same broker-side
+conditions (`channel.Qos`, `channel.Consume`). Rather than extend the retry
+to both paths with a still-unanchored budget, this revision removes it:
+`Run()` fails fast on the first declaration or consumer-startup error, and
+backoff between restart attempts is delegated entirely to the container
+runtime's restart policy — which is already the standard backoff mechanism
+(`CrashLoopBackOff` on Kubernetes) and does not duplicate logic in-process.
+
+## Fix
+
+### Change 1 — `pkg/listenhandler/main.go`
+
+- `Run()` declares all listen queues (permanent + volatile) **synchronously**
+  (no retry — see above) and returns an error immediately if any declaration
+  fails.
+- Before declaring, `Run()` validates the **combined** permanent + volatile
+  queue-name list (each split on `,`, concatenated the same way
+  `listenRun` already does at `pkg/listenhandler/main.go:100-127`) for two
+  conditions, failing fast with a plain validation error (no broker call) if
+  either holds:
+  - any element is an empty string (config typo, e.g. a trailing comma in
+    `--rabbitmq_queue_listen`);
+  - any two elements are equal (config typo, e.g. a copy-pasted duplicate
+    entry, or `--rabbitmq_queue_listen` accidentally containing the same
+    value as the derived volatile queue name `asterisk.<id>.request`).
+
+  This second check is the one that actually matters operationally.
+  `registerConsumer` (`bin-common-handler/pkg/rabbitmqhandler/consume.go:108-120`)
+  rejects a second registration for a `queueName` that already has one, and
+  under this design that becomes a permanent, self-inflicted `Fatalf` crash
+  loop with no possible self-recovery (no broker fix can resolve a
+  process-local duplicate list) — worse than today's behavior, where it is
+  just a logged error and one queue silently loses its consumer. The
+  empty-string check is weaker justification on its own: a single trailing
+  comma produces exactly one empty element (not a duplicate, since
+  `registerConsumer` only rejects *repeated* names), and an empty queue name
+  reaching `QueueDeclare` triggers AMQP's broker-generated-name behavior,
+  which this codebase does not capture — the local `r.queues[""]` entry and
+  the broker's actual (different, generated) queue name diverge, so it fails
+  differently (at bind/consume time) rather than cleanly. It's still worth
+  rejecting outright rather than letting either failure mode occur, but the
+  duplicate check is the one closing a real crash-loop hole.
+- Consumer startup (`ConsumeRPC`) stays in per-queue goroutines (it blocks
+  until ctx cancellation on success, per `bin-common-handler` semantics — see
+  Transient-loss analysis for why a `ConsumeRPC` error return is a
+  startup-only signal here). The `ListenHandler` interface's `Run()`
+  signature changes from `Run() error` to `Run() (<-chan error, error)`: the
+  returned `error` is the synchronous declare/validation result (as today,
+  just now non-nil on failure); the returned channel is owned and sized by
+  `listenHandler` itself (buffered to the actual `len(listenQueues)`, known
+  internally once the split completes — not passed in by the caller, which
+  would otherwise have to duplicate the split logic to size it, reintroducing
+  the exact drift risk the duplicate-name validation above closes). Each
+  consumer goroutine sends its non-nil `ConsumeRPC` error on that channel
+  (never on a nil result — `ConsumeRPC` also returns nil on `ctx.Done()`,
+  which cannot occur today since `context.Background()` is passed, but the
+  send is guarded explicitly so a future context change can't turn a clean
+  shutdown into `Fatalf: err: <nil>`). This avoids a package-level mutable
+  var (no `fatalf` indirection) and keeps a single, testable exit point in
+  `main()`.
+- `pkg/listenhandler` has no `go:generate` directive or mock today (the
+  service's only mock is in `pkg/servicehandler`); this interface-signature
+  change does not require mock regeneration, and none is added as part of
+  this change.
+- Note on the `bin-call-manager` reference: its `Run()` matches the
+  synchronous-declare half of this change, but its `ConsumeRPC` goroutine
+  still only logs-and-swallows (same as asterisk-proxy today). The
+  error-channel escalation is a new, deliberately local pattern for this
+  service, not an existing monorepo convention — flagged in case a
+  service-wide follow-up is later warranted.
+- Fatal-vs-soft principle applied consistently in this change (see Change 2
+  for the concrete split): **fail fast only for failures that block
+  establishing the RabbitMQ consumer topology** (queue declaration, consumer
+  registration, and the inputs those two require — the Asterisk ID used in
+  the volatile queue name). Auxiliary features unrelated to the consumer
+  topology (Kubernetes annotation, GCS recording config, Redis address
+  registration) are explicitly out of scope and keep today's soft-failure
+  behavior — see Change 2 for why each one is classified the way it is.
+
+### Change 2 — `cmd/asterisk-proxy/main.go`
+
+```go
+chErr, err := listenHandler.Run()
+if err != nil {
+    log.Fatalf("Could not run the listen handler correctly. err: %v", err)
+}
+...
+select {
+case sig := <-chSigs:
+    log.Infof("Terminating asterisk-proxy. sig: %v", sig)
+case err := <-chErr:
+    log.Fatalf("Listen handler failed permanently. err: %v", err)
+}
+```
+
+`Fatalf` is applied narrowly — only to the paths that actually strand the
+process with a live-but-nonfunctional consumer topology, per-path:
+
+- `listenHandler.Run()` returning an error at call time (now possible after
+  Change 1) → `Fatalf` at the call site, same as before but now reachable.
+- Listen-handler consumer failure delivered via `chErr` → `Fatalf` as above.
+- `getAsteriskIDAddress` failure → `Fatalf`. Under the stated principle this
+  is in scope because the resolved ID feeds directly into the volatile queue
+  name (`asterisk.<id>.request`) — without it, `Run()` cannot even attempt
+  correct queue declaration. (It also happens to gate Redis registration and
+  annotation patching, but that is not why it is classified fatal here — see
+  `setProxyInfoAnnotation` below for the contrasting case, to keep the
+  principle, not the consequence, doing the classifying.)
+
+Left as `log.Errorf` + `return` (unchanged), based on review of each path:
+
+- `setProxyInfoRedis` — this one does *not* cleanly fall outside the stated
+  principle: `docs/subsystems.md` states upstream services read this Redis
+  key to construct the volatile queue name for targeted RPC routing, so a
+  correctly-declared volatile queue that nobody can address is functionally
+  close to this ticket's symptom (unreachable consumer topology). It is left
+  non-fatal anyway, but for a narrower, code-grounded reason: the function
+  itself cannot fail (dial happens lazily inside the update goroutine at
+  `cmd/asterisk-proxy/main.go:196-198`, whose errors are already logged
+  per-iteration, not returned to the caller) — so converting its `nil`-only
+  return path to `Fatalf` would be a no-op today regardless of the
+  principle. The *actual* gap — a persistent Redis write failure silently
+  leaving the routing key stale/missing forever, logged but never escalated
+  — is real and is called out explicitly under Out of scope rather than
+  silently waved through as "unrelated."
+- `setProxyInfoAnnotation` — under the stated principle, this is out of scope
+  by construction: Kubernetes pod-annotation patching is bookkeeping metadata
+  unrelated to establishing the RabbitMQ consumer topology (it doesn't feed
+  queue names, and nothing in `pkg/listenhandler` reads it). It also happens
+  to already have a documented soft-failure resolution in
+  `docs/operations.md` (missing `patch` verb → `--kubernetes_disabled=true` or
+  grant RBAC), which corroborates the classification but is not itself the
+  rule being applied.
+- `evtHandler.Run()` — confirmed dead path: `eventHandler.Run()` unconditionally
+  returns `nil` (`pkg/eventhandler/main.go:63-72`), so this call site cannot
+  currently return an error either way. Left unchanged; no behavior change to
+  claim here.
+
+## Out of scope
+
+- `pkg/eventhandler` / ARI event loop: auto-reconnects every 1s internally
+  (documented in service docs); does not strand the process. Unchanged.
+- Post-startup consumer loss (`reconsumerAll` exhaustion, channel-level AMQP
+  errors that end `consumeRPCWorker` without triggering `reconnector`): real
+  gap, same symptom as this ticket, but requires a `bin-common-handler` change
+  with a 38-service blast radius. Follow-up ticket to be filed after this
+  merges, referencing this design doc.
+- Health-check endpoint exposing consumer liveness (ticket lists it as an
+  alternative; fail-fast is the chosen primary mechanism for the startup
+  case; a liveness endpoint would also help catch the post-startup gap above
+  and is a candidate approach for the follow-up ticket).
+- Persistent Redis write failure for the address-key routing entry
+  (`setProxyInfoRedis`'s per-iteration goroutine at
+  `cmd/asterisk-proxy/main.go:196-198`) is logged but never escalated, even
+  though it can leave the volatile queue effectively unaddressed by upstream
+  services. Not fixed here (left non-fatal for the code-level reason given in
+  Change 2), but noted so it isn't mistaken for "already covered."
+
+## Acceptance criteria mapping
+
+| AC | How satisfied | Residual gap |
+|----|---------------|---------------|
+| Exits non-zero when listen handler cannot be established | Change 1 (sync declare, no retry) + Change 2 (`Fatalf` via error channel), applied uniformly to declaration failure and consumer-startup failure | Post-startup consumer loss after a successful start is not covered — see Out of scope |
+| `restart: always` self-heals after transient RabbitMQ failure | Two distinct mechanisms: (a) broker-unreachable at boot — `sockHandler.Connect()` blocks and retries internally every 1s, process never exits, no restart needed because it never stopped trying; (b) topology failure (this ticket's actual trigger, e.g. missing plugin) — immediate `Fatalf` → container restart → retries the whole sequence including (a), with backoff timing owned by the restart policy, not this code | Case (a) window is not itself a `Fatalf` path; documented as intentional (connection retry is already unbounded and self-healing without needing a process restart) |
+| Sandbox scenario replay (break plugin → start → fix → recover) | Gates merge — see Testing | Recovery latency is bounded by the restart policy's backoff (see deployment note below), not by anything in this change |
+
+Deployment note: `restart: always` is docker-compose syntax; production runs
+on GKE where the equivalent is the pod's default `RestartPolicy: Always` with
+exponential backoff (up to 5 min between attempts via CrashLoopBackOff). MTTR
+after a broker fix therefore differs materially between sandbox
+(docker-compose, near-immediate restart) and production (K8s, up to 5 min
+backoff) — call this out during the sandbox replay so the observed recovery
+time isn't assumed to hold in production. This is also the reason no
+in-process retry/backoff was added (see Deployment model check): duplicating
+backoff logic in-process would only create two backoff timers disagreeing
+with each other.
+
+## Testing
+
+- Unit (mock `SockHandler`), run with `-race`:
+  - `Run()` returns a validation error immediately (no queue declaration
+    attempted) when the permanent or volatile queue-name list contains an
+    empty element (trailing-comma config case).
+  - `Run()` returns error immediately when permanent-queue declaration fails;
+    no attempt is made to declare the volatile queue or start any consumer
+    (fail-fast, no partial topology left half-declared beyond what the broker
+    itself already accepted before the failing call). Note the precise shape
+    of the ticket's own trigger for this case: `queueCreateNormal`
+    (`bin-common-handler/pkg/rabbitmqhandler/queue.go:50-62`) first calls
+    `QueueDeclare` — which **succeeds**, the queue now exists on the broker —
+    and only then calls `queueConfig`, which fails at
+    `ExchangeDeclareForDelay` because the delayed-message plugin is missing.
+    So "declaration fails" here means the queue is declared but never
+    finishes its exchange/bind config; the volatile queue is never attempted
+    at all (not "declared but its own declare failed").
+  - `Run()` returns error immediately when volatile-queue declaration fails,
+    after the permanent queue already succeeded; assert no consumer goroutine
+    is started for either queue.
+  - `Run()` declares both queues and starts one consumer goroutine per queue
+    on success.
+  - A consumer goroutine's `ConsumeRPC` error is delivered on the (buffered)
+    error channel without blocking, including the case where two queues both
+    fail.
+- `main()`-level: exercised indirectly (exit-code behavior is not something
+  Go unit tests observe directly); the `select` wiring is simple enough that
+  code review substitutes for a dedicated test — call out explicitly that
+  AC1's exit-code requirement is verified end-to-end only by the sandbox
+  replay below, not by unit tests.
+- Full monorepo verification workflow (`go mod tidy && go mod vendor &&
+  go generate ./... && go test ./... && golangci-lint run`).
+- Sandbox replay per AC3 — **gates merge**, not deferred: break the
+  delayed-message plugin, start the stack, confirm proxies exit/restart-loop,
+  fix the plugin, confirm proxies recover consumers without manual
+  intervention. Record observed timing. While in the crash-loop window,
+  additionally check RabbitMQ queue depth on the permanent queue: its
+  `QueueDeclare` succeeds even when the subsequent exchange config fails (see
+  the precise mechanism noted in Testing above), so it exists on the broker
+  with zero consumers and publishers keep enqueuing into it — see
+  Documentation updates for the operator guidance this produces.
+
+## Documentation updates (same commit, per root CLAUDE.md service-docs-sync rule)
+
+- `docs/architecture.md` — listen-handler routing/behavior section: note the
+  synchronous, no-retry declare-and-consume with fatal-on-first-failure
+  behavior, and the empty-queue-name validation.
+- `docs/operations.md`:
+  - "RabbitMQ consumer not receiving requests" row — update resolution: the
+    process now exits non-zero and restarts on sustained topology failure;
+    add guidance that a *crash-looping* proxy (vs. a silently-idle one) is now
+    the expected failure signature during a topology break, and that queue
+    depth on the (already-declared) permanent queue should be checked after
+    recovery for a backlog of stale, already-timed-out call requests
+    accumulated during the crash-loop window.
+  - Add a row (or extend the `--interface_name` config row) noting that a
+    misconfigured/missing interface now causes a fatal exit rather than a
+    silent no-op.
+- `docs/subsystems.md` — Deployment Notes / Container model section: add a
+  note that the single-container model, if used, means a listen-handler
+  crash-loop restarts the co-located Asterisk process and drops in-progress
+  calls; confirm the running topology (sidecar vs. single-container) before
+  relying on this fail-fast behavior in that configuration.

--- a/docs/plans/2026-08-02-asterisk-proxy-fail-fast-implementation-plan.md
+++ b/docs/plans/2026-08-02-asterisk-proxy-fail-fast-implementation-plan.md
@@ -1,0 +1,270 @@
+# VOIP-1279: asterisk-proxy fail-fast — Implementation Plan
+
+Date: 2026-08-02
+Ticket: VOIP-1279
+Design: [2026-08-02-asterisk-proxy-fail-fast-design.md](2026-08-02-asterisk-proxy-fail-fast-design.md)
+
+## Steps
+
+### 1. `pkg/listenhandler/main.go`
+
+- Change `ListenHandler` interface: `Run() error` → `Run() (<-chan error, error)`.
+- Rewrite `Run()`:
+  - Build `listenQueues` by splitting+concatenating permanent and volatile
+    queue-name lists exactly as `listenRun` does today.
+  - Validate `listenQueues`: reject if any element is `""`, reject if any
+    two elements are equal (return a plain `fmt.Errorf`, no broker call).
+  - Declare each queue synchronously (permanent as `"normal"`, volatile as
+    `"volatile"`) via `h.sockHandler.QueueCreate`. On first failure, return
+    `(nil, err)` immediately — no further declarations, no consumers
+    started.
+  - On success, create `chErr := make(chan error, len(listenQueues))`.
+  - For each queue, start a goroutine calling `ConsumeRPC`; only send on
+    `chErr` when the returned error is non-nil (log it either way). This
+    guard matters because `ConsumeRPC` also returns nil on `ctx.Done()` —
+    unreachable today since `context.Background()` is passed, but the guard
+    prevents a future context change from turning a clean shutdown into
+    `Fatalf: err: <nil>` (design lines 176-181).
+  - Return `(chErr, nil)`.
+- Remove the old `listenRun` helper (folded into `Run()`), or keep as a
+  private helper invoked synchronously from `Run()` — implementer's choice,
+  keep it small and testable.
+- Audit: confirm `Run()` has exactly one caller (`cmd/asterisk-proxy/main.go`)
+  and that `pkg/listenhandler` has no `go:generate` directive / mock to
+  regenerate for this interface change (grep for `ListenHandler` and for
+  `.Run()` call sites across the monorepo before editing, to catch any other
+  consumer). As of this plan being written there are none — re-verify at
+  implementation time in case that has changed.
+
+### 2. `cmd/asterisk-proxy/main.go`
+
+- Review all five startup error paths; change exactly two, per the design's
+  per-path classification:
+  - `getAsteriskIDAddress` failure → change to `log.Fatalf`.
+  - `listenHandler.Run()` returning a non-nil `error` → change to
+    `log.Fatalf` at the call site (replaces today's `log.Errorf` + `return`).
+  - `setProxyInfoRedis`, `setProxyInfoAnnotation`, `evtHandler.Run()` →
+    leave unchanged (`log.Errorf` + `return`, exit code 0). Note in the diff
+    or PR description that this is deliberate scoping (design lines 26-35):
+    both docker-compose `restart: unless-stopped`/`always` and Kubernetes
+    `RestartPolicy: Always` restart on any container exit regardless of exit
+    code, so these paths don't need a non-zero exit to be healed by the
+    restart policy; fixing their exit code is a separate, smaller cleanup
+    not required by this ticket's acceptance criteria.
+- Capture `chErr` from `listenHandler.Run()`.
+- Replace the trailing `sig := <-chSigs` with:
+  ```go
+  select {
+  case sig := <-chSigs:
+      log.Infof("Terminating asterisk-proxy. sig: %v", sig)
+  case err := <-chErr:
+      log.Fatalf("Listen handler failed permanently. err: %v", err)
+  }
+  ```
+
+### 3. Tests — `pkg/listenhandler/main_test.go` (new or extended)
+
+Construct the handler under test directly as `&listenHandler{...}` (matching
+the existing pattern in `proxy_handler_test.go`), setting at least
+`sockHandler`, `rabbitQueueListenRequestPermanent`, and
+`rabbitQueueListenRequestVolatile`. Use `MockSockHandler`
+(`bin-common-handler/pkg/sockhandler`) with `gomock.NewController(t)` /
+`defer mc.Finish()`, matching existing package convention.
+
+**Synchronization note (required, not optional):** `ConsumeRPC` runs in a
+goroutine per queue. A test asserting "`ConsumeRPC` was called" or "error was
+delivered on `chErr`" must not call `mc.Finish()` (or let `defer` run it)
+before that goroutine has actually invoked the mock — otherwise the test is
+flaky (unmet-expectation failures) or panics ("call after Finish"). Use
+`EXPECT().ConsumeRPC(...).DoAndReturn(func(...) error { defer close(done); return tt.consumeErr })`
+with a per-queue `done chan struct{}`, and have the test `select` on all
+`done` channels with a timeout (e.g. `time.After(2*time.Second)`) before
+proceeding to assertions or letting the deferred `Finish()` run.
+
+Cases:
+
+- `Run()` returns a validation error and makes no `QueueCreate` call when the
+  combined permanent+volatile queue list contains an empty element (e.g.
+  permanent queue list `"asterisk.call.request,"`).
+- `Run()` returns a validation error and makes no `QueueCreate` call when the
+  combined list contains a duplicate element — cover both a duplicate within
+  the permanent list and the volatile-name-collision case (permanent list
+  value equal to the derived `asterisk.<id>.request`).
+- `Run()` returns a non-nil error immediately when the permanent queue's
+  `QueueCreate` fails; assert (via `gomock` call expectations / `Times(0)`)
+  that `QueueCreate` for the volatile queue and `ConsumeRPC` are never
+  called; returned channel is nil.
+- `Run()` returns a non-nil error immediately when the volatile queue's
+  `QueueCreate` fails after the permanent queue's `QueueCreate` succeeded;
+  assert `ConsumeRPC` is never called for either queue.
+- `Run()` succeeds: both queues' `QueueCreate` called, one `ConsumeRPC`
+  goroutine started per queue, a non-nil `chErr` and nil `error` returned.
+- A single `ConsumeRPC` mock returning an error delivers that error on
+  `chErr`, read with a timeout (not a blocking read) to prove the channel is
+  buffered and the send didn't need a receiver ready.
+- Both `ConsumeRPC` mocks (permanent and volatile) returning errors
+  concurrently both land on `chErr` without either goroutine blocking on
+  send — this is the case that actually exercises the buffer being sized to
+  `len(listenQueues)` rather than 1; read both off `chErr` with a timeout.
+- Run the package's tests with `-race` (folded into step 4, not a separate
+  invocation).
+
+### 4. Verification workflow (mandatory, run in `voip-asterisk-proxy/`)
+
+```bash
+go mod tidy && \
+go mod vendor && \
+go generate ./... && \
+go test -race ./... && \
+golangci-lint run -v --timeout 5m
+```
+
+### 5. Documentation updates (same commit)
+
+- `voip-asterisk-proxy/docs/architecture.md` — listen-handler section: describe
+  synchronous no-retry declare, empty/duplicate validation, fatal-on-first-
+  failure, and the error-channel consumer-failure signal.
+- `voip-asterisk-proxy/docs/operations.md`:
+  - Update "RabbitMQ consumer not receiving requests" row resolution.
+  - Update/add the `--interface_name` config row to note fatal-on-missing.
+  - Add guidance to check permanent-queue depth after recovering from a
+    crash-loop window.
+- `voip-asterisk-proxy/docs/subsystems.md` — Deployment Notes: add the
+  single-container residual-risk note (Asterisk restart on proxy crash-loop).
+
+### 5b. Rollout-safety check (before requesting merge)
+
+The new empty/duplicate queue-name validation converts a config quirk that
+today is a logged oddity into a permanent, self-inflicted crash loop no
+broker-side fix can resolve (design lines ~130-153). Since this monorepo does
+not contain the Kubernetes manifests for production deployment, add an
+explicit check as part of the PR, not an assumption: confirm (with whoever
+owns the deployment config, or by inspecting it directly if accessible) that
+every deployed asterisk-proxy instance's `--rabbitmq_queue_listen` /
+`RABBITMQ_QUEUE_LISTEN` value is non-empty, has no stray/trailing commas, and
+does not collide with the derived volatile name `asterisk.<id>.request`.
+State this check's result in the PR description.
+
+### 6. Sandbox replay (gates merge, per design's Testing section)
+
+This exercises the **sidecar** case only. In `~/gitvoipbin/sandbox`, all
+three asterisk-proxy instances run as separate containers using
+`network_mode: "service:asterisk-<call|registrar|conference>"` to share
+Asterisk's network namespace — a proxy crash-loop there does not restart
+Asterisk. That matches the design's scoping (the single-container risk is a
+deploy-time topology check, not something this replay can exercise) — state
+this explicitly in the PR description rather than letting the replay result
+read as covering both deployment models.
+
+Getting the branch's code into the sandbox: `docker-compose.yml` pins the
+three proxy services by image digest, not by local build context, so
+starting the stack as-is exercises the *published* image, not this branch —
+that would produce a false "replay passed" against pre-fix behavior. Before
+replaying:
+
+1. Build from the **monorepo/worktree root**, not the service subdirectory —
+   the Dockerfile does `COPY ./ .` then `cd voip-asterisk-proxy && go mod vendor`,
+   so it needs the whole tree (including sibling modules referenced by
+   `replace` directives, e.g. `bin-common-handler`) as build context:
+   ```
+   docker build -t voipbin/voip-asterisk-proxy:VOIP-1279-local -f voip-asterisk-proxy/Dockerfile .
+   ```
+   (run from the worktree root, e.g.
+   `~/gitvoipbin/monorepo/.worktrees/VOIP-1279-Asterisk-proxy-fail-fast-listen-handler/`).
+   Check for a `Makefile`/build script in `~/gitvoipbin/sandbox` first and
+   prefer it if one already encodes this correctly.
+2. Add a `docker-compose.override.yml` in the sandbox directory pinning
+   `image: voipbin/voip-asterisk-proxy:VOIP-1279-local` for all three proxy
+   services (`asterisk-call-proxy`, `asterisk-registrar-proxy`,
+   `asterisk-conference-proxy`).
+3. Confirm each container actually started from the local image
+   (`docker inspect` image ID, or a log line unique to the new build) before
+   proceeding — don't rely on "the compose file says so."
+
+Breaking the delayed-message plugin: `~/gitvoipbin/sandbox/docker-compose.yml`'s
+`rabbitmq` service entrypoint runs, on every container start: if
+`/opt/rabbitmq-extra-plugins/rabbitmq_delayed_message_exchange-3.13.0.ez`
+(volume-mounted from `./config/rabbitmq/plugins/`) is **missing**, download
+it; then unconditionally `rabbitmq-plugins enable --offline
+rabbitmq_delayed_message_exchange`. This means **removing or renaming the
+file does not work** — both make the existence check false and trigger a
+fresh download, silently undoing the break on the next container start. The
+break must happen without changing whether the file is present at that exact
+path:
+
+1. Back up
+   `~/gitvoipbin/sandbox/config/rabbitmq/plugins/rabbitmq_delayed_message_exchange-3.13.0.ez`
+   to a location outside the mounted directory (e.g. `/tmp`), so it can be
+   restored byte-for-byte afterward.
+2. Truncate or corrupt the file **in place, keeping the same filename** (e.g.
+   `truncate -s 0 <path>` or overwrite with garbage bytes) so the
+   entrypoint's existence check stays true (no re-download) but
+   `rabbitmq-plugins enable` fails to load a valid plugin.
+3. Also check whether `enabled_plugins` state persists in the `rabbitmq_data`
+   named volume from a prior run (independent of the `.ez` file) — if the
+   plugin was already enabled in a previous sandbox session, a corrupted
+   `.ez` alone may not un-enable it. If so, additionally remove/reset the
+   relevant named volume (`docker compose down -v` scoped to that volume, or
+   the sandbox's documented data-reset procedure) before starting the replay,
+   so the replay starts from a genuinely plugin-absent state.
+
+Replay procedure:
+
+- With the plugin broken and the branch's build in place, start the RabbitMQ
+  service first and verify the **precondition** before starting the proxies:
+  RabbitMQ reports healthy (`docker compose ps` shows `Up (healthy)`, or
+  equivalent), and `rabbitmq-plugins list -e` does **not** list
+  `rabbitmq_delayed_message_exchange`. This matters because the design draws
+  a hard line between "broker unreachable" (proxies retry forever inside
+  `sockHandler.Connect()`, never `Fatalf`) and "broker reachable but topology
+  declaration fails" (proxies `Fatalf`) — if RabbitMQ itself is unhealthy
+  rather than merely missing the plugin, the replay would land in the wrong
+  case and still show "proxies crash-looping," giving a false pass.
+- Start (or restart) the three proxy services. Confirm all three exit
+  non-zero and enter a restart loop (not silently "Up") — check both exit
+  code, using the actual container IDs since these services have no
+  `container_name` set (e.g.
+  `docker inspect --format='{{.State.ExitCode}}' $(docker compose ps -aq asterisk-call-proxy)`,
+  repeated per service), and logs.
+- Fix the plugin: restore the backed-up `.ez` file exactly (reverse step 2
+  above), and if step 3 required a volume reset, allow the entrypoint to
+  re-provision from a clean state. Confirm all three proxies recover
+  consumers without manual `docker compose restart`.
+- Check RabbitMQ permanent-queue depth (`asterisk.call.request` etc.) for
+  backlog accumulated during the outage window; note it in the PR
+  description per the ops-doc guidance from step 5.
+- Record observed restart/recovery timing, and the sandbox's actual restart
+  policy value as configured (`unless-stopped` for all three proxy services,
+  not `always`) alongside it — the design's AC2 table distinguishes
+  docker-compose from Kubernetes MTTR on the premise of "restart on any
+  exit," which `unless-stopped` also satisfies, but record the literal
+  policy string observed rather than assuming `always`.
+- Revert the `docker-compose.override.yml` / local image tag, confirm the
+  `.ez` file backup was restored and matches the original (checksum), and
+  confirm the plugin state is otherwise as it was before the replay.
+
+### 7. File the follow-up ticket
+
+Per the design's Out-of-scope section (post-startup consumer loss —
+`reconsumerAll` exhaustion after 3 attempts, `redeclareAll` log-and-continue
+on failed `QueueDeclare`): file a follow-up Jira ticket against
+`bin-common-handler` referencing this design doc, describing the gap and
+that any fix there has a 38-service verification blast radius per the
+package's admission rule. Link it from the PR description.
+
+## Order of work
+
+1 → 2 → 3 → 4 (iterate 1-4 until verification is clean) → 5 → 5b → 6 → 7.
+
+## PR description must include
+
+- Summary of the fix direction (from the design doc).
+- The accepted trade-off: event-pump loss on `Fatalf`, fleet-correlated
+  restart risk, single-container residual risk (ask deployer to confirm
+  topology before rollout).
+- Result of the rollout-safety check (step 5b): confirmed queue-name config
+  is empty/duplicate-clean for all deployed instances, or an explanation of
+  what could not be confirmed and why.
+- Sandbox replay results and timing, explicitly noting it covers the
+  sidecar case only, plus the actual restart policy value observed.
+- Link to the follow-up ticket filed in step 7.

--- a/voip-asterisk-proxy/cmd/asterisk-proxy/main.go
+++ b/voip-asterisk-proxy/cmd/asterisk-proxy/main.go
@@ -82,8 +82,7 @@ func main() {
 	// get asterisk id and internal address
 	asteriskID, asteriskAddress, err := getAsteriskIDAddress(interfaceName)
 	if err != nil {
-		log.Errorf("Could not get correct asterisk-id, asterisk-address info.")
-		return
+		log.Fatalf("Could not get correct asterisk-id, asterisk-address info. err: %v", err)
 	}
 
 	if errSet := setProxyInfoRedis(redisAddress, redisPassword, redisDatabase, asteriskID, asteriskAddress); errSet != nil {
@@ -141,14 +140,18 @@ func main() {
 	)
 
 	// run listen handler
-	if err := listenHandler.Run(); err != nil {
-		log.Errorf("Could not run the listen handler correctly. err: %v", err)
-		return
+	chErr, err := listenHandler.Run()
+	if err != nil {
+		log.Fatalf("Could not run the listen handler correctly. err: %v", err)
 	}
 	log.Debugf("The listen handler is running now. id: %s, address: %v", asteriskID, asteriskAddress)
 
-	sig := <-chSigs
-	log.Infof("Terminating api-manager. sig: %v", sig)
+	select {
+	case sig := <-chSigs:
+		log.Infof("Terminating asterisk-proxy. sig: %v", sig)
+	case err := <-chErr:
+		log.Fatalf("Listen handler failed permanently. err: %v", err)
+	}
 
 }
 

--- a/voip-asterisk-proxy/docs/architecture.md
+++ b/voip-asterisk-proxy/docs/architecture.md
@@ -65,3 +65,13 @@ Unmatched URIs return HTTP 400. The pattern match runs in `processRequest()` in 
 | Volatile | `asterisk.<mac-address>.request` | Instance-specific; routes requests to one specific Asterisk pod |
 
 Both queues are consumed concurrently. The volatile queue enables targeted control (e.g., hang up a specific call on a specific pod).
+
+### Startup behavior (fail-fast)
+
+`ListenHandler.Run()` (`pkg/listenhandler/main.go`) declares all listen queues (permanent + volatile) **synchronously** before starting any consumer, with no retry:
+
+1. Builds the combined permanent + volatile queue-name list and validates it: rejects if any element is an empty string (e.g. a trailing comma in `--rabbitmq_queue_listen`), and rejects if any two elements are equal — including the case where a permanent queue name collides with the derived volatile queue name `asterisk.<id>.request`. Validation failures return an error immediately with no broker call.
+2. Declares each queue via `QueueCreate` (permanent as `"normal"`, volatile as `"volatile"`). The first declaration failure returns an error immediately — no further declarations are attempted and no consumer is started.
+3. Only once every queue is declared does `Run()` start one consumer goroutine per queue (`ConsumeRPC`) and return a buffered error channel (sized to the number of listen queues) alongside a `nil` error.
+
+Each consumer goroutine sends its own `ConsumeRPC` error (if non-nil) on that channel; `cmd/asterisk-proxy/main.go` treats any error returned by `Run()` or delivered on this channel as fatal (`log.Fatalf`), so the process exits non-zero and relies on the container runtime's restart policy to recover — see `docs/operations.md` and `docs/subsystems.md` for the operational and deployment implications.

--- a/voip-asterisk-proxy/docs/operations.md
+++ b/voip-asterisk-proxy/docs/operations.md
@@ -6,7 +6,7 @@
 |---------|-------------|------------|
 | ARI WebSocket connection errors in logs, events stop flowing | Asterisk not yet started or ARI service not enabled | Verify Asterisk is running; check `--ari_address`; ensure `ari.conf` enables HTTP and the correct application |
 | AMI TCP connection failures | Wrong AMI host/port/credentials; `manager.conf` not enabled | Check `--ami_host`, `--ami_port`, `--ami_username`, `--ami_password`; verify `manager.conf` in Asterisk |
-| RabbitMQ consumer not receiving requests | Wrong queue name or RabbitMQ address | Verify `--rabbitmq_queue_listen` matches what upstream services publish to; check connectivity |
+| RabbitMQ consumer not receiving requests | Wrong queue name or RabbitMQ address | Verify `--rabbitmq_queue_listen` matches what upstream services publish to; check connectivity. As of the fail-fast change (VOIP-1279), a listen-handler queue-declare or consumer-startup failure now exits the process non-zero instead of silently leaving it up with zero consumers — the expected failure signature during a topology break (e.g. a missing broker plugin/exchange) is a **crash-looping** proxy, not a silently-idle one. Check `kubectl get pods` / `docker compose ps` for a restart loop and inspect logs for the `Fatalf` message. After the underlying broker/config issue is fixed and the proxy recovers, check the permanent queue's depth (e.g. `asterisk.call.request`) for a backlog of stale, already-timed-out call requests that accumulated during the crash-loop window — its `QueueDeclare` can succeed even when later topology config fails, so the queue exists on the broker and keeps accepting publishes with zero consumers throughout the outage |
 | Pod annotation patch failing | Not running in Kubernetes or service account lacks patch permission | Set `--kubernetes_disabled=true` for non-k8s environments; grant `patch` verb on pods to service account |
 | Recording upload fails | GCS bucket not configured or ADC not available | Set `--recording_bucket_name`; ensure the pod's service account has `roles/storage.objectCreator` on the bucket |
 | Redis write errors | Wrong `--redis_address` or Redis unavailable | Verify connectivity; service continues without Redis but upstream routing by address will fail |
@@ -76,7 +76,7 @@ All parameters can be set via command-line flags or environment variables. Flags
 | `--ami_username` | `AMI_USERNAME` | `asterisk` | AMI username |
 | `--ami_password` | `AMI_PASSWORD` | `asterisk` | AMI password |
 | `--ami_event_filter` | `AMI_EVENT_FILTER` | `` | Comma-separated AMI event types to forward (empty = all) |
-| `--interface_name` | `INTERFACE_NAME` | `eth0` | Network interface for MAC-based identity |
+| `--interface_name` | `INTERFACE_NAME` | `eth0` | Network interface for MAC-based identity. A missing/misconfigured interface now causes a fatal exit (`log.Fatalf`) at startup rather than a silent no-op, since the resolved MAC feeds the volatile queue name (`asterisk.<id>.request`) that the listen handler must declare |
 | `--rabbitmq_address` | `RABBITMQ_ADDRESS` | `amqp://guest:guest@localhost:5672` | RabbitMQ server |
 | `--rabbitmq_queue_listen` | `RABBITMQ_QUEUE_LISTEN` | `asterisk.call.request` | Permanent RabbitMQ listen queue |
 | `--redis_address` | `REDIS_ADDRESS` | `localhost:6379` | Redis server |

--- a/voip-asterisk-proxy/docs/subsystems.md
+++ b/voip-asterisk-proxy/docs/subsystems.md
@@ -83,6 +83,8 @@ The Dockerfile (`voip-asterisk-proxy/Dockerfile`) builds only the Go binary. Ast
 
 In either case, the Go proxy and Asterisk must share the same network namespace so that `localhost:8088` and `127.0.0.1:5038` resolve to Asterisk.
 
+**Residual risk (VOIP-1279 fail-fast behavior):** the proxy now exits non-zero (`log.Fatalf`) when it cannot establish its RabbitMQ listen-queue topology at startup (e.g. queue declaration failure, consumer registration failure), relying on the container runtime's restart policy to recover. Under the **single-container model**, a proxy crash-loop restarts the co-located Asterisk process in the same container, dropping in-progress calls — a real, non-hypothetical consequence of this model, not just a slower recovery. Under the **sidecar model**, the proxy container restarts independently and Asterisk is unaffected, though in-progress calls still lose their ARI/AMI event relay (hangup/state-change notifications) until the proxy reconnects, since `Fatalf` also stops the event handler in the same process. Confirm which topology is actually deployed before relying on this fail-fast behavior, and treat single-container deployments as carrying materially higher blast radius per crash-loop event.
+
 ### Startup order
 
 Asterisk must be fully started and ARI/AMI must be accepting connections before the proxy's event loops can attach. The proxy handles this via auto-reconnect: it will retry every 1 second until Asterisk becomes available. No explicit init ordering (e.g., `initContainers`) is required, but Asterisk startup time should be accounted for in readiness probes.

--- a/voip-asterisk-proxy/pkg/listenhandler/main.go
+++ b/voip-asterisk-proxy/pkg/listenhandler/main.go
@@ -16,7 +16,7 @@ import (
 
 // ListenHandler interface type
 type ListenHandler interface {
-	Run() error
+	Run() (<-chan error, error)
 }
 
 type listenHandler struct {
@@ -80,63 +80,77 @@ func NewListenHandler(
 	return handler
 }
 
-// Run runs the listen handler.
-func (h *listenHandler) Run() error {
-	log := logrus.New().WithField("func", "Run")
+// Run declares all listen queues (permanent + volatile) synchronously and,
+// on success, starts one consumer goroutine per queue. It returns an error
+// immediately if queue-name validation or queue declaration fails (no
+// consumer is started in that case). On success it returns a channel on
+// which each consumer goroutine reports its own (non-nil) ConsumeRPC error,
+// buffered to the number of listen queues so no goroutine blocks on send.
+func (h *listenHandler) Run() (<-chan error, error) {
+	log := logrus.WithField("func", "Run")
 
-	go func() {
-		if err := h.listenRun(); err != nil {
-			log.Errorf("Could not exeucte the listen handler: %v", err)
-		}
-	}()
-
-	return nil
-}
-
-// listenRun initiate and start to listening the request from the rabbitmq queue.
-func (h *listenHandler) listenRun() error {
-	log := logrus.WithField("func", "listenRun")
-
-	listenQueues := []string{}
+	permQueues, volQueues, err := h.buildListenQueues()
+	if err != nil {
+		return nil, fmt.Errorf("could not build the listen queue list. err: %v", err)
+	}
 
 	// queue declare for permanent
-	permQueues := strings.Split(h.rabbitQueueListenRequestPermanent, ",")
 	for _, queue := range permQueues {
+		log.Debugf("Declaring permanent request queue. queue: %s", queue)
 
-		if err := h.sockHandler.QueueCreate(queue, "normal"); err != nil {
-			return fmt.Errorf("could not declare the queue for listenHandler. err: %v", err)
+		if errCreate := h.sockHandler.QueueCreate(queue, "normal"); errCreate != nil {
+			return nil, fmt.Errorf("could not declare the permanent queue for listenHandler. queue: %s, err: %v", queue, errCreate)
 		}
-
-		// append it to listen queue
-		listenQueues = append(listenQueues, queue)
 	}
 
 	// queue declare for volatile
-	volQueues := strings.Split(h.rabbitQueueListenRequestVolatile, ",")
 	for _, queue := range volQueues {
+		log.Debugf("Declaring volatile request queue. queue: %s", queue)
 
-		// declare queue
-		log.Debugf("Declaring permenant request queue. queue: %s", queue)
-
-		if err := h.sockHandler.QueueCreate(queue, "volatile"); err != nil {
-			return fmt.Errorf("could not declare the queue for listenHandler. err: %v", err)
+		if errCreate := h.sockHandler.QueueCreate(queue, "volatile"); errCreate != nil {
+			return nil, fmt.Errorf("could not declare the volatile queue for listenHandler. queue: %s, err: %v", queue, errCreate)
 		}
-
-		// append it to liesten queue
-		listenQueues = append(listenQueues, queue)
 	}
 
-	// listening the queue
+	// all queues are declared successfully. start a consumer per queue.
+	listenQueues := append(append([]string{}, permQueues...), volQueues...)
+	chErr := make(chan error, len(listenQueues))
 	for _, listenQueue := range listenQueues {
 		log.Infof("Running the request listener. queue: %s", listenQueue)
 		go func(queue string) {
-			if errConsume := h.sockHandler.ConsumeRPC(context.Background(), queue, "asterisk-proxy", false, false, false, 10, h.processRequest); errConsume != nil {
+			errConsume := h.sockHandler.ConsumeRPC(context.Background(), queue, "asterisk-proxy", false, false, false, 10, h.processRequest)
+			if errConsume != nil {
 				log.Errorf("Could not handle the request message correctly. err: %v", errConsume)
+				chErr <- errConsume
 			}
 		}(listenQueue)
 	}
 
-	return nil
+	return chErr, nil
+}
+
+// buildListenQueues splits the permanent and volatile listen queue name
+// configuration and validates the combined list: no empty elements, no
+// duplicate elements (either within a list or across the two).
+func (h *listenHandler) buildListenQueues() (permQueues []string, volQueues []string, err error) {
+	permQueues = strings.Split(h.rabbitQueueListenRequestPermanent, ",")
+	volQueues = strings.Split(h.rabbitQueueListenRequestVolatile, ",")
+
+	listenQueues := append(append([]string{}, permQueues...), volQueues...)
+
+	seen := make(map[string]bool, len(listenQueues))
+	for _, queue := range listenQueues {
+		if queue == "" {
+			return nil, nil, fmt.Errorf("listen queue name must not be empty")
+		}
+
+		if seen[queue] {
+			return nil, nil, fmt.Errorf("duplicate listen queue name: %s", queue)
+		}
+		seen[queue] = true
+	}
+
+	return permQueues, volQueues, nil
 }
 
 func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) {

--- a/voip-asterisk-proxy/pkg/listenhandler/main_test.go
+++ b/voip-asterisk-proxy/pkg/listenhandler/main_test.go
@@ -1,0 +1,288 @@
+package listenhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+)
+
+// waitTimeout is the max time a test waits for a consumer goroutine to
+// signal completion via its done channel, or for a value on chErr.
+const waitTimeout = 2 * time.Second
+
+func Test_Run_validation_error(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		rabbitQueueListenRequestPermanent string
+		rabbitQueueListenRequestVolatile  string
+	}{
+		{
+			name: "empty element from trailing comma in permanent list",
+
+			rabbitQueueListenRequestPermanent: "asterisk.call.request,",
+			rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+		},
+		{
+			name: "empty element from trailing comma in volatile list",
+
+			rabbitQueueListenRequestPermanent: "asterisk.call.request",
+			rabbitQueueListenRequestVolatile:  "",
+		},
+		{
+			name: "duplicate element within permanent list",
+
+			rabbitQueueListenRequestPermanent: "asterisk.call.request,asterisk.call.request",
+			rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+		},
+		{
+			name: "volatile queue name collides with permanent queue name",
+
+			rabbitQueueListenRequestPermanent: "asterisk.11:22:33:44:55:66.request",
+			rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+
+			// no QueueCreate call is expected for any of these cases -- the
+			// controller will fail the test if QueueCreate is called since
+			// no expectation was set.
+
+			h := &listenHandler{
+				sockHandler:                       mockSock,
+				rabbitQueueListenRequestPermanent: tt.rabbitQueueListenRequestPermanent,
+				rabbitQueueListenRequestVolatile:  tt.rabbitQueueListenRequestVolatile,
+			}
+
+			chErr, err := h.Run()
+			if err == nil {
+				t.Errorf("Wrong match. expect: error, got: ok")
+			}
+			if chErr != nil {
+				t.Errorf("Wrong match. expect: nil channel, got: %v", chErr)
+			}
+		})
+	}
+}
+
+func Test_Run_permanent_declare_failure(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:                       mockSock,
+		rabbitQueueListenRequestPermanent: "asterisk.call.request",
+		rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+	}
+
+	mockSock.EXPECT().QueueCreate("asterisk.call.request", "normal").Return(fmt.Errorf("could not declare exchange"))
+	// no other QueueCreate or ConsumeRPC calls are expected -- the strict
+	// mock controller fails the test if they occur.
+
+	chErr, err := h.Run()
+	if err == nil {
+		t.Errorf("Wrong match. expect: error, got: ok")
+	}
+	if chErr != nil {
+		t.Errorf("Wrong match. expect: nil channel, got: %v", chErr)
+	}
+}
+
+func Test_Run_volatile_declare_failure(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:                       mockSock,
+		rabbitQueueListenRequestPermanent: "asterisk.call.request",
+		rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+	}
+
+	mockSock.EXPECT().QueueCreate("asterisk.call.request", "normal").Return(nil)
+	mockSock.EXPECT().QueueCreate("asterisk.11:22:33:44:55:66.request", "volatile").Return(fmt.Errorf("could not declare exchange"))
+	// no ConsumeRPC call is expected for either queue.
+
+	chErr, err := h.Run()
+	if err == nil {
+		t.Errorf("Wrong match. expect: error, got: ok")
+	}
+	if chErr != nil {
+		t.Errorf("Wrong match. expect: nil channel, got: %v", chErr)
+	}
+}
+
+func Test_Run_success(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:                       mockSock,
+		rabbitQueueListenRequestPermanent: "asterisk.call.request",
+		rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+	}
+
+	donePermanent := make(chan struct{})
+	doneVolatile := make(chan struct{})
+
+	mockSock.EXPECT().QueueCreate("asterisk.call.request", "normal").Return(nil)
+	mockSock.EXPECT().QueueCreate("asterisk.11:22:33:44:55:66.request", "volatile").Return(nil)
+
+	mockSock.EXPECT().ConsumeRPC(gomock.Any(), "asterisk.call.request", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error {
+			defer close(donePermanent)
+			return nil
+		},
+	)
+	mockSock.EXPECT().ConsumeRPC(gomock.Any(), "asterisk.11:22:33:44:55:66.request", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error {
+			defer close(doneVolatile)
+			return nil
+		},
+	)
+
+	chErr, err := h.Run()
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+	if chErr == nil {
+		t.Errorf("Wrong match. expect: non-nil channel, got: nil")
+	}
+
+	waitDone(t, donePermanent, "permanent consumer")
+	waitDone(t, doneVolatile, "volatile consumer")
+}
+
+func Test_Run_single_consumer_error(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:                       mockSock,
+		rabbitQueueListenRequestPermanent: "asterisk.call.request",
+		rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+	}
+
+	done := make(chan struct{})
+	expectedErr := fmt.Errorf("consumer died")
+
+	mockSock.EXPECT().QueueCreate("asterisk.call.request", "normal").Return(nil)
+	mockSock.EXPECT().QueueCreate("asterisk.11:22:33:44:55:66.request", "volatile").Return(nil)
+
+	mockSock.EXPECT().ConsumeRPC(gomock.Any(), "asterisk.call.request", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error {
+			defer close(done)
+			return expectedErr
+		},
+	)
+	mockSock.EXPECT().ConsumeRPC(gomock.Any(), "asterisk.11:22:33:44:55:66.request", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	chErr, err := h.Run()
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	waitDone(t, done, "permanent consumer")
+
+	select {
+	case gotErr := <-chErr:
+		if gotErr != expectedErr {
+			t.Errorf("Wrong match. expect: %v, got: %v", expectedErr, gotErr)
+		}
+	case <-time.After(waitTimeout):
+		t.Errorf("Timed out waiting for the consumer error on chErr")
+	}
+}
+
+func Test_Run_concurrent_consumer_errors(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:                       mockSock,
+		rabbitQueueListenRequestPermanent: "asterisk.call.request",
+		rabbitQueueListenRequestVolatile:  "asterisk.11:22:33:44:55:66.request",
+	}
+
+	donePermanent := make(chan struct{})
+	doneVolatile := make(chan struct{})
+	errPermanent := fmt.Errorf("permanent consumer died")
+	errVolatile := fmt.Errorf("volatile consumer died")
+
+	mockSock.EXPECT().QueueCreate("asterisk.call.request", "normal").Return(nil)
+	mockSock.EXPECT().QueueCreate("asterisk.11:22:33:44:55:66.request", "volatile").Return(nil)
+
+	mockSock.EXPECT().ConsumeRPC(gomock.Any(), "asterisk.call.request", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error {
+			defer close(donePermanent)
+			return errPermanent
+		},
+	)
+	mockSock.EXPECT().ConsumeRPC(gomock.Any(), "asterisk.11:22:33:44:55:66.request", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, queueName string, consumerName string, exclusive bool, noLocal bool, noWait bool, workerNum int, cbConsume sock.CbMsgRPC) error {
+			defer close(doneVolatile)
+			return errVolatile
+		},
+	)
+
+	chErr, err := h.Run()
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	// both goroutines must actually invoke ConsumeRPC (and therefore have
+	// sent, or be about to send, on chErr) before we read anything off the
+	// channel -- otherwise this test would pass even if the channel were
+	// sized 1 instead of len(listenQueues), since one goroutine could
+	// simply not have run yet.
+	waitDone(t, donePermanent, "permanent consumer")
+	waitDone(t, doneVolatile, "volatile consumer")
+
+	got := map[error]bool{}
+	for i := range 2 {
+		select {
+		case gotErr := <-chErr:
+			got[gotErr] = true
+		case <-time.After(waitTimeout):
+			t.Fatalf("Timed out waiting for consumer error #%d on chErr", i+1)
+		}
+	}
+
+	if !got[errPermanent] || !got[errVolatile] {
+		t.Errorf("Wrong match. expect both errors delivered on chErr. got: %v", got)
+	}
+}
+
+// waitDone waits for the given channel to be closed, failing the test if it
+// isn't closed within waitTimeout.
+func waitDone(t *testing.T, done chan struct{}, label string) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(waitTimeout):
+		t.Fatalf("Timed out waiting for %s to run", label)
+	}
+}


### PR DESCRIPTION
Make asterisk-proxy exit non-zero when its RabbitMQ listen handler cannot establish or permanently loses its consumer topology at startup, so restart policy heals the instance instead of it running indefinitely with zero consumers. Found during VOIP-1275 live internal-mode verification, where a missing delayed-message exchange plugin left three proxy instances "Up" but unable to service any RPC request.

- voip-asterisk-proxy: ListenHandler.Run() now declares all listen queues (permanent + volatile) synchronously with no retry, validates the combined queue-name list for empty or duplicate entries before any broker call, and returns an error immediately on the first declare failure
- voip-asterisk-proxy: Run() returns a buffered error channel (sized to the number of listen queues) that consumer goroutines use to report a ConsumeRPC failure after a successful start, without ever blocking on send
- voip-asterisk-proxy: main() now calls log.Fatalf when getAsteriskIDAddress fails or when the listen handler cannot be established at startup or reports a consumer failure via the error channel; Redis address registration, Kubernetes annotation patching, and the ARI/AMI event handler intentionally keep their existing soft-failure (log and continue) behavior — see the design doc for the per-path reasoning
- voip-asterisk-proxy: add unit tests covering queue-name validation, permanent/volatile declare failure paths, successful consumer startup, single and concurrent consumer-error delivery on the buffered channel
- voip-asterisk-proxy: update docs/architecture.md, docs/operations.md, docs/subsystems.md to describe the new fail-fast startup sequence, the resulting operational signature (crash-loop instead of a silently-idle proxy), and the residual single-container deployment risk
- docs: add the design doc and implementation plan for this change (docs/plans/), both went through multiple rounds of independent review

Design trade-offs accepted (detailed in the design doc):
- log.Fatalf also stops the ARI/AMI event relay, in sidecar mode as well as single-container — in-progress calls lose their terminal-event path during the crash-loop window, in exchange for visibility and self-healing over today's silent, unbounded outage
- The observed trigger (missing broker plugin) is fleet-correlated, so all proxy instances would crash-loop together rather than one instance silently degrading
- No in-process retry/backoff was added; backoff between restart attempts is left entirely to the container runtime's restart policy
- Post-startup consumer loss (bin-common-handler's reconsumerAll exhausting its bounded retry after a reconnect) is a related but separate gap requiring a bin-common-handler change with a 38-service blast radius — out of scope here, follow-up ticket to be filed after this merges

Still pending before merge (implementation plan steps 5b/6/7, need live infra access):
- Confirm deployed instances' --rabbitmq_queue_listen config has no empty/duplicate/colliding queue names (the new validation turns that into a permanent crash loop)
- Sandbox replay: break the delayed-message plugin, start the stack, confirm proxies crash-loop, fix the plugin, confirm consumers recover without manual intervention — this design's stated merge gate
- File the bin-common-handler follow-up ticket for the post-startup consumer-loss gap noted above

Test plan:
- [x] go mod tidy && go mod vendor && go generate ./... && go test -race ./... && golangci-lint run — all clean (35 tests passing)
- [x] Design doc: 5 rounds of independent review, 2 consecutive approvals
- [x] Implementation plan: 4 rounds of independent review, 2 consecutive approvals
- [x] Code: 3 rounds of independent review (functional correctness, security/concurrency, quality), all approved
- [ ] Sandbox replay of the VOIP-1279 scenario (gates merge per design doc)
- [ ] Rollout-safety confirmation of deployed queue-name config