### PR TITLE
VOIP-1284-Migrate-tickers-to-schedule-manager

### DIFF
--- a/bin-ai-manager/cmd/ai-manager/main.go
+++ b/bin-ai-manager/cmd/ai-manager/main.go
@@ -7,7 +7,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	commondatabasehandler "monorepo/bin-common-handler/pkg/databasehandler"
@@ -162,19 +161,6 @@ func run(sqlDB *sql.DB, cache cachehandler.CacheHandler) error {
 	geminiProposalHandler := geminiproposalhandler.NewGeminiProposalHandler(cfg.GoogleAPIKey)
 	aipromptproposalHandler := aipromptproposalhandler.NewAIPromptProposalHandler(db, geminiProposalHandler)
 	aipromptproposalHandler.SweepStaleProposals(context.Background())
-	go func() {
-		ctx := context.Background()
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				aipromptproposalHandler.SweepExpiredProposals(ctx)
-			}
-		}
-	}()
 
 	// run listen
 	if errListen := runListen(sockHandler, aiHandler, aicallHandler, aiauditHandler, aiprompthistoryHandler, aipromptproposalHandler, messageHandler, summaryHandler, teamHandler, participantHandler, analysisHandler); errListen != nil {

--- a/bin-ai-manager/docs/architecture.md
+++ b/bin-ai-manager/docs/architecture.md
@@ -79,6 +79,7 @@ ListenHandler (`pkg/listenhandler/`) routes by regex URI pattern over the shared
 | `GET /v1/aipromptproposals/<uuid>` | Get a single AI prompt improvement proposal |
 | `POST /v1/aipromptproposals/<uuid>/accept` | Accept a proposal and apply it to the AI's `init_prompt` |
 | `POST /v1/aipromptproposals/<uuid>/reject` | Reject a proposal without applying it |
+| `POST /v1/aipromptproposals/expire` | Sweep endpoint: expire completed proposals whose basis prompt has drifted (invoked by schedule-manager cron, replaces the old in-process ticker) |
 | `DELETE /v1/aipromptproposals/<uuid>` | Soft-delete an AI prompt improvement proposal |
 
 ## Event Subscriptions

--- a/bin-ai-manager/pkg/aipromptproposalhandler/main.go
+++ b/bin-ai-manager/pkg/aipromptproposalhandler/main.go
@@ -41,7 +41,7 @@ type AIPromptProposalHandler interface {
 	Reject(ctx context.Context, customerID uuid.UUID, id uuid.UUID) (*aipromptproposal.AIPromptProposal, error)
 	Delete(ctx context.Context, id uuid.UUID) (*aipromptproposal.AIPromptProposal, error)
 	SweepStaleProposals(ctx context.Context)
-	SweepExpiredProposals(ctx context.Context)
+	SweepExpiredProposals(ctx context.Context) (int, error)
 }
 
 type aipromptproposalHandler struct {

--- a/bin-ai-manager/pkg/aipromptproposalhandler/mock_main.go
+++ b/bin-ai-manager/pkg/aipromptproposalhandler/mock_main.go
@@ -133,9 +133,12 @@ func (mr *MockAIPromptProposalHandlerMockRecorder) Reject(ctx, customerID, id an
 }
 
 // SweepExpiredProposals mocks base method.
-func (m *MockAIPromptProposalHandler) SweepExpiredProposals(ctx context.Context) {
+func (m *MockAIPromptProposalHandler) SweepExpiredProposals(ctx context.Context) (int, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SweepExpiredProposals", ctx)
+	ret := m.ctrl.Call(m, "SweepExpiredProposals", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SweepExpiredProposals indicates an expected call of SweepExpiredProposals.

--- a/bin-ai-manager/pkg/aipromptproposalhandler/sweep.go
+++ b/bin-ai-manager/pkg/aipromptproposalhandler/sweep.go
@@ -2,6 +2,7 @@ package aipromptproposalhandler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -36,8 +37,11 @@ func (h *aipromptproposalHandler) SweepStaleProposals(ctx context.Context) {
 	}
 }
 
-// SweepExpiredProposals marks completed proposals as expired when the AI's basis prompt has drifted.
-func (h *aipromptproposalHandler) SweepExpiredProposals(ctx context.Context) {
+// SweepExpiredProposals marks completed proposals as expired when the AI's basis prompt has
+// drifted. Returns the number of proposals marked expired. Non-nil err is returned only when
+// the initial list fetch fails (nothing could be attempted); per-row AIGet failures are skipped
+// and do not fail the batch or count toward expired.
+func (h *aipromptproposalHandler) SweepExpiredProposals(ctx context.Context) (int, error) {
 	cutoff := h.utilHandler.TimeGetCurTimeAdd(-proposalExpiryHours * time.Hour)
 	filters := map[aipromptproposal.Field]any{
 		aipromptproposal.FieldStatus:  aipromptproposal.StatusCompleted,
@@ -47,9 +51,10 @@ func (h *aipromptproposalHandler) SweepExpiredProposals(ctx context.Context) {
 	cand, err := h.db.AIPromptProposalList(ctx, 1000, cutoff, filters)
 	if err != nil {
 		logrus.WithError(err).Error("expiry sweep: list failed")
-		return
+		return 0, fmt.Errorf("could not list candidate proposals: %w", err)
 	}
 
+	expired := 0
 	for _, p := range cand {
 		ai, gerr := h.db.AIGet(ctx, p.AIID)
 		if gerr != nil {
@@ -60,6 +65,10 @@ func (h *aipromptproposalHandler) SweepExpiredProposals(ctx context.Context) {
 		}
 		if _, uerr := h.db.AIPromptProposalUpdateExpired(ctx, p.ID, string(aipromptproposal.ErrorPromptVersionDrifted)); uerr != nil {
 			logrus.WithError(uerr).Errorf("expiry sweep: could not mark %s expired", p.ID)
+			continue
 		}
+		expired++
 	}
+
+	return expired, nil
 }

--- a/bin-ai-manager/pkg/aipromptproposalhandler/sweep_test.go
+++ b/bin-ai-manager/pkg/aipromptproposalhandler/sweep_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
 	"monorepo/bin-ai-manager/models/ai"
@@ -56,7 +57,9 @@ func TestSweepExpiredProposals_DriftedOnly(t *testing.T) {
 	mdb.EXPECT().AIGet(gomock.Any(), aiID).Return(&ai.AI{CurrentPromptHistoryID: current}, nil)
 	mdb.EXPECT().AIPromptProposalUpdateExpired(gomock.Any(), pid, string(aipromptproposal.ErrorPromptVersionDrifted)).Return(int64(1), nil)
 
-	h.SweepExpiredProposals(context.Background())
+	expired, err := h.SweepExpiredProposals(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, expired)
 }
 
 func TestSweepExpiredProposals_NotDrifted_LeftAlone(t *testing.T) {
@@ -76,7 +79,9 @@ func TestSweepExpiredProposals_NotDrifted_LeftAlone(t *testing.T) {
 	}}, nil)
 	mdb.EXPECT().AIGet(gomock.Any(), aiID).Return(&ai.AI{CurrentPromptHistoryID: hist}, nil)
 
-	h.SweepExpiredProposals(context.Background())
+	expired, err := h.SweepExpiredProposals(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, expired)
 }
 
 func TestSweepExpiredProposals_AIGetError_SkipsSilently(t *testing.T) {
@@ -97,5 +102,43 @@ func TestSweepExpiredProposals_AIGetError_SkipsSilently(t *testing.T) {
 	mdb.EXPECT().AIGet(gomock.Any(), aiID).Return(nil, dbhandler.ErrNotFound)
 	// No UpdateExpired expected.
 
-	h.SweepExpiredProposals(context.Background())
+	expired, err := h.SweepExpiredProposals(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, expired)
+}
+
+func TestSweepExpiredProposals_UpdateExpiredError_NotCounted(t *testing.T) {
+	h, mdb, _, mc := newHandlerWithMocks(t)
+	defer mc.Finish()
+	injectRealUtilHandler(h)
+
+	pid := uuid.Must(uuid.NewV4())
+	aiID := uuid.Must(uuid.NewV4())
+	basis := uuid.Must(uuid.NewV4())
+	current := uuid.Must(uuid.NewV4())
+
+	mdb.EXPECT().AIPromptProposalList(gomock.Any(), uint64(1000), gomock.Any(), gomock.Any()).Return([]*aipromptproposal.AIPromptProposal{{
+		Identity:             commonidentity.Identity{ID: pid},
+		AIID:                 aiID,
+		BasisPromptHistoryID: basis,
+		Status:               aipromptproposal.StatusCompleted,
+	}}, nil)
+	mdb.EXPECT().AIGet(gomock.Any(), aiID).Return(&ai.AI{CurrentPromptHistoryID: current}, nil)
+	mdb.EXPECT().AIPromptProposalUpdateExpired(gomock.Any(), pid, string(aipromptproposal.ErrorPromptVersionDrifted)).Return(int64(0), dbhandler.ErrNotFound)
+
+	expired, err := h.SweepExpiredProposals(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, expired)
+}
+
+func TestSweepExpiredProposals_ListError_ReturnsError(t *testing.T) {
+	h, mdb, _, mc := newHandlerWithMocks(t)
+	defer mc.Finish()
+	injectRealUtilHandler(h)
+
+	mdb.EXPECT().AIPromptProposalList(gomock.Any(), uint64(1000), gomock.Any(), gomock.Any()).Return(nil, dbhandler.ErrNotFound)
+
+	expired, err := h.SweepExpiredProposals(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, 0, expired)
 }

--- a/bin-ai-manager/pkg/listenhandler/main.go
+++ b/bin-ai-manager/pkg/listenhandler/main.go
@@ -100,6 +100,7 @@ var (
 	regV1AIPromptProposalsID       = regexp.MustCompile("/v1/aipromptproposals/" + regUUID + "$")
 	regV1AIPromptProposalsIDAccept = regexp.MustCompile("/v1/aipromptproposals/" + regUUID + "/accept$")
 	regV1AIPromptProposalsIDReject = regexp.MustCompile("/v1/aipromptproposals/" + regUUID + "/reject$")
+	regV1AIPromptProposalsExpire   = regexp.MustCompile("/v1/aipromptproposals/expire$")
 
 	// messages
 	regV1MessagesGet = regexp.MustCompile(`/v1/messages\?`)
@@ -389,6 +390,11 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1AIPromptProposalsIDReject.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		response, err = h.processV1AIPromptProposalsIDRejectPost(ctx, m)
 		requestType = "/v1/aipromptproposals/<id>/reject"
+
+	// POST /aipromptproposals/expire
+	case regV1AIPromptProposalsExpire.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1AIPromptProposalsExpirePost(ctx, m)
+		requestType = "/v1/aipromptproposals/expire"
 
 	// GET /aipromptproposals
 	case regV1AIPromptProposalsGet.MatchString(m.URI) && m.Method == sock.RequestMethodGet:

--- a/bin-ai-manager/pkg/listenhandler/models/response/aipromptproposal.go
+++ b/bin-ai-manager/pkg/listenhandler/models/response/aipromptproposal.go
@@ -1,0 +1,10 @@
+package response
+
+// V1ResponseAIPromptProposalsExpire is
+// v1 response type struct for
+// /v1/aipromptproposals/expire POST
+//
+// Wraps the bare expired-row count — a scalar with no domain type (style B).
+type V1ResponseAIPromptProposalsExpire struct {
+	Expired int `json:"expired"`
+}

--- a/bin-ai-manager/pkg/listenhandler/v1_aipromptproposals.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aipromptproposals.go
@@ -12,6 +12,7 @@ import (
 
 	"monorepo/bin-ai-manager/models/aipromptproposal"
 	"monorepo/bin-ai-manager/pkg/listenhandler/models/request"
+	"monorepo/bin-ai-manager/pkg/listenhandler/models/response"
 	"monorepo/bin-common-handler/models/sock"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 )
@@ -49,6 +50,30 @@ func (h *listenHandler) processV1AIPromptProposalsPost(ctx context.Context, m *s
 		return simpleResponse(500), nil
 	}
 	return &sock.Response{StatusCode: 202, DataType: "application/json", Data: data}, nil
+}
+
+// processV1AIPromptProposalsExpirePost handles POST /v1/aipromptproposals/expire.
+// It sweeps completed proposals whose basis prompt has drifted, marking them expired
+// (design §4/§6: scheduled sweep, invoked by the seeded ai-proposal-expiry schedule).
+func (h *listenHandler) processV1AIPromptProposalsExpirePost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{"func": "processV1AIPromptProposalsExpirePost", "request": m})
+
+	expired, err := h.aipromptproposalHandler.SweepExpiredProposals(ctx)
+	if err != nil {
+		log.Errorf("Could not sweep expired proposals. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	tmp := &response.V1ResponseAIPromptProposalsExpire{
+		Expired: expired,
+	}
+
+	data, mErr := json.Marshal(tmp)
+	if mErr != nil {
+		log.Errorf("Could not marshal response. err: %v", mErr)
+		return simpleResponse(500), nil
+	}
+	return &sock.Response{StatusCode: 200, DataType: "application/json", Data: data}, nil
 }
 
 // processV1AIPromptProposalsGet handles GET /v1/aipromptproposals.

--- a/bin-ai-manager/pkg/listenhandler/v1_aipromptproposals_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_aipromptproposals_test.go
@@ -512,6 +512,81 @@ func Test_processV1AIPromptProposalsIDDelete(t *testing.T) {
 	}
 }
 
+func Test_processV1AIPromptProposalsExpirePost(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *sock.Request
+
+		responseExpired int
+		responseErr     error
+
+		expectedRes *sock.Response
+	}{
+		{
+			name: "normal",
+			request: &sock.Request{
+				URI:    "/v1/aipromptproposals/expire",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseExpired: 3,
+			responseErr:     nil,
+
+			expectedRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"expired":3}`),
+			},
+		},
+		{
+			name: "list_error_returns_500",
+			request: &sock.Request{
+				URI:    "/v1/aipromptproposals/expire",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseExpired: 0,
+			responseErr:     &listFailedError{},
+
+			expectedRes: &sock.Response{
+				StatusCode: 500,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockProposal := aipromptproposalhandler.NewMockAIPromptProposalHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:             mockSock,
+				aipromptproposalHandler: mockProposal,
+			}
+
+			mockProposal.EXPECT().SweepExpiredProposals(gomock.Any()).Return(tt.responseExpired, tt.responseErr)
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectedRes) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectedRes, res)
+			}
+		})
+	}
+}
+
+// listFailedError simulates a generic list-fetch failure from SweepExpiredProposals.
+type listFailedError struct{}
+
+func (e *listFailedError) Error() string {
+	return "could not list candidate proposals: db unavailable"
+}
+
 // proposalRateLimitError simulates a "rate limit exceeded" error from Create.
 type proposalRateLimitError struct{}
 

--- a/bin-billing-manager/cmd/billing-control/main.go
+++ b/bin-billing-manager/cmd/billing-control/main.go
@@ -740,8 +740,16 @@ func runTopUpRun(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if err := db.AccountTopUpTokens(context.Background(), a.ID, a.CustomerID, tokenAmount, string(a.PlanType)); err != nil {
+		applied, err := db.AccountTopUpTokens(context.Background(), a.ID, a.CustomerID, tokenAmount, string(a.PlanType))
+		if err != nil {
 			fmt.Printf("ERROR: account_id=%s err=%v\n", a.ID, err)
+			continue
+		}
+		if !applied {
+			// CAS-skip: already topped up this cycle by a concurrent claimant. This
+			// command already pre-filters by a.TmNextTopUp.After(now) above, so this
+			// only happens under a genuine race with the scheduled job.
+			fmt.Printf("SKIP: account_id=%s already topped up this cycle\n", a.ID)
 			continue
 		}
 		fmt.Printf("OK: account_id=%s tokens=%d\n", a.ID, tokenAmount)

--- a/bin-billing-manager/cmd/billing-manager/main.go
+++ b/bin-billing-manager/cmd/billing-manager/main.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"context"
 	"database/sql"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-common-handler/models/sock"
@@ -21,7 +18,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"monorepo/bin-billing-manager/internal/config"
-	"monorepo/bin-billing-manager/models/account"
 	"monorepo/bin-billing-manager/pkg/accounthandler"
 	"monorepo/bin-billing-manager/pkg/billinghandler"
 	"monorepo/bin-billing-manager/pkg/cachehandler"
@@ -110,8 +106,6 @@ func signalHandler() {
 
 // run runs the billing-manager
 func run(sqlDB *sql.DB, cache cachehandler.CacheHandler) error {
-	log := logrus.WithField("func", "run")
-
 	// dbhandler
 	db := dbhandler.NewHandler(sqlDB, cache)
 
@@ -131,41 +125,32 @@ func run(sqlDB *sql.DB, cache cachehandler.CacheHandler) error {
 	accountHandler := accounthandler.NewAccountHandler(reqHandler, db, notifyHandler, paddleHandler)
 	billingHandler := billinghandler.NewBillingHandler(reqHandler, db, notifyHandler, accountHandler)
 
+	// build the subscribe handler and its failed event handler together — this must
+	// happen before runListen so the failed event handler can be wired into the
+	// listenhandler for the /v1/failed_events/retry route.
+	subHandler, failedHandler := buildFailedEventHandler(db, sockHandler, accountHandler, billingHandler)
+
 	// run listen
-	if err := runListen(sockHandler, accountHandler, billingHandler, paddleHandler); err != nil {
+	if err := runListen(sockHandler, accountHandler, billingHandler, paddleHandler, failedHandler); err != nil {
 		return err
 	}
 
-	// run subscribe (with failed event handler)
-	if err := runSubscribe(db, sockHandler, accountHandler, billingHandler); err != nil {
+	// run subscribe
+	if err := runSubscribe(subHandler); err != nil {
 		return err
 	}
-
-	// run monthly token top-up cron
-	go func() {
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if err := runMonthlyTopUp(context.Background(), db); err != nil {
-					log.Errorf("Monthly top-up failed. err: %v", err)
-				}
-			case <-chDone:
-				return
-			}
-		}
-	}()
 
 	return nil
 }
 
-// runSubscribe runs the subscribed event handler
-func runSubscribe(db dbhandler.DBHandler, sockHandler sockhandler.SockHandler, accoutHandler accounthandler.AccountHandler, billingHandler billinghandler.BillingHandler) error {
-	log := logrus.WithFields(logrus.Fields{
-		"func": "runSubscribe",
-	})
-
+// buildFailedEventHandler constructs the subscribe handler and its failed event
+// handler together. The two have a circular dependency: the failed event handler
+// needs the subscribe handler's event processor to retry events, and the subscribe
+// handler needs the failed event handler to persist events it fails to process. The
+// subscribe handler is created first with a nil failed-event processor placeholder,
+// then the failed event handler is built from its event processor, then patched back
+// onto the subscribe handler.
+func buildFailedEventHandler(db dbhandler.DBHandler, sockHandler sockhandler.SockHandler, accoutHandler accounthandler.AccountHandler, billingHandler billinghandler.BillingHandler) (subscribehandler.SubscribeHandler, failedeventhandler.FailedEventHandler) {
 	subscribeTargets := []string{
 		string(commonoutline.QueueNameCallEvent),
 		string(commonoutline.QueueNameMessageEvent),
@@ -175,13 +160,8 @@ func runSubscribe(db dbhandler.DBHandler, sockHandler sockhandler.SockHandler, a
 		string(commonoutline.QueueNameTTSEvent),
 	}
 
-	// create subscribe handler first, then wire the failed event handler with a circular reference
-	// to the subscribe handler's processEvent
-	var subHandler subscribehandler.SubscribeHandler
-	var failedHandler failedeventhandler.FailedEventHandler
-
 	// placeholder processor — will be set after subscribe handler is created
-	subHandler = subscribehandler.NewSubscribeHandler(
+	subHandler := subscribehandler.NewSubscribeHandler(
 		sockHandler,
 		string(commonoutline.QueueNameBillingSubscribe),
 		subscribeTargets,
@@ -191,92 +171,39 @@ func runSubscribe(db dbhandler.DBHandler, sockHandler sockhandler.SockHandler, a
 	)
 
 	// create failed event handler with the subscribe handler's process function
-	failedHandler = failedeventhandler.NewFailedEventHandler(db, subscribehandler.GetEventProcessor(subHandler))
+	failedHandler := failedeventhandler.NewFailedEventHandler(db, subscribehandler.GetEventProcessor(subHandler))
 
 	// set the failed event handler on the subscribe handler
 	subscribehandler.SetFailedEventHandler(subHandler, failedHandler)
 
-	// run
+	return subHandler, failedHandler
+}
+
+// runSubscribe runs the subscribed event handler
+func runSubscribe(subHandler subscribehandler.SubscribeHandler) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func": "runSubscribe",
+	})
+
 	if err := subHandler.Run(); err != nil {
 		log.Errorf("Could not run the subscribe handler. err: %v", err)
 		return err
 	}
 
-	// start failed event retry loop
-	go func() {
-		ticker := time.NewTicker(60 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if err := failedHandler.RetryPending(context.Background()); err != nil {
-					log.Errorf("Failed event retry error. err: %v", err)
-				}
-			case <-chDone:
-				return
-			}
-		}
-	}()
-
 	return nil
 }
 
 // runListen runs the listen handler
-func runListen(sockHandler sockhandler.SockHandler, accoutHandler accounthandler.AccountHandler, billingHandler billinghandler.BillingHandler, paddleHandler paddlehandler.PaddleHandler) error {
+func runListen(sockHandler sockhandler.SockHandler, accoutHandler accounthandler.AccountHandler, billingHandler billinghandler.BillingHandler, paddleHandler paddlehandler.PaddleHandler, failedHandler failedeventhandler.FailedEventHandler) error {
 	log := logrus.WithFields(logrus.Fields{
 		"func": "runListen",
 	})
 
-	listenHandler := listenhandler.NewListenHandler(sockHandler, accoutHandler, billingHandler, paddleHandler)
+	listenHandler := listenhandler.NewListenHandler(sockHandler, accoutHandler, billingHandler, paddleHandler, failedHandler)
 
 	if err := listenHandler.Run(string(commonoutline.QueueNameBillingRequest), string(commonoutline.QueueNameDelay)); err != nil {
 		log.Errorf("Could not run the listenhandler correctly. err: %v", err)
 		return err
-	}
-
-	return nil
-}
-
-func runMonthlyTopUp(ctx context.Context, db dbhandler.DBHandler) error {
-	log := logrus.WithField("func", "runMonthlyTopUp")
-
-	now := time.Now()
-	filters := map[account.Field]any{
-		account.FieldDeleted: false,
-	}
-
-	// Paginate through all accounts
-	var pageToken string
-	for {
-		accounts, err := db.AccountList(ctx, 500, pageToken, filters)
-		if err != nil {
-			return fmt.Errorf("could not list accounts. err: %v", err)
-		}
-		if len(accounts) == 0 {
-			break
-		}
-
-		for _, a := range accounts {
-			if a.TmNextTopUp == nil || a.TmNextTopUp.After(now) {
-				continue
-			}
-
-			tokenAmount, ok := account.PlanTokenMap[a.PlanType]
-			if !ok || tokenAmount <= 0 {
-				continue
-			}
-
-			if err := db.AccountTopUpTokens(ctx, a.ID, a.CustomerID, tokenAmount, string(a.PlanType)); err != nil {
-				log.Errorf("Could not top up tokens for account. account_id: %s, err: %v", a.ID, err)
-				continue
-			}
-			log.Infof("Topped up tokens for account. account_id: %s, tokens: %d", a.ID, tokenAmount)
-		}
-
-		if len(accounts) < 500 {
-			break
-		}
-		pageToken = accounts[len(accounts)-1].TMCreate.Format(time.RFC3339Nano)
 	}
 
 	return nil

--- a/bin-billing-manager/docs/architecture.md
+++ b/bin-billing-manager/docs/architecture.md
@@ -45,6 +45,7 @@ The `listenhandler` consumes from queue `bin-manager.billing-manager.request` an
 | GET | `/v1/accounts/{uuid}` | Get account |
 | PUT | `/v1/accounts/{uuid}` | Update account |
 | DELETE | `/v1/accounts/{uuid}` | Delete account |
+| POST | `/v1/accounts/top_up` | Sweep endpoint: process due monthly top-ups (invoked by schedule-manager cron, replaces the old in-process ticker) |
 | POST | `/v1/accounts/{uuid}/balance_add_force` | Force-add balance |
 | POST | `/v1/accounts/{uuid}/balance_subtract_force` | Force-subtract balance |
 | POST | `/v1/accounts/{uuid}/is_valid_balance` | Check balance sufficiency |
@@ -56,3 +57,4 @@ The `listenhandler` consumes from queue `bin-manager.billing-manager.request` an
 | GET | `/v1/billings/{uuid}` | Get billing record |
 | POST | `/v1/accounts/is_valid_balance_by_customer_id` | Check balance by customer ID |
 | GET | `/v1/accounts/is_valid_resource_limit_by_customer_id` | Check resource limit by customer ID |
+| POST | `/v1/failed_events/retry` | Sweep endpoint: retry pending failed billing events (invoked by schedule-manager cron, replaces the old in-process ticker) |

--- a/bin-billing-manager/pkg/accounthandler/event.go
+++ b/bin-billing-manager/pkg/accounthandler/event.go
@@ -81,10 +81,13 @@ func (h *accountHandler) EventCUCustomerCreated(ctx context.Context, cu *cucusto
 	// initial token topup for new customer
 	tokenAmount, ok := account.PlanTokenMap[account.PlanTypeFree]
 	if ok && tokenAmount > 0 {
-		if errTopup := h.db.AccountTopUpTokens(ctx, b.ID, cu.ID, tokenAmount, string(account.PlanTypeFree)); errTopup != nil {
+		if _, errTopup := h.db.AccountTopUpTokens(ctx, b.ID, cu.ID, tokenAmount, string(account.PlanTypeFree)); errTopup != nil {
 			log.Errorf("Could not perform initial token topup. err: %v", errTopup)
 			// non-fatal: account is created, tokens can be topped up later
 		}
+		// applied=false here is nearly impossible (TmNextTopUp is unset on a brand-new
+		// account, so the CAS's IS NULL branch always matches) but is handled the same
+		// as the other callers for consistency: not an error, nothing further to do.
 	}
 
 	return nil

--- a/bin-billing-manager/pkg/accounthandler/event_test.go
+++ b/bin-billing-manager/pkg/accounthandler/event_test.go
@@ -163,7 +163,7 @@ func Test_EventCUCustomerCreated(t *testing.T) {
 				account.FieldPlanType: account.PlanTypeFree,
 			}).Return(nil)
 			mockDB.EXPECT().AccountGet(ctx, tt.responseAccount.ID).Return(tt.responseAccount, nil)
-			mockDB.EXPECT().AccountTopUpTokens(ctx, tt.responseAccount.ID, tt.customer.ID, int64(100), string(account.PlanTypeFree)).Return(nil)
+			mockDB.EXPECT().AccountTopUpTokens(ctx, tt.responseAccount.ID, tt.customer.ID, int64(100), string(account.PlanTypeFree)).Return(true, nil)
 
 			if err := h.EventCUCustomerCreated(ctx, tt.customer); err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
@@ -215,7 +215,7 @@ func Test_EventCUCustomerCreated_topup_error(t *testing.T) {
 	mockDB.EXPECT().AccountGet(ctx, accountID).Return(responseAccount, nil)
 
 	// topup fails — should NOT cause EventCUCustomerCreated to return error
-	mockDB.EXPECT().AccountTopUpTokens(ctx, accountID, customerID, int64(100), string(account.PlanTypeFree)).Return(fmt.Errorf("topup failed"))
+	mockDB.EXPECT().AccountTopUpTokens(ctx, accountID, customerID, int64(100), string(account.PlanTypeFree)).Return(false, fmt.Errorf("topup failed"))
 
 	err := h.EventCUCustomerCreated(ctx, customer)
 	if err != nil {

--- a/bin-billing-manager/pkg/accounthandler/main.go
+++ b/bin-billing-manager/pkg/accounthandler/main.go
@@ -59,6 +59,8 @@ type AccountHandler interface {
 	EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error
 	EventCUCustomerFrozen(ctx context.Context, cu *cucustomer.Customer) error
 	EventCUCustomerRecovered(ctx context.Context, cu *cucustomer.Customer) error
+
+	TopUpDue(ctx context.Context) (int, int, error)
 }
 
 // accountHandler define

--- a/bin-billing-manager/pkg/accounthandler/mock_main.go
+++ b/bin-billing-manager/pkg/accounthandler/mock_main.go
@@ -468,6 +468,22 @@ func (mr *MockAccountHandlerMockRecorder) SubtractTokensWithCheck(ctx, accountID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubtractTokensWithCheck", reflect.TypeOf((*MockAccountHandler)(nil).SubtractTokensWithCheck), ctx, accountID, amount)
 }
 
+// TopUpDue mocks base method.
+func (m *MockAccountHandler) TopUpDue(ctx context.Context) (int, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TopUpDue", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// TopUpDue indicates an expected call of TopUpDue.
+func (mr *MockAccountHandlerMockRecorder) TopUpDue(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopUpDue", reflect.TypeOf((*MockAccountHandler)(nil).TopUpDue), ctx)
+}
+
 // UpdateBasicInfo mocks base method.
 func (m *MockAccountHandler) UpdateBasicInfo(ctx context.Context, id uuid.UUID, name, detail string) (*account.Account, error) {
 	m.ctrl.T.Helper()

--- a/bin-billing-manager/pkg/accounthandler/topup.go
+++ b/bin-billing-manager/pkg/accounthandler/topup.go
@@ -1,0 +1,74 @@
+package accounthandler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-billing-manager/models/account"
+)
+
+// TopUpDue pages through all non-deleted accounts and applies the monthly token
+// top-up to every account whose tm_next_topup is due. A per-row error is logged and
+// counted as failed without aborting the batch. A CAS-skip (AccountTopUpTokens
+// returning applied=false with a nil error — the account was already topped up this
+// cycle by a concurrent claimant) increments neither counter. Only a failure of the
+// AccountList call itself (nothing could be attempted) returns a non-nil error.
+func (h *accountHandler) TopUpDue(ctx context.Context) (int, int, error) {
+	log := logrus.WithField("func", "TopUpDue")
+
+	now := h.utilHandler.TimeNow()
+	filters := map[account.Field]any{
+		account.FieldDeleted: false,
+	}
+
+	processed := 0
+	failed := 0
+
+	// Paginate through all accounts
+	var pageToken string
+	for {
+		accounts, err := h.db.AccountList(ctx, 500, pageToken, filters)
+		if err != nil {
+			return processed, failed, fmt.Errorf("TopUpDue: could not list accounts. err: %v", err)
+		}
+		if len(accounts) == 0 {
+			break
+		}
+
+		for _, a := range accounts {
+			if a.TmNextTopUp == nil || a.TmNextTopUp.After(*now) {
+				continue
+			}
+
+			tokenAmount, ok := account.PlanTokenMap[a.PlanType]
+			if !ok || tokenAmount <= 0 {
+				continue
+			}
+
+			applied, errTopUp := h.db.AccountTopUpTokens(ctx, a.ID, a.CustomerID, tokenAmount, string(a.PlanType))
+			if errTopUp != nil {
+				log.Errorf("Could not top up tokens for account. account_id: %s, err: %v", a.ID, errTopUp)
+				failed++
+				continue
+			}
+			if !applied {
+				// CAS-skip: already topped up this cycle by a concurrent claimant.
+				// Neither processed nor failed.
+				continue
+			}
+
+			processed++
+			log.Infof("Topped up tokens for account. account_id: %s, tokens: %d", a.ID, tokenAmount)
+		}
+
+		if len(accounts) < 500 {
+			break
+		}
+		pageToken = accounts[len(accounts)-1].TMCreate.Format(time.RFC3339Nano)
+	}
+
+	return processed, failed, nil
+}

--- a/bin-billing-manager/pkg/accounthandler/topup_test.go
+++ b/bin-billing-manager/pkg/accounthandler/topup_test.go
@@ -1,0 +1,170 @@
+package accounthandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-billing-manager/models/account"
+	"monorepo/bin-billing-manager/pkg/dbhandler"
+)
+
+func Test_TopUpDue(t *testing.T) {
+
+	now := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Hour)
+	future := now.Add(1 * time.Hour)
+
+	customerID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+
+	dueAccount := &account.Account{
+		Identity:    commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000001"), CustomerID: customerID},
+		PlanType:    account.PlanTypeFree,
+		TmNextTopUp: &past,
+		TMCreate:    &now,
+	}
+	notDueAccount := &account.Account{
+		Identity:    commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000002"), CustomerID: customerID},
+		PlanType:    account.PlanTypeFree,
+		TmNextTopUp: &future,
+		TMCreate:    &now,
+	}
+	casSkipAccount := &account.Account{
+		Identity:    commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000003"), CustomerID: customerID},
+		PlanType:    account.PlanTypeFree,
+		TmNextTopUp: &past,
+		TMCreate:    &now,
+	}
+	errorAccount := &account.Account{
+		Identity:    commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000004"), CustomerID: customerID},
+		PlanType:    account.PlanTypeFree,
+		TmNextTopUp: &past,
+		TMCreate:    &now,
+	}
+	noPlanAccount := &account.Account{
+		Identity:    commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000005"), CustomerID: customerID},
+		PlanType:    account.PlanType("unknown"),
+		TmNextTopUp: &past,
+		TMCreate:    &now,
+	}
+
+	t.Run("pagination across two pages with due, not-due, cas-skip, per-row error, and unknown-plan accounts", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		mockUtil := utilhandler.NewMockUtilHandler(mc)
+		mockDB := dbhandler.NewMockDBHandler(mc)
+
+		h := &accountHandler{
+			utilHandler: mockUtil,
+			db:          mockDB,
+		}
+		ctx := context.Background()
+
+		filters := map[account.Field]any{
+			account.FieldDeleted: false,
+		}
+
+		mockUtil.EXPECT().TimeNow().Return(&now)
+
+		// page 1: exactly 500 not-due accounts — a full page, forcing TopUpDue to
+		// request a second page. None of these are due, so no AccountTopUpTokens
+		// calls are expected for this page.
+		page1 := make([]*account.Account, 500)
+		for i := range page1 {
+			page1[i] = &account.Account{
+				Identity:    commonidentity.Identity{ID: uuid.Must(uuid.NewV4()), CustomerID: customerID},
+				PlanType:    account.PlanTypeFree,
+				TmNextTopUp: &future,
+				TMCreate:    &now,
+			}
+		}
+		mockDB.EXPECT().AccountList(ctx, uint64(500), "", filters).Return(page1, nil)
+
+		// page 2: fewer than 500 rows, ends pagination. Exercises due, cas-skip,
+		// per-row-error, and unknown-plan-type accounts.
+		page2 := []*account.Account{dueAccount, notDueAccount, casSkipAccount, errorAccount, noPlanAccount}
+		pageToken := now.Format(time.RFC3339Nano)
+		mockDB.EXPECT().AccountList(ctx, uint64(500), pageToken, filters).Return(page2, nil)
+
+		mockDB.EXPECT().AccountTopUpTokens(ctx, dueAccount.ID, customerID, int64(100), string(account.PlanTypeFree)).Return(true, nil)
+		mockDB.EXPECT().AccountTopUpTokens(ctx, casSkipAccount.ID, customerID, int64(100), string(account.PlanTypeFree)).Return(false, nil)
+		mockDB.EXPECT().AccountTopUpTokens(ctx, errorAccount.ID, customerID, int64(100), string(account.PlanTypeFree)).Return(false, fmt.Errorf("db error"))
+
+		processed, failed, err := h.TopUpDue(ctx)
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+		if processed != 1 {
+			t.Errorf("expected processed=1, got: %d", processed)
+		}
+		if failed != 1 {
+			t.Errorf("expected failed=1, got: %d", failed)
+		}
+	})
+
+	t.Run("AccountList failure returns error", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		mockUtil := utilhandler.NewMockUtilHandler(mc)
+		mockDB := dbhandler.NewMockDBHandler(mc)
+
+		h := &accountHandler{
+			utilHandler: mockUtil,
+			db:          mockDB,
+		}
+		ctx := context.Background()
+
+		filters := map[account.Field]any{
+			account.FieldDeleted: false,
+		}
+
+		mockUtil.EXPECT().TimeNow().Return(&now)
+		mockDB.EXPECT().AccountList(ctx, uint64(500), "", filters).Return(nil, fmt.Errorf("list failed"))
+
+		processed, failed, err := h.TopUpDue(ctx)
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+		if processed != 0 || failed != 0 {
+			t.Errorf("expected processed=0, failed=0, got processed=%d, failed=%d", processed, failed)
+		}
+	})
+
+	t.Run("empty list returns zero counts", func(t *testing.T) {
+		mc := gomock.NewController(t)
+		defer mc.Finish()
+
+		mockUtil := utilhandler.NewMockUtilHandler(mc)
+		mockDB := dbhandler.NewMockDBHandler(mc)
+
+		h := &accountHandler{
+			utilHandler: mockUtil,
+			db:          mockDB,
+		}
+		ctx := context.Background()
+
+		filters := map[account.Field]any{
+			account.FieldDeleted: false,
+		}
+
+		mockUtil.EXPECT().TimeNow().Return(&now)
+		mockDB.EXPECT().AccountList(ctx, uint64(500), "", filters).Return(nil, nil)
+
+		processed, failed, err := h.TopUpDue(ctx)
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+		if processed != 0 || failed != 0 {
+			t.Errorf("expected processed=0, failed=0, got processed=%d, failed=%d", processed, failed)
+		}
+	})
+}

--- a/bin-billing-manager/pkg/dbhandler/billing.go
+++ b/bin-billing-manager/pkg/dbhandler/billing.go
@@ -512,10 +512,14 @@ func (h *handler) BillingDelete(ctx context.Context, id uuid.UUID) error {
 }
 
 // AccountTopUpTokens resets the account token balance and creates a ledger entry.
-func (h *handler) AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, customerID uuid.UUID, tokenAmount int64, planType string) error {
+// The update is CAS-guarded on tm_next_topup so that a concurrent replica processing
+// the same due account is a no-op instead of a duplicate ledger insert. applied=false
+// with a nil error means the account was already topped up this cycle by a concurrent
+// claimant — a normal outcome, not an error.
+func (h *handler) AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, customerID uuid.UUID, tokenAmount int64, planType string) (bool, error) {
 	tx, err := h.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("AccountTopUpTokens: could not begin transaction. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not begin transaction. err: %v", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
@@ -526,9 +530,9 @@ func (h *handler) AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, c
 		accountID.Bytes())
 	if err := row.Scan(&currentToken, &currentCredit); err != nil {
 		if err == sql.ErrNoRows {
-			return ErrNotFound
+			return false, ErrNotFound
 		}
-		return fmt.Errorf("AccountTopUpTokens: could not read account. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not read account. err: %v", err)
 	}
 
 	now := h.utilHandler.TimeNow()
@@ -539,17 +543,30 @@ func (h *handler) AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, c
 	// Calculate next top-up date (first of next month)
 	nextMonth := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Update account
-	_, err = tx.ExecContext(ctx,
+	// Update account. CAS guard: only apply when due (tm_next_topup unset, or already
+	// past). A concurrent claimant that already topped up this cycle leaves 0 rows
+	// affected here.
+	res, err := tx.ExecContext(ctx,
 		`UPDATE billing_accounts SET
 			balance_token = ?,
 			tm_last_topup = ?,
 			tm_next_topup = ?,
 			tm_update = ?
-		WHERE id = ?`,
-		newBalanceToken, now, nextMonth, now, accountID.Bytes())
+		WHERE id = ? AND (tm_next_topup IS NULL OR tm_next_topup <= ?)`,
+		newBalanceToken, now, nextMonth, now, accountID.Bytes(), now)
 	if err != nil {
-		return fmt.Errorf("AccountTopUpTokens: could not update account. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not update account. err: %v", err)
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("AccountTopUpTokens: could not read rows affected. err: %v", err)
+	}
+	if affected == 0 {
+		// CAS-skip: already topped up this cycle by a concurrent claimant. Never let
+		// the ledger insert below run on this path.
+		_ = tx.Rollback()
+		return false, nil
 	}
 
 	// Insert ledger entry for the top-up
@@ -574,27 +591,27 @@ func (h *handler) AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, c
 
 	fields, err := commondatabasehandler.PrepareFields(topupBilling)
 	if err != nil {
-		return fmt.Errorf("AccountTopUpTokens: could not prepare billing fields. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not prepare billing fields. err: %v", err)
 	}
 
 	query, args, err := sq.Insert(billingsTable).SetMap(fields).ToSql()
 	if err != nil {
-		return fmt.Errorf("AccountTopUpTokens: could not build billing insert query. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not build billing insert query. err: %v", err)
 	}
 
 	_, err = tx.ExecContext(ctx, query, args...)
 	if err != nil {
-		return fmt.Errorf("AccountTopUpTokens: could not insert billing record. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not insert billing record. err: %v", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("AccountTopUpTokens: could not commit. err: %v", err)
+		return false, fmt.Errorf("AccountTopUpTokens: could not commit. err: %v", err)
 	}
 
 	// Invalidate caches
 	_ = h.accountUpdateToCache(ctx, accountID)
 
-	return nil
+	return true, nil
 }
 
 // isDuplicateKeyError checks if the error is a MySQL duplicate key error (1062)

--- a/bin-billing-manager/pkg/dbhandler/billing_test.go
+++ b/bin-billing-manager/pkg/dbhandler/billing_test.go
@@ -2,6 +2,7 @@ package dbhandler
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"reflect"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	commonidentity "monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
@@ -42,6 +44,7 @@ func Test_BillingCreate(t *testing.T) {
 					ID:         uuid.FromStringOrNil("012b0808-07ae-11ee-956e-a31693cf908b"),
 					CustomerID: uuid.FromStringOrNil("01845d18-07ae-11ee-b9ed-17e7ec2627df"),
 				},
+				IdempotencyKey:    uuid.FromStringOrNil("012b0808-07ae-11ee-956e-a31693cf908b"),
 				AccountID:         uuid.FromStringOrNil("01eaf474-07ae-11ee-b506-b75479a482cc"),
 				TransactionType:   billing.TransactionTypeUsage,
 				Status:            billing.StatusProgressing,
@@ -58,6 +61,7 @@ func Test_BillingCreate(t *testing.T) {
 					ID:         uuid.FromStringOrNil("012b0808-07ae-11ee-956e-a31693cf908b"),
 					CustomerID: uuid.FromStringOrNil("01845d18-07ae-11ee-b9ed-17e7ec2627df"),
 				},
+				IdempotencyKey:    uuid.FromStringOrNil("012b0808-07ae-11ee-956e-a31693cf908b"),
 				AccountID:         uuid.FromStringOrNil("01eaf474-07ae-11ee-b506-b75479a482cc"),
 				TransactionType:   billing.TransactionTypeUsage,
 				Status:            billing.StatusProgressing,
@@ -78,8 +82,9 @@ func Test_BillingCreate(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
 				},
-				ReferenceType: billing.ReferenceTypeCall,
-				ReferenceID:   uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
+				IdempotencyKey: uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
+				ReferenceType:  billing.ReferenceTypeCall,
+				ReferenceID:    uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
 			},
 
 			responseCurTime: &tmCreate2,
@@ -87,11 +92,12 @@ func Test_BillingCreate(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
 				},
-				ReferenceType: billing.ReferenceTypeCall,
-				ReferenceID:   uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
-				TMCreate:      &tmCreate2,
-				TMUpdate:      nil,
-				TMDelete:      nil,
+				IdempotencyKey: uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
+				ReferenceType:  billing.ReferenceTypeCall,
+				ReferenceID:    uuid.FromStringOrNil("a94849ce-07ae-11ee-a930-9b5e28e2ead9"),
+				TMCreate:       &tmCreate2,
+				TMUpdate:       nil,
+				TMDelete:       nil,
 			},
 		},
 	}
@@ -165,16 +171,18 @@ func Test_BillingList(t *testing.T) {
 						ID:         uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
 						CustomerID: uuid.FromStringOrNil("a9db1420-07ae-11ee-ab10-1ffa68fea7d8"),
 					},
-					ReferenceType: billing.ReferenceTypeSMS,
-					ReferenceID:   uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
+					IdempotencyKey: uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
+					ReferenceType:  billing.ReferenceTypeSMS,
+					ReferenceID:    uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
 				},
 				{
 					Identity: commonidentity.Identity{
 						ID:         uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
 						CustomerID: uuid.FromStringOrNil("a9db1420-07ae-11ee-ab10-1ffa68fea7d8"),
 					},
-					ReferenceType: billing.ReferenceTypeSMS,
-					ReferenceID:   uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
+					IdempotencyKey: uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
+					ReferenceType:  billing.ReferenceTypeSMS,
+					ReferenceID:    uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
 				},
 			},
 
@@ -189,22 +197,24 @@ func Test_BillingList(t *testing.T) {
 						ID:         uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
 						CustomerID: uuid.FromStringOrNil("a9db1420-07ae-11ee-ab10-1ffa68fea7d8"),
 					},
-					ReferenceType: billing.ReferenceTypeSMS,
-					ReferenceID:   uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
-					TMCreate:      &tmCreate,
-					TMUpdate:      nil,
-					TMDelete:      nil,
+					IdempotencyKey: uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
+					ReferenceType:  billing.ReferenceTypeSMS,
+					ReferenceID:    uuid.FromStringOrNil("a97bade6-07ae-11ee-8916-4f8af853ac9b"),
+					TMCreate:       &tmCreate,
+					TMUpdate:       nil,
+					TMDelete:       nil,
 				},
 				{
 					Identity: commonidentity.Identity{
 						ID:         uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
 						CustomerID: uuid.FromStringOrNil("a9db1420-07ae-11ee-ab10-1ffa68fea7d8"),
 					},
-					ReferenceType: billing.ReferenceTypeSMS,
-					ReferenceID:   uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
-					TMCreate:      &tmCreate,
-					TMUpdate:      nil,
-					TMDelete:      nil,
+					IdempotencyKey: uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
+					ReferenceType:  billing.ReferenceTypeSMS,
+					ReferenceID:    uuid.FromStringOrNil("a9ab7120-07ae-11ee-9a8d-6f3e025fae7a"),
+					TMCreate:       &tmCreate,
+					TMUpdate:       nil,
+					TMDelete:       nil,
 				},
 			},
 		},
@@ -275,6 +285,7 @@ func Test_BillingSetStatusEnd(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("1441f0ac-07b1-11ee-a5d8-cb0119ac5064"),
 				},
+				IdempotencyKey:    uuid.FromStringOrNil("1441f0ac-07b1-11ee-a5d8-cb0119ac5064"),
 				ReferenceType:     billing.ReferenceTypeCall,
 				ReferenceID:       uuid.FromStringOrNil("1441f0ac-07b1-11ee-a5d8-cb0119ac5064"),
 				Status:            billing.StatusProgressing,
@@ -296,6 +307,7 @@ func Test_BillingSetStatusEnd(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("1441f0ac-07b1-11ee-a5d8-cb0119ac5064"),
 				},
+				IdempotencyKey:        uuid.FromStringOrNil("1441f0ac-07b1-11ee-a5d8-cb0119ac5064"),
 				ReferenceType:         billing.ReferenceTypeCall,
 				ReferenceID:           uuid.FromStringOrNil("1441f0ac-07b1-11ee-a5d8-cb0119ac5064"),
 				Status:                billing.StatusEnd,
@@ -379,9 +391,10 @@ func Test_BillingSetStatus(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
 				},
-				ReferenceType: billing.ReferenceTypeNumber,
-				ReferenceID:   uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
-				Status:        billing.StatusProgressing,
+				IdempotencyKey: uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
+				ReferenceType:  billing.ReferenceTypeNumber,
+				ReferenceID:    uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
+				Status:         billing.StatusProgressing,
 			},
 
 			id:     uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
@@ -392,9 +405,10 @@ func Test_BillingSetStatus(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
 				},
-				ReferenceType: billing.ReferenceTypeNumber,
-				ReferenceID:   uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
-				Status:        billing.StatusFinished,
+				IdempotencyKey: uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
+				ReferenceType:  billing.ReferenceTypeNumber,
+				ReferenceID:    uuid.FromStringOrNil("1d30c8de-07b4-11ee-b80c-c7c0f2007941"),
+				Status:         billing.StatusFinished,
 
 				TMCreate: &tmCreate,
 				TMUpdate: &tmCreate,
@@ -466,8 +480,9 @@ func Test_BillingDelete(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
 				},
-				ReferenceType: billing.ReferenceTypeNumberRenew,
-				ReferenceID:   uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
+				IdempotencyKey: uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
+				ReferenceType:  billing.ReferenceTypeNumberRenew,
+				ReferenceID:    uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
 			},
 
 			id: uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
@@ -477,8 +492,9 @@ func Test_BillingDelete(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
 				},
-				ReferenceType: billing.ReferenceTypeNumberRenew,
-				ReferenceID:   uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
+				IdempotencyKey: uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
+				ReferenceType:  billing.ReferenceTypeNumberRenew,
+				ReferenceID:    uuid.FromStringOrNil("699bdc72-07b4-11ee-83bc-db5341c91127"),
 
 				TMCreate: &tmCreate,
 				TMUpdate: &tmCreate,
@@ -549,8 +565,9 @@ func Test_BillingGetByReferenceTypeAndID(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("f1a2b3c4-d5e6-11ee-abcd-1234567890ab"),
 				},
-				ReferenceType: billing.ReferenceTypeCall,
-				ReferenceID:   uuid.FromStringOrNil("f2a2b3c4-d5e6-11ee-abcd-1234567890ab"),
+				IdempotencyKey: uuid.FromStringOrNil("f1a2b3c4-d5e6-11ee-abcd-1234567890ab"),
+				ReferenceType:  billing.ReferenceTypeCall,
+				ReferenceID:    uuid.FromStringOrNil("f2a2b3c4-d5e6-11ee-abcd-1234567890ab"),
 			},
 
 			referenceType: billing.ReferenceTypeCall,
@@ -560,11 +577,12 @@ func Test_BillingGetByReferenceTypeAndID(t *testing.T) {
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("f1a2b3c4-d5e6-11ee-abcd-1234567890ab"),
 				},
-				ReferenceType: billing.ReferenceTypeCall,
-				ReferenceID:   uuid.FromStringOrNil("f2a2b3c4-d5e6-11ee-abcd-1234567890ab"),
-				TMCreate:      &tmCreate,
-				TMUpdate:      nil,
-				TMDelete:      nil,
+				IdempotencyKey: uuid.FromStringOrNil("f1a2b3c4-d5e6-11ee-abcd-1234567890ab"),
+				ReferenceType:  billing.ReferenceTypeCall,
+				ReferenceID:    uuid.FromStringOrNil("f2a2b3c4-d5e6-11ee-abcd-1234567890ab"),
+				TMCreate:       &tmCreate,
+				TMUpdate:       nil,
+				TMDelete:       nil,
 			},
 		},
 	}
@@ -643,8 +661,9 @@ func Test_BillingGetByReferenceTypeAndID_deleted_not_returned(t *testing.T) {
 		Identity: commonidentity.Identity{
 			ID: uuid.FromStringOrNil("e1a2b3c4-d5e6-11ee-abcd-ffffffffffff"),
 		},
-		ReferenceType: billing.ReferenceTypeSMS,
-		ReferenceID:   uuid.FromStringOrNil("e2a2b3c4-d5e6-11ee-abcd-ffffffffffff"),
+		IdempotencyKey: uuid.FromStringOrNil("e1a2b3c4-d5e6-11ee-abcd-ffffffffffff"),
+		ReferenceType:  billing.ReferenceTypeSMS,
+		ReferenceID:    uuid.FromStringOrNil("e2a2b3c4-d5e6-11ee-abcd-ffffffffffff"),
 	}
 
 	// create
@@ -671,3 +690,225 @@ func Test_BillingGetByReferenceTypeAndID_deleted_not_returned(t *testing.T) {
 // Note: AccountSubtractBalanceWithCheck uses SELECT ... FOR UPDATE which is
 // MySQL-specific and not supported by SQLite. This function is tested through
 // the accounthandler mock-based tests instead.
+
+// Note: AccountTopUpTokens also uses SELECT ... FOR UPDATE (not supported by SQLite),
+// so it is tested with sqlmock below, same convention as accountAdjustCreditWithLedger.
+
+func Test_AccountTopUpTokens_due(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("could not create sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &handler{db: db, cache: mockCache, utilHandler: mockUtil}
+	ctx := context.Background()
+
+	accountID := uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	customerID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+	billingID := uuid.FromStringOrNil("dddddddd-dddd-dddd-dddd-000000000001")
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	var currentToken int64 = 0
+	var currentCredit int64 = 1000000
+	var tokenAmount int64 = 5000
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockUtil.EXPECT().UUIDCreate().Return(billingID)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT balance_token, balance_credit FROM billing_accounts WHERE").
+		WithArgs(accountID.Bytes()).
+		WillReturnRows(sqlmock.NewRows([]string{"balance_token", "balance_credit"}).
+			AddRow(currentToken, currentCredit))
+	mock.ExpectExec("UPDATE billing_accounts SET").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO billing_billings").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	applied, err := h.AccountTopUpTokens(ctx, accountID, customerID, tokenAmount, "free")
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if !applied {
+		t.Errorf("expected applied=true, got false")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func Test_AccountTopUpTokens_not_due(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("could not create sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &handler{db: db, cache: mockCache, utilHandler: mockUtil}
+	ctx := context.Background()
+
+	accountID := uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	customerID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	var currentToken int64 = 100
+	var currentCredit int64 = 1000000
+	var tokenAmount int64 = 5000
+
+	// CAS-skip: no UUIDCreate for a fresh ledger entry, since the ledger insert must
+	// never be reached on this path.
+	mockUtil.EXPECT().TimeNow().Return(&now)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT balance_token, balance_credit FROM billing_accounts WHERE").
+		WithArgs(accountID.Bytes()).
+		WillReturnRows(sqlmock.NewRows([]string{"balance_token", "balance_credit"}).
+			AddRow(currentToken, currentCredit))
+	mock.ExpectExec("UPDATE billing_accounts SET").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	applied, err := h.AccountTopUpTokens(ctx, accountID, customerID, tokenAmount, "free")
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if applied {
+		t.Errorf("expected applied=false, got true")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func Test_AccountTopUpTokens_not_found(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("could not create sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &handler{db: db, cache: mockCache, utilHandler: mockUtil}
+	ctx := context.Background()
+
+	accountID := uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	customerID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+	var tokenAmount int64 = 5000
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT balance_token, balance_credit FROM billing_accounts WHERE").
+		WithArgs(accountID.Bytes()).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectRollback()
+
+	applied, err := h.AccountTopUpTokens(ctx, accountID, customerID, tokenAmount, "free")
+	if err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+	if applied {
+		t.Errorf("expected applied=false, got true")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// Test_AccountTopUpTokens_sequential_CAS proves the CAS guard: calling AccountTopUpTokens
+// twice in a row for the same account with the same "now" must apply exactly once. This is
+// the sequential-not-concurrent proof called for in the design (§5.1) — SQLite's lack of
+// SELECT ... FOR UPDATE support rules out a real two-goroutine race test at this layer;
+// the row lock plus this CAS predicate together are what make a second serialized writer a
+// no-op, which this test demonstrates by code inspection of the mock call sequence: the
+// second call's UPDATE affects 0 rows and the ledger INSERT is never issued again.
+func Test_AccountTopUpTokens_sequential_CAS(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("could not create sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+
+	h := &handler{db: db, cache: mockCache, utilHandler: mockUtil}
+	ctx := context.Background()
+
+	accountID := uuid.FromStringOrNil("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	customerID := uuid.FromStringOrNil("11111111-2222-3333-4444-555555555555")
+	billingID := uuid.FromStringOrNil("dddddddd-dddd-dddd-dddd-000000000002")
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	var currentToken int64 = 0
+	var currentCredit int64 = 1000000
+	var tokenAmount int64 = 5000
+
+	// first call: due, applies, inserts exactly one ledger row
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockUtil.EXPECT().UUIDCreate().Return(billingID)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT balance_token, balance_credit FROM billing_accounts WHERE").
+		WithArgs(accountID.Bytes()).
+		WillReturnRows(sqlmock.NewRows([]string{"balance_token", "balance_credit"}).
+			AddRow(currentToken, currentCredit))
+	mock.ExpectExec("UPDATE billing_accounts SET").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO billing_billings").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	applied1, err := h.AccountTopUpTokens(ctx, accountID, customerID, tokenAmount, "free")
+	if err != nil {
+		t.Fatalf("first call: expected no error, got: %v", err)
+	}
+	if !applied1 {
+		t.Fatalf("first call: expected applied=true, got false")
+	}
+
+	// second call: same account, same "now" — the CAS predicate must now fail (the
+	// account's tm_next_topup has already advanced), so the UPDATE affects 0 rows and
+	// no second ledger row is ever inserted.
+	mockUtil.EXPECT().TimeNow().Return(&now)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT balance_token, balance_credit FROM billing_accounts WHERE").
+		WithArgs(accountID.Bytes()).
+		WillReturnRows(sqlmock.NewRows([]string{"balance_token", "balance_credit"}).
+			AddRow(tokenAmount, currentCredit))
+	mock.ExpectExec("UPDATE billing_accounts SET").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	applied2, err := h.AccountTopUpTokens(ctx, accountID, customerID, tokenAmount, "free")
+	if err != nil {
+		t.Fatalf("second call: expected no error, got: %v", err)
+	}
+	if applied2 {
+		t.Fatalf("second call: expected applied=false (CAS-skip), got true")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}

--- a/bin-billing-manager/pkg/dbhandler/main.go
+++ b/bin-billing-manager/pkg/dbhandler/main.go
@@ -28,7 +28,7 @@ type DBHandler interface {
 	AccountAddBalance(ctx context.Context, accountID uuid.UUID, amount int64) error
 	AccountSubtractBalance(ctx context.Context, accountID uuid.UUID, amount int64) error
 	AccountSubtractBalanceWithCheck(ctx context.Context, accountID uuid.UUID, amount int64) error
-	AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, customerID uuid.UUID, tokenAmount int64, planType string) error
+	AccountTopUpTokens(ctx context.Context, accountID uuid.UUID, customerID uuid.UUID, tokenAmount int64, planType string) (bool, error)
 	AccountAddTokens(ctx context.Context, accountID uuid.UUID, amount int64) error
 	AccountSubtractTokens(ctx context.Context, accountID uuid.UUID, amount int64) error
 	AccountSubtractTokensWithCheck(ctx context.Context, accountID uuid.UUID, amount int64) error

--- a/bin-billing-manager/pkg/dbhandler/mock_main.go
+++ b/bin-billing-manager/pkg/dbhandler/mock_main.go
@@ -274,11 +274,12 @@ func (mr *MockDBHandlerMockRecorder) AccountSubtractTokensWithCheck(ctx, account
 }
 
 // AccountTopUpTokens mocks base method.
-func (m *MockDBHandler) AccountTopUpTokens(ctx context.Context, accountID, customerID uuid.UUID, tokenAmount int64, planType string) error {
+func (m *MockDBHandler) AccountTopUpTokens(ctx context.Context, accountID, customerID uuid.UUID, tokenAmount int64, planType string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AccountTopUpTokens", ctx, accountID, customerID, tokenAmount, planType)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AccountTopUpTokens indicates an expected call of AccountTopUpTokens.

--- a/bin-billing-manager/pkg/failedeventhandler/main.go
+++ b/bin-billing-manager/pkg/failedeventhandler/main.go
@@ -25,7 +25,7 @@ type EventProcessor func(m *sock.Event) error
 // FailedEventHandler manages persistence and retry of failed billing events.
 type FailedEventHandler interface {
 	Save(ctx context.Context, event *sock.Event, processingErr error) error
-	RetryPending(ctx context.Context) error
+	RetryPending(ctx context.Context) (retried int, succeeded int, exhausted int, err error)
 }
 
 type failedEventHandler struct {
@@ -127,22 +127,32 @@ func (h *failedEventHandler) Save(ctx context.Context, event *sock.Event, proces
 }
 
 // RetryPending processes all pending failed events that are due for retry.
-func (h *failedEventHandler) RetryPending(ctx context.Context) error {
+// Returns the number of events attempted (retried), the number that succeeded, and
+// the number that exhausted all retries (or had unparseable event data). A non-nil
+// err is returned only if the initial list-fetch itself fails.
+func (h *failedEventHandler) RetryPending(ctx context.Context) (int, int, int, error) {
 	log := logrus.WithField("func", "RetryPending")
 
 	now := time.Now().UTC()
 
 	events, err := h.db.FailedEventListPendingRetry(ctx, now)
 	if err != nil {
-		return fmt.Errorf("could not query failed events. err: %v", err)
+		return 0, 0, 0, fmt.Errorf("could not query failed events. err: %v", err)
 	}
 
+	retried := 0
+	succeeded := 0
+	exhausted := 0
+
 	for _, fe := range events {
+		retried++
+
 		// unmarshal the event
 		var event sock.Event
 		if err := json.Unmarshal([]byte(fe.EventData), &event); err != nil {
 			log.Errorf("Could not unmarshal failed event. err: %v", err)
 			h.markExhausted(ctx, fe)
+			exhausted++
 			continue
 		}
 
@@ -155,6 +165,7 @@ func (h *failedEventHandler) RetryPending(ctx context.Context) error {
 				log.Errorf("Failed event exhausted all retries. event_type: %s, publisher: %s", fe.EventType, fe.EventPublisher)
 				promFailedEventExhaustedTotal.WithLabelValues(fe.EventType).Inc()
 				h.markExhausted(ctx, fe)
+				exhausted++
 				continue
 			}
 
@@ -180,9 +191,10 @@ func (h *failedEventHandler) RetryPending(ctx context.Context) error {
 			log.Errorf("Could not delete retried event. err: %v", errDelete)
 		}
 		log.Infof("Successfully retried failed event. event_type: %s, publisher: %s", fe.EventType, fe.EventPublisher)
+		succeeded++
 	}
 
-	return nil
+	return retried, succeeded, exhausted, nil
 }
 
 // markExhausted marks a failed event as exhausted.

--- a/bin-billing-manager/pkg/failedeventhandler/main_test.go
+++ b/bin-billing-manager/pkg/failedeventhandler/main_test.go
@@ -176,12 +176,21 @@ func Test_RetryPending_success(t *testing.T) {
 			mockDB.EXPECT().FailedEventListPendingRetry(ctx, gomock.Any()).Return(tt.events, nil)
 			mockDB.EXPECT().FailedEventDelete(ctx, tt.events[0].ID).Return(nil)
 
-			err := h.RetryPending(ctx)
+			retried, succeeded, exhausted, err := h.RetryPending(ctx)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 			if !processorCalled {
 				t.Errorf("Event processor was not called")
+			}
+			if retried != 1 {
+				t.Errorf("Wrong retried count. expect: 1, got: %d", retried)
+			}
+			if succeeded != 1 {
+				t.Errorf("Wrong succeeded count. expect: 1, got: %d", succeeded)
+			}
+			if exhausted != 0 {
+				t.Errorf("Wrong exhausted count. expect: 0, got: %d", exhausted)
 			}
 		})
 	}
@@ -263,9 +272,18 @@ func Test_RetryPending_failure_increments_retry(t *testing.T) {
 				},
 			)
 
-			err := h.RetryPending(ctx)
+			retried, succeeded, exhausted, err := h.RetryPending(ctx)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if retried != 1 {
+				t.Errorf("Wrong retried count. expect: 1, got: %d", retried)
+			}
+			if succeeded != 0 {
+				t.Errorf("Wrong succeeded count. expect: 0, got: %d", succeeded)
+			}
+			if exhausted != 0 {
+				t.Errorf("Wrong exhausted count. expect: 0, got: %d", exhausted)
 			}
 		})
 	}
@@ -320,9 +338,18 @@ func Test_RetryPending_exhausted(t *testing.T) {
 				},
 			)
 
-			err := h.RetryPending(ctx)
+			retried, succeeded, exhausted, err := h.RetryPending(ctx)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if retried != 1 {
+				t.Errorf("Wrong retried count. expect: 1, got: %d", retried)
+			}
+			if succeeded != 0 {
+				t.Errorf("Wrong succeeded count. expect: 0, got: %d", succeeded)
+			}
+			if exhausted != 1 {
+				t.Errorf("Wrong exhausted count. expect: 1, got: %d", exhausted)
 			}
 		})
 	}
@@ -379,12 +406,21 @@ func Test_RetryPending_unmarshal_error_marks_exhausted(t *testing.T) {
 				},
 			)
 
-			err := h.RetryPending(ctx)
+			retried, succeeded, exhausted, err := h.RetryPending(ctx)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 			if processorCalled {
 				t.Errorf("Event processor should not be called for invalid event data")
+			}
+			if retried != 1 {
+				t.Errorf("Wrong retried count. expect: 1, got: %d", retried)
+			}
+			if succeeded != 0 {
+				t.Errorf("Wrong succeeded count. expect: 0, got: %d", succeeded)
+			}
+			if exhausted != 1 {
+				t.Errorf("Wrong exhausted count. expect: 1, got: %d", exhausted)
 			}
 		})
 	}
@@ -411,12 +447,15 @@ func Test_RetryPending_empty_list(t *testing.T) {
 
 	mockDB.EXPECT().FailedEventListPendingRetry(ctx, gomock.Any()).Return(nil, nil)
 
-	err := h.RetryPending(ctx)
+	retried, succeeded, exhausted, err := h.RetryPending(ctx)
 	if err != nil {
 		t.Errorf("Wrong match. expect: ok, got: %v", err)
 	}
 	if processorCalled {
 		t.Errorf("Event processor should not be called when no events")
+	}
+	if retried != 0 || succeeded != 0 || exhausted != 0 {
+		t.Errorf("Wrong counts. expect: 0/0/0, got: %d/%d/%d", retried, succeeded, exhausted)
 	}
 }
 
@@ -435,9 +474,12 @@ func Test_RetryPending_db_list_error(t *testing.T) {
 
 	mockDB.EXPECT().FailedEventListPendingRetry(ctx, gomock.Any()).Return(nil, fmt.Errorf("db error"))
 
-	err := h.RetryPending(ctx)
+	retried, succeeded, exhausted, err := h.RetryPending(ctx)
 	if err == nil {
 		t.Errorf("Wrong match. expect: error, got: nil")
+	}
+	if retried != 0 || succeeded != 0 || exhausted != 0 {
+		t.Errorf("Wrong counts. expect: 0/0/0, got: %d/%d/%d", retried, succeeded, exhausted)
 	}
 }
 
@@ -503,7 +545,7 @@ func Test_RetryPending_backoff_calculation(t *testing.T) {
 				},
 			)
 
-			err := h.RetryPending(ctx)
+			_, _, _, err := h.RetryPending(ctx)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}

--- a/bin-billing-manager/pkg/failedeventhandler/mock_main.go
+++ b/bin-billing-manager/pkg/failedeventhandler/mock_main.go
@@ -42,11 +42,14 @@ func (m *MockFailedEventHandler) EXPECT() *MockFailedEventHandlerMockRecorder {
 }
 
 // RetryPending mocks base method.
-func (m *MockFailedEventHandler) RetryPending(ctx context.Context) error {
+func (m *MockFailedEventHandler) RetryPending(ctx context.Context) (int, int, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetryPending", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(int)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // RetryPending indicates an expected call of RetryPending.

--- a/bin-billing-manager/pkg/listenhandler/main.go
+++ b/bin-billing-manager/pkg/listenhandler/main.go
@@ -19,6 +19,7 @@ import (
 	"monorepo/bin-billing-manager/pkg/accounthandler"
 	"monorepo/bin-billing-manager/pkg/billinghandler"
 	"monorepo/bin-billing-manager/pkg/dbhandler"
+	"monorepo/bin-billing-manager/pkg/failedeventhandler"
 	"monorepo/bin-billing-manager/pkg/paddlehandler"
 )
 
@@ -40,10 +41,11 @@ type ListenHandler interface {
 type listenHandler struct {
 	sockHandler sockhandler.SockHandler
 
-	utilHandler    utilhandler.UtilHandler
-	accountHandler accounthandler.AccountHandler
-	billingHandler billinghandler.BillingHandler
-	paddleHandler  paddlehandler.PaddleHandler
+	utilHandler        utilhandler.UtilHandler
+	accountHandler     accounthandler.AccountHandler
+	billingHandler     billinghandler.BillingHandler
+	paddleHandler      paddlehandler.PaddleHandler
+	failedEventHandler failedeventhandler.FailedEventHandler
 }
 
 var (
@@ -64,6 +66,8 @@ var (
 
 	regV1AccountsGet = regexp.MustCompile(`/v1/accounts\?`)
 
+	regV1AccountsTopUp = regexp.MustCompile("/v1/accounts/top_up$")
+
 	// billings
 	regV1BillingsGet = regexp.MustCompile(`/v1/billings\?`)
 	regV1BillingGet  = regexp.MustCompile("/v1/billings/" + regUUID + "$")
@@ -73,6 +77,9 @@ var (
 
 	// paddle portal session
 	regV1AccountsIDPaddlePortalSession = regexp.MustCompile("/v1/accounts/" + regUUID + "/paddle_portal_session$")
+
+	// failed events
+	regV1FailedEventsRetry = regexp.MustCompile("/v1/failed_events/retry$")
 )
 
 var (
@@ -144,13 +151,15 @@ func NewListenHandler(
 	accountHandler accounthandler.AccountHandler,
 	billingHandler billinghandler.BillingHandler,
 	paddleHandler paddlehandler.PaddleHandler,
+	failedEventHandler failedeventhandler.FailedEventHandler,
 ) ListenHandler {
 	h := &listenHandler{
-		sockHandler:    sockHandler,
-		utilHandler:    utilhandler.NewUtilHandler(),
-		accountHandler: accountHandler,
-		billingHandler: billingHandler,
-		paddleHandler:  paddleHandler,
+		sockHandler:        sockHandler,
+		utilHandler:        utilhandler.NewUtilHandler(),
+		accountHandler:     accountHandler,
+		billingHandler:     billingHandler,
+		paddleHandler:      paddleHandler,
+		failedEventHandler: failedEventHandler,
 	}
 
 	return h
@@ -249,6 +258,19 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1AccountsIsValidResourceLimitByCustomerID.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		response, err = h.processV1AccountsIsValidResourceLimitByCustomerIDPost(ctx, m)
 		requestType = "/v1/accounts/is_valid_resource_limit_by_customer_id"
+
+	// POST /accounts/top_up
+	case regV1AccountsTopUp.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1AccountsTopUpPost(ctx, m)
+		requestType = "/v1/accounts/top_up"
+
+	////////////////////
+	// failed events
+	////////////////////
+	// POST /failed_events/retry
+	case regV1FailedEventsRetry.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1FailedEventsRetryPost(ctx, m)
+		requestType = "/v1/failed_events/retry"
 
 	////////////////////
 	// billings

--- a/bin-billing-manager/pkg/listenhandler/models/response/account.go
+++ b/bin-billing-manager/pkg/listenhandler/models/response/account.go
@@ -13,3 +13,11 @@ type V1ResponseAccountsIDIsValidBalance struct {
 type V1ResponseAccountsIDIsValidResourceLimit struct {
 	Valid bool `json:"valid"`
 }
+
+// V1ResponseAccountsTopUp is
+// v1 response type for
+// /v1/accounts/top_up POST
+type V1ResponseAccountsTopUp struct {
+	Processed int `json:"processed"`
+	Failed    int `json:"failed"`
+}

--- a/bin-billing-manager/pkg/listenhandler/models/response/failed_events.go
+++ b/bin-billing-manager/pkg/listenhandler/models/response/failed_events.go
@@ -1,0 +1,10 @@
+package response
+
+// V1ResponseFailedEventsRetry is
+// v1 response type for
+// /v1/failed_events/retry POST
+type V1ResponseFailedEventsRetry struct {
+	Retried   int `json:"retried"`
+	Succeeded int `json:"succeeded"`
+	Exhausted int `json:"exhausted"`
+}

--- a/bin-billing-manager/pkg/listenhandler/v1_accounts.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_accounts.go
@@ -392,6 +392,39 @@ func (h *listenHandler) processV1AccountsIsValidResourceLimitByCustomerIDPost(ct
 	return res, nil
 }
 
+// processV1AccountsTopUpPost handles POST /v1/accounts/top_up request
+func (h *listenHandler) processV1AccountsTopUpPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "processV1AccountsTopUpPost",
+		"request": m,
+	})
+
+	processed, failed, err := h.accountHandler.TopUpDue(ctx)
+	if err != nil {
+		log.Errorf("Could not process monthly top-up. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	tmp := &response.V1ResponseAccountsTopUp{
+		Processed: processed,
+		Failed:    failed,
+	}
+
+	data, err := json.Marshal(tmp)
+	if err != nil {
+		log.Errorf("Could not marshal top-up response. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}
+
 // processV1AccountsIDPaymentInfoPut handles PUT /v1/accounts/<account-id>/payment_info request
 func (h *listenHandler) processV1AccountsIDPaymentInfoPut(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-billing-manager/pkg/listenhandler/v1_accounts_test.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_accounts_test.go
@@ -1,6 +1,7 @@
 package listenhandler
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -456,6 +457,80 @@ func Test_processV1AccountsIDIsValidResourceLimitPost(t *testing.T) {
 			}
 
 			mockAccount.EXPECT().IsValidResourceLimit(gomock.Any(), tt.expectAccountID, tt.expectResourceType).Return(tt.responseValid, nil)
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_processV1AccountsTopUpPost(t *testing.T) {
+
+	type test struct {
+		name    string
+		request *sock.Request
+
+		responseProcessed int
+		responseFailed    int
+		responseErr       error
+
+		expectRes *sock.Response
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			request: &sock.Request{
+				URI:    "/v1/accounts/top_up",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseProcessed: 3,
+			responseFailed:    1,
+			responseErr:       nil,
+
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"processed":3,"failed":1}`),
+			},
+		},
+		{
+			name: "handler error maps to non-2xx",
+			request: &sock.Request{
+				URI:    "/v1/accounts/top_up",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseProcessed: 0,
+			responseFailed:    0,
+			responseErr:       fmt.Errorf("could not list accounts"),
+
+			expectRes: &sock.Response{
+				StatusCode: 500,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockAccount := accounthandler.NewMockAccountHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:    mockSock,
+				accountHandler: mockAccount,
+			}
+
+			mockAccount.EXPECT().TopUpDue(gomock.Any()).Return(tt.responseProcessed, tt.responseFailed, tt.responseErr)
 			res, err := h.processRequest(tt.request)
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)

--- a/bin-billing-manager/pkg/listenhandler/v1_failed_events.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_failed_events.go
@@ -1,0 +1,46 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-billing-manager/pkg/listenhandler/models/response"
+)
+
+// processV1FailedEventsRetryPost handles POST /v1/failed_events/retry request
+func (h *listenHandler) processV1FailedEventsRetryPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "processV1FailedEventsRetryPost",
+		"request": m,
+	})
+
+	retried, succeeded, exhausted, err := h.failedEventHandler.RetryPending(ctx)
+	if err != nil {
+		log.Errorf("Could not retry pending failed events. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	tmp := &response.V1ResponseFailedEventsRetry{
+		Retried:   retried,
+		Succeeded: succeeded,
+		Exhausted: exhausted,
+	}
+
+	data, err := json.Marshal(tmp)
+	if err != nil {
+		log.Errorf("Could not marshal failed event retry response. err: %v", err)
+		return simpleResponse(500), nil
+	}
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}

--- a/bin-billing-manager/pkg/listenhandler/v1_failed_events_test.go
+++ b/bin-billing-manager/pkg/listenhandler/v1_failed_events_test.go
@@ -1,0 +1,91 @@
+package listenhandler
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-billing-manager/pkg/failedeventhandler"
+)
+
+func Test_processV1FailedEventsRetryPost(t *testing.T) {
+
+	type test struct {
+		name    string
+		request *sock.Request
+
+		responseRetried   int
+		responseSucceeded int
+		responseExhausted int
+		responseErr       error
+
+		expectRes *sock.Response
+	}
+
+	tests := []test{
+		{
+			name: "normal",
+			request: &sock.Request{
+				URI:    "/v1/failed_events/retry",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseRetried:   5,
+			responseSucceeded: 3,
+			responseExhausted: 1,
+			responseErr:       nil,
+
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"retried":5,"succeeded":3,"exhausted":1}`),
+			},
+		},
+		{
+			name: "handler error maps to non-2xx",
+			request: &sock.Request{
+				URI:    "/v1/failed_events/retry",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseRetried:   0,
+			responseSucceeded: 0,
+			responseExhausted: 0,
+			responseErr:       fmt.Errorf("could not query failed events"),
+
+			expectRes: &sock.Response{
+				StatusCode: 500,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockFailedEvent := failedeventhandler.NewMockFailedEventHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:        mockSock,
+				failedEventHandler: mockFailedEvent,
+			}
+
+			mockFailedEvent.EXPECT().RetryPending(gomock.Any()).Return(tt.responseRetried, tt.responseSucceeded, tt.responseExhausted, tt.responseErr)
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}

--- a/bin-billing-manager/scripts/database_scripts_test/table_billing_billings.sql
+++ b/bin-billing-manager/scripts/database_scripts_test/table_billing_billings.sql
@@ -39,5 +39,5 @@ create index idx_billing_billings_customer_id on billing_billings(customer_id);
 create index idx_billing_billings_account_id on billing_billings(account_id);
 create index idx_billing_billings_reference_id on billing_billings(reference_id);
 create unique index idx_billings_ref_type_id_active on billing_billings(reference_type, reference_id, tm_delete);
-create index idx_billing_billings_idempotency_key on billing_billings(idempotency_key);
+create unique index ux_billing_billings_idempotency_key on billing_billings(idempotency_key);
 create index idx_billing_billings_create on billing_billings(tm_create);

--- a/bin-customer-manager/cmd/customer-manager/main.go
+++ b/bin-customer-manager/cmd/customer-manager/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"database/sql"
 	"net/http"
 	"os"
@@ -96,12 +95,6 @@ func startServices(sqlDB *sql.DB, cache cachehandler.CacheHandler) error {
 	customerHandler := customerhandler.NewCustomerHandler(reqHandler, db, cache, notifyHandler, accesskeyHandler)
 
 	listenHandler := listenhandler.NewListenHandler(sockHandler, reqHandler, customerHandler, accesskeyHandler)
-
-	// start background cleanup job for expired unverified customers
-	go customerHandler.RunCleanupUnverified(context.Background())
-
-	// start background cleanup job for frozen accounts past grace period
-	go customerHandler.RunCleanupFrozenExpired(context.Background())
 
 	return listenHandler.Run(string(commonoutline.QueueNameCustomerRequest), string(commonoutline.QueueNameDelay))
 }

--- a/bin-customer-manager/docs/architecture.md
+++ b/bin-customer-manager/docs/architecture.md
@@ -46,6 +46,8 @@ The `listenhandler` consumes from queue `bin-manager.customer-manager.request` a
 | PUT | `/v1/customers/{uuid}/metadata` | Update metadata |
 | POST | `/v1/customers/signup` | New customer self-registration |
 | POST | `/v1/customers/email_verify` | Email verification callback |
+| POST | `/v1/customers/cleanup_unverified` | Sweep endpoint: expire unverified customers past `unverifiedMaxAge` (invoked by schedule-manager cron, replaces the old in-process ticker) |
+| POST | `/v1/customers/cleanup_frozen_expired` | Sweep endpoint: anonymize PII and publish `customer_deleted` for frozen customers past the grace period (invoked by schedule-manager cron, replaces the old in-process ticker) |
 | POST | `/v1/customers/{uuid}/freeze` | Freeze customer account |
 | POST | `/v1/customers/{uuid}/recover` | Recover frozen customer |
 | POST | `/v1/customers/{uuid}/freeze_and_delete` | Freeze and schedule deletion |

--- a/bin-customer-manager/pkg/customerhandler/cleanup.go
+++ b/bin-customer-manager/pkg/customerhandler/cleanup.go
@@ -10,31 +10,16 @@ import (
 )
 
 const (
-	cleanupInterval   = 15 * time.Minute
-	unverifiedMaxAge  = time.Hour
+	unverifiedMaxAge = time.Hour
 )
 
-// RunCleanupUnverified periodically removes unverified customers older than maxAge.
-func (h *customerHandler) RunCleanupUnverified(ctx context.Context) {
-	log := logrus.WithField("func", "RunCleanupUnverified")
-	log.Info("Starting unverified customer cleanup job.")
-
-	ticker := time.NewTicker(cleanupInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Info("Stopping unverified customer cleanup job.")
-			return
-		case <-ticker.C:
-			h.cleanupUnverified(ctx)
-		}
-	}
-}
-
-func (h *customerHandler) cleanupUnverified(ctx context.Context) {
-	log := logrus.WithField("func", "cleanupUnverified")
+// CleanupUnverified removes unverified customers older than unverifiedMaxAge.
+// Returns the number of customers actually expired. A per-row CustomerUpdate
+// failure is logged and does not abort the batch, but is excluded from the
+// returned count. A non-nil error is returned only when the initial
+// CustomerList call fails.
+func (h *customerHandler) CleanupUnverified(ctx context.Context) (int, error) {
+	log := logrus.WithField("func", "CleanupUnverified")
 	log.Debug("Running unverified customer cleanup.")
 
 	cutoff := time.Now().Add(-unverifiedMaxAge)
@@ -48,9 +33,10 @@ func (h *customerHandler) cleanupUnverified(ctx context.Context) {
 	customers, err := h.db.CustomerList(ctx, 100, cutoffStr, filters)
 	if err != nil {
 		log.Errorf("Could not list unverified customers. err: %v", err)
-		return
+		return 0, err
 	}
 
+	expired := 0
 	for _, c := range customers {
 		log.Infof("Expiring unverified customer. customer_id: %s, email: %s", c.ID, c.Email)
 
@@ -61,10 +47,14 @@ func (h *customerHandler) cleanupUnverified(ctx context.Context) {
 		}
 		if err := h.db.CustomerUpdate(ctx, c.ID, fields); err != nil {
 			log.Errorf("Could not expire customer. customer_id: %s, err: %v", c.ID, err)
+			continue
 		}
+		expired++
 	}
 
-	if len(customers) > 0 {
-		log.Infof("Cleanup completed. expired: %d", len(customers))
+	if expired > 0 {
+		log.Infof("Cleanup completed. expired: %d", expired)
 	}
+
+	return expired, nil
 }

--- a/bin-customer-manager/pkg/customerhandler/cleanup_test.go
+++ b/bin-customer-manager/pkg/customerhandler/cleanup_test.go
@@ -16,26 +16,25 @@ import (
 )
 
 func TestCleanupConstants(t *testing.T) {
-	if cleanupInterval != 15*time.Minute {
-		t.Errorf("cleanupInterval = %v, expected %v", cleanupInterval, 15*time.Minute)
-	}
 	if unverifiedMaxAge != time.Hour {
 		t.Errorf("unverifiedMaxAge = %v, expected %v", unverifiedMaxAge, time.Hour)
 	}
 }
 
-func Test_cleanupUnverified(t *testing.T) {
+func Test_CleanupUnverified(t *testing.T) {
 	tests := []struct {
 		name string
 
 		responseCustomers []*customer.Customer
 		expectUpdateCount int
+		expectExpired     int
 	}{
 		{
 			name: "no unverified customers",
 
 			responseCustomers: []*customer.Customer{},
 			expectUpdateCount: 0,
+			expectExpired:     0,
 		},
 		{
 			name: "one unverified customer - soft deleted",
@@ -49,6 +48,7 @@ func Test_cleanupUnverified(t *testing.T) {
 				},
 			},
 			expectUpdateCount: 1,
+			expectExpired:     1,
 		},
 		{
 			name: "multiple unverified customers - all soft deleted",
@@ -68,6 +68,7 @@ func Test_cleanupUnverified(t *testing.T) {
 				},
 			},
 			expectUpdateCount: 2,
+			expectExpired:     2,
 		},
 	}
 
@@ -106,12 +107,18 @@ func Test_cleanupUnverified(t *testing.T) {
 				)
 			}
 
-			h.cleanupUnverified(ctx)
+			expired, err := h.CleanupUnverified(ctx)
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+			if expired != tt.expectExpired {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectExpired, expired)
+			}
 		})
 	}
 }
 
-func Test_cleanupUnverified_updateError(t *testing.T) {
+func Test_CleanupUnverified_updateError(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
@@ -151,11 +158,18 @@ func Test_cleanupUnverified_updateError(t *testing.T) {
 	mockUtil.EXPECT().TimeNow().Return(&now2)
 	mockDB.EXPECT().CustomerUpdate(ctx, customers[1].ID, gomock.Any()).Return(nil)
 
-	// should not panic, should process both customers
-	h.cleanupUnverified(ctx)
+	// should not panic, should process both customers, and the failed row
+	// must not be counted as expired
+	expired, err := h.CleanupUnverified(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if expired != 1 {
+		t.Errorf("Wrong match. expect: 1, got: %d", expired)
+	}
 }
 
-func Test_cleanupUnverified_listError(t *testing.T) {
+func Test_CleanupUnverified_listError(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
@@ -170,6 +184,12 @@ func Test_cleanupUnverified_listError(t *testing.T) {
 
 	mockDB.EXPECT().CustomerList(ctx, uint64(100), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("db error"))
 
-	// should not panic
-	h.cleanupUnverified(ctx)
+	// should not panic, should return the list error
+	expired, err := h.CleanupUnverified(ctx)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if expired != 0 {
+		t.Errorf("Wrong match. expect: 0, got: %d", expired)
+	}
 }

--- a/bin-customer-manager/pkg/customerhandler/expiry.go
+++ b/bin-customer-manager/pkg/customerhandler/expiry.go
@@ -2,40 +2,33 @@ package customerhandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"monorepo/bin-customer-manager/models/customer"
+	"monorepo/bin-customer-manager/pkg/dbhandler"
 
 	"github.com/sirupsen/logrus"
 )
 
 const (
-	expiryCheckInterval = 24 * time.Hour
-	gracePeriod         = 30 * 24 * time.Hour // 30 days
+	gracePeriod = 30 * 24 * time.Hour // 30 days
 )
 
-// RunCleanupFrozenExpired periodically checks for frozen customers whose grace period has expired.
-func (h *customerHandler) RunCleanupFrozenExpired(ctx context.Context) {
-	log := logrus.WithField("func", "RunCleanupFrozenExpired")
-	log.Info("Starting frozen customer expiry cleanup job.")
-
-	ticker := time.NewTicker(expiryCheckInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Info("Stopping frozen customer expiry cleanup job.")
-			return
-		case <-ticker.C:
-			h.cleanupFrozenExpired(ctx)
-		}
-	}
-}
-
-func (h *customerHandler) cleanupFrozenExpired(ctx context.Context) {
-	log := logrus.WithField("func", "cleanupFrozenExpired")
+// CleanupFrozenExpired processes frozen customers whose grace period has
+// expired: it anonymizes PII and publishes a customer_deleted event for each
+// one it successfully claims. Returns the number of customers actually
+// processed.
+//
+// CustomerAnonymizePII now guards on status='frozen' AND tm_delete IS NULL
+// (design §5.5), so a 0-rows result (dbhandler.ErrNotFound) is an expected,
+// routine outcome under concurrent replicas racing the same row — it is not
+// logged as an error, not counted as processed, and does not publish an
+// event. Any other error is still logged and skipped, unchanged from before.
+// A non-nil error is returned only when CustomerListFrozenExpired fails.
+func (h *customerHandler) CleanupFrozenExpired(ctx context.Context) (int, error) {
+	log := logrus.WithField("func", "CleanupFrozenExpired")
 	log.Debug("Running frozen customer expiry cleanup.")
 
 	cutoff := time.Now().Add(-gracePeriod)
@@ -43,9 +36,10 @@ func (h *customerHandler) cleanupFrozenExpired(ctx context.Context) {
 	customers, err := h.db.CustomerListFrozenExpired(ctx, cutoff)
 	if err != nil {
 		log.Errorf("Could not list frozen expired customers. err: %v", err)
-		return
+		return 0, err
 	}
 
+	processed := 0
 	for _, c := range customers {
 		log.Infof("Processing expired frozen customer. customer_id: %s, email: %s", c.ID, c.Email)
 
@@ -55,6 +49,12 @@ func (h *customerHandler) cleanupFrozenExpired(ctx context.Context) {
 		anonEmail := fmt.Sprintf("deleted_%s@removed.voipbin.net", shortID)
 
 		if err := h.db.CustomerAnonymizePII(ctx, c.ID, anonName, anonEmail); err != nil {
+			if errors.Is(err, dbhandler.ErrNotFound) {
+				// A concurrent claimant already won the guard (status/tm_delete
+				// no longer matched) — routine CAS-skip, not a failure.
+				log.Debugf("Frozen customer already claimed by a concurrent run. customer_id: %s", c.ID)
+				continue
+			}
 			log.Errorf("Could not anonymize customer PII. customer_id: %s, err: %v", c.ID, err)
 			continue
 		}
@@ -69,9 +69,12 @@ func (h *customerHandler) cleanupFrozenExpired(ctx context.Context) {
 		// Publish customer_deleted event (reuse existing event type for cascading cleanup)
 		h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerDeleted, res)
 		log.Infof("Processed expired frozen customer. customer_id: %s", c.ID)
+		processed++
 	}
 
-	if len(customers) > 0 {
-		log.Infof("Frozen expiry cleanup completed. processed: %d", len(customers))
+	if processed > 0 {
+		log.Infof("Frozen expiry cleanup completed. processed: %d", processed)
 	}
+
+	return processed, nil
 }

--- a/bin-customer-manager/pkg/customerhandler/expiry_test.go
+++ b/bin-customer-manager/pkg/customerhandler/expiry_test.go
@@ -16,19 +16,22 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-func Test_cleanupFrozenExpired(t *testing.T) {
+func Test_CleanupFrozenExpired(t *testing.T) {
 	tests := []struct {
 		name string
 
 		responseFrozenExpired []*customer.Customer
 		responseFrozenErr     error
 
-		expectAnonymize       bool
-		anonymizeErr          error
-		expectGet             bool
-		getResponse           *customer.Customer
-		getErr                error
-		expectPublish         bool
+		expectAnonymize bool
+		anonymizeErr    error
+		expectGet       bool
+		getResponse     *customer.Customer
+		getErr          error
+		expectPublish   bool
+
+		expectProcessed int
+		expectErr       bool
 	}{
 		{
 			name: "expired frozen customers - anonymized and event published",
@@ -47,8 +50,9 @@ func Test_cleanupFrozenExpired(t *testing.T) {
 				Name:  "deleted_user_4cd23368",
 				Email: "deleted_4cd23368@removed.voipbin.net",
 			},
-			getErr:        nil,
-			expectPublish: true,
+			getErr:          nil,
+			expectPublish:   true,
+			expectProcessed: 1,
 		},
 		{
 			name:                  "no frozen customers - no action",
@@ -57,6 +61,7 @@ func Test_cleanupFrozenExpired(t *testing.T) {
 			expectAnonymize:       false,
 			expectGet:             false,
 			expectPublish:         false,
+			expectProcessed:       0,
 		},
 		{
 			name:                  "list frozen expired error - no action",
@@ -65,6 +70,8 @@ func Test_cleanupFrozenExpired(t *testing.T) {
 			expectAnonymize:       false,
 			expectGet:             false,
 			expectPublish:         false,
+			expectProcessed:       0,
+			expectErr:             true,
 		},
 		{
 			name: "anonymize error - continues to next",
@@ -79,6 +86,22 @@ func Test_cleanupFrozenExpired(t *testing.T) {
 			anonymizeErr:      fmt.Errorf("anonymize error"),
 			expectGet:         false,
 			expectPublish:     false,
+			expectProcessed:   0,
+		},
+		{
+			name: "anonymize ErrNotFound - concurrent claimant won the guard, CAS-skip",
+			responseFrozenExpired: []*customer.Customer{
+				{
+					ID:    uuid.FromStringOrNil("4cd23368-7cb7-11ec-9466-8318ef5a7125"),
+					Email: "test@example.com",
+				},
+			},
+			responseFrozenErr: nil,
+			expectAnonymize:   true,
+			anonymizeErr:      dbhandler.ErrNotFound,
+			expectGet:         false,
+			expectPublish:     false,
+			expectProcessed:   0,
 		},
 		{
 			name: "get after anonymize error - continues to next",
@@ -95,6 +118,7 @@ func Test_cleanupFrozenExpired(t *testing.T) {
 			getResponse:       nil,
 			getErr:            fmt.Errorf("get error"),
 			expectPublish:     false,
+			expectProcessed:   0,
 		},
 	}
 
@@ -133,12 +157,22 @@ func Test_cleanupFrozenExpired(t *testing.T) {
 				mockNotify.EXPECT().PublishEvent(gomock.Any(), customer.EventTypeCustomerDeleted, tt.getResponse).Return()
 			}
 
-			h.cleanupFrozenExpired(ctx)
+			processed, err := h.CleanupFrozenExpired(ctx)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error, got nil")
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+			if processed != tt.expectProcessed {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectProcessed, processed)
+			}
 		})
 	}
 }
 
-func Test_cleanupFrozenExpired_MultipleCustomers(t *testing.T) {
+func Test_CleanupFrozenExpired_MultipleCustomers(t *testing.T) {
 	mc := gomock.NewController(t)
 	defer mc.Finish()
 
@@ -184,13 +218,16 @@ func Test_cleanupFrozenExpired_MultipleCustomers(t *testing.T) {
 	mockDB.EXPECT().CustomerGet(gomock.Any(), id2).Return(anonymized2, nil)
 	mockNotify.EXPECT().PublishEvent(gomock.Any(), customer.EventTypeCustomerDeleted, anonymized2).Return()
 
-	h.cleanupFrozenExpired(ctx)
+	processed, err := h.CleanupFrozenExpired(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if processed != 2 {
+		t.Errorf("Wrong match. expect: 2, got: %d", processed)
+	}
 }
 
 func Test_expiryConstants(t *testing.T) {
-	if expiryCheckInterval != 24*time.Hour {
-		t.Errorf("expiryCheckInterval = %v, expected %v", expiryCheckInterval, 24*time.Hour)
-	}
 	if gracePeriod != 30*24*time.Hour {
 		t.Errorf("gracePeriod = %v, expected %v", gracePeriod, 30*24*time.Hour)
 	}

--- a/bin-customer-manager/pkg/customerhandler/freeze_test.go
+++ b/bin-customer-manager/pkg/customerhandler/freeze_test.go
@@ -2,7 +2,10 @@ package customerhandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,10 +26,10 @@ func Test_Freeze(t *testing.T) {
 
 		responseCustomerGet *customer.Customer
 
-		expectDBFreeze  bool
-		expectDBGet2    bool
-		expectPublish   bool
-		expectErr       bool
+		expectDBFreeze       bool
+		expectDBGet2         bool
+		expectPublish        bool
+		expectErr            bool
 		responseCustomerGet2 *customer.Customer
 	}{
 		{
@@ -86,8 +89,8 @@ func Test_Freeze(t *testing.T) {
 			expectErr:      true,
 		},
 		{
-			name: "get customer fails - error",
-			id:   uuid.FromStringOrNil("4cd23368-7cb7-11ec-9466-8318ef5a7125"),
+			name:                "get customer fails - error",
+			id:                  uuid.FromStringOrNil("4cd23368-7cb7-11ec-9466-8318ef5a7125"),
 			responseCustomerGet: nil,
 			expectDBFreeze:      false,
 			expectDBGet2:        false,
@@ -436,6 +439,126 @@ func Test_FreezeAndDelete_GetAfterAnonymizeError(t *testing.T) {
 	}
 }
 
+// Test_FreezeAndDelete_ConcurrentRace exercises the real, observable behavior
+// change design §5.5 calls out for this out-of-scope-but-affected caller:
+// today two concurrent FreezeAndDelete calls on the same customer both
+// silently succeed and both publish customer_deleted (the same duplicate-
+// cascade bug the CustomerAnonymizePII status guard fixes for the scheduled
+// sweep); after the guard, the loser receives dbhandler.ErrNotFound and does
+// not publish a second event.
+//
+// Both goroutines see the customer as already frozen, so Freeze() takes the
+// idempotent early-return path (a single Get, no DB freeze, no frozen-event
+// publish) and only CustomerAnonymizePII actually races.
+func Test_FreezeAndDelete_ConcurrentRace(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := &customerHandler{
+		reqHandler:    mockReq,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	id := uuid.FromStringOrNil("4cd23368-7cb7-11ec-9466-8318ef5a7125")
+
+	frozenCustomer := &customer.Customer{
+		ID:     id,
+		Status: customer.StatusFrozen,
+	}
+	anonymizedCustomer := &customer.Customer{
+		ID:     id,
+		Status: customer.StatusDeleted,
+	}
+
+	shortID := id.String()[:8]
+	anonName := fmt.Sprintf("deleted_user_%s", shortID)
+	anonEmail := fmt.Sprintf("deleted_%s@removed.voipbin.net", shortID)
+
+	// CustomerGet must reflect whatever the (mocked) DB state actually is at
+	// call time, not call registration order — two goroutines calling
+	// Freeze()'s initial Get and the post-anonymize Get interleave
+	// unpredictably, so the response is driven off the same atomic flag that
+	// CustomerAnonymizePII flips, mirroring real DB read-your-writes
+	// semantics instead of asserting a fixed call count per response.
+	//
+	// The two pre-anonymize Get calls (one per goroutine, from Freeze()'s
+	// idempotent-check) are additionally barriered so both goroutines are
+	// guaranteed to observe "frozen" and reach FreezeAndDelete's anonymize
+	// step before either one's CustomerAnonymizePII call can flip the
+	// anonymized flag — otherwise a goroutine that runs to completion before
+	// the other even starts would make the race deterministic instead of
+	// contested, and the second goroutine would see an already-deleted
+	// customer at the Freeze() step instead of racing CustomerAnonymizePII.
+	var anonymized int32
+	var preAnonymizeGets int32
+	preAnonymizeBarrier := make(chan struct{})
+	var closeBarrierOnce sync.Once
+	mockDB.EXPECT().CustomerGet(gomock.Any(), id).DoAndReturn(
+		func(_ context.Context, _ uuid.UUID) (*customer.Customer, error) {
+			if atomic.LoadInt32(&anonymized) == 1 {
+				return anonymizedCustomer, nil
+			}
+			if atomic.AddInt32(&preAnonymizeGets, 1) >= 2 {
+				closeBarrierOnce.Do(func() { close(preAnonymizeBarrier) })
+			} else {
+				<-preAnonymizeBarrier
+			}
+			return frozenCustomer, nil
+		},
+	).AnyTimes()
+
+	var claimed int32
+	mockDB.EXPECT().CustomerAnonymizePII(gomock.Any(), id, anonName, anonEmail).DoAndReturn(
+		func(_ context.Context, _ uuid.UUID, _, _ string) error {
+			if atomic.CompareAndSwapInt32(&claimed, 0, 1) {
+				atomic.StoreInt32(&anonymized, 1)
+				return nil
+			}
+			return dbhandler.ErrNotFound
+		},
+	).Times(2)
+
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), customer.EventTypeCustomerDeleted, anonymizedCustomer).Times(1).Return()
+
+	const n = 2
+	var wg sync.WaitGroup
+	results := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			_, err := h.FreezeAndDelete(ctx, id)
+			results[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	losers := 0
+	for _, err := range results {
+		switch {
+		case err == nil:
+			winners++
+		case errors.Is(err, dbhandler.ErrNotFound):
+			losers++
+		default:
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+	if winners != 1 {
+		t.Errorf("Wrong match. expect: exactly 1 winner, got: %d", winners)
+	}
+	if losers != 1 {
+		t.Errorf("Wrong match. expect: exactly 1 loser, got: %d", losers)
+	}
+}
+
 func Test_Recover(t *testing.T) {
 	tests := []struct {
 		name string
@@ -443,10 +566,10 @@ func Test_Recover(t *testing.T) {
 
 		responseCustomerGet *customer.Customer
 
-		expectDBRecover bool
-		expectDBGet2    bool
-		expectPublish   bool
-		expectErr       bool
+		expectDBRecover      bool
+		expectDBGet2         bool
+		expectPublish        bool
+		expectErr            bool
 		responseCustomerGet2 *customer.Customer
 	}{
 		{

--- a/bin-customer-manager/pkg/customerhandler/main.go
+++ b/bin-customer-manager/pkg/customerhandler/main.go
@@ -63,8 +63,8 @@ type CustomerHandler interface {
 	) (*customer.SignupResult, error)
 	EmailVerify(ctx context.Context, token string) (*customer.EmailVerifyResult, error)
 
-	RunCleanupUnverified(ctx context.Context)
-	RunCleanupFrozenExpired(ctx context.Context)
+	CleanupUnverified(ctx context.Context) (int, error)
+	CleanupFrozenExpired(ctx context.Context) (int, error)
 }
 
 type customerHandler struct {

--- a/bin-customer-manager/pkg/customerhandler/mock_main.go
+++ b/bin-customer-manager/pkg/customerhandler/mock_main.go
@@ -42,6 +42,36 @@ func (m *MockCustomerHandler) EXPECT() *MockCustomerHandlerMockRecorder {
 	return m.recorder
 }
 
+// CleanupFrozenExpired mocks base method.
+func (m *MockCustomerHandler) CleanupFrozenExpired(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupFrozenExpired", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanupFrozenExpired indicates an expected call of CleanupFrozenExpired.
+func (mr *MockCustomerHandlerMockRecorder) CleanupFrozenExpired(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupFrozenExpired", reflect.TypeOf((*MockCustomerHandler)(nil).CleanupFrozenExpired), ctx)
+}
+
+// CleanupUnverified mocks base method.
+func (m *MockCustomerHandler) CleanupUnverified(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupUnverified", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CleanupUnverified indicates an expected call of CleanupUnverified.
+func (mr *MockCustomerHandlerMockRecorder) CleanupUnverified(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupUnverified", reflect.TypeOf((*MockCustomerHandler)(nil).CleanupUnverified), ctx)
+}
+
 // Create mocks base method.
 func (m *MockCustomerHandler) Create(ctx context.Context, name, detail, email, phoneNumber, address string, webhookMethod customer.WebhookMethod, webhookURI string) (*customer.Customer, error) {
 	m.ctrl.T.Helper()
@@ -160,30 +190,6 @@ func (m *MockCustomerHandler) Recover(ctx context.Context, id uuid.UUID) (*custo
 func (mr *MockCustomerHandlerMockRecorder) Recover(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recover", reflect.TypeOf((*MockCustomerHandler)(nil).Recover), ctx, id)
-}
-
-// RunCleanupFrozenExpired mocks base method.
-func (m *MockCustomerHandler) RunCleanupFrozenExpired(ctx context.Context) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RunCleanupFrozenExpired", ctx)
-}
-
-// RunCleanupFrozenExpired indicates an expected call of RunCleanupFrozenExpired.
-func (mr *MockCustomerHandlerMockRecorder) RunCleanupFrozenExpired(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCleanupFrozenExpired", reflect.TypeOf((*MockCustomerHandler)(nil).RunCleanupFrozenExpired), ctx)
-}
-
-// RunCleanupUnverified mocks base method.
-func (m *MockCustomerHandler) RunCleanupUnverified(ctx context.Context) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RunCleanupUnverified", ctx)
-}
-
-// RunCleanupUnverified indicates an expected call of RunCleanupUnverified.
-func (mr *MockCustomerHandlerMockRecorder) RunCleanupUnverified(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCleanupUnverified", reflect.TypeOf((*MockCustomerHandler)(nil).RunCleanupUnverified), ctx)
 }
 
 // Signup mocks base method.

--- a/bin-customer-manager/pkg/dbhandler/customer.go
+++ b/bin-customer-manager/pkg/dbhandler/customer.go
@@ -427,6 +427,10 @@ func (h *handler) CustomerListFrozenExpired(ctx context.Context, expiredBefore t
 }
 
 // CustomerAnonymizePII anonymizes the customer's personally identifiable information.
+// Guarded on status='frozen' AND tm_delete IS NULL so a concurrent claimant
+// cannot double-fire the anonymization (and the customer_deleted publish that
+// follows it) — returns ErrNotFound when 0 rows are affected, whether because
+// the row genuinely does not exist or because the guard no longer matched.
 func (h *handler) CustomerAnonymizePII(ctx context.Context, id uuid.UUID, anonName, anonEmail string) error {
 	start := time.Now()
 	status := "error"
@@ -456,6 +460,8 @@ func (h *handler) CustomerAnonymizePII(ctx context.Context, id uuid.UUID, anonNa
 	sb := squirrel.Update(customerTable).
 		SetMap(tmpFields).
 		Where(squirrel.Eq{string(customer.FieldID): id.Bytes()}).
+		Where(squirrel.Eq{string(customer.FieldStatus): string(customer.StatusFrozen)}).
+		Where(squirrel.Eq{string(customer.FieldTMDelete): nil}).
 		PlaceholderFormat(squirrel.Question)
 
 	sqlStr, args, err := sb.ToSql()

--- a/bin-customer-manager/pkg/dbhandler/customer_test.go
+++ b/bin-customer-manager/pkg/dbhandler/customer_test.go
@@ -2,8 +2,10 @@ package dbhandler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -514,5 +516,197 @@ func Test_CustomerHardDelete(t *testing.T) {
 				t.Errorf("Wrong match. expect: error (not found), got: nil")
 			}
 		})
+	}
+}
+
+// Test_CustomerAnonymizePII covers the status guard added to the WHERE
+// clause (design §5.5): the method only anonymizes a customer that is
+// currently `frozen` and not already soft-deleted. A non-matching row
+// returns ErrNotFound and leaves the row untouched.
+func Test_CustomerAnonymizePII(t *testing.T) {
+	curTime := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+
+		initialStatus customer.Status
+
+		expectErr        bool
+		expectAnonymized bool
+	}{
+		{
+			name:             "frozen customer - guard matches, anonymized",
+			initialStatus:    customer.StatusFrozen,
+			expectErr:        false,
+			expectAnonymized: true,
+		},
+		{
+			name:             "active customer - guard does not match, ErrNotFound",
+			initialStatus:    customer.StatusActive,
+			expectErr:        true,
+			expectAnonymized: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockCache := cachehandler.NewMockCacheHandler(mc)
+
+			h := handler{
+				utilHandler: mockUtil,
+				db:          dbTest,
+				cache:       mockCache,
+			}
+			ctx := context.Background()
+
+			id, err := uuid.NewV4()
+			if err != nil {
+				t.Fatalf("could not generate uuid: %v", err)
+			}
+
+			mockUtil.EXPECT().TimeNow().Return(&curTime)
+			mockCache.EXPECT().CustomerSet(ctx, gomock.Any()).Return(nil)
+			if err := h.CustomerCreate(ctx, &customer.Customer{
+				ID:     id,
+				Name:   "orig name",
+				Email:  "orig@test.com",
+				Status: tt.initialStatus,
+			}); err != nil {
+				t.Fatalf("could not create customer: %v", err)
+			}
+
+			mockUtil.EXPECT().TimeNow().Return(&curTime)
+			if tt.expectAnonymized {
+				mockCache.EXPECT().CustomerSet(ctx, gomock.Any()).Return(nil)
+			}
+
+			anonErr := h.CustomerAnonymizePII(ctx, id, "deleted_user_xxx", "deleted_xxx@removed.voipbin.net")
+			if tt.expectErr {
+				if !errors.Is(anonErr, ErrNotFound) {
+					t.Errorf("Wrong match. expect: ErrNotFound, got: %v", anonErr)
+				}
+			} else if anonErr != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", anonErr)
+			}
+
+			mockCache.EXPECT().CustomerGet(ctx, id).Return(nil, fmt.Errorf(""))
+			mockCache.EXPECT().CustomerSet(ctx, gomock.Any()).Return(nil)
+			res, err := h.CustomerGet(ctx, id)
+			if err != nil {
+				t.Fatalf("could not get customer: %v", err)
+			}
+
+			if tt.expectAnonymized {
+				if res.Status != customer.StatusDeleted {
+					t.Errorf("Wrong match. expect status: %v, got: %v", customer.StatusDeleted, res.Status)
+				}
+				if res.Name != "deleted_user_xxx" {
+					t.Errorf("Wrong match. expect anonymized name, got: %v", res.Name)
+				}
+			} else {
+				if res.Status != tt.initialStatus {
+					t.Errorf("Wrong match. expect status unchanged: %v, got: %v", tt.initialStatus, res.Status)
+				}
+				if res.Name != "orig name" {
+					t.Errorf("Wrong match. expect name unchanged, got: %v", res.Name)
+				}
+			}
+		})
+	}
+}
+
+// Test_CustomerAnonymizePII_DoubleFire races CustomerAnonymizePII against a
+// single sqlite-backed handler for the same frozen customer. Unlike Phase
+// 1's billing CAS (which needs FOR UPDATE), this method is a plain UPDATE
+// with a status-guarded WHERE clause, so the shared sqlite harness
+// (SetMaxOpenConns(1)) is enough to prove the CAS holds: exactly one caller
+// succeeds, every other caller observes ErrNotFound, and the row is
+// anonymized exactly once. Same shape as
+// bin-schedule-manager/pkg/dbhandler/execution_test.go's Test_DoubleFire.
+func Test_CustomerAnonymizePII_DoubleFire(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	mockCache.EXPECT().CustomerSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	h := handler{
+		utilHandler: mockUtil,
+		db:          dbTest,
+		cache:       mockCache,
+	}
+	ctx := context.Background()
+
+	curTime := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&curTime).AnyTimes()
+
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("could not generate uuid: %v", err)
+	}
+
+	if err := h.CustomerCreate(ctx, &customer.Customer{
+		ID:     id,
+		Name:   "orig name",
+		Email:  "orig@test.com",
+		Status: customer.StatusFrozen,
+	}); err != nil {
+		t.Fatalf("could not create customer: %v", err)
+	}
+
+	const n = 20
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	winners := 0
+	losers := 0
+	var unexpected []error
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			callErr := h.CustomerAnonymizePII(ctx, id, "deleted_user_race", "deleted_race@removed.voipbin.net")
+
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case callErr == nil:
+				winners++
+			case errors.Is(callErr, ErrNotFound):
+				losers++
+			default:
+				unexpected = append(unexpected, callErr)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(unexpected) != 0 {
+		t.Fatalf("Expected no unexpected errors, got: %v", unexpected)
+	}
+	if winners != 1 {
+		t.Errorf("Wrong match. expect: exactly 1 winner, got: %d", winners)
+	}
+	if losers != n-1 {
+		t.Errorf("Wrong match. expect: %d losers, got: %d", n-1, losers)
+	}
+
+	mockCache.EXPECT().CustomerGet(ctx, id).Return(nil, fmt.Errorf(""))
+	res, err := h.CustomerGet(ctx, id)
+	if err != nil {
+		t.Fatalf("could not get customer: %v", err)
+	}
+	if res.Status != customer.StatusDeleted {
+		t.Errorf("Wrong match. expect status: %v, got: %v", customer.StatusDeleted, res.Status)
+	}
+	if res.Name != "deleted_user_race" {
+		t.Errorf("Wrong match. expect anonymized name exactly once, got: %v", res.Name)
 	}
 }

--- a/bin-customer-manager/pkg/listenhandler/main.go
+++ b/bin-customer-manager/pkg/listenhandler/main.go
@@ -58,11 +58,14 @@ var (
 	regV1Customers                     = regexp.MustCompile("/v1/customers$")
 	regV1CustomersGet                  = regexp.MustCompile(`/v1/customers\?(.*)$`)
 	regV1CustomersID                   = regexp.MustCompile("/v1/customers/" + regUUID + "$")
-	regV1CustomersIDIsBillingAccountID              = regexp.MustCompile("/v1/customers/" + regUUID + "/billing_account_id$")
-	regV1CustomersIDIsMetadata                      = regexp.MustCompile("/v1/customers/" + regUUID + "/metadata$")
+	regV1CustomersIDIsBillingAccountID = regexp.MustCompile("/v1/customers/" + regUUID + "/billing_account_id$")
+	regV1CustomersIDIsMetadata         = regexp.MustCompile("/v1/customers/" + regUUID + "/metadata$")
 
 	regV1CustomersSignup      = regexp.MustCompile("/v1/customers/signup$")
 	regV1CustomersEmailVerify = regexp.MustCompile("/v1/customers/email_verify$")
+
+	regV1CustomersCleanupUnverified    = regexp.MustCompile("/v1/customers/cleanup_unverified$")
+	regV1CustomersCleanupFrozenExpired = regexp.MustCompile("/v1/customers/cleanup_frozen_expired$")
 
 	regV1CustomersIDFreeze          = regexp.MustCompile("/v1/customers/" + regUUID + "/freeze$")
 	regV1CustomersIDRecover         = regexp.MustCompile("/v1/customers/" + regUUID + "/recover$")
@@ -200,6 +203,16 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1CustomersEmailVerify.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
 		response, err = h.processV1CustomersEmailVerifyPost(ctx, m)
 		requestType = "/v1/customers/email_verify"
+
+	// POST /customers/cleanup_unverified
+	case regV1CustomersCleanupUnverified.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1CustomersCleanupUnverifiedPost(ctx, m)
+		requestType = "/v1/customers/cleanup_unverified"
+
+	// POST /customers/cleanup_frozen_expired
+	case regV1CustomersCleanupFrozenExpired.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		response, err = h.processV1CustomersCleanupFrozenExpiredPost(ctx, m)
+		requestType = "/v1/customers/cleanup_frozen_expired"
 
 	// GET /customers
 	case regV1CustomersGet.MatchString(m.URI) && m.Method == sock.RequestMethodGet:

--- a/bin-customer-manager/pkg/listenhandler/models/response/customers.go
+++ b/bin-customer-manager/pkg/listenhandler/models/response/customers.go
@@ -1,0 +1,22 @@
+// Package response defines the wire response DTOs for the customer-manager
+// RPC listener. Only wire-only shapes live here (root CLAUDE.md layering,
+// style B): domain types are marshaled directly by the listener (style A).
+package response
+
+// V1ResponseCustomersCleanupUnverified is
+// v1 response type struct for
+// /v1/customers/cleanup_unverified POST
+//
+// Wraps the bare expired-row count — a scalar with no domain type (style B).
+type V1ResponseCustomersCleanupUnverified struct {
+	Expired int `json:"expired"`
+}
+
+// V1ResponseCustomersCleanupFrozenExpired is
+// v1 response type struct for
+// /v1/customers/cleanup_frozen_expired POST
+//
+// Wraps the bare processed-row count — a scalar with no domain type (style B).
+type V1ResponseCustomersCleanupFrozenExpired struct {
+	Processed int `json:"processed"`
+}

--- a/bin-customer-manager/pkg/listenhandler/v1_customers.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers.go
@@ -15,6 +15,7 @@ import (
 
 	"monorepo/bin-customer-manager/models/customer"
 	"monorepo/bin-customer-manager/pkg/listenhandler/models/request"
+	"monorepo/bin-customer-manager/pkg/listenhandler/models/response"
 )
 
 // processV1CustomersGet handles GET /v1/customers request
@@ -104,6 +105,74 @@ func (h *listenHandler) processV1CustomersPost(ctx context.Context, m *sock.Requ
 	data, err := json.Marshal(tmp)
 	if err != nil {
 		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		return simpleResponse(500), nil
+	}
+	log.Debugf("Sending result: %v", data)
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}
+
+// processV1CustomersCleanupUnverifiedPost handles POST /v1/customers/cleanup_unverified request
+func (h *listenHandler) processV1CustomersCleanupUnverifiedPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "processV1CustomersCleanupUnverifiedPost",
+		"request": m,
+	})
+	log.Debug("Executing processV1CustomersCleanupUnverifiedPost.")
+
+	expired, err := h.customerHandler.CleanupUnverified(ctx)
+	if err != nil {
+		log.Errorf("Could not cleanup unverified customers. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	tmp := &response.V1ResponseCustomersCleanupUnverified{
+		Expired: expired,
+	}
+
+	data, err := json.Marshal(tmp)
+	if err != nil {
+		log.Debugf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		return simpleResponse(500), nil
+	}
+	log.Debugf("Sending result: %v", data)
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}
+
+// processV1CustomersCleanupFrozenExpiredPost handles POST /v1/customers/cleanup_frozen_expired request
+func (h *listenHandler) processV1CustomersCleanupFrozenExpiredPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "processV1CustomersCleanupFrozenExpiredPost",
+		"request": m,
+	})
+	log.Debug("Executing processV1CustomersCleanupFrozenExpiredPost.")
+
+	processed, err := h.customerHandler.CleanupFrozenExpired(ctx)
+	if err != nil {
+		log.Errorf("Could not cleanup frozen expired customers. err: %v", err)
+		return errorResponse(err), nil
+	}
+
+	tmp := &response.V1ResponseCustomersCleanupFrozenExpired{
+		Processed: processed,
+	}
+
+	data, err := json.Marshal(tmp)
+	if err != nil {
+		log.Debugf("Could not marshal the response message. message: %v, err: %v", tmp, err)
 		return simpleResponse(500), nil
 	}
 	log.Debugf("Sending result: %v", data)

--- a/bin-customer-manager/pkg/listenhandler/v1_customers_test.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers_test.go
@@ -575,3 +575,146 @@ func Test_processV1CustomersIDMetadataPut(t *testing.T) {
 	}
 }
 
+func Test_processV1CustomersCleanupUnverifiedPost(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		request *sock.Request
+
+		responseExpired int
+		responseErr     error
+
+		expectRes *sock.Response
+	}{
+		{
+			name: "normal",
+			request: &sock.Request{
+				URI:    "/v1/customers/cleanup_unverified",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseExpired: 3,
+			responseErr:     nil,
+
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"expired":3}`),
+			},
+		},
+		{
+			name: "handler error",
+			request: &sock.Request{
+				URI:    "/v1/customers/cleanup_unverified",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseExpired: 0,
+			responseErr:     fmt.Errorf("db error"),
+
+			expectRes: &sock.Response{
+				StatusCode: 500,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockCustomer := customerhandler.NewMockCustomerHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:     mockSock,
+				reqHandler:      mockReq,
+				customerHandler: mockCustomer,
+			}
+
+			mockCustomer.EXPECT().CleanupUnverified(gomock.Any()).Return(tt.responseExpired, tt.responseErr)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_processV1CustomersCleanupFrozenExpiredPost(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		request *sock.Request
+
+		responseProcessed int
+		responseErr       error
+
+		expectRes *sock.Response
+	}{
+		{
+			name: "normal",
+			request: &sock.Request{
+				URI:    "/v1/customers/cleanup_frozen_expired",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseProcessed: 2,
+			responseErr:       nil,
+
+			expectRes: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"processed":2}`),
+			},
+		},
+		{
+			name: "handler error",
+			request: &sock.Request{
+				URI:    "/v1/customers/cleanup_frozen_expired",
+				Method: sock.RequestMethodPost,
+			},
+
+			responseProcessed: 0,
+			responseErr:       fmt.Errorf("db error"),
+
+			expectRes: &sock.Response{
+				StatusCode: 500,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockCustomer := customerhandler.NewMockCustomerHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:     mockSock,
+				reqHandler:      mockReq,
+				customerHandler: mockCustomer,
+			}
+
+			mockCustomer.EXPECT().CleanupFrozenExpired(gomock.Any()).Return(tt.responseProcessed, tt.responseErr)
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, tt.expectRes) != true {
+				t.Errorf("Wrong match.\nexepct: %v\ngot: %v", tt.expectRes, res)
+			}
+		})
+	}
+}

--- a/bin-dbscheme-manager/bin-manager/main/versions/0c037bf0a362_schedule_schedules_seed_phase2_ticker_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/0c037bf0a362_schedule_schedules_seed_phase2_ticker_.py
@@ -1,0 +1,186 @@
+"""schedule_schedules_seed_phase2_ticker_jobs
+
+Revision ID: 0c037bf0a362
+Revises: a5e6f559299c
+Create Date: 2026-08-02 09:02:26.971220
+
+Seeds the five Phase 2 ticker-migration schedules for
+bin-schedule-manager (VOIP-1284). See
+docs/plans/2026-08-01-schedule-manager-phase2-tickers-design.md §7.
+
+All five rows use the nil-UUID customer_id (platform jobs) and
+UNHEX(REPLACE(UUID(),'-','')) ids per docs/conventions/database.md
+§7.0a. The name column, not the id, is the stable cross-environment
+handle (the dbscheme image bakes migration output into a schema dump at
+build time, so the UUID() values are fixed per image build).
+
+tm_next_run is seeded NULL = compute on next scan.
+
+target_data uses JSON_OBJECT() (empty object; none of these jobs take a
+payload) instead of a raw '{}' string literal: alembic op.execute()
+passes raw SQL through sqlalchemy.text(), which treats a bare colon as
+a bind-parameter marker (e.g. ':28' -> "A value is required for bind
+parameter '28'"). JSON_OBJECT produces the identical JSON value with no
+colon in the SQL text -- this is the VOIP-1283 hotfix pitfall.
+
+All five ship enabled (enabled=1), matching the tickers they replace,
+with retry_max=0 throughout (Phase 1's number-renew precedent -- a
+failed run waits for the next natural slot rather than retrying
+in-run).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0c037bf0a362'
+down_revision = 'a5e6f559299c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO schedule_schedules (
+            id, customer_id, name, detail, type, cron,
+            target_queue, target_uri, target_method, target_data_type, target_data,
+            timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update
+        ) VALUES (
+            UNHEX(REPLACE(UUID(), '-', '')),
+            UNHEX('00000000000000000000000000000000'),
+            'billing-monthly-topup',
+            'Monthly token top-up for due billing accounts',
+            'rpc',
+            '0 * * * *',
+            'bin-manager.billing-manager.request',
+            '/v1/accounts/top_up',
+            'POST',
+            'application/json',
+            JSON_OBJECT(),
+            300000,
+            0,
+            1,
+            NULL,
+            UTC_TIMESTAMP(6),
+            UTC_TIMESTAMP(6)
+        );
+    """)
+    op.execute("""
+        INSERT INTO schedule_schedules (
+            id, customer_id, name, detail, type, cron,
+            target_queue, target_uri, target_method, target_data_type, target_data,
+            timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update
+        ) VALUES (
+            UNHEX(REPLACE(UUID(), '-', '')),
+            UNHEX('00000000000000000000000000000000'),
+            'billing-failed-event-retry',
+            'Retry billing events that failed initial processing',
+            'rpc',
+            '* * * * *',
+            'bin-manager.billing-manager.request',
+            '/v1/failed_events/retry',
+            'POST',
+            'application/json',
+            JSON_OBJECT(),
+            60000,
+            0,
+            1,
+            NULL,
+            UTC_TIMESTAMP(6),
+            UTC_TIMESTAMP(6)
+        );
+    """)
+    op.execute("""
+        INSERT INTO schedule_schedules (
+            id, customer_id, name, detail, type, cron,
+            target_queue, target_uri, target_method, target_data_type, target_data,
+            timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update
+        ) VALUES (
+            UNHEX(REPLACE(UUID(), '-', '')),
+            UNHEX('00000000000000000000000000000000'),
+            'ai-proposal-expiry',
+            'Expire completed AI prompt proposals past the drift window',
+            'rpc',
+            '0 * * * *',
+            'bin-manager.ai-manager.request',
+            '/v1/aipromptproposals/expire',
+            'POST',
+            'application/json',
+            JSON_OBJECT(),
+            300000,
+            0,
+            1,
+            NULL,
+            UTC_TIMESTAMP(6),
+            UTC_TIMESTAMP(6)
+        );
+    """)
+    op.execute("""
+        INSERT INTO schedule_schedules (
+            id, customer_id, name, detail, type, cron,
+            target_queue, target_uri, target_method, target_data_type, target_data,
+            timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update
+        ) VALUES (
+            UNHEX(REPLACE(UUID(), '-', '')),
+            UNHEX('00000000000000000000000000000000'),
+            'customer-unverified-cleanup',
+            'Soft-delete unverified customers past the grace period',
+            'rpc',
+            '*/15 * * * *',
+            'bin-manager.customer-manager.request',
+            '/v1/customers/cleanup_unverified',
+            'POST',
+            'application/json',
+            JSON_OBJECT(),
+            60000,
+            0,
+            1,
+            NULL,
+            UTC_TIMESTAMP(6),
+            UTC_TIMESTAMP(6)
+        );
+    """)
+    op.execute("""
+        INSERT INTO schedule_schedules (
+            id, customer_id, name, detail, type, cron,
+            target_queue, target_uri, target_method, target_data_type, target_data,
+            timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update
+        ) VALUES (
+            UNHEX(REPLACE(UUID(), '-', '')),
+            UNHEX('00000000000000000000000000000000'),
+            'customer-frozen-expiry',
+            'Anonymize and soft-delete frozen customers past their deletion grace period',
+            'rpc',
+            '0 4 * * *',
+            'bin-manager.customer-manager.request',
+            '/v1/customers/cleanup_frozen_expired',
+            'POST',
+            'application/json',
+            JSON_OBJECT(),
+            600000,
+            0,
+            1,
+            NULL,
+            UTC_TIMESTAMP(6),
+            UTC_TIMESTAMP(6)
+        );
+    """)
+
+
+def downgrade():
+    # No executions cleanup needed: there is no FK from
+    # schedule_executions.schedule_id to schedule_schedules.id, so a
+    # plain DELETE leaves at most orphaned audit rows, consistent with
+    # how schedule_executions already outlives soft-deleted schedules
+    # via the app-level DELETE /v1/schedules/<id> API path.
+    op.execute("""
+        DELETE FROM schedule_schedules
+        WHERE name IN (
+            'billing-monthly-topup',
+            'billing-failed-event-retry',
+            'ai-proposal-expiry',
+            'customer-unverified-cleanup',
+            'customer-frozen-expiry'
+        )
+          AND customer_id = UNHEX('00000000000000000000000000000000');
+    """)

--- a/docs/.docs-gen/bin-ai-manager.extracted.json
+++ b/docs/.docs-gen/bin-ai-manager.extracted.json
@@ -10,16 +10,31 @@
       "pattern": "/v1/ais$"
     },
     {
+      "pattern": "/v1/ais/{{UUID}}/activate_insight$"
+    },
+    {
       "pattern": "/v1/ais/{{UUID}}/direct-hash-regenerate$"
     },
     {
+      "pattern": "/v1/ais/{{UUID}}/participants(\\?|$)"
+    },
+    {
       "pattern": "/v1/ais/{{UUID}}$"
+    },
+    {
+      "pattern": "/v1/ais/{{UUID}}/prompt_histories\\?"
+    },
+    {
+      "pattern": "/v1/ais/{{UUID}}/prompt_histories/{{UUID}}$"
     },
     {
       "pattern": "/v1/aicalls\\?"
     },
     {
       "pattern": "/v1/aicalls$"
+    },
+    {
+      "pattern": "/v1/aicalls/{{UUID}}/participants(\\?|$)"
     },
     {
       "pattern": "/v1/aicalls/{{UUID}}$"
@@ -29,6 +44,33 @@
     },
     {
       "pattern": "/v1/aicalls/{{UUID}}/tool_execute$"
+    },
+    {
+      "pattern": "/v1/aiaudits\\?"
+    },
+    {
+      "pattern": "/v1/aiaudits$"
+    },
+    {
+      "pattern": "/v1/aiaudits/{{UUID}}$"
+    },
+    {
+      "pattern": "/v1/aipromptproposals\\?"
+    },
+    {
+      "pattern": "/v1/aipromptproposals$"
+    },
+    {
+      "pattern": "/v1/aipromptproposals/{{UUID}}$"
+    },
+    {
+      "pattern": "/v1/aipromptproposals/{{UUID}}/accept$"
+    },
+    {
+      "pattern": "/v1/aipromptproposals/{{UUID}}/reject$"
+    },
+    {
+      "pattern": "/v1/aipromptproposals/expire$"
     },
     {
       "pattern": "/v1/messages\\?"
@@ -47,6 +89,9 @@
     },
     {
       "pattern": "/v1/services/type/task$"
+    },
+    {
+      "pattern": "/v1/services/type/analysis$"
     },
     {
       "pattern": "/v1/summaries\\?"
@@ -162,6 +207,10 @@
       "local_path": "../bin-flow-manager"
     },
     {
+      "module_path": "monorepo/bin-webchat-manager",
+      "local_path": "../bin-webchat-manager"
+    },
+    {
       "module_path": "monorepo/bin-hook-manager",
       "local_path": "../bin-hook-manager"
     },
@@ -196,6 +245,10 @@
     {
       "module_path": "monorepo/bin-route-manager",
       "local_path": "../bin-route-manager"
+    },
+    {
+      "module_path": "monorepo/bin-schedule-manager",
+      "local_path": "../bin-schedule-manager"
     },
     {
       "module_path": "monorepo/bin-storage-manager",
@@ -252,12 +305,48 @@
       "flag": "engine_key_chatgpt"
     },
     {
+      "flag": "google_api_key"
+    },
+    {
       "flag": "aicall_conversation_idle_timeout_hours"
+    },
+    {
+      "flag": "aicall_contact_case_recreate_rate_limit_minutes"
+    },
+    {
+      "flag": "aicall_send_cooldown_seconds"
+    },
+    {
+      "flag": "analysis_default_model"
+    },
+    {
+      "flag": "analysis_allowed_models"
+    },
+    {
+      "flag": "analysis_engine_base_url"
+    },
+    {
+      "flag": "analysis_reasoning_effort"
+    },
+    {
+      "flag": "none"
+    },
+    {
+      "flag": "analysis_max_input_bytes"
+    },
+    {
+      "flag": "analysis_max_output_tokens"
     }
   ],
   "metrics": [
     {
+      "name": "actions"
+    },
+    {
       "name": "aicall_backstop_reply_total"
+    },
+    {
+      "name": "aicall_contact_case_recreate_rate_limited_total"
     },
     {
       "name": "aicall_create_total"
@@ -281,10 +370,157 @@
       "name": "aicall_tool_execute_total"
     },
     {
+      "name": "ai_id"
+    },
+    {
+      "name": "analysis_gateway_run_duration_seconds"
+    },
+    {
+      "name": "analysis_gateway_run_total"
+    },
+    {
+      "name": "anonymous"
+    },
+    {
+      "name": "assistance_id"
+    },
+    {
+      "name": "assistance_type"
+    },
+    {
+      "name": "async"
+    },
+    {
+      "name": "attachments"
+    },
+    {
+      "name": "beep_start"
+    },
+    {
+      "name": "bool"
+    },
+    {
+      "name": "chained"
+    },
+    {
+      "name": "condition"
+    },
+    {
+      "name": "confbridge_id"
+    },
+    {
+      "name": "conference_id"
+    },
+    {
       "name": "connect"
     },
     {
+      "name": "connection_type"
+    },
+    {
+      "name": "content"
+    },
+    {
+      "name": "conversation_id"
+    },
+    {
       "name": "conversation_reply_send_total"
+    },
+    {
+      "name": "data"
+    },
+    {
+      "name": "data_type"
+    },
+    {
+      "name": "day"
+    },
+    {
+      "name": "default_target_id"
+    },
+    {
+      "name": "destinations"
+    },
+    {
+      "name": "detail"
+    },
+    {
+      "name": "digits"
+    },
+    {
+      "name": "digits_handle"
+    },
+    {
+      "name": "direction"
+    },
+    {
+      "name": "direction_listen"
+    },
+    {
+      "name": "direction_speak"
+    },
+    {
+      "name": "duration"
+    },
+    {
+      "name": "early_execution"
+    },
+    {
+      "name": "early_media"
+    },
+    {
+      "name": "encapsulation"
+    },
+    {
+      "name": "end_of_key"
+    },
+    {
+      "name": "end_of_silence"
+    },
+    {
+      "name": "evaluation_response"
+    },
+    {
+      "name": "event_method"
+    },
+    {
+      "name": "event_url"
+    },
+    {
+      "name": "external_host"
+    },
+    {
+      "name": "false_target_id"
+    },
+    {
+      "name": "flow_id"
+    },
+    {
+      "name": "format"
+    },
+    {
+      "name": "hour"
+    },
+    {
+      "name": "int"
+    },
+    {
+      "name": "interval"
+    },
+    {
+      "name": "key"
+    },
+    {
+      "name": "language"
+    },
+    {
+      "name": "length"
+    },
+    {
+      "name": "loop_count"
+    },
+    {
+      "name": "machine_handle"
     },
     {
       "name": "message_create_total"
@@ -296,7 +532,64 @@
       "name": "message_send"
     },
     {
+      "name": "method"
+    },
+    {
+      "name": "minute"
+    },
+    {
+      "name": "month"
+    },
+    {
+      "name": "name"
+    },
+    {
+      "name": "note"
+    },
+    {
+      "name": "number"
+    },
+    {
+      "name": "on_end_flow_id"
+    },
+    {
+      "name": "proposal_response"
+    },
+    {
+      "name": "provider"
+    },
+    {
+      "name": "queue_id"
+    },
+    {
+      "name": "reason"
+    },
+    {
       "name": "receive_request_process_time"
+    },
+    {
+      "name": "reference_id"
+    },
+    {
+      "name": "reference_type"
+    },
+    {
+      "name": "relay_reason"
+    },
+    {
+      "name": "source"
+    },
+    {
+      "name": "status"
+    },
+    {
+      "name": "stream_urls"
+    },
+    {
+      "name": "string"
+    },
+    {
+      "name": "subject"
     },
     {
       "name": "subscribe_event_process_time"
@@ -306,6 +599,54 @@
     },
     {
       "name": "summary_start_total"
+    },
+    {
+      "name": "sync"
+    },
+    {
+      "name": "target_id"
+    },
+    {
+      "name": "target_ids"
+    },
+    {
+      "name": "text"
+    },
+    {
+      "name": "transport"
+    },
+    {
+      "name": "transport_data"
+    },
+    {
+      "name": "uri"
+    },
+    {
+      "name": "uuid"
+    },
+    {
+      "name": "value"
+    },
+    {
+      "name": "value_length"
+    },
+    {
+      "name": "value_number"
+    },
+    {
+      "name": "value_string"
+    },
+    {
+      "name": "value_type"
+    },
+    {
+      "name": "variable"
+    },
+    {
+      "name": "voice_id"
+    },
+    {
+      "name": "weekdays"
     }
   ],
   "missing_fields": []

--- a/docs/.docs-gen/bin-billing-manager.extracted.json
+++ b/docs/.docs-gen/bin-billing-manager.extracted.json
@@ -31,6 +31,9 @@
       "pattern": "/v1/accounts\\?"
     },
     {
+      "pattern": "/v1/accounts/top_up$"
+    },
+    {
       "pattern": "/v1/billings\\?"
     },
     {
@@ -41,6 +44,9 @@
     },
     {
       "pattern": "/v1/accounts/{{UUID}}/paddle_portal_session$"
+    },
+    {
+      "pattern": "/v1/failed_events/retry$"
     }
   ],
   "events_subscribed": [
@@ -114,6 +120,10 @@
       "local_path": "../bin-flow-manager"
     },
     {
+      "module_path": "monorepo/bin-webchat-manager",
+      "local_path": "../bin-webchat-manager"
+    },
+    {
       "module_path": "monorepo/bin-hook-manager",
       "local_path": "../bin-hook-manager"
     },
@@ -148,6 +158,10 @@
     {
       "module_path": "monorepo/bin-route-manager",
       "local_path": "../bin-route-manager"
+    },
+    {
+      "module_path": "monorepo/bin-schedule-manager",
+      "local_path": "../bin-schedule-manager"
     },
     {
       "module_path": "monorepo/bin-storage-manager",

--- a/docs/.docs-gen/bin-customer-manager.extracted.json
+++ b/docs/.docs-gen/bin-customer-manager.extracted.json
@@ -34,6 +34,12 @@
       "pattern": "/v1/customers/email_verify$"
     },
     {
+      "pattern": "/v1/customers/cleanup_unverified$"
+    },
+    {
+      "pattern": "/v1/customers/cleanup_frozen_expired$"
+    },
+    {
       "pattern": "/v1/customers/{{UUID}}/freeze$"
     },
     {
@@ -103,6 +109,10 @@
       "local_path": "../bin-flow-manager"
     },
     {
+      "module_path": "monorepo/bin-webchat-manager",
+      "local_path": "../bin-webchat-manager"
+    },
+    {
       "module_path": "monorepo/bin-hook-manager",
       "local_path": "../bin-hook-manager"
     },
@@ -137,6 +147,10 @@
     {
       "module_path": "monorepo/bin-route-manager",
       "local_path": "../bin-route-manager"
+    },
+    {
+      "module_path": "monorepo/bin-schedule-manager",
+      "local_path": "../bin-schedule-manager"
     },
     {
       "module_path": "monorepo/bin-storage-manager",

--- a/docs/plans/2026-08-01-schedule-manager-phase2-tickers-design.md
+++ b/docs/plans/2026-08-01-schedule-manager-phase2-tickers-design.md
@@ -1,0 +1,441 @@
+# bin-schedule-manager Phase 2 — Migrate in-process tickers into schedule definitions (VOIP-1284)
+
+Status: approved (design review loop: 3 rounds — RC, Approve, Approve)
+Ticket: VOIP-1284 — bin-schedule-manager Phase 2
+Depends on: VOIP-1283 (bin-schedule-manager Phase 1, merged: PR #1154 + hotfix PR #1155)
+Related: VOIP-1282 (campaign-manager / queue-manager investigation — concluded neither needs
+scheduler-manager; see §2)
+
+## 1. Problem
+
+Five `time.Ticker`-based periodic jobs run in-process inside three services, with no leader
+election, no distributed lock, and no claim mechanism:
+
+| # | Service | Job | Cadence | File:line (2026-08-01) |
+|---|---|---|---|---|
+| 1 | billing-manager | monthly token top-up | 1h | `cmd/billing-manager/main.go:144-158` |
+| 2 | billing-manager | failed-event retry | 60s | `cmd/billing-manager/main.go:205-219` |
+| 3 | ai-manager | expired-proposal sweep | 1h | `cmd/ai-manager/main.go:165-177` |
+| 4 | customer-manager | unverified-customer cleanup | 15m | `cmd/customer-manager/main.go:100-101` → `pkg/customerhandler/cleanup.go` |
+| 5 | customer-manager | frozen-customer expiry | 24h | `cmd/customer-manager/main.go:103-104` → `pkg/customerhandler/expiry.go` |
+
+**This is not a theoretical risk.** All three services already run `replicas: 2` in production
+Kubernetes today (`bin-billing-manager/k8s/deployment.yml:8`, `bin-ai-manager/k8s/deployment.yml:8`,
+`bin-customer-manager/k8s/deployment.yml:8`). Every hazard below is live.
+
+Two further structural problems independent of replica count:
+
+- **`time.Ticker` fires relative to pod start, not wall-clock.** The 24h customer-frozen-expiry
+  ticker only runs 24h after the pod started; a service redeployed more often than daily never
+  runs it. The 1h jobs have the same drift, just less severe.
+- **Shutdown is broken on 4 of 5.** Only the two billing-manager tickers are wired to `chDone`
+  (`main.go:154`, `main.go:215`). The ai-manager and both customer-manager tickers select on
+  `context.Background().Done()`, which never fires — dead code, and the goroutine dies mid-tick
+  when the process exits rather than draining cleanly.
+
+Sandbox already carries a "replica guard" (`voipbin-cli.py:2266-2311`) that warns operators not
+to scale billing-manager/ai-manager above 1 replica — an acknowledgment that this problem exists,
+worked around by refusing to exercise the failure mode rather than fixing it. The guard doesn't
+even cover customer-manager (undiscovered when it was written) and is silently violated by every
+K8s `replicas: 2` deployment.
+
+## 2. VOIP-1282 scope check (why campaign/queue are NOT here)
+
+VOIP-1284's description flagged VOIP-1282 findings as a possible fold-in. Investigation (VOIP-1282,
+concluded before this design) found:
+
+- **campaign-manager** dial loop and **queue-manager** wait/service timeouts are both already
+  self-driving via one-shot RabbitMQ `x-delayed-message` self-RPC (500ms–5000ms campaign re-arm;
+  per-call timeout arm at queue-join/service-start). Neither is broken, dormant, or waiting on an
+  external scheduler — their CLAUDE.md/README documentation describing a dependency on "an external
+  scheduler" is simply stale (fixed separately, doc-only).
+- Both are **fine-grained, per-entity, sub-minute-precision, one-shot** timers. bin-schedule-manager
+  is a 5-field UTC cron engine with MySQL rows and DB-CAS claims per slot — a poor fit for
+  thousands of concurrent one-shot timers, and pushing either loop through it would be a latency
+  and correctness regression, not an improvement.
+- Real bugs were found in both (campaign-manager silently swallows re-arm errors at two of four
+  call sites, leaving the loop capable of permanent silent death; queue-manager timeouts are lost
+  when a call is parked in `connecting` state, and the delayed publish is `amqp.Transient` with no
+  delivery confirmation). These are tracked as separate follow-up tickets, not folded into this
+  design — they are bug fixes in campaign-manager/queue-manager's existing delayed-RPC mechanism,
+  not schedule-manager work.
+
+**Conclusion: VOIP-1284's scope is exactly the five tickers in §1. Nothing from VOIP-1282 is
+in scope here.**
+
+## 3. Goals / non-goals
+
+**Goals:**
+
+- All five jobs dispatch through bin-schedule-manager: at-most-once claim, Forbid overlap, audit
+  trail, per-job Prometheus metrics — the same guarantees Phase 1 gave `number-renew`.
+- Fix the two genuine correctness bugs found during exploration: `AccountTopUpTokens` (§5.1) and
+  `CustomerAnonymizePII` (§5.5) are not safe under concurrent execution — both must be fixed as
+  part of this migration, since moving an unsafe job onto infrastructure whose entire selling
+  point is "safe under N replicas" without fixing the job itself would be a lie of omission.
+- Remove the five ticker goroutines and their dead/broken shutdown wiring.
+- Remove (or correct) the sandbox replica-guard warning for billing-manager/ai-manager, sequenced
+  after the monorepo fixes are released and pinned (§9) — and correct the guard's premise: it was
+  never accurate to omit customer-manager. One of the two customer-manager jobs (frozen expiry,
+  §5.5) has exactly the same class of double-fire hazard as billing's top-up — a duplicate
+  `customer_deleted` cascade into number-manager and billing-manager — and was live at
+  `replicas: 2` the whole time the guard existed without covering it. The other customer job
+  (unverified cleanup, §5.4) is structurally idempotent and was never at risk, same as the ai
+  proposal sweep (§5.3).
+
+**Non-goals:**
+
+- campaign-manager / queue-manager (§2 — explicitly out of scope, tracked separately).
+- route-manager SIP OPTIONS health check, pipecat-manager tool-cache refresh, timeline flush,
+  transport keepalives — per-instance/per-pod semantics, already evaluated and rejected for
+  centralization in the Phase 1 design (`2026-08-01-bin-schedule-manager-design.md` §2/§9.3).
+- The two ai-manager **startup** one-shot sweeps (`SweepStaleAudits`, `SweepStaleProposals`) —
+  these recover state orphaned by *this pod's own* crashed goroutines; their entire premise is
+  "ran once, by this process, right after it started." Centralizing them would fire on a pod that
+  never owned the orphaned rows, at a cadence unrelated to restarts. Stays per-boot, unchanged.
+  (Direct analogue of the route-manager decision above — same reasoning, different service.)
+- `bin-common-handler` changes: none needed. All five target queues
+  (`QueueNameBillingRequest`, `QueueNameAIRequest`, `QueueNameCustomerRequest`) are already in
+  `QueueNameRequestAll()` from Phase 1. No new typed client methods are required — schedule rows
+  dispatch generically via `target_queue`/`target_uri`, exactly like `number-renew`. This keeps
+  the 38-service verification blast radius at zero, same as Phase 1's design intent.
+- Two bugs found but out of scope for this ticket (filed separately, see §8): the inert
+  `idempotency_key`/`reference_id` mismatch in the billing ledger (harmless once the top-up itself
+  is made idempotent — the ledger will simply stop producing duplicate rows, so the mismatch
+  becomes moot for this job, but the underlying dead code is worth cleaning up on its own); the
+  unbounded `CustomerListFrozenExpired` query (no `LIMIT`, unlike every other job in this batch).
+
+## 4. New endpoints (per service, following the Phase 1 `number-renew` / `/v1/executions/prune` pattern)
+
+All five follow the established sweep-endpoint shape: POST, empty or trivial JSON body, no path
+parameters, business handler returns `(count int, err error)` instead of today's `error`-only or
+`void` signature, listenhandler marshals a small response DTO (style B — bare scalars, no domain
+type equivalent, same precedent as `V1ResponseExecutionsPrune`).
+
+| Service | Route | Business change | Response |
+|---|---|---|---|
+| billing-manager | `POST /v1/accounts/top_up` | `runMonthlyTopUp` moves from `cmd/billing-manager/main.go` into `pkg/accounthandler` (or `pkg/billinghandler`, whichever owns `Account`), returns `(processed, failed int, err error)`. **Also fixes the CAS bug, §5.1.** | `{"processed": n, "failed": n}` |
+| billing-manager | `POST /v1/failed_events/retry` | `failedeventhandler.RetryPending` changes signature to return `(retried, succeeded, exhausted int, err error)` | `{"retried": n, "succeeded": n, "exhausted": n}` |
+| ai-manager | `POST /v1/aipromptproposals/expire` | `aipromptproposalhandler.SweepExpiredProposals` changes signature to return `(expired int, err error)` | `{"expired": n}` |
+| customer-manager | `POST /v1/customers/cleanup_unverified` | `customerhandler.cleanupUnverified` exported (or a thin exported wrapper added) returning `(expired int, err error)` | `{"expired": n}` |
+| customer-manager | `POST /v1/customers/cleanup_frozen_expired` | `customerhandler.cleanupFrozenExpired` exported, returns `(processed int, err error)`. **Fixes the double-publish bug, §5.5.** | `{"processed": n}` |
+
+Route regex, dispatch-switch placement, and request/response DTO naming follow each service's
+own local convention exactly (billing uses uppercase DTO suffixes, ai/customer use mixed-case —
+verified in exploration; do not normalize across services, match the file you're editing).
+`bin-schedule-manager`'s dispatcher treats 2xx as success and non-2xx as failure
+(`dispatchhandler/dispatch.go`), so every new handler must return a real HTTP-style status via the
+existing `errorResponse`/`simpleResponse` helpers — a handler that always returns 200 regardless of
+outcome would make the execution audit trail lie.
+
+**Partial-failure contract.** All five jobs today are log-and-continue loops over a candidate
+list: a single row erroring does not abort the batch (e.g. `expiry.go:57-60`,
+`cleanup.go`, `sweep.go:47-62` — the ai sweep also swallows the list-fetch error itself at
+`sweep.go:49-51`, returning silently). The migrated handlers must not reproduce silent
+swallowing under a green (200) audit row, which the stated goal above explicitly rules out. Rule
+for all five: the handler returns non-2xx (mapped via `errorResponse`) if and only if the
+**list/fetch call itself fails** (nothing could be attempted — a genuine job failure); per-row
+processing errors within a successful list are counted and logged as before, and returned in the
+response body as a `failed`/equivalent counter (as `billing-monthly-topup` already does) so the
+count is visible without failing the whole run over one bad row. Apply this counter field
+uniformly: `{"processed": n, "failed": n}` shape for the two jobs that iterate a candidate list end
+to end (top-up, frozen-expiry), `{"expired": n}` / `{"retried": n, "succeeded": n, "exhausted": n}`
+where the existing terminology is clearer, per the table above — but every handler must propagate
+a non-2xx when its own list-fetch fails, closing the ai-sweep's current silent-failure gap as a
+side effect of this migration.
+
+## 5. Per-job correctness analysis
+
+### 5.1 billing-manager: monthly top-up — **not safe today, must be fixed**
+
+`AccountTopUpTokens` (`pkg/dbhandler/billing.go:514-598`) takes a `SELECT ... FOR UPDATE` row lock
+but then unconditionally overwrites `balance_token = tokenAmount` (assignment, not increment) and
+advances `tm_next_topup` by wall-clock arithmetic rather than reading and incrementing the existing
+value. Net effect under two concurrent replicas processing the same due account:
+
+- **Balance**: harmless by accident — both writes set the same absolute value, so the final
+  balance is correct regardless of ordering.
+- **Ledger**: not harmless — two `billing_billings` rows are inserted (each `+tokenAmount`), one
+  per replica. The intended dedup key is `idempotency_key`, which is set to a fresh random UUID
+  per call (`billing.go:558`), not the deterministic `reference_id = UUIDv5(accountID, "topup:"+yearMonth)`
+  computed two lines later (`billing.go:566`) — the unique index is on `idempotency_key`
+  (`ux_billing_billings_idempotency_key`), so the deterministic value never collides and dedup
+  never engages. Ledger sum drifts from wallet balance over time.
+- **Sequential (not just concurrent) hazard**: if replica A tops up and the customer burns tokens
+  before replica B's stale in-memory read of `tm_next_topup` is superseded, B can silently
+  re-grant a full month's allowance mid-cycle.
+
+**Fix required as part of this ticket** (in `AccountTopUpTokens`, scoped to the UPDATE statement):
+add a CAS guard so the update only applies when due —
+`WHERE id = ? AND (tm_next_topup IS NULL OR tm_next_topup <= ?)`, using the method's own internal
+`h.utilHandler.TimeNow()` value (the existing `now` local at `billing.go:534`; no new parameter,
+no signature change) as the bound value. Check `RowsAffected` **immediately after the UPDATE,
+inside the same transaction, before the ledger INSERT**: if 0, `tx.Rollback()` and `return nil`
+(the method's existing signature is `error`-only) — the account was already topped up this cycle
+by a concurrent claimant, this is a normal outcome, not an error, and critically the ledger
+INSERT and `tx.Commit()` at
+`billing.go:580-588`/`598` must never execute on this path (this is the entire point of the fix —
+a guard that still lets the ledger row through duplicates the effect the CAS exists to prevent).
+Mirrors the `ScheduleClaimAndCreateExecution` CAS-then-conditional-insert pattern from Phase 1
+(`bin-schedule-manager/pkg/dbhandler/execution.go`). Fixing the `idempotency_key`/`reference_id`
+mismatch is explicitly **not** bundled here (§3 non-goals, §8) — once the UPDATE is CAS-guarded,
+the ledger simply stops producing the duplicate rows that made the mismatch matter for this job;
+the mismatch is dead code worth cleaning up on its own schedule, not a blocker for Phase 2.
+
+A CAS-skip (`nil` — no error, no effect) is neither a processed row nor a failure; the handler's
+`(processed, failed int)` counters must not increment either on that outcome (same "neither
+processed nor failed" treatment as the `CustomerAnonymizePII` guard-miss case in §5.5, for
+symmetry).
+
+`billing-control topup run` (`cmd/billing-control/main.go:716-752`) and the initial top-up on
+`customer_created` (`pkg/accounthandler/event.go:84`) both call `AccountTopUpTokens` directly and
+get the same safety for free with no call-site change — the fix is entirely inside the dbhandler
+method. `billing-control` needs no endpoint change since it already calls the dbhandler directly;
+`event.go:84`'s hardening is a side benefit (duplicate `customer_created` delivery would currently
+double-grant the signup bonus) worth noting, not a separate task.
+
+### 5.2 billing-manager: failed-event retry — **partially safe, cadence risk**
+
+`FailedEventUpdate` has no CAS guard (`WHERE status='pending'` or similar), so two replicas can
+both re-process the same due row: whichever billing insert races second is protected by the
+`billing_billings.idempotency_key` unique index (real, correctly wired here — this is the
+downstream call the top-up bug's ledger insert should have used), but retry-count bookkeeping is
+not — a duplicate increment burns the 5-retry budget at 2x, and the delete race (winner deletes,
+loser's update finds 0 rows, silently no-ops) is cosmetic, not corrupting.
+
+**No dbhandler fix required** — downstream idempotency already covers the outcome that matters
+(no duplicate billing effects). Only the *retry accounting* is imprecise under double-fire, which
+Forbid overlap eliminates at the source (this job never overlaps itself under schedule-manager,
+so the question is moot post-migration).
+
+Cadence note: 60s is the tightest cadence in this batch and the tightest the scheduler will carry
+anywhere (`SCHEDULE_TICK_INTERVAL_SEC` default 10s already assumes multi-minute jobs are typical).
+At 60s this generates 1440 execution audit rows/day for one job alone, against
+`SCHEDULE_EXECUTION_RETENTION_DAYS=90` (~130k rows for this job's lifetime retention window) —
+not a correctness problem, but worth a deliberate choice. Design decision: keep 60s (`* * * * *`)
+to preserve current behavior/responsiveness — a customer's billing event that failed to process
+should recover within a minute, not five. Revisit only if `execution_rows` growth becomes an
+operational concern (already monitored per Phase 1 §5.7).
+
+### 5.3 ai-manager: proposal sweep — **already safe**
+
+`AIPromptProposalUpdateExpired` is CAS-guarded
+(`WHERE id = ? AND tm_delete IS NULL AND status = 'completed'`, `pkg/dbhandler/aipromptproposal.go:147-161`).
+A second concurrent (or overlapping) run affects 0 rows on the second pass. No dbhandler change
+needed. Safe to migrate as-is.
+
+### 5.4 customer-manager: unverified cleanup — **already safe**
+
+`CustomerUpdate` sets `tm_delete`, which removes the row from the `deleted=false` filter every
+subsequent list query uses — a second concurrent pass simply won't see rows the first pass already
+flipped (last-writer-wins on the timestamp value is harmless, there's no side effect to double).
+No dbhandler change needed.
+
+Correction to the original ticket description: this job does **not** delete or cascade — it is a
+bare soft-delete + status flip (`FieldStatus: StatusExpired`, `FieldTMDelete: now`) via
+`CustomerUpdate`, no event publish, no downstream fan-out. "Destructive deletes" in the VOIP-1284
+inventory table overstated this one; §5.5 below is the job that actually publishes a cascading
+event.
+
+### 5.5 customer-manager: frozen expiry — **not safe today, must be fixed**
+
+`CustomerAnonymizePII` has no status guard (`WHERE id = ?` only) — so unlike §5.4, this job
+**does** have a real double-fire consequence: two concurrent replicas both anonymize successfully
+(each sees `RowsAffected=1`, since there's no CAS to lose), both re-fetch, and **both call
+`notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerDeleted, res)`**. Per
+`bin-customer-manager/CLAUDE.md`, `customer_deleted` triggers cascading cleanup in
+`bin-number-manager` and `bin-billing-manager` — a duplicate cascade fan-out into two other
+services.
+
+**Fix required as part of this ticket**: add a status guard to `CustomerAnonymizePII`'s WHERE
+clause (`AND status = 'frozen' AND tm_delete IS NULL`, matching the read-path filter in
+`CustomerListFrozenExpired`), check `RowsAffected`, and skip the event publish when 0 rows were
+affected (already-processed by a concurrent claimant).
+
+**Second caller, same fix, different error-semantics handling.** `CustomerAnonymizePII` has a
+second call site: `pkg/customerhandler/freeze.go:91` (`FreezeAndDelete`, which also publishes
+`customer_deleted` at `freeze.go:104`). The added guard is compatible there too — `Freeze` runs
+before `FreezeAndDelete` in the normal flow, so the row is already `frozen` when this method is
+reached — but the two callers must diverge on what a 0-rows result means, because the method
+**already** returns `dbhandler.ErrNotFound` today when `RowsAffected == 0`
+(`customer.go:474-476`), and "guard didn't match" and "genuinely missing row" become
+indistinguishable once the status guard is added:
+
+- **`expiry.go` (the scheduled sweep, this ticket's concern):** a 0-rows result is an *expected,
+  routine* outcome under concurrent replicas — count it as neither a failure nor a processed row
+  in the new `(processed int, err error)` return, do not log it as an error (today's
+  `expiry.go:57-60` logs-and-continues on any error from this call; post-fix that log line would
+  fire on every race loss and must be demoted to a no-op or debug-level trace).
+- **`FreezeAndDelete` (API-driven, out of scope for this ticket, call site untouched):** a 0-rows
+  result here still surfaces as `ErrNotFound` to the caller, same as today — the dbhandler's
+  return contract is not changed, only the WHERE clause is tightened, so this call site's code is
+  unmodified. **This is, however, a real behavior change for that caller under the specific race
+  scenario**, worth stating plainly rather than filed as a non-regression: today, two concurrent
+  `FreezeAndDelete` calls on the same customer both silently succeed and both publish
+  `customer_deleted` (the same duplicate-cascade bug §5.5 fixes for the scheduled sweep); after
+  this change, the loser instead receives `ErrNotFound`. That is strictly better — a visible,
+  already-defined error replaces a silent duplicate side effect — but it is a behavior change an
+  API caller could observe, not a no-op, and should be called out as such when this fix ships
+  rather than only described as "must not regress."
+
+`pkg/customerhandler/freeze_test.go` (mocks `CustomerAnonymizePII` at lines ~323/386/428) needs
+its expectations reviewed against the guard addition; §10 adds an explicit concurrent-race test
+for `FreezeAndDelete` (not just a review of existing mock expectations) asserting the loser
+receives `ErrNotFound` and does not publish a second `customer_deleted` event.
+
+The unbounded `CustomerListFrozenExpired` query (no `LIMIT`, `pkg/dbhandler/customer.go:383-427`)
+is real but is a capacity/latency concern, not a correctness one for this ticket — tracked
+separately (§8), not blocking.
+
+## 6. Startup-sweep decision (ai-manager)
+
+`SweepStaleAudits` / `SweepStaleProposals` (both 5-minute staleness threshold, both CAS-guarded on
+`status='progressing'`) stay exactly as they are: synchronous calls in `run()` before
+`runListen`/`runSubscribe`. See §3 non-goals for the reasoning. Documented here so a future reader
+of this design doesn't wonder why two of the four ai-manager sweep-shaped functions were migrated
+and two weren't.
+
+## 7. Seed schedules
+
+Five new rows in `schedule_schedules`, seeded by an Alembic migration in `bin-dbscheme-manager`
+following the exact pattern of `a5e6f559299c_schedule_schedules_seed_platform_jobs.py` (raw SQL via
+`op.execute`, `JSON_OBJECT()` for `target_data` — **never a raw `'{"k":v}'` string literal**, per
+the VOIP-1283 hotfix: `sqlalchemy.text()` misparses a bare colon as a bind parameter and breaks
+`alembic upgrade`; `UNHEX(REPLACE(UUID(),'-',''))` ids, nil-UUID customer_id for platform jobs,
+`name` is the stable cross-environment handle).
+
+| name | cron (UTC) | target | data | timeout_ms | retry_max | enabled |
+|---|---|---|---|---|---|---|
+| `billing-monthly-topup` | `0 * * * *` | billing-manager `/v1/accounts/top_up` POST | `{}` | 300000 | 0 | 1 |
+| `billing-failed-event-retry` | `* * * * *` | billing-manager `/v1/failed_events/retry` POST | `{}` | 60000 | 0 | 1 |
+| `ai-proposal-expiry` | `0 * * * *` | ai-manager `/v1/aipromptproposals/expire` POST | `{}` | 300000 | 0 | 1 |
+| `customer-unverified-cleanup` | `*/15 * * * *` | customer-manager `/v1/customers/cleanup_unverified` POST | `{}` | 60000 | 0 | 1 |
+| `customer-frozen-expiry` | `0 4 * * *` | customer-manager `/v1/customers/cleanup_frozen_expired` POST | `{}` | 600000 | 0 | 1 |
+
+Cadence matches current ticker intervals exactly (no behavior change beyond fixing the
+pod-start-relative drift): **`billing-monthly-topup` is hourly (`0 * * * *`), matching the
+existing 1h ticker** — not daily. This matters beyond consistency: `tm_next_topup` lands exactly
+on `00:00:00 UTC` of the 1st of the month (`billing.go:540`, and identically in
+`account_paddle.go:221`), so a once-daily schedule would have zero margin against that boundary —
+any clock skew or a failed run (`retry_max: 0`) would push a free-plan customer's monthly top-up
+out by up to 24h instead of ≤1h. Hourly preserves the current recovery window. `0 4 * * *` for
+frozen-expiry avoids collision with the three Phase 1 platform jobs at 01:00/02:00/02:30.
+`retry_max: 0` throughout, matching Phase 1's `number-renew` precedent — a failed run waits for
+the next natural slot rather than immediate in-run retry; `billing-failed-event-retry`'s own
+5-attempt internal retry budget already provides retry semantics at the business-logic layer, a
+second retry layer at the dispatch layer would be redundant.
+
+`timeout_ms` set generously above each job's expected runtime bound from exploration, per job:
+`billing-monthly-topup` paginates *all* accounts at 500/page with no upper bound (300000ms);
+`billing-failed-event-retry` and `customer-unverified-cleanup` are single-page, ≤ a few hundred
+rows (60000ms each); `ai-proposal-expiry` is a single page of ≤1000 rows with one cached `AIGet`
+per candidate (300000ms); `customer-frozen-expiry` is the one unbounded query in this batch
+(no `LIMIT` in `CustomerListFrozenExpired`, §8) and gets the largest budget, 600000ms/10min, as a
+circuit-breaker until the separate unbounded-query fix lands.
+
+**Abandoned-run / overlap-guard interaction for the 60s job.** `billing-failed-event-retry`'s
+`timeout_ms` (60000) equals its own cron period. Per Phase 1's reaper formula
+(`tm_deadline = tm_start + timeout_ms×(retry_max+1) + 5000×retry_max + 60000`ms margin — the
+`5000×retry_max` term is 0 here since every Phase 2 job seeds `retry_max: 0`, but is included for
+completeness since a future job with retries would need it; `bin-schedule-manager` design §5.6),
+an abandoned run of this job blocks the Forbid overlap guard for ~2 scheduled slots (~2 minutes)
+before the reaper marks it `abandoned` and the next tick can claim — a wider window than the
+60000ms number alone suggests. Acceptable (matches the existing service's own tolerance for a
+stuck retry loop) but worth having on record rather than discovered during an incident.
+
+## 8. Explicitly deferred (separate follow-up tickets, not this ticket)
+
+- `idempotency_key`/`reference_id` mismatch in `AccountTopUpTokens`'s ledger insert (dead
+  deterministic-key code; moot for double-fire once §5.1's CAS fix lands, but worth its own
+  cleanup).
+- Unbounded `CustomerListFrozenExpired` query — add pagination/LIMIT.
+- campaign-manager swallowed re-arm errors (`execute.go:84,108`) — VOIP-1282 follow-up.
+- queue-manager lost-timeout-in-`connecting`-state gap, transient delayed-publish durability —
+  VOIP-1282 follow-up.
+- Stale documentation in campaign-manager/queue-manager CLAUDE.md/README/operations.md claiming a
+  dependency on an external scheduler — VOIP-1282 follow-up (doc-only).
+
+## 9. Sandbox changes (separate repository — sequenced after monorepo release)
+
+The sandbox is a **different repository** (`/home/pchero/gitvoipbin/sandbox`) that pins monorepo
+service images by digest (`_create_initial_version_pins` / `versions.lock`). §11's single-PR
+discipline applies to the *monorepo* change only; the sandbox change is a separate PR in a
+separate repo and must not land first — removing the guard before the fixed billing-manager /
+customer-manager images are built, released, and pinned in the sandbox would silently re-expose
+the exact hazard the guard exists to catch. Ordering:
+
+1. Monorepo PR (this design) merges and the fixed images are built/released.
+2. Sandbox `versions.lock` is bumped to pin the fixed images (routine version-bump PR).
+3. Only then, in a follow-up sandbox PR: remove `_check_ticker_replica_guard`
+   (`scripts/voipbin-cli.py:2266-2311`) and its two call sites (`cmd_start`, lines 2328/2358) —
+   the hazard it warns about no longer exists once steps 1-2 land (both
+   money-affecting/cascade-affecting jobs are fixed at the dbhandler layer *and* run through
+   Forbid-overlap dispatch; the three already-safe jobs never needed the guard).
+4. Delete or rewrite `scripts/tests/test_ticker_replica_guard.py` (4 cases, G1–G4) in the same
+   sandbox PR.
+5. Update `docs/plans/2026-07-05-production-grade-horizontal-scale-design.md` §1.4 (the guard's
+   origin) and its Phase-2 roadmap line (224) — supersede with a pointer to this design doc rather
+   than the deferred "redsync lock, when an operator requests N>1" plan, which this ticket makes
+   moot.
+
+## 10. Testing strategy
+
+- Each fixed dbhandler method (`AccountTopUpTokens`, `CustomerAnonymizePII`) gets a concurrent
+  double-fire test at the dbhandler layer, same shape as Phase 1's
+  `Test_DoubleFire`/`Test_KillNineStateMachine` in `bin-schedule-manager/pkg/dbhandler/execution_test.go`:
+  two "replica" instances racing the same due row against one sqlite/mysql-fixture DB, asserting
+  exactly one side effect (one ledger row / one event publish).
+- Each new signature change (`(count, err)`/`(processed, failed int, err error)` instead of
+  `(err)`/`void`) needs its existing unit test updated to assert the returned count, not just
+  error-nil. Existing test files to update: `cleanup_test.go`, `expiry_test.go`,
+  `freeze_test.go` (mocks `CustomerAnonymizePII` at ~L323/386/428 — review expectations against
+  the new status guard even though `FreezeAndDelete` itself is untouched, §5.5) in
+  customer-manager; `sweep_test.go` in ai-manager; `failedeventhandler/main_test.go` in
+  billing-manager. `runMonthlyTopUp` currently has **no test** at all (lives in
+  `cmd/billing-manager/main.go`, untested) — moving it into a handler package is a net
+  test-coverage win, not just a refactor; new tests required as part of this move.
+- `bin-billing-manager/scripts/database_scripts_test/table_billing_billings.sql` currently
+  declares `idx_billing_billings_idempotency_key` as **non-unique**, while the real MySQL schema
+  has it `UNIQUE` (`ux_billing_billings_idempotency_key`). Fix the sqlite fixture to match —
+  without it, the double-fire test for `AccountTopUpTokens` (below) cannot actually observe the
+  duplicate-ledger-row failure mode it's meant to catch pre-fix, and would pass even without the
+  CAS guard.
+- Concurrent-race test for `CustomerAnonymizePII`'s two callers: one at the dbhandler layer (two
+  concurrent claimants racing the scheduled sweep's read-then-anonymize, asserting exactly one
+  `customer_deleted` publish — same shape as Phase 1's `Test_DoubleFire`), and one specifically for
+  `FreezeAndDelete` (§5.5) asserting the race loser receives `ErrNotFound` and no duplicate event.
+- New listenhandler routing tests per new route (5), following the Phase 1
+  `bin-schedule-manager/pkg/listenhandler` pattern (mocked handler `EXPECT`, no `gomock.Any()` on
+  parsed payloads).
+- Migration: standard Alembic `alembic revision` flow, `alembic heads` single-head check, matching
+  sqlite test fixtures if `scripts/database_scripts_test/` conventions in the three touched
+  services require it (they don't seed data today — schedule seeding lives entirely in
+  bin-dbscheme-manager, per Phase 1 precedent). Seed rows use the full column set from
+  `a5e6f559299c_schedule_schedules_seed_platform_jobs.py` (`id, customer_id, name, detail, type,
+  cron, target_queue, target_uri, target_method, target_data_type, target_data, timeout_ms,
+  retry_max, enabled, tm_next_run, tm_create, tm_update`), not just the subset shown in §7's
+  table — `type: 'rpc'`, `target_data_type: 'application/json'`, `tm_next_run: NULL`.
+- Per root CLAUDE.md's service-docs-sync rule: adding routes to `pkg/listenhandler/main.go` and
+  removing goroutines from `cmd/*/main.go` obligates updating `docs/architecture.md` (routing
+  table + events section) for all three touched services in the same commit
+  (`bash docs/reference/extractor.sh <service-dir>` to re-extract).
+- End-to-end: verify each new schedule fires via bin-schedule-manager's existing manual-execute
+  endpoint (`POST /v1/schedules/<id>/execute`) against a fixture with known due rows, asserting the
+  count response and downstream side effect.
+
+## 11. Rollout / risk
+
+- Additive at the schedule-manager layer (new rows only, no engine change) — the risk surface is
+  entirely in the three services being edited (billing/ai/customer-manager) and is bounded to:
+  removing five goroutines, adding five endpoints, and two dbhandler CAS fixes.
+- The two CAS fixes are the only behavior changes with production consequence beyond
+  "job now runs on a schedule instead of a ticker" — both are strictly safety-improving (a
+  double-fire that used to silently corrupt ledger/cascade data now no-ops instead).
+- Seeded `enabled: 1` for all five (unlike Phase 1's `database-backup`, which shipped disabled) —
+  these are direct replacements for jobs already running unconditionally in production; there is
+  no "opt-in later" step analogous to self-hosted backup enablement.
+- Cutover: land the endpoints + dbhandler fixes + seed migration in one monorepo PR (mirrors
+  Phase 1's single-PR discipline), remove the ticker goroutines in the same PR (no transition
+  period running both — that would double-fire by construction). Verify via manual-execute before
+  relying on the cron schedule in any environment that matters. Sandbox guard removal is a
+  separate, later PR in the sandbox repo (§9).

--- a/docs/plans/2026-08-01-schedule-manager-phase2-tickers-implementation-plan.md
+++ b/docs/plans/2026-08-01-schedule-manager-phase2-tickers-implementation-plan.md
@@ -1,0 +1,455 @@
+# bin-schedule-manager Phase 2 — Implementation Plan (VOIP-1284)
+
+Status: approved (plan review loop: 6 rounds — RC, RC, Approve, RC, Approve, Approve)
+Design: [2026-08-01-schedule-manager-phase2-tickers-design.md](2026-08-01-schedule-manager-phase2-tickers-design.md) (approved, 3-round review)
+Branch: `VOIP-1284-Migrate-tickers-to-schedule-manager`
+(worktree `.worktrees/VOIP-1284-Migrate-tickers-to-schedule-manager`)
+
+Single monorepo PR (design §11). Sandbox guard removal is a separate, later PR in the sandbox
+repo, sequenced after image release (design §9) — not part of this plan.
+
+Commit granularity: one commit per numbered step below; each must pass the full verification
+workflow in its own service directory before the next step starts.
+
+## Step 1 — billing-manager: fix `AccountTopUpTokens`, add the top-up endpoint
+
+**Signature change (required — see below):**
+`AccountTopUpTokens(ctx, accountID, customerID uuid.UUID, tokenAmount int64, planType string) error`
+becomes `AccountTopUpTokens(ctx, accountID, customerID uuid.UUID, tokenAmount int64, planType string) (applied bool, err error)`.
+An `error`-only return cannot distinguish "CAS-skip, not due yet" from "actually applied" —
+both must resolve to `nil` error — and the design's `TopUpDue` counter logic (§5.1: CAS-skip
+counts as neither `processed` nor `failed`) requires that distinction. Three call sites, all
+updated in this step:
+- `pkg/dbhandler/main.go:31` — interface declaration.
+- `cmd/billing-manager/main.go:269` (moving into `pkg/accounthandler/topup.go` in this same step,
+  see below) — becomes the primary caller that reads `applied`.
+- `cmd/billing-control/main.go:743` (`billing-control topup run`) — already pre-filters candidates
+  by `a.TmNextTopUp.After(now)` before calling; on the new CAS, `applied=false` for a filtered-in
+  candidate only happens under a genuine race with the scheduled job, which is fine — log at
+  debug and continue, do not treat as an error.
+- `pkg/accounthandler/event.go:84` (initial top-up on `customer_created`) — `applied=false` here
+  is nearly impossible (`TmNextTopUp` is unset on a brand-new account, so `IS NULL` always
+  matches) but handle it the same way as the other callers for consistency: not an error.
+- `pkg/accounthandler/event_test.go:166,218` — existing `mockDB.EXPECT().AccountTopUpTokens(...).Return(nil)` /
+  `.Return(fmt.Errorf(...))` mock expectations must be updated to the two-value return
+  (`.Return(true, nil)` / `.Return(false, fmt.Errorf(...))`) or these tests will fail to compile
+  once the signature changes — self-evident from `go test ./...` in Step 1's verify block, listed
+  here explicitly so it isn't missed while editing.
+- Regenerate `pkg/dbhandler/mock_main.go`.
+
+Files:
+- `pkg/dbhandler/billing.go` (`AccountTopUpTokens`, L514-598 today): add the CAS WHERE clause to
+  the UPDATE (today's plain `UPDATE ... WHERE id = ?` around L543-552) —
+  `WHERE id = ? AND (tm_next_topup IS NULL OR tm_next_topup <= ?)`, reusing the `now` local the
+  method **already computes** at `billing.go:534` (`now := h.utilHandler.TimeNow()`) as the bound
+  value — no new clock call needed inside this method. Check `sql.Result.RowsAffected()`
+  immediately after the UPDATE, inside the transaction, before the ledger INSERT block
+  (L555-588 today): if 0, `tx.Rollback()` (already deferred, but call it explicitly for clarity)
+  and `return false, nil` — normal CAS-skip, not an error. On the UPDATE succeeding, proceed to
+  the ledger insert and commit as today, then `return true, nil`.
+- `pkg/dbhandler/billing_test.go`: **net-new** test coverage for `AccountTopUpTokens` — this
+  function has zero existing test cases in this file today (verified: no case for it exists to
+  "update alongside"). Add table cases: due account → `applied=true`, ledger row inserted,
+  balance set; not-yet-due account (`tm_next_topup` in the future) → `applied=false, err=nil`, no
+  ledger row, no balance change; account not found → `err=ErrNotFound` (existing behavior,
+  confirm unchanged).
+- **No dbhandler-layer double-fire test in this step.** `AccountTopUpTokens` opens with
+  `SELECT ... FOR UPDATE` (`billing.go:524-526`), which SQLite does not support — the shared
+  sqlite harness pins `SetMaxOpenConns(1)` (`pkg/dbhandler/main_test.go:21`), which serializes
+  writers and would mask a real race even if `FOR UPDATE` didn't error outright first. The
+  concurrency proof for this fix is
+  therefore **not** a Phase-1-style two-goroutine sqlite test. Instead: (a) a single-threaded
+  test that calls `AccountTopUpTokens` twice in a row for the same account with the same `now`,
+  asserting the second call returns `applied=false` and exactly one `billing_billings` row exists
+  — this proves the CAS logic is correct without needing real concurrency; (b) note in the PR
+  description that true concurrent-replica proof for this specific fix relies on the row lock
+  (`FOR UPDATE`) plus the CAS predicate together, which cannot be exercised in the sqlite unit
+  harness and is not blocking for this PR (the row lock forces serialization at the DB layer
+  regardless of the CAS; the CAS is what makes the second serialized writer a no-op instead of a
+  second write — this is provable by code inspection plus the sequential test in (a), not by a
+  race test).
+- `scripts/database_scripts_test/table_billing_billings.sql`: change
+  `idx_billing_billings_idempotency_key` from a plain index to a **unique** index
+  (`ux_billing_billings_idempotency_key`), matching the real MySQL schema (correctness fix,
+  independent of the point above — this makes the sqlite fixture accurately reflect production
+  even though the specific double-fire scenario can't be raced in sqlite).
+- `pkg/accounthandler/topup.go` (new file): move `runMonthlyTopUp`'s body out of
+  `cmd/billing-manager/main.go:240-283` into an exported method, e.g.
+  `TopUpDue(ctx context.Context) (processed, failed int, err error)`, on the existing
+  `AccountHandler`. Keep the identical pagination shape (500/page, cursor on `tm_create`,
+  `FieldDeleted: false` filter, `PlanTokenMap` lookup, skip `tokenAmount <= 0`), but switch the
+  `time.Now()` call (today `main.go:243`) to `h.utilHandler.TimeNow()` (the handler already has
+  `utilHandler` — verify via `pkg/accounthandler/main.go`'s struct fields) so the new
+  `topup_test.go` can control the clock. Per row: call `h.db.AccountTopUpTokens(...)`; `applied
+  == true` → increment `processed`; `applied == false, err == nil` → increment neither (CAS-skip,
+  matches design §5.1); `err != nil` → increment `failed`, log (as today), `continue` (does not
+  abort the loop). Return a non-nil `err` from `TopUpDue` only if the `AccountList` call itself
+  fails (nothing could be attempted) — per design §4's partial-failure contract.
+- `pkg/accounthandler/topup_test.go` (new): table-driven test for `TopUpDue` with a mocked
+  dbhandler — pagination across 2 pages, a due account, a not-due account (mocked `applied=false`),
+  a per-row error, an `AccountList` failure. This logic currently has zero test coverage (lived
+  untested in `cmd/main.go`).
+- `pkg/accounthandler/main.go`: add `TopUpDue(ctx context.Context) (int, int, error)` to the
+  `AccountHandler` interface; regenerate `pkg/accounthandler/mock_main.go`.
+- `pkg/listenhandler/main.go`: add `regV1AccountsTopUp = regexp.MustCompile("/v1/accounts/top_up$")`
+  and a switch case → `processV1AccountsTopUpPost`, placed among the other literal-path
+  `/v1/accounts/...` routes per this file's existing ordering.
+- `pkg/listenhandler/v1_accounts.go`: new handler func `processV1AccountsTopUpPost` — no request
+  body; calls `h.accountHandler.TopUpDue(ctx)`; on handler error → `errorResponse(err)`
+  (non-2xx); on success → marshal `response.V1ResponseAccountsTopUp{Processed: n, Failed: n}`
+  (style B, bare scalars) → 200.
+- `pkg/listenhandler/models/response/account.go`: add `V1ResponseAccountsTopUp{Processed, Failed
+  int}` to this **existing** file (it already holds `V1ResponseAccountsIDIsValidBalance` —
+  confirmed present at `bin-billing-manager/pkg/listenhandler/models/response/account.go`; do not
+  create a new file).
+- Routing test (wherever this service's `pkg/listenhandler` routing tests live — check for a
+  `main_test.go` or per-route test file pattern and match it): mocked `AccountHandler.TopUpDue`
+  EXPECT, assert response body on success, assert non-2xx mapping on handler error.
+- `cmd/billing-manager/main.go`: delete the top-up ticker goroutine (`run()`, currently
+  L144-158) and `runMonthlyTopUp` (currently L240-283, now moved). Prune now-unused imports in
+  this file if `runMonthlyTopUp` was their only user (verify — `time` is still needed by the
+  failed-event-retry ticker touched in Step 2, so do not remove it yet).
+
+Verify: full 5-step workflow in `bin-billing-manager`.
+
+## Step 2 — billing-manager: failed-event retry endpoint + main.go restructure
+
+**This step requires restructuring `run()`/`runSubscribe()`, not just adding a route.**
+`failedEventHandler` is built *inside* `runSubscribe()` (`cmd/billing-manager/main.go`, current
+flow: `runListen()` at line ~134 runs **before** `runSubscribe()` at line ~139, and
+`failedHandler` is a local variable constructed inside `runSubscribe()` at ~L194, via a circular
+wiring dance: `subHandler` is created first with a `nil` failed-event processor placeholder, then
+`failedHandler := failedeventhandler.NewFailedEventHandler(db, subscribehandler.GetEventProcessor(subHandler))`,
+then `subscribehandler.SetFailedEventHandler(subHandler, failedHandler)` patches it back onto
+`subHandler`). `failedHandler` is never passed to `listenhandler.NewListenHandler` (called inside
+`runListen`), and cannot be without restructuring, since it doesn't exist yet at that point in the
+current call order.
+
+**Required restructure:** extract the `subHandler`/`failedHandler` circular-construction block
+(currently inside `runSubscribe`) into its own function, e.g. `buildFailedEventHandler(db,
+sockHandler, accountHandler, billingHandler) (subscribehandler.SubscribeHandler,
+failedeventhandler.FailedEventHandler)`, called from `run()` **before** `runListen`. Change
+`runListen`'s signature to accept `failedHandler failedeventhandler.FailedEventHandler` and pass
+it through to `listenhandler.NewListenHandler`. Change `runSubscribe` to accept the
+already-constructed `subHandler` (just calls `.Run()` on it) instead of building it. Existing
+`pkg/listenhandler/*_test.go` files construct `&listenHandler{...}` struct literals directly
+rather than calling `NewListenHandler` — adding a `failedEventHandler` field to the struct does
+not break those literals (unset fields default to nil), so no test call-site update is needed
+there; the new route's own test (below) is what actually exercises the new field.
+
+Files:
+- `pkg/failedeventhandler/main.go` (`RetryPending`): both the interface declaration and the
+  implementation live in this one file (unlike Steps 3-5's services), so no separate
+  interface-file edit is needed here — change the signature from `(ctx) error` to
+  `(ctx) (retried, succeeded, exhausted int, err error)` in place; `go generate ./...`
+  regenerates `mock_main.go` from the same file's `mockgen -source main.go` directive. Internals
+  unchanged (no CAS needed per
+  design §5.2 — downstream `billing_billings.idempotency_key` uniqueness, now genuinely `UNIQUE`
+  in the sqlite fixture per Step 1, already protects the outcome that matters); accumulate the
+  three counters across the existing loop body. Return a non-nil `err` only if the initial
+  `FailedEventListPendingRetry` call fails.
+- `pkg/failedeventhandler/main_test.go`: update existing `RetryPending` test cases to assert the
+  three returned counts, not just error-nil.
+- `pkg/listenhandler/main.go`: add
+  `regV1FailedEventsRetry = regexp.MustCompile("/v1/failed_events/retry$")` + switch case;
+  `NewListenHandler`'s signature and the `listenHandler` struct gain a `failedEventHandler
+  failedeventhandler.FailedEventHandler` field.
+- `pkg/listenhandler/v1_accounts.go` (or a new `v1_failed_events.go` if this file's route
+  grouping convention favors a dedicated file per resource — match the existing pattern, e.g.
+  `v1_accounts.go` holds account routes, a billing-record-adjacent route may deserve its own
+  file): handler `processV1FailedEventsRetryPost` → `h.failedEventHandler.RetryPending(ctx)` →
+  `response.V1ResponseFailedEventsRetry{Retried, Succeeded, Exhausted int}` on success (new file
+  in `models/response/`, e.g. `failed_events.go`), `errorResponse` on list-fetch failure.
+- Routing test for the new route, same shape as Step 1.
+- `cmd/billing-manager/main.go`: delete the failed-event-retry ticker goroutine (currently at the
+  end of `runSubscribe`, ~L205-219). `chDone` is still needed by `run()`'s own shutdown wait
+  regardless of tickers — do not remove it.
+
+Verify: full 5-step workflow in `bin-billing-manager` (second commit in this service directory,
+Step 1's changes still present).
+
+## Step 3 — ai-manager: proposal expiry endpoint (no dbhandler fix needed — design §5.3)
+
+Files:
+- `pkg/aipromptproposalhandler/sweep.go` (`SweepExpiredProposals`): change signature to
+  `(ctx) (expired int, err error)` (verify its exact current signature first — exploration
+  reported it as called without inspecting a return value; confirm at the call site in
+  `cmd/ai-manager/main.go:171` before assuming `void` vs. an already-present unused `error`).
+  `AIPromptProposalUpdateExpired` is already CAS-guarded (`WHERE status='completed'`) — no
+  dbhandler change. Per design §4's partial-failure contract: return non-nil `err` only if
+  `AIPromptProposalList` fails; count `expired` across the loop; a per-row `AIGet` failure
+  (`continue`s today) does not increment `expired` and does not fail the batch.
+- `pkg/aipromptproposalhandler/main.go:44`: the `AIPromptProposalHandler` interface declares
+  `SweepExpiredProposals(ctx context.Context)` **in a separate file** from the implementation
+  above — update this line to the new `(ctx) (expired int, err error)` signature. `go generate
+  ./...` (part of the standard verify workflow) regenerates `mock_main.go` from this file's
+  `//go:generate mockgen -source main.go` directive once the interface line is edited by hand;
+  it does not update itself from the `sweep.go` implementation alone.
+- `pkg/aipromptproposalhandler/sweep_test.go`: update to assert the returned count.
+- `pkg/listenhandler/main.go`: add
+  `regV1AIPromptProposalsExpire = regexp.MustCompile("/v1/aipromptproposals/expire$")` + switch
+  case, positioned near the existing `/v1/aipromptproposals/...` routes.
+- `pkg/listenhandler/v1_aipromptproposals.go` (confirmed existing file — this is where
+  `/v1/aipromptproposals/...` handlers live, not `v1_data_aipromptproposals.go`, which is the
+  **request DTO** file under `models/request/`): new handler func
+  `processV1AIPromptProposalsExpirePost` → `h.aiPromptProposalHandler.SweepExpiredProposals(ctx)`
+  → `response.V1ResponseAIPromptProposalsExpire{Expired: n}` / `errorResponse`. Add the response
+  DTO to `pkg/listenhandler/models/response/` (this package **exists** for ai-manager — confirmed
+  `bin-ai-manager/pkg/listenhandler/models/response/`; add a new file or extend an existing one
+  matching the resource, check current contents first).
+- Routing test for the new route.
+- `cmd/ai-manager/main.go`: delete the proposal-sweep ticker goroutine (currently L165-177, the
+  one with the dead `ctx.Done()` arm where `ctx := context.Background()`). **Do not touch** the
+  two startup one-shot sweep calls (`SweepStaleAudits`, `SweepStaleProposals`) — design §6,
+  explicitly out of scope, stays per-boot. Prune the now-unused `"time"` import if the deleted
+  ticker was its only user in this file (it likely is — verify).
+
+Verify: full 5-step workflow in `bin-ai-manager`.
+
+## Step 4 — customer-manager: unverified cleanup endpoint (no dbhandler fix needed — design §5.4)
+
+Files:
+- `pkg/customerhandler/cleanup.go`: export `cleanupUnverified` (or add a thin exported wrapper —
+  match whatever the existing private/public split convention in this package looks like; check
+  the actual current function name and visibility first) with signature `(ctx) (expired int, err
+  error)`. `CustomerUpdate` needs no CAS — soft-delete via `tm_delete` is structurally idempotent
+  (design §5.4). Non-nil `err` only on `CustomerList` failure. **Count `expired` only on
+  successful `CustomerUpdate` calls** — today's code reports `len(customers)` unconditionally
+  regardless of per-row update failures (`cleanup.go`, confirm exact lines); this is a real
+  behavior fix, not a mechanical signature change: a row whose `CustomerUpdate` errors must not
+  be counted as expired.
+- `pkg/customerhandler/main.go:66`: the `CustomerHandler` interface declares
+  `RunCleanupUnverified(ctx context.Context)` **in a separate file** from `cleanup.go` — update
+  this line to the new exported name and `(ctx) (expired int, err error)` signature. `go generate
+  ./...` regenerates `mock_main.go` from this file's `mockgen -source main.go` directive once the
+  interface line is hand-edited; it does not follow from editing `cleanup.go` alone.
+- `pkg/customerhandler/cleanup_test.go`: update to assert the returned count, including a case
+  where a per-row `CustomerUpdate` fails and confirm it is excluded from the count.
+- `pkg/listenhandler/main.go`: add
+  `regV1CustomersCleanupUnverified = regexp.MustCompile("/v1/customers/cleanup_unverified$")` +
+  switch case, placed as a literal-path route **before** `regV1CustomersID`
+  (`"/v1/customers/" + regUUID + "$"`, confirmed at `pkg/listenhandler/main.go:60`) in file
+  order, matching this file's existing convention for `/v1/customers/signup` and
+  `/v1/customers/email_verify` (`regV1CustomersID` cannot match `/cleanup_unverified` since it
+  requires a UUID segment, so there's no functional collision either way — placement is purely
+  matching the file's established literal-path-first convention).
+- `pkg/listenhandler/v1_customers.go` (confirmed existing file — general customer routes; the
+  freeze-family routes live in the separate `v1_customers_freeze.go`, which this new pair of
+  routes resembles more closely — use whichever of the two this service's convention would put a
+  new "customer lifecycle action" route in; default to `v1_customers.go` unless
+  `v1_customers_freeze.go`'s existing content suggests otherwise): handler
+  `processV1CustomersCleanupUnverifiedPost` → `h.customerHandler.CleanupUnverified(ctx)` (final
+  exported name matches whatever Step 4's dbhandler-adjacent change above settles on) →
+  `response.V1ResponseCustomersCleanupUnverified{Expired: n}` / `errorResponse`.
+- `pkg/listenhandler/models/response/` (**new package** — customer-manager currently has only
+  `models/request/`, confirmed no `models/response/` directory exists today): create
+  `pkg/listenhandler/models/response/customers.go` holding both this step's and Step 5's response
+  DTOs.
+- Routing test for the new route.
+- `cmd/customer-manager/main.go`: delete the unverified-cleanup ticker call site (currently
+  `go customerHandler.RunCleanupUnverified(context.Background())`, ~L100-101). Grep for other
+  callers of `RunCleanupUnverified` before deleting the function itself — if none, delete the
+  ticker-loop wrapper function in `cleanup.go` too, in this same step (leaving a dead exported
+  function whose only caller was just removed is worse than a slightly larger single-step diff).
+
+Verify: full 5-step workflow in `bin-customer-manager`.
+
+## Step 5 — customer-manager: fix `CustomerAnonymizePII`, add the frozen-expiry endpoint
+
+Files:
+- `pkg/dbhandler/customer.go` (`CustomerAnonymizePII`, ~L430-484): add
+  `AND status = 'frozen' AND tm_delete IS NULL` to the WHERE clause. Return contract unchanged —
+  still returns `dbhandler.ErrNotFound` when `RowsAffected == 0` (this now covers both "genuinely
+  missing row" and "guard didn't match, a concurrent claimant already won"; the two customer-
+  handler call sites interpret which applies, per design §5.5 — the dbhandler contract itself
+  does not change).
+- `pkg/dbhandler/customer_test.go`: add a case exercising the new guard (row not in `frozen`
+  status → `ErrNotFound`, no anonymization applied) alongside existing `CustomerAnonymizePII`
+  coverage.
+- `pkg/dbhandler/customer_test.go` (new): **double-fire test** at the dbhandler layer — this
+  package's sqlite harness works for this method (plain `UPDATE`, no `FOR UPDATE`, unlike Step
+  1's billing case) — two goroutines racing `CustomerAnonymizePII` for the same frozen customer
+  against one sqlite DB; assert exactly one call returns success (nil error) and the other
+  returns `ErrNotFound`, and the row ends in `status=deleted` with anonymized fields exactly
+  once (not double-anonymized in a way that would matter, but primarily proving the CAS holds).
+  Same shape as Phase 1's `Test_DoubleFire` in `bin-schedule-manager/pkg/dbhandler/execution_test.go`.
+- `pkg/customerhandler/expiry.go` (`cleanupFrozenExpired` or equivalent — export per this step,
+  confirm exact current name/visibility first): signature `(ctx) (processed int, err error)`. At
+  the `CustomerAnonymizePII` call site (currently ~L57-60, log-and-continue on any error): if the
+  error `errors.Is(err, dbhandler.ErrNotFound)`, treat as a **normal CAS-skip** — do not log as
+  an error, do not increment `processed`, do not call `CustomerGet`/`PublishEvent`, `continue`.
+  Any other error still logs and `continue`s without incrementing `processed`, unchanged from
+  today's behavior. On success (no error): `CustomerGet` + `PublishEvent(customer_deleted)` as
+  today, increment `processed`. Non-nil `err` returned from `cleanupFrozenExpired` itself only if
+  `CustomerListFrozenExpired` fails.
+- `pkg/customerhandler/main.go:67`: the `CustomerHandler` interface declares
+  `RunCleanupFrozenExpired(ctx context.Context)` **in a separate file** from `expiry.go` — update
+  this line to the new exported name and `(ctx) (processed int, err error)` signature (this is
+  the same file Step 4 already touches for its own interface line — both edits land in the same
+  file across Steps 4 and 5). `go generate ./...` regenerates `mock_main.go` once the interface
+  line is hand-edited.
+- `pkg/customerhandler/expiry_test.go`: update to assert the returned count; add a case for the
+  `ErrNotFound`-as-CAS-skip path (not logged as an error, not counted, no event published) — this
+  test is at the **handler** layer with a mocked dbhandler, distinct from the dbhandler-layer
+  double-fire test above.
+- `pkg/customerhandler/freeze_test.go`: add a concurrent-race test for `FreezeAndDelete`
+  (`pkg/customerhandler/freeze.go:91` calls `CustomerAnonymizePII`) — two concurrent calls on the
+  same customer at the dbhandler layer (or mocked at the handler layer with the second call
+  returning `ErrNotFound`, matching how this test file's existing style mocks the dbhandler);
+  assert the winner succeeds and publishes `customer_deleted` once, the loser receives
+  `dbhandler.ErrNotFound` (design §5.5's real, observable behavior change for this
+  out-of-scope-but-affected caller: today both concurrent calls silently succeed and both
+  publish; after this fix, the loser gets a visible error and does not publish) and does not
+  publish a second event. Review the existing mocked `CustomerAnonymizePII` expectations at
+  ~L323/386/428 against the new WHERE clause — no code change needed there since the dbhandler
+  signature/contract is unchanged, confirm the mocks still make sense as-is.
+- `pkg/listenhandler/main.go`: add
+  `regV1CustomersCleanupFrozenExpired = regexp.MustCompile("/v1/customers/cleanup_frozen_expired$")`
+  + switch case, same literal-path-first placement as Step 4.
+- `pkg/listenhandler/v1_customers.go` (or wherever Step 4 placed the sibling route): handler
+  `processV1CustomersCleanupFrozenExpiredPost` →
+  `response.V1ResponseCustomersCleanupFrozenExpired{Processed: n}` / `errorResponse`, added to
+  the same `models/response/customers.go` file created in Step 4.
+- Routing test for the new route.
+- `cmd/customer-manager/main.go`: delete the frozen-expiry ticker call site (currently
+  `go customerHandler.RunCleanupFrozenExpired(context.Background())`, ~L103-104) and, per the
+  same grep-first rule as Step 4, the now-dead `RunCleanupFrozenExpired` ticker-loop wrapper if
+  it has no other callers.
+- After Steps 4 and 5: check whether `cmd/customer-manager/main.go`'s `"context"` import is now
+  unused (it was only referenced by the two deleted `context.Background()` ticker calls) and
+  prune if so.
+
+Verify: full 5-step workflow in `bin-customer-manager` (third commit in this service directory,
+Step 4's changes still present).
+
+## Step 6 — Seed migration (bin-dbscheme-manager)
+
+```bash
+cd bin-dbscheme-manager/bin-manager
+cp -n alembic.ini.sample alembic.ini
+alembic -c alembic.ini revision -m "schedule_schedules_seed_phase2_ticker_jobs"
+alembic -c alembic.ini heads   # exactly ONE head
+```
+
+One migration, five `op.execute` INSERTs into `schedule_schedules`, following
+`a5e6f559299c_schedule_schedules_seed_platform_jobs.py`'s exact pattern: full column list
+(`id, customer_id, name, detail, type, cron, target_queue, target_uri, target_method,
+target_data_type, target_data, timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update`),
+`UNHEX(REPLACE(UUID(),'-',''))` ids, nil-UUID customer_id, `type='rpc'`,
+`target_data_type='application/json'`, `target_data=JSON_OBJECT()` for all five (**never** a raw
+`'{...}'` string literal — the VOIP-1283 hotfix pitfall: a bare colon inside a string literal is
+misparsed as a bind parameter by `sqlalchemy.text()`), `tm_next_run=NULL`,
+`tm_create`/`tm_update=UTC_TIMESTAMP(6)`.
+
+| name | cron | target_queue | target_uri | timeout_ms | retry_max | enabled |
+|---|---|---|---|---|---|---|
+| `billing-monthly-topup` | `0 * * * *` | `bin-manager.billing-manager.request` | `/v1/accounts/top_up` | 300000 | 0 | 1 |
+| `billing-failed-event-retry` | `* * * * *` | `bin-manager.billing-manager.request` | `/v1/failed_events/retry` | 60000 | 0 | 1 |
+| `ai-proposal-expiry` | `0 * * * *` | `bin-manager.ai-manager.request` | `/v1/aipromptproposals/expire` | 300000 | 0 | 1 |
+| `customer-unverified-cleanup` | `*/15 * * * *` | `bin-manager.customer-manager.request` | `/v1/customers/cleanup_unverified` | 60000 | 0 | 1 |
+| `customer-frozen-expiry` | `0 4 * * *` | `bin-manager.customer-manager.request` | `/v1/customers/cleanup_frozen_expired` | 600000 | 0 | 1 |
+
+All `target_method='POST'`. Downgrade: `DELETE FROM schedule_schedules WHERE name IN (...) AND
+customer_id = UNHEX('00000000000000000000000000000000')`. Note (unlike Phase 1's seed, which ran
+before any execution could reference the rows): by the time this downgrade could plausibly run,
+`schedule_executions` rows referencing these five schedules may already exist. There is no FK
+constraint from `schedule_executions.schedule_id` to `schedule_schedules.id` (confirm against the
+Phase 1 DDL), so the plain `DELETE` does not need a corresponding executions cleanup to succeed —
+it would simply leave orphaned audit rows pointing at a deleted schedule, which is consistent with
+how `schedule_executions` already outlives soft-deleted schedules via the app-level API (`DELETE
+/v1/schedules/<id>` is a soft-delete, not a hard delete, and doesn't touch executions either).
+No change needed; noted for the downgrade's author.
+
+NEVER run `alembic upgrade`/`downgrade` (repo rule) — create and edit the file only.
+
+Verify: `alembic -c alembic.ini heads` → single head; `python3 -m py_compile` on the new revision;
+confirm all five `target_queue` values match `commonoutline.QueueName{Billing,AI,Customer}Request`
+string values exactly (they must, to pass `bin-schedule-manager`'s `isValidTargetQueue` allowlist
+check — no `bin-common-handler` change is needed per design §3, but a typo here would silently
+fail forever since nothing creates these rows through the validated CRUD API path).
+
+## Step 7 — Service docs sync
+
+Per root CLAUDE.md's service-docs-sync table (route/event changes in `pkg/listenhandler/main.go`
+and `cmd/*/main.go` require a same-commit `docs/architecture.md` update) for all three touched
+services:
+
+- `bin-billing-manager/docs/architecture.md`: routing table gains `/v1/accounts/top_up`,
+  `/v1/failed_events/retry`; events section drops the two ticker descriptions.
+- `bin-ai-manager/docs/architecture.md`: routing table gains `/v1/aipromptproposals/expire`;
+  events section updated (startup sweeps stay documented, ticker sweep entry removed).
+- `bin-customer-manager/docs/architecture.md`: routing table gains
+  `/v1/customers/cleanup_unverified`, `/v1/customers/cleanup_frozen_expired`; events section
+  drops both ticker descriptions.
+
+Re-extract via `bash docs/reference/extractor.sh <service-dir>` per service, then hand-verify the
+routing table matches the new `pkg/listenhandler/main.go` exactly (the extractor's whitelist
+gaps found during Phase 1 — e.g. it didn't know `schedule`/`execution` as event-package names —
+may need the same manual patch-up here if it doesn't recognize `account`/`aipromptproposal`
+event types cleanly; verify, don't assume).
+
+`bin-schedule-manager/docs/domain.md` or `CLAUDE.md`: no change required — Phase 2 adds rows to
+the existing seeded-schedule pattern, doesn't change the engine; the "Housekeeping dogfoods the
+engine" language in `bin-schedule-manager/CLAUDE.md` referred to `execution-retention`/
+`database-backup` specifically and doesn't need updating for unrelated services' schedules.
+
+Verify: `bash scripts/check-service-docs.sh` (or trust the PostToolUse hook) shows no warnings for
+the three touched services; `make lint-docs` at repo root.
+
+## Step 8 — Full verification + cross-service sanity
+
+- Re-run the full 5-step workflow one final time in all three touched service directories
+  (`bin-billing-manager`, `bin-ai-manager`, `bin-customer-manager`) with all steps' changes
+  present together, to catch any cross-step interaction — in particular, confirm
+  `cmd/billing-manager/main.go` compiles cleanly after both Step 1's and Step 2's edits together
+  (Step 2's `run()`/`runListen`/`runSubscribe` restructure is the highest-risk interaction point
+  in this plan).
+- `bin-dbscheme-manager/bin-manager`: `alembic -c alembic.ini heads` → single head (re-verify
+  after Step 7's doc changes haven't touched migrations, this is just a final sanity check).
+- No `bin-common-handler` changes in this ticket (design §3) — confirm `git diff` touches nothing
+  under `bin-common-handler/`.
+- Manual-execute smoke check (design §10): for each of the 5 new schedule rows, once seeded in a
+  local/throwaway environment, exercise `POST /v1/schedules/<id>/execute` against
+  `bin-schedule-manager` and confirm the response count matches expectations against known fixture
+  data — this is a manual verification step for the PR description, not an automated test, since
+  it requires a running multi-service environment.
+
+## Step 9 — Code review loop, PR
+
+- Code review loop per session policy: minimum 3 rounds, 2 consecutive approvals, max 30.
+- Pre-PR: `git fetch origin main`; `git merge-tree` conflict check; `git log --oneline HEAD..origin/main`.
+- Commit/PR body lists affected projects: `bin-billing-manager:`, `bin-ai-manager:`,
+  `bin-customer-manager:`, `bin-dbscheme-manager:`, `monorepo:` (docs sync). PR title
+  `VOIP-1284-Migrate-tickers-to-schedule-manager`. No AI attribution. Single PR. NO merge without
+  explicit user authorization.
+- PR description explicitly notes: (a) two dbhandler-layer bug fixes shipped as part of this
+  migration (`AccountTopUpTokens` CAS + signature change to `(applied bool, err error)`,
+  `CustomerAnonymizePII` status guard) with a one-line explanation of the production impact each
+  fixes; (b) the `AccountTopUpTokens` concurrency proof is by code inspection + sequential test,
+  not a race test, due to sqlite's lack of `SELECT ... FOR UPDATE` support (Step 1 rationale);
+  (c) sandbox guard removal is tracked as a separate follow-up PR in the sandbox repo, sequenced
+  after this PR's images are released and pinned (design §9) — not part of this PR.
+
+## Acceptance mapping (design §1/§3 ↔ ticket)
+
+| Criterion | Where proven |
+|---|---|
+| All 5 jobs fire via bin-schedule-manager, no ticker goroutines remain | Steps 1-6 |
+| Billing monthly top-up proven single-fire under 2 replicas | Step 1 sequential CAS test + code-inspection argument (row lock + CAS); not a race test, see Step 1/9 rationale |
+| Customer frozen-expiry proven single-fire under 2 replicas | Step 5 dbhandler-layer double-fire test |
+| Sandbox replica-guard warnings removed for billing/ai | Explicitly deferred to a separate sandbox-repo PR (design §9) — not this PR |
+| Per-job metrics visible; execution audit rows present | Inherited from Phase 1 engine, no new work — confirmed in Step 8 manual smoke check |
+| Monorepo conventions: unit tests, docs sync, review loops | Steps 1-9 |
+
+## Explicitly out of scope (this PR)
+
+- campaign-manager / queue-manager (design §2 — VOIP-1282 concluded neither needs schedule-manager)
+- `idempotency_key`/`reference_id` mismatch cleanup in billing ledger (design §8, separate ticket)
+- Unbounded `CustomerListFrozenExpired` query fix (design §8, separate ticket)
+- campaign-manager swallowed re-arm errors, queue-manager lost-timeout gap (design §8, VOIP-1282 follow-ups)
+- Stale campaign/queue-manager documentation (design §8, VOIP-1282 follow-up, doc-only)
+- ai-manager startup one-shot sweeps (design §6 — stay per-boot, unchanged)
+- Sandbox guard removal (design §9 — separate, later, separate-repo PR)
+- `FreezeAndDelete`'s call-site behavior itself is unchanged by this PR (only the shared
+  dbhandler method it calls gains a guard) — its new observable behavior under a race is a
+  documented side effect (§5.5, Step 5), not a scoped feature of this PR


### PR DESCRIPTION
Phase 2 of bin-schedule-manager (VOIP-1283): migrates five in-process time.Ticker jobs — billing-manager monthly token top-up, billing-manager failed-event retry, ai-manager expired-proposal sweep, customer-manager unverified-customer cleanup, customer-manager frozen-customer expiry — into schedule-manager-dispatched RPC endpoints. All three touched services already run replicas:2 in production, so the double-fire hazard these tickers carried (no leader election, no lock) was live, not theoretical. Two real concurrency bugs found during investigation are fixed as part of this migration: AccountTopUpTokens had no CAS guard (ledger could double-insert under concurrent replicas); CustomerAnonymizePII had no status guard (could publish customer_deleted twice, double-triggering the number-manager/billing-manager cascade). VOIP-1282 (campaign-manager/queue-manager) concluded neither needs schedule-manager — both are already self-driving via RabbitMQ delayed-message self-RPC — so this PR does not touch them. Design approved over 3 review rounds, implementation plan over 6 rounds, code over 3 rounds (all Approve). No bin-common-handler changes: schedules dispatch generically via target_queue/target_uri, same as Phase 1's number-renew.

- bin-billing-manager: Fix AccountTopUpTokens to CAS-guard the monthly top-up (WHERE tm_next_topup is due; skip is not an error) and stop the ledger double-insert; add POST /v1/accounts/top_up; add POST /v1/failed_events/retry (RetryPending now reports retried/succeeded/exhausted counts); restructure cmd/billing-manager/main.go so the failed-event handler is built before the listen handler needs it; remove both ticker goroutines
- bin-ai-manager: Add POST /v1/aipromptproposals/expire (already CAS-guarded downstream, no dbhandler change); remove the proposal-expiry ticker; the two startup one-shot stale-recovery sweeps are untouched (per-boot, not a scheduler concern)
- bin-customer-manager: Fix CustomerAnonymizePII to guard on status=frozen, closing the duplicate customer_deleted publish; add POST /v1/customers/cleanup_unverified (also fixes an existing undercount — expired now reflects only successful updates) and POST /v1/customers/cleanup_frozen_expired; remove both ticker goroutines
- bin-dbscheme-manager: Seed the five new platform schedules (billing-monthly-topup hourly, billing-failed-event-retry every minute, ai-proposal-expiry hourly, customer-unverified-cleanup every 15 minutes, customer-frozen-expiry daily), all enabled

Sandbox replica-guard removal (scripts/voipbin-cli.py) is a separate, later PR in the sandbox repo, sequenced after these images are released and pinned — not part of this PR.