### PR TITLE
VOIP-1287-mask-sip-password-logs

### DIFF
--- a/bin-registrar-manager/cmd/registrar-manager/main.go
+++ b/bin-registrar-manager/cmd/registrar-manager/main.go
@@ -27,6 +27,7 @@ import (
 	"monorepo/bin-registrar-manager/pkg/dbhandler"
 	"monorepo/bin-registrar-manager/pkg/extensionhandler"
 	"monorepo/bin-registrar-manager/pkg/listenhandler"
+	"monorepo/bin-registrar-manager/pkg/redacthandler"
 	"monorepo/bin-registrar-manager/pkg/subscribehandler"
 	"monorepo/bin-registrar-manager/pkg/trunkhandler"
 )
@@ -61,7 +62,19 @@ func runDaemon() error {
 	initProm(config.Get().PrometheusEndpoint, config.Get().PrometheusListenAddress)
 
 	log := logrus.WithField("func", "runDaemon")
-	log.WithField("config", config.Get()).Info("Starting registrar-manager...")
+	cfg := config.Get()
+	log.WithFields(logrus.Fields{
+		"rabbitmq_address":          redacthandler.String(cfg.RabbitMQAddress),
+		"prometheus_endpoint":       cfg.PrometheusEndpoint,
+		"prometheus_listen_address": cfg.PrometheusListenAddress,
+		"database_dsn_bin":          redacthandler.String(cfg.DatabaseDSNBin),
+		"database_dsn_asterisk":     redacthandler.String(cfg.DatabaseDSNAsterisk),
+		"redis_address":             cfg.RedisAddress,
+		"redis_password":            redacthandler.String(cfg.RedisPassword),
+		"redis_database":            cfg.RedisDatabase,
+		"domain_name_extension":     cfg.DomainNameExtension,
+		"domain_name_trunk":         cfg.DomainNameTrunk,
+	}).Info("Starting registrar-manager...")
 
 	sqlDBBin, err := commondatabasehandler.Connect(config.Get().DatabaseDSNBin)
 	if err != nil {

--- a/bin-registrar-manager/pkg/extensionhandler/event.go
+++ b/bin-registrar-manager/pkg/extensionhandler/event.go
@@ -38,7 +38,7 @@ func (h *extensionHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucus
 			log.Errorf("Could not delete extension info. err: %v", err)
 			continue
 		}
-		log.WithField("extension", tmp).Debugf("Deleted extension info. extension_id: %s", tmp.ID)
+		log.Debugf("Deleted extension info. extension_id: %s", tmp.ID)
 	}
 
 	return nil

--- a/bin-registrar-manager/pkg/extensionhandler/extension.go
+++ b/bin-registrar-manager/pkg/extensionhandler/extension.go
@@ -20,6 +20,7 @@ import (
 	"monorepo/bin-registrar-manager/models/extension"
 	"monorepo/bin-registrar-manager/models/sipauth"
 	"monorepo/bin-registrar-manager/pkg/dbhandler"
+	"monorepo/bin-registrar-manager/pkg/redacthandler"
 )
 
 // Create creates a new extension
@@ -36,7 +37,7 @@ func (h *extensionHandler) Create(
 		"func":        "Create",
 		"customer_id": customerID,
 		"extension":   ext,
-		"password":    password,
+		"password":    redacthandler.String(password),
 	})
 
 	// check resource limit
@@ -103,7 +104,7 @@ func (h *extensionHandler) Create(
 		log.Errorf("Could not create direct hash. err: %v", err)
 		return nil, fmt.Errorf("could not create direct hash: %w", err)
 	}
-	log.WithField("direct", d).Debugf("Created direct hash. direct_id: %s", d.ID)
+	log.WithField("direct_id", d.ID).Debug("Created direct hash.")
 
 	// create a new extension
 	e := &extension.Extension{
@@ -212,7 +213,7 @@ func (h *extensionHandler) List(ctx context.Context, token string, limit uint64,
 func (h *extensionHandler) Update(ctx context.Context, id uuid.UUID, fields map[extension.Field]any) (*extension.Extension, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"extension_id": id,
-		"fields":       fields,
+		"fields":       redacthandler.Fields(fields),
 	})
 
 	// create a update extension
@@ -344,7 +345,7 @@ func (h *extensionHandler) DirectHashRegenerate(ctx context.Context, id uuid.UUI
 		log.Errorf("Could not get extension. err: %v", err)
 		return nil, fmt.Errorf("could not get extension: %w", err)
 	}
-	log.WithField("extension", ext).Debugf("Retrieved extension info. extension_id: %s", ext.ID)
+	log.Debugf("Retrieved extension info. extension_id: %s", ext.ID)
 
 	// regenerate or create direct
 	var d *dmdirect.Direct
@@ -361,7 +362,7 @@ func (h *extensionHandler) DirectHashRegenerate(ctx context.Context, id uuid.UUI
 			return nil, fmt.Errorf("could not create direct hash: %w", err)
 		}
 	}
-	log.WithField("direct", d).Debugf("Direct hash regenerated. direct_id: %s, hash: %s", d.ID, d.Hash)
+	log.WithField("direct_id", d.ID).Debug("Direct hash regenerated.")
 
 	// update extension with new direct info
 	fields := map[extension.Field]any{

--- a/bin-registrar-manager/pkg/extensionhandler/redact_regression_test.go
+++ b/bin-registrar-manager/pkg/extensionhandler/redact_regression_test.go
@@ -1,0 +1,162 @@
+package extensionhandler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	bmaccount "monorepo/bin-billing-manager/models/account"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	dmdirect "monorepo/bin-direct-manager/models/direct"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-registrar-manager/models/common"
+	"monorepo/bin-registrar-manager/models/extension"
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
+)
+
+// assertNoLeak fails the test if any captured log entry (message or any
+// field, formatted the same way logrus would emit it) contains needle.
+// This is a regression guard for VOIP-1287: several rounds of review found
+// plaintext SIP passwords / direct-hashes leaking into logrus fields even
+// after the transport-layer (pkg/listenhandler) redaction was in place, so
+// this asserts the business layer never emits the secret at all, rather
+// than trusting each call site was updated correctly by inspection.
+func assertNoLeak(t *testing.T, entries []*logrus.Entry, needle string) {
+	t.Helper()
+
+	for _, entry := range entries {
+		if strings.Contains(entry.Message, needle) {
+			t.Errorf("Secret leaked into log message: %q", entry.Message)
+		}
+		for k, v := range entry.Data {
+			if strings.Contains(fmt.Sprintf("%v", v), needle) {
+				t.Errorf("Secret leaked into log field %q: %v", k, v)
+			}
+		}
+	}
+}
+
+func Test_Create_neverLogsPlaintextPassword(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer func() { logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks)) }()
+
+	const plaintextPassword = "S3cr3tSipPassw0rd-must-not-leak"
+
+	customerID := uuid.FromStringOrNil("0040713e-7fed-11ec-954b-ff6d17e2a264")
+	extID := uuid.FromStringOrNil("b2fce137-6ece-4259-8480-473b6c1f2dee")
+	directID := uuid.FromStringOrNil("d1d1d1d1-1111-1111-1111-111111111111")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDBAst := dbhandler.NewMockDBHandler(mc)
+	mockDBBin := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &extensionHandler{
+		utilHandler:   mockUtil,
+		reqHandler:    mockReq,
+		dbAst:         mockDBAst,
+		dbBin:         mockDBBin,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	defer common.ResetBaseDomainNamesForTest()
+	if errSet := common.SetBaseDomainNames("registrar.voipbin.net", "trunk.voipbin.net"); errSet != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", errSet)
+	}
+
+	responseDirect := &dmdirect.Direct{
+		Identity:     commonidentity.Identity{ID: directID, CustomerID: customerID},
+		ResourceType: "extension",
+		ResourceID:   extID,
+		Hash:         "abc123def456-must-not-leak",
+	}
+	responseExtension := &extension.Extension{
+		Identity:   commonidentity.Identity{ID: extID},
+		Extension:  "ce4f2a40-6ec1-11eb-a84c-2bb788ac26e4",
+		Realm:      "0040713e-7fed-11ec-954b-ff6d17e2a264.registrar.voipbin.net",
+		Username:   "ce4f2a40-6ec1-11eb-a84c-2bb788ac26e4",
+		Password:   plaintextPassword,
+		DirectID:   directID,
+		DirectHash: responseDirect.Hash,
+	}
+
+	mockReq.EXPECT().BillingV1AccountIsValidResourceLimitByCustomerID(ctx, customerID, bmaccount.ResourceTypeExtension).Return(true, nil)
+	mockDBAst.EXPECT().AstAORCreate(ctx, gomock.Any()).Return(nil)
+	mockDBAst.EXPECT().AstAuthCreate(ctx, gomock.Any()).Return(nil)
+	mockDBAst.EXPECT().AstEndpointCreate(ctx, gomock.Any()).Return(nil)
+	mockUtil.EXPECT().UUIDCreate().Return(extID)
+	mockReq.EXPECT().DirectV1DirectCreate(ctx, customerID, dmdirect.ResourceTypeExtension, extID).Return(responseDirect, nil)
+	mockDBBin.EXPECT().ExtensionCreate(ctx, gomock.Any()).Return(nil)
+	mockDBBin.EXPECT().ExtensionGet(ctx, extID).Return(responseExtension, nil)
+	mockDBBin.EXPECT().SIPAuthCreate(ctx, gomock.Any()).Return(nil)
+	mockNotify.EXPECT().PublishEvent(ctx, extension.EventTypeExtensionCreated, responseExtension)
+
+	if _, err := h.Create(ctx, customerID, "test name", "test detail", "ce4f2a40-6ec1-11eb-a84c-2bb788ac26e4", plaintextPassword); err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	assertNoLeak(t, hook.AllEntries(), plaintextPassword)
+}
+
+func Test_Update_neverLogsPlaintextPassword(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer func() { logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks)) }()
+
+	const plaintextPassword = "an0ther-S3cr3t-must-not-leak"
+
+	id := uuid.FromStringOrNil("66f6b86c-6f44-11eb-ab55-934942c23f91")
+	fields := map[extension.Field]any{
+		extension.FieldName:     "update name",
+		extension.FieldPassword: plaintextPassword,
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDBAst := dbhandler.NewMockDBHandler(mc)
+	mockDBBin := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &extensionHandler{
+		dbAst:         mockDBAst,
+		dbBin:         mockDBBin,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	before := &extension.Extension{
+		Identity: commonidentity.Identity{ID: id},
+		AuthID:   "66f6b86c-6f44-11eb-ab55-934942c23f91@test.registrar.voipbin.net",
+	}
+	after := &extension.Extension{
+		Identity: commonidentity.Identity{ID: id},
+		AuthID:   before.AuthID,
+		Password: plaintextPassword,
+	}
+
+	mockDBBin.EXPECT().ExtensionGet(gomock.Any(), id).Return(before, nil)
+	mockDBAst.EXPECT().AstAuthUpdate(gomock.Any(), gomock.Any()).Return(nil)
+	mockDBBin.EXPECT().ExtensionUpdate(gomock.Any(), id, fields).Return(nil)
+	mockDBBin.EXPECT().ExtensionGet(gomock.Any(), id).Return(after, nil)
+	mockDBBin.EXPECT().SIPAuthUpdate(ctx, id, gomock.Any()).Return(nil)
+	mockNotify.EXPECT().PublishEvent(gomock.Any(), extension.EventTypeExtensionUpdated, after)
+
+	if _, err := h.Update(ctx, id, fields); err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	assertNoLeak(t, hook.AllEntries(), plaintextPassword)
+}

--- a/bin-registrar-manager/pkg/listenhandler/main.go
+++ b/bin-registrar-manager/pkg/listenhandler/main.go
@@ -175,7 +175,7 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 		"uri":       m.URI,
 		"method":    m.Method,
 		"data_type": m.DataType,
-		"data":      m.Data,
+		"data":      redactSensitiveJSON(m.Data),
 	},
 	)
 	log.Debugf("Received request. method: %s, uri: %s", m.Method, m.URI)
@@ -294,7 +294,7 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	}
 
 	log.WithFields(logrus.Fields{
-		"response": response,
+		"response": redactResponseForLog(response),
 	}).Debugf("Sending back the result. method: %s, uri: %s", m.Method, m.URI)
 
 	return response, err

--- a/bin-registrar-manager/pkg/listenhandler/redact.go
+++ b/bin-registrar-manager/pkg/listenhandler/redact.go
@@ -1,0 +1,92 @@
+package listenhandler
+
+import (
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"monorepo/bin-registrar-manager/pkg/redacthandler"
+)
+
+// redactSensitiveJSON returns a copy of data with the values of any
+// sensitive keys (password, secret, token, credential — see
+// redacthandler.IsSensitive) replaced with a fixed placeholder, so it is
+// safe to attach to a log line. extension/trunk create and update payloads
+// carry a plaintext SIP password; this must run before any such payload is
+// logged.
+//
+// If data is not valid JSON, the raw bytes are never returned — a fixed
+// placeholder is used instead, since a malformed body can still contain a
+// plaintext password in a field the caller intended to redact.
+func redactSensitiveJSON(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	var parsed any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return []byte(`"[unparseable body redacted]"`)
+	}
+
+	out, err := json.Marshal(redactJSONValue(parsed))
+	if err != nil {
+		return []byte(`"[redaction failed]"`)
+	}
+
+	return out
+}
+
+// redactJSONValue walks a decoded JSON value (as produced by
+// json.Unmarshal into `any`) and replaces the value of any sensitive key
+// in every object, at any nesting depth, including inside arrays.
+func redactJSONValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, vv := range val {
+			if redacthandler.IsSensitive(k) {
+				out[k] = redacthandler.Placeholder
+				continue
+			}
+			out[k] = redactJSONValue(vv)
+		}
+		return out
+
+	case []any:
+		out := make([]any, len(val))
+		for i, vv := range val {
+			out[i] = redactJSONValue(vv)
+		}
+		return out
+
+	default:
+		return val
+	}
+}
+
+// redactRequestForLog returns a shallow copy of m with Data passed through
+// redactSensitiveJSON, safe to attach to a log line (e.g. via
+// logrus.Fields{"request": redactRequestForLog(m)}). The original request
+// is left untouched.
+func redactRequestForLog(m *sock.Request) *sock.Request {
+	if m == nil {
+		return nil
+	}
+
+	redacted := *m
+	redacted.Data = redactSensitiveJSON(m.Data)
+	return &redacted
+}
+
+// redactResponseForLog returns a shallow copy of r with Data passed through
+// redactSensitiveJSON, safe to attach to a log line. The original response
+// is left untouched.
+func redactResponseForLog(r *sock.Response) *sock.Response {
+	if r == nil {
+		return nil
+	}
+
+	redacted := *r
+	redacted.Data = redactSensitiveJSON(r.Data)
+	return &redacted
+}

--- a/bin-registrar-manager/pkg/listenhandler/redact_regression_test.go
+++ b/bin-registrar-manager/pkg/listenhandler/redact_regression_test.go
@@ -1,0 +1,90 @@
+package listenhandler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-registrar-manager/models/extension"
+	"monorepo/bin-registrar-manager/pkg/extensionhandler"
+)
+
+// assertNoLeak fails the test if any captured log entry (message or any
+// field, formatted the same way logrus would emit it) contains needle. See
+// pkg/extensionhandler/redact_regression_test.go for the rationale; this
+// exercises the transport (listenhandler) layer specifically, since the
+// direct_hash leak found in VOIP-1287 review only reproduced through the
+// response-body logging path in processRequest, not through the business
+// layer directly.
+func assertNoLeak(t *testing.T, entries []*logrus.Entry, needle string) {
+	t.Helper()
+
+	for _, entry := range entries {
+		if strings.Contains(entry.Message, needle) {
+			t.Errorf("Secret leaked into log message: %q", entry.Message)
+		}
+		for k, v := range entry.Data {
+			if strings.Contains(fmt.Sprintf("%v", v), needle) {
+				t.Errorf("Secret leaked into log field %q: %v", k, v)
+			}
+		}
+	}
+}
+
+func Test_processV1ExtensionsIDDirectHashRegenerate_neverLogsPlaintextHash(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer func() { logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks)) }()
+	logrus.SetLevel(logrus.DebugLevel)
+	defer logrus.SetLevel(logrus.InfoLevel)
+
+	const plaintextHash = "direct-hash-must-not-leak-9f8e7d"
+
+	extensionID := uuid.FromStringOrNil("a1b2c3d4-0001-0001-0001-000000000001")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockExtension := extensionhandler.NewMockExtensionHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:      mockSock,
+		reqHandler:       mockReq,
+		extensionHandler: mockExtension,
+	}
+
+	responseExtension := &extension.Extension{
+		Identity:   commonidentity.Identity{ID: extensionID},
+		DirectHash: plaintextHash,
+	}
+	mockExtension.EXPECT().DirectHashRegenerate(gomock.Any(), extensionID).Return(responseExtension, nil)
+
+	req := &sock.Request{
+		URI:    "/v1/extensions/a1b2c3d4-0001-0001-0001-000000000001/direct-hash-regenerate",
+		Method: sock.RequestMethodPost,
+	}
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("Wrong status code. expect: 200, got: %d", res.StatusCode)
+	}
+	if !strings.Contains(string(res.Data), plaintextHash) {
+		t.Fatalf("Test setup invalid: response body does not contain the hash, redaction couldn't have been exercised")
+	}
+
+	assertNoLeak(t, hook.AllEntries(), plaintextHash)
+}

--- a/bin-registrar-manager/pkg/listenhandler/redact_test.go
+++ b/bin-registrar-manager/pkg/listenhandler/redact_test.go
@@ -1,0 +1,206 @@
+package listenhandler
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+)
+
+func Test_redactSensitiveJSON(t *testing.T) {
+
+	tests := []struct {
+		name string
+		data []byte
+
+		expectRes []byte
+	}{
+		{
+			name: "normal, top level password field is redacted",
+			data: []byte(`{"customer_id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","name":"ext-1000","password":"s3cr3t-plaintext"}`),
+
+			expectRes: []byte(`{"customer_id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","name":"ext-1000","password":"[REDACTED]"}`),
+		},
+		{
+			name: "sensitive keys are matched case-insensitively",
+			data: []byte(`{"Password":"a","SECRET":"b","Token":"c","credential":"d","name":"unchanged"}`),
+
+			expectRes: []byte(`{"Password":"[REDACTED]","SECRET":"[REDACTED]","Token":"[REDACTED]","credential":"[REDACTED]","name":"unchanged"}`),
+		},
+		{
+			name: "direct_hash field is redacted (extension direct-dial bearer secret)",
+			data: []byte(`{"id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","direct_id":"aaaa","direct_hash":"plaintext-direct-hash"}`),
+
+			expectRes: []byte(`{"id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","direct_id":"aaaa","direct_hash":"[REDACTED]"}`),
+		},
+		{
+			name: "nested object password field is redacted",
+			data: []byte(`{"trunk":{"username":"carrier1","password":"nested-secret"},"name":"trunk-1"}`),
+
+			expectRes: []byte(`{"name":"trunk-1","trunk":{"password":"[REDACTED]","username":"carrier1"}}`),
+		},
+		{
+			name: "password inside array elements is redacted",
+			data: []byte(`[{"password":"a"},{"password":"b","name":"keep"}]`),
+
+			expectRes: []byte(`[{"password":"[REDACTED]"},{"name":"keep","password":"[REDACTED]"}]`),
+		},
+		{
+			name: "no sensitive fields, data unchanged",
+			data: []byte(`{"customer_id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","extension":"1000"}`),
+
+			expectRes: []byte(`{"customer_id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","extension":"1000"}`),
+		},
+		{
+			name: "empty data returned as is",
+			data: []byte{},
+
+			expectRes: []byte{},
+		},
+		{
+			name: "nil data returned as is",
+			data: nil,
+
+			expectRes: nil,
+		},
+		{
+			name: "malformed json falls back to a fixed placeholder, never the raw bytes",
+			data: []byte(`{"password":"leaked-if-not-careful"`),
+
+			expectRes: []byte(`"[unparseable body redacted]"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := redactSensitiveJSON(tt.data)
+
+			if len(tt.expectRes) == 0 {
+				if len(res) != 0 {
+					t.Errorf("Wrong match. expect: empty, got: %s", res)
+				}
+				return
+			}
+
+			// compare as decoded JSON so key ordering differences don't fail the test
+			var resDecoded, expectDecoded any
+			if err := json.Unmarshal(res, &resDecoded); err != nil {
+				t.Fatalf("redactSensitiveJSON returned invalid JSON: %v, res: %s", err, res)
+			}
+			if err := json.Unmarshal(tt.expectRes, &expectDecoded); err != nil {
+				t.Fatalf("test expectation is not valid JSON: %v", err)
+			}
+
+			if !reflect.DeepEqual(expectDecoded, resDecoded) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", expectDecoded, resDecoded)
+			}
+		})
+	}
+}
+
+func Test_redactSensitiveJSON_neverLeaksPlaintextPassword(t *testing.T) {
+	data := []byte(`{"customer_id":"7c1a1c3e-1111-11ea-af75-3f1e61b9a236","name":"ext-1000","password":"MyS3cretSipPassw0rd!"}`)
+
+	res := redactSensitiveJSON(data)
+
+	if strings.Contains(string(res), "MyS3cretSipPassw0rd!") {
+		t.Errorf("Plaintext password leaked into redacted output: %s", res)
+	}
+}
+
+func Test_redactRequestForLog(t *testing.T) {
+
+	tests := []struct {
+		name string
+		m    *sock.Request
+	}{
+		{
+			name: "normal",
+			m: &sock.Request{
+				URI:    "/v1/extensions",
+				Method: sock.RequestMethodPost,
+				Data:   []byte(`{"password":"plaintext-secret"}`),
+			},
+		},
+		{
+			name: "nil request",
+			m:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := redactRequestForLog(tt.m)
+
+			if tt.m == nil {
+				if res != nil {
+					t.Errorf("Wrong match. expect: nil, got: %v", res)
+				}
+				return
+			}
+
+			if strings.Contains(string(res.Data), "plaintext-secret") {
+				t.Errorf("Plaintext password leaked into redacted request: %s", res.Data)
+			}
+			if res.URI != tt.m.URI {
+				t.Errorf("Wrong match. expect: %s, got: %s", tt.m.URI, res.URI)
+			}
+			if res.Method != tt.m.Method {
+				t.Errorf("Wrong match. expect: %s, got: %s", tt.m.Method, res.Method)
+			}
+
+			// the original request passed in by the caller must be untouched
+			if !strings.Contains(string(tt.m.Data), "plaintext-secret") {
+				t.Errorf("Original request was mutated: %s", tt.m.Data)
+			}
+		})
+	}
+}
+
+func Test_redactResponseForLog(t *testing.T) {
+
+	tests := []struct {
+		name string
+		r    *sock.Response
+	}{
+		{
+			name: "normal",
+			r: &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       []byte(`{"password":"plaintext-secret"}`),
+			},
+		},
+		{
+			name: "nil response",
+			r:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := redactResponseForLog(tt.r)
+
+			if tt.r == nil {
+				if res != nil {
+					t.Errorf("Wrong match. expect: nil, got: %v", res)
+				}
+				return
+			}
+
+			if strings.Contains(string(res.Data), "plaintext-secret") {
+				t.Errorf("Plaintext password leaked into redacted response: %s", res.Data)
+			}
+			if res.StatusCode != tt.r.StatusCode {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.r.StatusCode, res.StatusCode)
+			}
+
+			// the original response passed in by the caller must be untouched
+			if !strings.Contains(string(tt.r.Data), "plaintext-secret") {
+				t.Errorf("Original response was mutated: %s", tt.r.Data)
+			}
+		})
+	}
+}

--- a/bin-registrar-manager/pkg/listenhandler/v1_contacts.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_contacts.go
@@ -14,7 +14,7 @@ import (
 func (h *listenHandler) processV1ContactsGet(ctx context.Context, req *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ContactsGet",
-		"request": req,
+		"request": redactRequestForLog(req),
 	})
 
 	// Parse filters from request body
@@ -29,7 +29,7 @@ func (h *listenHandler) processV1ContactsGet(ctx context.Context, req *sock.Requ
 	log.WithFields(logrus.Fields{
 		"customer_id":      reqData.CustomerID,
 		"extension":        reqData.Extension,
-		"filters_raw_data": string(req.Data),
+		"filters_raw_data": string(redactSensitiveJSON(req.Data)),
 	}).Debug("processV1ContactsGet: Parsed filters from request body")
 
 	resContacts, err := h.contactHandler.ContactGetsByExtension(ctx, reqData.CustomerID, reqData.Extension)
@@ -57,7 +57,7 @@ func (h *listenHandler) processV1ContactsGet(ctx context.Context, req *sock.Requ
 func (h *listenHandler) processV1ContactsPut(ctx context.Context, req *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ContactsPut",
-		"request": req,
+		"request": redactRequestForLog(req),
 	})
 
 	// Parse filters from request body
@@ -72,7 +72,7 @@ func (h *listenHandler) processV1ContactsPut(ctx context.Context, req *sock.Requ
 	log.WithFields(logrus.Fields{
 		"customer_id":      reqData.CustomerID,
 		"extension":        reqData.Extension,
-		"filters_raw_data": string(req.Data),
+		"filters_raw_data": string(redactSensitiveJSON(req.Data)),
 	}).Debug("processV1ContactsPut: Parsed filters from request body")
 
 	if err := h.contactHandler.ContactRefreshByEndpoint(ctx, reqData.CustomerID, reqData.Extension); err != nil {

--- a/bin-registrar-manager/pkg/listenhandler/v1_count.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_count.go
@@ -22,7 +22,7 @@ type countByCustomerResponse struct {
 func (h *listenHandler) processV1ExtensionsCountByCustomerGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsCountByCustomerGet",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	var req countByCustomerRequest
@@ -54,7 +54,7 @@ func (h *listenHandler) processV1ExtensionsCountByCustomerGet(ctx context.Contex
 func (h *listenHandler) processV1TrunksCountByCustomerGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1TrunksCountByCustomerGet",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	var req countByCustomerRequest

--- a/bin-registrar-manager/pkg/listenhandler/v1_extensions.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_extensions.go
@@ -21,7 +21,7 @@ import (
 func (h *listenHandler) processV1ExtensionsPost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsPost",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	uriItems := strings.Split(m.URI, "/")
@@ -31,7 +31,7 @@ func (h *listenHandler) processV1ExtensionsPost(ctx context.Context, m *sock.Req
 
 	var req request.V1DataExtensionsPost
 	if err := json.Unmarshal([]byte(m.Data), &req); err != nil {
-		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", m.Data, err)
+		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", redactSensitiveJSON(m.Data), err)
 		return simpleResponse(400), nil
 	}
 
@@ -50,7 +50,7 @@ func (h *listenHandler) processV1ExtensionsPost(ctx context.Context, m *sock.Req
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Errorf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		log.Errorf("Could not marshal the response message. err: %v", err)
 		return simpleResponse(500), nil
 	}
 
@@ -67,7 +67,7 @@ func (h *listenHandler) processV1ExtensionsPost(ctx context.Context, m *sock.Req
 func (h *listenHandler) processV1ExtensionsIDGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsIDGet",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	u, err := url.Parse(m.URI)
@@ -104,7 +104,7 @@ func (h *listenHandler) processV1ExtensionsIDGet(ctx context.Context, m *sock.Re
 func (h *listenHandler) processV1ExtensionsIDPut(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsIDPut",
-		"Request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	u, err := url.Parse(m.URI)
@@ -118,7 +118,7 @@ func (h *listenHandler) processV1ExtensionsIDPut(ctx context.Context, m *sock.Re
 
 	var req request.V1DataExtensionsIDPut
 	if err := json.Unmarshal([]byte(m.Data), &req); err != nil {
-		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", m.Data, err)
+		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", redactSensitiveJSON(m.Data), err)
 		return simpleResponse(400), nil
 	}
 
@@ -159,7 +159,7 @@ func (h *listenHandler) processV1ExtensionsIDPut(ctx context.Context, m *sock.Re
 func (h *listenHandler) processV1ExtensionsIDDelete(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsIDDelete",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	u, err := url.Parse(m.URI)
@@ -196,7 +196,7 @@ func (h *listenHandler) processV1ExtensionsIDDelete(ctx context.Context, m *sock
 func (h *listenHandler) processV1ExtensionsGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsGet",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	u, err := url.Parse(m.URI)
@@ -248,7 +248,7 @@ func (h *listenHandler) processV1ExtensionsGet(ctx context.Context, m *sock.Requ
 func (h *listenHandler) processV1ExtensionsExtensionExtensionGet(ctx context.Context, m *sock.Request) (*sock.Response, error) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":    "processV1ExtensionsExtensionExtensionGet",
-		"request": m,
+		"request": redactRequestForLog(m),
 	})
 
 	// Parse filters from request body
@@ -271,7 +271,7 @@ func (h *listenHandler) processV1ExtensionsExtensionExtensionGet(ctx context.Con
 	log.WithFields(logrus.Fields{
 		"customer_id":      reqData.CustomerID,
 		"extension":        ext,
-		"filters_raw_data": string(m.Data),
+		"filters_raw_data": string(redactSensitiveJSON(m.Data)),
 	}).Debug("processV1ExtensionsExtensionExtensionGet: Parsed filters from request body")
 
 	tmp, err := h.extensionHandler.GetByExtension(ctx, reqData.CustomerID, ext)

--- a/bin-registrar-manager/pkg/listenhandler/v1_extensions_direct_hash.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_extensions_direct_hash.go
@@ -22,7 +22,7 @@ func (h *listenHandler) processV1ExtensionsIDDirectHashRegenerate(ctx context.Co
 		"func":         "processV1ExtensionsIDDirectHashRegenerate",
 		"extension_id": id,
 	})
-	log.WithField("request", m).Debug("Received request.")
+	log.WithField("request", redactRequestForLog(m)).Debug("Received request.")
 
 	tmp, err := h.extensionHandler.DirectHashRegenerate(ctx, id)
 	if err != nil {

--- a/bin-registrar-manager/pkg/listenhandler/v1_trunks.go
+++ b/bin-registrar-manager/pkg/listenhandler/v1_trunks.go
@@ -30,7 +30,7 @@ func (h *listenHandler) processV1TrunksPost(ctx context.Context, m *sock.Request
 
 	var req request.V1DataTrunksPost
 	if err := json.Unmarshal([]byte(m.Data), &req); err != nil {
-		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", m.Data, err)
+		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", redactSensitiveJSON(m.Data), err)
 		return simpleResponse(400), nil
 	}
 
@@ -42,7 +42,7 @@ func (h *listenHandler) processV1TrunksPost(ctx context.Context, m *sock.Request
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Errorf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		log.Errorf("Could not marshal the response message. err: %v", err)
 		return simpleResponse(500), nil
 	}
 
@@ -167,7 +167,7 @@ func (h *listenHandler) processV1TrunksIDPut(ctx context.Context, req *sock.Requ
 
 	var reqData request.V1DataTrunksIDPut
 	if err := json.Unmarshal([]byte(req.Data), &reqData); err != nil {
-		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", req.Data, err)
+		log.Debugf("Could not unmarshal the request data. data: %v, err: %v", redactSensitiveJSON(req.Data), err)
 		return simpleResponse(400), nil
 	}
 

--- a/bin-registrar-manager/pkg/redacthandler/redact.go
+++ b/bin-registrar-manager/pkg/redacthandler/redact.go
@@ -1,0 +1,58 @@
+// Package redacthandler masks credential-shaped values (password, secret,
+// token, credential, and any *_hash field) before they are attached to a
+// log line. It is the single source of truth for "which field names carry
+// a plaintext credential" across this service's transport
+// (pkg/listenhandler) and business (pkg/extensionhandler,
+// pkg/trunkhandler) layers.
+package redacthandler
+
+import "strings"
+
+// Placeholder replaces the value of any sensitive field before logging.
+const Placeholder = "[REDACTED]"
+
+// sensitiveKeys are field/JSON-key names whose values must never reach the
+// logs in plaintext (case-insensitive match).
+var sensitiveKeys = map[string]bool{
+	"password":   true,
+	"secret":     true,
+	"token":      true,
+	"credential": true,
+}
+
+// IsSensitive reports whether name (matched case-insensitively) is a known
+// credential-shaped field name: an exact match against sensitiveKeys, or a
+// name ending in "hash" (covers "hash"/"direct_hash"/any future *_hash
+// field carrying a direct-dial or similar bearer secret, without needing
+// every such field name enumerated explicitly).
+func IsSensitive(name string) bool {
+	lower := strings.ToLower(name)
+	return sensitiveKeys[lower] || strings.HasSuffix(lower, "hash")
+}
+
+// Fields returns a shallow copy of fields with the value of any sensitive
+// key (see IsSensitive) replaced with Placeholder, safe to attach to a log
+// line (e.g. logrus.Fields{"fields": redacthandler.Fields(updateFields)}).
+// The input map is left untouched.
+func Fields[K ~string, V any](fields map[K]V) map[K]any {
+	out := make(map[K]any, len(fields))
+	for k, v := range fields {
+		if IsSensitive(string(k)) {
+			out[k] = Placeholder
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// String returns Placeholder if s is non-empty, otherwise "". Use to mask a
+// single sensitive scalar (e.g. a password function argument) before
+// attaching it to a log line, while still indicating whether a value was
+// supplied.
+func String(s string) string {
+	if s == "" {
+		return ""
+	}
+	return Placeholder
+}

--- a/bin-registrar-manager/pkg/redacthandler/redact_test.go
+++ b/bin-registrar-manager/pkg/redacthandler/redact_test.go
@@ -1,0 +1,104 @@
+package redacthandler
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testField string
+
+func Test_IsSensitive(t *testing.T) {
+
+	tests := []struct {
+		name string
+		key  string
+
+		expectRes bool
+	}{
+		{"password lowercase", "password", true},
+		{"Password mixed case", "Password", true},
+		{"SECRET uppercase", "SECRET", true},
+		{"token", "token", true},
+		{"credential", "credential", true},
+		{"hash", "hash", true},
+		{"direct_hash suffix match", "direct_hash", true},
+		{"Direct_Hash mixed case", "Direct_Hash", true},
+		{"unrelated key", "customer_id", false},
+		{"unrelated key ending in ash but not hash", "trash", false},
+		{"empty key", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := IsSensitive(tt.key)
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %v, got: %v", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_Fields(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		fields map[testField]any
+
+		expectRes map[testField]any
+	}{
+		{
+			name: "password field is redacted, others untouched",
+			fields: map[testField]any{
+				testField("name"):     "ext-1000",
+				testField("password"): "plaintext-secret",
+			},
+			expectRes: map[testField]any{
+				testField("name"):     "ext-1000",
+				testField("password"): Placeholder,
+			},
+		},
+		{
+			name:      "empty map",
+			fields:    map[testField]any{},
+			expectRes: map[testField]any{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Fields(tt.fields)
+			if !reflect.DeepEqual(tt.expectRes, res) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, res)
+			}
+
+			// the original map passed in by the caller must be untouched
+			if _, ok := tt.fields[testField("password")]; ok {
+				if tt.fields[testField("password")] == Placeholder {
+					t.Errorf("Original fields map was mutated: %v", tt.fields)
+				}
+			}
+		})
+	}
+}
+
+func Test_String(t *testing.T) {
+
+	tests := []struct {
+		name string
+		s    string
+
+		expectRes string
+	}{
+		{"non-empty value is masked", "plaintext-secret", Placeholder},
+		{"empty value stays empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := String(tt.s)
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %s, got: %s", tt.expectRes, res)
+			}
+		})
+	}
+}

--- a/bin-registrar-manager/pkg/trunkhandler/event.go
+++ b/bin-registrar-manager/pkg/trunkhandler/event.go
@@ -38,7 +38,7 @@ func (h *trunkHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustome
 			log.Errorf("Could not delete trunk info. err: %v", err)
 			continue
 		}
-		log.WithField("trunk", tmp).Debugf("Deleted trunk info. trunk_id: %s", tmp.ID)
+		log.Debugf("Deleted trunk info. trunk_id: %s", tmp.ID)
 	}
 
 	return nil

--- a/bin-registrar-manager/pkg/trunkhandler/redact_regression_test.go
+++ b/bin-registrar-manager/pkg/trunkhandler/redact_regression_test.go
@@ -1,0 +1,78 @@
+package trunkhandler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/notifyhandler"
+
+	"github.com/gofrs/uuid"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-registrar-manager/models/trunk"
+	"monorepo/bin-registrar-manager/pkg/dbhandler"
+)
+
+// assertNoLeak fails the test if any captured log entry (message or any
+// field, formatted the same way logrus would emit it) contains needle. See
+// pkg/extensionhandler/redact_regression_test.go for the rationale: this
+// guards against the same class of regression VOIP-1287 review rounds
+// found in this package's Update handler.
+func assertNoLeak(t *testing.T, entries []*logrus.Entry, needle string) {
+	t.Helper()
+
+	for _, entry := range entries {
+		if strings.Contains(entry.Message, needle) {
+			t.Errorf("Secret leaked into log message: %q", entry.Message)
+		}
+		for k, v := range entry.Data {
+			if strings.Contains(fmt.Sprintf("%v", v), needle) {
+				t.Errorf("Secret leaked into log field %q: %v", k, v)
+			}
+		}
+	}
+}
+
+func Test_Update_neverLogsPlaintextPassword(t *testing.T) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	defer func() { logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks)) }()
+
+	const plaintextPassword = "trunk-S3cr3t-must-not-leak"
+
+	id := uuid.FromStringOrNil("80a7dd20-5229-11ee-bf8c-a3fb6b428056")
+	fields := map[trunk.Field]any{
+		trunk.FieldName:     "update name",
+		trunk.FieldPassword: plaintextPassword,
+	}
+	responseTrunk := &trunk.Trunk{
+		Identity: commonidentity.Identity{ID: id},
+		Password: plaintextPassword,
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDBBin := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	h := &trunkHandler{
+		db:            mockDBBin,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	mockDBBin.EXPECT().TrunkUpdate(ctx, id, fields).Return(nil)
+	mockDBBin.EXPECT().TrunkGet(ctx, id).Return(responseTrunk, nil)
+	mockDBBin.EXPECT().SIPAuthUpdate(ctx, id, gomock.Any()).Return(nil)
+	mockNotify.EXPECT().PublishEvent(ctx, trunk.EventTypeTrunkUpdated, responseTrunk)
+
+	if _, err := h.Update(ctx, id, fields); err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	assertNoLeak(t, hook.AllEntries(), plaintextPassword)
+}

--- a/bin-registrar-manager/pkg/trunkhandler/trunk.go
+++ b/bin-registrar-manager/pkg/trunkhandler/trunk.go
@@ -17,6 +17,7 @@ import (
 	"monorepo/bin-registrar-manager/models/sipauth"
 	"monorepo/bin-registrar-manager/models/trunk"
 	"monorepo/bin-registrar-manager/pkg/dbhandler"
+	"monorepo/bin-registrar-manager/pkg/redacthandler"
 )
 
 // Create creates a new trunk and returns a created trunk info
@@ -169,7 +170,7 @@ func (h *trunkHandler) Update(ctx context.Context, id uuid.UUID, fields map[trun
 	log := logrus.WithFields(logrus.Fields{
 		"func":     "Update",
 		"trunk_id": id,
-		"fields":   fields,
+		"fields":   redacthandler.Fields(fields),
 	})
 
 	// update


### PR DESCRIPTION
Mask SIP passwords and adjacent credential fields (direct-dial hash, DB/Redis/RabbitMQ connection strings) before they reach logrus output in bin-registrar-manager, closing a plaintext-credential-in-production-logs exposure reported in VOIP-1287.

- bin-registrar-manager: Add pkg/redacthandler, a shared helper that masks values under credential-shaped field names (password, secret, token, credential, and any *_hash field) before they are attached to a log line
- bin-registrar-manager: Add pkg/listenhandler/redact.go and wire it into every request/response logging call site in pkg/listenhandler (main.go, v1_extensions.go, v1_trunks.go, v1_contacts.go, v1_count.go, v1_extensions_direct_hash.go) so no raw request/response body reaches the logs
- bin-registrar-manager: Stop logging raw password/fields/direct-hash values in pkg/extensionhandler (extension.go, event.go) and pkg/trunkhandler (trunk.go, event.go)
- bin-registrar-manager: Mask database DSNs, Redis password, and RabbitMQ address in the cmd/registrar-manager startup log, previously emitted in plaintext at Info level on every process start
- bin-registrar-manager: Add regression tests across the transport, extension, and trunk layers that fail if a plaintext password or direct-hash ever reaches a logrus entry again