### PR TITLE
VOIP-1294-Fix-message-deleted-event-type

### DIFF
--- a/bin-message-manager/models/message/event.go
+++ b/bin-message-manager/models/message/event.go
@@ -4,5 +4,5 @@ package message
 const (
 	EventTypeMessageCreated string = "message_created" // the message has created
 	EventTypeMessageUpdated string = "message_updated" // the message's info has updated
-	EventTypeMessageDeleted string = "message_ringing" // the message is ringing
+	EventTypeMessageDeleted string = "message_deleted" // the message has been deleted
 )

--- a/bin-message-manager/models/message/event_test.go
+++ b/bin-message-manager/models/message/event_test.go
@@ -12,7 +12,7 @@ func TestEventTypeConstants(t *testing.T) {
 	}{
 		{"event_type_message_created", EventTypeMessageCreated, "message_created"},
 		{"event_type_message_updated", EventTypeMessageUpdated, "message_updated"},
-		{"event_type_message_deleted", EventTypeMessageDeleted, "message_ringing"},
+		{"event_type_message_deleted", EventTypeMessageDeleted, "message_deleted"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix a copy-paste bug where EventTypeMessageDeleted was defined as
"message_ringing" instead of "message_deleted", causing message-deleted
webhook events to be published with the wrong type field. The correct
value was already documented in webhook_tutorial.rst but never matched
the actual code.

- bin-message-manager: Fix EventTypeMessageDeleted constant value from "message_ringing" to "message_deleted", matching documented behavior and sibling constants (message_created, message_updated)