### PR TITLE
VOIP-1292-Fix-frozen-account-block-bypass

### DIFF
--- a/bin-api-manager/docs/auth.md
+++ b/bin-api-manager/docs/auth.md
@@ -86,6 +86,8 @@ func (h *serviceHandler) ResourceGet(ctx context.Context, a *amagent.Agent, reso
 }
 ```
 
+**Exception:** a handful of methods intentionally skip the `hasPermission` check because they are internal-only (no public HTTP route) and self-scoped (they always operate on the caller's own `a.CustomerID`, never a caller-supplied target), making a permission gate both unnecessary and counterproductive — e.g. `CustomerRawSelfGet`, used exclusively by the frozen-account auth middleware, which must be able to check ANY authenticated non-direct identity, not just permission-holding ones. Self-scoping (no target parameter) is what keeps these safe; do not add a target-ID parameter to a permission-free method.
+
 ### Permission Levels
 
 Permissions are bit flags defined in `bin-agent-manager/models/agent/`. Key levels:

--- a/bin-api-manager/lib/middleware/authenticate.go
+++ b/bin-api-manager/lib/middleware/authenticate.go
@@ -203,9 +203,12 @@ func isFrozenAccountBlocked(c *gin.Context, a *auth.AuthIdentity) bool {
 		return false
 	}
 
-	// Fetch customer to check frozen status
+	// Fetch customer to check frozen status. Uses CustomerRawSelfGet (self-scoped,
+	// no permission gate) rather than CustomerGet (requires ProjectSuperAdmin) —
+	// this check must apply to every non-direct identity, not just super admins,
+	// who are already exempted above.
 	serviceHandler := c.MustGet(modelscommon.OBJServiceHandler).(servicehandler.ServiceHandler)
-	cu, err := serviceHandler.CustomerGet(c.Request.Context(), a, a.CustomerID)
+	cu, err := serviceHandler.CustomerRawSelfGet(c.Request.Context(), a)
 	if err != nil {
 		// If we can't fetch the customer, don't block (fail open)
 		return false

--- a/bin-api-manager/lib/middleware/authenticate_test.go
+++ b/bin-api-manager/lib/middleware/authenticate_test.go
@@ -306,7 +306,7 @@ func TestAuthenticate(t *testing.T) {
 				mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 					"agent": testAgent,
 				}, nil)
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testAgent.CustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 					Status: cscustomer.StatusActive,
 				}, nil)
 			},
@@ -468,7 +468,7 @@ func TestAuthenticate_FrozenAccountEnvelope(t *testing.T) {
 	mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 		"agent": testAgent,
 	}, nil)
-	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+	mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 		Status:              cscustomer.StatusFrozen,
 		TMDeletionScheduled: &deletionTime,
 	}, nil)
@@ -569,7 +569,7 @@ func TestAuthenticateWithMalformedAgentJSON(t *testing.T) {
 		},
 	}, nil)
 	// Agent will have zero-value fields (including zero Permission), so frozen check runs
-	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), uuid.Nil).Return(&cscustomer.WebhookMessage{
+	mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 		Status: cscustomer.StatusActive,
 	}, nil)
 
@@ -737,7 +737,7 @@ func TestAuthenticateAgentStoredInContext(t *testing.T) {
 	mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 		"agent": testAgent,
 	}, nil)
-	mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testAgent.CustomerID).Return(&cscustomer.WebhookMessage{
+	mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 		Status: cscustomer.StatusActive,
 	}, nil)
 
@@ -806,7 +806,7 @@ func TestAuthenticateAccesskey(t *testing.T) {
 					CustomerID: testCustomerID,
 					Name:       "test-key",
 				}, nil)
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 					Status: cscustomer.StatusActive,
 				}, nil)
 			},
@@ -927,7 +927,7 @@ func Test_isFrozenAccountBlocked(t *testing.T) {
 			method: http.MethodGet,
 			path:   "/v1.0/agents",
 			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 					Status: cscustomer.StatusActive,
 				}, nil)
 			},
@@ -943,7 +943,47 @@ func Test_isFrozenAccountBlocked(t *testing.T) {
 			method: http.MethodGet,
 			path:   "/v1.0/agents",
 			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
+					Status:              cscustomer.StatusFrozen,
+					TMDeletionScheduled: &deletionTime,
+				}, nil)
+			},
+			expectBlock:  true,
+			expectStatus: 403,
+		},
+		{
+			// Regression coverage for VOIP-1292: previously CustomerGet's
+			// ProjectSuperAdmin permission gate made this fail-open for every
+			// non-super-admin caller regardless of identity type, so
+			// accesskey/delegate callers of a frozen customer were never
+			// blocked either.
+			name: "Frozen account - accesskey identity blocked",
+			agent: auth.NewAccesskeyIdentity(&csaccesskey.Accesskey{
+				ID:         uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001"),
+				CustomerID: testCustomerID,
+			}),
+			method: http.MethodGet,
+			path:   "/v1.0/agents",
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
+					Status:              cscustomer.StatusFrozen,
+					TMDeletionScheduled: &deletionTime,
+				}, nil)
+			},
+			expectBlock:  true,
+			expectStatus: 403,
+		},
+		{
+			name: "Frozen account - delegate identity blocked",
+			agent: auth.NewDelegateIdentity(&auth.DelegateScope{
+				CustomerID: testCustomerID,
+				IssuedBy:   uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+				JTI:        "some-jti",
+			}),
+			method: http.MethodGet,
+			path:   "/v1.0/agents",
+			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 					Status:              cscustomer.StatusFrozen,
 					TMDeletionScheduled: &deletionTime,
 				}, nil)
@@ -1002,7 +1042,7 @@ func Test_isFrozenAccountBlocked(t *testing.T) {
 			expectStatus: 200,
 		},
 		{
-			name: "CustomerGet error - fail open (not blocked)",
+			name: "CustomerRawSelfGet error - fail open (not blocked)",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity:   commonidentity.Identity{CustomerID: testCustomerID},
 				Permission: amagent.PermissionCustomerAdmin,
@@ -1010,7 +1050,7 @@ func Test_isFrozenAccountBlocked(t *testing.T) {
 			method: http.MethodGet,
 			path:   "/v1.0/agents",
 			mockSetup: func(mockSH *servicehandler.MockServiceHandler) {
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(nil, fmt.Errorf("service unavailable"))
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("service unavailable"))
 			},
 			expectBlock:  false,
 			expectStatus: 200,
@@ -1086,7 +1126,7 @@ func TestAuthenticateFrozenAccount(t *testing.T) {
 				mockSH.EXPECT().AuthJWTParse(gomock.Any(), "validToken").Return(map[string]interface{}{
 					"agent": testAgent,
 				}, nil)
-				mockSH.EXPECT().CustomerGet(gomock.Any(), gomock.Any(), testCustomerID).Return(&cscustomer.WebhookMessage{
+				mockSH.EXPECT().CustomerRawSelfGet(gomock.Any(), gomock.Any()).Return(&cscustomer.WebhookMessage{
 					Status:              cscustomer.StatusFrozen,
 					TMDeletionScheduled: &deletionTime,
 				}, nil)

--- a/bin-api-manager/pkg/servicehandler/customer.go
+++ b/bin-api-manager/pkg/servicehandler/customer.go
@@ -189,6 +189,28 @@ func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *auth.AuthIdenti
 	return res, nil
 }
 
+// CustomerRawSelfGet returns the authenticated identity's own customer record
+// (via ConvertWebhookMessage, which includes Status and TMDeletionScheduled)
+// without requiring any permission beyond being a non-direct authenticated
+// identity. Self-scoped only — always fetches by the caller's own
+// a.CustomerID, never an arbitrary target, so it cannot be used to inspect
+// another customer's status. Intended solely for the frozen-account auth
+// middleware, which must be able to check ANY authenticated caller (agent,
+// accesskey, or delegate — not just super admins or CustomerAdmin/Manager
+// holders, unlike CustomerSelfGet).
+func (h *serviceHandler) CustomerRawSelfGet(ctx context.Context, a *auth.AuthIdentity) (*cscustomer.WebhookMessage, error) {
+	if a.IsDirect() {
+		return nil, serviceerrors.ErrDirectAccessNotSupported
+	}
+
+	tmp, err := h.customerGet(ctx, a.CustomerID)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmp.ConvertWebhookMessage(), nil
+}
+
 // CustomerGets returns list of all customers
 func (h *serviceHandler) CustomerList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, filters map[string]string) ([]*cscustomer.WebhookMessage, error) {
 	log := logrus.WithFields(logrus.Fields{

--- a/bin-api-manager/pkg/servicehandler/customer_test.go
+++ b/bin-api-manager/pkg/servicehandler/customer_test.go
@@ -17,6 +17,8 @@ import (
 
 	amagent "monorepo/bin-agent-manager/models/agent"
 	"monorepo/bin-api-manager/models/auth"
+	"monorepo/bin-api-manager/pkg/serviceerrors"
+	csaccesskey "monorepo/bin-customer-manager/models/accesskey"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/mock/gomock"
@@ -435,6 +437,137 @@ func Test_CustomerSelfGet(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
 			}
 		})
+	}
+}
+
+func Test_CustomerRawSelfGet(t *testing.T) {
+	tests := []struct {
+		name string
+
+		agent *auth.AuthIdentity
+
+		responseCustomer *cscustomer.Customer
+		expectRes        *cscustomer.WebhookMessage
+	}{
+		{
+			name: "agent identity, no elevated permission required",
+
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				},
+				// Deliberately no permission bits set at all — this method
+				// must work for the lowest-privilege agent, since it exists
+				// specifically to let the frozen-account middleware check
+				// every non-direct caller, not just super admins.
+				Permission: amagent.Permission(0),
+			}),
+
+			responseCustomer: &cscustomer.Customer{
+				ID:            uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				Status:        cscustomer.StatusFrozen,
+				WebhookSecret: "test-webhook-secret",
+			},
+			expectRes: &cscustomer.WebhookMessage{
+				ID:     uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				Status: cscustomer.StatusFrozen,
+			},
+		},
+		{
+			name: "accesskey identity",
+
+			agent: auth.NewAccesskeyIdentity(&csaccesskey.Accesskey{
+				ID:         uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000001"),
+				CustomerID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+			}),
+
+			responseCustomer: &cscustomer.Customer{
+				ID:     uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				Status: cscustomer.StatusActive,
+			},
+			expectRes: &cscustomer.WebhookMessage{
+				ID:     uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				Status: cscustomer.StatusActive,
+			},
+		},
+		{
+			name: "delegate identity",
+
+			agent: auth.NewDelegateIdentity(&auth.DelegateScope{
+				CustomerID: uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				IssuedBy:   uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+				JTI:        "some-jti",
+			}),
+
+			responseCustomer: &cscustomer.Customer{
+				ID:     uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				Status: cscustomer.StatusFrozen,
+			},
+			expectRes: &cscustomer.WebhookMessage{
+				ID:     uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+				Status: cscustomer.StatusFrozen,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+
+			h := serviceHandler{
+				reqHandler: mockReq,
+				dbHandler:  mockDB,
+			}
+
+			ctx := context.Background()
+
+			// Must always fetch by the caller's own CustomerID — never an
+			// arbitrary target — so this method cannot become a
+			// confused-deputy vector for inspecting another customer.
+			mockReq.EXPECT().CustomerV1CustomerGet(ctx, tt.agent.CustomerID).Return(tt.responseCustomer, nil)
+
+			res, err := h.CustomerRawSelfGet(ctx, tt.agent)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expectRes) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+func Test_CustomerRawSelfGet_DirectNotSupported(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+
+	h := serviceHandler{
+		reqHandler: mockReq,
+		dbHandler:  mockDB,
+	}
+
+	agent := auth.NewDirectIdentity(&auth.DirectScope{
+		CustomerID:   uuid.FromStringOrNil("a0f4b592-837e-11ec-9f5f-2f2051d4adac"),
+		ResourceType: "aicall",
+		ResourceID:   uuid.FromStringOrNil("a1b2c3d4-0000-0000-0000-000000000000"),
+	})
+
+	// No mockReq.EXPECT() — must reject before ever calling the backend.
+	res, err := h.CustomerRawSelfGet(context.Background(), agent)
+	if err != serviceerrors.ErrDirectAccessNotSupported {
+		t.Errorf("Wrong match. expect: %v, got: %v", serviceerrors.ErrDirectAccessNotSupported, err)
+	}
+	if res != nil {
+		t.Errorf("Wrong match. expect: nil, got: %v", res)
 	}
 }
 

--- a/bin-api-manager/pkg/servicehandler/main.go
+++ b/bin-api-manager/pkg/servicehandler/main.go
@@ -611,6 +611,7 @@ type ServiceHandler interface {
 	) (*cscustomer.WebhookMessage, error)
 	CustomerGet(ctx context.Context, a *auth.AuthIdentity, customerID uuid.UUID) (*cscustomer.WebhookMessage, error)
 	CustomerSelfGet(ctx context.Context, a *auth.AuthIdentity) (*cscustomer.SelfWebhookMessage, error)
+	CustomerRawSelfGet(ctx context.Context, a *auth.AuthIdentity) (*cscustomer.WebhookMessage, error)
 	CustomerList(ctx context.Context, a *auth.AuthIdentity, size uint64, token string, filters map[string]string) ([]*cscustomer.WebhookMessage, error)
 	CustomerUpdate(
 		ctx context.Context,

--- a/bin-api-manager/pkg/servicehandler/mock_main.go
+++ b/bin-api-manager/pkg/servicehandler/mock_main.go
@@ -2594,6 +2594,21 @@ func (mr *MockServiceHandlerMockRecorder) CustomerList(ctx, a, size, token, filt
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerList", reflect.TypeOf((*MockServiceHandler)(nil).CustomerList), ctx, a, size, token, filters)
 }
 
+// CustomerRawSelfGet mocks base method.
+func (m *MockServiceHandler) CustomerRawSelfGet(ctx context.Context, a *auth.AuthIdentity) (*customer.WebhookMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CustomerRawSelfGet", ctx, a)
+	ret0, _ := ret[0].(*customer.WebhookMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CustomerRawSelfGet indicates an expected call of CustomerRawSelfGet.
+func (mr *MockServiceHandlerMockRecorder) CustomerRawSelfGet(ctx, a any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomerRawSelfGet", reflect.TypeOf((*MockServiceHandler)(nil).CustomerRawSelfGet), ctx, a)
+}
+
 // CustomerRecover mocks base method.
 func (m *MockServiceHandler) CustomerRecover(ctx context.Context, a *auth.AuthIdentity, customerID uuid.UUID) (*customer.WebhookMessage, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Add self-scoped CustomerRawSelfGet and switch the frozen-account
middleware to use it instead of the ProjectSuperAdmin-gated
CustomerGet, which made the frozen-account block a no-op for every
non-super-admin caller.

- bin-api-manager: Add CustomerRawSelfGet to ServiceHandler, a self-scoped, permission-free customer lookup for the auth middleware
- bin-api-manager: Switch isFrozenAccountBlocked to call CustomerRawSelfGet instead of the ProjectSuperAdmin-gated CustomerGet
- bin-api-manager: Regenerate MockServiceHandler for the new interface method
- bin-api-manager: Update existing frozen-account middleware tests and add coverage for accesskey/delegate identities, which were also silently unblocked by the bug
- bin-api-manager: Add unit tests for CustomerRawSelfGet (self-scoping, zero-permission access, direct-identity rejection)
- bin-api-manager: Document the permission-free internal method exception in docs/auth.md