### PR TITLE
NOJIRA-Conversation-manager-email-outbound-broker

### DIFF
--- a/bin-conversation-manager/docs/architecture.md
+++ b/bin-conversation-manager/docs/architecture.md
@@ -62,6 +62,9 @@ SubscribeHandler (`pkg/subscribehandler/`) consumes:
 | Queue | Event | Action |
 |-------|-------|--------|
 | `bin-manager.message-manager.event` | `message_created` | Create or update conversation record; create incoming message; publish conversation/message events |
+| `bin-manager.email-manager.event` | `email_created` | Record the sent email as an outgoing conversation message (status=progressing); one message per destination, keyed by a composite `email.ID + peer` transaction ID |
+| `bin-manager.email-manager.event` | `email_updated` | Reconcile the matching outgoing message's status from email-manager's own provider-webhook-driven lifecycle (`delivered`/`open`/`click`/`unsubscribe`/`spamreport` -> done; `bounce`/`dropped` -> failed); non-terminal statuses and already-terminal messages are no-ops |
+| `bin-manager.webchat-manager.event` | `webchat_message_created` | Mirror the webchat-manager message onto the conversation (mirrors the message-manager pattern; unmarshaled inside `conversationHandler.Event`) |
 
 ## Events Published
 

--- a/bin-conversation-manager/pkg/conversationhandler/email.go
+++ b/bin-conversation-manager/pkg/conversationhandler/email.go
@@ -18,11 +18,11 @@ import (
 
 // EmailEventSent records a sent email as an outgoing conversation message.
 //
-// Outbound-only: the email-manager email_created event fires before the
-// provider send is attempted, so the conversation message is recorded at
-// status=progressing and is never updated afterward (the conversation message
-// is an immutable send-time fact log, mirroring the SMS absorption path; the
-// service does not subscribe to email_updated/email_deleted).
+// The email-manager email_created event fires before the provider send is
+// attempted, so the conversation message is recorded at status=progressing.
+// That status is later reconciled by EmailEventUpdated, which follows
+// email-manager's own email_updated event rather than guessing an outcome
+// here -- see the package doc on EmailEventUpdated.
 //
 // One email may have multiple destinations; each destination yields its own
 // (self, peer) conversation and its own outgoing message. Idempotency is keyed
@@ -117,4 +117,88 @@ func (h *conversationHandler) EmailEventSent(ctx context.Context, e *emmemail.Em
 	}
 
 	return firstErr
+}
+
+// EmailEventUpdated reconciles an outgoing conversation message's status
+// with an email-manager status change.
+//
+// conversation-manager is a broker for email: it does not infer delivery
+// outcomes on its own (e.g. by assuming success once the send RPC returns).
+// It only reflects the status email-manager itself reports via its
+// provider-webhook-driven lifecycle (initiated -> processed -> delivered/
+// open/click, or -> bounce/dropped/deferred/unsubscribe/spamreport; see
+// bin-email-manager/docs/domain.md "Email Status Lifecycle"). Non-terminal
+// statuses (e.g. processed, deferred) are no-ops here; the message stays at
+// status=progressing until a terminal outcome is reported.
+func (h *conversationHandler) EmailEventUpdated(ctx context.Context, e *emmemail.Email) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":     "EmailEventUpdated",
+		"email_id": e.ID,
+	})
+
+	newStatus, ok := emailStatusToMessageStatus(e.Status)
+	if !ok {
+		// Non-terminal provider status (e.g. initiated, processed, deferred).
+		// Nothing to reconcile yet.
+		return nil
+	}
+
+	var firstErr error
+	for _, destination := range e.Destinations {
+		normalizedPeer, _ := commonaddress.NormalizeTarget(destination.Type, destination.Target)
+		txID := e.ID.String() + ":" + normalizedPeer
+
+		existing, errGet := h.db.MessageGetsByTransactionID(ctx, txID, "", 1)
+		if errGet != nil {
+			log.Errorf("Could not find the message for the email destination. transaction_id: %s, err: %v", txID, errGet)
+			if firstErr == nil {
+				firstErr = errors.Wrapf(errGet, "could not find the message. transaction_id: %s", txID)
+			}
+			continue
+		}
+		if len(existing) == 0 {
+			// The message has not been materialized yet by EmailEventSent
+			// (event ordering race), or it never was. Nothing to update.
+			log.Debugf("No message found for this email destination yet. Skipping. transaction_id: %s", txID)
+			continue
+		}
+
+		if existing[0].Status == message.StatusDone || existing[0].Status == message.StatusFailed {
+			// Already at a terminal status. Provider webhooks are not
+			// guaranteed to arrive in order (e.g. a delayed "delivered" can
+			// land after an earlier "bounce" already marked this failed);
+			// once terminal, further reconciliation is a no-op rather than
+			// letting a stale/out-of-order webhook flip the outcome.
+			continue
+		}
+
+		if _, errUpd := h.messageHandler.UpdateStatus(ctx, existing[0].ID, newStatus); errUpd != nil {
+			log.Errorf("Could not update the message status. message_id: %s, err: %v", existing[0].ID, errUpd)
+			if firstErr == nil {
+				firstErr = errors.Wrapf(errUpd, "could not update the message status. message_id: %s", existing[0].ID)
+			}
+			continue
+		}
+	}
+
+	return firstErr
+}
+
+// emailStatusToMessageStatus maps an email-manager provider-webhook status
+// onto conversation-manager's 3-state message status. It returns ok=false
+// for statuses that are not a terminal outcome, so the caller can leave the
+// message untouched rather than guess.
+func emailStatusToMessageStatus(status emmemail.Status) (message.Status, bool) {
+	switch status {
+	case emmemail.StatusDelivered, emmemail.StatusOpen, emmemail.StatusClick, emmemail.StatusUnsubscribe, emmemail.StatusSpamreport:
+		return message.StatusDone, true
+
+	case emmemail.StatusBounce, emmemail.StatusDropped:
+		return message.StatusFailed, true
+
+	default:
+		// StatusNone, StatusInitiated, StatusProcessed, StatusDeffered, or an
+		// unrecognized provider status: none are a terminal outcome.
+		return "", false
+	}
 }

--- a/bin-conversation-manager/pkg/conversationhandler/email_test.go
+++ b/bin-conversation-manager/pkg/conversationhandler/email_test.go
@@ -303,3 +303,261 @@ func Test_EmailEventSent_nilSource(t *testing.T) {
 		t.Errorf("Wrong match. expect: ok, got: %v", err)
 	}
 }
+
+func Test_EmailEventUpdated(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		email *emmemail.Email
+
+		expectStatus message.Status
+	}{
+		{
+			name: "delivered maps to done",
+
+			email: &emmemail.Email{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("66666666-6666-6666-6666-666666666666"),
+				},
+				Status: emmemail.StatusDelivered,
+				Destinations: []commonaddress.Address{
+					{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+				},
+			},
+
+			expectStatus: message.StatusDone,
+		},
+		{
+			name: "bounce maps to failed",
+
+			email: &emmemail.Email{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("77777777-7777-7777-7777-777777777777"),
+				},
+				Status: emmemail.Status("bounce"),
+				Destinations: []commonaddress.Address{
+					{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+				},
+			},
+
+			expectStatus: message.StatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockMessage := messagehandler.NewMockMessageHandler(mc)
+			h := &conversationHandler{
+				db:             mockDB,
+				messageHandler: mockMessage,
+			}
+
+			ctx := context.Background()
+
+			normalizedPeer, _ := commonaddress.NormalizeTarget(tt.email.Destinations[0].Type, tt.email.Destinations[0].Target)
+			txID := tt.email.ID.String() + ":" + normalizedPeer
+			existing := &message.Message{
+				Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("f0000000-0000-0000-0000-000000000001")},
+				Status:   message.StatusProgressing,
+			}
+
+			mockDB.EXPECT().
+				MessageGetsByTransactionID(ctx, txID, "", uint64(1)).
+				Return([]*message.Message{existing}, nil)
+
+			mockMessage.EXPECT().UpdateStatus(ctx, existing.ID, tt.expectStatus).Return(existing, nil)
+
+			if err := h.EmailEventUpdated(ctx, tt.email); err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+		})
+	}
+}
+
+func Test_EmailEventUpdated_nonTerminalIsNoop(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	// "processed" is a non-terminal status: no DB or message-handler calls
+	// expected at all (mc.Finish asserts this).
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("88888888-8888-8888-8888-888888888888"),
+		},
+		Status: emmemail.Status("processed"),
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+		},
+	}
+
+	if err := h.EmailEventUpdated(ctx, e); err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+}
+
+func Test_EmailEventUpdated_messageNotYetMaterialized(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("99999999-9999-9999-9999-999999999999"),
+		},
+		Status: emmemail.StatusDelivered,
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+		},
+	}
+
+	normalizedPeer, _ := commonaddress.NormalizeTarget(e.Destinations[0].Type, e.Destinations[0].Target)
+	txID := e.ID.String() + ":" + normalizedPeer
+
+	// Raced ahead of EmailEventSent: no message exists yet. UpdateStatus must
+	// NOT be called (mc.Finish asserts this).
+	mockDB.EXPECT().MessageGetsByTransactionID(ctx, txID, "", uint64(1)).Return([]*message.Message{}, nil)
+
+	if err := h.EmailEventUpdated(ctx, e); err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+}
+
+func Test_EmailEventUpdated_alreadyReconciledIsNoop(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("aaaaaaab-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+		},
+		Status: emmemail.StatusDelivered,
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+		},
+	}
+
+	normalizedPeer, _ := commonaddress.NormalizeTarget(e.Destinations[0].Type, e.Destinations[0].Target)
+	txID := e.ID.String() + ":" + normalizedPeer
+	existing := &message.Message{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("f0000000-0000-0000-0000-000000000002")},
+		Status:   message.StatusDone,
+	}
+
+	// Already at the target status (duplicate/replayed webhook): UpdateStatus
+	// must NOT be called (mc.Finish asserts this).
+	mockDB.EXPECT().MessageGetsByTransactionID(ctx, txID, "", uint64(1)).Return([]*message.Message{existing}, nil)
+
+	if err := h.EmailEventUpdated(ctx, e); err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+}
+
+func Test_EmailEventUpdated_terminalStatusIsNotDowngraded(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	// A "delivered" webhook arriving after the message was already marked
+	// failed (e.g. an earlier "bounce" landed first, or webhooks arrived
+	// out of order). The already-terminal status must not be overwritten:
+	// UpdateStatus must NOT be called (mc.Finish asserts this).
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+		},
+		Status: emmemail.StatusDelivered,
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+		},
+	}
+
+	normalizedPeer, _ := commonaddress.NormalizeTarget(e.Destinations[0].Type, e.Destinations[0].Target)
+	txID := e.ID.String() + ":" + normalizedPeer
+	existing := &message.Message{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("f0000000-0000-0000-0000-000000000003")},
+		Status:   message.StatusFailed,
+	}
+
+	mockDB.EXPECT().MessageGetsByTransactionID(ctx, txID, "", uint64(1)).Return([]*message.Message{existing}, nil)
+
+	if err := h.EmailEventUpdated(ctx, e); err != nil {
+		t.Errorf("Wrong match. expect: ok, got: %v", err)
+	}
+}
+
+func Test_EmailEventUpdated_updateStatusErrorIsAccumulated(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMessage := messagehandler.NewMockMessageHandler(mc)
+	h := &conversationHandler{
+		db:             mockDB,
+		messageHandler: mockMessage,
+	}
+
+	ctx := context.Background()
+
+	e := &emmemail.Email{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+		},
+		Status: emmemail.StatusDelivered,
+		Destinations: []commonaddress.Address{
+			{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+		},
+	}
+
+	normalizedPeer, _ := commonaddress.NormalizeTarget(e.Destinations[0].Type, e.Destinations[0].Target)
+	txID := e.ID.String() + ":" + normalizedPeer
+	existing := &message.Message{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("f0000000-0000-0000-0000-000000000004")},
+		Status:   message.StatusProgressing,
+	}
+
+	mockDB.EXPECT().MessageGetsByTransactionID(ctx, txID, "", uint64(1)).Return([]*message.Message{existing}, nil)
+	mockMessage.EXPECT().UpdateStatus(ctx, existing.ID, message.StatusDone).Return(nil, fmt.Errorf("boom"))
+
+	if err := h.EmailEventUpdated(ctx, e); err == nil {
+		t.Errorf("Wrong match. expect: error, got: nil")
+	}
+}

--- a/bin-conversation-manager/pkg/conversationhandler/main.go
+++ b/bin-conversation-manager/pkg/conversationhandler/main.go
@@ -89,6 +89,7 @@ type ConversationHandler interface {
 	HookVerify(ctx context.Context, uri string, mode string, verifyToken string, challenge string) (string, error)
 	Event(ctx context.Context, conversationType conversation.Type, data []byte) error
 	EmailEventSent(ctx context.Context, e *emmemail.Email) error
+	EmailEventUpdated(ctx context.Context, e *emmemail.Email) error
 
 	MessageSend(ctx context.Context, conversationID uuid.UUID, text string, medias []media.Media) (*message.Message, error)
 }

--- a/bin-conversation-manager/pkg/conversationhandler/mock_conversationhandler.go
+++ b/bin-conversation-manager/pkg/conversationhandler/mock_conversationhandler.go
@@ -90,6 +90,20 @@ func (mr *MockConversationHandlerMockRecorder) EmailEventSent(ctx, e any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmailEventSent", reflect.TypeOf((*MockConversationHandler)(nil).EmailEventSent), ctx, e)
 }
 
+// EmailEventUpdated mocks base method.
+func (m *MockConversationHandler) EmailEventUpdated(ctx context.Context, e *email.Email) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EmailEventUpdated", ctx, e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EmailEventUpdated indicates an expected call of EmailEventUpdated.
+func (mr *MockConversationHandlerMockRecorder) EmailEventUpdated(ctx, e any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmailEventUpdated", reflect.TypeOf((*MockConversationHandler)(nil).EmailEventUpdated), ctx, e)
+}
+
 // Event mocks base method.
 func (m *MockConversationHandler) Event(ctx context.Context, conversationType conversation.Type, data []byte) error {
 	m.ctrl.T.Helper()

--- a/bin-conversation-manager/pkg/messagehandler/send.go
+++ b/bin-conversation-manager/pkg/messagehandler/send.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	commonaddress "monorepo/bin-common-handler/models/address"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -38,6 +41,9 @@ func (h *messageHandler) Send(ctx context.Context, cv *conversation.Conversation
 
 	case conversation.TypeWebchat:
 		return h.sendWebchat(ctx, cv, text)
+
+	case conversation.TypeEmail:
+		return h.sendEmail(ctx, cv, text)
 
 	default:
 		log.Errorf("Unsupported reference type. reference_type: %s", cv.Type)
@@ -209,6 +215,63 @@ func (h *messageHandler) sendWebchat(ctx context.Context, cv *conversation.Conve
 	}
 
 	return res, nil
+}
+
+// sendEmail sends the message via bin-email-manager, the sole owner of email
+// delivery, provider selection, and account credentials.
+//
+// conversation-manager is a broker for email, not a source of truth: it does
+// not create or persist the outgoing message itself here. The durable
+// conversation message is created asynchronously by
+// conversationHandler.EmailEventSent when it receives email-manager's
+// email_created event for this send, and its status is later reconciled by
+// EmailEventUpdated from email-manager's email_updated event (see
+// pkg/conversationhandler/email.go). The *message.Message returned here is a
+// non-persisted projection for the immediate caller; the durable row that
+// eventually lands in the conversation carries its own DB-assigned ID.
+//
+// Because that DB-assigned ID does not exist yet, the projection's ID is set
+// to the email's own ID (also carried in ReferenceID) rather than left as
+// the zero UUID: callers (e.g. bin-api-manager's send response) must not see
+// a "00000000-...-0000" id. This is a synthetic stand-in, not the eventual
+// message row's primary key -- look the message up via the conversation's
+// message list (or the shared TransactionID) once EmailEventSent has
+// materialized it, not by re-fetching this ID.
+func (h *messageHandler) sendEmail(ctx context.Context, cv *conversation.Conversation, text string) (*message.Message, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":         "sendEmail",
+		"conversation": cv,
+		"text":         text,
+	})
+
+	source, destination := DeriveEndpoints(cv, message.DirectionOutgoing)
+
+	res, err := h.reqHandler.EmailV1EmailSend(ctx, cv.CustomerID, uuid.Nil, []commonaddress.Address{destination}, "", text, nil)
+	if err != nil {
+		log.Errorf("Could not send the email. err: %v", err)
+		return nil, err
+	}
+
+	// Same composite key EmailEventSent/EmailEventUpdated use to correlate the
+	// eventually-materialized conversation message to this email.
+	normalizedPeer, _ := commonaddress.NormalizeTarget(destination.Type, destination.Target)
+	txID := res.ID.String() + ":" + normalizedPeer
+
+	return &message.Message{
+		Identity: commonidentity.Identity{
+			ID:         res.ID,
+			CustomerID: cv.CustomerID,
+		},
+		ConversationID: cv.ID,
+		Direction:      message.DirectionOutgoing,
+		Status:         message.StatusProgressing,
+		ReferenceType:  message.ReferenceTypeEmail,
+		ReferenceID:    res.ID,
+		TransactionID:  txID,
+		Text:           text,
+		Source:         source,
+		Destination:    destination,
+	}, nil
 }
 
 // sendLine sends the message to the line type of conversation.

--- a/bin-conversation-manager/pkg/messagehandler/send_test.go
+++ b/bin-conversation-manager/pkg/messagehandler/send_test.go
@@ -2,6 +2,7 @@ package messagehandler
 
 import (
 	"context"
+	"errors"
 	reflect "reflect"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 	"monorepo/bin-conversation-manager/pkg/smshandler"
 	"monorepo/bin-conversation-manager/pkg/whatsapphandler"
 
+	ememail "monorepo/bin-email-manager/models/email"
 	wcmessage "monorepo/bin-webchat-manager/models/message"
 )
 
@@ -238,6 +240,140 @@ func Test_Send_sendWebchat(t *testing.T) {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.expectMessage, res)
 			}
 		})
+	}
+}
+
+func Test_Send_sendEmail(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		conversation *conversation.Conversation
+		text         string
+
+		responseEmail *ememail.Email
+	}{
+		{
+			name: "email type",
+
+			conversation: &conversation.Conversation{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("e1a9c2d0-1234-11f0-aaaa-aaaaaaaaaaaa"),
+					CustomerID: uuid.FromStringOrNil("e2b0c3d1-1234-11f0-bbbb-bbbbbbbbbbbb"),
+				},
+				Type: conversation.TypeEmail,
+				Self: commonaddress.Address{
+					Type:   commonaddress.TypeEmail,
+					Target: "sender@voipbin.net",
+				},
+				Peer: commonaddress.Address{
+					Type:   commonaddress.TypeEmail,
+					Target: "customer@example.com",
+				},
+			},
+			text: "Hello from voipbin!",
+
+			responseEmail: &ememail.Email{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("e4e2f5a3-1234-11f0-dddd-dddddddddddd"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &messageHandler{
+				utilHandler:   mockUtil,
+				db:            mockDB,
+				notifyHandler: mockNotify,
+				reqHandler:    mockReq,
+			}
+			ctx := context.Background()
+
+			// sendEmail delegates the send to email-manager and does not touch
+			// the DB itself -- no MessageCreate/MessageGet call is expected
+			// here (mc.Finish asserts this). The durable message is created
+			// asynchronously by conversationHandler.EmailEventSent.
+			mockReq.EXPECT().EmailV1EmailSend(
+				ctx,
+				tt.conversation.CustomerID,
+				uuid.Nil,
+				[]commonaddress.Address{tt.conversation.Peer},
+				"",
+				tt.text,
+				nil,
+			).Return(tt.responseEmail, nil)
+
+			normalizedPeer, _ := commonaddress.NormalizeTarget(tt.conversation.Peer.Type, tt.conversation.Peer.Target)
+			expectMessage := &message.Message{
+				Identity: commonidentity.Identity{
+					ID:         tt.responseEmail.ID,
+					CustomerID: tt.conversation.CustomerID,
+				},
+				ConversationID: tt.conversation.ID,
+				Direction:      message.DirectionOutgoing,
+				Status:         message.StatusProgressing,
+				ReferenceType:  message.ReferenceTypeEmail,
+				ReferenceID:    tt.responseEmail.ID,
+				TransactionID:  tt.responseEmail.ID.String() + ":" + normalizedPeer,
+				Text:           tt.text,
+				Source:         tt.conversation.Self,
+				Destination:    tt.conversation.Peer,
+			}
+
+			res, err := h.Send(ctx, tt.conversation, tt.text, nil)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if !reflect.DeepEqual(res, expectMessage) {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", expectMessage, res)
+			}
+		})
+	}
+}
+
+func Test_Send_sendEmail_sendError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &messageHandler{
+		utilHandler:   mockUtil,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+		reqHandler:    mockReq,
+	}
+	ctx := context.Background()
+
+	cv := &conversation.Conversation{
+		Identity: commonidentity.Identity{
+			ID:         uuid.FromStringOrNil("e1a9c2d0-1234-11f0-aaaa-aaaaaaaaaaaa"),
+			CustomerID: uuid.FromStringOrNil("e2b0c3d1-1234-11f0-bbbb-bbbbbbbbbbbb"),
+		},
+		Type: conversation.TypeEmail,
+		Self: commonaddress.Address{Type: commonaddress.TypeEmail, Target: "sender@voipbin.net"},
+		Peer: commonaddress.Address{Type: commonaddress.TypeEmail, Target: "customer@example.com"},
+	}
+
+	mockReq.EXPECT().EmailV1EmailSend(
+		ctx, cv.CustomerID, uuid.Nil, []commonaddress.Address{cv.Peer}, "", "hi", nil,
+	).Return(nil, errors.New("boom"))
+
+	res, err := h.Send(ctx, cv, "hi", nil)
+	if err == nil {
+		t.Errorf("Wrong match. expect: error, got: nil, res: %v", res)
 	}
 }
 

--- a/bin-conversation-manager/pkg/subscribehandler/emailmanager.go
+++ b/bin-conversation-manager/pkg/subscribehandler/emailmanager.go
@@ -32,3 +32,27 @@ func (h *subscribeHandler) processEventEmailEmailCreated(ctx context.Context, m 
 
 	return nil
 }
+
+// processEventEmailEmailUpdated handles the email-manager's email_updated event.
+//
+// Reconciles the matching outgoing conversation message's status with
+// email-manager's own provider-webhook-driven status.
+func (h *subscribeHandler) processEventEmailEmailUpdated(ctx context.Context, m *sock.Event) error {
+	log := logrus.WithFields(logrus.Fields{
+		"func":  "processEventEmailEmailUpdated",
+		"event": m,
+	})
+
+	e := &emmemail.Email{}
+	if err := json.Unmarshal([]byte(m.Data), e); err != nil {
+		log.Errorf("Could not unmarshal the data. err: %v", err)
+		return err
+	}
+
+	if errEvent := h.conversationHandler.EmailEventUpdated(ctx, e); errEvent != nil {
+		log.Errorf("Could not handle the event correctly. err: %v", errEvent)
+		return errEvent
+	}
+
+	return nil
+}

--- a/bin-conversation-manager/pkg/subscribehandler/main.go
+++ b/bin-conversation-manager/pkg/subscribehandler/main.go
@@ -148,6 +148,9 @@ func (h *subscribeHandler) processEvent(m *sock.Event) {
 	case m.Publisher == publisherEmailManager && (m.Type == emmemail.EventTypeCreated):
 		err = h.processEventEmailEmailCreated(ctx, m)
 
+	case m.Publisher == publisherEmailManager && (m.Type == emmemail.EventTypeUpdated):
+		err = h.processEventEmailEmailUpdated(ctx, m)
+
 	// webchat-manager
 	case m.Publisher == publisherWebchatManager && (m.Type == wmmessage.EventTypeMessageCreated):
 		err = h.processEventWebchatMessageMessageCreated(ctx, m)


### PR DESCRIPTION
Add outbound email support to conversation-manager's unified message send path, brokering delivery to email-manager the same way SMS/LINE/WhatsApp/Webchat already delegate to their owning services. Reconcile message status from email-manager's own delivery lifecycle instead of guessing locally.

- bin-conversation-manager: Add TypeEmail case and sendEmail() to messagehandler.Send, delegating to email-manager's existing EmailV1EmailSend RPC without creating or persisting a local message row (the durable row is created asynchronously by the existing EmailEventSent email_created subscriber)
- bin-conversation-manager: Add EmailEventUpdated to reconcile an outgoing message's status from email-manager's email_updated event, mapping its provider-webhook-driven lifecycle (delivered/open/click/unsubscribe/spamreport -> done, bounce/dropped -> failed) with a monotonicity guard against out-of-order webhooks
- bin-conversation-manager: Wire email_updated event routing in subscribehandler
- bin-conversation-manager: Update docs/architecture.md event subscriptions table (email_created, email_updated, webchat_message_created)