### PR TITLE
VOIP-1291-Redact-customer-accesskey-secrets-from-debug-logs

### DIFF
--- a/bin-agent-manager/pkg/agenthandler/event.go
+++ b/bin-agent-manager/pkg/agenthandler/event.go
@@ -104,8 +104,8 @@ func (h *agentHandler) EventGroupcallProgressing(ctx context.Context, c *cmgroup
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *agentHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all agents in customer. customer_id: %s", cu.ID)
 
@@ -137,8 +137,8 @@ func (h *agentHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.
 // EventCustomerCreated handles the customer-manager's customer_created event
 func (h *agentHandler) EventCustomerCreated(ctx context.Context, cu *cmcustomer.Customer, headless bool) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerCreated",
-		"customer": cu,
+		"func":        "EventCustomerCreated",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Creating basic customer admin agent for new customer. customer_id: %s", cu.ID)
 

--- a/bin-api-manager/pkg/servicehandler/accesskeys.go
+++ b/bin-api-manager/pkg/servicehandler/accesskeys.go
@@ -62,7 +62,7 @@ func (h *serviceHandler) AccesskeyCreate(ctx context.Context, a *auth.AuthIdenti
 		log.Errorf("Could not create activeflow. erR: %v", err)
 		return nil, err
 	}
-	log.WithField("accesskey", tmp).Debugf("Created accesskey. accesskey_id: %s", tmp.ID)
+	log.WithField("accesskey_id", tmp.ID).Debugf("Created accesskey. accesskey_id: %s", tmp.ID)
 
 	res := tmp.ConvertWebhookMessage()
 	return res, nil

--- a/bin-api-manager/pkg/servicehandler/billingaccount.go
+++ b/bin-api-manager/pkg/servicehandler/billingaccount.go
@@ -206,7 +206,7 @@ func (h *serviceHandler) BillingAccountSelfGet(ctx context.Context, a *auth.Auth
 		log.Errorf("Could not get the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Info("Customer has no billing account.")
@@ -244,7 +244,7 @@ func (h *serviceHandler) BillingAccountSelfUpdateBasicInfo(ctx context.Context, 
 		log.Errorf("Could not get the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Info("Customer has no billing account.")
@@ -281,7 +281,7 @@ func (h *serviceHandler) BillingAccountSelfUpdatePaymentInfo(ctx context.Context
 		log.Errorf("Could not get the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Info("Customer has no billing account.")
@@ -319,7 +319,7 @@ func (h *serviceHandler) BillingAccountSelfCreatePaddlePortalSession(ctx context
 		log.Infof("Could not get customer info. err: %v", err)
 		return "", fmt.Errorf("%w: could not get customer info", serviceerrors.ErrInternal)
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.BillingAccountID == uuid.Nil {
 		log.Infof("Customer has no billing account. customer_id: %s", c.ID)

--- a/bin-api-manager/pkg/servicehandler/boot.go
+++ b/bin-api-manager/pkg/servicehandler/boot.go
@@ -103,7 +103,7 @@ func (h *serviceHandler) AuthBoot(ctx context.Context, directHash string) (*Boot
 		log.Infof("Could not get customer. err: %v", err)
 		return nil, fmt.Errorf("%w: customer not found", serviceerrors.ErrNotFound)
 	}
-	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
+	log.WithField("customer_id", cu.ID).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 
 	if cu.Status != cscustomer.StatusActive {
 		log.Infof("Customer is not active. status: %s", cu.Status)

--- a/bin-api-manager/pkg/servicehandler/call.go
+++ b/bin-api-manager/pkg/servicehandler/call.go
@@ -77,7 +77,7 @@ func (h *serviceHandler) CallCreate(ctx context.Context, a *auth.AuthIdentity, f
 			log.Errorf("Could not get customer info for verification check. err: %v", err)
 			return nil, nil, fmt.Errorf("%w: could not verify customer identity status", serviceerrors.ErrInternal)
 		}
-		log.WithField("customer", cu).Debugf("Retrieved customer info for verification check. customer_id: %s", cu.ID)
+		log.WithField("customer_id", cu.ID).Debugf("Retrieved customer info for verification check. customer_id: %s", cu.ID)
 
 		if cu.IdentityVerificationStatus != cscustomer.IdentityVerificationStatusVerified {
 			log.Infof("Customer identity verification required for PSTN calls. customer_id: %s, status: %s", a.CustomerID, cu.IdentityVerificationStatus)

--- a/bin-api-manager/pkg/servicehandler/customer.go
+++ b/bin-api-manager/pkg/servicehandler/customer.go
@@ -30,7 +30,7 @@ func (h *serviceHandler) customerGet(ctx context.Context, customerID uuid.UUID) 
 		log.Errorf("Could not get the customer. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", res).Debug("Received result.")
+	log.WithField("customer_id", res.ID).Debug("Received result.")
 
 	return res, nil
 }
@@ -155,7 +155,7 @@ func (h *serviceHandler) CustomerGet(ctx context.Context, a *auth.AuthIdentity, 
 		log.Errorf("Could not get the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", tmp).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
+	log.WithField("customer_id", tmp.ID).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
 
 	return tmp.ConvertWebhookMessage(), nil
 }
@@ -183,7 +183,7 @@ func (h *serviceHandler) CustomerSelfGet(ctx context.Context, a *auth.AuthIdenti
 		log.Errorf("Could not get the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", tmp).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
+	log.WithField("customer_id", tmp.ID).Debugf("Retrieved customer info. customer_id: %s", tmp.ID)
 
 	res := tmp.ConvertWebhookMessageSelf()
 	return res, nil
@@ -301,7 +301,7 @@ func (h *serviceHandler) CustomerUpdate(
 		log.Errorf("Could not validate the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	// send request
 	res, err := h.reqHandler.CustomerV1CustomerUpdate(ctx, id, name, detail, email, phoneNumber, address, webhookMethod, webhookURI)
@@ -617,7 +617,7 @@ func (h *serviceHandler) CustomerUpdateMetadata(ctx context.Context, a *auth.Aut
 		log.Errorf("Could not validate the customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	res, err := h.reqHandler.CustomerV1CustomerUpdateMetadata(ctx, customerID, metadata)
 	if err != nil {
@@ -688,7 +688,7 @@ func (h *serviceHandler) CustomerSelfUpdateMetadata(ctx context.Context, a *auth
 		log.Errorf("Could not update the customer's metadata. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", res).Debugf("Updated customer metadata. customer_id: %s", res.ID)
+	log.WithField("customer_id", res.ID).Debugf("Updated customer metadata. customer_id: %s", res.ID)
 
 	return res.ConvertWebhookMessage(), nil
 }

--- a/bin-api-manager/pkg/servicehandler/numbers.go
+++ b/bin-api-manager/pkg/servicehandler/numbers.go
@@ -124,7 +124,7 @@ func (h *serviceHandler) NumberCreate(ctx context.Context, a *auth.AuthIdentity,
 			log.Errorf("Could not get customer info for verification check. err: %v", err)
 			return nil, fmt.Errorf("%w: could not verify customer identity status", serviceerrors.ErrInternal)
 		}
-		log.WithField("customer", cu).Debugf("Retrieved customer info for verification check. customer_id: %s", cu.ID)
+		log.WithField("customer_id", cu.ID).Debugf("Retrieved customer info for verification check. customer_id: %s", cu.ID)
 
 		if cu.IdentityVerificationStatus != cscustomer.IdentityVerificationStatusVerified {
 			log.Infof("Customer identity verification required for number purchase. customer_id: %s, status: %s", a.CustomerID, cu.IdentityVerificationStatus)

--- a/bin-billing-manager/pkg/accounthandler/event.go
+++ b/bin-billing-manager/pkg/accounthandler/event.go
@@ -13,8 +13,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *accountHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all accounts of the customer. customer_id: %s", cu.ID)
 
@@ -46,8 +46,8 @@ func (h *accountHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucusto
 // EventCUCustomerCreated handles the customer-manager's customer_created event
 func (h *accountHandler) EventCUCustomerCreated(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerCreated",
-		"customer": cu,
+		"func":        "EventCUCustomerCreated",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Creatinga a new billing account for new customer. customer_id: %s", cu.ID)
 
@@ -69,7 +69,7 @@ func (h *accountHandler) EventCUCustomerCreated(ctx context.Context, cu *cucusto
 		log.Errorf("Could not update customer's billing account id. err: %v", err)
 		return errors.Wrap(err, "could not update customer's billing account id")
 	}
-	log.WithField("customer", tmp).Debugf("Updated customer's billing account id. customer_id: %s, billing_account_id: %s", tmp.ID, tmp.BillingAccountID)
+	log.WithField("customer_id", tmp.ID).Debugf("Updated customer's billing account id. customer_id: %s, billing_account_id: %s", tmp.ID, tmp.BillingAccountID)
 
 	// set default plan type for new account
 	if _, errPlan := h.dbUpdatePlanType(ctx, b.ID, account.PlanTypeFree); errPlan != nil {
@@ -96,8 +96,8 @@ func (h *accountHandler) EventCUCustomerCreated(ctx context.Context, cu *cucusto
 // EventCUCustomerFrozen handles the customer-manager's customer_frozen event
 func (h *accountHandler) EventCUCustomerFrozen(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerFrozen",
-		"customer": cu,
+		"func":        "EventCUCustomerFrozen",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Freezing all accounts of the customer. customer_id: %s", cu.ID)
 
@@ -126,8 +126,8 @@ func (h *accountHandler) EventCUCustomerFrozen(ctx context.Context, cu *cucustom
 // EventCUCustomerRecovered handles the customer-manager's customer_recovered event
 func (h *accountHandler) EventCUCustomerRecovered(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerRecovered",
-		"customer": cu,
+		"func":        "EventCUCustomerRecovered",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Recovering frozen accounts of the customer. customer_id: %s", cu.ID)
 

--- a/bin-call-manager/pkg/callhandler/event.go
+++ b/bin-call-manager/pkg/callhandler/event.go
@@ -16,8 +16,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *callHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all calls of the customer. customer_id: %s", cu.ID)
 
@@ -102,8 +102,8 @@ func (h *callHandler) EventSMPodDeleted(ctx context.Context, p *smpod.Pod) error
 // EventCUCustomerFrozen handles the customer-manager's customer_frozen event
 func (h *callHandler) EventCUCustomerFrozen(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerFrozen",
-		"customer": cu,
+		"func":        "EventCUCustomerFrozen",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Hanging up all calls for frozen customer. customer_id: %s", cu.ID)
 

--- a/bin-call-manager/pkg/callhandler/outgoing_call.go
+++ b/bin-call-manager/pkg/callhandler/outgoing_call.go
@@ -154,7 +154,7 @@ func (h *callHandler) CreateCallOutgoing(
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get customer info")
 	}
-	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
+	log.WithField("customer_id", cu.ID).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 
 	// embed rtp_debug in call metadata at creation time so status.go doesn't need to re-fetch the customer.
 	// guard: if rtp_debug is already set (e.g. forced by providercallhandler), preserve it even when

--- a/bin-call-manager/pkg/callhandler/start.go
+++ b/bin-call-manager/pkg/callhandler/start.go
@@ -575,7 +575,7 @@ func (h *callHandler) startCallTypeFlow(ctx context.Context, cn *channel.Channel
 		_, _ = h.channelHandler.HangingUp(ctx, cn.ID, ari.ChannelCauseNetworkOutOfOrder)
 		return
 	}
-	log.WithField("customer", cs).Debugf("Retrieved customer info. customer_id: %s", customerID)
+	log.WithField("customer_id", customerID).Debugf("Retrieved customer info. customer_id: %s", customerID)
 
 	// validate balance
 	if validBalance := h.ValidateCustomerBalance(ctx, id, customerID, call.DirectionIncoming, *source, *destination); !validBalance {

--- a/bin-call-manager/pkg/callhandler/validate.go
+++ b/bin-call-manager/pkg/callhandler/validate.go
@@ -34,7 +34,7 @@ func (h *callHandler) ValidateCustomerStatusOutgoing(ctx context.Context, custom
 		log.Errorf("Could not get customer info, failing open. err: %v", err)
 		return nil, true
 	}
-	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
+	log.WithField("customer_id", cu.ID).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 
 	if cu.Status != cucustomer.StatusActive {
 		log.Infof("Customer account is not active. Rejecting outgoing call. status: %s", cu.Status)
@@ -61,7 +61,7 @@ func (h *callHandler) ValidateCustomerStatusIncoming(ctx context.Context, custom
 		log.Errorf("Could not get customer info, failing open. err: %v", err)
 		return nil, true
 	}
-	log.WithField("customer", cu).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
+	log.WithField("customer_id", cu.ID).Debugf("Retrieved customer info. customer_id: %s", cu.ID)
 
 	if cu.Status != cucustomer.StatusActive && cu.Status != cucustomer.StatusInitial {
 		log.Infof("Customer account is not active or initial. Rejecting incoming call. status: %s", cu.Status)

--- a/bin-call-manager/pkg/confbridgehandler/event.go
+++ b/bin-call-manager/pkg/confbridgehandler/event.go
@@ -12,8 +12,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *confbridgeHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all calls of the customer. customer_id: %s", cu.ID)
 

--- a/bin-call-manager/pkg/groupcallhandler/event.go
+++ b/bin-call-manager/pkg/groupcallhandler/event.go
@@ -13,8 +13,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *groupcallHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all groupcalls of the customer. customer_id: %s", cu.ID)
 

--- a/bin-customer-manager/pkg/customerhandler/db.go
+++ b/bin-customer-manager/pkg/customerhandler/db.go
@@ -258,7 +258,7 @@ func (h *customerHandler) UpdateMetadata(ctx context.Context, id uuid.UUID, meta
 		log.Errorf("Could not get updated customer. err: %v", err)
 		return nil, fmt.Errorf("could not get updated customer")
 	}
-	log.WithField("customer", res).Debugf("Retrieved updated customer info. customer_id: %s", res.ID)
+	log.WithField("customer_id", res.ID).Debugf("Retrieved updated customer info. customer_id: %s", res.ID)
 
 	// notify
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerUpdated, res)

--- a/bin-customer-manager/pkg/customerhandler/identity_verification.go
+++ b/bin-customer-manager/pkg/customerhandler/identity_verification.go
@@ -28,7 +28,7 @@ func (h *customerHandler) UpdateIdentityVerificationStatus(ctx context.Context, 
 		log.Errorf("Could not get customer info. err: %v", err)
 		return nil, err
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithFields(logrus.Fields{"customer_id": c.ID, "identity_verification_status": c.IdentityVerificationStatus}).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.IdentityVerificationStatus == status {
 		log.Infof("Customer already has status %s. customer_id: %s", status, id)
@@ -48,7 +48,7 @@ func (h *customerHandler) UpdateIdentityVerificationStatus(ctx context.Context, 
 		log.Errorf("Could not get updated customer. err: %v", err)
 		return nil, fmt.Errorf("could not get updated customer")
 	}
-	log.WithField("customer", res).Debugf("Retrieved updated customer info. customer_id: %s", res.ID)
+	log.WithFields(logrus.Fields{"customer_id": res.ID, "identity_verification_status": res.IdentityVerificationStatus}).Debugf("Retrieved updated customer info. customer_id: %s", res.ID)
 
 	h.notifyHandler.PublishEvent(ctx, customer.EventTypeCustomerIdentityVerificationUpdated, res)
 

--- a/bin-customer-manager/pkg/customerhandler/signup.go
+++ b/bin-customer-manager/pkg/customerhandler/signup.go
@@ -92,7 +92,7 @@ func (h *customerHandler) Signup(
 		metricshandler.SignupTotal.WithLabelValues("error").Inc()
 		return nil, err
 	}
-	log.WithField("customer", res).Debugf("Created unverified customer. customer_id: %s", res.ID)
+	log.WithField("customer_id", res.ID).Debugf("Created unverified customer. customer_id: %s", res.ID)
 
 	// Create AccessKey at signup time so headless clients can authenticate immediately
 	ak, err := h.accesskeyHandler.Create(ctx, id, "default", "Auto-provisioned API key", defaultAccesskeyExpire)
@@ -101,7 +101,7 @@ func (h *customerHandler) Signup(
 		metricshandler.SignupTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("could not create access key")
 	}
-	log.WithField("accesskey", ak).Debugf("Created access key. accesskey_id: %s", ak.ID)
+	log.WithField("accesskey_id", ak.ID).Debugf("Created access key. accesskey_id: %s", ak.ID)
 
 	// Publish customer_created event with headless=true at signup time.
 	// This triggers downstream resource creation (billing, agent, storage).
@@ -161,7 +161,7 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 		metricshandler.EmailVerificationTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("customer not found")
 	}
-	log.WithField("customer", c).Debugf("Retrieved customer info. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Retrieved customer info. customer_id: %s", c.ID)
 
 	if c.EmailVerified {
 		log.Infof("Customer already verified. customer_id: %s", c.ID)
@@ -195,7 +195,7 @@ func (h *customerHandler) EmailVerify(ctx context.Context, token string) (*custo
 		metricshandler.EmailVerificationTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("could not get verified customer")
 	}
-	log.WithField("customer", updated).Debugf("Customer verified. customer_id: %s", updated.ID)
+	log.WithField("customer_id", updated.ID).Debugf("Customer verified. customer_id: %s", updated.ID)
 
 	// Send password reset email so browser users can set their admin password.
 	// Non-fatal — customer is verified even if this fails.

--- a/bin-customer-manager/pkg/listenhandler/v1_accesskeys.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_accesskeys.go
@@ -101,10 +101,13 @@ func (h *listenHandler) processV1AccesskeysPost(ctx context.Context, m *sock.Req
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("accesskey_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	// Do not log the marshaled response body here: unlike every other accesskey
+	// endpoint, tmp.RawToken is populated on create (the one-time plaintext token
+	// return), and it has no json:"-" tag since the API response must carry it.
+	log.WithField("accesskey_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,

--- a/bin-flow-manager/pkg/activeflowhandler/event.go
+++ b/bin-flow-manager/pkg/activeflowhandler/event.go
@@ -34,8 +34,8 @@ func (h *activeflowHandler) EventCallHangup(ctx context.Context, c *cmcall.Call)
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *activeflowHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Stopping all activeflows of customer. customer_id: %s", cu.ID)
 

--- a/bin-flow-manager/pkg/flowhandler/event.go
+++ b/bin-flow-manager/pkg/flowhandler/event.go
@@ -13,8 +13,8 @@ import (
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *flowHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all flows of customer. customer_id: %s", cu.ID)
 

--- a/bin-number-manager/pkg/numberhandler/event.go
+++ b/bin-number-manager/pkg/numberhandler/event.go
@@ -16,8 +16,8 @@ import (
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *numberHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 
 	// get all numbers of the given customer

--- a/bin-number-manager/pkg/subscribehandler/customer_manager.go
+++ b/bin-number-manager/pkg/subscribehandler/customer_manager.go
@@ -24,7 +24,7 @@ func (h *subscribeHandler) processEventCUCustomerDeleted(ctx context.Context, m 
 		return err
 	}
 
-	log.WithField("customer", c).Debugf("Received customer deleted event. customer_id: %s", c.ID)
+	log.WithField("customer_id", c.ID).Debugf("Received customer deleted event. customer_id: %s", c.ID)
 	if errRemove := h.numberHandler.EventCustomerDeleted(ctx, c); errRemove != nil {
 		log.Errorf("Could not handle the customer deleted event. err: %v", errRemove)
 		return errors.Wrap(errRemove, "Could not handle the customer deleted event.")

--- a/bin-queue-manager/pkg/queuecallhandler/event.go
+++ b/bin-queue-manager/pkg/queuecallhandler/event.go
@@ -98,8 +98,8 @@ func (h *queuecallHandler) EventCallConfbridgeLeaved(ctx context.Context, refere
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *queuecallHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all queues in customer. customer_id: %s", cu.ID)
 

--- a/bin-queue-manager/pkg/queuehandler/event.go
+++ b/bin-queue-manager/pkg/queuehandler/event.go
@@ -14,8 +14,8 @@ import (
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *queueHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all queues in customer. customer_id: %s", cu.ID)
 

--- a/bin-registrar-manager/pkg/extensionhandler/event.go
+++ b/bin-registrar-manager/pkg/extensionhandler/event.go
@@ -14,8 +14,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *extensionHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all extension of the customer. customer_id: %s", cu.ID)
 

--- a/bin-registrar-manager/pkg/trunkhandler/event.go
+++ b/bin-registrar-manager/pkg/trunkhandler/event.go
@@ -14,8 +14,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *trunkHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all trunks of the customer. customer_id: %s", cu.ID)
 

--- a/bin-schedule-manager/pkg/schedulehandler/customer.go
+++ b/bin-schedule-manager/pkg/schedulehandler/customer.go
@@ -21,14 +21,14 @@ const eventListLimit = 1000
 // Nil-customer platform schedules are never touched (design §6): a nil
 // customer id in the event is refused instead of matching the platform rows.
 func (h *scheduleHandler) EventCustomerDeleted(ctx context.Context, c *cmcustomer.Customer) error {
-	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": c,
-	})
-
 	if c == nil || c.ID == uuid.Nil {
 		return errors.New("customer id is empty — refusing to delete nil-customer platform schedules")
 	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func":        "EventCustomerDeleted",
+		"customer_id": c.ID,
+	})
 
 	filters := map[schedule.Field]any{
 		schedule.FieldCustomerID: c.ID,

--- a/bin-storage-manager/pkg/accounthandler/event.go
+++ b/bin-storage-manager/pkg/accounthandler/event.go
@@ -12,8 +12,8 @@ import (
 // EventCustomerCreated handles the customer-manager's customer_created event
 func (h *accountHandler) EventCustomerCreated(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerCreated",
-		"customer": cu,
+		"func":        "EventCustomerCreated",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Creating a new account for customer. customer_id: %s", cu.ID)
 
@@ -30,8 +30,8 @@ func (h *accountHandler) EventCustomerCreated(ctx context.Context, cu *cmcustome
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *accountHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting customer's all files. customer_id: %s", cu.ID)
 

--- a/bin-storage-manager/pkg/filehandler/event.go
+++ b/bin-storage-manager/pkg/filehandler/event.go
@@ -13,8 +13,8 @@ import (
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *fileHandler) EventCustomerDeleted(ctx context.Context, cu *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting customer's all files. customer_id: %s", cu.ID)
 

--- a/bin-tag-manager/pkg/taghandler/event.go
+++ b/bin-tag-manager/pkg/taghandler/event.go
@@ -13,8 +13,8 @@ import (
 // EventCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *tagHandler) EventCustomerDeleted(ctx context.Context, c *cmcustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCustomerDeleted",
-		"customer": c,
+		"func":        "EventCustomerDeleted",
+		"customer_id": c.ID,
 	})
 
 	// build filters for the customer's tags

--- a/bin-transcribe-manager/pkg/transcribehandler/event.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/event.go
@@ -17,8 +17,8 @@ import (
 // EventCUCustomerDeleted handles the customer-manager's customer_deleted event
 func (h *transcribeHandler) EventCUCustomerDeleted(ctx context.Context, cu *cucustomer.Customer) error {
 	log := logrus.WithFields(logrus.Fields{
-		"func":     "EventCUCustomerDeleted",
-		"customer": cu,
+		"func":        "EventCUCustomerDeleted",
+		"customer_id": cu.ID,
 	})
 	log.Debugf("Deleting all transcribes of the customer. customer_id: %s", cu.ID)
 


### PR DESCRIPTION
Stop internal Customer/Accesskey structs (and their WebhookSecret/RawToken fields) from being serialized into DEBUG logs via the joonix Stackdriver JSON formatter, which does a plain field marshal with no redaction. Replaces full-struct log fields with ID-only logging across 13 services. Scope grew across review rounds from an initial 21-site sample (bin-api-manager/bin-customer-manager) to a verified-complete sweep once two more leak-pattern classes were found: 6 more anchored-pattern sites in other services, and 23 sites where the struct is bound into a base logrus.WithFields() context logger (leaking on every subsequent log call, not just one DEBUG line, in 14 more services).

- bin-api-manager: Replace WithField("customer"/"accesskey", <struct>) with ID-only fields in customer.go, numbers.go, call.go, billingaccount.go, boot.go, accesskeys.go (14 sites)
- bin-customer-manager: Same in db.go, signup.go (7 sites, incl. the accesskey creation site); identity_verification.go additionally logs identity_verification_status for debugging value. Also stop processV1AccesskeysPost from logging the marshaled response body, which uniquely carries the plaintext RawToken on the create path
- bin-billing-manager: Fix accounthandler/event.go (5 sites total, 1 direct WithField + 4 base-context-logger sites across the EventCU* customer lifecycle handlers)
- bin-call-manager: Fix callhandler/{outgoing_call,start,validate}.go (4 sites) and callhandler/event.go, confbridgehandler/event.go, groupcallhandler/event.go (3 base-context-logger sites)
- bin-number-manager: Fix subscribehandler/customer_manager.go and numberhandler/event.go
- bin-agent-manager, bin-flow-manager, bin-queue-manager, bin-registrar-manager, bin-storage-manager, bin-tag-manager, bin-transcribe-manager: Fix the base-context-logger WithFields(logrus.Fields{"customer": cu, ...}) pattern in each service's customer-event handler (16 sites total)
- bin-schedule-manager: Fix the same base-context-logger pattern in schedulehandler/customer.go, and reorder its existing nil-customer guard to run before the logger construction (the mechanical fix would otherwise dereference a nil customer pointer — caught by the service's own Test_EventCustomerDeleted_nilCustomer test)

Deferred to a follow-up ticket, not in this PR's scope: 17 sibling "Sending result: %v" sites in bin-customer-manager's listenhandler package that marshal-and-log full Customer responses (carrying WebhookSecret) on non-create endpoints.

Verification: full 5-step workflow (go mod tidy/vendor/generate/test/lint) run and passing in all 13 touched services. Two classes of unrelated local tool-version drift (oapi-codegen gen.go regeneration in bin-api-manager, mockgen parameter-name anonymization in several mock_main.go files) were encountered during go generate and reverted as out of scope.