### PR TITLE
VOIP-1304-Redact-marshaled-response-body-from-debug-logs

### DIFF
--- a/bin-customer-manager/pkg/listenhandler/v1_accesskeys.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_accesskeys.go
@@ -58,10 +58,10 @@ func (h *listenHandler) processV1AccesskeysGet(ctx context.Context, m *sock.Requ
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		log.WithField("count", len(tmp)).Debugf("Could not marshal the response message. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("count", len(tmp)).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -140,10 +140,10 @@ func (h *listenHandler) processV1AccesskeysIDGet(ctx context.Context, m *sock.Re
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("accesskey_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("accesskey_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -175,10 +175,10 @@ func (h *listenHandler) processV1AccesskeysIDDelete(ctx context.Context, m *sock
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("accesskey_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("accesskey_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -222,10 +222,10 @@ func (h *listenHandler) processV1AccesskeysIDPut(ctx context.Context, m *sock.Re
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("accesskey_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("accesskey_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,

--- a/bin-customer-manager/pkg/listenhandler/v1_customers.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers.go
@@ -58,10 +58,10 @@ func (h *listenHandler) processV1CustomersGet(ctx context.Context, m *sock.Reque
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		log.WithField("count", len(tmp)).Debugf("Could not marshal the response message. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("count", len(tmp)).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -104,10 +104,10 @@ func (h *listenHandler) processV1CustomersPost(ctx context.Context, m *sock.Requ
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -138,10 +138,10 @@ func (h *listenHandler) processV1CustomersCleanupUnverifiedPost(ctx context.Cont
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		log.WithField("expired", expired).Debugf("Could not marshal the response message. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("expired", expired).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -172,10 +172,10 @@ func (h *listenHandler) processV1CustomersCleanupFrozenExpiredPost(ctx context.C
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the response message. message: %v, err: %v", tmp, err)
+		log.WithField("processed", processed).Debugf("Could not marshal the response message. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("processed", processed).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -209,10 +209,10 @@ func (h *listenHandler) processV1CustomersIDGet(ctx context.Context, m *sock.Req
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -246,10 +246,10 @@ func (h *listenHandler) processV1CustomersIDDelete(ctx context.Context, m *sock.
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -301,10 +301,10 @@ func (h *listenHandler) processV1CustomersIDPut(ctx context.Context, m *sock.Req
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -343,10 +343,10 @@ func (h *listenHandler) processV1CustomersIDBillingAccountIDPut(ctx context.Cont
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -385,10 +385,10 @@ func (h *listenHandler) processV1CustomersIDMetadataPut(ctx context.Context, m *
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,

--- a/bin-customer-manager/pkg/listenhandler/v1_customers_freeze.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers_freeze.go
@@ -33,10 +33,10 @@ func (h *listenHandler) processV1CustomersIDFreezePost(ctx context.Context, m *s
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -69,10 +69,10 @@ func (h *listenHandler) processV1CustomersIDFreezeAndDeletePost(ctx context.Cont
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -105,10 +105,10 @@ func (h *listenHandler) processV1CustomersIDRecoverPost(ctx context.Context, m *
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,

--- a/bin-customer-manager/pkg/listenhandler/v1_customers_signup.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers_signup.go
@@ -41,12 +41,17 @@ func (h *listenHandler) processV1CustomersSignupPost(ctx context.Context, m *soc
 		return simpleResponse(400), nil
 	}
 
+	// Signup creates both a customer and an accesskey; log both created resources'
+	// IDs, consistent with other creation endpoints. Neither Customer.WebhookSecret
+	// nor the freshly-issued Accesskey.RawToken (present in tmp) is logged.
+	resultLog := log.WithFields(logrus.Fields{"customer_id": tmp.Customer.ID, "accesskey_id": tmp.Accesskey.ID})
+
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		resultLog.Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	resultLog.Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,
@@ -79,10 +84,10 @@ func (h *listenHandler) processV1CustomersEmailVerifyPost(ctx context.Context, m
 
 	data, err := json.Marshal(tmp)
 	if err != nil {
-		log.Debugf("Could not marshal the result data. data: %v, err: %v", tmp, err)
+		log.WithField("customer_id", tmp.Customer.ID).Debugf("Could not marshal the result data. err: %v", err)
 		return simpleResponse(500), nil
 	}
-	log.Debugf("Sending result: %v", data)
+	log.WithField("customer_id", tmp.Customer.ID).Debug("Sending result.")
 
 	res := &sock.Response{
 		StatusCode: 200,

--- a/bin-customer-manager/pkg/listenhandler/v1_customers_signup_test.go
+++ b/bin-customer-manager/pkg/listenhandler/v1_customers_signup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 
+	"monorepo/bin-customer-manager/models/accesskey"
 	"monorepo/bin-customer-manager/models/customer"
 	"monorepo/bin-customer-manager/pkg/customerhandler"
 )
@@ -34,6 +35,9 @@ func Test_processV1CustomersSignupPost(t *testing.T) {
 				Data:     []byte(`{"name":"test signup","detail":"signup detail","email":"signup@voipbin.net","phone_number":"+821100000001","address":"somewhere","webhook_method":"POST","webhook_uri":"test.com","client_ip":"10.0.0.1"}`),
 			},
 
+			// Signup always returns a populated Accesskey in production (customerHandler.Signup
+			// auto-provisions one via accesskeyHandler.Create before returning) -- this fixture
+			// mirrors that invariant so it also exercises the tmp.Accesskey.ID logging path.
 			responseSignupResult: &customer.SignupResult{
 				Customer: &customer.Customer{
 					ID:            uuid.FromStringOrNil("e1e2e3e4-0000-0000-0000-000000000001"),
@@ -45,11 +49,17 @@ func Test_processV1CustomersSignupPost(t *testing.T) {
 					WebhookMethod: "POST",
 					WebhookURI:    "test.com",
 				},
+				Accesskey: &accesskey.Accesskey{
+					ID:         uuid.FromStringOrNil("a1a2a3a4-0000-0000-0000-000000000001"),
+					CustomerID: uuid.FromStringOrNil("e1e2e3e4-0000-0000-0000-000000000001"),
+					Name:       "default",
+					Detail:     "Auto-provisioned API key",
+				},
 			},
 			expectRes: &sock.Response{
 				StatusCode: 200,
 				DataType:   "application/json",
-				Data:       []byte(`{"customer":{"id":"e1e2e3e4-0000-0000-0000-000000000001","name":"test signup","detail":"signup detail","email":"signup@voipbin.net","phone_number":"+821100000001","address":"somewhere","webhook_method":"POST","webhook_uri":"test.com","billing_account_id":"00000000-0000-0000-0000-000000000000","email_verified":false,"status":"","identity_verification_status":"","metadata":{"rtp_debug":false},"tm_deletion_scheduled":null,"tm_create":null,"tm_update":null,"tm_delete":null}}`),
+				Data:       []byte(`{"customer":{"id":"e1e2e3e4-0000-0000-0000-000000000001","name":"test signup","detail":"signup detail","email":"signup@voipbin.net","phone_number":"+821100000001","address":"somewhere","webhook_method":"POST","webhook_uri":"test.com","billing_account_id":"00000000-0000-0000-0000-000000000000","email_verified":false,"status":"","identity_verification_status":"","metadata":{"rtp_debug":false},"tm_deletion_scheduled":null,"tm_create":null,"tm_update":null,"tm_delete":null},"accesskey":{"id":"a1a2a3a4-0000-0000-0000-000000000001","customer_id":"e1e2e3e4-0000-0000-0000-000000000001","name":"default","detail":"Auto-provisioned API key","token_prefix":"","tm_expire":null,"tm_create":null,"tm_update":null,"tm_delete":null}}`),
 			},
 		},
 	}


### PR DESCRIPTION
Stop bin-customer-manager/pkg/listenhandler from logging full marshaled RPC response bodies at DEBUG level, which leaked Customer.WebhookSecret (reusable HMAC signing secret) and, on the Signup endpoint specifically, a freshly-issued Accesskey.RawToken (one-time plaintext bearer token) alongside it. Follow-up to VOIP-1291/PR #1171, which fixed a different logging pattern (WithField("customer"/"accesskey", <struct>)) in the same package but left this one (json.Marshal(tmp); log.Debugf("Sending result: %v", data)) unaddressed.

- bin-customer-manager: Fix 18 sites across v1_customers.go (9), v1_customers_signup.go (2), v1_customers_freeze.go (3), and v1_accesskeys.go (4) -- both the marshal-error-path log (which also referenced the full struct/data) and the success-path log now emit only an ID (or count for List endpoints, or the pre-existing expired/processed int for the two cleanup endpoints that never carried a secret to begin with). Signup logs both customer_id and accesskey_id since it provisions both resources. Of the 18 sites, 12 were genuine secret leaks (7 in v1_customers.go, 3 in v1_customers_freeze.go, 2 in v1_customers_signup.go); the other 6 (customer cleanup endpoints, accesskey List/Get/Delete/Put) carried no live secret but shared the same log-the-marshaled-body anti-pattern.
- bin-customer-manager: Fix a pre-existing test-fixture bug found during implementation -- Test_processV1CustomersSignupPost's mock left SignupResult.Accesskey nil, which the old code never touched but the new tmp.Accesskey.ID logging dereferences. Production's customerHandler.Signup always auto-provisions an accesskey, so the fixture now reflects that invariant with a realistic Accesskey and a correspondingly updated expected response JSON.

The accesskey creation endpoint (processV1AccesskeysPost) was already fixed in VOIP-1291 and is untouched here.

Verification: full 5-step workflow (go mod tidy/vendor/generate/test/lint) passing in bin-customer-manager. Confirmed the actual API response body (sock.Response.Data) is byte-identical to before this change in every touched function -- only the debug-log statements were modified.