### PR TITLE
VOIP-1307-Add-required-field-validation

### DIFF
--- a/bin-api-manager/server/agents.go
+++ b/bin-api-manager/server/agents.go
@@ -111,6 +111,14 @@ func (h *server) PostAgents(c *gin.Context) {
 			addresses = append(addresses, ConvertCommonAddress(v))
 		}
 	}
+	// OpenAPI marks addresses as required, but BindJSON doesn't enforce
+	// presence on a slice field. Guard explicitly so the spec's contract
+	// is actually honored.
+	if len(addresses) == 0 {
+		log.Error("addresses is required and must not be empty.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "addresses is required and must not be empty."))
+		return
+	}
 
 	res, err := h.serviceHandler.AgentCreate(c.Request.Context(), a, req.Username, req.Password, req.Name, req.Detail, amagent.RingMethod(req.RingMethod), amagent.Permission(req.Permission), tagIDs, addresses)
 	if err != nil {

--- a/bin-api-manager/server/agents_test.go
+++ b/bin-api-manager/server/agents_test.go
@@ -38,7 +38,10 @@ func Test_PostAgents(t *testing.T) {
 		expectedPermission amagent.Permission
 		expectedTagIDs     []uuid.UUID
 		expectedAddresses  []commonaddress.Address
-		expectRes          string
+
+		expectCallService bool
+		expectStatus      int
+		expectRes         string
 	}{
 		{
 			name: "full data",
@@ -72,10 +75,15 @@ func Test_PostAgents(t *testing.T) {
 					Target: "+123456789",
 				},
 			},
-			expectRes: `{"id":"bd8cee04-4f21-11ec-9955-db7041b6d997","customer_id":"00000000-0000-0000-0000-000000000000","username":"","name":"","detail":"","ring_method":"","status":"","permission":0,"tag_ids":null,"addresses":null,"direct_hash":""}`,
+
+			expectCallService: true,
+			expectStatus:      http.StatusOK,
+			expectRes:         `{"id":"bd8cee04-4f21-11ec-9955-db7041b6d997","customer_id":"00000000-0000-0000-0000-000000000000","username":"","name":"","detail":"","ring_method":"","status":"","permission":0,"tag_ids":null,"addresses":null,"direct_hash":""}`,
 		},
 		{
-			name: "empty",
+			// addresses is required by the OpenAPI spec; an empty body must
+			// be rejected with 400, not silently treated as "no addresses".
+			name: "empty body -- addresses missing is rejected",
 			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
 					ID: uuid.FromStringOrNil("7cf444aa-8df4-11ee-abd9-b762d225dc87"),
@@ -84,21 +92,23 @@ func Test_PostAgents(t *testing.T) {
 
 			reqBody: []byte(`{}`),
 
-			responseAgent: &amagent.WebhookMessage{
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
+		},
+		{
+			// An explicit empty array is likewise not a valid substitute
+			// for at least one address.
+			name: "empty addresses array is rejected",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
 				Identity: commonidentity.Identity{
-					ID: uuid.FromStringOrNil("3071bee2-79af-11ec-9f30-83b56e9d88b5"),
+					ID: uuid.FromStringOrNil("9c3d0e5c-79b0-11ec-8f88-af8a4f6b6e37"),
 				},
-			},
+			}),
 
-			expectedUsername:   "",
-			expectedPassword:   "",
-			expectedName:       "",
-			expectedDetail:     "",
-			expectedRingMethod: "",
-			expectedPermission: 0,
-			expectedTagIDs:     []uuid.UUID{},
-			expectedAddresses:  []commonaddress.Address{},
-			expectRes:          `{"id":"3071bee2-79af-11ec-9f30-83b56e9d88b5","customer_id":"00000000-0000-0000-0000-000000000000","username":"","name":"","detail":"","ring_method":"","status":"","permission":0,"tag_ids":null,"addresses":null,"direct_hash":""}`,
+			reqBody: []byte(`{"username":"test2","password":"password2","name":"test2 name","detail":"test2 detail","addresses":[]}`),
+
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
 		}}
 
 	for _, tt := range tests {
@@ -122,14 +132,16 @@ func Test_PostAgents(t *testing.T) {
 			req, _ := http.NewRequest("POST", "/agents", bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
 
-			mockSvc.EXPECT().AgentCreate(req.Context(), tt.agent, tt.expectedUsername, tt.expectedPassword, tt.expectedName, tt.expectedDetail, tt.expectedRingMethod, tt.expectedPermission, tt.expectedTagIDs, tt.expectedAddresses).Return(tt.responseAgent, nil)
-
-			r.ServeHTTP(w, req)
-			if w.Code != http.StatusOK {
-				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			if tt.expectCallService {
+				mockSvc.EXPECT().AgentCreate(req.Context(), tt.agent, tt.expectedUsername, tt.expectedPassword, tt.expectedName, tt.expectedDetail, tt.expectedRingMethod, tt.expectedPermission, tt.expectedTagIDs, tt.expectedAddresses).Return(tt.responseAgent, nil)
 			}
 
-			if w.Body.String() != tt.expectRes {
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectStatus, w.Code)
+			}
+
+			if tt.expectRes != "" && w.Body.String() != tt.expectRes {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
 			}
 		})

--- a/bin-api-manager/server/campaigns.go
+++ b/bin-api-manager/server/campaigns.go
@@ -411,7 +411,24 @@ func (h *server) PutCampaignsIdNextCampaignId(c *gin.Context, id string) {
 		return
 	}
 
-	nextCampaignID := uuid.FromStringOrNil(req.NextCampaignId)
+	// next_campaign_id's zero value (uuid.Nil) is a valid, meaningful
+	// domain value here -- it means "unchain this campaign from any next
+	// campaign" (see bin-campaign-manager's isValidNextCampaignID, which
+	// explicitly treats uuid.Nil as valid), and this endpoint is the only
+	// way to set it. So an empty/omitted next_campaign_id must NOT be
+	// rejected -- only a syntactically invalid, non-empty value should be,
+	// since that's a genuine client error rather than an intentional
+	// unchain request.
+	nextCampaignID := uuid.Nil
+	if req.NextCampaignId != "" {
+		var errParse error
+		nextCampaignID, errParse = uuid.FromString(req.NextCampaignId)
+		if errParse != nil {
+			log.Errorf("Could not parse next_campaign_id. err: %v", errParse)
+			abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "next_campaign_id is not a valid UUID."))
+			return
+		}
+	}
 
 	res, err := h.serviceHandler.CampaignUpdateNextCampaignID(c.Request.Context(), a, target, nextCampaignID)
 	if err != nil {

--- a/bin-api-manager/server/campaigns_test.go
+++ b/bin-api-manager/server/campaigns_test.go
@@ -775,7 +775,10 @@ func Test_campaignsIDNextCampaignIDPUT(t *testing.T) {
 
 		expectCampaignID     uuid.UUID
 		expectNextCampaignID uuid.UUID
-		expectRes            string
+
+		expectCallService bool
+		expectStatus      int
+		expectRes         string
 	}{
 		{
 			name: "normal",
@@ -796,7 +799,53 @@ func Test_campaignsIDNextCampaignIDPUT(t *testing.T) {
 			},
 
 			expectNextCampaignID: uuid.FromStringOrNil("b045bff6-c6b7-11ec-8d03-2f6187fcf80f"),
-			expectRes:            `{"id":"a76dcb26-c6b7-11ec-b0dc-23d4f8625f83","customer_id":"00000000-0000-0000-0000-000000000000","type":"","name":"","detail":"","status":"","service_level":0,"end_handle":"","actions":null,"outplan_id":"00000000-0000-0000-0000-000000000000","outdial_id":"00000000-0000-0000-0000-000000000000","queue_id":"00000000-0000-0000-0000-000000000000","next_campaign_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null}`,
+
+			expectCallService: true,
+			expectStatus:      http.StatusOK,
+			expectRes:         `{"id":"a76dcb26-c6b7-11ec-b0dc-23d4f8625f83","customer_id":"00000000-0000-0000-0000-000000000000","type":"","name":"","detail":"","status":"","service_level":0,"end_handle":"","actions":null,"outplan_id":"00000000-0000-0000-0000-000000000000","outdial_id":"00000000-0000-0000-0000-000000000000","queue_id":"00000000-0000-0000-0000-000000000000","next_campaign_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			// next_campaign_id's zero value is a valid, meaningful domain
+			// value ("unchain this campaign") -- an empty/omitted body must
+			// still be accepted and forwarded as uuid.Nil, not rejected.
+			name: "empty body -- next_campaign_id omitted means unchain, not an error",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			}),
+			expectCampaignID: uuid.FromStringOrNil("a76dcb26-c6b7-11ec-b0dc-23d4f8625f83"),
+
+			reqQuery: "/campaigns/a76dcb26-c6b7-11ec-b0dc-23d4f8625f83/next_campaign_id",
+			reqBody:  []byte(`{}`),
+
+			responseCampaign: &cacampaign.WebhookMessage{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("a76dcb26-c6b7-11ec-b0dc-23d4f8625f83"),
+				},
+			},
+
+			expectNextCampaignID: uuid.Nil,
+
+			expectCallService: true,
+			expectStatus:      http.StatusOK,
+			expectRes:         `{"id":"a76dcb26-c6b7-11ec-b0dc-23d4f8625f83","customer_id":"00000000-0000-0000-0000-000000000000","type":"","name":"","detail":"","status":"","service_level":0,"end_handle":"","actions":null,"outplan_id":"00000000-0000-0000-0000-000000000000","outdial_id":"00000000-0000-0000-0000-000000000000","queue_id":"00000000-0000-0000-0000-000000000000","next_campaign_id":"00000000-0000-0000-0000-000000000000","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			// A syntactically invalid, non-empty value IS a genuine client
+			// error and must still be rejected.
+			name: "invalid uuid next_campaign_id is rejected",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			}),
+
+			reqQuery: "/campaigns/a76dcb26-c6b7-11ec-b0dc-23d4f8625f83/next_campaign_id",
+			reqBody:  []byte(`{"next_campaign_id":"not-a-uuid"}`),
+
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
 		},
 	}
 
@@ -821,14 +870,16 @@ func Test_campaignsIDNextCampaignIDPUT(t *testing.T) {
 
 			req, _ := http.NewRequest("PUT", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
-			mockSvc.EXPECT().CampaignUpdateNextCampaignID(req.Context(), tt.agent, tt.expectCampaignID, tt.expectNextCampaignID).Return(tt.responseCampaign, nil)
-
-			r.ServeHTTP(w, req)
-			if w.Code != http.StatusOK {
-				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			if tt.expectCallService {
+				mockSvc.EXPECT().CampaignUpdateNextCampaignID(req.Context(), tt.agent, tt.expectCampaignID, tt.expectNextCampaignID).Return(tt.responseCampaign, nil)
 			}
 
-			if w.Body.String() != tt.expectRes {
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectStatus, w.Code)
+			}
+
+			if tt.expectRes != "" && w.Body.String() != tt.expectRes {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
 			}
 		})

--- a/bin-api-manager/server/outdials.go
+++ b/bin-api-manager/server/outdials.go
@@ -32,6 +32,30 @@ func (h *server) PostOutdials(c *gin.Context) {
 	}
 
 	campaignID := uuid.FromStringOrNil(req.CampaignId)
+	// OpenAPI marks campaign_id/name/detail/data as required, but BindJSON
+	// doesn't enforce presence on string fields (an omitted field just binds
+	// to the zero value). Guard explicitly so the spec's contract is
+	// actually honored.
+	if campaignID == uuid.Nil {
+		log.Error("campaign_id is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "campaign_id is required."))
+		return
+	}
+	if req.Name == "" {
+		log.Error("name is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "name is required."))
+		return
+	}
+	if req.Detail == "" {
+		log.Error("detail is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "detail is required."))
+		return
+	}
+	if req.Data == "" {
+		log.Error("data is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "data is required."))
+		return
+	}
 
 	res, err := h.serviceHandler.OutdialCreate(c.Request.Context(), a, campaignID, req.Name, req.Detail, req.Data)
 	if err != nil {
@@ -304,6 +328,39 @@ func (h *server) PostOutdialsIdTargets(c *gin.Context, id string) {
 	destination2 := ConvertCommonAddress(req.Destination2)
 	destination3 := ConvertCommonAddress(req.Destination3)
 	destination4 := ConvertCommonAddress(req.Destination4)
+
+	// OpenAPI marks name/detail/data and all 5 destination_N fields as
+	// required, but BindJSON doesn't enforce presence on a struct field --
+	// an omitted destination_N silently binds to a zero-value CommonAddress.
+	// name/detail/data are enforced as the spec states (must be non-empty).
+	// For the 5 destination_N fields, this deliberately enforces a looser
+	// rule than the spec's literal "all 5 required" -- only that at least
+	// one destination has a target -- since the domain model treats each
+	// destination_N as an independent, nullable retry slot (see
+	// bin-outdial-manager's outdial target dbhandler) and a target-less
+	// destination has no reachable endpoint anyway. The spec's `required`
+	// list overstates the actual constraint; tracked in VOIP-1308 to relax
+	// the spec once the oapi-codegen regeneration blocker is resolved.
+	if req.Name == "" {
+		log.Error("name is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "name is required."))
+		return
+	}
+	if req.Detail == "" {
+		log.Error("detail is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "detail is required."))
+		return
+	}
+	if req.Data == "" {
+		log.Error("data is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "data is required."))
+		return
+	}
+	if destination0.Target == "" && destination1.Target == "" && destination2.Target == "" && destination3.Target == "" && destination4.Target == "" {
+		log.Error("At least one destination_N target is required.")
+		abortWithError(c, cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "INVALID_ARGUMENT", "At least one destination_N target is required."))
+		return
+	}
 
 	res, err := h.serviceHandler.OutdialtargetCreate(c.Request.Context(), a, target, req.Name, req.Detail, req.Data, &destination0, &destination1, &destination2, &destination3, &destination4)
 	if err != nil {

--- a/bin-api-manager/server/outdials_test.go
+++ b/bin-api-manager/server/outdials_test.go
@@ -146,7 +146,10 @@ func Test_outdialsPOST(t *testing.T) {
 		expectName       string
 		expectDetail     string
 		expectData       string
-		expectRes        string
+
+		expectCallService bool
+		expectStatus      int
+		expectRes         string
 	}{
 		{
 			name: "normal",
@@ -169,7 +172,40 @@ func Test_outdialsPOST(t *testing.T) {
 			expectName:       "test name",
 			expectDetail:     "test detail",
 			expectData:       "test data",
-			expectRes:        `{"id":"99b197a5-010e-4f4e-b9fc-aae44e241ddb","customer_id":"00000000-0000-0000-0000-000000000000","campaign_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","data":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+
+			expectCallService: true,
+			expectStatus:      http.StatusOK,
+			expectRes:         `{"id":"99b197a5-010e-4f4e-b9fc-aae44e241ddb","customer_id":"00000000-0000-0000-0000-000000000000","campaign_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","data":"","tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			// campaign_id/name/detail/data are all required by the OpenAPI
+			// spec; an empty body must be rejected with 400.
+			name: "empty body -- required fields missing is rejected",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("f0e5f5d0-79b1-11ec-8a97-2b2a5c6a3f4b"),
+				},
+			}),
+
+			reqQuery: "/outdials",
+			reqBody:  []byte(`{}`),
+
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
+		},
+		{
+			name: "campaign_id missing is rejected",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("06f4a1c2-79b2-11ec-93c8-cf6e7f9a1d0e"),
+				},
+			}),
+
+			reqQuery: "/outdials",
+			reqBody:  []byte(`{"name":"test name","detail":"test detail","data":"test data"}`),
+
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
 		},
 	}
 
@@ -194,14 +230,16 @@ func Test_outdialsPOST(t *testing.T) {
 
 			req, _ := http.NewRequest("POST", "/outdials", bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
-			mockSvc.EXPECT().OutdialCreate(req.Context(), tt.agent, tt.expectCampaignID, tt.expectName, tt.expectDetail, tt.expectData).Return(tt.responseOutdial, nil)
-
-			r.ServeHTTP(w, req)
-			if w.Code != http.StatusOK {
-				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			if tt.expectCallService {
+				mockSvc.EXPECT().OutdialCreate(req.Context(), tt.agent, tt.expectCampaignID, tt.expectName, tt.expectDetail, tt.expectData).Return(tt.responseOutdial, nil)
 			}
 
-			if w.Body.String() != tt.expectRes {
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectStatus, w.Code)
+			}
+
+			if tt.expectRes != "" && w.Body.String() != tt.expectRes {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
 			}
 		})
@@ -581,7 +619,10 @@ func Test_outdialsIDTargetsPOST(t *testing.T) {
 		expectDestination2 *commonaddress.Address
 		expectDestination3 *commonaddress.Address
 		expectDestination4 *commonaddress.Address
-		expectRes          string
+
+		expectCallService bool
+		expectStatus      int
+		expectRes         string
 	}{
 		{
 			name: "normal",
@@ -622,7 +663,43 @@ func Test_outdialsIDTargetsPOST(t *testing.T) {
 				Type:   commonaddress.TypeTel,
 				Target: "+821100000005",
 			},
-			expectRes: `{"id":"e3097653-4c68-4915-add3-78b12a4ba151","outdial_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","data":"","status":"","destination_0":null,"destination_1":null,"destination_2":null,"destination_3":null,"destination_4":null,"try_count_0":0,"try_count_1":0,"try_count_2":0,"try_count_3":0,"try_count_4":0,"tm_create":null,"tm_update":null,"tm_delete":null}`,
+
+			expectCallService: true,
+			expectStatus:      http.StatusOK,
+			expectRes:         `{"id":"e3097653-4c68-4915-add3-78b12a4ba151","outdial_id":"00000000-0000-0000-0000-000000000000","name":"","detail":"","data":"","status":"","destination_0":null,"destination_1":null,"destination_2":null,"destination_3":null,"destination_4":null,"try_count_0":0,"try_count_1":0,"try_count_2":0,"try_count_3":0,"try_count_4":0,"tm_create":null,"tm_update":null,"tm_delete":null}`,
+		},
+		{
+			// name/detail/data and at least one destination_N target are
+			// all required by the OpenAPI spec; an empty body must be
+			// rejected with 400.
+			name: "empty body -- required fields missing is rejected",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			}),
+
+			reqQuery: "/outdials/726d6b88-2028-44fe-a415-a58067d98acf/targets",
+			reqBody:  []byte(`{}`),
+
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
+		},
+		{
+			// name/detail/data present, but no destination_N carries a
+			// target -- there is no reachable endpoint to dial.
+			name: "no destination target is rejected",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID: uuid.FromStringOrNil("2a2ec0ba-8004-11ec-aea5-439829c92a7c"),
+				},
+			}),
+
+			reqQuery: "/outdials/726d6b88-2028-44fe-a415-a58067d98acf/targets",
+			reqBody:  []byte(`{"name":"test name","detail":"test detail","data":"test data"}`),
+
+			expectCallService: false,
+			expectStatus:      http.StatusBadRequest,
 		},
 	}
 
@@ -647,14 +724,16 @@ func Test_outdialsIDTargetsPOST(t *testing.T) {
 
 			req, _ := http.NewRequest("POST", tt.reqQuery, bytes.NewBuffer(tt.reqBody))
 			req.Header.Set("Content-Type", "application/json")
-			mockSvc.EXPECT().OutdialtargetCreate(req.Context(), tt.agent, tt.expectOutdialID, tt.expectName, tt.expectDetail, tt.expectData, tt.expectDestination0, tt.expectDestination1, tt.expectDestination2, tt.expectDestination3, tt.expectDestination4).Return(tt.responseOutdialtarget, nil)
-
-			r.ServeHTTP(w, req)
-			if w.Code != http.StatusOK {
-				t.Errorf("Wrong match. expect: %d, got: %d", http.StatusOK, w.Code)
+			if tt.expectCallService {
+				mockSvc.EXPECT().OutdialtargetCreate(req.Context(), tt.agent, tt.expectOutdialID, tt.expectName, tt.expectDetail, tt.expectData, tt.expectDestination0, tt.expectDestination1, tt.expectDestination2, tt.expectDestination3, tt.expectDestination4).Return(tt.responseOutdialtarget, nil)
 			}
 
-			if w.Body.String() != tt.expectRes {
+			r.ServeHTTP(w, req)
+			if w.Code != tt.expectStatus {
+				t.Errorf("Wrong match. expect: %d, got: %d", tt.expectStatus, w.Code)
+			}
+
+			if tt.expectRes != "" && w.Body.String() != tt.expectRes {
 				t.Errorf("Wrong match.\nexpect: %v\ngot: %v", tt.expectRes, w.Body)
 			}
 		})


### PR DESCRIPTION
4 endpoints had OpenAPI spec fields marked required that bin-api-manager's handlers accepted without validating presence (Gin's BindJSON doesn't enforce presence on non-pointer fields). Adds explicit validation matching each field's intended contract, following the existing idiom in server/providercalls.go.

- bin-api-manager: Reject POST /agents when addresses is empty (spec-required, was previously unvalidated)
- bin-api-manager: Reject POST /outdials when campaign_id/name/detail/data is empty (spec-required, was previously unvalidated)
- bin-api-manager: Reject POST /outdials/{id}/targets when name/detail/data is empty or no destination_N carries a target (deliberately looser than the spec's literal all-5-required, since destination_N are independent nullable retry slots -- tracked in VOIP-1308)
- bin-api-manager: Reject PUT /campaigns/{id}/next_campaign_id only when next_campaign_id is a non-empty but malformed UUID; an empty/omitted value still passes through as uuid.Nil (the documented "unchain this campaign" state), preserving existing behavior