### PR TITLE
SQUARE-24-hide-assign-button-closed-case

### DIFF
--- a/bin-api-manager/pkg/serviceerrors/sentinels.go
+++ b/bin-api-manager/pkg/serviceerrors/sentinels.go
@@ -23,10 +23,12 @@ var (
 	ErrServiceUnavailable           = stderrors.New("service unavailable")
 	ErrInsufficientBalance          = stderrors.New("insufficient balance")
 
-	// ErrCaseClosed is returned by Case-message-send validation (design
-	// §4.5 step 1) when the target case is not status='open'. Points the
-	// caller at POST /v1.0/contact_cases/{id}/continue.
-	ErrCaseClosed = stderrors.New("case is closed; call continue to reopen it before sending a message")
+	// ErrCaseClosed is returned whenever an operation requires the target
+	// case to be status='open' and it is not -- originally Case-message-send
+	// validation (design §4.5 step 1), now also reused by
+	// ServiceAgentCaseAssign (SQUARE-24). Points the caller at
+	// POST /v1.0/contact_cases/{id}/continue.
+	ErrCaseClosed = stderrors.New("case is closed; call continue to reopen it before performing this action")
 
 	// ErrCaseDestinationNotAssociated is the SINGLE GENERIC error for
 	// design §4.5 step 2's destination-to-case binding check. It MUST be

--- a/bin-api-manager/pkg/servicehandler/serviceagent_case.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_case.go
@@ -111,9 +111,15 @@ func (h *serviceHandler) ServiceAgentCaseAssign(ctx context.Context, a *auth.Aut
 		return nil, serviceerrors.ErrPermissionDenied
 	}
 
-	if _, err := h.caseGet(ctx, a.CustomerID, id); err != nil {
+	c, err := h.caseGet(ctx, a.CustomerID, id)
+	if err != nil {
 		log.Errorf("Could not get the case info. err: %v", err)
 		return nil, err
+	}
+
+	if c.Status == cmkase.StatusClosed {
+		log.Infof("Case is closed, status: %s", c.Status)
+		return nil, serviceerrors.ErrCaseClosed
 	}
 
 	owner, err := h.reqHandler.AgentV1AgentGet(ctx, ownerID)

--- a/bin-api-manager/pkg/servicehandler/serviceagent_case_test.go
+++ b/bin-api-manager/pkg/servicehandler/serviceagent_case_test.go
@@ -2,6 +2,7 @@ package servicehandler
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -244,6 +245,7 @@ func Test_ServiceAgentCaseAssign(t *testing.T) {
 		expectAssignCall   bool
 		expectRes          *cmkase.Case
 		expectErr          bool
+		expectErrIs        error
 	}
 
 	agentCustomerID := uuid.FromStringOrNil("5f621078-8e5f-11ee-97b2-cfe7337b701c")
@@ -344,6 +346,32 @@ func Test_ServiceAgentCaseAssign(t *testing.T) {
 			expectAssignCall:   false,
 			expectErr:          true,
 		},
+		{
+			// The case is CLOSED. Must be rejected with ErrCaseClosed before
+			// the owner agent is even looked up, and ContactV1CaseAssign
+			// must never be called.
+			name: "case is closed",
+			agent: auth.NewAgentIdentity(&amagent.Agent{
+				Identity: commonidentity.Identity{
+					ID:         uuid.FromStringOrNil("d152e69e-105b-11ee-b395-eb18426de979"),
+					CustomerID: agentCustomerID,
+				},
+				Permission: amagent.PermissionCustomerAgent,
+			}),
+			caseID:  uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+			ownerID: uuid.FromStringOrNil("f6b8b5f0-8270-11ed-9e5a-4bcaa2b972d6"),
+
+			responseCaseGet: &cmkase.Case{
+				ID:         uuid.FromStringOrNil("df394b78-8270-11ed-914d-6bceafeffecb"),
+				CustomerID: agentCustomerID,
+				Status:     cmkase.StatusClosed,
+			},
+
+			expectAgentGetCall: false,
+			expectAssignCall:   false,
+			expectErr:          true,
+			expectErrIs:        serviceerrors.ErrCaseClosed,
+		},
 	}
 
 	for _, tt := range tests {
@@ -373,6 +401,9 @@ func Test_ServiceAgentCaseAssign(t *testing.T) {
 			if tt.expectErr {
 				if err == nil {
 					t.Errorf("Wrong match. expect: error, got: ok")
+				}
+				if tt.expectErrIs != nil && !errors.Is(err, tt.expectErrIs) {
+					t.Errorf("Wrong match. expect: %v, got: %v", tt.expectErrIs, err)
 				}
 				return
 			}

--- a/bin-api-manager/server/error_translate.go
+++ b/bin-api-manager/server/error_translate.go
@@ -109,7 +109,7 @@ func translateToVoipbinError(err error) (out *cerrors.VoipbinError) {
 			"Customer balance is below the minimum required for this operation.").Wrap(err)
 	case stderrors.Is(err, serviceerrors.ErrCaseClosed):
 		return cerrors.FailedPrecondition(commonoutline.ServiceNameAPIManager, "CASE_CLOSED",
-			"This case is closed. Call POST /v1.0/contact_cases/{id}/continue to reopen it before sending a message.")
+			"This case is closed. Call POST /v1.0/contact_cases/{id}/continue to reopen it before performing this action.")
 	case stderrors.Is(err, serviceerrors.ErrCaseDestinationNotAssociated):
 		return cerrors.InvalidArgument(commonoutline.ServiceNameAPIManager, "DESTINATION_NOT_ASSOCIATED",
 			"destination is not associated with this case")


### PR DESCRIPTION
Reject case assignment when the target case is already closed, matching the frontend change that hides the Assign button for closed cases.

- bin-api-manager: Reject ServiceAgentCaseAssign on a closed case (reuse existing ErrCaseClosed sentinel, already wired to HTTP status translation)
- bin-api-manager: Add test coverage asserting assign-on-closed-case is rejected before the owner-agent lookup / ContactV1CaseAssign call

Frontend companion change (hide Assign button on closed cases): monorepo-javascript PR https://github.com/voipbin/monorepo-javascript/pull/412