### PR TITLE
VOIP-1290-Fix-trunk-domain-string-typos

### DIFF
--- a/bin-api-manager/pkg/servicehandler/trunk.go
+++ b/bin-api-manager/pkg/servicehandler/trunk.go
@@ -67,12 +67,12 @@ func (h *serviceHandler) TrunkDelete(ctx context.Context, a *auth.AuthIdentity, 
 		"username":    a.DisplayName(),
 		"trunk_id":    id,
 	})
-	log.Debug("Deleting the domain.")
+	log.Debug("Deleting the trunk.")
 
 	t, err := h.trunkGet(ctx, id)
 	if err != nil {
-		log.Errorf("Could not get the domain info. err: %v", err)
-		return nil, fmt.Errorf("%w: could not get domain info", err)
+		log.Errorf("Could not get the trunk info. err: %v", err)
+		return nil, fmt.Errorf("%w: could not get trunk info", err)
 	}
 
 	// permission check
@@ -102,7 +102,7 @@ func (h *serviceHandler) TrunkGet(ctx context.Context, a *auth.AuthIdentity, id 
 		"func":        "TrunkGet",
 		"customer_id": a.CustomerID,
 		"username":    a.DisplayName(),
-		"domain_id":   id,
+		"trunk_id":    id,
 	})
 	log.Debug("Getting a trunk.")
 
@@ -196,7 +196,7 @@ func (h *serviceHandler) TrunkUpdateBasicInfo(ctx context.Context, a *auth.AuthI
 	t, err := h.trunkGet(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get trunk info from the registrar-manager. err: %v", err)
-		return nil, fmt.Errorf("%w: could not find domain info", err)
+		return nil, fmt.Errorf("%w: could not find trunk info", err)
 	}
 
 	// permission check


### PR DESCRIPTION
Fix a cosmetic naming mismatch flagged during the VOIP-1290 RST docs audit (item 14): several log/error strings in the trunk service handler said "domain" when they actually refer to trunks.

- bin-api-manager: Rename "domain" to "trunk" in 5 log/error strings in pkg/servicehandler/trunk.go (TrunkDelete's debug/error messages, TrunkGet's "domain_id" log field key -> "trunk_id" to match the other three handler functions in the file, and TrunkUpdateBasicInfo's wrapped error message). No behavior change; the legitimate domainName/domain_name SIP-domain field on TrunkCreate is untouched.