### PR TITLE
VOIP-1305-Fix-confbridge-recording-ids-uuid-encoding

### DIFF
--- a/bin-call-manager/pkg/dbhandler/call.go
+++ b/bin-call-manager/pkg/dbhandler/call.go
@@ -531,10 +531,6 @@ func (h *handler) CallSetForRouteFailover(ctx context.Context, id uuid.UUID, cha
 //
 // WHY squirrel.Expr: MySQL json_array_append has no squirrel builder form; see
 // json_expr.go.
-//
-// Note this site binds recordID.String(), unlike ConfbridgeAddRecordingIDs
-// which binds .Bytes(). That inconsistency is a suspected pre-existing bug in
-// the confbridge site (plan §6 item 3) and is deliberately NOT changed here.
 func buildCallAddRecordingIDs(id, recordID uuid.UUID, tmUpdate any) squirrel.UpdateBuilder {
 	return squirrel.
 		Update(callTable).

--- a/bin-call-manager/pkg/dbhandler/confbridge.go
+++ b/bin-call-manager/pkg/dbhandler/confbridge.go
@@ -322,17 +322,12 @@ func (h *handler) ConfbridgeSetRecordingID(ctx context.Context, id uuid.UUID, re
 // WHY squirrel.Expr: MySQL json_array_append has no squirrel builder form; see
 // json_expr.go.
 //
-// NOTE (plan §6 item 3, suspected pre-existing bug, deliberately NOT fixed
-// here): this site binds recordingID.Bytes(), whereas the semantically
-// identical CallAddRecordingIDs and ConfbridgeAddExternalMediaID bind
-// .String(). Since recording_ids unmarshals as []uuid.UUID (a JSON string
-// array), .Bytes() likely stores a malformed element. The existing behavior is
-// carried over verbatim by this refactor; fixing it needs its own ticket plus a
-// data backfill/integrity check for rows already written this way.
+// recordingID.String(): fixed in VOIP-1305 (historically bound .Bytes(), which
+// stored malformed elements; see the backfill migration in bin-dbscheme-manager).
 func buildConfbridgeAddRecordingIDs(id, recordingID uuid.UUID, tmUpdate any) squirrel.UpdateBuilder {
 	return squirrel.
 		Update(confbridgeTable).
-		Set(string(confbridge.FieldRecordingIDs), exprJSONArrayAppend(string(confbridge.FieldRecordingIDs), recordingID.Bytes())).
+		Set(string(confbridge.FieldRecordingIDs), exprJSONArrayAppend(string(confbridge.FieldRecordingIDs), recordingID.String())).
 		Set(string(confbridge.FieldTMUpdate), tmUpdate).
 		Where(squirrel.Eq{string(confbridge.FieldID): id.Bytes()}).
 		PlaceholderFormat(squirrel.Question)

--- a/bin-call-manager/pkg/dbhandler/json_expr_golden_test.go
+++ b/bin-call-manager/pkg/dbhandler/json_expr_golden_test.go
@@ -195,13 +195,11 @@ func Test_goldenConfbridgeJSONExpr(t *testing.T) {
 
 	runGoldenCases(t, []goldenCase{
 		{
-			// NOTE: binds .Bytes(), not .String() — carried over as-is from the
-			// pre-migration SQL. Suspected pre-existing bug, plan §6 item 3.
 			name:     "ConfbridgeAddRecordingIDs",
 			sql:      addRecSQL,
 			args:     addRecArgs,
 			wantSQL:  "UPDATE call_confbridges SET recording_ids = json_array_append(recording_ids, '$', ?), tm_update = ? WHERE id = ?",
-			wantArgs: []any{other.Bytes(), tmUpdate, id.Bytes()},
+			wantArgs: []any{other.String(), tmUpdate, id.Bytes()},
 		},
 		{
 			name:     "ConfbridgeAddExternalMediaID",

--- a/bin-call-manager/pkg/dbhandler/recording_ids_scan_test.go
+++ b/bin-call-manager/pkg/dbhandler/recording_ids_scan_test.go
@@ -1,0 +1,111 @@
+package dbhandler
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+)
+
+// Test_recordingIDsCorruptedFormsFailUnmarshal pins the read-path failure modes
+// of VOIP-1305 and is the executable documentation for why
+// buildConfbridgeAddRecordingIDs must bind recordingID.String().
+//
+// Background: before VOIP-1305 the builder bound recordingID.Bytes(), so
+// json_array_append stored a 16-byte binary value instead of the 36-char UUID
+// text. Depending on the go-sql-driver protocol path, that produced one of two
+// corrupted element shapes in the recording_ids JSON column (verified against
+// MySQL 8.0 with the real driver):
+//
+//   - Form A: prepared-statement path (driver default, the likely production
+//     path). The raw 16 bytes land inside a JSON STRING element; MySQL escapes
+//     control bytes and quotes, non-ASCII bytes stay raw (invalid UTF-8).
+//   - Form B: interpolateParams=true text-protocol path (or a _binary SQL
+//     literal). MySQL stores an opaque JSON BLOB element that renders as
+//     "base64:type15:<payload>".
+//
+// The model field Confbridge.RecordingIDs is []uuid.UUID (db tag
+// "recording_ids,json"), so reads go through the ScanRow copyJSON path in
+// bin-common-handler/pkg/databasehandler/mapping.go: the column arrives as
+// sql.NullString and is json.Unmarshal-ed into []uuid.UUID. This test feeds
+// each stored shape through that same json.Unmarshal step.
+//
+// Assertions are deliberately limited to err nil / non-nil (plus value
+// equality for the clean control): the corrupted forms must fail, the clean
+// .String() form must succeed. Error strings are not asserted because the uuid
+// library wording differs across versions.
+func Test_recordingIDsCorruptedFormsFailUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     []byte
+		wantErr bool
+		want    []uuid.UUID
+	}{
+		{
+			// Form A, invalid UTF-8: the 16 raw bytes of UUID
+			// deadbeef-0011-2233-4455-66778899aabb as stored by the
+			// prepared-statement path. MySQL kept the printable ASCII bytes
+			// (3DUfw), JSON-escaped the control bytes 0x00 and 0x11 to
+			// backslash-u sequences and the quote byte 0x22 to an escaped
+			// quote, and left the non-ASCII bytes raw, which makes the
+			// document invalid UTF-8. The raw literal below reproduces that
+			// stored document byte for byte.
+			name:    "form A raw bytes with invalid UTF-8 fails",
+			raw:     []byte("[\"\xde\xad\xbe\xef\\u0000\\u0011\\\"3DUfw\x88\x99\xaa\xbb\"]"),
+			wantErr: true,
+		},
+		{
+			// Form A, all-ASCII: a UUID whose 16 raw bytes are all printable
+			// ASCII (here 0x30..0x66, the bytes of UUID
+			// 30313233-3435-3637-3839-616263646566). The prepared-statement
+			// path stores them as a plain 16-char JSON string. The document
+			// is valid JSON and valid UTF-8, but the element is 16 chars,
+			// not the 36-char UUID text form.
+			name:    "form A ascii 16-byte string fails",
+			raw:     []byte(`["0123456789abcdef"]`),
+			wantErr: true,
+		},
+		{
+			// Form B: the interpolateParams / text-protocol path (or a
+			// _binary literal) makes MySQL store an opaque JSON BLOB, which
+			// the server renders as base64:type15:<payload>. The payload is
+			// the base64 of the same 16 raw bytes of
+			// deadbeef-0011-2233-4455-66778899aabb.
+			name:    "form B base64 opaque blob rendering fails",
+			raw:     []byte(`["base64:type15:3q2+7wARIjNEVWZ3iJmquw=="]`),
+			wantErr: true,
+		},
+		{
+			// Control: the shape written by binding recordingID.String(),
+			// which is what the fixed builder produces and what the backfill
+			// migration restores corrupted elements to.
+			name:    "clean uuid string form succeeds",
+			raw:     []byte(`["deadbeef-0011-2233-4455-66778899aabb"]`),
+			wantErr: false,
+			want:    []uuid.UUID{uuid.FromStringOrNil("deadbeef-0011-2233-4455-66778899aabb")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []uuid.UUID
+			err := json.Unmarshal(tt.raw, &got)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected unmarshal error, got nil. result: %v", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected success, got err: %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unexpected result.\nwant: %v\ngot:  %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/bin-dbscheme-manager/bin-manager/main/versions/ede50012c416_call_confbridges_backfill_recording_ids.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/ede50012c416_call_confbridges_backfill_recording_ids.py
@@ -1,0 +1,203 @@
+"""call_confbridges_backfill_recording_ids
+
+Revision ID: ede50012c416
+Revises: 902325885953
+Create Date: 2026-08-10 20:00:03.914006
+
+VOIP-1305 data backfill. Design document,
+docs/plans/2026-08-10-voip-1305-confbridge-recording-ids-fix-and-backfill-design.md
+
+Before VOIP-1305, bin-call-manager ConfbridgeAddRecordingIDs bound
+recordingID.Bytes() (16 raw bytes) instead of recordingID.String() (36 char
+UUID text) into json_array_append, so call_confbridges.recording_ids collected
+corrupted elements that the Go read path ([]uuid.UUID unmarshal) cannot parse.
+Depending on the go-sql-driver protocol path there are two corruption forms:
+
+  Form A (prepared statement path, driver default): the raw 16 bytes stored as
+    a JSON STRING element. Detected per element with
+    JSON_TYPE(elem) = 'STRING' AND LENGTH(JSON_UNQUOTE(elem)) = 16
+    (byte length; a healthy UUID string is 36 bytes).
+  Form B (interpolateParams text protocol or a _binary literal): an opaque JSON
+    BLOB element that MySQL renders as base64 with a type tag. Detected with
+    JSON_TYPE(elem) = 'BLOB'.
+
+This migration restores both forms to the lowercase 36 char UUID text form,
+element by element with JSON_REPLACE (array order preserved, healthy elements
+untouched). All detection and conversion happens in server side SQL. Only
+BINARY(16) row ids and integer counts ever reach the Python client, so the
+corrupted bytes never cross the driver boundary (avoids UTF-8 decode issues).
+
+Idempotent and re-run safe. Repaired elements no longer match any detection
+condition, so a re-run collects nothing new and updates nothing. Elements that
+match detection but cannot be converted (for example a BLOB whose payload does
+not decode to exactly 16 bytes) are preserved as is and reported in
+remaining_anomaly_rows for manual investigation.
+
+Constraint. The always executed Phase 0 path must stay MariaDB compatible,
+because the dbscheme Docker image build runs the whole migration chain against
+a temporary MariaDB with empty tables. Phase 0 uses only COALESCE, MAX and
+JSON_LENGTH, and exits early on the empty table, so later MySQL specific
+behavior is never reached in that environment.
+
+SQL text in this file deliberately contains no colon characters. op.execute
+and text() treat a colon prefixed identifier as a bind parameter, which has
+bitten this repository before. The Form B separator is produced with CHAR(58)
+and the id lists are inlined as UNHEX hex literals (hex digits only).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ede50012c416'
+down_revision = '902325885953'
+branch_labels = None
+depends_on = None
+
+
+TABLE = 'call_confbridges'
+CHUNK_SIZE = 500
+
+
+def _element_corrupted_predicate(i):
+    """SQL predicate matching a corrupted element at array index i.
+
+    Form B first (opaque BLOB), then Form A (16 byte STRING). LENGTH counts
+    bytes, so a healthy 36 char UUID string never matches.
+    """
+    elem = "JSON_EXTRACT(recording_ids, '$[{i}]')".format(i=i)
+    return (
+        "( JSON_TYPE({elem}) = 'BLOB'"
+        " OR (JSON_TYPE({elem}) = 'STRING'"
+        " AND LENGTH(JSON_UNQUOTE({elem})) = 16) )"
+    ).format(elem=elem)
+
+
+def _in_list(hex_ids):
+    """Inline IN list of UNHEX literals for a chunk of id hex strings.
+
+    The hex strings come from bytes.hex() and contain only 0-9a-f, so literal
+    inlining is safe and avoids text() bind parameters entirely.
+    """
+    return ', '.join("UNHEX('" + h + "')" for h in hex_ids)
+
+
+def _chunks(items, size):
+    for pos in range(0, len(items), size):
+        yield items[pos:pos + size]
+
+
+def _collect_corrupted_ids(conn, max_len, restrict_hex_ids=None):
+    """Collect the hex ids of rows holding at least one corrupted element.
+
+    Plain SELECTs only. Under REPEATABLE READ a plain SELECT is a lock free
+    consistent read, unlike INSERT ... SELECT which takes shared next key locks
+    on every scanned source row (measured; that approach was rejected in design
+    review). When restrict_hex_ids is given (Phase 3 re-check), the scan is
+    limited to those rows in CHUNK_SIZE batches.
+    """
+    found = set()
+    for i in range(max_len):
+        base = (
+            'SELECT id FROM ' + TABLE +
+            ' WHERE recording_ids IS NOT NULL'
+            ' AND JSON_LENGTH(recording_ids) > {i}'
+            ' AND {pred}'
+        ).format(i=i, pred=_element_corrupted_predicate(i))
+
+        if restrict_hex_ids is None:
+            rows = conn.execute(sa.text(base)).fetchall()
+            found.update(bytes(row[0]).hex() for row in rows)
+        else:
+            for chunk in _chunks(sorted(restrict_hex_ids), CHUNK_SIZE):
+                sql = base + ' AND id IN (' + _in_list(chunk) + ')'
+                rows = conn.execute(sa.text(sql)).fetchall()
+                found.update(bytes(row[0]).hex() for row in rows)
+    return found
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Phase 0. Scalar upper bound for the per index loops. Returns a number
+    # only. Must stay MariaDB compatible (see module docstring). Caveat, a row
+    # whose recording_ids is the JSON null scalar has JSON_LENGTH = 1, so
+    # max_len can be >= 1 with zero corrupted rows. That is harmless, the
+    # loops below simply match nothing for such rows.
+    max_len = conn.execute(sa.text(
+        'SELECT COALESCE(MAX(JSON_LENGTH(recording_ids)), 0) FROM ' + TABLE
+    )).scalar()
+    max_len = int(max_len or 0)
+
+    if max_len == 0:
+        print('VOIP-1305 backfill: candidate_rows=0, repaired_rows=0, '
+              'remaining_anomaly_rows=0 (no non empty recording_ids)')
+        return
+
+    # Phase 1. Collect the ids of corrupted rows (bytes to hex set).
+    corrupted_ids = _collect_corrupted_ids(conn, max_len)
+    if not corrupted_ids:
+        print('VOIP-1305 backfill: candidate_rows=0, repaired_rows=0, '
+              'remaining_anomaly_rows=0 (no corrupted elements found)')
+        return
+
+    # Phase 2. Repair with primary key targeted UPDATEs so exclusive locks
+    # touch only the corrupted rows. UUID text restore expression, HEX of the
+    # 16 raw bytes reformatted to 8-4-4-4-12 lowercase. Form A feeds HEX the
+    # unquoted string bytes. Form B feeds it the FROM_BASE64 decoded payload
+    # after the last CHAR(58) separator of the opaque value rendering, and
+    # only when that payload decodes to exactly 16 bytes.
+    for chunk in _chunks(sorted(corrupted_ids), CHUNK_SIZE):
+        in_list = _in_list(chunk)
+        for i in range(max_len):
+            elem = "JSON_EXTRACT(recording_ids, '$[{i}]')".format(i=i)
+            unq = 'JSON_UNQUOTE(' + elem + ')'
+            b64 = 'FROM_BASE64(SUBSTRING_INDEX(' + unq + ', CHAR(58), -1))'
+
+            form_a = (
+                'UPDATE ' + TABLE + ' SET recording_ids = '
+                "JSON_REPLACE(recording_ids, '$[{i}]', "
+                'LOWER(INSERT(INSERT(INSERT(INSERT('
+                'HEX({unq})'
+                ", 9, 0, '-'), 14, 0, '-'), 19, 0, '-'), 24, 0, '-')))"
+                ' WHERE id IN ({ids})'
+                " AND JSON_TYPE({elem}) = 'STRING'"
+                ' AND LENGTH({unq}) = 16'
+            ).format(i=i, unq=unq, elem=elem, ids=in_list)
+            conn.execute(sa.text(form_a))
+
+            form_b = (
+                'UPDATE ' + TABLE + ' SET recording_ids = '
+                "JSON_REPLACE(recording_ids, '$[{i}]', "
+                'LOWER(INSERT(INSERT(INSERT(INSERT('
+                'HEX({b64})'
+                ", 9, 0, '-'), 14, 0, '-'), 19, 0, '-'), 24, 0, '-')))"
+                ' WHERE id IN ({ids})'
+                " AND JSON_TYPE({elem}) = 'BLOB'"
+                ' AND LENGTH({b64}) = 16'
+            ).format(i=i, b64=b64, elem=elem, ids=in_list)
+            conn.execute(sa.text(form_b))
+
+    # Phase 3. Verify and report, id set based so a row with several corrupted
+    # elements counts once. Only the Phase 1 candidates are re-checked.
+    remaining_ids = _collect_corrupted_ids(
+        conn, max_len, restrict_hex_ids=corrupted_ids)
+
+    candidates = len(corrupted_ids)
+    remaining = len(remaining_ids)
+    repaired = candidates - remaining
+    print('VOIP-1305 backfill: candidate_rows={c}, repaired_rows={r}, '
+          'remaining_anomaly_rows={a}'.format(c=candidates, r=repaired,
+                                              a=remaining))
+    if remaining > 0:
+        print('VOIP-1305 backfill WARNING: {a} row(s) still hold elements '
+              'that match corruption detection but could not be converted. '
+              'They were preserved unchanged, manual investigation '
+              'required.'.format(a=remaining))
+
+
+def downgrade():
+    # No downgrade. Reversing a data repair would mean re-corrupting the
+    # restored UUID strings, which is never desirable. Precedent for a no-op
+    # downgrade, 9443d2d65ad8_add_join_bridge.py.
+    pass

--- a/docs/plans/2026-08-10-voip-1305-confbridge-recording-ids-fix-and-backfill-design.md
+++ b/docs/plans/2026-08-10-voip-1305-confbridge-recording-ids-fix-and-backfill-design.md
@@ -1,0 +1,152 @@
+# VOIP-1305: Confbridge recording_ids UUID encoding fix and backfill, Design
+
+Date: 2026-08-10
+Ticket: VOIP-1305
+Services: bin-call-manager (code fix), bin-dbscheme-manager (data backfill)
+
+## Problem
+
+`buildConfbridgeAddRecordingIDs` in `bin-call-manager/pkg/dbhandler/confbridge.go`
+bound `recordingID.Bytes()` (16 raw bytes) into `json_array_append`, while every
+semantically identical site (`CallAddRecordingIDs`,
+`ConfbridgeAddExternalMediaID`, conference-manager, queue-manager) binds
+`.String()` (the 36 char UUID text). The write succeeds without error, so each
+confbridge recording start appended a corrupted element to the
+`call_confbridges.recording_ids` JSON column.
+
+The read path unmarshals that column into `[]uuid.UUID`
+(`bin-common-handler/pkg/databasehandler/mapping.go`, copyJSON). A corrupted
+element makes `ScanRow` fail, so `ConfbridgeGetFromDB` fails permanently for
+that row. The failure is delayed: the Redis cache (TTL 24h) keeps serving the
+last good snapshot until expiry, eviction, or pod restart, after which the
+confbridge becomes unreadable. From the moment of corruption, the ignored cache
+refresh in `ConfbridgeAddRecordingIDs` leaves an error log signature
+(confbridge cache update failure), usable to estimate historical occurrences.
+
+The behavior was carried over verbatim by the VOIP-1078 squirrel migration with
+an explicit "needs its own ticket" note. VOIP-1305 is that ticket.
+
+## Two corruption forms
+
+`.Bytes()` binding produces a different stored shape depending on the
+go-sql-driver protocol path. Both were reproduced against MySQL 8.0 with the
+real driver, and both must be handled because the production DSN (k8s secret)
+cannot be inspected from the repository.
+
+| Form | Driver path | Stored shape | JSON_TYPE | Detection (per element) |
+|---|---|---|---|---|
+| A | prepared statement (driver default, likely production path) | raw 16 bytes inside a JSON STRING (control bytes escaped, non ASCII bytes raw, possibly invalid UTF-8) | STRING | `LENGTH(JSON_UNQUOTE(elem)) = 16` (byte length; healthy UUID text is 36 bytes) |
+| B | `interpolateParams=true` text protocol, or a `_binary` SQL literal | opaque JSON BLOB, rendered as `base64:type<N>:<payload>` | BLOB | `JSON_TYPE(elem) = 'BLOB'` |
+
+A healthy 36 char UUID string matches neither condition. `CAST`/regexp based
+detection was rejected: invalid UTF-8 makes it return NULL or misbehave
+(measured), so detection uses only `JSON_TYPE` plus byte `LENGTH`.
+
+## Code fix (bin-call-manager)
+
+| File | Change |
+|---|---|
+| `pkg/dbhandler/confbridge.go` | `buildConfbridgeAddRecordingIDs` binds `recordingID.String()`; the carried-over-bug NOTE is replaced by a one line fix record |
+| `pkg/dbhandler/call.go` | removed the comparison NOTE above `buildCallAddRecordingIDs` (obsolete after the fix) |
+| `pkg/dbhandler/json_expr_golden_test.go` | ConfbridgeAddRecordingIDs golden case now asserts `.String()` argument |
+| `pkg/dbhandler/recording_ids_scan_test.go` (new) | pins that Form A (invalid UTF-8 and all ASCII variants) and Form B fail `[]uuid.UUID` unmarshal on the ScanRow-equivalent path, and that the clean `.String()` shape round-trips; error strings are not asserted |
+
+## Backfill migration (bin-dbscheme-manager)
+
+Revision `ede50012c416_call_confbridges_backfill_recording_ids` (generated with
+`alembic revision`, chained after `902325885953`, single head verified).
+Repairs both forms element by element, in server side SQL only. Only BINARY(16)
+row ids and integer counts reach the Python client, so corrupted bytes never
+cross the driver boundary (no UTF-8 decode hazard).
+
+Algorithm:
+
+1. Phase 0, scope probe. `SELECT COALESCE(MAX(JSON_LENGTH(recording_ids)), 0)`
+   as the per index loop bound; exit immediately when 0. This always executed
+   path stays MariaDB compatible because the dbscheme Docker image build runs
+   the whole migration chain against an empty temporary MariaDB (Phase 0 exits
+   early there). A JSON null scalar row yields JSON_LENGTH 1, which is harmless
+   (the loops match nothing for it).
+2. Phase 1, candidate collection. For each array index, a plain `SELECT id`
+   with the per element detection predicate collects corrupted row ids into a
+   hex set. Plain SELECTs are lock free consistent reads under REPEATABLE READ
+   (an earlier `INSERT ... SELECT` staging design was rejected because it takes
+   shared next-key locks on every scanned row, measured as a real writer
+   blocker). Exit with a zero report when the set is empty.
+3. Phase 2, repair. The id set is processed in 500 id chunks as
+   `IN (UNHEX('<hex>'), ...)` literals (hex digits only, no bind parameters),
+   so exclusive locks touch only corrupted rows. Per index, two `JSON_REPLACE`
+   UPDATEs restore the element to lowercase 8-4-4-4-12 UUID text: Form A feeds
+   `HEX()` the unquoted 16 byte string; Form B feeds it the `FROM_BASE64`
+   decoded payload after the last `CHAR(58)` separator, guarded by a decoded
+   length of exactly 16. Array order is preserved; healthy elements are
+   untouched. The SQL text contains no colon characters: `op.execute`/`text()`
+   treat `:name` as a bind parameter, so the Form B separator is `CHAR(58)`.
+4. Phase 3, verify and report. The Phase 1 scan is re-run restricted to the
+   candidate chunks, then the migration prints
+   `VOIP-1305 backfill: candidate_rows=N, repaired_rows=N, remaining_anomaly_rows=N`
+   and a warning when remaining is greater than zero.
+
+`downgrade()` is a no-op with a reason comment: reversing a data repair would
+re-corrupt restored values (precedent: `9443d2d65ad8_add_join_bridge.py`).
+
+Idempotency: repaired elements no longer match detection, so a re-run collects
+only still-anomalous rows and changes nothing. Verified on a throwaway MySQL
+8.0 with the full fixture matrix (both forms, mixed arrays with corruption at
+index above 0, a partially repairable row, clean, SQL NULL, JSON null, and
+empty array rows): exact UUID restoration, order preserved, untouched rows
+byte identical, second run reported repaired 0 with zero data changes.
+
+## Production runbook
+
+1. Pre-check (read only, requires MySQL 8.0.4 or newer for JSON_TABLE; the
+   migration itself does not use JSON_TABLE):
+
+   ```sql
+   SELECT COUNT(DISTINCT c.id) FROM call_confbridges c,
+     JSON_TABLE(c.recording_ids, '$[*]' COLUMNS (elem JSON PATH '$')) jt
+   WHERE JSON_TYPE(jt.elem) = 'BLOB'
+      OR (JSON_TYPE(jt.elem) = 'STRING' AND LENGTH(JSON_UNQUOTE(jt.elem)) = 16);
+   ```
+
+   A zero count does not block applying the migration (it is a no-op then);
+   apply anyway to keep the revision chain consistent.
+2. Apply: a human runs `alembic upgrade head` over VPN (AI execution of
+   upgrade against shared databases is prohibited). A low traffic window is
+   recommended to soften the Phase 1 scan load; writers are only ever blocked
+   on the corrupted rows themselves during Phase 2.
+3. Post-check: re-run the query from step 1, expect 0. If the migration
+   printed `remaining_anomaly_rows` greater than zero, those elements matched
+   detection but could not be safely converted; they are preserved unchanged
+   and need manual investigation.
+4. Cache: stale confbridge entries in Redis converge naturally within the 24h
+   TTL; no manual invalidation required.
+5. Ordering: neither order (code fix deploy vs migration) can create new
+   corruption. However, applying the migration before the fixed code is
+   deployed leaves any corruption written after the Phase 1 snapshot
+   unrepaired (the post-check query catches it), so deploying the code fix
+   first and then applying the migration is recommended for a complete repair.
+6. Optional forensics: confbridge cache update failure error logs mark past
+   corruption events.
+
+## Scope exclusion
+
+`exprJSONArrayAppend` has no `coalesce(recording_ids, '[]')` guard, unlike the
+conference-manager and queue-manager equivalents, so an append against a SQL
+NULL column is silently lost. Current `ConfbridgeCreate` always writes `[]`,
+so only legacy or manually created NULL rows are affected. This asymmetry is
+deliberately out of scope for VOIP-1305; it is recorded as an observation and
+tracked in a separate follow-up Jira ticket.
+
+## RST docs impact: none
+
+The fix restores the intended storage contract (a JSON array of UUID strings)
+for an internal column; the API and webhook shapes are unchanged. Confbridge
+is an internal resource with no WebhookMessage, so there is no user facing
+struct documentation to update.
+
+## Service docs impact: none
+
+The change is confined to `pkg/dbhandler` internals plus a data migration. No
+routing table, event set, configuration, domain model shape, or dependency
+changed, so no `docs/*.md` extraction target in bin-call-manager is affected.

--- a/docs/plans/2026-08-10-voip-1305-confbridge-recording-ids-fix-and-backfill-design.md
+++ b/docs/plans/2026-08-10-voip-1305-confbridge-recording-ids-fix-and-backfill-design.md
@@ -104,13 +104,18 @@ byte identical, second run reported repaired 0 with zero data changes.
 
    ```sql
    SELECT COUNT(DISTINCT c.id) FROM call_confbridges c,
-     JSON_TABLE(c.recording_ids, '$[*]' COLUMNS (elem JSON PATH '$')) jt
+     JSON_TABLE(COALESCE(c.recording_ids, JSON_ARRAY()), '$[*]'
+       COLUMNS (elem JSON PATH '$')) jt
    WHERE JSON_TYPE(jt.elem) = 'BLOB'
       OR (JSON_TYPE(jt.elem) = 'STRING' AND LENGTH(JSON_UNQUOTE(jt.elem)) = 16);
    ```
 
-   A zero count does not block applying the migration (it is a no-op then);
-   apply anyway to keep the revision chain consistent.
+   The COALESCE guard keeps JSON_TABLE away from SQL NULL documents, which
+   some older 8.0 patch levels reject; on current 8.0 the behavior is
+   identical (verified: NULL, JSON null, and empty array rows are ignored,
+   corrupted rows are counted). A zero count does not block applying the
+   migration (it is a no-op then); apply anyway to keep the revision chain
+   consistent.
 2. Apply: a human runs `alembic upgrade head` over VPN (AI execution of
    upgrade against shared databases is prohibited). A low traffic window is
    recommended to soften the Phase 1 scan load; writers are only ever blocked


### PR DESCRIPTION
Fix the ConfbridgeAddRecordingIDs UUID encoding mismatch that silently stored malformed elements in call_confbridges.recording_ids, and ship an idempotent backfill migration plus a production runbook for repairing existing rows.

buildConfbridgeAddRecordingIDs bound recordingID.Bytes() where every sibling writer binds .String(). MySQL accepts the binary bind without error and stores a malformed element (a raw 16 byte JSON STRING via the default prepared statement path, or an opaque base64 BLOB via the text protocol path). Reads then fail when unmarshaling recording_ids into []uuid.UUID, so an affected confbridge becomes unreadable from the database once its Redis cache entry (TTL 24h) expires. Conference recording is the only trigger path.

- bin-call-manager: Fix ConfbridgeAddRecordingIDs to bind recordingID.String() instead of .Bytes(), matching CallAddRecordingIDs and ConfbridgeAddExternalMediaID
- bin-call-manager: Update the json_expr golden test to pin the corrected argument and remove the carried over bug notes from VOIP-1078
- bin-call-manager: Add a regression test pinning that both corruption forms fail to unmarshal into []uuid.UUID while the correct string form round trips
- bin-dbscheme-manager: Add migration ede50012c416 backfilling corrupted recording_ids elements (both forms, element wise, order preserving, idempotent, nonlocking id collection, PK targeted updates in 500 id chunks); applying it stays manual per the Alembic policy
- docs: Add docs/plans/2026-08-10-voip-1305-confbridge-recording-ids-fix-and-backfill-design.md with the corruption model, migration algorithm, and production runbook

Runbook summary: run the read only precheck query from the design doc to count affected rows, deploy the code fix first, then apply the migration over VPN in a low traffic window and rerun the query expecting zero. A remaining_anomaly_rows value above zero means unconvertible elements were preserved for manual investigation.