### PR TITLE
NOJIRA-Bm-ssh-deploy-rollout-all-services

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -10,6 +10,9 @@ references:
   gcp_image: &gcp_image
     - image: cimg/gcp:2026.02
   gcloud_image: &gcloud_image
+    # Still needed: bin-sentinel-manager-release is the one remaining GKE
+    # deploy job (sentinel-manager requires the Kubernetes API and has no
+    # docker-compose equivalent on bm-nyc-01 - see that job's comment).
     - image: google/cloud-sdk:debian_component_based
 
 
@@ -203,7 +206,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-agent-manager-test
-      - bin-agent-manager-release:
+      - bin-agent-manager-deploy:
           <<: *context_production
           requires:
             - bin-agent-manager-build
@@ -221,7 +224,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-api-manager-test
-      - bin-api-manager-release:
+      - bin-api-manager-deploy:
           <<: *context_production
           requires:
             - bin-api-manager-build
@@ -238,7 +241,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-billing-manager-test
-      - bin-billing-manager-release:
+      - bin-billing-manager-deploy:
           <<: *context_production
           requires:
             - bin-billing-manager-build
@@ -255,22 +258,19 @@ workflows:
           <<: *context_production
           requires:
             - bin-call-manager-test
-      - bin-call-manager-deploy-approval:
-          type: approval
-          # Deliberately NOT restricted to main: bm-nyc-01 is the only
-          # environment we have, so it doubles as staging - deploying an
-          # unmerged branch's build here to verify it before merge is the
-          # whole point, not a risk to avoid. The manual approval click
-          # itself is the safety control (same as any other approval job in
-          # this file), not a branch restriction. Do not add a
-          # `filters: branches: only: main` here without re-confirming this
-          # reasoning with the team first.
-          requires:
-            - bin-call-manager-build
       - bin-call-manager-deploy:
           <<: *context_production
+          # Single approval gate (build-approval, above) covers the whole
+          # pipeline including this deploy - matches the old GKE release
+          # job's convenience (build-approval alone used to be enough to
+          # reach production). A second deploy-specific approval was tried
+          # and dropped: bm-nyc-01 is the only environment we have, so it
+          # doubles as staging, and requiring two clicks per deploy added
+          # friction without a safety benefit distinct from build-approval
+          # itself. Do not add a second approval gate here without
+          # re-confirming with the team first.
           requires:
-            - bin-call-manager-deploy-approval
+            - bin-call-manager-build
 
   bin-campaign-manager:
     when: << pipeline.parameters.run-bin-campaign-manager >>
@@ -284,7 +284,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-campaign-manager-test
-      - bin-campaign-manager-release:
+      - bin-campaign-manager-deploy:
           <<: *context_production
           requires:
             - bin-campaign-manager-build
@@ -301,7 +301,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-ai-manager-test
-      - bin-ai-manager-release:
+      - bin-ai-manager-deploy:
           <<: *context_production
           requires:
             - bin-ai-manager-build
@@ -327,7 +327,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-contact-manager-test
-      - bin-contact-manager-release:
+      - bin-contact-manager-deploy:
           <<: *context_production
           requires:
             - bin-contact-manager-build
@@ -344,7 +344,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-conference-manager-test
-      - bin-conference-manager-release:
+      - bin-conference-manager-deploy:
           <<: *context_production
           requires:
             - bin-conference-manager-build
@@ -361,7 +361,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-conversation-manager-test
-      - bin-conversation-manager-release:
+      - bin-conversation-manager-deploy:
           <<: *context_production
           requires:
             - bin-conversation-manager-build
@@ -378,7 +378,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-customer-manager-test
-      - bin-customer-manager-release:
+      - bin-customer-manager-deploy:
           <<: *context_production
           requires:
             - bin-customer-manager-build
@@ -429,7 +429,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-direct-manager-test
-      - bin-direct-manager-release:
+      - bin-direct-manager-deploy:
           <<: *context_production
           requires:
             - bin-direct-manager-build
@@ -446,7 +446,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-email-manager-test
-      - bin-email-manager-release:
+      - bin-email-manager-deploy:
           <<: *context_production
           requires:
             - bin-email-manager-build
@@ -463,7 +463,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-flow-manager-test
-      - bin-flow-manager-release:
+      - bin-flow-manager-deploy:
           <<: *context_production
           requires:
             - bin-flow-manager-build
@@ -480,7 +480,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-hook-manager-test
-      - bin-hook-manager-release:
+      - bin-hook-manager-deploy:
           <<: *context_production
           requires:
             - bin-hook-manager-build
@@ -497,7 +497,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-message-manager-test
-      - bin-message-manager-release:
+      - bin-message-manager-deploy:
           <<: *context_production
           requires:
             - bin-message-manager-build
@@ -514,7 +514,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-number-manager-test
-      - bin-number-manager-release:
+      - bin-number-manager-deploy:
           <<: *context_production
           requires:
             - bin-number-manager-build
@@ -540,7 +540,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-outdial-manager-test
-      - bin-outdial-manager-release:
+      - bin-outdial-manager-deploy:
           <<: *context_production
           requires:
             - bin-outdial-manager-build
@@ -557,7 +557,7 @@ workflows:
           <<: *context_production
           requires:
             - build-approval
-      - bin-pipecat-manager-release:
+      - bin-pipecat-manager-deploy:
           <<: *context_production
           requires:
             - bin-pipecat-manager-build
@@ -574,7 +574,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-queue-manager-test
-      - bin-queue-manager-release:
+      - bin-queue-manager-deploy:
           <<: *context_production
           requires:
             - bin-queue-manager-build
@@ -591,7 +591,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-rag-manager-test
-      - bin-rag-manager-release:
+      - bin-rag-manager-deploy:
           <<: *context_production
           requires:
             - bin-rag-manager-build
@@ -608,7 +608,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-registrar-manager-test
-      - bin-registrar-manager-release:
+      - bin-registrar-manager-deploy:
           <<: *context_production
           requires:
             - bin-registrar-manager-build
@@ -625,7 +625,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-route-manager-test
-      - bin-route-manager-release:
+      - bin-route-manager-deploy:
           <<: *context_production
           requires:
             - bin-route-manager-build
@@ -642,7 +642,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-schedule-manager-test
-      - bin-schedule-manager-release:
+      - bin-schedule-manager-deploy:
           <<: *context_production
           requires:
             - bin-schedule-manager-build
@@ -660,6 +660,14 @@ workflows:
           requires:
             - bin-sentinel-manager-test
       - bin-sentinel-manager-release:
+          # NOT converted to ssh-deploy like the other 32 services:
+          # sentinel-manager requires the Kubernetes API
+          # (rest.InClusterConfig) and is intentionally excluded from
+          # bm-nyc-01's docker-compose.yml (see voipbin/voipbin's
+          # install/docker-compose.yml.dist and
+          # sync-compose-images.sh's LOCK_ONLY_IMAGES comment) - it has no
+          # compose service to deploy to there, so it stays on GKE until a
+          # non-Kubernetes runtime path exists for it.
           <<: *context_production
           requires:
             - bin-sentinel-manager-build
@@ -676,7 +684,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-storage-manager-test
-      - bin-storage-manager-release:
+      - bin-storage-manager-deploy:
           <<: *context_production
           requires:
             - bin-storage-manager-build
@@ -693,7 +701,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-tag-manager-test
-      - bin-tag-manager-release:
+      - bin-tag-manager-deploy:
           <<: *context_production
           requires:
             - bin-tag-manager-build
@@ -710,7 +718,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-talk-manager-test
-      - bin-talk-manager-release:
+      - bin-talk-manager-deploy:
           <<: *context_production
           requires:
             - bin-talk-manager-build
@@ -727,7 +735,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-timeline-manager-test
-      - bin-timeline-manager-release:
+      - bin-timeline-manager-deploy:
           <<: *context_production
           requires:
             - bin-timeline-manager-build
@@ -744,7 +752,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-transcribe-manager-test
-      - bin-transcribe-manager-release:
+      - bin-transcribe-manager-deploy:
           <<: *context_production
           requires:
             - bin-transcribe-manager-build
@@ -761,7 +769,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-transfer-manager-test
-      - bin-transfer-manager-release:
+      - bin-transfer-manager-deploy:
           <<: *context_production
           requires:
             - bin-transfer-manager-build
@@ -793,7 +801,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-tts-manager-test
-      - bin-tts-manager-release:
+      - bin-tts-manager-deploy:
           <<: *context_production
           requires:
             - bin-tts-manager-build
@@ -810,7 +818,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-webchat-manager-test
-      - bin-webchat-manager-release:
+      - bin-webchat-manager-deploy:
           <<: *context_production
           requires:
             - bin-webchat-manager-build
@@ -827,7 +835,7 @@ workflows:
           <<: *context_production
           requires:
             - bin-webhook-manager-test
-      - bin-webhook-manager-release:
+      - bin-webhook-manager-deploy:
           <<: *context_production
           requires:
             - bin-webhook-manager-build
@@ -903,15 +911,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-agent-manager
 
-  bin-agent-manager-release:
-    docker: *gcloud_image
+  bin-agent-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-agent-manager
-          image-name: agent-manager
-          project-id: voipbin
-          project-repository: bin-agent-manager
+      - checkout
+      - run:
+          name: Deploy bin-agent-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-agent-manager agent-manager
 
   # bin-api-manager
   bin-api-manager-test:
@@ -930,15 +938,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-api-manager
 
-  bin-api-manager-release:
-    docker: *gcloud_image
+  bin-api-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-api-manager
-          image-name: api-manager
-          project-id: voipbin
-          project-repository: bin-api-manager
+      - checkout
+      - run:
+          name: Deploy bin-api-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-api-manager api-manager
 
   # bin-billing-manager
   bin-billing-manager-test:
@@ -957,15 +965,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-billing-manager
 
-  bin-billing-manager-release:
-    docker: *gcloud_image
+  bin-billing-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-billing-manager
-          image-name: billing-manager
-          source-directory: bin-billing-manager
+      - checkout
+      - run:
+          name: Deploy bin-billing-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-billing-manager billing-manager
 
   # bin-call-manager
   bin-call-manager-test:
@@ -1021,15 +1029,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-campaign-manager
 
-  bin-campaign-manager-release:
-    docker: *gcloud_image
+  bin-campaign-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-campaign-manager
-          image-name: campaign-manager
-          project-id: voipbin
-          project-repository: bin-campaign-manager
+      - checkout
+      - run:
+          name: Deploy bin-campaign-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-campaign-manager campaign-manager
 
   # bin-ai-manager
   bin-ai-manager-test:
@@ -1048,15 +1056,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-ai-manager
 
-  bin-ai-manager-release:
-    docker: *gcloud_image
+  bin-ai-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-ai-manager
-          image-name: ai-manager
-          project-id: voipbin
-          project-repository: bin-ai-manager
+      - checkout
+      - run:
+          name: Deploy bin-ai-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-ai-manager ai-manager
 
   # bin-common-handler
   bin-common-handler-test:
@@ -1083,15 +1091,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-contact-manager
 
-  bin-contact-manager-release:
-    docker: *gcloud_image
+  bin-contact-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-contact-manager
-          image-name: contact-manager
-          project-id: voipbin
-          project-repository: bin-contact-manager
+      - checkout
+      - run:
+          name: Deploy bin-contact-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-contact-manager contact-manager
 
   # bin-conference-manager
   bin-conference-manager-test:
@@ -1110,15 +1118,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-conference-manager
 
-  bin-conference-manager-release:
-    docker: *gcloud_image
+  bin-conference-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-conference-manager
-          image-name: conference-manager
-          project-id: voipbin
-          project-repository: bin-conference-manager
+      - checkout
+      - run:
+          name: Deploy bin-conference-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-conference-manager conference-manager
 
   # bin-conversation-manager
   bin-conversation-manager-test:
@@ -1137,15 +1145,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-conversation-manager
 
-  bin-conversation-manager-release:
-    docker: *gcloud_image
+  bin-conversation-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-conversation-manager
-          image-name: conversation-manager
-          project-id: voipbin
-          project-repository: bin-conversation-manager
+      - checkout
+      - run:
+          name: Deploy bin-conversation-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-conversation-manager conversation-manager
 
   # bin-customer-manager
   bin-customer-manager-test:
@@ -1164,15 +1172,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-customer-manager
 
-  bin-customer-manager-release:
-    docker: *gcloud_image
+  bin-customer-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-customer-manager
-          image-name: customer-manager
-          project-id: voipbin
-          project-repository: bin-customer-manager
+      - checkout
+      - run:
+          name: Deploy bin-customer-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-customer-manager customer-manager
 
   # bin-dbscheme-manager has no build/deploy job -- production DB is not
   # reachable from CircleCI, so all migration application is manual/VPN.
@@ -1241,15 +1249,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-direct-manager
 
-  bin-direct-manager-release:
-    docker: *gcloud_image
+  bin-direct-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-direct-manager
-          image-name: direct-manager
-          project-id: voipbin
-          project-repository: bin-direct-manager
+      - checkout
+      - run:
+          name: Deploy bin-direct-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-direct-manager direct-manager
 
   # bin-email-manager
   bin-email-manager-test:
@@ -1268,15 +1276,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-email-manager
 
-  bin-email-manager-release:
-    docker: *gcloud_image
+  bin-email-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-email-manager
-          image-name: email-manager
-          project-id: voipbin
-          project-repository: bin-email-manager
+      - checkout
+      - run:
+          name: Deploy bin-email-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-email-manager email-manager
 
   # bin-flow-manager
   bin-flow-manager-test:
@@ -1295,15 +1303,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-flow-manager
 
-  bin-flow-manager-release:
-    docker: *gcloud_image
+  bin-flow-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-flow-manager
-          image-name: flow-manager
-          project-id: voipbin
-          project-repository: bin-flow-manager
+      - checkout
+      - run:
+          name: Deploy bin-flow-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-flow-manager flow-manager
 
   # bin-hook-manager
   bin-hook-manager-test:
@@ -1322,15 +1330,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-hook-manager
 
-  bin-hook-manager-release:
-    docker: *gcloud_image
+  bin-hook-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-hook-manager
-          image-name: hook-manager
-          project-id: voipbin
-          project-repository: bin-hook-manager
+      - checkout
+      - run:
+          name: Deploy bin-hook-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-hook-manager hook-manager
 
   # bin-message-manager
   bin-message-manager-test:
@@ -1349,15 +1357,15 @@ jobs:
           project-repository: bin-message-manager
           source-directory: bin-message-manager
 
-  bin-message-manager-release:
-    docker: *gcloud_image
+  bin-message-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-message-manager
-          source-directory: bin-message-manager
-          image-name: message-manager
+      - checkout
+      - run:
+          name: Deploy bin-message-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-message-manager message-manager
 
   # bin-number-manager
   bin-number-manager-test:
@@ -1376,15 +1384,15 @@ jobs:
           project-repository: bin-number-manager
           source-directory: bin-number-manager
 
-  bin-number-manager-release:
-    docker: *gcloud_image
+  bin-number-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-number-manager
-          source-directory: bin-number-manager
-          image-name: number-manager
+      - checkout
+      - run:
+          name: Deploy bin-number-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-number-manager number-manager
 
   # bin-openapi-manager
   bin-openapi-manager-validate:
@@ -1431,15 +1439,15 @@ jobs:
           project-repository: bin-outdial-manager
           source-directory: bin-outdial-manager
 
-  bin-outdial-manager-release:
-    docker: *gcloud_image
+  bin-outdial-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-outdial-manager
-          source-directory: bin-outdial-manager
-          image-name: outdial-manager
+      - checkout
+      - run:
+          name: Deploy bin-outdial-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-outdial-manager outdial-manager
 
   # bin-pipecat-manager
   bin-pipecat-manager-test:
@@ -1458,15 +1466,15 @@ jobs:
           project-repository: bin-pipecat-manager
           source-directory: bin-pipecat-manager
 
-  bin-pipecat-manager-release:
-    docker: *gcloud_image
+  bin-pipecat-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-pipecat-manager
-          source-directory: bin-pipecat-manager
-          image-name: pipecat-manager
+      - checkout
+      - run:
+          name: Deploy bin-pipecat-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-pipecat-manager pipecat-manager
 
   # bin-queue-manager
   bin-queue-manager-test:
@@ -1485,15 +1493,15 @@ jobs:
           project-repository: bin-queue-manager
           source-directory: bin-queue-manager
 
-  bin-queue-manager-release:
-    docker: *gcloud_image
+  bin-queue-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-queue-manager
-          image-name: queue-manager
-          source-directory: bin-queue-manager
+      - checkout
+      - run:
+          name: Deploy bin-queue-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-queue-manager queue-manager
 
   # bin-rag-manager
   bin-rag-manager-test:
@@ -1512,15 +1520,15 @@ jobs:
           project-id: voipbin
           project-repository: bin-rag-manager
 
-  bin-rag-manager-release:
-    docker: *gcloud_image
+  bin-rag-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          source-directory: bin-rag-manager
-          image-name: rag-manager
-          project-id: voipbin
-          project-repository: bin-rag-manager
+      - checkout
+      - run:
+          name: Deploy bin-rag-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-rag-manager rag-manager
 
   # bin-registrar-manager
   bin-registrar-manager-test:
@@ -1539,15 +1547,15 @@ jobs:
           project-repository: bin-registrar-manager
           source-directory: bin-registrar-manager
 
-  bin-registrar-manager-release:
-    docker: *gcloud_image
+  bin-registrar-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-registrar-manager
-          source-directory: bin-registrar-manager
-          image-name: registrar-manager
+      - checkout
+      - run:
+          name: Deploy bin-registrar-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-registrar-manager registrar-manager
 
   # bin-route-manager
   bin-route-manager-test:
@@ -1566,15 +1574,15 @@ jobs:
           project-repository: bin-route-manager
           source-directory: bin-route-manager
 
-  bin-route-manager-release:
-    docker: *gcloud_image
+  bin-route-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-route-manager
-          source-directory: bin-route-manager
-          image-name: route-manager
+      - checkout
+      - run:
+          name: Deploy bin-route-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-route-manager route-manager
 
   # bin-schedule-manager
   bin-schedule-manager-test:
@@ -1593,15 +1601,15 @@ jobs:
           project-repository: bin-schedule-manager
           source-directory: bin-schedule-manager
 
-  bin-schedule-manager-release:
-    docker: *gcloud_image
+  bin-schedule-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-schedule-manager
-          image-name: schedule-manager
-          source-directory: bin-schedule-manager
+      - checkout
+      - run:
+          name: Deploy bin-schedule-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-schedule-manager schedule-manager
 
   # bin-sentinel-manager
   bin-sentinel-manager-test:
@@ -1647,15 +1655,15 @@ jobs:
           project-repository: bin-storage-manager
           source-directory: bin-storage-manager
 
-  bin-storage-manager-release:
-    docker: *gcloud_image
+  bin-storage-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-storage-manager
-          source-directory: bin-storage-manager
-          image-name: storage-manager
+      - checkout
+      - run:
+          name: Deploy bin-storage-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-storage-manager storage-manager
 
   # bin-tag-manager
   bin-tag-manager-test:
@@ -1674,15 +1682,15 @@ jobs:
           project-repository: bin-tag-manager
           source-directory: bin-tag-manager
 
-  bin-tag-manager-release:
-    docker: *gcloud_image
+  bin-tag-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-tag-manager
-          image-name: tag-manager
-          source-directory: bin-tag-manager
+      - checkout
+      - run:
+          name: Deploy bin-tag-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-tag-manager tag-manager
 
   # bin-talk-manager
   bin-talk-manager-test:
@@ -1701,15 +1709,15 @@ jobs:
           project-repository: bin-talk-manager
           source-directory: bin-talk-manager
 
-  bin-talk-manager-release:
-    docker: *gcloud_image
+  bin-talk-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-talk-manager
-          image-name: talk-manager
-          source-directory: bin-talk-manager
+      - checkout
+      - run:
+          name: Deploy bin-talk-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-talk-manager talk-manager
 
   # bin-timeline-manager
   bin-timeline-manager-test:
@@ -1728,15 +1736,15 @@ jobs:
           project-repository: bin-timeline-manager
           source-directory: bin-timeline-manager
 
-  bin-timeline-manager-release:
-    docker: *gcloud_image
+  bin-timeline-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-timeline-manager
-          image-name: timeline-manager
-          source-directory: bin-timeline-manager
+      - checkout
+      - run:
+          name: Deploy bin-timeline-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-timeline-manager timeline-manager
 
   # bin-transcribe-manager
   bin-transcribe-manager-test:
@@ -1755,15 +1763,15 @@ jobs:
           project-repository: bin-transcribe-manager
           source-directory: bin-transcribe-manager
 
-  bin-transcribe-manager-release:
-    docker: *gcloud_image
+  bin-transcribe-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-transcribe-manager
-          source-directory: bin-transcribe-manager
-          image-name: transcribe-manager
+      - checkout
+      - run:
+          name: Deploy bin-transcribe-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-transcribe-manager transcribe-manager
 
   # bin-transfer-manager
   bin-transfer-manager-test:
@@ -1782,15 +1790,15 @@ jobs:
           project-repository: bin-transfer-manager
           source-directory: bin-transfer-manager
 
-  bin-transfer-manager-release:
-    docker: *gcloud_image
+  bin-transfer-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-transfer-manager
-          image-name: transfer-manager
-          source-directory: bin-transfer-manager
+      - checkout
+      - run:
+          name: Deploy bin-transfer-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-transfer-manager transfer-manager
 
   # bin-trigger-sender
   bin-trigger-sender-test:
@@ -1826,15 +1834,15 @@ jobs:
           project-repository: bin-tts-manager
           source-directory: bin-tts-manager
 
-  bin-tts-manager-release:
-    docker: *gcloud_image
+  bin-tts-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-tts-manager
-          image-name: tts-manager
-          source-directory: bin-tts-manager
+      - checkout
+      - run:
+          name: Deploy bin-tts-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-tts-manager tts-manager
 
   # bin-webchat-manager
   bin-webchat-manager-test:
@@ -1853,15 +1861,15 @@ jobs:
           project-repository: bin-webchat-manager
           source-directory: bin-webchat-manager
 
-  bin-webchat-manager-release:
-    docker: *gcloud_image
+  bin-webchat-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-webchat-manager
-          source-directory: bin-webchat-manager
-          image-name: webchat-manager
+      - checkout
+      - run:
+          name: Deploy bin-webchat-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-webchat-manager webchat-manager
 
   # bin-webhook-manager
   bin-webhook-manager-test:
@@ -1880,15 +1888,15 @@ jobs:
           project-repository: bin-webhook-manager
           source-directory: bin-webhook-manager
 
-  bin-webhook-manager-release:
-    docker: *gcloud_image
+  bin-webhook-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
     resource_class: small
     steps:
-      - docker-release:
-          project-id: voipbin
-          project-repository: bin-webhook-manager
-          source-directory: bin-webhook-manager
-          image-name: webhook-manager
+      - checkout
+      - run:
+          name: Deploy bin-webhook-manager to bm-nyc-01
+          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-webhook-manager webhook-manager
 
   ############################################
   # namespace: voip
@@ -2113,6 +2121,8 @@ commands:
 
             echo "Image pushed to << parameters.project-id >>/<< parameters.project-repository >>:$CIRCLE_SHA1"
 
+  # Still used by bin-sentinel-manager-release only - see that job's
+  # comment for why sentinel-manager stays on GKE instead of ssh-deploy.
   docker-release:
     description: "release the docker image"
     parameters:

--- a/bin-agent-manager/README.md
+++ b/bin-agent-manager/README.md
@@ -79,3 +79,13 @@ Represents agent's skills and groups.
 
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-agent-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-agent-manager-deploy` runs after `bin-agent-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-ai-manager/README.md
+++ b/bin-ai-manager/README.md
@@ -1,3 +1,13 @@
 # ai-manager
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-ai-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-ai-manager-deploy` runs after `bin-ai-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-api-manager/README.md
+++ b/bin-api-manager/README.md
@@ -250,3 +250,13 @@ See [CLAUDE.md](./CLAUDE.md).
 Copyright © 2024 VoIPBIN. All rights reserved.
 
 <!-- Updated dependencies: 2026-04-28 -->
+
+# Deploy
+
+`bin-api-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-api-manager-deploy` runs after `bin-api-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-billing-manager/README.md
+++ b/bin-billing-manager/README.md
@@ -109,3 +109,13 @@ Usage of ./billing-manager:
 ```
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-billing-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-billing-manager-deploy` runs after `bin-billing-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-call-manager/README.md
+++ b/bin-call-manager/README.md
@@ -105,11 +105,12 @@ Notification event for call's hangup.
 # Deploy
 
 This service is the pilot for CircleCI's direct-SSH deploy to bm-nyc-01, our
-only server:
-`bin-call-manager-build` pushes the image, then `bin-call-manager-deploy-approval`
-(manual) gates `bin-call-manager-deploy`, which bumps this service's pin on
-bm-nyc-01 and recreates the container. See `.circleci/scripts/ssh-deploy.sh`.
-The previous GKE deploy path for this service has been removed.
+only server: `build-approval` gates the whole pipeline (test → build →
+deploy) with a single click, matching the old GKE release job's convenience.
+`bin-call-manager-deploy` runs after `bin-call-manager-build`, bumping this
+service's pin on bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh`. The previous GKE deploy path for this
+service has been removed.
 
 # Note
 

--- a/bin-campaign-manager/README.md
+++ b/bin-campaign-manager/README.md
@@ -62,3 +62,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-campaign-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-campaign-manager-deploy` runs after `bin-campaign-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-conference-manager/README.md
+++ b/bin-conference-manager/README.md
@@ -56,3 +56,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-conference-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-conference-manager-deploy` runs after `bin-conference-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-contact-manager/README.md
+++ b/bin-contact-manager/README.md
@@ -1,3 +1,13 @@
 # contact-manager
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-contact-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-contact-manager-deploy` runs after `bin-contact-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-conversation-manager/README.md
+++ b/bin-conversation-manager/README.md
@@ -3,3 +3,13 @@
 Manages multi-channel conversations (SMS/MMS, LINE, WhatsApp) and their messages, handling bidirectional communication with external messaging platforms.
 
 <!-- Updated dependencies: 2026-03-30 -->
+
+# Deploy
+
+`bin-conversation-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-conversation-manager-deploy` runs after `bin-conversation-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-customer-manager/README.md
+++ b/bin-customer-manager/README.md
@@ -55,3 +55,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-customer-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-customer-manager-deploy` runs after `bin-customer-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-direct-manager/README.md
+++ b/bin-direct-manager/README.md
@@ -136,3 +136,13 @@ The CLI uses the same configuration flags and environment variables as `direct-m
 ## Prometheus Metrics
 
 - `direct_manager_receive_request_process_time` - Histogram of RPC request processing time (labels: type, method)
+
+# Deploy
+
+`bin-direct-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-direct-manager-deploy` runs after `bin-direct-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-email-manager/README.md
+++ b/bin-email-manager/README.md
@@ -18,3 +18,13 @@ For SendGrid, configure your webhook to point to the following endpoint:
 ```Sendgrid: https://hook.voipbin.net/v1.0/emails/sendgrid```
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-email-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-email-manager-deploy` runs after `bin-email-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-flow-manager/README.md
+++ b/bin-flow-manager/README.md
@@ -239,3 +239,13 @@ $ go build ./cmd/...
 ```
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-flow-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-flow-manager-deploy` runs after `bin-flow-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-hook-manager/README.md
+++ b/bin-hook-manager/README.md
@@ -28,3 +28,13 @@ $ cat <your cert file> | base64 -w 0
 * https://hook.voipbin.net/v1.0/conversation : conversation-manager
 
 <!-- Updated dependencies: 2026-03-30 -->
+
+# Deploy
+
+`bin-hook-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-hook-manager-deploy` runs after `bin-hook-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-message-manager/README.md
+++ b/bin-message-manager/README.md
@@ -53,3 +53,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-message-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-message-manager-deploy` runs after `bin-message-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-number-manager/README.md
+++ b/bin-number-manager/README.md
@@ -12,3 +12,13 @@ account: sungtae@voipbin.net
 * +14703298699
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-number-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-number-manager-deploy` runs after `bin-number-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-outdial-manager/README.md
+++ b/bin-outdial-manager/README.md
@@ -55,3 +55,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-outdial-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-outdial-manager-deploy` runs after `bin-outdial-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-pipecat-manager/README.md
+++ b/bin-pipecat-manager/README.md
@@ -3,3 +3,13 @@
 # requirements.txt
 poetry export -f requirements.txt --output requirements.txt --without-hashes
 <!-- Updated dependencies: 2026-03-30 -->
+
+# Deploy
+
+`bin-pipecat-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-pipecat-manager-deploy` runs after `bin-pipecat-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-queue-manager/README.md
+++ b/bin-queue-manager/README.md
@@ -56,3 +56,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-queue-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-queue-manager-deploy` runs after `bin-queue-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-rag-manager/README.md
+++ b/bin-rag-manager/README.md
@@ -1,3 +1,13 @@
 # rag-manager
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-rag-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-rag-manager-deploy` runs after `bin-rag-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-registrar-manager/README.md
+++ b/bin-registrar-manager/README.md
@@ -54,3 +54,13 @@ bin-manager.registrar-manager.event
 
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-registrar-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-registrar-manager-deploy` runs after `bin-registrar-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-route-manager/README.md
+++ b/bin-route-manager/README.md
@@ -32,3 +32,13 @@ in `bin-common-handler`). The provider's `health_status` field is updated to
 circuit breaker protects against downstream failure.
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-route-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-route-manager-deploy` runs after `bin-route-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-schedule-manager/README.md
+++ b/bin-schedule-manager/README.md
@@ -54,3 +54,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-schedule-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-schedule-manager-deploy` runs after `bin-schedule-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-sentinel-manager/README.md
+++ b/bin-sentinel-manager/README.md
@@ -1,3 +1,12 @@
 # sentinel-manager
 
+# Deploy
+
+Unlike the other `bin-*-manager` services, this one is NOT deployed via
+direct SSH to bm-nyc-01 - it requires the Kubernetes API
+(`rest.InClusterConfig`) and has no bm-nyc-01 compose-service equivalent
+(see `voipbin/voipbin`'s `install/docker-compose.yml.dist` and
+`sync-compose-images.sh`'s `LOCK_ONLY_IMAGES` list), so it stays on the
+original GKE `bin-sentinel-manager-release` job.
+
 <!-- Updated dependencies: 2026-02-20 -->

--- a/bin-storage-manager/README.md
+++ b/bin-storage-manager/README.md
@@ -40,3 +40,13 @@ Usage of ./storage-manager:
 ```
 
 <!-- Updated dependencies: 2026-03-30 -->
+
+# Deploy
+
+`bin-storage-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-storage-manager-deploy` runs after `bin-storage-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-tag-manager/README.md
+++ b/bin-tag-manager/README.md
@@ -49,3 +49,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-tag-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-tag-manager-deploy` runs after `bin-tag-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-timeline-manager/README.md
+++ b/bin-timeline-manager/README.md
@@ -1,3 +1,13 @@
 # timeline-manager
 
 <!-- Updated dependencies: 2026-03-15 -->
+
+# Deploy
+
+`bin-timeline-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-timeline-manager-deploy` runs after `bin-timeline-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-transcribe-manager/README.md
+++ b/bin-transcribe-manager/README.md
@@ -27,3 +27,13 @@ Speech-to-text service.
 ```
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-transcribe-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-transcribe-manager-deploy` runs after `bin-transcribe-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-transfer-manager/README.md
+++ b/bin-transfer-manager/README.md
@@ -49,3 +49,13 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - [docs/domain.md](docs/domain.md)
 - [docs/dependencies.md](docs/dependencies.md)
 - [docs/operations.md](docs/operations.md)
+
+# Deploy
+
+`bin-transfer-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-transfer-manager-deploy` runs after `bin-transfer-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-tts-manager/README.md
+++ b/bin-tts-manager/README.md
@@ -45,3 +45,13 @@ Usage of ./tts-manager:
 ```
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-tts-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-tts-manager-deploy` runs after `bin-tts-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.

--- a/bin-webchat-manager/README.md
+++ b/bin-webchat-manager/README.md
@@ -1,12 +1,10 @@
-# talk-manager
-
-<!-- Updated dependencies: 2026-03-30 -->
+# webchat-manager
 
 # Deploy
 
-`bin-talk-manager-build` pushes the image, and a single `build-approval` gate covers
+`bin-webchat-manager-build` pushes the image, and a single `build-approval` gate covers
 the whole pipeline (test -> build -> deploy) through to production.
-`bin-talk-manager-deploy` runs after `bin-talk-manager-build`, bumping this service's pin on
+`bin-webchat-manager-deploy` runs after `bin-webchat-manager-build`, bumping this service's pin on
 bm-nyc-01 and recreating the container. See
 `.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
 bin-call-manager). The previous GKE deploy path for this service has been

--- a/bin-webhook-manager/README.md
+++ b/bin-webhook-manager/README.md
@@ -30,3 +30,13 @@ go test ./...
 ```
 
 <!-- Updated dependencies: 2026-02-20 -->
+
+# Deploy
+
+`bin-webhook-manager-build` pushes the image, and a single `build-approval` gate covers
+the whole pipeline (test -> build -> deploy) through to production.
+`bin-webhook-manager-deploy` runs after `bin-webhook-manager-build`, bumping this service's pin on
+bm-nyc-01 and recreating the container. See
+`.circleci/scripts/ssh-deploy.sh` (this pattern was piloted with
+bin-call-manager). The previous GKE deploy path for this service has been
+removed.


### PR DESCRIPTION
Rolls out the bm-nyc-01 direct-SSH deploy pattern, already piloted and production-verified for bin-call-manager, to 31 more bin-*-manager services. Each service's GKE -release job is replaced with a -deploy job that runs .circleci/scripts/ssh-deploy.sh, bumping that service's pin on bm-nyc-01's live versions.lock/docker-compose.yml and recreating the container. Also documents the new deploy path in each affected service's README.md.

- monorepo: convert 31 services to ssh-deploy: bin-agent-manager, bin-api-manager, bin-billing-manager, bin-campaign-manager, bin-ai-manager, bin-contact-manager, bin-conference-manager, bin-conversation-manager, bin-customer-manager, bin-direct-manager, bin-email-manager, bin-flow-manager, bin-hook-manager, bin-message-manager, bin-number-manager, bin-outdial-manager, bin-pipecat-manager, bin-queue-manager, bin-rag-manager, bin-registrar-manager, bin-route-manager, bin-schedule-manager, bin-storage-manager, bin-tag-manager, bin-talk-manager, bin-timeline-manager, bin-transcribe-manager, bin-transfer-manager, bin-tts-manager, bin-webchat-manager, bin-webhook-manager
- monorepo: bin-sentinel-manager deliberately excluded and left on GKE - it requires the Kubernetes API and has no bm-nyc-01 compose-service equivalent
- monorepo: simplify the approval flow to a single build-approval gate for all bm-nyc-01-deploying services (including bin-call-manager, retroactively) - matches the old GKE convenience, bm-nyc-01 doubles as our only environment so a second deploy-specific approval added friction without a distinct safety benefit
- monorepo: remove the now-fully-unreferenced docker-release command and gcloud_image anchor for the 31 migrated services, keeping both for bin-sentinel-manager's remaining GKE deploy
- monorepo: document the new deploy path in each affected service's README.md; bin-webchat-manager had no README, so a minimal one was created; bin-sentinel-manager's README documents its exclusion