### PR TITLE
VOIP-1341-Add-komodo-api-deploy-script

### DIFF
--- a/.circleci/scripts/komodo-api-deploy.sh
+++ b/.circleci/scripts/komodo-api-deploy.sh
@@ -1,0 +1,414 @@
+#!/bin/bash
+# VoIPBin - deploy via Komodo API (kustomize-style: git is the source of
+# truth, this script pushes the compose file's CURRENT content to Komodo
+# and triggers a deploy). Reusable across services; not yet wired into any
+# individual service's CircleCI job (VOIP-1341 scope - see that ticket).
+#
+# Mirrors ssh-deploy.sh's SSH/security pattern (key handling, host key
+# pinning, no runtime ssh-keyscan) - same target host, same 'deploy'
+# account/CC_DEPLOY_SSH_KEY context variable. See that script's header for
+# the full rationale on those choices; this header only documents what's
+# different here.
+#
+# What this does:
+#   1. SSHes into bm-nyc-01 (never exposes Komodo's API outside that
+#      session - Komodo core stays bound to 127.0.0.1, no public IP/domain,
+#      per the explicit decision this ticket documents).
+#   2. From inside that SSH session, calls Komodo's REST API against
+#      http://127.0.0.1:9120:
+#        a. POST /write   {"type":"UpdateStack", ...file_contents...}
+#        b. POST /execute {"type":"DeployStack", ...}
+#        c. POST /read    {"type":"GetUpdate", ...} - polled until terminal
+#   3. Exits 0 only if the Update's terminal status is Complete+success.
+#
+# What this does NOT do:
+#   - Does NOT decompose the existing monolithic docker-compose.yml (32
+#     services in one file) into per-service files - that's separate,
+#     deferred work (see VOIP-1341's "스코프 제외" section). This script is
+#     ready to be adopted per-service once that decomposition happens; it
+#     is not wired into any service's deploy job yet.
+#   - Does NOT expose Komodo's API publicly. Every call happens inside an
+#     SSH session to bm-nyc-01, targeting 127.0.0.1:9120 - deliberate
+#     decision (see VOIP-1341) given Komodo Periphery's host-root-
+#     equivalent docker.sock access.
+#   - Does NOT enable Komodo's own polling/webhook auto-deploy for the
+#     target stack. CI remains the only trigger, matching the explicit,
+#     deliberate-only-on-CI-action model ssh-deploy.sh already uses.
+#   - Does NOT create the target Stack. It must already exist (Write
+#     permission for the 'circleci' Komodo Service User granted on it) -
+#     same "only bumps an existing entry" precondition ssh-deploy.sh has
+#     for versions.lock.
+#
+# Usage:
+#   CC_DEPLOY_SSH_KEY=<base64-private-key> \
+#   CC_KOMODO_API_KEY=<key> CC_KOMODO_API_SECRET=<secret> \
+#     ./.circleci/scripts/komodo-api-deploy.sh <stack-name> <local-compose-file>
+#
+#   <stack-name>          The Komodo Stack resource's name (or id). Must
+#                         already exist - see Preconditions below. Must
+#                         match ^[A-Za-z0-9._-]+$ (enforced below) - this
+#                         keeps it safe to splice into the remote script
+#                         template without any risk of breaking out of its
+#                         quoting context.
+#   <local-compose-file>  Path to the docker-compose.yml IN THE CI CHECKOUT
+#                         (never touches bm-nyc-01's filesystem - no rsync,
+#                         no scp, nothing written to disk on the server).
+#                         This script reads the file locally, base64-
+#                         encodes it, and embeds that content directly in
+#                         the Komodo API request body (file_contents) sent
+#                         over the SSH session. The CURRENT content at the
+#                         checked-out commit becomes the Stack's new
+#                         file_contents - this is what makes the model
+#                         "kustomize-style": git is the only source of
+#                         truth for deployed content, Komodo just executes
+#                         it on request.
+#
+# Environment:
+#   CC_DEPLOY_SSH_KEY      Same key ssh-deploy.sh uses (base64-encoded, ONE
+#                          line). Required. Never echoed; written to a 600
+#                          temp file removed on exit.
+#   CC_KOMODO_API_KEY      Komodo API key for the 'circleci' Service User.
+#   CC_KOMODO_API_SECRET   Matching API secret. Required alongside the key.
+#                          Crosses the SSH boundary over stdin (read by a
+#                          `read -r` in the very first two lines of the
+#                          remote script), never as a command-line argument
+#                          and never via SSH's SendEnv (bm-nyc-01's sshd
+#                          AcceptEnv allowlist does not include these names
+#                          - checked directly against the live sshd_config
+#                          before choosing this approach; SendEnv fails
+#                          silently, not loudly, when the server doesn't
+#                          accept a variable, which would have produced a
+#                          confusing empty-header failure downstream
+#                          instead of a clear one here). Command arguments
+#                          are visible to any local user via `ps` for the
+#                          process's lifetime; stdin is not - this keeps
+#                          the secret out of that exposure even though
+#                          bm-nyc-01 currently only has root+deploy
+#                          accounts.
+#   CC_KOMODO_POLL_ATTEMPTS    Optional. How many times to poll Komodo's
+#                              GetUpdate before giving up. Default: 30.
+#   CC_KOMODO_POLL_INTERVAL_S  Optional. Seconds to sleep between polls.
+#                              Default: 2 (so 30x2s = 60s total by
+#                              default). Raise either for a stack whose
+#                              `docker compose pull && up` genuinely takes
+#                              longer than 60s.
+#
+# Preconditions (caller's responsibility):
+#   - The target Stack's underlying image has already been built and
+#     pushed (this script does not build or push anything - same
+#     precondition as ssh-deploy.sh).
+#   - The Stack already exists in Komodo, with the 'circleci' Service User
+#     granted Write permission on it (Write implies Execute - verified
+#     empirically against a live Komodo instance before this script was
+#     written). Creating a Stack/granting permission is a manual, one-time
+#     bootstrap step (Komodo UI or API), not something this script does.
+#   - bm-nyc-01 has jq installed (used to build/parse the API JSON
+#     payloads on the remote side).
+#
+# Implementation note: the remote script is captured via a QUOTED heredoc
+# (<<'REMOTE_SCRIPT_EOF') so the local shell performs zero expansion on it
+# - no $VAR substitution, no backslash processing, no command
+# substitution. The two dynamic values (stack name, base64 compose
+# content) are spliced in afterward via a plain `sed` replace of two
+# unique placeholder tokens. This was deliberately chosen over interpolating
+# variables directly into an unquoted heredoc (the first version of this
+# script did that and had a real, caught-in-testing quoting bug from the
+# nested backslash-escaping needed for jq's JSON filters inside an
+# SSH-command-inside-a-heredoc-inside-a-bash-script) - the placeholder+sed
+# approach has exactly one substitution mechanism to reason about instead
+# of three nested ones.
+set -euo pipefail
+
+DEPLOY_HOST="104.243.38.39"
+DEPLOY_USER="deploy"
+KNOWN_HOSTS_LINE_RSA="104.243.38.39 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtenMCo++fOqJ2NZiPDGlsteCEHTY5kFR7TCBpZsC/LyYaQYVeZaW+HRrhs1KS3FQhfDFSjYs6htnXoK6U8t+qiWb4c7iExQEeFgagxozIAkjmRERy5wnlH4RJ76loeKIcC/cDmW+eyASkGinCeAyT3DbYK5BVo0VnpXazNzgHzW7cK8G9w86+8gSt/G7f2e4iHk4qeXd2zMtuSXCF5L2gO0h3cfAHXecRUKMnWLPsczXJv/HlLSM3Xm7IjOVFHIZksJO/iD0kw2RN+fSehofokuc03Qq7462eZqjgsF53p4pEmNnWGDsQmdbE/e18NVsHh82I+1APaeORj2za+GCiEOUY+74oeLr1Omg5KiGEK6GagvVe8Ca/zJ19e0T+VkiIAGjZgseBOON3UyEHzEyUusfTsmBYWLubv1Fag4SP280yd+MeydCqr4IJg8jbGtQ+KWixxKDzXnIfuIk0lsyMfojVKeRkxKyxxwdEzWgX+nhtBPgHD2WKx+heCh5ri4E="
+KNOWN_HOSTS_LINE_ED25519="104.243.38.39 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGU/p87VedpGVqLoASzbDGJJjoFtjmKHREQzA+9gaRzq"
+
+log_info()  { echo "[INFO] $*"; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+usage() {
+  sed -n '2,/^[^#]/{/^[^#]/!p}' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+STACK_NAME="$1"
+LOCAL_COMPOSE_FILE="$2"
+
+if [[ ! "$STACK_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  log_error "stack-name must match ^[A-Za-z0-9._-]+\$ (got: $STACK_NAME)"
+  exit 1
+fi
+
+if [[ ! -f "$LOCAL_COMPOSE_FILE" ]]; then
+  log_error "local-compose-file does not exist: $LOCAL_COMPOSE_FILE"
+  exit 1
+fi
+
+if [[ -z "${CC_DEPLOY_SSH_KEY:-}" ]]; then
+  log_error "CC_DEPLOY_SSH_KEY is not set"
+  exit 1
+fi
+if [[ -z "${CC_KOMODO_API_KEY:-}" ]]; then
+  log_error "CC_KOMODO_API_KEY is not set"
+  exit 1
+fi
+if [[ -z "${CC_KOMODO_API_SECRET:-}" ]]; then
+  log_error "CC_KOMODO_API_SECRET is not set"
+  exit 1
+fi
+
+# The remote side reads these as two `read -r` lines off this ssh
+# session's stdin, in order (see the ssh invocation at the bottom of this
+# file). A literal newline embedded in either value would desync that
+# two-line protocol - CC_KOMODO_API_KEY would be silently truncated at the
+# embedded newline and CC_KOMODO_API_SECRET would pick up the remainder,
+# producing a confusing auth failure instead of a clear error here.
+if [[ "$CC_KOMODO_API_KEY" == *$'\n'* ]]; then
+  log_error "CC_KOMODO_API_KEY must not contain a newline"
+  exit 1
+fi
+if [[ "$CC_KOMODO_API_SECRET" == *$'\n'* ]]; then
+  log_error "CC_KOMODO_API_SECRET must not contain a newline"
+  exit 1
+fi
+
+# The remote side embeds these into a curl -K config file's
+# `header = "X-Api-Key: ..."` directive (see call_api in the remote
+# script template below) rather than curl argv, specifically to keep
+# them out of `ps`/`/proc/<pid>/cmdline` visibility on bm-nyc-01, the
+# same property already enforced for the SSH hop itself. curl config
+# files support backslash-escaping inside a quoted directive value, but
+# rather than replicate that escaping logic here (or on the remote side)
+# just to handle a `"` or `\` that a Komodo API token has no legitimate
+# reason to contain, reject it up front with a clear error - simpler and
+# safer than a bespoke escaper that only gets exercised on the rare
+# input it needs to handle correctly.
+if [[ "$CC_KOMODO_API_KEY" == *'"'* || "$CC_KOMODO_API_KEY" == *'\'* ]]; then
+  log_error "CC_KOMODO_API_KEY must not contain a double-quote or backslash character"
+  exit 1
+fi
+if [[ "$CC_KOMODO_API_SECRET" == *'"'* || "$CC_KOMODO_API_SECRET" == *'\'* ]]; then
+  log_error "CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"
+  exit 1
+fi
+
+# How long to wait for Komodo to finish applying the deploy before giving
+# up (POLL_ATTEMPTS x POLL_INTERVAL_S seconds total, 60s by default).
+# Override for stacks whose `docker compose pull && up` genuinely takes
+# longer than that.
+POLL_ATTEMPTS="${CC_KOMODO_POLL_ATTEMPTS:-30}"
+POLL_INTERVAL_S="${CC_KOMODO_POLL_INTERVAL_S:-2}"
+# No leading zero: the remote script does arithmetic on these
+# ($((POLL_ATTEMPTS * POLL_INTERVAL_S)) in its timeout message) and bash
+# arithmetic treats a leading-zero numeral as octal - "038" would be a
+# runtime arithmetic error (8/9 aren't valid octal digits), not just a
+# cosmetic issue. ^[1-9][0-9]*$ also rejects "0" itself, which wouldn't
+# make sense operationally (zero attempts/zero-second interval).
+if [[ ! "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  log_error "CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero (got: $POLL_ATTEMPTS)"
+  exit 1
+fi
+if [[ ! "$POLL_INTERVAL_S" =~ ^[1-9][0-9]*$ ]]; then
+  log_error "CC_KOMODO_POLL_INTERVAL_S must be a positive integer with no leading zero (got: $POLL_INTERVAL_S)"
+  exit 1
+fi
+
+SSH_KEY_FILE="$(mktemp)"
+KNOWN_HOSTS_FILE="$(mktemp)"
+cleanup() {
+  rm -f "$SSH_KEY_FILE" "$KNOWN_HOSTS_FILE"
+}
+trap cleanup EXIT
+chmod 600 "$SSH_KEY_FILE"
+
+# See ssh-deploy.sh's identical block for why base64 (not raw multi-line
+# key) and why the permissive character strip before decoding.
+CLEANED_KEY="$(printf '%s' "$CC_DEPLOY_SSH_KEY" | tr -dc 'A-Za-z0-9+/=\n')"
+if ! printf '%s' "$CLEANED_KEY" | base64 -d > "$SSH_KEY_FILE" 2>/dev/null; then
+  log_error "CC_DEPLOY_SSH_KEY is not valid base64 (must be 'base64 -w0 <private-key-file>', not the raw key)"
+  exit 1
+fi
+if ! grep -q "PRIVATE KEY" "$SSH_KEY_FILE"; then
+  log_error "CC_DEPLOY_SSH_KEY decoded but does not look like a private key (no 'PRIVATE KEY' marker) - check the value registered in the CircleCI context"
+  exit 1
+fi
+
+printf '%s\n%s\n' "$KNOWN_HOSTS_LINE_RSA" "$KNOWN_HOSTS_LINE_ED25519" > "$KNOWN_HOSTS_FILE"
+
+SSH_OPTS=(
+  -i "$SSH_KEY_FILE"
+  -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE"
+  -o GlobalKnownHostsFile=/dev/null
+  -o StrictHostKeyChecking=yes
+  -o ConnectTimeout=10
+  -o BatchMode=yes
+)
+
+# Base64-encode the compose content so it can be embedded as a single,
+# shell-metacharacter-free token in the remote script template below -
+# avoids any quoting/escaping hazard from the file's own content (which
+# can contain quotes, `$`, backticks, etc.). The remote side decodes it
+# and hands it to `jq --arg` for JSON-safe embedding into the API request
+# body - jq handles the JSON string escaping, this script never
+# hand-builds JSON via string concatenation.
+COMPOSE_B64="$(base64 -w0 < "$LOCAL_COMPOSE_FILE")"
+
+log_info "Deploying Stack '$STACK_NAME' from local file $LOCAL_COMPOSE_FILE (content pushed via Komodo API, nothing written to bm-nyc-01's disk)..."
+
+# ---- Remote script template. Fully quoted heredoc - no expansion at
+# capture time. @@STACK_NAME@@/@@COMPOSE_B64@@/@@POLL_ATTEMPTS@@/
+# @@POLL_INTERVAL_S@@ are literal placeholder tokens, replaced below via a
+# single chained `sed` before this is sent as the SSH command. The `@`
+# delimiter is deliberate, not cosmetic: all four substituted values
+# (STACK_NAME's ^[A-Za-z0-9._-]+$ charset, COMPOSE_B64's base64 alphabet,
+# and the two digit-only POLL_* values) are structurally incapable of
+# containing `@`, so none of them can ever equal - or get corrupted into
+# resembling - one of these tokens partway through the chain. An earlier
+# draft used `__NAME__`-style tokens built from the SAME charset
+# STACK_NAME is allowed to contain; a caller passing
+# `stack-name=__COMPOSE_B64__` (a legal value per the regex) would have
+# had their STACK_NAME silently overwritten by a LATER s/// in the same
+# chain re-matching text an EARLIER s/// had just inserted - caught in
+# review, verified by reproducing the exact corruption locally, before
+# this shipped. All API calls target 127.0.0.1:9120 - Komodo core is
+# never reachable outside this SSH session. CC_KOMODO_API_KEY/SECRET are
+# read from this script's own stdin (first two lines) - see the ssh
+# invocation at the bottom of this file for what feeds them in. ----
+REMOTE_SCRIPT_TEMPLATE=$(cat <<'REMOTE_SCRIPT_EOF'
+set -euo pipefail
+IFS= read -r CC_KOMODO_API_KEY
+IFS= read -r CC_KOMODO_API_SECRET
+API="http://127.0.0.1:9120"
+STACK_NAME="@@STACK_NAME@@"
+POLL_ATTEMPTS="@@POLL_ATTEMPTS@@"
+POLL_INTERVAL_S="@@POLL_INTERVAL_S@@"
+# Command substitution strips trailing newlines; a trailing 'X' sentinel
+# (stripped right after) preserves any trailing newline(s) the source
+# compose file actually had, so file_contents stays byte-for-byte
+# identical to what's checked into git - the script's own stated goal.
+compose_content="$(printf '%s' '@@COMPOSE_B64@@' | base64 -d; printf X)"
+compose_content="${compose_content%X}"
+
+# Shared helper so all three API calls (write/execute/read) get identical
+# error handling: on a non-2xx or a curl-level (connection) failure, print
+# the request type and the actual response body to stderr before
+# propagating the failure - losing this on 2 of 3 calls (as an earlier
+# draft did) leaves an operator with only a generic "deploy failed", no
+# idea why.
+#
+# Deliberately does NOT use `curl -f` ("fail on HTTP error"): -f discards
+# the response body entirely on a non-2xx response (that's its documented
+# behavior - the body is only preserved with --fail-with-body, which needs
+# curl >=7.76 and isn't guaranteed available on bm-nyc-01), which would
+# silently defeat the whole point of this helper - caught empirically
+# during review by running this exact heredoc body against a stand-in
+# HTTP server and observing "Response: " print blank on both an HTTP 400
+# and a refused connection. Instead: request the HTTP status code via
+# `-w '\n%{http_code}'` appended after the body, split it off the
+# captured output ourselves, and treat any non-2xx as failure while still
+# having the real body in hand to print. `-sS` (not bare `-s`) keeps
+# curl's own connection-level error text (refused/timeout/DNS) flowing to
+# this script's stderr - visible in the CI job's ssh output - instead of
+# being suppressed.
+#
+# The two Komodo secrets are passed to curl via `-K -` (a config file fed
+# on curl's own stdin, `header = "..."` directives), NOT `-H` on curl's
+# argv. `-H "X-Api-Secret: $CC_KOMODO_API_SECRET"` would put the secret
+# in plaintext in this process's argv for its whole lifetime - visible to
+# any other local account on bm-nyc-01 via `ps`/`/proc/<pid>/cmdline` -
+# caught in review as undercutting the exact same `ps`-exposure guarantee
+# this script already goes out of its way to provide for the SSH hop
+# (see CC_KOMODO_API_KEY/SECRET in this file's header). The local-side
+# checks rejecting `"`/`\` in either secret (see the main script body)
+# exist so this config-file value never needs its own escaping logic.
+call_api() {
+  local endpoint="$1" body="$2" resp http_code http_body header_config
+  header_config="$(printf 'header = "X-Api-Key: %s"\nheader = "X-Api-Secret: %s"\n' \
+    "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET")"
+  # --connect-timeout/--max-time bound how long a hung/unresponsive
+  # Komodo core (TCP connects fine but never replies) can stall this
+  # script - without them, a hang here is bounded only by the CI job's
+  # own overall timeout, not by anything under this script's control.
+  if ! resp="$(printf '%s' "$header_config" | curl -sS -K - -w '\n%{http_code}' --connect-timeout 10 --max-time 30 -X POST "$API/$endpoint" \
+      -H "Content-Type: application/json" \
+      -d "$body")"; then
+    echo "Komodo API call to /$endpoint failed to execute (network/connection error - see curl's error output above). Request body: $body" >&2
+    return 1
+  fi
+  http_code="${resp##*$'\n'}"
+  http_body="${resp%$'\n'*}"
+  if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+    echo "Komodo API call to /$endpoint returned HTTP $http_code. Request body: $body" >&2
+    echo "Response body: $http_body" >&2
+    return 1
+  fi
+  printf '%s' "$http_body"
+}
+
+update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$compose_content" \
+  '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents}}}')"
+if ! call_api write "$update_body" >/dev/null; then
+  echo "UpdateStack failed - Stack '$STACK_NAME' may not exist yet (this script does not create Stacks, see its header)." >&2
+  exit 1
+fi
+
+deploy_body="$(jq -n --arg stack "$STACK_NAME" \
+  '{type:"DeployStack",params:{stack:$stack,services:[],stop_time:null}}')"
+deploy_res="$(call_api execute "$deploy_body")" || exit 1
+update_id="$(printf '%s' "$deploy_res" | jq -r '._id."$oid"')"
+if [[ -z "$update_id" || "$update_id" == "null" ]]; then
+  echo "DeployStack did not return an update id. Response: $deploy_res" >&2
+  exit 1
+fi
+
+for i in $(seq 1 "$POLL_ATTEMPTS"); do
+  sleep "$POLL_INTERVAL_S"
+  status_body="$(jq -n --arg id "$update_id" '{type:"GetUpdate",params:{id:$id}}')"
+  status_res="$(call_api read "$status_body")" || exit 1
+  status="$(printf '%s' "$status_res" | jq -r '.status')"
+  if [[ "$status" == "Complete" ]]; then
+    success="$(printf '%s' "$status_res" | jq -r '.success')"
+    if [[ "$success" == "true" ]]; then
+      echo "DEPLOY_OK stack=$STACK_NAME update_id=$update_id"
+      exit 0
+    else
+      echo "DEPLOY_FAILED stack=$STACK_NAME update_id=$update_id" >&2
+      printf '%s' "$status_res" | jq -r '.logs[]?.stderr // empty' >&2
+      exit 1
+    fi
+  fi
+done
+echo "DEPLOY_TIMEOUT stack=$STACK_NAME update_id=$update_id (still InProgress after $((POLL_ATTEMPTS * POLL_INTERVAL_S))s)" >&2
+exit 1
+REMOTE_SCRIPT_EOF
+)
+
+# Delimiter is '|', not '/': COMPOSE_B64 is base64 (alphabet A-Za-z0-9+/=)
+# and CAN legitimately contain '/', which would terminate a '/'-delimited
+# sed s/// pattern early and corrupt the substitution. '|' and '&' are not
+# in the base64 alphabet, so this is safe without further escaping (sed's
+# replacement text also treats '&' as "whole match" - irrelevant here
+# since neither substituted value contains '&').
+REMOTE_CMD="$(printf '%s' "$REMOTE_SCRIPT_TEMPLATE" | sed "s|@@STACK_NAME@@|${STACK_NAME}|g; s|@@COMPOSE_B64@@|${COMPOSE_B64}|g; s|@@POLL_ATTEMPTS@@|${POLL_ATTEMPTS}|g; s|@@POLL_INTERVAL_S@@|${POLL_INTERVAL_S}|g")"
+
+if printf '%s\n%s\n' "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET" | \
+    ssh "${SSH_OPTS[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" "$REMOTE_CMD"; then
+  log_info "Deploy succeeded: $STACK_NAME is up on bm-nyc-01 (via Komodo)"
+  exit 0
+else
+  rc=$?
+  log_error "Deploy failed (exit $rc). $STACK_NAME on bm-nyc-01 may be running a bad image."
+  log_error "This script does not auto-rollback - a human must decide the next step:"
+  log_error "  ssh ${DEPLOY_USER}@${DEPLOY_HOST} \"curl -s http://127.0.0.1:9120/read -H 'X-Api-Key: <key>' -H 'X-Api-Secret: <secret>' -d '{\\\"type\\\":\\\"GetStack\\\",\\\"params\\\":{\\\"stack\\\":\\\"$STACK_NAME\\\"}}'\""
+  exit "$rc"
+fi

--- a/.circleci/tests/komodo-api-deploy.bats
+++ b/.circleci/tests/komodo-api-deploy.bats
@@ -1,0 +1,606 @@
+#!/usr/bin/env bats
+# Tests for .circleci/scripts/komodo-api-deploy.sh
+
+load 'test_helper'
+
+setup() {
+    setup_test_env
+    COMPOSE_FIXTURE="$TEST_TEMP_DIR/docker-compose.yml"
+    cat > "$COMPOSE_FIXTURE" <<'EOF'
+services:
+  test:
+    image: nginx:latest
+EOF
+}
+
+teardown() {
+    teardown_test_env
+}
+
+run_script() {
+    bash "$SCRIPTS_DIR/komodo-api-deploy.sh" "$@"
+}
+
+# A tiny Komodo API stand-in used only by the "remote body execution"
+# tests below - unlike every other test in this file (which stubs `ssh`
+# and only inspects the constructed command string), these actually
+# extract and EXECUTE the remote heredoc body against a real local HTTP
+# server. This closes a real gap: a bug where `curl -f` silently
+# discarded the HTTP response body on failure "looked right" in the
+# constructed command string (the code to print the body was right
+# there) but was wrong at actual execution time - only caught by running
+# it. $1 selects a canned response scenario.
+start_mock_komodo() {
+    local scenario="$1"
+    MOCK_KOMODO_PORT=19977
+    MOCK_KOMODO_SCRIPT="$TEST_TEMP_DIR/mock_komodo.py"
+    MOCK_KOMODO_LOG="$TEST_TEMP_DIR/mock_komodo.log"
+    case "$scenario" in
+    http_error)
+        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
+import http.server, json, sys
+port = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0)); self.rfile.read(n)
+        self.send_response(400)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": "stack not found: teststack"}).encode())
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
+PYEOF
+        ;;
+    deploy_success)
+        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
+import http.server, json, sys
+port = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0))
+        body = json.loads(self.rfile.read(n))
+        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
+        t = body.get('type')
+        if t == 'UpdateStack':
+            resp = {"ok": True}
+        elif t == 'DeployStack':
+            resp = {"_id": {"$oid": "abc123"}}
+        else:
+            resp = {"status": "Complete", "success": True, "logs": []}
+        self.wfile.write(json.dumps(resp).encode())
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
+PYEOF
+        ;;
+    deploy_failure)
+        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
+import http.server, json, sys
+port = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0))
+        body = json.loads(self.rfile.read(n))
+        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
+        t = body.get('type')
+        if t == 'UpdateStack':
+            resp = {"ok": True}
+        elif t == 'DeployStack':
+            resp = {"_id": {"$oid": "def456"}}
+        else:
+            resp = {"status": "Complete", "success": False, "logs": [{"stderr": "Error: image pull failed"}]}
+        self.wfile.write(json.dumps(resp).encode())
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
+PYEOF
+        ;;
+    esac
+    python3 "$MOCK_KOMODO_SCRIPT" "$MOCK_KOMODO_PORT" > "$MOCK_KOMODO_LOG" 2>&1 &
+    MOCK_KOMODO_PID=$!
+    # Poll until the server actually accepts connections instead of a
+    # fixed sleep - avoids flakiness under load.
+    for _ in $(seq 1 50); do
+        if curl -s -o /dev/null "http://127.0.0.1:$MOCK_KOMODO_PORT/" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+}
+
+stop_mock_komodo() {
+    [[ -n "${MOCK_KOMODO_PID:-}" ]] && kill "$MOCK_KOMODO_PID" 2>/dev/null
+}
+
+# Extracts the remote heredoc body from the real script, points its API
+# base at our mock server's port instead of the real 127.0.0.1:9120, and
+# substitutes placeholder tokens the same way the script's own sed does.
+run_remote_body_against_mock() {
+    local stack_name="$1" compose_b64="$2"
+    extract_heredoc_body "$SCRIPTS_DIR/komodo-api-deploy.sh" "REMOTE_SCRIPT_EOF" \
+        | sed "s|127.0.0.1:9120|127.0.0.1:$MOCK_KOMODO_PORT|" \
+        | sed "s|@@STACK_NAME@@|${stack_name}|; s|@@COMPOSE_B64@@|${compose_b64}|; s|@@POLL_ATTEMPTS@@|3|; s|@@POLL_INTERVAL_S@@|1|" \
+        > "$TEST_TEMP_DIR/extracted_remote.sh"
+    printf 'fake-api-key\nfake-api-secret\n' | bash "$TEST_TEMP_DIR/extracted_remote.sh"
+}
+
+@test "[remote body] HTTP error response body is actually captured and printed, not discarded by curl -f" {
+    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
+    start_mock_komodo http_error
+    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
+    stop_mock_komodo
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"returned HTTP 400"* ]]
+    [[ "$output" == *"stack not found: teststack"* ]]
+}
+
+@test "[remote body] full write -> execute -> read poll loop succeeds against a real HTTP server" {
+    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
+    start_mock_komodo deploy_success
+    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
+    stop_mock_komodo
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"DEPLOY_OK stack=teststack update_id=abc123"* ]]
+}
+
+@test "[remote body] a deploy that completes with success=false reports failure and the remote logs" {
+    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
+    start_mock_komodo deploy_failure
+    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
+    stop_mock_komodo
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"DEPLOY_FAILED stack=teststack update_id=def456"* ]]
+    [[ "$output" == *"Error: image pull failed"* ]]
+}
+
+FAKE_KEY_CONTENT="-----BEGIN OPENSSH PRIVATE KEY-----
+ZmFrZS1rZXktbWF0ZXJpYWwtZm9yLXRlc3Rpbmctb25seQ==
+-----END OPENSSH PRIVATE KEY-----"
+
+valid_env() {
+    export CC_DEPLOY_SSH_KEY="$(printf '%s' "$FAKE_KEY_CONTENT" | base64 -w0)"
+    export CC_KOMODO_API_KEY="fake-komodo-api-key"
+    export CC_KOMODO_API_SECRET="fake-komodo-api-secret"
+}
+
+@test "-h/--help prints usage and exits 0 without requiring any env" {
+    run run_script --help
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "-h prints usage and exits 0 without requiring any env" {
+    run run_script -h
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "refuses with wrong argument count (too few)" {
+    run run_script "voipbin-test-stack"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* || "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "refuses with wrong argument count (too many)" {
+    valid_env
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE" "unexpected-extra-arg"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* || "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "refuses a stack-name with unexpected characters" {
+    valid_env
+    run run_script "test-stack; rm -rf /" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"stack-name must be"* || "$output" == *"stack-name must match"* ]]
+}
+
+@test "refuses when local-compose-file does not exist" {
+    valid_env
+    run run_script "voipbin-test-stack" "$TEST_TEMP_DIR/does-not-exist.yml"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"local-compose-file does not exist"* ]]
+}
+
+@test "refuses to run when CC_DEPLOY_SSH_KEY is not set" {
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    unset CC_DEPLOY_SSH_KEY
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_DEPLOY_SSH_KEY is not set"* ]]
+}
+
+@test "refuses to run when CC_KOMODO_API_KEY is not set" {
+    valid_env
+    unset CC_KOMODO_API_KEY
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY is not set"* ]]
+}
+
+@test "refuses to run when CC_KOMODO_API_SECRET is not set" {
+    valid_env
+    unset CC_KOMODO_API_SECRET
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET is not set"* ]]
+}
+
+@test "refuses when CC_DEPLOY_SSH_KEY is not valid base64" {
+    export CC_DEPLOY_SSH_KEY="not-valid-base64!!!"
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"not valid base64"* ]]
+}
+
+@test "refuses when CC_DEPLOY_SSH_KEY decodes to something without a PRIVATE KEY marker" {
+    export CC_DEPLOY_SSH_KEY="$(printf 'just some unrelated text' | base64 -w0)"
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"does not look like a private key"* ]]
+}
+
+@test "happy path: succeeds and reports success when ssh exits 0" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Deploy succeeded"* ]]
+    [[ "$output" == *"voipbin-test-stack"* ]]
+    [[ "$(ssh_call_count)" -eq 1 ]]
+}
+
+@test "ssh is invoked against the correct user@host with host-key pinning (not runtime ssh-keyscan)" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    local args
+    args="$(ssh_call_args 1)"
+    [[ "$args" == *"deploy@104.243.38.39"* ]]
+    [[ "$args" == *"StrictHostKeyChecking=yes"* ]]
+    [[ "$args" == *"UserKnownHostsFile="* ]]
+    [[ "$output" != *"ssh-keyscan"* ]]
+}
+
+@test "the remote command targets Komodo's loopback-only API, never a public address" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *"http://127.0.0.1:9120"* ]]
+    # Never anything other than loopback for the API base.
+    [[ "$remote_cmd" != *"0.0.0.0:9120"* ]]
+}
+
+@test "the remote command's decoded compose content matches the local fixture exactly" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    local remote_cmd embedded_b64 decoded expected
+    remote_cmd="$(ssh_call_remote_command 1)"
+    embedded_b64="$(printf '%s' "$remote_cmd" | grep -o "printf '%s' '[^']*' | base64 -d" | sed "s/^printf '%s' '//; s/' | base64 -d$//")"
+    [[ -n "$embedded_b64" ]]
+    decoded="$(printf '%s' "$embedded_b64" | base64 -d)"
+    expected="$(cat "$COMPOSE_FIXTURE")"
+    [[ "$decoded" == "$expected" ]]
+}
+
+@test "a compose file whose base64 encoding contains '/' still substitutes correctly (sed delimiter regression)" {
+    # Three 0xFF bytes base64-encode to '////' - guarantees '/' characters
+    # land in the embedded payload, which would corrupt a '/'-delimited
+    # sed substitution. This is the exact bug caught and fixed before
+    # shipping (see the script's own comment on the sed delimiter choice).
+    valid_env
+    printf '\xff\xff\xffservices:\n  test:\n    image: nginx\n' > "$COMPOSE_FIXTURE"
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    # No leftover placeholder tokens - if the sed substitution had been
+    # corrupted by an embedded '/', a literal placeholder or a truncated
+    # command would remain instead of a clean substitution.
+    [[ "$remote_cmd" != *"@@STACK_NAME@@"* ]]
+    [[ "$remote_cmd" != *"@@COMPOSE_B64@@"* ]]
+    [[ "$remote_cmd" == *"STACK_NAME=\"voipbin-test-stack\""* ]]
+}
+
+@test "a stack-name equal to another placeholder token's name does not corrupt the chained sed substitution" {
+    # Regression test for a real bug caught in security review: the four
+    # placeholders are substituted via one chained sed (multiple s///
+    # separated by ';'), which re-scans text earlier substitutions just
+    # inserted. With the OLD __NAME__-style tokens (same charset
+    # STACK_NAME is allowed to contain), a stack-name equal to e.g.
+    # "COMPOSE_B64" could get re-matched and corrupted by a later s///
+    # in the chain. The @@NAME@@ tokens use '@', which is outside
+    # STACK_NAME's ^[A-Za-z0-9._-]+$ charset, structurally preventing
+    # this - this test proves a stack-name that WOULD have collided
+    # under the old scheme now substitutes cleanly.
+    valid_env
+    install_fake_ssh 0
+    run run_script "COMPOSE_B64" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *'STACK_NAME="COMPOSE_B64"'* ]]
+    # The compose content placeholder must still have been replaced by
+    # the actual base64 payload, not corrupted/overwritten by the
+    # stack-name substitution that ran first in the chain.
+    [[ "$remote_cmd" != *"@@COMPOSE_B64@@"* ]]
+}
+
+@test "Komodo API key/secret are never present in the extracted remote script's curl invocation (no argv leak via ps)" {
+    # Regression test for a real bug caught in security review: curl -H
+    # puts header VALUES directly in this process's argv, visible to any
+    # other local account on bm-nyc-01 via ps/proc for the call's
+    # duration - undercutting the same ps-exposure guarantee this script
+    # already provides for the SSH hop. Verify the source never
+    # constructs a curl invocation with -H "X-Api-...: <value>" as actual
+    # code (excluding comment lines, which legitimately reference this
+    # exact pattern by name when explaining why it was replaced).
+    run bash -c "grep -vE '^[[:space:]]*#' '$SCRIPTS_DIR/komodo-api-deploy.sh' | grep -E '-H \"X-Api-(Key|Secret): \\\$'"
+    [[ "$status" -ne 0 ]]
+    # And confirm the actual replacement mechanism (curl -K -, config
+    # fed on curl's own stdin) is present.
+    run grep -F 'curl -sS -K -' "$SCRIPTS_DIR/komodo-api-deploy.sh"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "the remote command's decoded compose content preserves a trailing newline byte-for-byte" {
+    # Command substitution strips trailing newlines; the script guards
+    # against this with a trailing sentinel char that gets stripped back
+    # off (see script.sh's comment on `compose_content`). Verify the
+    # decoded content on the remote side keeps the source file's trailing
+    # newline instead of silently losing it.
+    valid_env
+    printf 'services:\n  test:\n    image: nginx\n\n\n' > "$COMPOSE_FIXTURE"
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -eq 0 ]]
+
+    local remote_cmd embedded_b64
+    remote_cmd="$(ssh_call_remote_command 1)"
+    embedded_b64="$(printf '%s' "$remote_cmd" | grep -o "printf '%s' '[^']*' | base64 -d" | sed "s/^printf '%s' '//; s/' | base64 -d$//")"
+    # Decode straight to a file (not through a $() string, which would
+    # itself strip trailing newlines and defeat the point of this test) -
+    # byte-for-byte diff against the source fixture is the real assertion.
+    printf '%s' "$embedded_b64" | base64 -d > "$TEST_TEMP_DIR/decoded_output.yml"
+    diff "$COMPOSE_FIXTURE" "$TEST_TEMP_DIR/decoded_output.yml"
+}
+
+@test "CC_KOMODO_POLL_ATTEMPTS and CC_KOMODO_POLL_INTERVAL_S override the default poll loop" {
+    valid_env
+    export CC_KOMODO_POLL_ATTEMPTS=5
+    export CC_KOMODO_POLL_INTERVAL_S=1
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *'POLL_ATTEMPTS="5"'* ]]
+    [[ "$remote_cmd" == *'POLL_INTERVAL_S="1"'* ]]
+}
+
+@test "refuses a non-numeric CC_KOMODO_POLL_ATTEMPTS" {
+    valid_env
+    export CC_KOMODO_POLL_ATTEMPTS="thirty"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_POLL_ATTEMPTS must be a positive integer"* ]]
+}
+
+@test "refuses a CC_KOMODO_POLL_ATTEMPTS with a leading zero" {
+    # Regression test: bash arithmetic treats a leading-zero numeral as
+    # octal ($((POLL_ATTEMPTS * POLL_INTERVAL_S)) in the remote script's
+    # timeout message would hard-fail on e.g. "038" - 8/9 aren't valid
+    # octal digits). Caught in review before shipping.
+    valid_env
+    export CC_KOMODO_POLL_ATTEMPTS="030"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero"* ]]
+}
+
+@test "refuses a CC_KOMODO_POLL_INTERVAL_S with a leading zero" {
+    valid_env
+    export CC_KOMODO_POLL_INTERVAL_S="02"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_POLL_INTERVAL_S must be a positive integer with no leading zero"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_KEY containing an embedded newline" {
+    valid_env
+    export CC_KOMODO_API_KEY=$'line-one\nline-two'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a newline"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_SECRET containing an embedded newline" {
+    valid_env
+    export CC_KOMODO_API_SECRET=$'line-one\nline-two'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a newline"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_KEY containing a double-quote" {
+    # This validation is the load-bearing control that lets call_api's
+    # curl -K header_config skip implementing curl's config-file
+    # quote-escaping (see script.sh's comment on the check). Without it,
+    # a key/secret containing '"' could break out of the `header = "..."`
+    # directive's quoting on the remote side.
+    valid_env
+    export CC_KOMODO_API_KEY='has"a-quote'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a double-quote or backslash character"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_KEY containing a backslash" {
+    valid_env
+    export CC_KOMODO_API_KEY='has\a-backslash'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a double-quote or backslash character"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_SECRET containing a double-quote" {
+    valid_env
+    export CC_KOMODO_API_SECRET='has"a-quote'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_SECRET containing a backslash" {
+    valid_env
+    export CC_KOMODO_API_SECRET='has\a-backslash'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"* ]]
+}
+
+@test "a different stack name propagates correctly (not hardcoded)" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "some-other-stack" "$COMPOSE_FIXTURE"
+
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *"STACK_NAME=\"some-other-stack\""* ]]
+}
+
+@test "failure path: reports failure and manual-recovery guidance when ssh/remote exits non-zero" {
+    valid_env
+    install_fake_ssh 1
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Deploy failed"* ]]
+    [[ "$output" == *"does not auto-rollback"* ]]
+    [[ "$output" == *"voipbin-test-stack"* ]]
+}
+
+@test "the SSH key temp file is removed after the script exits (success path)" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -eq 0 ]]
+
+    local args key_file
+    args="$(ssh_call_args 1)"
+    key_file="$(echo "$args" | grep -A1 '^-i$' | tail -1)"
+    [[ -n "$key_file" ]]
+    [[ ! -f "$key_file" ]]
+}
+
+@test "the SSH key temp file is removed after the script exits (failure path)" {
+    valid_env
+    install_fake_ssh 1
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+
+    local args key_file
+    args="$(ssh_call_args 1)"
+    key_file="$(echo "$args" | grep -A1 '^-i$' | tail -1)"
+    [[ -n "$key_file" ]]
+    [[ ! -f "$key_file" ]]
+}
+
+secret_env() {
+    local content="-----BEGIN OPENSSH PRIVATE KEY-----
+super-secret-deploy-key-xyz789
+-----END OPENSSH PRIVATE KEY-----"
+    export CC_DEPLOY_SSH_KEY="$(printf '%s' "$content" | base64 -w0)"
+    export CC_KOMODO_API_KEY="super-secret-api-key-abc123"
+    export CC_KOMODO_API_SECRET="super-secret-api-secret-def456"
+}
+
+@test "SSH key value never appears in stdout/stderr output" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"super-secret-deploy-key-xyz789"* ]]
+    [[ "$output" != *"$CC_DEPLOY_SSH_KEY"* ]]
+}
+
+@test "Komodo API key/secret never appear in stdout/stderr output" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"super-secret-api-key-abc123"* ]]
+    [[ "$output" != *"super-secret-api-secret-def456"* ]]
+}
+
+@test "Komodo API key/secret never appear in the ssh invocation's argv" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local args
+    args="$(ssh_call_args 1)"
+    [[ "$args" != *"super-secret-api-key-abc123"* ]]
+    [[ "$args" != *"super-secret-api-secret-def456"* ]]
+}
+
+@test "Komodo API key/secret never appear in the remote command string" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" != *"super-secret-api-key-abc123"* ]]
+    [[ "$remote_cmd" != *"super-secret-api-secret-def456"* ]]
+}
+
+@test "Komodo API key/secret are delivered via ssh stdin, as the first two lines, in order" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local stdin_content first_line second_line
+    stdin_content="$(ssh_call_stdin 1)"
+    first_line="$(printf '%s' "$stdin_content" | sed -n '1p')"
+    second_line="$(printf '%s' "$stdin_content" | sed -n '2p')"
+    [[ "$first_line" == "super-secret-api-key-abc123" ]]
+    [[ "$second_line" == "super-secret-api-secret-def456" ]]
+}
+
+@test "refuses when CC_DEPLOY_SSH_KEY decoding leaves no readable temp file after failure (no leftover key material)" {
+    export CC_DEPLOY_SSH_KEY="not-valid-base64!!!"
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    local before after
+    before="$(find "$TEST_TEMP_DIR" -maxdepth 1 -type f | wc -l)"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    after="$(find "$TEST_TEMP_DIR" -maxdepth 1 -type f | wc -l)"
+    # mktemp files land outside TEST_TEMP_DIR (system TMPDIR) - this just
+    # guards against a future refactor accidentally writing key material
+    # into our own fixture directory.
+    [[ "$before" -eq "$after" ]]
+}

--- a/.circleci/tests/test_helper.bash
+++ b/.circleci/tests/test_helper.bash
@@ -32,9 +32,17 @@ teardown_test_env() {
 # newlines (it's a multi-line shell script), which would otherwise be
 # misread as invocation boundaries. Lets tests assert on exactly what
 # remote command was constructed, without a real network call.
+#
+# Also captures whatever is piped into ssh's stdin to $SSH_STDIN_LOG,
+# one record per invocation separated by 0x1d - used by scripts (like
+# komodo-api-deploy.sh) that feed secrets to the remote side over stdin
+# rather than via argv or SendEnv. Scripts that don't pipe anything into
+# ssh (like ssh-deploy.sh) just produce empty records here; harmless.
 install_fake_ssh() {
     SSH_LOG="$TEST_TEMP_DIR/ssh_calls.log"
+    SSH_STDIN_LOG="$TEST_TEMP_DIR/ssh_stdin.log"
     : > "$SSH_LOG"
+    : > "$SSH_STDIN_LOG"
     local exit_code="${1:-0}"
     cat > "$MOCK_BIN_DIR/ssh" <<EOF
 #!/bin/bash
@@ -44,6 +52,10 @@ install_fake_ssh() {
     done
     printf '\x1d'
 } >> "$SSH_LOG"
+{
+    cat
+    printf '\x1d'
+} >> "$SSH_STDIN_LOG"
 exit $exit_code
 EOF
     chmod +x "$MOCK_BIN_DIR/ssh"
@@ -79,3 +91,36 @@ ssh_call_remote_command() {
 ssh_call_count() {
     awk -v RS='\035' 'END{print NR}' "$SSH_LOG"
 }
+
+# The Nth (1-indexed) ssh invocation's full stdin content, exactly as
+# piped in (no field splitting - callers grep/compare this as one blob).
+ssh_call_stdin() {
+    local n="$1"
+    awk -v RS='\035' -v n="$n" 'NR==n{print; exit}' "$SSH_STDIN_LOG"
+}
+
+# Extracts the body of a `VAR=$(cat <<'DELIM' ... DELIM)` quoted heredoc
+# from a script file, i.e. the remote-side script komodo-api-deploy.sh
+# builds up and ships over ssh as a single command string. Runs it as
+# real bash (with placeholders substituted) so tests can catch bugs a
+# pure string-inspection assertion on the constructed command cannot -
+# e.g. the round-2-review-caught bug where `curl -f` silently discarded
+# the HTTP response body on failure, which "looks right" in the
+# constructed command string but is wrong at actual execution time.
+# Args: script_file heredoc_delimiter
+extract_heredoc_body() {
+    local script_file="$1" delim="$2"
+    # Only treat a line as the heredoc OPENER if the start token is its
+    # actual trailing content (ignoring trailing whitespace), not merely
+    # present anywhere on the line - a prose comment elsewhere in the
+    # file may reference the same "<<'DELIM'" text without being the
+    # real heredoc, which would otherwise start extraction from the
+    # wrong place entirely.
+    awk -v start="<<'${delim}'" -v delim="$delim" '
+        { line = $0; sub(/[ \t]+$/, "", line) }
+        !flag && line ~ (start "$") { flag=1; next }
+        flag && $0 == delim { flag=0 }
+        flag { print }
+    ' "$script_file"
+}
+


### PR DESCRIPTION
Add a reusable, kustomize-style deploy script that pushes a docker-compose file's content to Komodo (via its REST API, over an SSH tunnel to bm-nyc-01, never exposed publicly) and triggers a deploy. This is the mechanism decided on for moving CircleCI's deploy path from raw SSH+docker commands (ssh-deploy.sh) to Komodo-managed deployment while keeping git as the sole source of truth and CI's approval gate as the only deploy trigger (Komodo's own polling/webhook auto-deploy is left disabled). Not yet wired into any service's CircleCI job - the existing monolithic docker-compose.yml (32 services) needs to be decomposed into per-service files first, which is separate, deferred work.

- monorepo: add .circleci/scripts/komodo-api-deploy.sh - SSHes into bm-nyc-01 as the existing 'deploy' account (same SSH key/host-key pinning pattern as ssh-deploy.sh), then inside that session calls Komodo's REST API (127.0.0.1:9120 only) to UpdateStack with the local compose file's content, DeployStack, then polls GetUpdate until Complete; exits 0 only on Complete+success
- monorepo: the compose file's content never touches bm-nyc-01's disk - no rsync/scp - it's base64-encoded locally and embedded directly in the Komodo API request body (file_contents), decoded and JSON-escaped via jq on the remote side
- monorepo: the two Komodo API secrets cross the SSH boundary over stdin (read as the first two lines of the remote script), never as SSH argv or SendEnv (bm-nyc-01's sshd AcceptEnv doesn't allow them) and never in curl's own argv on the remote side either (curl -K - reads them from a config piped on curl's own stdin, keeping them out of ps/proc visibility end to end)
- monorepo: add .circleci/tests/komodo-api-deploy.bats - stubs ssh to assert on the constructed remote command/stdin, plus 3 tests that actually extract and execute the real remote-script heredoc body against a local mock HTTP server (write/execute/read poll loop, HTTP-error response body handling, failed-deploy log reporting)
- monorepo: extend .circleci/tests/test_helper.bash with stdin capture on the fake ssh and a heredoc-body extractor, both additive and non-breaking to the existing ssh-deploy.bats suite