### PR TITLE
VOIP-1342-Cut-bin-call-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -992,11 +992,12 @@ jobs:
           project-id: voipbin
           project-repository: bin-call-manager
 
-  # Pilot: direct SSH deploy to bm-nyc-01, bypassing voipbin/voipbin
-  # entirely (no PR, no git checkout of that repo). Runs the image already
-  # pushed by bin-call-manager-build. The pre-existing GKE release job for
-  # this service has been removed - bm-nyc-01 is now the only deploy
-  # target, so there is no second target left to disambiguate against.
+  # VOIP-1342 pilot: Komodo-managed deploy, replacing the SSH+
+  # versions.lock path (ssh-deploy.sh) other bin-*-manager services still
+  # use. See docs/plans/2026-08-16-komodo-call-manager-cutover-design.md.
+  # This job only performs ROUTINE (post-cutover) deploys - the first,
+  # cutover deploy itself is a manual, watched operation (design doc §7),
+  # not run through this job.
   bin-call-manager-deploy:
     docker:
       - image: cimg/base:2024.02
@@ -1004,13 +1005,22 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Deploy bin-call-manager to bm-nyc-01
-          # Second arg is the docker-compose SERVICE name, which drops the
-          # 'bin-' prefix (matches the image-name convention other
-          # services' release jobs use, e.g. "call-manager" not
-          # "bin-call-manager") - confirmed against bm-nyc-01's actual
-          # docker-compose.yml, not assumed.
-          command: .circleci/scripts/ssh-deploy.sh voipbin/bin-call-manager call-manager
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-call-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-call-manager via Komodo API
+          # CC_KOMODO_POLL_ATTEMPTS/CC_KOMODO_POLL_INTERVAL_S set explicitly
+          # per design doc §4, rather than left at the script's 60s
+          # default: bin-call-manager's image is small (distroless + one Go
+          # binary, no vendored runtime), but a cold `docker compose pull`
+          # can still be slow on a congested host/registry, and the
+          # 3-consecutive-running follow-up check (§5 gate a) adds its own
+          # fixed ~16s on top of whatever this budget covers. 180s (60x3s)
+          # is a conservative estimate, not a measured value - tighten or
+          # loosen once real deploy timings are observed.
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-call-manager bin-call-manager/komodo/docker-compose.yml
 
   # bin-campaign-manager
   bin-campaign-manager-test:

--- a/.circleci/scripts/komodo-api-deploy-ssh-fallback.sh
+++ b/.circleci/scripts/komodo-api-deploy-ssh-fallback.sh
@@ -1,0 +1,436 @@
+#!/bin/bash
+# VoIPBin - deploy via Komodo API (kustomize-style: git is the source of
+# truth, this script pushes the compose file's CURRENT content to Komodo
+# and triggers a deploy). Reusable across services; not yet wired into any
+# individual service's CircleCI job (VOIP-1341 scope - see that ticket).
+#
+# BREAK-GLASS FALLBACK (renamed as of VOIP-1342): the primary
+# komodo-api-deploy.sh now talks to Komodo directly over HTTPS
+# (https://komodo.voipbin.net), no SSH hop. This SSH-tunnel version is
+# kept as the manual break-glass path for a production incident where
+# that HTTPS endpoint itself is unreachable - functionally unchanged, with
+# one deliberate exception: the deploy-failure path no longer prints
+# Komodo's raw (post-interpolation, potentially secret-carrying) remote
+# log verbatim, matching the same guard the primary script has always had
+# (code review round 2, security finding). See
+# docs/plans/2026-08-16-komodo-call-manager-cutover-design.md §2 for why
+# (bin-call-manager no longer has ssh-deploy.sh available at all after
+# cutover, so *something* manual must still work). Not invoked by any CI
+# job - run by hand, same way ssh-deploy.sh's manual-recovery path already
+# works.
+#
+# Mirrors ssh-deploy.sh's SSH/security pattern (key handling, host key
+# pinning, no runtime ssh-keyscan) - same target host, same 'deploy'
+# account/CC_DEPLOY_SSH_KEY context variable. See that script's header for
+# the full rationale on those choices; this header only documents what's
+# different here.
+#
+# What this does:
+#   1. SSHes into bm-nyc-01 (never exposes Komodo's API outside that
+#      session - Komodo core stays bound to 127.0.0.1, no public IP/domain,
+#      per the explicit decision this ticket documents).
+#   2. From inside that SSH session, calls Komodo's REST API against
+#      http://127.0.0.1:9120:
+#        a. POST /write   {"type":"UpdateStack", ...file_contents...}
+#        b. POST /execute {"type":"DeployStack", ...}
+#        c. POST /read    {"type":"GetUpdate", ...} - polled until terminal
+#   3. Exits 0 only if the Update's terminal status is Complete+success.
+#
+# What this does NOT do:
+#   - Does NOT decompose the existing monolithic docker-compose.yml (32
+#     services in one file) into per-service files - that's separate,
+#     deferred work (see VOIP-1341's "스코프 제외" section). This script is
+#     ready to be adopted per-service once that decomposition happens; it
+#     is not wired into any service's deploy job yet.
+#   - Does NOT expose Komodo's API publicly. Every call happens inside an
+#     SSH session to bm-nyc-01, targeting 127.0.0.1:9120 - deliberate
+#     decision (see VOIP-1341) given Komodo Periphery's host-root-
+#     equivalent docker.sock access.
+#   - Does NOT enable Komodo's own polling/webhook auto-deploy for the
+#     target stack. CI remains the only trigger, matching the explicit,
+#     deliberate-only-on-CI-action model ssh-deploy.sh already uses.
+#   - Does NOT create the target Stack. It must already exist (Write
+#     permission for the 'circleci' Komodo Service User granted on it) -
+#     same "only bumps an existing entry" precondition ssh-deploy.sh has
+#     for versions.lock.
+#
+# Usage:
+#   CC_DEPLOY_SSH_KEY=<base64-private-key> \
+#   CC_KOMODO_API_KEY=<key> CC_KOMODO_API_SECRET=<secret> \
+#     ./.circleci/scripts/komodo-api-deploy-ssh-fallback.sh <stack-name> <local-compose-file>
+#
+#   <stack-name>          The Komodo Stack resource's name (or id). Must
+#                         already exist - see Preconditions below. Must
+#                         match ^[A-Za-z0-9._-]+$ (enforced below) - this
+#                         keeps it safe to splice into the remote script
+#                         template without any risk of breaking out of its
+#                         quoting context.
+#   <local-compose-file>  Path to the docker-compose.yml IN THE CI CHECKOUT
+#                         (never touches bm-nyc-01's filesystem - no rsync,
+#                         no scp, nothing written to disk on the server).
+#                         This script reads the file locally, base64-
+#                         encodes it, and embeds that content directly in
+#                         the Komodo API request body (file_contents) sent
+#                         over the SSH session. The CURRENT content at the
+#                         checked-out commit becomes the Stack's new
+#                         file_contents - this is what makes the model
+#                         "kustomize-style": git is the only source of
+#                         truth for deployed content, Komodo just executes
+#                         it on request.
+#
+# Environment:
+#   CC_DEPLOY_SSH_KEY      Same key ssh-deploy.sh uses (base64-encoded, ONE
+#                          line). Required. Never echoed; written to a 600
+#                          temp file removed on exit.
+#   CC_KOMODO_API_KEY      Komodo API key for the 'circleci' Service User.
+#   CC_KOMODO_API_SECRET   Matching API secret. Required alongside the key.
+#                          Crosses the SSH boundary over stdin (read by a
+#                          `read -r` in the very first two lines of the
+#                          remote script), never as a command-line argument
+#                          and never via SSH's SendEnv (bm-nyc-01's sshd
+#                          AcceptEnv allowlist does not include these names
+#                          - checked directly against the live sshd_config
+#                          before choosing this approach; SendEnv fails
+#                          silently, not loudly, when the server doesn't
+#                          accept a variable, which would have produced a
+#                          confusing empty-header failure downstream
+#                          instead of a clear one here). Command arguments
+#                          are visible to any local user via `ps` for the
+#                          process's lifetime; stdin is not - this keeps
+#                          the secret out of that exposure even though
+#                          bm-nyc-01 currently only has root+deploy
+#                          accounts.
+#   CC_KOMODO_POLL_ATTEMPTS    Optional. How many times to poll Komodo's
+#                              GetUpdate before giving up. Default: 30.
+#   CC_KOMODO_POLL_INTERVAL_S  Optional. Seconds to sleep between polls.
+#                              Default: 2 (so 30x2s = 60s total by
+#                              default). Raise either for a stack whose
+#                              `docker compose pull && up` genuinely takes
+#                              longer than 60s.
+#
+# Preconditions (caller's responsibility):
+#   - The target Stack's underlying image has already been built and
+#     pushed (this script does not build or push anything - same
+#     precondition as ssh-deploy.sh).
+#   - The Stack already exists in Komodo, with the 'circleci' Service User
+#     granted Write permission on it (Write implies Execute - verified
+#     empirically against a live Komodo instance before this script was
+#     written). Creating a Stack/granting permission is a manual, one-time
+#     bootstrap step (Komodo UI or API), not something this script does.
+#   - bm-nyc-01 has jq installed (used to build/parse the API JSON
+#     payloads on the remote side).
+#
+# Implementation note: the remote script is captured via a QUOTED heredoc
+# (<<'REMOTE_SCRIPT_EOF') so the local shell performs zero expansion on it
+# - no $VAR substitution, no backslash processing, no command
+# substitution. The two dynamic values (stack name, base64 compose
+# content) are spliced in afterward via a plain `sed` replace of two
+# unique placeholder tokens. This was deliberately chosen over interpolating
+# variables directly into an unquoted heredoc (the first version of this
+# script did that and had a real, caught-in-testing quoting bug from the
+# nested backslash-escaping needed for jq's JSON filters inside an
+# SSH-command-inside-a-heredoc-inside-a-bash-script) - the placeholder+sed
+# approach has exactly one substitution mechanism to reason about instead
+# of three nested ones.
+set -euo pipefail
+
+DEPLOY_HOST="104.243.38.39"
+DEPLOY_USER="deploy"
+KNOWN_HOSTS_LINE_RSA="104.243.38.39 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtenMCo++fOqJ2NZiPDGlsteCEHTY5kFR7TCBpZsC/LyYaQYVeZaW+HRrhs1KS3FQhfDFSjYs6htnXoK6U8t+qiWb4c7iExQEeFgagxozIAkjmRERy5wnlH4RJ76loeKIcC/cDmW+eyASkGinCeAyT3DbYK5BVo0VnpXazNzgHzW7cK8G9w86+8gSt/G7f2e4iHk4qeXd2zMtuSXCF5L2gO0h3cfAHXecRUKMnWLPsczXJv/HlLSM3Xm7IjOVFHIZksJO/iD0kw2RN+fSehofokuc03Qq7462eZqjgsF53p4pEmNnWGDsQmdbE/e18NVsHh82I+1APaeORj2za+GCiEOUY+74oeLr1Omg5KiGEK6GagvVe8Ca/zJ19e0T+VkiIAGjZgseBOON3UyEHzEyUusfTsmBYWLubv1Fag4SP280yd+MeydCqr4IJg8jbGtQ+KWixxKDzXnIfuIk0lsyMfojVKeRkxKyxxwdEzWgX+nhtBPgHD2WKx+heCh5ri4E="
+KNOWN_HOSTS_LINE_ED25519="104.243.38.39 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGU/p87VedpGVqLoASzbDGJJjoFtjmKHREQzA+9gaRzq"
+
+log_info()  { echo "[INFO] $*"; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+usage() {
+  sed -n '2,/^[^#]/{/^[^#]/!p}' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+STACK_NAME="$1"
+LOCAL_COMPOSE_FILE="$2"
+
+if [[ ! "$STACK_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  log_error "stack-name must match ^[A-Za-z0-9._-]+\$ (got: $STACK_NAME)"
+  exit 1
+fi
+
+if [[ ! -f "$LOCAL_COMPOSE_FILE" ]]; then
+  log_error "local-compose-file does not exist: $LOCAL_COMPOSE_FILE"
+  exit 1
+fi
+
+if [[ -z "${CC_DEPLOY_SSH_KEY:-}" ]]; then
+  log_error "CC_DEPLOY_SSH_KEY is not set"
+  exit 1
+fi
+if [[ -z "${CC_KOMODO_API_KEY:-}" ]]; then
+  log_error "CC_KOMODO_API_KEY is not set"
+  exit 1
+fi
+if [[ -z "${CC_KOMODO_API_SECRET:-}" ]]; then
+  log_error "CC_KOMODO_API_SECRET is not set"
+  exit 1
+fi
+
+# The remote side reads these as two `read -r` lines off this ssh
+# session's stdin, in order (see the ssh invocation at the bottom of this
+# file). A literal newline embedded in either value would desync that
+# two-line protocol - CC_KOMODO_API_KEY would be silently truncated at the
+# embedded newline and CC_KOMODO_API_SECRET would pick up the remainder,
+# producing a confusing auth failure instead of a clear error here.
+if [[ "$CC_KOMODO_API_KEY" == *$'\n'* ]]; then
+  log_error "CC_KOMODO_API_KEY must not contain a newline"
+  exit 1
+fi
+if [[ "$CC_KOMODO_API_SECRET" == *$'\n'* ]]; then
+  log_error "CC_KOMODO_API_SECRET must not contain a newline"
+  exit 1
+fi
+
+# The remote side embeds these into a curl -K config file's
+# `header = "X-Api-Key: ..."` directive (see call_api in the remote
+# script template below) rather than curl argv, specifically to keep
+# them out of `ps`/`/proc/<pid>/cmdline` visibility on bm-nyc-01, the
+# same property already enforced for the SSH hop itself. curl config
+# files support backslash-escaping inside a quoted directive value, but
+# rather than replicate that escaping logic here (or on the remote side)
+# just to handle a `"` or `\` that a Komodo API token has no legitimate
+# reason to contain, reject it up front with a clear error - simpler and
+# safer than a bespoke escaper that only gets exercised on the rare
+# input it needs to handle correctly.
+if [[ "$CC_KOMODO_API_KEY" == *'"'* || "$CC_KOMODO_API_KEY" == *'\'* ]]; then
+  log_error "CC_KOMODO_API_KEY must not contain a double-quote or backslash character"
+  exit 1
+fi
+if [[ "$CC_KOMODO_API_SECRET" == *'"'* || "$CC_KOMODO_API_SECRET" == *'\'* ]]; then
+  log_error "CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"
+  exit 1
+fi
+
+# How long to wait for Komodo to finish applying the deploy before giving
+# up (POLL_ATTEMPTS x POLL_INTERVAL_S seconds total, 60s by default).
+# Override for stacks whose `docker compose pull && up` genuinely takes
+# longer than that.
+POLL_ATTEMPTS="${CC_KOMODO_POLL_ATTEMPTS:-30}"
+POLL_INTERVAL_S="${CC_KOMODO_POLL_INTERVAL_S:-2}"
+# No leading zero: the remote script does arithmetic on these
+# ($((POLL_ATTEMPTS * POLL_INTERVAL_S)) in its timeout message) and bash
+# arithmetic treats a leading-zero numeral as octal - "038" would be a
+# runtime arithmetic error (8/9 aren't valid octal digits), not just a
+# cosmetic issue. ^[1-9][0-9]*$ also rejects "0" itself, which wouldn't
+# make sense operationally (zero attempts/zero-second interval).
+if [[ ! "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  log_error "CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero (got: $POLL_ATTEMPTS)"
+  exit 1
+fi
+if [[ ! "$POLL_INTERVAL_S" =~ ^[1-9][0-9]*$ ]]; then
+  log_error "CC_KOMODO_POLL_INTERVAL_S must be a positive integer with no leading zero (got: $POLL_INTERVAL_S)"
+  exit 1
+fi
+
+SSH_KEY_FILE="$(mktemp)"
+KNOWN_HOSTS_FILE="$(mktemp)"
+cleanup() {
+  rm -f "$SSH_KEY_FILE" "$KNOWN_HOSTS_FILE"
+}
+trap cleanup EXIT
+chmod 600 "$SSH_KEY_FILE"
+
+# See ssh-deploy.sh's identical block for why base64 (not raw multi-line
+# key) and why the permissive character strip before decoding.
+CLEANED_KEY="$(printf '%s' "$CC_DEPLOY_SSH_KEY" | tr -dc 'A-Za-z0-9+/=\n')"
+if ! printf '%s' "$CLEANED_KEY" | base64 -d > "$SSH_KEY_FILE" 2>/dev/null; then
+  log_error "CC_DEPLOY_SSH_KEY is not valid base64 (must be 'base64 -w0 <private-key-file>', not the raw key)"
+  exit 1
+fi
+if ! grep -q "PRIVATE KEY" "$SSH_KEY_FILE"; then
+  log_error "CC_DEPLOY_SSH_KEY decoded but does not look like a private key (no 'PRIVATE KEY' marker) - check the value registered in the CircleCI context"
+  exit 1
+fi
+
+printf '%s\n%s\n' "$KNOWN_HOSTS_LINE_RSA" "$KNOWN_HOSTS_LINE_ED25519" > "$KNOWN_HOSTS_FILE"
+
+SSH_OPTS=(
+  -i "$SSH_KEY_FILE"
+  -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE"
+  -o GlobalKnownHostsFile=/dev/null
+  -o StrictHostKeyChecking=yes
+  -o ConnectTimeout=10
+  -o BatchMode=yes
+)
+
+# Base64-encode the compose content so it can be embedded as a single,
+# shell-metacharacter-free token in the remote script template below -
+# avoids any quoting/escaping hazard from the file's own content (which
+# can contain quotes, `$`, backticks, etc.). The remote side decodes it
+# and hands it to `jq --arg` for JSON-safe embedding into the API request
+# body - jq handles the JSON string escaping, this script never
+# hand-builds JSON via string concatenation.
+COMPOSE_B64="$(base64 -w0 < "$LOCAL_COMPOSE_FILE")"
+
+log_info "Deploying Stack '$STACK_NAME' from local file $LOCAL_COMPOSE_FILE (content pushed via Komodo API, nothing written to bm-nyc-01's disk)..."
+
+# ---- Remote script template. Fully quoted heredoc - no expansion at
+# capture time. @@STACK_NAME@@/@@COMPOSE_B64@@/@@POLL_ATTEMPTS@@/
+# @@POLL_INTERVAL_S@@ are literal placeholder tokens, replaced below via a
+# single chained `sed` before this is sent as the SSH command. The `@`
+# delimiter is deliberate, not cosmetic: all four substituted values
+# (STACK_NAME's ^[A-Za-z0-9._-]+$ charset, COMPOSE_B64's base64 alphabet,
+# and the two digit-only POLL_* values) are structurally incapable of
+# containing `@`, so none of them can ever equal - or get corrupted into
+# resembling - one of these tokens partway through the chain. An earlier
+# draft used `__NAME__`-style tokens built from the SAME charset
+# STACK_NAME is allowed to contain; a caller passing
+# `stack-name=__COMPOSE_B64__` (a legal value per the regex) would have
+# had their STACK_NAME silently overwritten by a LATER s/// in the same
+# chain re-matching text an EARLIER s/// had just inserted - caught in
+# review, verified by reproducing the exact corruption locally, before
+# this shipped. All API calls target 127.0.0.1:9120 - Komodo core is
+# never reachable outside this SSH session. CC_KOMODO_API_KEY/SECRET are
+# read from this script's own stdin (first two lines) - see the ssh
+# invocation at the bottom of this file for what feeds them in. ----
+REMOTE_SCRIPT_TEMPLATE=$(cat <<'REMOTE_SCRIPT_EOF'
+set -euo pipefail
+IFS= read -r CC_KOMODO_API_KEY
+IFS= read -r CC_KOMODO_API_SECRET
+API="http://127.0.0.1:9120"
+STACK_NAME="@@STACK_NAME@@"
+POLL_ATTEMPTS="@@POLL_ATTEMPTS@@"
+POLL_INTERVAL_S="@@POLL_INTERVAL_S@@"
+# Command substitution strips trailing newlines; a trailing 'X' sentinel
+# (stripped right after) preserves any trailing newline(s) the source
+# compose file actually had, so file_contents stays byte-for-byte
+# identical to what's checked into git - the script's own stated goal.
+compose_content="$(printf '%s' '@@COMPOSE_B64@@' | base64 -d; printf X)"
+compose_content="${compose_content%X}"
+
+# Shared helper so all three API calls (write/execute/read) get identical
+# error handling: on a non-2xx or a curl-level (connection) failure, print
+# the request type and the actual response body to stderr before
+# propagating the failure - losing this on 2 of 3 calls (as an earlier
+# draft did) leaves an operator with only a generic "deploy failed", no
+# idea why.
+#
+# Deliberately does NOT use `curl -f` ("fail on HTTP error"): -f discards
+# the response body entirely on a non-2xx response (that's its documented
+# behavior - the body is only preserved with --fail-with-body, which needs
+# curl >=7.76 and isn't guaranteed available on bm-nyc-01), which would
+# silently defeat the whole point of this helper - caught empirically
+# during review by running this exact heredoc body against a stand-in
+# HTTP server and observing "Response: " print blank on both an HTTP 400
+# and a refused connection. Instead: request the HTTP status code via
+# `-w '\n%{http_code}'` appended after the body, split it off the
+# captured output ourselves, and treat any non-2xx as failure while still
+# having the real body in hand to print. `-sS` (not bare `-s`) keeps
+# curl's own connection-level error text (refused/timeout/DNS) flowing to
+# this script's stderr - visible in the CI job's ssh output - instead of
+# being suppressed.
+#
+# The two Komodo secrets are passed to curl via `-K -` (a config file fed
+# on curl's own stdin, `header = "..."` directives), NOT `-H` on curl's
+# argv. `-H "X-Api-Secret: $CC_KOMODO_API_SECRET"` would put the secret
+# in plaintext in this process's argv for its whole lifetime - visible to
+# any other local account on bm-nyc-01 via `ps`/`/proc/<pid>/cmdline` -
+# caught in review as undercutting the exact same `ps`-exposure guarantee
+# this script already goes out of its way to provide for the SSH hop
+# (see CC_KOMODO_API_KEY/SECRET in this file's header). The local-side
+# checks rejecting `"`/`\` in either secret (see the main script body)
+# exist so this config-file value never needs its own escaping logic.
+call_api() {
+  local endpoint="$1" body="$2" resp http_code http_body header_config
+  header_config="$(printf 'header = "X-Api-Key: %s"\nheader = "X-Api-Secret: %s"\n' \
+    "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET")"
+  # --connect-timeout/--max-time bound how long a hung/unresponsive
+  # Komodo core (TCP connects fine but never replies) can stall this
+  # script - without them, a hang here is bounded only by the CI job's
+  # own overall timeout, not by anything under this script's control.
+  if ! resp="$(printf '%s' "$header_config" | curl -sS -K - -w '\n%{http_code}' --connect-timeout 10 --max-time 30 -X POST "$API/$endpoint" \
+      -H "Content-Type: application/json" \
+      -d "$body")"; then
+    echo "Komodo API call to /$endpoint failed to execute (network/connection error - see curl's error output above). Request body: $body" >&2
+    return 1
+  fi
+  http_code="${resp##*$'\n'}"
+  http_body="${resp%$'\n'*}"
+  if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+    echo "Komodo API call to /$endpoint returned HTTP $http_code. Request body: $body" >&2
+    echo "Response body: $http_body" >&2
+    return 1
+  fi
+  printf '%s' "$http_body"
+}
+
+update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$compose_content" \
+  '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents}}}')"
+if ! call_api write "$update_body" >/dev/null; then
+  echo "UpdateStack failed - Stack '$STACK_NAME' may not exist yet (this script does not create Stacks, see its header)." >&2
+  exit 1
+fi
+
+deploy_body="$(jq -n --arg stack "$STACK_NAME" \
+  '{type:"DeployStack",params:{stack:$stack,services:[],stop_time:null}}')"
+deploy_res="$(call_api execute "$deploy_body")" || exit 1
+update_id="$(printf '%s' "$deploy_res" | jq -r '._id."$oid"')"
+if [[ -z "$update_id" || "$update_id" == "null" ]]; then
+  echo "DeployStack did not return an update id. Response: $deploy_res" >&2
+  exit 1
+fi
+
+for i in $(seq 1 "$POLL_ATTEMPTS"); do
+  sleep "$POLL_INTERVAL_S"
+  status_body="$(jq -n --arg id "$update_id" '{type:"GetUpdate",params:{id:$id}}')"
+  status_res="$(call_api read "$status_body")" || exit 1
+  status="$(printf '%s' "$status_res" | jq -r '.status')"
+  if [[ "$status" == "Complete" ]]; then
+    success="$(printf '%s' "$status_res" | jq -r '.success')"
+    if [[ "$success" == "true" ]]; then
+      echo "DEPLOY_OK stack=$STACK_NAME update_id=$update_id"
+      exit 0
+    else
+      echo "DEPLOY_FAILED stack=$STACK_NAME update_id=$update_id" >&2
+      # Deliberately does NOT print status_res's raw log content (VOIP-1342
+      # code review round 2, security): this response is post-interpolation
+      # - a compose parse/exec error can echo real secret values
+      # ([[BIN_MANAGER__*]] etc. already resolved) into whatever captures
+      # this script's own stderr (terminal scrollback, a paste into an
+      # incident channel - this is a manual break-glass script, not a
+      # sandboxed CI log). Same guard as the primary komodo-api-deploy.sh.
+      echo "Check the failure details via the Komodo UI/API directly (an authenticated channel) - not reproduced here to avoid leaking post-interpolation secret values." >&2
+      exit 1
+    fi
+  fi
+done
+echo "DEPLOY_TIMEOUT stack=$STACK_NAME update_id=$update_id (still InProgress after $((POLL_ATTEMPTS * POLL_INTERVAL_S))s)" >&2
+exit 1
+REMOTE_SCRIPT_EOF
+)
+
+# Delimiter is '|', not '/': COMPOSE_B64 is base64 (alphabet A-Za-z0-9+/=)
+# and CAN legitimately contain '/', which would terminate a '/'-delimited
+# sed s/// pattern early and corrupt the substitution. '|' and '&' are not
+# in the base64 alphabet, so this is safe without further escaping (sed's
+# replacement text also treats '&' as "whole match" - irrelevant here
+# since neither substituted value contains '&').
+REMOTE_CMD="$(printf '%s' "$REMOTE_SCRIPT_TEMPLATE" | sed "s|@@STACK_NAME@@|${STACK_NAME}|g; s|@@COMPOSE_B64@@|${COMPOSE_B64}|g; s|@@POLL_ATTEMPTS@@|${POLL_ATTEMPTS}|g; s|@@POLL_INTERVAL_S@@|${POLL_INTERVAL_S}|g")"
+
+if printf '%s\n%s\n' "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET" | \
+    ssh "${SSH_OPTS[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" "$REMOTE_CMD"; then
+  log_info "Deploy succeeded: $STACK_NAME is up on bm-nyc-01 (via Komodo)"
+  exit 0
+else
+  rc=$?
+  log_error "Deploy failed (exit $rc). $STACK_NAME on bm-nyc-01 may be running a bad image."
+  log_error "This script does not auto-rollback - a human must decide the next step:"
+  log_error "  ssh ${DEPLOY_USER}@${DEPLOY_HOST} \"curl -s http://127.0.0.1:9120/read -H 'X-Api-Key: <key>' -H 'X-Api-Secret: <secret>' -d '{\\\"type\\\":\\\"GetStack\\\",\\\"params\\\":{\\\"stack\\\":\\\"$STACK_NAME\\\"}}'\""
+  exit "$rc"
+fi

--- a/.circleci/scripts/komodo-api-deploy.sh
+++ b/.circleci/scripts/komodo-api-deploy.sh
@@ -1,128 +1,104 @@
 #!/bin/bash
-# VoIPBin - deploy via Komodo API (kustomize-style: git is the source of
-# truth, this script pushes the compose file's CURRENT content to Komodo
-# and triggers a deploy). Reusable across services; not yet wired into any
-# individual service's CircleCI job (VOIP-1341 scope - see that ticket).
+# VoIPBin - deploy via Komodo API, direct HTTPS (kustomize-style: git is
+# the source of truth, this script pushes the compose file's CURRENT
+# content to Komodo and triggers a deploy).
 #
-# Mirrors ssh-deploy.sh's SSH/security pattern (key handling, host key
-# pinning, no runtime ssh-keyscan) - same target host, same 'deploy'
-# account/CC_DEPLOY_SSH_KEY context variable. See that script's header for
-# the full rationale on those choices; this header only documents what's
-# different here.
+# VOIP-1342 rewrite of the VOIP-1341 script: that version talked to Komodo
+# over an SSH tunnel to bm-nyc-01 (Komodo core was loopback-only at the
+# time). Komodo is now reachable directly over HTTPS
+# (https://komodo.voipbin.net, via bm-nyc-01's own Caddy - see
+# monorepo-etc/infra-komodo/README.md's "Public access" section and
+# monorepo-etc's infra-secret-sync-komodo.sh, which already uses this same
+# transport for the same endpoint), so this script no longer needs SSH at
+# all. The SSH-tunnel version is kept (functionally unchanged, one
+# security hardening fix - see its own header) as
+# komodo-api-deploy-ssh-fallback.sh - the break-glass path for an incident
+# where this HTTPS endpoint itself is unreachable (see this repo's
+# docs/plans/2026-08-16-komodo-call-manager-cutover-design.md §2/§3).
 #
 # What this does:
-#   1. SSHes into bm-nyc-01 (never exposes Komodo's API outside that
-#      session - Komodo core stays bound to 127.0.0.1, no public IP/domain,
-#      per the explicit decision this ticket documents).
-#   2. From inside that SSH session, calls Komodo's REST API against
-#      http://127.0.0.1:9120:
-#        a. POST /write   {"type":"UpdateStack", ...file_contents...}
-#        b. POST /execute {"type":"DeployStack", ...}
-#        c. POST /read    {"type":"GetUpdate", ...} - polled until terminal
-#   3. Exits 0 only if the Update's terminal status is Complete+success.
+#   1. GET (via /read GetStack) to confirm the target Stack exists. Does
+#      NOT create it - same precondition the VOIP-1341 script had:
+#      creating a Stack is a manual, one-time bootstrap step, not
+#      something this script does (see the cutover design doc §2 item 1
+#      for why CI doesn't auto-create, given the CI credential is full
+#      Komodo Admin).
+#   2. Guards against any unfilled `__PLACEHOLDER__`-shaped token in the
+#      rendered compose content before sending it anywhere - catches not
+#      just a missed image-tag substitution (render-image-tag.sh already
+#      guards that one specifically) but any other placeholder a compose
+#      fragment might still contain (e.g. a network name meant to be
+#      filled in by hand once - see the cutover design doc §1).
+#   3. POST /write   {"type":"UpdateStack", ...file_contents...}
+#   4. POST /execute {"type":"DeployStack", ...}
+#   5. POST /read    {"type":"GetUpdate", ...} - polled until terminal.
+#   6. Exits 0 only if the Update's terminal status is Complete+success.
 #
 # What this does NOT do:
-#   - Does NOT decompose the existing monolithic docker-compose.yml (32
-#     services in one file) into per-service files - that's separate,
-#     deferred work (see VOIP-1341's "스코프 제외" section). This script is
-#     ready to be adopted per-service once that decomposition happens; it
-#     is not wired into any service's deploy job yet.
-#   - Does NOT expose Komodo's API publicly. Every call happens inside an
-#     SSH session to bm-nyc-01, targeting 127.0.0.1:9120 - deliberate
-#     decision (see VOIP-1341) given Komodo Periphery's host-root-
-#     equivalent docker.sock access.
+#   - Does NOT create the target Stack (see step 1 above).
 #   - Does NOT enable Komodo's own polling/webhook auto-deploy for the
-#     target stack. CI remains the only trigger, matching the explicit,
-#     deliberate-only-on-CI-action model ssh-deploy.sh already uses.
-#   - Does NOT create the target Stack. It must already exist (Write
-#     permission for the 'circleci' Komodo Service User granted on it) -
-#     same "only bumps an existing entry" precondition ssh-deploy.sh has
-#     for versions.lock.
+#     target stack - CI remains the only trigger (set at Stack bootstrap
+#     time: poll_for_updates/auto_update/webhook_enabled all false).
+#   - Does NOT print Komodo's raw deploy-failure log content to CI's own
+#     output. Komodo's GetUpdate response, on a compose parse error, can
+#     echo real interpolated secret values (DSN/AMQP credentials) - this
+#     script's own request bodies stay safe (un-interpolated `[[VAR]]`
+#     placeholders, never real values), but the *response* on failure is
+#     post-interpolation. On failure this script prints only the update ID
+#     and a pointer to check it via the Komodo UI/API directly (an
+#     authenticated channel), not CI's broadly-readable job log.
 #
 # Usage:
-#   CC_DEPLOY_SSH_KEY=<base64-private-key> \
 #   CC_KOMODO_API_KEY=<key> CC_KOMODO_API_SECRET=<secret> \
 #     ./.circleci/scripts/komodo-api-deploy.sh <stack-name> <local-compose-file>
 #
 #   <stack-name>          The Komodo Stack resource's name (or id). Must
 #                         already exist - see Preconditions below. Must
-#                         match ^[A-Za-z0-9._-]+$ (enforced below) - this
-#                         keeps it safe to splice into the remote script
-#                         template without any risk of breaking out of its
-#                         quoting context.
-#   <local-compose-file>  Path to the docker-compose.yml IN THE CI CHECKOUT
-#                         (never touches bm-nyc-01's filesystem - no rsync,
-#                         no scp, nothing written to disk on the server).
-#                         This script reads the file locally, base64-
-#                         encodes it, and embeds that content directly in
-#                         the Komodo API request body (file_contents) sent
-#                         over the SSH session. The CURRENT content at the
-#                         checked-out commit becomes the Stack's new
-#                         file_contents - this is what makes the model
-#                         "kustomize-style": git is the only source of
-#                         truth for deployed content, Komodo just executes
-#                         it on request.
+#                         match ^[A-Za-z0-9._-]+$ (enforced below).
+#   <local-compose-file>  Path to the docker-compose.yml IN THE CI CHECKOUT.
+#                         This script reads the file locally and sends its
+#                         CURRENT content as the Stack's new file_contents
+#                         - this is what makes the model "kustomize-style":
+#                         git is the only source of truth for deployed
+#                         content, Komodo just executes it on request.
 #
 # Environment:
-#   CC_DEPLOY_SSH_KEY      Same key ssh-deploy.sh uses (base64-encoded, ONE
-#                          line). Required. Never echoed; written to a 600
-#                          temp file removed on exit.
 #   CC_KOMODO_API_KEY      Komodo API key for the 'circleci' Service User.
 #   CC_KOMODO_API_SECRET   Matching API secret. Required alongside the key.
-#                          Crosses the SSH boundary over stdin (read by a
-#                          `read -r` in the very first two lines of the
-#                          remote script), never as a command-line argument
-#                          and never via SSH's SendEnv (bm-nyc-01's sshd
-#                          AcceptEnv allowlist does not include these names
-#                          - checked directly against the live sshd_config
-#                          before choosing this approach; SendEnv fails
-#                          silently, not loudly, when the server doesn't
-#                          accept a variable, which would have produced a
-#                          confusing empty-header failure downstream
-#                          instead of a clear one here). Command arguments
-#                          are visible to any local user via `ps` for the
-#                          process's lifetime; stdin is not - this keeps
-#                          the secret out of that exposure even though
-#                          bm-nyc-01 currently only has root+deploy
-#                          accounts.
+#                          Sent to curl via `-K -` (a config file fed on
+#                          curl's own stdin, `header = "..."` directives),
+#                          NOT `-H` on curl's argv - keeps secrets out of
+#                          this process's argv/`ps` visibility for its
+#                          whole lifetime, same property ssh-deploy.sh and
+#                          the prior SSH-tunnel version of this script
+#                          already maintain for their own secrets.
 #   CC_KOMODO_POLL_ATTEMPTS    Optional. How many times to poll Komodo's
 #                              GetUpdate before giving up. Default: 30.
 #   CC_KOMODO_POLL_INTERVAL_S  Optional. Seconds to sleep between polls.
 #                              Default: 2 (so 30x2s = 60s total by
 #                              default). Raise either for a stack whose
 #                              `docker compose pull && up` genuinely takes
-#                              longer than 60s.
+#                              longer than 60s - set explicitly per job,
+#                              don't rely on this default, for any service
+#                              with a large image (see the cutover design
+#                              doc §4).
+#   CC_KOMODO_RUNNING_CHECK_INTERVAL_S  Optional. Seconds between the up-to-8
+#                              samples of the post-deploy 3-consecutive-
+#                              running check (design doc §5 gate a).
+#                              Default: 2.
 #
 # Preconditions (caller's responsibility):
 #   - The target Stack's underlying image has already been built and
-#     pushed (this script does not build or push anything - same
-#     precondition as ssh-deploy.sh).
+#     pushed (this script does not build or push anything).
 #   - The Stack already exists in Komodo, with the 'circleci' Service User
-#     granted Write permission on it (Write implies Execute - verified
-#     empirically against a live Komodo instance before this script was
-#     written). Creating a Stack/granting permission is a manual, one-time
-#     bootstrap step (Komodo UI or API), not something this script does.
-#   - bm-nyc-01 has jq installed (used to build/parse the API JSON
-#     payloads on the remote side).
-#
-# Implementation note: the remote script is captured via a QUOTED heredoc
-# (<<'REMOTE_SCRIPT_EOF') so the local shell performs zero expansion on it
-# - no $VAR substitution, no backslash processing, no command
-# substitution. The two dynamic values (stack name, base64 compose
-# content) are spliced in afterward via a plain `sed` replace of two
-# unique placeholder tokens. This was deliberately chosen over interpolating
-# variables directly into an unquoted heredoc (the first version of this
-# script did that and had a real, caught-in-testing quoting bug from the
-# nested backslash-escaping needed for jq's JSON filters inside an
-# SSH-command-inside-a-heredoc-inside-a-bash-script) - the placeholder+sed
-# approach has exactly one substitution mechanism to reason about instead
-# of three nested ones.
+#     granted Write permission on it (Write implies Execute).
+#   - The rendered compose file has no unfilled `__PLACEHOLDER__` tokens
+#     left in it (checked in step 2 above, but the caller's render step -
+#     e.g. render-image-tag.sh - should already have handled the ones it
+#     owns).
 set -euo pipefail
 
-DEPLOY_HOST="104.243.38.39"
-DEPLOY_USER="deploy"
-KNOWN_HOSTS_LINE_RSA="104.243.38.39 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtenMCo++fOqJ2NZiPDGlsteCEHTY5kFR7TCBpZsC/LyYaQYVeZaW+HRrhs1KS3FQhfDFSjYs6htnXoK6U8t+qiWb4c7iExQEeFgagxozIAkjmRERy5wnlH4RJ76loeKIcC/cDmW+eyASkGinCeAyT3DbYK5BVo0VnpXazNzgHzW7cK8G9w86+8gSt/G7f2e4iHk4qeXd2zMtuSXCF5L2gO0h3cfAHXecRUKMnWLPsczXJv/HlLSM3Xm7IjOVFHIZksJO/iD0kw2RN+fSehofokuc03Qq7462eZqjgsF53p4pEmNnWGDsQmdbE/e18NVsHh82I+1APaeORj2za+GCiEOUY+74oeLr1Omg5KiGEK6GagvVe8Ca/zJ19e0T+VkiIAGjZgseBOON3UyEHzEyUusfTsmBYWLubv1Fag4SP280yd+MeydCqr4IJg8jbGtQ+KWixxKDzXnIfuIk0lsyMfojVKeRkxKyxxwdEzWgX+nhtBPgHD2WKx+heCh5ri4E="
-KNOWN_HOSTS_LINE_ED25519="104.243.38.39 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGU/p87VedpGVqLoASzbDGJJjoFtjmKHREQzA+9gaRzq"
+API_BASE="https://komodo.voipbin.net"
 
 log_info()  { echo "[INFO] $*"; }
 log_error() { echo "[ERROR] $*" >&2; }
@@ -154,10 +130,6 @@ if [[ ! -f "$LOCAL_COMPOSE_FILE" ]]; then
   exit 1
 fi
 
-if [[ -z "${CC_DEPLOY_SSH_KEY:-}" ]]; then
-  log_error "CC_DEPLOY_SSH_KEY is not set"
-  exit 1
-fi
 if [[ -z "${CC_KOMODO_API_KEY:-}" ]]; then
   log_error "CC_KOMODO_API_KEY is not set"
   exit 1
@@ -166,13 +138,15 @@ if [[ -z "${CC_KOMODO_API_SECRET:-}" ]]; then
   log_error "CC_KOMODO_API_SECRET is not set"
   exit 1
 fi
-
-# The remote side reads these as two `read -r` lines off this ssh
-# session's stdin, in order (see the ssh invocation at the bottom of this
-# file). A literal newline embedded in either value would desync that
-# two-line protocol - CC_KOMODO_API_KEY would be silently truncated at the
-# embedded newline and CC_KOMODO_API_SECRET would pick up the remainder,
-# producing a confusing auth failure instead of a clear error here.
+# Both secrets are interpolated into the curl -K config file's
+# `header = "..."` directives (see call_api below) via a plain printf, one
+# directive per line. An embedded newline in either value would let it
+# inject an entirely new config-file directive (not just corrupt one
+# header's value) - curl config files support more than headers (e.g.
+# proxy), so this is checked before the quote/backslash check below, not
+# folded into it. (Dropped by mistake in this script's rewrite from the
+# SSH-tunnel version - see komodo-api-deploy-ssh-fallback.sh, which still
+# has this check - and restored here.)
 if [[ "$CC_KOMODO_API_KEY" == *$'\n'* ]]; then
   log_error "CC_KOMODO_API_KEY must not contain a newline"
   exit 1
@@ -181,18 +155,10 @@ if [[ "$CC_KOMODO_API_SECRET" == *$'\n'* ]]; then
   log_error "CC_KOMODO_API_SECRET must not contain a newline"
   exit 1
 fi
-
-# The remote side embeds these into a curl -K config file's
-# `header = "X-Api-Key: ..."` directive (see call_api in the remote
-# script template below) rather than curl argv, specifically to keep
-# them out of `ps`/`/proc/<pid>/cmdline` visibility on bm-nyc-01, the
-# same property already enforced for the SSH hop itself. curl config
-# files support backslash-escaping inside a quoted directive value, but
-# rather than replicate that escaping logic here (or on the remote side)
-# just to handle a `"` or `\` that a Komodo API token has no legitimate
-# reason to contain, reject it up front with a clear error - simpler and
-# safer than a bespoke escaper that only gets exercised on the rare
-# input it needs to handle correctly.
+# The header-config-file value never needs its own escaping logic as long
+# as these can't contain a `"` or `\` - a Komodo API token has no
+# legitimate reason to contain either, so reject up front rather than
+# implement a bespoke escaper only exercised on input it shouldn't get.
 if [[ "$CC_KOMODO_API_KEY" == *'"'* || "$CC_KOMODO_API_KEY" == *'\'* ]]; then
   log_error "CC_KOMODO_API_KEY must not contain a double-quote or backslash character"
   exit 1
@@ -202,18 +168,9 @@ if [[ "$CC_KOMODO_API_SECRET" == *'"'* || "$CC_KOMODO_API_SECRET" == *'\'* ]]; t
   exit 1
 fi
 
-# How long to wait for Komodo to finish applying the deploy before giving
-# up (POLL_ATTEMPTS x POLL_INTERVAL_S seconds total, 60s by default).
-# Override for stacks whose `docker compose pull && up` genuinely takes
-# longer than that.
 POLL_ATTEMPTS="${CC_KOMODO_POLL_ATTEMPTS:-30}"
 POLL_INTERVAL_S="${CC_KOMODO_POLL_INTERVAL_S:-2}"
-# No leading zero: the remote script does arithmetic on these
-# ($((POLL_ATTEMPTS * POLL_INTERVAL_S)) in its timeout message) and bash
-# arithmetic treats a leading-zero numeral as octal - "038" would be a
-# runtime arithmetic error (8/9 aren't valid octal digits), not just a
-# cosmetic issue. ^[1-9][0-9]*$ also rejects "0" itself, which wouldn't
-# make sense operationally (zero attempts/zero-second interval).
+RUNNING_CHECK_INTERVAL_S="${CC_KOMODO_RUNNING_CHECK_INTERVAL_S:-2}"
 if [[ ! "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   log_error "CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero (got: $POLL_ATTEMPTS)"
   exit 1
@@ -222,193 +179,155 @@ if [[ ! "$POLL_INTERVAL_S" =~ ^[1-9][0-9]*$ ]]; then
   log_error "CC_KOMODO_POLL_INTERVAL_S must be a positive integer with no leading zero (got: $POLL_INTERVAL_S)"
   exit 1
 fi
-
-SSH_KEY_FILE="$(mktemp)"
-KNOWN_HOSTS_FILE="$(mktemp)"
-cleanup() {
-  rm -f "$SSH_KEY_FILE" "$KNOWN_HOSTS_FILE"
-}
-trap cleanup EXIT
-chmod 600 "$SSH_KEY_FILE"
-
-# See ssh-deploy.sh's identical block for why base64 (not raw multi-line
-# key) and why the permissive character strip before decoding.
-CLEANED_KEY="$(printf '%s' "$CC_DEPLOY_SSH_KEY" | tr -dc 'A-Za-z0-9+/=\n')"
-if ! printf '%s' "$CLEANED_KEY" | base64 -d > "$SSH_KEY_FILE" 2>/dev/null; then
-  log_error "CC_DEPLOY_SSH_KEY is not valid base64 (must be 'base64 -w0 <private-key-file>', not the raw key)"
-  exit 1
-fi
-if ! grep -q "PRIVATE KEY" "$SSH_KEY_FILE"; then
-  log_error "CC_DEPLOY_SSH_KEY decoded but does not look like a private key (no 'PRIVATE KEY' marker) - check the value registered in the CircleCI context"
+if [[ ! "$RUNNING_CHECK_INTERVAL_S" =~ ^[1-9][0-9]*$ ]]; then
+  log_error "CC_KOMODO_RUNNING_CHECK_INTERVAL_S must be a positive integer with no leading zero (got: $RUNNING_CHECK_INTERVAL_S)"
   exit 1
 fi
 
-printf '%s\n%s\n' "$KNOWN_HOSTS_LINE_RSA" "$KNOWN_HOSTS_LINE_ED25519" > "$KNOWN_HOSTS_FILE"
+# Placeholder guard (design doc §2 item 2): catches any remaining
+# __SOMETHING__-shaped token in the compose content that should have been
+# filled in before this script ever ran - a missed image-tag substitution
+# (render-image-tag.sh already checks that one specifically, but this is a
+# second, independent line of defense) or a network-name placeholder that
+# only gets filled in by hand, once, into the git-committed file.
+if grep -Eq '__[A-Z_]+__' "$LOCAL_COMPOSE_FILE"; then
+  log_error "compose file still contains an unfilled __PLACEHOLDER__ token - refusing to deploy:"
+  grep -En '__[A-Z_]+__' "$LOCAL_COMPOSE_FILE" >&2
+  exit 1
+fi
 
-SSH_OPTS=(
-  -i "$SSH_KEY_FILE"
-  -o "UserKnownHostsFile=$KNOWN_HOSTS_FILE"
-  -o GlobalKnownHostsFile=/dev/null
-  -o StrictHostKeyChecking=yes
-  -o ConnectTimeout=10
-  -o BatchMode=yes
-)
+COMPOSE_CONTENT="$(cat "$LOCAL_COMPOSE_FILE")"
 
-# Base64-encode the compose content so it can be embedded as a single,
-# shell-metacharacter-free token in the remote script template below -
-# avoids any quoting/escaping hazard from the file's own content (which
-# can contain quotes, `$`, backticks, etc.). The remote side decodes it
-# and hands it to `jq --arg` for JSON-safe embedding into the API request
-# body - jq handles the JSON string escaping, this script never
-# hand-builds JSON via string concatenation.
-COMPOSE_B64="$(base64 -w0 < "$LOCAL_COMPOSE_FILE")"
-
-log_info "Deploying Stack '$STACK_NAME' from local file $LOCAL_COMPOSE_FILE (content pushed via Komodo API, nothing written to bm-nyc-01's disk)..."
-
-# ---- Remote script template. Fully quoted heredoc - no expansion at
-# capture time. @@STACK_NAME@@/@@COMPOSE_B64@@/@@POLL_ATTEMPTS@@/
-# @@POLL_INTERVAL_S@@ are literal placeholder tokens, replaced below via a
-# single chained `sed` before this is sent as the SSH command. The `@`
-# delimiter is deliberate, not cosmetic: all four substituted values
-# (STACK_NAME's ^[A-Za-z0-9._-]+$ charset, COMPOSE_B64's base64 alphabet,
-# and the two digit-only POLL_* values) are structurally incapable of
-# containing `@`, so none of them can ever equal - or get corrupted into
-# resembling - one of these tokens partway through the chain. An earlier
-# draft used `__NAME__`-style tokens built from the SAME charset
-# STACK_NAME is allowed to contain; a caller passing
-# `stack-name=__COMPOSE_B64__` (a legal value per the regex) would have
-# had their STACK_NAME silently overwritten by a LATER s/// in the same
-# chain re-matching text an EARLIER s/// had just inserted - caught in
-# review, verified by reproducing the exact corruption locally, before
-# this shipped. All API calls target 127.0.0.1:9120 - Komodo core is
-# never reachable outside this SSH session. CC_KOMODO_API_KEY/SECRET are
-# read from this script's own stdin (first two lines) - see the ssh
-# invocation at the bottom of this file for what feeds them in. ----
-REMOTE_SCRIPT_TEMPLATE=$(cat <<'REMOTE_SCRIPT_EOF'
-set -euo pipefail
-IFS= read -r CC_KOMODO_API_KEY
-IFS= read -r CC_KOMODO_API_SECRET
-API="http://127.0.0.1:9120"
-STACK_NAME="@@STACK_NAME@@"
-POLL_ATTEMPTS="@@POLL_ATTEMPTS@@"
-POLL_INTERVAL_S="@@POLL_INTERVAL_S@@"
-# Command substitution strips trailing newlines; a trailing 'X' sentinel
-# (stripped right after) preserves any trailing newline(s) the source
-# compose file actually had, so file_contents stays byte-for-byte
-# identical to what's checked into git - the script's own stated goal.
-compose_content="$(printf '%s' '@@COMPOSE_B64@@' | base64 -d; printf X)"
-compose_content="${compose_content%X}"
-
-# Shared helper so all three API calls (write/execute/read) get identical
-# error handling: on a non-2xx or a curl-level (connection) failure, print
-# the request type and the actual response body to stderr before
-# propagating the failure - losing this on 2 of 3 calls (as an earlier
-# draft did) leaves an operator with only a generic "deploy failed", no
-# idea why.
+# Shared helper so all API calls get identical error handling: on a
+# non-2xx or a curl-level (connection) failure, print the request type and
+# the actual response body to stderr before propagating the failure.
 #
-# Deliberately does NOT use `curl -f` ("fail on HTTP error"): -f discards
-# the response body entirely on a non-2xx response (that's its documented
-# behavior - the body is only preserved with --fail-with-body, which needs
-# curl >=7.76 and isn't guaranteed available on bm-nyc-01), which would
-# silently defeat the whole point of this helper - caught empirically
-# during review by running this exact heredoc body against a stand-in
-# HTTP server and observing "Response: " print blank on both an HTTP 400
-# and a refused connection. Instead: request the HTTP status code via
-# `-w '\n%{http_code}'` appended after the body, split it off the
-# captured output ourselves, and treat any non-2xx as failure while still
-# having the real body in hand to print. `-sS` (not bare `-s`) keeps
-# curl's own connection-level error text (refused/timeout/DNS) flowing to
-# this script's stderr - visible in the CI job's ssh output - instead of
-# being suppressed.
+# Deliberately does NOT use `curl -f` - see the prior SSH-tunnel version
+# of this script for why (discards the response body on non-2xx, which
+# would defeat this helper's whole point). Instead requests the HTTP
+# status via `-w` and splits it off manually.
 #
-# The two Komodo secrets are passed to curl via `-K -` (a config file fed
-# on curl's own stdin, `header = "..."` directives), NOT `-H` on curl's
-# argv. `-H "X-Api-Secret: $CC_KOMODO_API_SECRET"` would put the secret
-# in plaintext in this process's argv for its whole lifetime - visible to
-# any other local account on bm-nyc-01 via `ps`/`/proc/<pid>/cmdline` -
-# caught in review as undercutting the exact same `ps`-exposure guarantee
-# this script already goes out of its way to provide for the SSH hop
-# (see CC_KOMODO_API_KEY/SECRET in this file's header). The local-side
-# checks rejecting `"`/`\` in either secret (see the main script body)
-# exist so this config-file value never needs its own escaping logic.
+# 404 and 502 are special-cased (design doc §2 item 6, §"Current state"):
+# both are Komodo/Caddy fragility modes this endpoint hits *routinely*
+# from unrelated operations (a `setup-host.sh` rerun deletes the Caddy
+# route -> 404; the main stack's own CircleCI recreating voipbin-web-proxy
+# drops the `docker network connect` -> 502) - a generic "non-2xx, check
+# the logs" message would leave an operator without the one piece of
+# information that actually resolves the failure.
 call_api() {
   local endpoint="$1" body="$2" resp http_code http_body header_config
   header_config="$(printf 'header = "X-Api-Key: %s"\nheader = "X-Api-Secret: %s"\n' \
     "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET")"
-  # --connect-timeout/--max-time bound how long a hung/unresponsive
-  # Komodo core (TCP connects fine but never replies) can stall this
-  # script - without them, a hang here is bounded only by the CI job's
-  # own overall timeout, not by anything under this script's control.
-  if ! resp="$(printf '%s' "$header_config" | curl -sS -K - -w '\n%{http_code}' --connect-timeout 10 --max-time 30 -X POST "$API/$endpoint" \
+  if ! resp="$(printf '%s' "$header_config" | curl -sS -K - -w '\n%{http_code}' --connect-timeout 10 --max-time 30 -X POST "$API_BASE/$endpoint" \
       -H "Content-Type: application/json" \
       -d "$body")"; then
-    echo "Komodo API call to /$endpoint failed to execute (network/connection error - see curl's error output above). Request body: $body" >&2
+    log_error "Komodo API call to /$endpoint failed to execute (network/connection error - see curl's error output above)."
     return 1
   fi
   http_code="${resp##*$'\n'}"
   http_body="${resp%$'\n'*}"
+  case "$http_code" in
+    404)
+      log_error "Komodo API call to /$endpoint returned HTTP 404."
+      log_error "This is the Caddy-route-missing failure mode: any 'setup-host.sh' rerun on bm-nyc-01 deletes the komodo.voipbin.net route."
+      log_error "Recovery: re-apply the Caddy block per monorepo-etc/infra-komodo/README.md's 'bm-nyc-01: Caddy route' section."
+      return 1
+      ;;
+    502)
+      log_error "Komodo API call to /$endpoint returned HTTP 502."
+      log_error "This is the network-attachment-dropped failure mode: voipbin-web-proxy being recreated (including routinely by the main stack's own CircleCI pipeline) undoes 'docker network connect komodo_default voipbin-web-proxy'."
+      log_error "Recovery: on bm-nyc-01, run: docker network connect komodo_default voipbin-web-proxy"
+      return 1
+      ;;
+  esac
   if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
-    echo "Komodo API call to /$endpoint returned HTTP $http_code. Request body: $body" >&2
-    echo "Response body: $http_body" >&2
+    log_error "Komodo API call to /$endpoint returned HTTP $http_code."
+    log_error "Response body: $http_body"
     return 1
   fi
   printf '%s' "$http_body"
 }
 
-update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$compose_content" \
-  '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents}}}')"
-if ! call_api write "$update_body" >/dev/null; then
-  echo "UpdateStack failed - Stack '$STACK_NAME' may not exist yet (this script does not create Stacks, see its header)." >&2
+log_info "Checking Komodo Stack '$STACK_NAME' exists..."
+get_stack_body="$(jq -n --arg stack "$STACK_NAME" '{type:"GetStack",params:{stack:$stack}}')"
+if ! call_api read "$get_stack_body" >/dev/null; then
+  log_error "GetStack failed - Stack '$STACK_NAME' may not exist yet. This script does not create Stacks (see its header) - bootstrap it manually first."
   exit 1
 fi
+
+log_info "Deploying Stack '$STACK_NAME' from local file $LOCAL_COMPOSE_FILE (content pushed via Komodo API, direct HTTPS)..."
+
+update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$COMPOSE_CONTENT" \
+  '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents}}}')"
+call_api write "$update_body" >/dev/null
 
 deploy_body="$(jq -n --arg stack "$STACK_NAME" \
   '{type:"DeployStack",params:{stack:$stack,services:[],stop_time:null}}')"
-deploy_res="$(call_api execute "$deploy_body")" || exit 1
+deploy_res="$(call_api execute "$deploy_body")"
 update_id="$(printf '%s' "$deploy_res" | jq -r '._id."$oid"')"
 if [[ -z "$update_id" || "$update_id" == "null" ]]; then
-  echo "DeployStack did not return an update id. Response: $deploy_res" >&2
+  log_error "DeployStack did not return an update id. Response: $deploy_res"
   exit 1
 fi
 
-for i in $(seq 1 "$POLL_ATTEMPTS"); do
+# Gate (a) part 2 (design doc §5): Komodo's own Complete+success (checked
+# below) only means `docker compose up` returned 0 - started, not
+# necessarily staying up. This second, independent check polls
+# ListStackServices (confirmed via Komodo's own API docs/source to return
+# each service's live container state, e.g. .container.state == "running")
+# for 3 CONSECUTIVE running samples ~6s apart, same numeric gate
+# ssh-deploy.sh already uses for the same reason (a single sample could
+# catch a crash-looping container mid-cycle and falsely report success).
+# Requires every service in the Stack to be running, not just one specific
+# name - keeps this generic across stacks with more than one service.
+# NOT YET verified against the live Komodo instance (only against Komodo's
+# published API docs/source) - design doc §5's own open item. If
+# `.container.state` turns out not to be the real field/shape on
+# bm-nyc-01's Komodo version, this poll will consistently report
+# not-running and every deploy will fail this gate - confirm this against
+# a real deploy before trusting it unattended in CI.
+check_stack_running() {
+  local services_body services_res states
+  services_body="$(jq -n --arg stack "$STACK_NAME" '{type:"ListStackServices",params:{stack:$stack}}')"
+  services_res="$(call_api read "$services_body")" || return 1
+  states="$(printf '%s' "$services_res" | jq -r '.[].container.state')"
+  [[ -n "$states" ]] && ! grep -qv '^running$' <<< "$states"
+}
+
+for _ in $(seq 1 "$POLL_ATTEMPTS"); do
   sleep "$POLL_INTERVAL_S"
   status_body="$(jq -n --arg id "$update_id" '{type:"GetUpdate",params:{id:$id}}')"
-  status_res="$(call_api read "$status_body")" || exit 1
+  status_res="$(call_api read "$status_body")"
   status="$(printf '%s' "$status_res" | jq -r '.status')"
   if [[ "$status" == "Complete" ]]; then
     success="$(printf '%s' "$status_res" | jq -r '.success')"
     if [[ "$success" == "true" ]]; then
-      echo "DEPLOY_OK stack=$STACK_NAME update_id=$update_id"
-      exit 0
+      consecutive_running=0
+      for _ in 1 2 3 4 5 6 7 8; do
+        sleep "$RUNNING_CHECK_INTERVAL_S"
+        if check_stack_running; then
+          consecutive_running=$((consecutive_running + 1))
+        else
+          consecutive_running=0
+        fi
+        if [[ "$consecutive_running" -ge 3 ]]; then
+          log_info "DEPLOY_OK stack=$STACK_NAME update_id=$update_id (3 consecutive running samples confirmed)"
+          exit 0
+        fi
+      done
+      log_error "DEPLOY_FAILED stack=$STACK_NAME update_id=$update_id (Komodo reported the compose update succeeded, but the stack's services never reached 3 consecutive 'running' samples afterward)"
+      exit 1
     else
-      echo "DEPLOY_FAILED stack=$STACK_NAME update_id=$update_id" >&2
-      printf '%s' "$status_res" | jq -r '.logs[]?.stderr // empty' >&2
+      # Deliberately does NOT print status_res's raw log content - see
+      # this script's header ("What this does NOT do") for why: Komodo's
+      # GetUpdate response is post-interpolation and could contain real
+      # secret values on a compose parse error.
+      log_error "DEPLOY_FAILED stack=$STACK_NAME update_id=$update_id"
+      log_error "Check the failure details via the Komodo UI/API directly (an authenticated channel) - not reproduced here to avoid leaking post-interpolation secret values into this CI log."
       exit 1
     fi
   fi
 done
-echo "DEPLOY_TIMEOUT stack=$STACK_NAME update_id=$update_id (still InProgress after $((POLL_ATTEMPTS * POLL_INTERVAL_S))s)" >&2
+log_error "DEPLOY_TIMEOUT stack=$STACK_NAME update_id=$update_id (still InProgress after $((POLL_ATTEMPTS * POLL_INTERVAL_S))s)"
+log_error "The deploy may still land after this script gives up - check Komodo directly before assuming failure and retrying."
 exit 1
-REMOTE_SCRIPT_EOF
-)
-
-# Delimiter is '|', not '/': COMPOSE_B64 is base64 (alphabet A-Za-z0-9+/=)
-# and CAN legitimately contain '/', which would terminate a '/'-delimited
-# sed s/// pattern early and corrupt the substitution. '|' and '&' are not
-# in the base64 alphabet, so this is safe without further escaping (sed's
-# replacement text also treats '&' as "whole match" - irrelevant here
-# since neither substituted value contains '&').
-REMOTE_CMD="$(printf '%s' "$REMOTE_SCRIPT_TEMPLATE" | sed "s|@@STACK_NAME@@|${STACK_NAME}|g; s|@@COMPOSE_B64@@|${COMPOSE_B64}|g; s|@@POLL_ATTEMPTS@@|${POLL_ATTEMPTS}|g; s|@@POLL_INTERVAL_S@@|${POLL_INTERVAL_S}|g")"
-
-if printf '%s\n%s\n' "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET" | \
-    ssh "${SSH_OPTS[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" "$REMOTE_CMD"; then
-  log_info "Deploy succeeded: $STACK_NAME is up on bm-nyc-01 (via Komodo)"
-  exit 0
-else
-  rc=$?
-  log_error "Deploy failed (exit $rc). $STACK_NAME on bm-nyc-01 may be running a bad image."
-  log_error "This script does not auto-rollback - a human must decide the next step:"
-  log_error "  ssh ${DEPLOY_USER}@${DEPLOY_HOST} \"curl -s http://127.0.0.1:9120/read -H 'X-Api-Key: <key>' -H 'X-Api-Secret: <secret>' -d '{\\\"type\\\":\\\"GetStack\\\",\\\"params\\\":{\\\"stack\\\":\\\"$STACK_NAME\\\"}}'\""
-  exit "$rc"
-fi

--- a/.circleci/scripts/komodo-api-deploy.sh
+++ b/.circleci/scripts/komodo-api-deploy.sh
@@ -17,12 +17,15 @@
 # docs/plans/2026-08-16-komodo-call-manager-cutover-design.md §2/§3).
 #
 # What this does:
-#   1. GET (via /read GetStack) to confirm the target Stack exists. Does
-#      NOT create it - same precondition the VOIP-1341 script had:
-#      creating a Stack is a manual, one-time bootstrap step, not
-#      something this script does (see the cutover design doc §2 item 1
-#      for why CI doesn't auto-create, given the CI credential is full
-#      Komodo Admin).
+#   1. GET (via /read GetStack) to confirm the target Stack exists.
+#      Idempotent ensure-exists (대표님's explicit instruction, 2026-08-16,
+#      reversing VOIP-1341's original "never creates a Stack" precondition
+#      - manual per-service bootstrap doesn't scale to 32 services): if
+#      Komodo reports the Stack doesn't exist, CreateStack it (empty
+#      file_contents, poll_for_updates/auto_update/webhook_enabled all
+#      false, server = $KOMODO_SERVER_NAME) before continuing. Any other
+#      GetStack failure (a real API/auth/network problem) still aborts -
+#      only the specific "not found" case triggers a create.
 #   2. Guards against any unfilled `__PLACEHOLDER__`-shaped token in the
 #      rendered compose content before sending it anywhere - catches not
 #      just a missed image-tag substitution (render-image-tag.sh already
@@ -35,7 +38,10 @@
 #   6. Exits 0 only if the Update's terminal status is Complete+success.
 #
 # What this does NOT do:
-#   - Does NOT create the target Stack (see step 1 above).
+#   - Does NOT touch an EXISTING Stack's config beyond `file_contents`
+#     (UpdateStack, step 3 below, is PATCH-style) - the ensure-exists check
+#     in step 1 only ever creates a Stack that doesn't exist yet; it never
+#     modifies one that's already there.
 #   - Does NOT enable Komodo's own polling/webhook auto-deploy for the
 #     target stack - CI remains the only trigger (set at Stack bootstrap
 #     time: poll_for_updates/auto_update/webhook_enabled all false).
@@ -86,12 +92,16 @@
 #                              samples of the post-deploy 3-consecutive-
 #                              running check (design doc §5 gate a).
 #                              Default: 2.
+#   CC_KOMODO_SERVER_NAME      Optional. The Komodo Server to create the
+#                              Stack on if it doesn't exist yet (step 1
+#                              above). Default: bm-nyc-01.
 #
 # Preconditions (caller's responsibility):
 #   - The target Stack's underlying image has already been built and
 #     pushed (this script does not build or push anything).
-#   - The Stack already exists in Komodo, with the 'circleci' Service User
-#     granted Write permission on it (Write implies Execute).
+#   - The 'circleci' Komodo Service User has Write permission on the
+#     target Stack if it already exists, or Admin (to create new
+#     resources) if it doesn't yet - both already true for this account.
 #   - The rendered compose file has no unfilled `__PLACEHOLDER__` tokens
 #     left in it (checked in step 2 above, but the caller's render step -
 #     e.g. render-image-tag.sh - should already have handled the ones it
@@ -171,6 +181,12 @@ fi
 POLL_ATTEMPTS="${CC_KOMODO_POLL_ATTEMPTS:-30}"
 POLL_INTERVAL_S="${CC_KOMODO_POLL_INTERVAL_S:-2}"
 RUNNING_CHECK_INTERVAL_S="${CC_KOMODO_RUNNING_CHECK_INTERVAL_S:-2}"
+# Target Server for a Stack this script ends up creating (see the
+# ensure-exists block below) - Komodo's own CreateStack validation
+# resolves a Server by name as well as by id ("in case it comes in as
+# name", per its own source), so the plain host name is safe to pass
+# as-is. Override per-job if a service ever deploys to a different host.
+KOMODO_SERVER_NAME="${CC_KOMODO_SERVER_NAME:-bm-nyc-01}"
 if [[ ! "$POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   log_error "CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero (got: $POLL_ATTEMPTS)"
   exit 1
@@ -214,8 +230,14 @@ COMPOSE_CONTENT="$(cat "$LOCAL_COMPOSE_FILE")"
 # drops the `docker network connect` -> 502) - a generic "non-2xx, check
 # the logs" message would leave an operator without the one piece of
 # information that actually resolves the failure.
+# LAST_ERROR_BODY is set on the generic (non-404/502) failure branch below
+# so callers that need to distinguish *why* a call failed (e.g. GetStack's
+# ensure-exists check just below) can inspect the actual response body,
+# not just the fact that call_api returned non-zero.
+LAST_ERROR_BODY=""
 call_api() {
   local endpoint="$1" body="$2" resp http_code http_body header_config
+  LAST_ERROR_BODY=""
   header_config="$(printf 'header = "X-Api-Key: %s"\nheader = "X-Api-Secret: %s"\n' \
     "$CC_KOMODO_API_KEY" "$CC_KOMODO_API_SECRET")"
   if ! resp="$(printf '%s' "$header_config" | curl -sS -K - -w '\n%{http_code}' --connect-timeout 10 --max-time 30 -X POST "$API_BASE/$endpoint" \
@@ -243,16 +265,32 @@ call_api() {
   if [[ ! "$http_code" =~ ^2[0-9][0-9]$ ]]; then
     log_error "Komodo API call to /$endpoint returned HTTP $http_code."
     log_error "Response body: $http_body"
+    LAST_ERROR_BODY="$http_body"
     return 1
   fi
   printf '%s' "$http_body"
 }
 
+# Ensure-exists (idempotent): GetStack, and if Komodo reports the Stack
+# doesn't exist, CreateStack (대표님's explicit instruction, 2026-08-16 -
+# reverses this script's original "never creates a Stack" precondition,
+# since manual per-service bootstrap doesn't scale to 32 services). Note
+# Komodo returns this as an HTTP 500 with a specific error message, NOT a
+# 404 - confirmed empirically against the live instance, not assumed - so
+# detection is by message match, not status code.
 log_info "Checking Komodo Stack '$STACK_NAME' exists..."
 get_stack_body="$(jq -n --arg stack "$STACK_NAME" '{type:"GetStack",params:{stack:$stack}}')"
 if ! call_api read "$get_stack_body" >/dev/null; then
-  log_error "GetStack failed - Stack '$STACK_NAME' may not exist yet. This script does not create Stacks (see its header) - bootstrap it manually first."
-  exit 1
+  if [[ "$LAST_ERROR_BODY" == *"Did not find any Stack matching"* ]]; then
+    log_info "Stack '$STACK_NAME' does not exist yet - creating it (idempotent bootstrap, server=$KOMODO_SERVER_NAME)."
+    create_body="$(jq -n --arg name "$STACK_NAME" --arg server "$KOMODO_SERVER_NAME" \
+      '{type:"CreateStack",params:{name:$name,config:{server_id:$server,file_contents:"",poll_for_updates:false,auto_update:false,webhook_enabled:false}}}')"
+    call_api write "$create_body" >/dev/null
+    log_info "Stack '$STACK_NAME' created."
+  else
+    log_error "GetStack failed for a reason other than 'Stack not found' - not attempting to create one. See the error above."
+    exit 1
+  fi
 fi
 
 log_info "Deploying Stack '$STACK_NAME' from local file $LOCAL_COMPOSE_FILE (content pushed via Komodo API, direct HTTPS)..."

--- a/.circleci/scripts/render-image-tag.sh
+++ b/.circleci/scripts/render-image-tag.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# VoIPBin - substitute a real image tag into a Komodo compose fragment's
+# __IMAGE_TAG__ placeholder, in place.
+#
+# Replaces bump-image-digest.sh's role for services on the Komodo deploy
+# path (VOIP-1342): no versions.lock, no digest resolution - the image
+# reference is a plain tag (the same $CIRCLE_SHA1 the build step already
+# pushed), substituted directly into the compose fragment that
+# komodo-api-deploy.sh will push to Komodo. See
+# docs/plans/2026-08-16-komodo-call-manager-cutover-design.md §3.
+#
+# Usage:
+#   ./.circleci/scripts/render-image-tag.sh <compose-file> <tag>
+#
+#   <compose-file>  Path to a komodo/docker-compose.yml containing exactly
+#                   one __IMAGE_TAG__ placeholder (per image line - a file
+#                   with multiple services each needs their own call, or
+#                   the placeholder needs to be unique per line, which it
+#                   already will be as long as the tag substituted is the
+#                   same for all of them, since this is a plain string
+#                   replace of every occurrence).
+#   <tag>           The tag to substitute in, e.g. $CIRCLE_SHA1. Must look
+#                   like a plausible Docker tag (enforced below) - this is
+#                   not a full Docker tag grammar validator, just a
+#                   sanity check against the empty-string/whitespace/
+#                   shell-metacharacter failure modes that would otherwise
+#                   produce a broken-but-plausible-looking compose file.
+set -euo pipefail
+
+log_error() { echo "[ERROR] $*" >&2; }
+
+usage() {
+  sed -n '2,/^[^#]/{/^[^#]/!p}' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+COMPOSE_FILE="$1"
+TAG="$2"
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  log_error "compose-file does not exist: $COMPOSE_FILE"
+  exit 1
+fi
+
+# Docker tags are [A-Za-z0-9_][A-Za-z0-9._-]{0,127}; this is a deliberately
+# looser check (just rejects empty/whitespace/shell-metacharacter input,
+# not the full grammar) since the real validation that matters is "did the
+# build step actually push something at this tag", which this script has
+# no way to check anyway.
+if [[ -z "$TAG" || ! "$TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  log_error "tag must be a non-empty string of [A-Za-z0-9._-] characters, starting alphanumeric (got: '$TAG')"
+  exit 1
+fi
+
+if ! grep -q '__IMAGE_TAG__' "$COMPOSE_FILE"; then
+  log_error "__IMAGE_TAG__ placeholder not found in $COMPOSE_FILE - refusing to proceed (a silent no-op substitution would push the literal string '__IMAGE_TAG__' as the image ref, which is a worse failure than this explicit error)"
+  exit 1
+fi
+
+# In-place substitute. sed's `|` delimiter is safe here since TAG's
+# allowed charset (checked above) cannot contain `|`.
+sed -i "s|__IMAGE_TAG__|${TAG}|g" "$COMPOSE_FILE"
+
+echo "[INFO] Rendered __IMAGE_TAG__ -> $TAG in $COMPOSE_FILE"

--- a/.circleci/tests/komodo-api-deploy-ssh-fallback.bats
+++ b/.circleci/tests/komodo-api-deploy-ssh-fallback.bats
@@ -1,0 +1,611 @@
+#!/usr/bin/env bats
+# Tests for .circleci/scripts/komodo-api-deploy-ssh-fallback.sh
+
+load 'test_helper'
+
+setup() {
+    setup_test_env
+    COMPOSE_FIXTURE="$TEST_TEMP_DIR/docker-compose.yml"
+    cat > "$COMPOSE_FIXTURE" <<'EOF'
+services:
+  test:
+    image: nginx:latest
+EOF
+}
+
+teardown() {
+    teardown_test_env
+}
+
+run_script() {
+    bash "$SCRIPTS_DIR/komodo-api-deploy-ssh-fallback.sh" "$@"
+}
+
+# A tiny Komodo API stand-in used only by the "remote body execution"
+# tests below - unlike every other test in this file (which stubs `ssh`
+# and only inspects the constructed command string), these actually
+# extract and EXECUTE the remote heredoc body against a real local HTTP
+# server. This closes a real gap: a bug where `curl -f` silently
+# discarded the HTTP response body on failure "looked right" in the
+# constructed command string (the code to print the body was right
+# there) but was wrong at actual execution time - only caught by running
+# it. $1 selects a canned response scenario.
+start_mock_komodo() {
+    local scenario="$1"
+    MOCK_KOMODO_PORT=19977
+    MOCK_KOMODO_SCRIPT="$TEST_TEMP_DIR/mock_komodo.py"
+    MOCK_KOMODO_LOG="$TEST_TEMP_DIR/mock_komodo.log"
+    case "$scenario" in
+    http_error)
+        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
+import http.server, json, sys
+port = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0)); self.rfile.read(n)
+        self.send_response(400)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": "stack not found: teststack"}).encode())
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
+PYEOF
+        ;;
+    deploy_success)
+        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
+import http.server, json, sys
+port = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0))
+        body = json.loads(self.rfile.read(n))
+        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
+        t = body.get('type')
+        if t == 'UpdateStack':
+            resp = {"ok": True}
+        elif t == 'DeployStack':
+            resp = {"_id": {"$oid": "abc123"}}
+        else:
+            resp = {"status": "Complete", "success": True, "logs": []}
+        self.wfile.write(json.dumps(resp).encode())
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
+PYEOF
+        ;;
+    deploy_failure)
+        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
+import http.server, json, sys
+port = int(sys.argv[1])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length', 0))
+        body = json.loads(self.rfile.read(n))
+        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
+        t = body.get('type')
+        if t == 'UpdateStack':
+            resp = {"ok": True}
+        elif t == 'DeployStack':
+            resp = {"_id": {"$oid": "def456"}}
+        else:
+            resp = {"status": "Complete", "success": False, "logs": [{"stderr": "Error: image pull failed"}]}
+        self.wfile.write(json.dumps(resp).encode())
+    def log_message(self, *a): pass
+http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
+PYEOF
+        ;;
+    esac
+    python3 "$MOCK_KOMODO_SCRIPT" "$MOCK_KOMODO_PORT" > "$MOCK_KOMODO_LOG" 2>&1 &
+    MOCK_KOMODO_PID=$!
+    # Poll until the server actually accepts connections instead of a
+    # fixed sleep - avoids flakiness under load.
+    for _ in $(seq 1 50); do
+        if curl -s -o /dev/null "http://127.0.0.1:$MOCK_KOMODO_PORT/" 2>/dev/null; then
+            break
+        fi
+        sleep 0.1
+    done
+}
+
+stop_mock_komodo() {
+    [[ -n "${MOCK_KOMODO_PID:-}" ]] && kill "$MOCK_KOMODO_PID" 2>/dev/null
+}
+
+# Extracts the remote heredoc body from the real script, points its API
+# base at our mock server's port instead of the real 127.0.0.1:9120, and
+# substitutes placeholder tokens the same way the script's own sed does.
+run_remote_body_against_mock() {
+    local stack_name="$1" compose_b64="$2"
+    extract_heredoc_body "$SCRIPTS_DIR/komodo-api-deploy-ssh-fallback.sh" "REMOTE_SCRIPT_EOF" \
+        | sed "s|127.0.0.1:9120|127.0.0.1:$MOCK_KOMODO_PORT|" \
+        | sed "s|@@STACK_NAME@@|${stack_name}|; s|@@COMPOSE_B64@@|${compose_b64}|; s|@@POLL_ATTEMPTS@@|3|; s|@@POLL_INTERVAL_S@@|1|" \
+        > "$TEST_TEMP_DIR/extracted_remote.sh"
+    printf 'fake-api-key\nfake-api-secret\n' | bash "$TEST_TEMP_DIR/extracted_remote.sh"
+}
+
+@test "[remote body] HTTP error response body is actually captured and printed, not discarded by curl -f" {
+    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
+    start_mock_komodo http_error
+    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
+    stop_mock_komodo
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"returned HTTP 400"* ]]
+    [[ "$output" == *"stack not found: teststack"* ]]
+}
+
+@test "[remote body] full write -> execute -> read poll loop succeeds against a real HTTP server" {
+    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
+    start_mock_komodo deploy_success
+    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
+    stop_mock_komodo
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"DEPLOY_OK stack=teststack update_id=abc123"* ]]
+}
+
+@test "[remote body] a deploy that completes with success=false reports failure without leaking the raw (post-interpolation) remote log" {
+    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
+    start_mock_komodo deploy_failure
+    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
+    stop_mock_komodo
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"DEPLOY_FAILED stack=teststack update_id=def456"* ]]
+    # VOIP-1342 code review round 2 (security): Komodo's GetUpdate response
+    # is post-interpolation and can contain real secret values on a
+    # compose failure - this script must not echo it verbatim (same guard
+    # as the primary komodo-api-deploy.sh).
+    [[ "$output" != *"Error: image pull failed"* ]]
+    [[ "$output" == *"Komodo UI/API directly"* ]]
+}
+
+FAKE_KEY_CONTENT="-----BEGIN OPENSSH PRIVATE KEY-----
+ZmFrZS1rZXktbWF0ZXJpYWwtZm9yLXRlc3Rpbmctb25seQ==
+-----END OPENSSH PRIVATE KEY-----"
+
+valid_env() {
+    export CC_DEPLOY_SSH_KEY="$(printf '%s' "$FAKE_KEY_CONTENT" | base64 -w0)"
+    export CC_KOMODO_API_KEY="fake-komodo-api-key"
+    export CC_KOMODO_API_SECRET="fake-komodo-api-secret"
+}
+
+@test "-h/--help prints usage and exits 0 without requiring any env" {
+    run run_script --help
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "-h prints usage and exits 0 without requiring any env" {
+    run run_script -h
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "refuses with wrong argument count (too few)" {
+    run run_script "voipbin-test-stack"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* || "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "refuses with wrong argument count (too many)" {
+    valid_env
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE" "unexpected-extra-arg"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Usage:"* || "$output" == *"deploy via Komodo API"* ]]
+}
+
+@test "refuses a stack-name with unexpected characters" {
+    valid_env
+    run run_script "test-stack; rm -rf /" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"stack-name must be"* || "$output" == *"stack-name must match"* ]]
+}
+
+@test "refuses when local-compose-file does not exist" {
+    valid_env
+    run run_script "voipbin-test-stack" "$TEST_TEMP_DIR/does-not-exist.yml"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"local-compose-file does not exist"* ]]
+}
+
+@test "refuses to run when CC_DEPLOY_SSH_KEY is not set" {
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    unset CC_DEPLOY_SSH_KEY
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_DEPLOY_SSH_KEY is not set"* ]]
+}
+
+@test "refuses to run when CC_KOMODO_API_KEY is not set" {
+    valid_env
+    unset CC_KOMODO_API_KEY
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY is not set"* ]]
+}
+
+@test "refuses to run when CC_KOMODO_API_SECRET is not set" {
+    valid_env
+    unset CC_KOMODO_API_SECRET
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET is not set"* ]]
+}
+
+@test "refuses when CC_DEPLOY_SSH_KEY is not valid base64" {
+    export CC_DEPLOY_SSH_KEY="not-valid-base64!!!"
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"not valid base64"* ]]
+}
+
+@test "refuses when CC_DEPLOY_SSH_KEY decodes to something without a PRIVATE KEY marker" {
+    export CC_DEPLOY_SSH_KEY="$(printf 'just some unrelated text' | base64 -w0)"
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"does not look like a private key"* ]]
+}
+
+@test "happy path: succeeds and reports success when ssh exits 0" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Deploy succeeded"* ]]
+    [[ "$output" == *"voipbin-test-stack"* ]]
+    [[ "$(ssh_call_count)" -eq 1 ]]
+}
+
+@test "ssh is invoked against the correct user@host with host-key pinning (not runtime ssh-keyscan)" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    local args
+    args="$(ssh_call_args 1)"
+    [[ "$args" == *"deploy@104.243.38.39"* ]]
+    [[ "$args" == *"StrictHostKeyChecking=yes"* ]]
+    [[ "$args" == *"UserKnownHostsFile="* ]]
+    [[ "$output" != *"ssh-keyscan"* ]]
+}
+
+@test "the remote command targets Komodo's loopback-only API, never a public address" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *"http://127.0.0.1:9120"* ]]
+    # Never anything other than loopback for the API base.
+    [[ "$remote_cmd" != *"0.0.0.0:9120"* ]]
+}
+
+@test "the remote command's decoded compose content matches the local fixture exactly" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    local remote_cmd embedded_b64 decoded expected
+    remote_cmd="$(ssh_call_remote_command 1)"
+    embedded_b64="$(printf '%s' "$remote_cmd" | grep -o "printf '%s' '[^']*' | base64 -d" | sed "s/^printf '%s' '//; s/' | base64 -d$//")"
+    [[ -n "$embedded_b64" ]]
+    decoded="$(printf '%s' "$embedded_b64" | base64 -d)"
+    expected="$(cat "$COMPOSE_FIXTURE")"
+    [[ "$decoded" == "$expected" ]]
+}
+
+@test "a compose file whose base64 encoding contains '/' still substitutes correctly (sed delimiter regression)" {
+    # Three 0xFF bytes base64-encode to '////' - guarantees '/' characters
+    # land in the embedded payload, which would corrupt a '/'-delimited
+    # sed substitution. This is the exact bug caught and fixed before
+    # shipping (see the script's own comment on the sed delimiter choice).
+    valid_env
+    printf '\xff\xff\xffservices:\n  test:\n    image: nginx\n' > "$COMPOSE_FIXTURE"
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    # No leftover placeholder tokens - if the sed substitution had been
+    # corrupted by an embedded '/', a literal placeholder or a truncated
+    # command would remain instead of a clean substitution.
+    [[ "$remote_cmd" != *"@@STACK_NAME@@"* ]]
+    [[ "$remote_cmd" != *"@@COMPOSE_B64@@"* ]]
+    [[ "$remote_cmd" == *"STACK_NAME=\"voipbin-test-stack\""* ]]
+}
+
+@test "a stack-name equal to another placeholder token's name does not corrupt the chained sed substitution" {
+    # Regression test for a real bug caught in security review: the four
+    # placeholders are substituted via one chained sed (multiple s///
+    # separated by ';'), which re-scans text earlier substitutions just
+    # inserted. With the OLD __NAME__-style tokens (same charset
+    # STACK_NAME is allowed to contain), a stack-name equal to e.g.
+    # "COMPOSE_B64" could get re-matched and corrupted by a later s///
+    # in the chain. The @@NAME@@ tokens use '@', which is outside
+    # STACK_NAME's ^[A-Za-z0-9._-]+$ charset, structurally preventing
+    # this - this test proves a stack-name that WOULD have collided
+    # under the old scheme now substitutes cleanly.
+    valid_env
+    install_fake_ssh 0
+    run run_script "COMPOSE_B64" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *'STACK_NAME="COMPOSE_B64"'* ]]
+    # The compose content placeholder must still have been replaced by
+    # the actual base64 payload, not corrupted/overwritten by the
+    # stack-name substitution that ran first in the chain.
+    [[ "$remote_cmd" != *"@@COMPOSE_B64@@"* ]]
+}
+
+@test "Komodo API key/secret are never present in the extracted remote script's curl invocation (no argv leak via ps)" {
+    # Regression test for a real bug caught in security review: curl -H
+    # puts header VALUES directly in this process's argv, visible to any
+    # other local account on bm-nyc-01 via ps/proc for the call's
+    # duration - undercutting the same ps-exposure guarantee this script
+    # already provides for the SSH hop. Verify the source never
+    # constructs a curl invocation with -H "X-Api-...: <value>" as actual
+    # code (excluding comment lines, which legitimately reference this
+    # exact pattern by name when explaining why it was replaced).
+    run bash -c "grep -vE '^[[:space:]]*#' '$SCRIPTS_DIR/komodo-api-deploy-ssh-fallback.sh' | grep -E '-H \"X-Api-(Key|Secret): \\\$'"
+    [[ "$status" -ne 0 ]]
+    # And confirm the actual replacement mechanism (curl -K -, config
+    # fed on curl's own stdin) is present.
+    run grep -F 'curl -sS -K -' "$SCRIPTS_DIR/komodo-api-deploy-ssh-fallback.sh"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "the remote command's decoded compose content preserves a trailing newline byte-for-byte" {
+    # Command substitution strips trailing newlines; the script guards
+    # against this with a trailing sentinel char that gets stripped back
+    # off (see script.sh's comment on `compose_content`). Verify the
+    # decoded content on the remote side keeps the source file's trailing
+    # newline instead of silently losing it.
+    valid_env
+    printf 'services:\n  test:\n    image: nginx\n\n\n' > "$COMPOSE_FIXTURE"
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -eq 0 ]]
+
+    local remote_cmd embedded_b64
+    remote_cmd="$(ssh_call_remote_command 1)"
+    embedded_b64="$(printf '%s' "$remote_cmd" | grep -o "printf '%s' '[^']*' | base64 -d" | sed "s/^printf '%s' '//; s/' | base64 -d$//")"
+    # Decode straight to a file (not through a $() string, which would
+    # itself strip trailing newlines and defeat the point of this test) -
+    # byte-for-byte diff against the source fixture is the real assertion.
+    printf '%s' "$embedded_b64" | base64 -d > "$TEST_TEMP_DIR/decoded_output.yml"
+    diff "$COMPOSE_FIXTURE" "$TEST_TEMP_DIR/decoded_output.yml"
+}
+
+@test "CC_KOMODO_POLL_ATTEMPTS and CC_KOMODO_POLL_INTERVAL_S override the default poll loop" {
+    valid_env
+    export CC_KOMODO_POLL_ATTEMPTS=5
+    export CC_KOMODO_POLL_INTERVAL_S=1
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *'POLL_ATTEMPTS="5"'* ]]
+    [[ "$remote_cmd" == *'POLL_INTERVAL_S="1"'* ]]
+}
+
+@test "refuses a non-numeric CC_KOMODO_POLL_ATTEMPTS" {
+    valid_env
+    export CC_KOMODO_POLL_ATTEMPTS="thirty"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_POLL_ATTEMPTS must be a positive integer"* ]]
+}
+
+@test "refuses a CC_KOMODO_POLL_ATTEMPTS with a leading zero" {
+    # Regression test: bash arithmetic treats a leading-zero numeral as
+    # octal ($((POLL_ATTEMPTS * POLL_INTERVAL_S)) in the remote script's
+    # timeout message would hard-fail on e.g. "038" - 8/9 aren't valid
+    # octal digits). Caught in review before shipping.
+    valid_env
+    export CC_KOMODO_POLL_ATTEMPTS="030"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero"* ]]
+}
+
+@test "refuses a CC_KOMODO_POLL_INTERVAL_S with a leading zero" {
+    valid_env
+    export CC_KOMODO_POLL_INTERVAL_S="02"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_POLL_INTERVAL_S must be a positive integer with no leading zero"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_KEY containing an embedded newline" {
+    valid_env
+    export CC_KOMODO_API_KEY=$'line-one\nline-two'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a newline"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_SECRET containing an embedded newline" {
+    valid_env
+    export CC_KOMODO_API_SECRET=$'line-one\nline-two'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a newline"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_KEY containing a double-quote" {
+    # This validation is the load-bearing control that lets call_api's
+    # curl -K header_config skip implementing curl's config-file
+    # quote-escaping (see script.sh's comment on the check). Without it,
+    # a key/secret containing '"' could break out of the `header = "..."`
+    # directive's quoting on the remote side.
+    valid_env
+    export CC_KOMODO_API_KEY='has"a-quote'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a double-quote or backslash character"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_KEY containing a backslash" {
+    valid_env
+    export CC_KOMODO_API_KEY='has\a-backslash'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a double-quote or backslash character"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_SECRET containing a double-quote" {
+    valid_env
+    export CC_KOMODO_API_SECRET='has"a-quote'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"* ]]
+}
+
+@test "refuses a CC_KOMODO_API_SECRET containing a backslash" {
+    valid_env
+    export CC_KOMODO_API_SECRET='has\a-backslash'
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"* ]]
+}
+
+@test "a different stack name propagates correctly (not hardcoded)" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "some-other-stack" "$COMPOSE_FIXTURE"
+
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" == *"STACK_NAME=\"some-other-stack\""* ]]
+}
+
+@test "failure path: reports failure and manual-recovery guidance when ssh/remote exits non-zero" {
+    valid_env
+    install_fake_ssh 1
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"Deploy failed"* ]]
+    [[ "$output" == *"does not auto-rollback"* ]]
+    [[ "$output" == *"voipbin-test-stack"* ]]
+}
+
+@test "the SSH key temp file is removed after the script exits (success path)" {
+    valid_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -eq 0 ]]
+
+    local args key_file
+    args="$(ssh_call_args 1)"
+    key_file="$(echo "$args" | grep -A1 '^-i$' | tail -1)"
+    [[ -n "$key_file" ]]
+    [[ ! -f "$key_file" ]]
+}
+
+@test "the SSH key temp file is removed after the script exits (failure path)" {
+    valid_env
+    install_fake_ssh 1
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+
+    local args key_file
+    args="$(ssh_call_args 1)"
+    key_file="$(echo "$args" | grep -A1 '^-i$' | tail -1)"
+    [[ -n "$key_file" ]]
+    [[ ! -f "$key_file" ]]
+}
+
+secret_env() {
+    local content="-----BEGIN OPENSSH PRIVATE KEY-----
+super-secret-deploy-key-xyz789
+-----END OPENSSH PRIVATE KEY-----"
+    export CC_DEPLOY_SSH_KEY="$(printf '%s' "$content" | base64 -w0)"
+    export CC_KOMODO_API_KEY="super-secret-api-key-abc123"
+    export CC_KOMODO_API_SECRET="super-secret-api-secret-def456"
+}
+
+@test "SSH key value never appears in stdout/stderr output" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"super-secret-deploy-key-xyz789"* ]]
+    [[ "$output" != *"$CC_DEPLOY_SSH_KEY"* ]]
+}
+
+@test "Komodo API key/secret never appear in stdout/stderr output" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"super-secret-api-key-abc123"* ]]
+    [[ "$output" != *"super-secret-api-secret-def456"* ]]
+}
+
+@test "Komodo API key/secret never appear in the ssh invocation's argv" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local args
+    args="$(ssh_call_args 1)"
+    [[ "$args" != *"super-secret-api-key-abc123"* ]]
+    [[ "$args" != *"super-secret-api-secret-def456"* ]]
+}
+
+@test "Komodo API key/secret never appear in the remote command string" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local remote_cmd
+    remote_cmd="$(ssh_call_remote_command 1)"
+    [[ "$remote_cmd" != *"super-secret-api-key-abc123"* ]]
+    [[ "$remote_cmd" != *"super-secret-api-secret-def456"* ]]
+}
+
+@test "Komodo API key/secret are delivered via ssh stdin, as the first two lines, in order" {
+    secret_env
+    install_fake_ssh 0
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+
+    [[ "$status" -eq 0 ]]
+    local stdin_content first_line second_line
+    stdin_content="$(ssh_call_stdin 1)"
+    first_line="$(printf '%s' "$stdin_content" | sed -n '1p')"
+    second_line="$(printf '%s' "$stdin_content" | sed -n '2p')"
+    [[ "$first_line" == "super-secret-api-key-abc123" ]]
+    [[ "$second_line" == "super-secret-api-secret-def456" ]]
+}
+
+@test "refuses when CC_DEPLOY_SSH_KEY decoding leaves no readable temp file after failure (no leftover key material)" {
+    export CC_DEPLOY_SSH_KEY="not-valid-base64!!!"
+    export CC_KOMODO_API_KEY="k"
+    export CC_KOMODO_API_SECRET="s"
+    local before after
+    before="$(find "$TEST_TEMP_DIR" -maxdepth 1 -type f | wc -l)"
+    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
+    [[ "$status" -ne 0 ]]
+    after="$(find "$TEST_TEMP_DIR" -maxdepth 1 -type f | wc -l)"
+    # mktemp files land outside TEST_TEMP_DIR (system TMPDIR) - this just
+    # guards against a future refactor accidentally writing key material
+    # into our own fixture directory.
+    [[ "$before" -eq "$after" ]]
+}

--- a/.circleci/tests/komodo-api-deploy.bats
+++ b/.circleci/tests/komodo-api-deploy.bats
@@ -116,12 +116,54 @@ EOF
     [ "$(curl_call_count)" -eq 0 ]
 }
 
-@test "GetStack: fails clearly, without creating the Stack, on a Stack that doesn't exist" {
-    queue_curl_response 404 '{"error":"not found"}'
+@test "ensure-exists: GetStack 'not found' (HTTP 500, Komodo's actual shape) triggers an idempotent CreateStack" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 500 '{"error":"Did not find any Stack matching bin-call-manager","trace":[]}'  # GetStack
+    queue_curl_response 200 '{"name":"bin-call-manager"}'   # CreateStack
+    queue_curl_response 200 '{}'                             # UpdateStack
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'  # DeployStack
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"does not exist yet - creating it"* ]]
+    body="$(curl_call_body 2)"  # CreateStack is the 2nd call
+    [[ "$body" == *'"CreateStack"'* ]]
+    [[ "$body" == *'"bm-nyc-01"'* ]]
+}
+
+@test "ensure-exists: uses CC_KOMODO_SERVER_NAME when set, not the bm-nyc-01 default" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    export CC_KOMODO_SERVER_NAME=some-other-host
+    queue_curl_response 500 '{"error":"Did not find any Stack matching bin-call-manager","trace":[]}'
+    queue_curl_response 200 '{"name":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    body="$(curl_call_body 2)"
+    [[ "$body" == *'"some-other-host"'* ]]
+}
+
+@test "ensure-exists: if CreateStack itself fails, the script aborts rather than proceeding to UpdateStack/DeployStack" {
+    queue_curl_response 500 '{"error":"Did not find any Stack matching bin-call-manager","trace":[]}'  # GetStack
+    queue_curl_response 500 '{"error":"insufficient permissions"}'                                       # CreateStack fails
     run run_deploy bin-call-manager "$COMPOSE_FILE"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"does not create Stacks"* ]]
-    [[ "$output" == *"bootstrap it manually"* ]]
+    [[ "$output" == *"does not exist yet - creating it"* ]]
+    # Only GetStack + the failed CreateStack - never got to UpdateStack/DeployStack.
+    [ "$(curl_call_count)" -eq 2 ]
+}
+
+@test "ensure-exists: a GetStack failure for any OTHER reason does not attempt to create a Stack" {
+    queue_curl_response 500 '{"error":"internal server error, unrelated to stack existence"}'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not attempting to create one"* ]]
+    # Only the one GetStack call - no CreateStack attempted.
+    [ "$(curl_call_count)" -eq 1 ]
 }
 
 @test "404 special-casing: points at the Caddy-route recovery step, not a generic message" {

--- a/.circleci/tests/komodo-api-deploy.bats
+++ b/.circleci/tests/komodo-api-deploy.bats
@@ -1,15 +1,24 @@
 #!/usr/bin/env bats
-# Tests for .circleci/scripts/komodo-api-deploy.sh
+# Tests for .circleci/scripts/komodo-api-deploy.sh (direct-HTTPS version,
+# VOIP-1342). See komodo-api-deploy-ssh-fallback.bats for the retained
+# SSH-tunnel script's own coverage.
 
 load 'test_helper'
 
 setup() {
     setup_test_env
-    COMPOSE_FIXTURE="$TEST_TEMP_DIR/docker-compose.yml"
-    cat > "$COMPOSE_FIXTURE" <<'EOF'
+    install_fake_curl
+    export CC_KOMODO_API_KEY="test-key"
+    export CC_KOMODO_API_SECRET="test-secret"
+    COMPOSE_FILE="$TEST_TEMP_DIR/docker-compose.yml"
+    cat > "$COMPOSE_FILE" <<'EOF'
 services:
-  test:
-    image: nginx:latest
+  call-manager:
+    image: voipbin/bin-call-manager:abc123
+networks:
+  default:
+    name: install_default
+    external: true
 EOF
 }
 
@@ -17,590 +26,230 @@ teardown() {
     teardown_test_env
 }
 
-run_script() {
+run_deploy() {
     bash "$SCRIPTS_DIR/komodo-api-deploy.sh" "$@"
 }
 
-# A tiny Komodo API stand-in used only by the "remote body execution"
-# tests below - unlike every other test in this file (which stubs `ssh`
-# and only inspects the constructed command string), these actually
-# extract and EXECUTE the remote heredoc body against a real local HTTP
-# server. This closes a real gap: a bug where `curl -f` silently
-# discarded the HTTP response body on failure "looked right" in the
-# constructed command string (the code to print the body was right
-# there) but was wrong at actual execution time - only caught by running
-# it. $1 selects a canned response scenario.
-start_mock_komodo() {
-    local scenario="$1"
-    MOCK_KOMODO_PORT=19977
-    MOCK_KOMODO_SCRIPT="$TEST_TEMP_DIR/mock_komodo.py"
-    MOCK_KOMODO_LOG="$TEST_TEMP_DIR/mock_komodo.log"
-    case "$scenario" in
-    http_error)
-        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
-import http.server, json, sys
-port = int(sys.argv[1])
-class H(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):
-        n = int(self.headers.get('Content-Length', 0)); self.rfile.read(n)
-        self.send_response(400)
-        self.send_header('Content-Type', 'application/json')
-        self.end_headers()
-        self.wfile.write(json.dumps({"error": "stack not found: teststack"}).encode())
-    def log_message(self, *a): pass
-http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
-PYEOF
-        ;;
-    deploy_success)
-        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
-import http.server, json, sys
-port = int(sys.argv[1])
-class H(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):
-        n = int(self.headers.get('Content-Length', 0))
-        body = json.loads(self.rfile.read(n))
-        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
-        t = body.get('type')
-        if t == 'UpdateStack':
-            resp = {"ok": True}
-        elif t == 'DeployStack':
-            resp = {"_id": {"$oid": "abc123"}}
-        else:
-            resp = {"status": "Complete", "success": True, "logs": []}
-        self.wfile.write(json.dumps(resp).encode())
-    def log_message(self, *a): pass
-http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
-PYEOF
-        ;;
-    deploy_failure)
-        cat > "$MOCK_KOMODO_SCRIPT" <<'PYEOF'
-import http.server, json, sys
-port = int(sys.argv[1])
-class H(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):
-        n = int(self.headers.get('Content-Length', 0))
-        body = json.loads(self.rfile.read(n))
-        self.send_response(200); self.send_header('Content-Type', 'application/json'); self.end_headers()
-        t = body.get('type')
-        if t == 'UpdateStack':
-            resp = {"ok": True}
-        elif t == 'DeployStack':
-            resp = {"_id": {"$oid": "def456"}}
-        else:
-            resp = {"status": "Complete", "success": False, "logs": [{"stderr": "Error: image pull failed"}]}
-        self.wfile.write(json.dumps(resp).encode())
-    def log_message(self, *a): pass
-http.server.HTTPServer(('127.0.0.1', port), H).serve_forever()
-PYEOF
-        ;;
-    esac
-    python3 "$MOCK_KOMODO_SCRIPT" "$MOCK_KOMODO_PORT" > "$MOCK_KOMODO_LOG" 2>&1 &
-    MOCK_KOMODO_PID=$!
-    # Poll until the server actually accepts connections instead of a
-    # fixed sleep - avoids flakiness under load.
-    for _ in $(seq 1 50); do
-        if curl -s -o /dev/null "http://127.0.0.1:$MOCK_KOMODO_PORT/" 2>/dev/null; then
-            break
-        fi
-        sleep 0.1
-    done
+@test "usage: prints help and exits 0 with -h" {
+    run run_deploy -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
 }
 
-stop_mock_komodo() {
-    [[ -n "${MOCK_KOMODO_PID:-}" ]] && kill "$MOCK_KOMODO_PID" 2>/dev/null
+@test "usage: exits 1 with wrong arg count" {
+    run run_deploy bin-call-manager
+    [ "$status" -eq 1 ]
 }
 
-# Extracts the remote heredoc body from the real script, points its API
-# base at our mock server's port instead of the real 127.0.0.1:9120, and
-# substitutes placeholder tokens the same way the script's own sed does.
-run_remote_body_against_mock() {
-    local stack_name="$1" compose_b64="$2"
-    extract_heredoc_body "$SCRIPTS_DIR/komodo-api-deploy.sh" "REMOTE_SCRIPT_EOF" \
-        | sed "s|127.0.0.1:9120|127.0.0.1:$MOCK_KOMODO_PORT|" \
-        | sed "s|@@STACK_NAME@@|${stack_name}|; s|@@COMPOSE_B64@@|${compose_b64}|; s|@@POLL_ATTEMPTS@@|3|; s|@@POLL_INTERVAL_S@@|1|" \
-        > "$TEST_TEMP_DIR/extracted_remote.sh"
-    printf 'fake-api-key\nfake-api-secret\n' | bash "$TEST_TEMP_DIR/extracted_remote.sh"
+@test "validation: rejects a stack name with shell metacharacters" {
+    run run_deploy 'bin-call-manager; rm -rf /' "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"stack-name must match"* ]]
 }
 
-@test "[remote body] HTTP error response body is actually captured and printed, not discarded by curl -f" {
-    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
-    start_mock_komodo http_error
-    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
-    stop_mock_komodo
-
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"returned HTTP 400"* ]]
-    [[ "$output" == *"stack not found: teststack"* ]]
+@test "validation: rejects a nonexistent compose file" {
+    run run_deploy bin-call-manager /nonexistent/path.yml
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not exist"* ]]
 }
 
-@test "[remote body] full write -> execute -> read poll loop succeeds against a real HTTP server" {
-    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
-    start_mock_komodo deploy_success
-    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
-    stop_mock_komodo
-
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == *"DEPLOY_OK stack=teststack update_id=abc123"* ]]
-}
-
-@test "[remote body] a deploy that completes with success=false reports failure and the remote logs" {
-    if ! command -v python3 >/dev/null 2>&1; then skip "python3 not available"; fi
-    start_mock_komodo deploy_failure
-    run run_remote_body_against_mock "teststack" "c2VydmljZXM6CiAgdGVzdDoKICAgIGltYWdlOiBuZ2lueAo="
-    stop_mock_komodo
-
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"DEPLOY_FAILED stack=teststack update_id=def456"* ]]
-    [[ "$output" == *"Error: image pull failed"* ]]
-}
-
-FAKE_KEY_CONTENT="-----BEGIN OPENSSH PRIVATE KEY-----
-ZmFrZS1rZXktbWF0ZXJpYWwtZm9yLXRlc3Rpbmctb25seQ==
------END OPENSSH PRIVATE KEY-----"
-
-valid_env() {
-    export CC_DEPLOY_SSH_KEY="$(printf '%s' "$FAKE_KEY_CONTENT" | base64 -w0)"
-    export CC_KOMODO_API_KEY="fake-komodo-api-key"
-    export CC_KOMODO_API_SECRET="fake-komodo-api-secret"
-}
-
-@test "-h/--help prints usage and exits 0 without requiring any env" {
-    run run_script --help
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == *"deploy via Komodo API"* ]]
-}
-
-@test "-h prints usage and exits 0 without requiring any env" {
-    run run_script -h
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == *"deploy via Komodo API"* ]]
-}
-
-@test "refuses with wrong argument count (too few)" {
-    run run_script "voipbin-test-stack"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"Usage:"* || "$output" == *"deploy via Komodo API"* ]]
-}
-
-@test "refuses with wrong argument count (too many)" {
-    valid_env
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE" "unexpected-extra-arg"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"Usage:"* || "$output" == *"deploy via Komodo API"* ]]
-}
-
-@test "refuses a stack-name with unexpected characters" {
-    valid_env
-    run run_script "test-stack; rm -rf /" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"stack-name must be"* || "$output" == *"stack-name must match"* ]]
-}
-
-@test "refuses when local-compose-file does not exist" {
-    valid_env
-    run run_script "voipbin-test-stack" "$TEST_TEMP_DIR/does-not-exist.yml"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"local-compose-file does not exist"* ]]
-}
-
-@test "refuses to run when CC_DEPLOY_SSH_KEY is not set" {
-    export CC_KOMODO_API_KEY="k"
-    export CC_KOMODO_API_SECRET="s"
-    unset CC_DEPLOY_SSH_KEY
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_DEPLOY_SSH_KEY is not set"* ]]
-}
-
-@test "refuses to run when CC_KOMODO_API_KEY is not set" {
-    valid_env
+@test "validation: requires CC_KOMODO_API_KEY" {
     unset CC_KOMODO_API_KEY
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
     [[ "$output" == *"CC_KOMODO_API_KEY is not set"* ]]
 }
 
-@test "refuses to run when CC_KOMODO_API_SECRET is not set" {
-    valid_env
+@test "validation: requires CC_KOMODO_API_SECRET" {
     unset CC_KOMODO_API_SECRET
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
     [[ "$output" == *"CC_KOMODO_API_SECRET is not set"* ]]
 }
 
-@test "refuses when CC_DEPLOY_SSH_KEY is not valid base64" {
-    export CC_DEPLOY_SSH_KEY="not-valid-base64!!!"
-    export CC_KOMODO_API_KEY="k"
-    export CC_KOMODO_API_SECRET="s"
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"not valid base64"* ]]
+@test "validation: rejects a newline embedded in CC_KOMODO_API_KEY" {
+    export CC_KOMODO_API_KEY=$'legit\nheader = "X-Evil: injected"'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a newline"* ]]
+    [ "$(curl_call_count)" -eq 0 ]
 }
 
-@test "refuses when CC_DEPLOY_SSH_KEY decodes to something without a PRIVATE KEY marker" {
-    export CC_DEPLOY_SSH_KEY="$(printf 'just some unrelated text' | base64 -w0)"
-    export CC_KOMODO_API_KEY="k"
-    export CC_KOMODO_API_SECRET="s"
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"does not look like a private key"* ]]
+@test "validation: rejects a newline embedded in CC_KOMODO_API_SECRET" {
+    export CC_KOMODO_API_SECRET=$'legit\nheader = "X-Evil: injected"'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a newline"* ]]
+    [ "$(curl_call_count)" -eq 0 ]
 }
 
-@test "happy path: succeeds and reports success when ssh exits 0" {
-    valid_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    [[ "$output" == *"Deploy succeeded"* ]]
-    [[ "$output" == *"voipbin-test-stack"* ]]
-    [[ "$(ssh_call_count)" -eq 1 ]]
+@test "validation: rejects a double-quote in CC_KOMODO_API_KEY" {
+    export CC_KOMODO_API_KEY='bad"key'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must not contain a double-quote"* ]]
 }
 
-@test "ssh is invoked against the correct user@host with host-key pinning (not runtime ssh-keyscan)" {
-    valid_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    local args
-    args="$(ssh_call_args 1)"
-    [[ "$args" == *"deploy@104.243.38.39"* ]]
-    [[ "$args" == *"StrictHostKeyChecking=yes"* ]]
-    [[ "$args" == *"UserKnownHostsFile="* ]]
-    [[ "$output" != *"ssh-keyscan"* ]]
-}
-
-@test "the remote command targets Komodo's loopback-only API, never a public address" {
-    valid_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    local remote_cmd
-    remote_cmd="$(ssh_call_remote_command 1)"
-    [[ "$remote_cmd" == *"http://127.0.0.1:9120"* ]]
-    # Never anything other than loopback for the API base.
-    [[ "$remote_cmd" != *"0.0.0.0:9120"* ]]
-}
-
-@test "the remote command's decoded compose content matches the local fixture exactly" {
-    valid_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    local remote_cmd embedded_b64 decoded expected
-    remote_cmd="$(ssh_call_remote_command 1)"
-    embedded_b64="$(printf '%s' "$remote_cmd" | grep -o "printf '%s' '[^']*' | base64 -d" | sed "s/^printf '%s' '//; s/' | base64 -d$//")"
-    [[ -n "$embedded_b64" ]]
-    decoded="$(printf '%s' "$embedded_b64" | base64 -d)"
-    expected="$(cat "$COMPOSE_FIXTURE")"
-    [[ "$decoded" == "$expected" ]]
-}
-
-@test "a compose file whose base64 encoding contains '/' still substitutes correctly (sed delimiter regression)" {
-    # Three 0xFF bytes base64-encode to '////' - guarantees '/' characters
-    # land in the embedded payload, which would corrupt a '/'-delimited
-    # sed substitution. This is the exact bug caught and fixed before
-    # shipping (see the script's own comment on the sed delimiter choice).
-    valid_env
-    printf '\xff\xff\xffservices:\n  test:\n    image: nginx\n' > "$COMPOSE_FIXTURE"
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    local remote_cmd
-    remote_cmd="$(ssh_call_remote_command 1)"
-    # No leftover placeholder tokens - if the sed substitution had been
-    # corrupted by an embedded '/', a literal placeholder or a truncated
-    # command would remain instead of a clean substitution.
-    [[ "$remote_cmd" != *"@@STACK_NAME@@"* ]]
-    [[ "$remote_cmd" != *"@@COMPOSE_B64@@"* ]]
-    [[ "$remote_cmd" == *"STACK_NAME=\"voipbin-test-stack\""* ]]
-}
-
-@test "a stack-name equal to another placeholder token's name does not corrupt the chained sed substitution" {
-    # Regression test for a real bug caught in security review: the four
-    # placeholders are substituted via one chained sed (multiple s///
-    # separated by ';'), which re-scans text earlier substitutions just
-    # inserted. With the OLD __NAME__-style tokens (same charset
-    # STACK_NAME is allowed to contain), a stack-name equal to e.g.
-    # "COMPOSE_B64" could get re-matched and corrupted by a later s///
-    # in the chain. The @@NAME@@ tokens use '@', which is outside
-    # STACK_NAME's ^[A-Za-z0-9._-]+$ charset, structurally preventing
-    # this - this test proves a stack-name that WOULD have collided
-    # under the old scheme now substitutes cleanly.
-    valid_env
-    install_fake_ssh 0
-    run run_script "COMPOSE_B64" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    local remote_cmd
-    remote_cmd="$(ssh_call_remote_command 1)"
-    [[ "$remote_cmd" == *'STACK_NAME="COMPOSE_B64"'* ]]
-    # The compose content placeholder must still have been replaced by
-    # the actual base64 payload, not corrupted/overwritten by the
-    # stack-name substitution that ran first in the chain.
-    [[ "$remote_cmd" != *"@@COMPOSE_B64@@"* ]]
-}
-
-@test "Komodo API key/secret are never present in the extracted remote script's curl invocation (no argv leak via ps)" {
-    # Regression test for a real bug caught in security review: curl -H
-    # puts header VALUES directly in this process's argv, visible to any
-    # other local account on bm-nyc-01 via ps/proc for the call's
-    # duration - undercutting the same ps-exposure guarantee this script
-    # already provides for the SSH hop. Verify the source never
-    # constructs a curl invocation with -H "X-Api-...: <value>" as actual
-    # code (excluding comment lines, which legitimately reference this
-    # exact pattern by name when explaining why it was replaced).
-    run bash -c "grep -vE '^[[:space:]]*#' '$SCRIPTS_DIR/komodo-api-deploy.sh' | grep -E '-H \"X-Api-(Key|Secret): \\\$'"
-    [[ "$status" -ne 0 ]]
-    # And confirm the actual replacement mechanism (curl -K -, config
-    # fed on curl's own stdin) is present.
-    run grep -F 'curl -sS -K -' "$SCRIPTS_DIR/komodo-api-deploy.sh"
-    [[ "$status" -eq 0 ]]
-}
-
-@test "the remote command's decoded compose content preserves a trailing newline byte-for-byte" {
-    # Command substitution strips trailing newlines; the script guards
-    # against this with a trailing sentinel char that gets stripped back
-    # off (see script.sh's comment on `compose_content`). Verify the
-    # decoded content on the remote side keeps the source file's trailing
-    # newline instead of silently losing it.
-    valid_env
-    printf 'services:\n  test:\n    image: nginx\n\n\n' > "$COMPOSE_FIXTURE"
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -eq 0 ]]
-
-    local remote_cmd embedded_b64
-    remote_cmd="$(ssh_call_remote_command 1)"
-    embedded_b64="$(printf '%s' "$remote_cmd" | grep -o "printf '%s' '[^']*' | base64 -d" | sed "s/^printf '%s' '//; s/' | base64 -d$//")"
-    # Decode straight to a file (not through a $() string, which would
-    # itself strip trailing newlines and defeat the point of this test) -
-    # byte-for-byte diff against the source fixture is the real assertion.
-    printf '%s' "$embedded_b64" | base64 -d > "$TEST_TEMP_DIR/decoded_output.yml"
-    diff "$COMPOSE_FIXTURE" "$TEST_TEMP_DIR/decoded_output.yml"
-}
-
-@test "CC_KOMODO_POLL_ATTEMPTS and CC_KOMODO_POLL_INTERVAL_S override the default poll loop" {
-    valid_env
-    export CC_KOMODO_POLL_ATTEMPTS=5
-    export CC_KOMODO_POLL_INTERVAL_S=1
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    local remote_cmd
-    remote_cmd="$(ssh_call_remote_command 1)"
-    [[ "$remote_cmd" == *'POLL_ATTEMPTS="5"'* ]]
-    [[ "$remote_cmd" == *'POLL_INTERVAL_S="1"'* ]]
-}
-
-@test "refuses a non-numeric CC_KOMODO_POLL_ATTEMPTS" {
-    valid_env
-    export CC_KOMODO_POLL_ATTEMPTS="thirty"
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
+@test "validation: rejects a leading-zero CC_KOMODO_POLL_ATTEMPTS" {
+    export CC_KOMODO_POLL_ATTEMPTS="030"
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
     [[ "$output" == *"CC_KOMODO_POLL_ATTEMPTS must be a positive integer"* ]]
 }
 
-@test "refuses a CC_KOMODO_POLL_ATTEMPTS with a leading zero" {
-    # Regression test: bash arithmetic treats a leading-zero numeral as
-    # octal ($((POLL_ATTEMPTS * POLL_INTERVAL_S)) in the remote script's
-    # timeout message would hard-fail on e.g. "038" - 8/9 aren't valid
-    # octal digits). Caught in review before shipping.
-    valid_env
-    export CC_KOMODO_POLL_ATTEMPTS="030"
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_POLL_ATTEMPTS must be a positive integer with no leading zero"* ]]
+@test "placeholder guard: refuses to deploy with an unfilled __PLACEHOLDER__ token" {
+    cat > "$COMPOSE_FILE" <<'EOF'
+services:
+  call-manager:
+    image: voipbin/bin-call-manager:__IMAGE_TAG__
+networks:
+  default:
+    name: __NETWORK_NAME__
+    external: true
+EOF
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unfilled __PLACEHOLDER__ token"* ]]
+    [[ "$output" == *"__IMAGE_TAG__"* ]]
+    [[ "$output" == *"__NETWORK_NAME__"* ]]
+    # Must fail before ever calling the API - no curl invocation logged.
+    [ "$(curl_call_count)" -eq 0 ]
 }
 
-@test "refuses a CC_KOMODO_POLL_INTERVAL_S with a leading zero" {
-    valid_env
-    export CC_KOMODO_POLL_INTERVAL_S="02"
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_POLL_INTERVAL_S must be a positive integer with no leading zero"* ]]
+@test "GetStack: fails clearly, without creating the Stack, on a Stack that doesn't exist" {
+    queue_curl_response 404 '{"error":"not found"}'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not create Stacks"* ]]
+    [[ "$output" == *"bootstrap it manually"* ]]
 }
 
-@test "refuses a CC_KOMODO_API_KEY containing an embedded newline" {
-    valid_env
-    export CC_KOMODO_API_KEY=$'line-one\nline-two'
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a newline"* ]]
+@test "404 special-casing: points at the Caddy-route recovery step, not a generic message" {
+    queue_curl_response 404 '{"error":"not found"}'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Caddy-route-missing"* ]]
+    [[ "$output" == *"setup-host.sh"* ]]
 }
 
-@test "refuses a CC_KOMODO_API_SECRET containing an embedded newline" {
-    valid_env
-    export CC_KOMODO_API_SECRET=$'line-one\nline-two'
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a newline"* ]]
+@test "502 special-casing: points at the docker network connect recovery step, not a generic message" {
+    queue_curl_response 502 'Bad Gateway'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"network-attachment-dropped"* ]]
+    [[ "$output" == *"docker network connect komodo_default voipbin-web-proxy"* ]]
 }
 
-@test "refuses a CC_KOMODO_API_KEY containing a double-quote" {
-    # This validation is the load-bearing control that lets call_api's
-    # curl -K header_config skip implementing curl's config-file
-    # quote-escaping (see script.sh's comment on the check). Without it,
-    # a key/secret containing '"' could break out of the `header = "..."`
-    # directive's quoting on the remote side.
-    valid_env
-    export CC_KOMODO_API_KEY='has"a-quote'
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a double-quote or backslash character"* ]]
+# All queue_running_samples calls below queue N ListStackServices
+# responses, each reporting a single service in state "running" - the gate
+# (a) part-2 check (design doc §5) that runs after Komodo itself reports
+# the compose update Complete+success.
+queue_running_samples() {
+    local n="$1"
+    for ((i = 0; i < n; i++)); do
+        queue_curl_response 200 '[{"service":"call-manager","container":{"state":"running"}}]'
+    done
 }
 
-@test "refuses a CC_KOMODO_API_KEY containing a backslash" {
-    valid_env
-    export CC_KOMODO_API_KEY='has\a-backslash'
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_API_KEY must not contain a double-quote or backslash character"* ]]
+@test "happy path: GetStack -> UpdateStack -> DeployStack -> GetUpdate(Complete,success) -> 3x running exits 0" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'              # GetStack
+    queue_curl_response 200 '{}'                                      # UpdateStack
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'           # DeployStack
+    queue_curl_response 200 '{"status":"Complete","success":true}'    # GetUpdate (poll 1)
+    queue_running_samples 3                                           # ListStackServices x3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DEPLOY_OK"* ]]
+    [[ "$output" == *"update_id=update-123"* ]]
+    [[ "$output" == *"3 consecutive running samples confirmed"* ]]
 }
 
-@test "refuses a CC_KOMODO_API_SECRET containing a double-quote" {
-    valid_env
-    export CC_KOMODO_API_SECRET='has"a-quote'
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"* ]]
+@test "running-gate: a non-running sample resets the consecutive count instead of failing immediately" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 2
+    queue_curl_response 200 '[{"service":"call-manager","container":{"state":"restarting"}}]'
+    queue_running_samples 3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DEPLOY_OK"* ]]
 }
 
-@test "refuses a CC_KOMODO_API_SECRET containing a backslash" {
-    valid_env
-    export CC_KOMODO_API_SECRET='has\a-backslash'
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"CC_KOMODO_API_SECRET must not contain a double-quote or backslash character"* ]]
+@test "running-gate: never reaching 3 consecutive running samples exits 1 (deploy 'succeeded' but stack unhealthy)" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    for i in 1 2 3 4 5 6 7 8; do
+        queue_curl_response 200 '[{"service":"call-manager","container":{"state":"restarting"}}]'
+    done
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"DEPLOY_FAILED"* ]]
+    [[ "$output" == *"never reached 3 consecutive"* ]]
 }
 
-@test "a different stack name propagates correctly (not hardcoded)" {
-    valid_env
-    install_fake_ssh 0
-    run run_script "some-other-stack" "$COMPOSE_FIXTURE"
-
-    local remote_cmd
-    remote_cmd="$(ssh_call_remote_command 1)"
-    [[ "$remote_cmd" == *"STACK_NAME=\"some-other-stack\""* ]]
+@test "happy path: sends secrets via -K header config, not curl argv" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    header_config="$(curl_call_header_config 1)"
+    [[ "$header_config" == *"X-Api-Key: test-key"* ]]
+    [[ "$header_config" == *"X-Api-Secret: test-secret"* ]]
+    # Not present as an argv-visible -H header carrying the secret.
+    run bash -c "grep -vE '^[[:space:]]*#' '$SCRIPTS_DIR/komodo-api-deploy.sh' | grep -E '\-H \"X-Api-(Key|Secret): \\\$'"
+    [ "$status" -ne 0 ]
 }
 
-@test "failure path: reports failure and manual-recovery guidance when ssh/remote exits non-zero" {
-    valid_env
-    install_fake_ssh 1
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -ne 0 ]]
-    [[ "$output" == *"Deploy failed"* ]]
-    [[ "$output" == *"does not auto-rollback"* ]]
-    [[ "$output" == *"voipbin-test-stack"* ]]
+@test "UpdateStack request body carries the compose content, un-rendered placeholders excluded by prior guard" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    body="$(curl_call_body 2)"  # UpdateStack is the 2nd call
+    [[ "$body" == *"voipbin/bin-call-manager:abc123"* ]]
+    [[ "$body" == *'"UpdateStack"'* ]]
 }
 
-@test "the SSH key temp file is removed after the script exits (success path)" {
-    valid_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -eq 0 ]]
-
-    local args key_file
-    args="$(ssh_call_args 1)"
-    key_file="$(echo "$args" | grep -A1 '^-i$' | tail -1)"
-    [[ -n "$key_file" ]]
-    [[ ! -f "$key_file" ]]
+@test "deploy failure (Complete, success=false): exits 1 without printing raw Komodo log content" {
+    export CC_KOMODO_POLL_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":false,"logs":[{"stderr":"amqp://realuser:realsecret@rabbitmq:5672"}]}'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"DEPLOY_FAILED"* ]]
+    # The log-leakage guard: the secret-shaped content from Komodo's own
+    # response must never appear in this script's own output.
+    [[ "$output" != *"realsecret"* ]]
+    [[ "$output" == *"Komodo UI/API directly"* ]]
 }
 
-@test "the SSH key temp file is removed after the script exits (failure path)" {
-    valid_env
-    install_fake_ssh 1
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-
-    local args key_file
-    args="$(ssh_call_args 1)"
-    key_file="$(echo "$args" | grep -A1 '^-i$' | tail -1)"
-    [[ -n "$key_file" ]]
-    [[ ! -f "$key_file" ]]
-}
-
-secret_env() {
-    local content="-----BEGIN OPENSSH PRIVATE KEY-----
-super-secret-deploy-key-xyz789
------END OPENSSH PRIVATE KEY-----"
-    export CC_DEPLOY_SSH_KEY="$(printf '%s' "$content" | base64 -w0)"
-    export CC_KOMODO_API_KEY="super-secret-api-key-abc123"
-    export CC_KOMODO_API_SECRET="super-secret-api-secret-def456"
-}
-
-@test "SSH key value never appears in stdout/stderr output" {
-    secret_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    [[ "$output" != *"super-secret-deploy-key-xyz789"* ]]
-    [[ "$output" != *"$CC_DEPLOY_SSH_KEY"* ]]
-}
-
-@test "Komodo API key/secret never appear in stdout/stderr output" {
-    secret_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    [[ "$output" != *"super-secret-api-key-abc123"* ]]
-    [[ "$output" != *"super-secret-api-secret-def456"* ]]
-}
-
-@test "Komodo API key/secret never appear in the ssh invocation's argv" {
-    secret_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    local args
-    args="$(ssh_call_args 1)"
-    [[ "$args" != *"super-secret-api-key-abc123"* ]]
-    [[ "$args" != *"super-secret-api-secret-def456"* ]]
-}
-
-@test "Komodo API key/secret never appear in the remote command string" {
-    secret_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    local remote_cmd
-    remote_cmd="$(ssh_call_remote_command 1)"
-    [[ "$remote_cmd" != *"super-secret-api-key-abc123"* ]]
-    [[ "$remote_cmd" != *"super-secret-api-secret-def456"* ]]
-}
-
-@test "Komodo API key/secret are delivered via ssh stdin, as the first two lines, in order" {
-    secret_env
-    install_fake_ssh 0
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-
-    [[ "$status" -eq 0 ]]
-    local stdin_content first_line second_line
-    stdin_content="$(ssh_call_stdin 1)"
-    first_line="$(printf '%s' "$stdin_content" | sed -n '1p')"
-    second_line="$(printf '%s' "$stdin_content" | sed -n '2p')"
-    [[ "$first_line" == "super-secret-api-key-abc123" ]]
-    [[ "$second_line" == "super-secret-api-secret-def456" ]]
-}
-
-@test "refuses when CC_DEPLOY_SSH_KEY decoding leaves no readable temp file after failure (no leftover key material)" {
-    export CC_DEPLOY_SSH_KEY="not-valid-base64!!!"
-    export CC_KOMODO_API_KEY="k"
-    export CC_KOMODO_API_SECRET="s"
-    local before after
-    before="$(find "$TEST_TEMP_DIR" -maxdepth 1 -type f | wc -l)"
-    run run_script "voipbin-test-stack" "$COMPOSE_FIXTURE"
-    [[ "$status" -ne 0 ]]
-    after="$(find "$TEST_TEMP_DIR" -maxdepth 1 -type f | wc -l)"
-    # mktemp files land outside TEST_TEMP_DIR (system TMPDIR) - this just
-    # guards against a future refactor accidentally writing key material
-    # into our own fixture directory.
-    [[ "$before" -eq "$after" ]]
+@test "deploy timeout: exits 1 after exhausting CC_KOMODO_POLL_ATTEMPTS" {
+    export CC_KOMODO_POLL_ATTEMPTS=2
+    export CC_KOMODO_POLL_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"InProgress"}'
+    queue_curl_response 200 '{"status":"InProgress"}'
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"DEPLOY_TIMEOUT"* ]]
+    [[ "$output" == *"may still land after this script gives up"* ]]
 }

--- a/.circleci/tests/render-image-tag.bats
+++ b/.circleci/tests/render-image-tag.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Tests for .circleci/scripts/render-image-tag.sh
+
+load 'test_helper'
+
+setup() {
+    setup_test_env
+    COMPOSE_FILE="$TEST_TEMP_DIR/docker-compose.yml"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+run_render() {
+    bash "$SCRIPTS_DIR/render-image-tag.sh" "$@"
+}
+
+@test "usage: prints help and exits 0 with -h" {
+    run run_render -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "usage: exits 1 with wrong arg count" {
+    run run_render "$COMPOSE_FILE"
+    [ "$status" -eq 1 ]
+}
+
+@test "validation: rejects a nonexistent compose file" {
+    run run_render /nonexistent/path.yml abc123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "validation: rejects an empty tag" {
+    echo 'image: voipbin/bin-call-manager:__IMAGE_TAG__' > "$COMPOSE_FILE"
+    run run_render "$COMPOSE_FILE" ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must be a non-empty string"* ]]
+}
+
+@test "validation: rejects a tag containing shell metacharacters" {
+    echo 'image: voipbin/bin-call-manager:__IMAGE_TAG__' > "$COMPOSE_FILE"
+    run run_render "$COMPOSE_FILE" 'abc; rm -rf /'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"must be a non-empty string"* ]]
+}
+
+@test "placeholder guard: fails loudly, unmodified file, when __IMAGE_TAG__ is missing" {
+    echo 'image: voipbin/bin-call-manager:already-pinned' > "$COMPOSE_FILE"
+    cp "$COMPOSE_FILE" "$COMPOSE_FILE.orig"
+    run run_render "$COMPOSE_FILE" abc123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"placeholder not found"* ]]
+    diff "$COMPOSE_FILE" "$COMPOSE_FILE.orig"
+}
+
+@test "substitution: replaces __IMAGE_TAG__ with the given tag, in place" {
+    printf 'services:\n  call-manager:\n    image: voipbin/bin-call-manager:__IMAGE_TAG__\n' > "$COMPOSE_FILE"
+    run run_render "$COMPOSE_FILE" "$(printf 'a%.0s' {1..40})"
+    [ "$status" -eq 0 ]
+    run cat "$COMPOSE_FILE"
+    [[ "$output" == *"voipbin/bin-call-manager:$(printf 'a%.0s' {1..40})"* ]]
+    [[ "$output" != *"__IMAGE_TAG__"* ]]
+}
+
+@test "substitution: touches nothing else in the file" {
+    printf 'services:\n  call-manager:\n    image: voipbin/bin-call-manager:__IMAGE_TAG__\nnetworks:\n  default:\n    name: install_default\n    external: true\n' > "$COMPOSE_FILE"
+    run run_render "$COMPOSE_FILE" deadbeef
+    [ "$status" -eq 0 ]
+    run grep -c "install_default" "$COMPOSE_FILE"
+    [ "$output" -eq 1 ]
+    run grep -c "external: true" "$COMPOSE_FILE"
+    [ "$output" -eq 1 ]
+}

--- a/.circleci/tests/test_helper.bash
+++ b/.circleci/tests/test_helper.bash
@@ -99,6 +99,87 @@ ssh_call_stdin() {
     awk -v RS='\035' -v n="$n" 'NR==n{print; exit}' "$SSH_STDIN_LOG"
 }
 
+# A fake `curl` for testing komodo-api-deploy.sh's direct-HTTPS calls.
+# Pops one canned response per invocation from a queue file
+# ($CURL_QUEUE, one "http_code<TAB>body" line per response, in call
+# order), and prints it in the shape the real script expects from
+# `curl -w '\n%{http_code}'` (body, then a newline, then the bare status
+# code). Logs each invocation's URL, -d body, and -K stdin config to
+# $CURL_LOG (one record per invocation, 0x1d-separated, fields
+# 0x1e-separated: url, body, stdin-config) so tests can assert on what
+# was actually sent, same separator convention as install_fake_ssh above
+# for the same embedded-newline reason (a compose file's file_contents
+# can itself contain newlines).
+install_fake_curl() {
+    export CURL_QUEUE="$TEST_TEMP_DIR/curl_queue.tsv"
+    export CURL_LOG="$TEST_TEMP_DIR/curl_calls.log"
+    : > "$CURL_QUEUE"
+    : > "$CURL_LOG"
+    cat > "$MOCK_BIN_DIR/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+url="" body="" stdin_config=""
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+    case "${args[$i]}" in
+        -d) body="${args[$((i+1))]}" ;;
+        -X|-H|-w|--connect-timeout|--max-time) ;; # value consumed on next iteration naturally via case above where relevant
+        http*://*) url="${args[$i]}" ;;
+    esac
+done
+stdin_config="$(cat)"
+{
+    printf '%s\x1e' "$url"
+    printf '%s\x1e' "$body"
+    printf '%s\x1e' "$stdin_config"
+    printf '\x1d'
+} >> "$CURL_LOG"
+
+if [[ ! -s "$CURL_QUEUE" ]]; then
+    echo "install_fake_curl: queue exhausted, no canned response left for this call" >&2
+    exit 1
+fi
+line="$(head -n1 "$CURL_QUEUE")"
+sed -i '1d' "$CURL_QUEUE"
+code="${line%%$'\t'*}"
+respbody="${line#*$'\t'}"
+printf '%s\n%s' "$respbody" "$code"
+EOF
+    chmod +x "$MOCK_BIN_DIR/curl"
+}
+
+# Queue one canned curl response (HTTP status code + response body) to be
+# returned on the next invocation, in the order queued.
+queue_curl_response() {
+    local code="$1" body="$2"
+    printf '%s\t%s\n' "$code" "$body" >> "$CURL_QUEUE"
+}
+
+# The Nth (1-indexed) curl invocation's URL / -d body / -K stdin config.
+# Three separate accessors (not one array-returning function) for the
+# same reason ssh_call_remote_command uses awk FS instead of a bash
+# `read -a`: the body field is real multi-line JSON (jq's pretty-printed
+# output), and `read` always stops at the first embedded newline
+# regardless of IFS - splitting bash-side would silently truncate it.
+# awk's FS, unlike `read`, does not treat embedded newlines specially.
+curl_call_url() {
+    local n="$1"
+    awk -v RS='\035' -v FS='\036' -v n="$n" 'NR==n{print $1; exit}' "$CURL_LOG"
+}
+curl_call_body() {
+    local n="$1"
+    awk -v RS='\035' -v FS='\036' -v n="$n" 'NR==n{print $2; exit}' "$CURL_LOG"
+}
+curl_call_header_config() {
+    local n="$1"
+    awk -v RS='\035' -v FS='\036' -v n="$n" 'NR==n{print $3; exit}' "$CURL_LOG"
+}
+
+# How many curl invocations were logged.
+curl_call_count() {
+    awk -v RS='\035' 'END{print NR}' "$CURL_LOG"
+}
+
 # Extracts the body of a `VAR=$(cat <<'DELIM' ... DELIM)` quoted heredoc
 # from a script file, i.e. the remote-side script komodo-api-deploy.sh
 # builds up and ships over ssh as a single command string. Runs it as

--- a/bin-call-manager/CLAUDE.md
+++ b/bin-call-manager/CLAUDE.md
@@ -26,7 +26,7 @@
 | `go test -v ./pkg/callhandler/...` | Test a specific package |
 | `golangci-lint run -v --timeout 5m` | Lint |
 | `go generate ./...` | Regenerate mocks |
-| `./bin/call-control call get --id <uuid>` | Inspect a call (bypasses RabbitMQ) |
+| `./bin/call-control call get --id <uuid>` | Inspect a call (reads DB/Redis directly; still dials RabbitMQ on startup via `initHandler`, with an unbounded retry loop if unreachable — does not bypass it) |
 | `./bin/call-control call update-status --id <uuid> --status hangup` | Force-update call status |
 
 ## Architecture

--- a/bin-call-manager/docs/operations.md
+++ b/bin-call-manager/docs/operations.md
@@ -70,6 +70,29 @@ Direct DB/cache tool for emergency inspection or repair (bypasses RabbitMQ):
 
 All output is JSON (stdout); logs go to stderr.
 
+## Deployment
+
+bin-call-manager is the Komodo-managed deploy pilot (VOIP-1342) — the first
+`bin-*-manager` service to move off `voipbin/voipbin`'s `install/`
+(`versions.lock`/`ssh-deploy.sh`) mechanism. The other 31 `bin-*-manager`
+services still deploy via `ssh-deploy.sh` until this pilot is verified in
+production and a follow-up ticket rolls the pattern out.
+
+- **Stack definition:** `bin-call-manager/komodo/docker-compose.yml` (git
+  is the source of truth for structure; Komodo only executes it on
+  request — no polling/webhook auto-deploy).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes the
+  built image tag, then `.circleci/scripts/komodo-api-deploy.sh` pushes
+  the file's content to Komodo (`UpdateStack`) and triggers a deploy
+  (`DeployStack`) over `https://komodo.voipbin.net`, gated by the
+  `bin-call-manager-deploy` job's poll/running checks.
+- **Break-glass fallback:** `.circleci/scripts/komodo-api-deploy-ssh-fallback.sh`
+  (SSH tunnel to bm-nyc-01, unchanged from VOIP-1341) for use if the public
+  HTTPS endpoint itself is unreachable.
+- **Full design, cutover sequencing, and rollback procedure:**
+  [docs/plans/2026-08-16-komodo-call-manager-cutover-design.md](../docs/plans/2026-08-16-komodo-call-manager-cutover-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Env Var | Default | Description |

--- a/bin-call-manager/komodo/docker-compose.yml
+++ b/bin-call-manager/komodo/docker-compose.yml
@@ -1,0 +1,64 @@
+# Komodo Stack definition for bin-call-manager (VOIP-1342).
+#
+# Deployed via CircleCI's .circleci/scripts/komodo-api-deploy.sh, which
+# pushes this file's content to Komodo's `bin-call-manager` Stack
+# (file_contents mode) and triggers a deploy - git is the source of truth
+# for structure, Komodo just executes it on request. See
+# docs/plans/2026-08-16-komodo-call-manager-cutover-design.md for the full
+# design and the manual, one-time steps this file depends on:
+#
+#   - __IMAGE_TAG__ is substituted by render-image-tag.sh before every
+#     deploy - never a real value in this committed file.
+#   - __NETWORK_NAME__ must be filled in by hand, once, with the value
+#     confirmed live on bm-nyc-01 (design doc §6) - do not assume
+#     "install_default" without checking.
+#   - [[BIN_MANAGER__*]] references are resolved by Komodo itself from its
+#     global Variables store (already synced from infra-secret via PR #90
+#     in monorepo-etc) - nothing here or in CI supplies these values.
+#   - This env list is a draft authored from voipbin/voipbin install/'s
+#     docker-compose.yml.dist. Reconcile it against the live container's
+#     actual env (design doc §6) before the real cutover - in particular,
+#     confirm whether REDIS_PASSWORD (commented out below) is actually
+#     required.
+#
+# No healthcheck: bin-call-manager's image is distroless
+# (gcr.io/distroless/static-debian12, no shell, no wget) - the wget-based
+# healthcheck in the live voipbin/voipbin install/ compose file has never
+# been able to pass on this image. Deploy success is gated by CI/the
+# cutover procedure instead (design doc §5), not a Docker healthcheck.
+#
+# No depends_on: this is a standalone, single-service compose project:
+# referencing db/redis/rabbitmq here (services this file doesn't define)
+# would be a hard Compose parse error. Connectivity comes from attaching
+# to the shared network below; restart:always plus the app's own
+# reconnect handling is the operative safety net, same as today.
+services:
+  call-manager:
+    image: voipbin/bin-call-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-call-mgr
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      # - REDIS_PASSWORD=[[BIN_MANAGER__REDIS_PASSWORD]]  # add only if the live container's env (design doc §6) shows this set today
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - PROJECT_BASE_DOMAIN=[[BIN_MANAGER__PROJECT_BASE_DOMAIN]]
+      - PROJECT_BUCKET_NAME=[[BIN_MANAGER__GCP_BUCKET_NAME_MEDIA]]
+      - HOMER_API_ADDRESS=[[BIN_MANAGER__HOMER_API_ADDRESS]]
+      - HOMER_AUTH_TOKEN=[[BIN_MANAGER__HOMER_AUTH_TOKEN]]
+      - HOMER_WHITELIST=[[BIN_MANAGER__HOMER_WHITELIST]]
+    command: ./call-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: __NETWORK_NAME__
+    external: true

--- a/bin-call-manager/komodo/docker-compose.yml
+++ b/bin-call-manager/komodo/docker-compose.yml
@@ -9,11 +9,28 @@
 #
 #   - __IMAGE_TAG__ is substituted by render-image-tag.sh before every
 #     deploy - never a real value in this committed file.
-#   - Network name confirmed against the live host (2026-08-16): the
-#     `install` compose project's default network is `install_default` -
-#     verified via `docker inspect voipbin-call-mgr --format
-#     '{{index .Config.Labels "com.docker.compose.project"}}
-#     {{json .NetworkSettings.Networks}}'` on bm-nyc-01, not assumed.
+#   - Network: uses `production`, the Komodo-managed shared backbone
+#     network (monorepo-etc's infra-komodo/komodo/, Stack id
+#     `production-network`), NOT `install_default`. VOIP-1343 (filed
+#     alongside VOIP-1342) calls out this exact migration for
+#     bin-call-manager specifically; the original 2026-08-16 cutover
+#     verification against the live host predates `production`'s
+#     existence and used `install_default` (still correct for the
+#     *old*, install-owned `voipbin-call-mgr` container, which stays on
+#     `install_default` until its own retirement).
+#     Precondition: db/redis/rabbitmq (and anything else this service
+#     dials) must actually be reachable from `production` - today that
+#     means monorepo-etc/infra-komodo/komodo/backfill-install-default.sh
+#     has been run with --apply on bm-nyc-01 (it bridges existing
+#     `install_default` containers, db/redis/rabbitmq included, onto
+#     `production` without recreating them - see that script's own
+#     header for why this bridge does not survive a container
+#     recreation). If that backfill has NOT been run/re-applied since
+#     db/redis/rabbitmq were last recreated, this Stack's deploy will
+#     still report Complete+success (the container starts) but fail the
+#     3-consecutive-running gate once the app crash-loops on an
+#     unreachable DB - treat that failure mode as "re-run the backfill",
+#     not as a bug in this file or in komodo-api-deploy.sh.
 #   - [[BIN_MANAGER__*]] references are resolved by Komodo itself from its
 #     global Variables store (already synced from infra-secret via PR #90
 #     in monorepo-etc) - nothing here or in CI supplies these values.
@@ -74,5 +91,5 @@ services:
       default: {}
 networks:
   default:
-    name: install_default
+    name: production
     external: true

--- a/bin-call-manager/komodo/docker-compose.yml
+++ b/bin-call-manager/komodo/docker-compose.yml
@@ -9,17 +9,19 @@
 #
 #   - __IMAGE_TAG__ is substituted by render-image-tag.sh before every
 #     deploy - never a real value in this committed file.
-#   - __NETWORK_NAME__ must be filled in by hand, once, with the value
-#     confirmed live on bm-nyc-01 (design doc §6) - do not assume
-#     "install_default" without checking.
+#   - Network name confirmed against the live host (2026-08-16): the
+#     `install` compose project's default network is `install_default` -
+#     verified via `docker inspect voipbin-call-mgr --format
+#     '{{index .Config.Labels "com.docker.compose.project"}}
+#     {{json .NetworkSettings.Networks}}'` on bm-nyc-01, not assumed.
 #   - [[BIN_MANAGER__*]] references are resolved by Komodo itself from its
 #     global Variables store (already synced from infra-secret via PR #90
 #     in monorepo-etc) - nothing here or in CI supplies these values.
-#   - This env list is a draft authored from voipbin/voipbin install/'s
-#     docker-compose.yml.dist. Reconcile it against the live container's
-#     actual env (design doc §6) before the real cutover - in particular,
-#     confirm whether REDIS_PASSWORD (commented out below) is actually
-#     required.
+#   - Env list confirmed against the live container's actual env
+#     (2026-08-16, same `docker inspect` session): the key set below
+#     matches exactly, and REDIS_PASSWORD is confirmed NOT set on the live
+#     container - the commented-out line below stays commented, this is
+#     not an open question anymore.
 #
 # No healthcheck: bin-call-manager's image is distroless
 # (gcr.io/distroless/static-debian12, no shell, no wget) - the wget-based
@@ -47,7 +49,7 @@ services:
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
       - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
       - REDIS_DATABASE=1
-      # - REDIS_PASSWORD=[[BIN_MANAGER__REDIS_PASSWORD]]  # add only if the live container's env (design doc §6) shows this set today
+      # - REDIS_PASSWORD=[[BIN_MANAGER__REDIS_PASSWORD]]  # confirmed NOT set on the live container (2026-08-16) - stays commented
       - PROMETHEUS_ENDPOINT=/metrics
       - PROMETHEUS_LISTEN_ADDRESS=:2112
       - PROJECT_BASE_DOMAIN=[[BIN_MANAGER__PROJECT_BASE_DOMAIN]]
@@ -60,5 +62,5 @@ services:
       default: {}
 networks:
   default:
-    name: __NETWORK_NAME__
+    name: install_default
     external: true

--- a/bin-call-manager/komodo/docker-compose.yml
+++ b/bin-call-manager/komodo/docker-compose.yml
@@ -23,6 +23,18 @@
 #     container - the commented-out line below stays commented, this is
 #     not an open question anymore.
 #
+# container_name is `voipbin-call-manager`, deliberately DIFFERENT from
+# the old container's name `voipbin-call-mgr` (대표님's explicit naming
+# decision, 2026-08-16 - matches GKE's `call-manager` app label rather
+# than install/'s host-wide `-mgr`-abbreviated convention; the other 31
+# bin-*-manager services stay on the old convention until they migrate).
+# Because the names differ, Docker will NOT refuse to run both containers
+# at once the way it would if they shared a name - the mutual-exclusion
+# safety net the original cutover design relied on is gone. §7's ordering
+# (old container removed BEFORE the new one is deployed) still holds, but
+# is no longer enforced by Docker itself - see the design doc's updated
+# §7 for the explicit verification step this requires.
+#
 # No healthcheck: bin-call-manager's image is distroless
 # (gcr.io/distroless/static-debian12, no shell, no wget) - the wget-based
 # healthcheck in the live voipbin/voipbin install/ compose file has never
@@ -42,7 +54,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-call-mgr
+    container_name: voipbin-call-manager
     restart: always
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -392,6 +392,18 @@ production (unchanged by this design).
 
 ### 6. Pre-cutover verification (round 1 HIGH; expanded round 2 — H2, H3)
 
+**Status: DONE (2026-08-16).** Ran against the live host after the first
+CI run correctly failed closed on the unfilled `__NETWORK_NAME__`
+placeholder (the guard doing exactly its job). Results: `com.docker.compose.project`
+= `install`, network = `install_default` (matches the pre-verification
+assumption, but was not trusted without checking — see below). Live env
+key set matches §1's draft list exactly; `REDIS_PASSWORD` confirmed **not**
+set on the live container, so it stays commented out in
+`bin-call-manager/komodo/docker-compose.yml`. `__NETWORK_NAME__` has been
+filled in with `install_default` in that file. `$LIVE_PROJECT` in §7/
+rollback below is `install` — matches what was already written there, now
+confirmed rather than assumed.
+
 Before touching anything, on bm-nyc-01, capture both the network/project
 identity and the full live env in one pass:
 ```bash

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -1,10 +1,11 @@
 # Design: cut bin-call-manager over to Komodo-managed deploy (VOIP-1342)
 
-Revision 6 — incorporates round-1 (3 CRITICAL, 4 HIGH, 5 MEDIUM), round-2
+Revision 7 — incorporates round-1 (3 CRITICAL, 4 HIGH, 5 MEDIUM), round-2
 (3 HIGH, 6 MEDIUM), round-3 (1 CRITICAL, 1 HIGH, 3 MEDIUM), and round-4
-(1 CRITICAL + reference cleanups) architect review findings, plus a
-post-approval naming change (below). See "Review corrections log" at the
-end for the full architect-review mapping.
+(1 CRITICAL + reference cleanups) architect review findings, plus two
+post-approval revisions from 대표님 (naming, and idempotent Stack
+auto-create — both below). See "Review corrections log" at the end for
+the full architect-review mapping.
 
 **Naming decision (2026-08-16, post-merge-review, 대표님):** the new
 container's name is `voipbin-call-manager` — matching GKE's `call-manager`
@@ -100,9 +101,9 @@ follow-up ticket rolls the pattern out.
 - **CI credentials already exist and are broad.** `CC_KOMODO_API_KEY`/`CC_KOMODO_API_SECRET`
   are already registered in the `production` CircleCI context, and the
   `circleci` Komodo Service User is already promoted to **Admin** (per PR
-  #90's spike). Because this is a full-admin credential, this design
-  deliberately does **not** have CI auto-create Stacks (round 1 finding —
-  see §2).
+  #90's spike). Round 1 initially had CI *not* auto-create Stacks because
+  of this — **superseded post-approval** (대표님, 2026-08-16): CI now does
+  create the Stack, idempotently, when missing — see §2 item 1.
 - `RABBITMQ_ADDRESS`/`DATABASE_DSN_BIN` in the `bin-manager` namespace are
   already full connection strings (`amqp://user:pass@host:port`,
   `user:pass@tcp(host:port)/db`), not decomposed into separate
@@ -262,14 +263,55 @@ future credential/domain change becomes a one-line edit).
 
 Interface: `komodo-api-deploy.sh <stack-name> <compose-file>`
 
-1. **Does NOT create the Stack.** Reversing VOIP-1341's original script
-   header ("Creating a Stack/granting permission is a manual, one-time
-   bootstrap step... not something this script does") was a round-1
-   finding, not adopted here: the CI credential is full Komodo **Admin**,
-   so an unattended auto-create path on a typo'd name is unnecessary blast
-   radius for a single-service pilot with an already-cheap manual bootstrap
-   step (§6). `GetStack` first; if missing, fail with a clear message
-   pointing at the manual bootstrap step, not silently create one.
+1. **Idempotent ensure-exists: `GetStack` first; if missing, `CreateStack`.**
+   Revised post-approval (대표님's explicit instruction, 2026-08-16 —
+   supersedes both this section's original text and round-1's finding
+   below, which had gone the other way for good reasons that no longer
+   win out against operational reality): a per-service *manual* bootstrap
+   step doesn't scale once this pattern rolls out to the other 31
+   `bin-*-manager` services — that would be 31 more watched, by-hand
+   Stack creations. CI now creates the Stack itself, idempotently, the
+   first time it's missing.
+   - **Detecting "missing" is by error-message match, not HTTP status.**
+     Confirmed empirically (2026-08-16, from a real CI failure, not
+     assumed): Komodo's `GetStack` returns **HTTP 500** — not 404 — with
+     body `{"error":"Did not find any Stack matching <name>","trace":[]}`
+     for a nonexistent Stack. `komodo-api-deploy.sh` matches on that exact
+     substring before deciding to create; any other failure (auth, a real
+     500, the 404/502 network-fragility modes above) still aborts without
+     attempting a create. **Unverified edge case (code-review round 5):**
+     if Komodo ever returns this same "not found" message for "exists but
+     caller lacks read permission" (a common API pattern, to avoid leaking
+     resource existence), this script would attempt `CreateStack` against
+     an already-existing name. The CI credential is Admin, not
+     read-restricted, so this is unlikely in practice — but it's untested.
+     Confirm before rolling this pattern out past this one pilot service.
+   - `CreateStack` uses `server_id` = `$KOMODO_SERVER_NAME` (default
+     `bm-nyc-01`, overridable via `CC_KOMODO_SERVER_NAME` per job) — safe
+     to pass the plain server **name**, not an internal id: Komodo's own
+     `validate_config` resolves `server_id` by name if it doesn't look
+     like an id ("in case it comes in as name", per its source), so no
+     separate `ListServers` lookup is needed to resolve bm-nyc-01's actual
+     Server resource id first. **Not yet confirmed against the live
+     instance** (code-review round 5 finding) — this specific behavior is
+     read from Komodo's source, not observed; §7 step 7 (the first real
+     bootstrap run) is effectively this assumption's first live test, so
+     watch it interactively rather than trusting it unattended the first
+     time.
+   - Same config values the (now-superseded) manual-bootstrap text always
+     specified: empty `file_contents` (the very next `UpdateStack` call
+     fills it), `poll_for_updates`/`auto_update`/`webhook_enabled` all
+     `false` — Komodo still does nothing on its own; CI is still the only
+     trigger. This did not change, only *who* performs the create did.
+   - **Round-1's original objection (recorded for the record, not
+     retracted as *wrong*, just overridden):** the CI credential is full
+     Komodo Admin, so an unattended auto-create path is real, if narrow,
+     blast radius — a typo'd `<stack-name>` argument creates a stray
+     Stack rather than failing loud. Accepted as a known, bounded
+     trade-off: `<stack-name>` is a literal string in version-controlled
+     CI config (`config_work.yml`), not attacker- or user-supplied input,
+     so the realistic failure mode is a caught-in-review typo, not a
+     runtime injection.
 2. **Before `UpdateStack`, guard against any unfilled placeholder token**
    (round 3 M3): `grep -Eq '__[A-Z_]+__' <rendered compose> && fail` — this
    catches not just a missed `__IMAGE_TAG__` substitution (already handled
@@ -481,11 +523,10 @@ exists to protect against.
    `pre-cutover-env.json`), plus the current image ref
    (`docker inspect voipbin-call-mgr --format '{{.Image}}'`) — all done
    first, well before anything below.
-2. **Manual Stack bootstrap** (watched, on bm-nyc-01 or via API by hand —
-   not CI-automated, §2 item 1): create the Komodo Stack `bin-call-manager`
-   (`server_id`=bm-nyc-01, `file_contents` mode, `poll_for_updates: false`,
-   `auto_update: false`, `webhook_enabled: false` — Komodo does nothing on
-   its own; CI is the only trigger).
+2. **Stack bootstrap — no longer a separate manual step.** §2 item 1's
+   revision means step 7 (running `komodo-api-deploy.sh` by hand) creates
+   the Stack itself, idempotently, the first time it doesn't find one.
+   Nothing to do here ahead of time.
 3. **Build and push the image by hand**, from a workstation (not via CI,
    and not tied to a `main` merge SHA — any clear, traceable tag works,
    e.g. the feature branch's current commit). Matches what CI's
@@ -767,3 +808,11 @@ reason):
   accordingly. References to the *old* container (pre-cutover checkpoint,
   §6's live-host captures) correctly stay `voipbin-call-mgr` — that
   container's real name is unchanged by this decision.
+
+**Post-approval Stack-bootstrap revision** (대표님, 2026-08-16, after the
+naming revision above): CI now creates the Komodo Stack itself,
+idempotently, reversing round-1's "does not create Stacks" finding — see
+§2 item 1 for the full reasoning and the empirically-confirmed detection
+mechanism (Komodo returns HTTP 500, not 404, for "Stack not found").
+§7 step 2's separate manual bootstrap is removed accordingly — folded into
+step 7's own first run.

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -817,13 +817,17 @@ mechanism (Komodo returns HTTP 500, not 404, for "Stack not found").
 §7 step 2's separate manual bootstrap is removed accordingly — folded into
 step 7's own first run.
 
-**Follow-up dependency, not in this PR's scope (대표님, 2026-08-16):** a
-neutral shared network (tentatively named `production`), owned by neither
-the `install` compose project nor any Komodo Stack, is being built out in
-a separate session — this is the same "network genuinely owned by neither
-compose project" follow-up this document already flagged (see the
-`install_default` shared-network note above). Once that network exists
-and `db`/`redis`/`rabbitmq` are attached to it, `bin-call-manager/komodo/docker-compose.yml`'s
+**Follow-up dependency, not in this PR's scope (대표님, 2026-08-16), tracked
+as [VOIP-1343](https://voipbin.atlassian.net/browse/VOIP-1343):** a
+neutral shared network `production`, owned by neither the `install`
+compose project nor any Komodo Stack, was built out in a separate session
+(`NOJIRA-Add-production-network-komodo-stack`, monorepo-etc PR #92) — this
+is the same "network genuinely owned by neither compose project"
+follow-up this document already flagged (see the `install_default`
+shared-network note above). **Verified live on bm-nyc-01 (2026-08-16): the
+`production` network exists, but `db`/`redis`/`rabbitmq` are not attached
+to it yet** — `backfill-install-default.sh` (in that PR) needs to run
+first. Once that's done, `bin-call-manager/komodo/docker-compose.yml`'s
 `networks.default.name` should move from `install_default` to
 `production` — but not before, and not as part of this pilot's cutover.
 Sequencing matters: that network must exist and carry the shared infra

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -142,6 +142,18 @@ empty-string interpolation with no detectable signal), stop and redesign
 the secrets-injection mechanism — do not proceed with a design whose
 secrets path can fail silently into a running-but-broken container.
 
+**Status (code review round 1, post-implementation): NOT YET PERFORMED.**
+The scripts/compose fragment/CI wiring in this PR were implemented and
+reviewed against Komodo's published API docs/source rather than against a
+disposable Stack on the live bm-nyc-01 instance (no access to that
+instance from this session). This is safe to merge as code because: (a)
+`bin-call-manager-deploy`'s CI wiring only affects *routine* deploys that
+happen after the real cutover, which is itself a manual, watched operation
+per §7; and (b) §7 step 3 explicitly requires this Step 0 spike to be
+completed, with results recorded here, before that manual cutover
+proceeds. Do not run the actual cutover (§7) until this section is updated
+with real results.
+
 ### 1. `bin-call-manager/komodo/docker-compose.yml` (new, git-tracked)
 
 Directory named `komodo/`, sibling to `k8s/` (대표님's explicit convention
@@ -215,8 +227,10 @@ Notes:
 ### 2. `komodo-api-deploy.sh` rewrite: direct HTTPS, SSH kept as fallback
 
 **The existing SSH-tunnel `komodo-api-deploy.sh` (VOIP-1341) is not
-deleted.** It's renamed to `komodo-api-deploy-ssh-fallback.sh`, unmodified,
-and documented as the break-glass path for a production incident where
+deleted.** It's renamed to `komodo-api-deploy-ssh-fallback.sh` (code
+review round 2 also fixed one latent log-leakage gap in it — see §"Log
+leakage guard" below, otherwise functionally unchanged), and documented as
+the break-glass path for a production incident where
 `https://komodo.voipbin.net` itself is down (round 1 "no break-glass path"
 finding — this service no longer has `ssh-deploy.sh` available at all
 after cutover, so *something* manual must still work).
@@ -318,12 +332,18 @@ call-manager from one that booted with an empty/broken DSN):
 
 **a. Automated, every deploy (routine CI runs):** Komodo's own
 `GetUpdate` `Complete`+`success` (started, not necessarily healthy) plus a
-poll of Komodo's Stack/service-status read for 3 consecutive `running`
-samples ~6s apart — same numeric gate `ssh-deploy.sh` already uses, read
-via Komodo's API instead of SSH `docker inspect`. **Open item to verify
-empirically during implementation:** confirm Komodo's read API actually
-exposes per-service container state in enough detail for this poll; if it
-doesn't, SSH may need to stay in the loop for this specific check (decide
+poll of `ListStackServices` (Komodo's read endpoint for per-service
+container state, per its published API docs/source) for 3 consecutive
+`.container.state == "running"` samples, same numeric gate `ssh-deploy.sh`
+already uses, read via Komodo's API instead of SSH `docker inspect`.
+**Implemented in `komodo-api-deploy.sh` (code review round 1), but NOT YET
+empirically verified against the live Komodo instance** — confirm
+`ListStackServices`'s actual response shape on bm-nyc-01 matches what the
+script assumes; if it doesn't, this gate will consistently report
+not-running and every deploy will fail it (fail-closed, not fail-open, but
+still worth confirming before relying on it unattended). If it turns out
+Komodo's read API doesn't expose this in enough detail after all, SSH may
+need to stay in the loop for this specific check (decide
 from the real response shape, not assumed here).
 
 **b. Manual, hard-blocking, cutover only (§7). Revised again per round 3

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -1,0 +1,676 @@
+# Design: cut bin-call-manager over to Komodo-managed deploy (VOIP-1342)
+
+Revision 5 — incorporates round-1 (3 CRITICAL, 4 HIGH, 5 MEDIUM), round-2
+(3 HIGH, 6 MEDIUM), round-3 (1 CRITICAL, 1 HIGH, 3 MEDIUM), and round-4
+(1 CRITICAL + reference cleanups) architect review findings. See "Review
+corrections log" at the end for the full mapping.
+
+## Goal
+
+Replace `ssh-deploy.sh` with a Komodo-API-based deploy path for
+bin-call-manager on bm-nyc-01 — the first production service to move off
+`voipbin/voipbin`'s `install/` (`versions.lock`/dist-live compose)
+mechanism entirely. `install/` stays as-is for external self-hosting users;
+this change does not touch it except to comment out one service block (see
+"Cutover sequencing"). Per 대표님's explicit decision, `versions.lock` and
+digest resolution are not carried forward — image references use a plain
+tag (`$CIRCLE_SHA1`), and CircleCI talks to Komodo directly over its public
+HTTPS endpoint for routine deploys, not an SSH tunnel.
+
+Scope: **bin-call-manager only**. The other 31 `bin-*-manager` services
+stay on `ssh-deploy.sh` until this pilot is verified in production and a
+follow-up ticket rolls the pattern out.
+
+## Current state (verified)
+
+- bin-call-manager's CircleCI job (`monorepo/.circleci/config_work.yml`)
+  builds+pushes `voipbin/bin-call-manager:$CIRCLE_SHA1`, then runs
+  `.circleci/scripts/ssh-deploy.sh voipbin/bin-call-manager call-manager`,
+  which SSHes to bm-nyc-01, bumps a digest pin in the live
+  `versions.lock`/`docker-compose.yml` under `/opt/voipbin/install`, and
+  runs `docker compose pull/up`.
+- The container runs as `voipbin-call-mgr`, currently attached to a
+  network commonly referred to as `install_default`. **Not asserted as
+  fact here** — Compose derives the network name from the active project
+  name, which can come from the directory name, an explicit
+  `COMPOSE_PROJECT_NAME`, or `install/.env` (`infra-komodo/README.md`
+  notes the main stack's own README recommends exporting
+  `COMPOSE_PROJECT_NAME=sandbox` in some contexts). §"Pre-cutover
+  verification" below makes confirming the real name on the live host a
+  mandatory first step, not an assumption.
+- No volumes are mounted on `voipbin-call-mgr` — safe to remove/recreate
+  with no data-loss concern.
+- **`bin-call-manager`'s image is distroless** (`gcr.io/distroless/static-debian12`,
+  confirmed via `bin-call-manager/Dockerfile`) — no shell, no `wget`. The
+  live `docker-compose.yml.dist` healthcheck (`wget`-based) has never been
+  able to pass on this image; it reports `unhealthy` permanently today.
+  **This design does not copy that healthcheck into the new file** — see
+  §1.
+- `komodo-api-deploy.sh` (VOIP-1341, merged, PR #1187) exists today and
+  talks to Komodo over an SSH tunnel (`ssh` to bm-nyc-01, then
+  `curl 127.0.0.1:9120` inside that session). **This design keeps it,
+  unmodified, as the break-glass fallback** (§2) rather than deleting it —
+  see "No break-glass path" finding below for why.
+- **Secrets are already in Komodo.** `NOJIRA-Retire-infra-vault-for-komodo-secrets`
+  (PR #90, merged) synced `infra-secret/secrets-source/bin-manager/**` into
+  Komodo Variables named `BIN_MANAGER__<KEY>`. Confirmed present:
+  `BIN_MANAGER__DATABASE_DSN_BIN`, `BIN_MANAGER__RABBITMQ_ADDRESS`,
+  `BIN_MANAGER__REDIS_ADDRESS`, `BIN_MANAGER__REDIS_PASSWORD`,
+  `BIN_MANAGER__HOMER_API_ADDRESS`, `BIN_MANAGER__HOMER_AUTH_TOKEN`,
+  `BIN_MANAGER__HOMER_WHITELIST`, `BIN_MANAGER__PROJECT_BASE_DOMAIN`,
+  `BIN_MANAGER__GCP_BUCKET_NAME_MEDIA`.
+- **Correction (round 1):** whether Komodo actually interpolates
+  `[[NAMESPACE__KEY]]` references into a Stack's `file_contents` at deploy
+  time is **NOT yet empirically verified**. PR #90's own spike
+  (`monorepo-etc/docs/.../2026-08-15-retire-infra-vault-komodo-secrets-design.md`
+  §4.3) verified only the Variables CRUD API and explicitly deferred
+  deploy-time interpolation behavior ("Implementers should not assume
+  either answer" for what happens with an unresolved `[[VAR]]`). This
+  design's secrets story depends on interpolation actually working — §"Step
+  0" below makes verifying it, empirically, against a disposable Stack, a
+  hard precondition before the real cutover, not an assumption carried
+  into production.
+- **Correction (round 1) — citation fix, not a retraction:** "`UpdateStack`
+  is PATCH-style, only replaces `file_contents`" *was* empirically verified
+  — via a disposable test Stack (`claude-env-verify-test`) — during the
+  now-discarded `VOIP-1341-Wire-komodo-deploy-bin-call-manager` draft's
+  design work on 2026-08-14, not in PR #90's spike (round 1 review
+  correctly flagged the original wrong citation). That empirical result
+  itself is still valid; only the surrounding document was discarded per
+  대표님's "design from scratch" instruction. Re-confirm it holds as part of
+  Step 0, since it's cheap to re-check while already standing up a
+  disposable Stack for the interpolation test.
+- **CI credentials already exist and are broad.** `CC_KOMODO_API_KEY`/`CC_KOMODO_API_SECRET`
+  are already registered in the `production` CircleCI context, and the
+  `circleci` Komodo Service User is already promoted to **Admin** (per PR
+  #90's spike). Because this is a full-admin credential, this design
+  deliberately does **not** have CI auto-create Stacks (round 1 finding —
+  see §2).
+- `RABBITMQ_ADDRESS`/`DATABASE_DSN_BIN` in the `bin-manager` namespace are
+  already full connection strings (`amqp://user:pass@host:port`,
+  `user:pass@tcp(host:port)/db`), not decomposed into separate
+  user/password/host fields — the compose fragment references the whole
+  string as one variable, not a reassembly (unlike the discarded draft's
+  `DATABASE_DSN=root:${MYSQL_ROOT_PASSWORD}@tcp(...)` construction, which
+  assumed a different, incorrect key shape for this namespace).
+- **`https://komodo.voipbin.net` has two independent, routine failure
+  modes**, both already documented from operating the same endpoint for
+  secrets sync (`infra-secret-sync-komodo.sh`):
+  1. The Caddy route is deleted by any `setup-host.sh` rerun on bm-nyc-01
+     (normal host-fix operation, not exceptional) — **symptom: HTTP 404**.
+  2. `docker network connect komodo_default voipbin-web-proxy` is a
+     non-persistent, manual attachment, undone whenever `voipbin-web-proxy`
+     is recreated — including **routinely by the main stack's own CircleCI
+     pipeline** — **symptom: HTTP 502**.
+  Both are plain HTTP responses (not connection-refused/TLS errors), and
+  both need to be special-cased in the rewritten script (§2), matching
+  `infra-secret-sync-komodo.sh`'s own handling of the identical endpoint.
+
+## Design
+
+### Step 0 (mandatory, before any CI wiring or cutover): empirical spike
+
+Using a disposable Stack (e.g. `claude-verify-call-manager-interp`,
+destroyed after), confirm — do not assume:
+
+1. A compose `environment` entry referencing `[[BIN_MANAGER__SOME_KEY]]`
+   actually resolves to that Variable's real value in the deployed
+   container (`docker inspect --format '{{json .Config.Env}}'` on
+   bm-nyc-01, read not printed if secret-shaped).
+2. What happens if a `[[VAR]]` reference does **not** resolve (typo a
+   nonexistent variable name) — empty string, the literal `[[VAR]]` text,
+   or a hard deploy failure. Whichever it is, the rewritten script (§2)
+   must be able to detect and fail loud on it, not just log it.
+3. Re-confirm `UpdateStack` with only `file_contents` in the request body
+   does not disturb other Stack config fields (`server_id`,
+   `poll_for_updates`, `auto_update`, `webhook_enabled`).
+4. **(Round 2 M3: generalized from `DATABASE_DSN_BIN` alone.)** For
+   *every* `BIN_MANAGER__*` variable referenced in §1's compose fragment
+   (`DATABASE_DSN_BIN`, `RABBITMQ_ADDRESS`, `REDIS_ADDRESS`,
+   `HOMER_API_ADDRESS`, `HOMER_AUTH_TOKEN`, `HOMER_WHITELIST`,
+   `PROJECT_BASE_DOMAIN`, `GCP_BUCKET_NAME_MEDIA`, and `REDIS_PASSWORD` if
+   §6 determines it's needed — see §1 note): confirm the stored value's
+   shape matches what bin-call-manager's code expects verbatim, not a
+   `.dist`-style unresolved placeholder (e.g. `${RABBITMQ_HOST:-rabbitmq}`)
+   that would interpolate "successfully" into a literal, broken string. If
+   any doesn't match, fix at the secret source (`infra-secret`), not in the
+   compose fragment.
+
+Document the results inline in this file (updating this section) before
+proceeding to implementation. If 1 or 2 comes back unfavorable (silent
+empty-string interpolation with no detectable signal), stop and redesign
+the secrets-injection mechanism — do not proceed with a design whose
+secrets path can fail silently into a running-but-broken container.
+
+### 1. `bin-call-manager/komodo/docker-compose.yml` (new, git-tracked)
+
+Directory named `komodo/`, sibling to `k8s/` (대표님's explicit convention
+— per-service deploy definitions live alongside the service, one directory
+per deploy target).
+
+**The env list below is a starting draft, authored from `.dist`'s
+call-manager block — it is NOT authoritative.** Round 2 (H3) found that
+`.dist` and the live, operator-owned host file are known to diverge (the
+whole reason §6 exists for the network name), and §1's env list inherited
+the same problem: e.g. `.dist` has no `REDIS_PASSWORD` for call-manager,
+but `BIN_MANAGER__REDIS_PASSWORD` exists as a Komodo Variable and
+`bin-call-manager` reads `REDIS_PASSWORD` from its config
+(`internal/config/main.go`) — whether it's actually required in production
+is unknown from `.dist` alone. **§6 (pre-cutover verification) now captures
+the live container's real env set and this file's final env list must be
+reconciled against that capture before cutover, not assumed from `.dist`.**
+
+```yaml
+services:
+  call-manager:
+    image: voipbin/bin-call-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-call-mgr
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      # - REDIS_PASSWORD=[[BIN_MANAGER__REDIS_PASSWORD]]  # add only if §6's live capture shows it set today
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - PROJECT_BASE_DOMAIN=[[BIN_MANAGER__PROJECT_BASE_DOMAIN]]
+      - PROJECT_BUCKET_NAME=[[BIN_MANAGER__GCP_BUCKET_NAME_MEDIA]]
+      - HOMER_API_ADDRESS=[[BIN_MANAGER__HOMER_API_ADDRESS]]
+      - HOMER_AUTH_TOKEN=[[BIN_MANAGER__HOMER_AUTH_TOKEN]]
+      - HOMER_WHITELIST=[[BIN_MANAGER__HOMER_WHITELIST]]
+    command: ./call-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: __NETWORK_NAME__
+    external: true
+```
+
+Notes:
+- **`healthcheck` intentionally omitted** (round 1 finding) — the live
+  `wget`-based check can never pass on this distroless image; copying it
+  into a *new* file would be an active regression, not preserved status
+  quo. No functional replacement is defined here either, since distroless
+  has no shell/exec target to probe from inside the container — see §5 for
+  how deploy success is actually gated instead.
+- `__IMAGE_TAG__` is a placeholder substituted by CI before each deploy
+  (see §3) — never committed as a real tag.
+- `__NETWORK_NAME__` is a placeholder filled in once, by hand, after §6
+  confirms the real live network name (round 1 finding — not hardcoded as
+  `install_default` without checking).
+- `[[BIN_MANAGER__*]]` references are resolved by Komodo at deploy time —
+  contingent on Step 0 confirming this actually works as intended.
+- `depends_on` intentionally omitted (would be a hard Compose parse error
+  referencing services this file doesn't define; `restart: always` +
+  the app's own reconnect handling is the actual safety net today and
+  doesn't change here).
+
+### 2. `komodo-api-deploy.sh` rewrite: direct HTTPS, SSH kept as fallback
+
+**The existing SSH-tunnel `komodo-api-deploy.sh` (VOIP-1341) is not
+deleted.** It's renamed to `komodo-api-deploy-ssh-fallback.sh`, unmodified,
+and documented as the break-glass path for a production incident where
+`https://komodo.voipbin.net` itself is down (round 1 "no break-glass path"
+finding — this service no longer has `ssh-deploy.sh` available at all
+after cutover, so *something* manual must still work).
+
+New `komodo-api-deploy.sh` — direct HTTPS to `https://komodo.voipbin.net`,
+authenticated via `X-Api-Key`/`X-Api-Secret` headers from
+`CC_KOMODO_API_KEY`/`CC_KOMODO_API_SECRET`. Same argv-avoidance discipline
+as today's script and `infra-secret-sync-komodo.sh` (`curl -K -`, secrets
+never in argv/env dump). All calls go through one `API_BASE` + `call_api`
+seam (matches `infra-secret-sync-komodo.sh`'s own stated rationale — a
+future credential/domain change becomes a one-line edit).
+
+Interface: `komodo-api-deploy.sh <stack-name> <compose-file>`
+
+1. **Does NOT create the Stack.** Reversing VOIP-1341's original script
+   header ("Creating a Stack/granting permission is a manual, one-time
+   bootstrap step... not something this script does") was a round-1
+   finding, not adopted here: the CI credential is full Komodo **Admin**,
+   so an unattended auto-create path on a typo'd name is unnecessary blast
+   radius for a single-service pilot with an already-cheap manual bootstrap
+   step (§6). `GetStack` first; if missing, fail with a clear message
+   pointing at the manual bootstrap step, not silently create one.
+2. **Before `UpdateStack`, guard against any unfilled placeholder token**
+   (round 3 M3): `grep -Eq '__[A-Z_]+__' <rendered compose> && fail` — this
+   catches not just a missed `__IMAGE_TAG__` substitution (already handled
+   by `render-image-tag.sh`'s own check, §3) but also `__NETWORK_NAME__`,
+   which is filled in by hand once into the git-committed file (§1) and
+   has no per-deploy script to guard it otherwise. Fails closed on the CI
+   side with a clear message, instead of failing mid-cutover as a Komodo-side
+   `external: true` network-not-found error.
+3. `UpdateStack(stack, config: {file_contents: <rendered compose>})` —
+   PATCH-style, verified not to disturb other config (Step 0, item 3).
+4. `DeployStack(stack)`.
+5. Poll `GetUpdate` until `status == Complete`; exit 0 only if
+   `success == true`.
+6. **`call_api`'s error handling special-cases 404 and 502** exactly as
+   `infra-secret-sync-komodo.sh` does against the same endpoint: a 404
+   response prints a pointer to `infra-komodo/README.md`'s Caddy-route
+   recovery steps; a 502 prints the `docker network connect
+   komodo_default voipbin-web-proxy` recovery command. A generic
+   "non-2xx" message is not acceptable here, since these two codes are the
+   expected/routine failure shapes for this endpoint, not edge cases.
+7. **Log leakage guard (round 1 MEDIUM finding):** the request bodies sent
+   are safe to log as-is (un-interpolated `[[VAR]]` placeholders, never
+   real secret values — a deliberate property of this design, worth
+   keeping). Komodo's own `GetUpdate` response logs are *post*-interpolation
+   `docker compose` output, and a compose parse error could echo real
+   DSN/AMQP values into CircleCI's job log. On failure, do not print
+   `GetUpdate`'s raw log content verbatim; print the update ID and a
+   pointer to check it via the Komodo UI/API directly (an authenticated
+   channel), not CI's own (broadly readable) log.
+8. **Secrets-at-rest surface, stated explicitly (round 2 M6):** after
+   interpolation, real production DSN/AMQP credentials exist in Komodo's
+   Mongo and on bm-nyc-01's Periphery-managed stack directory, readable by
+   anyone authenticated to `komodo.voipbin.net` — which per
+   `infra-komodo/README.md` is internet-exposed behind a single password,
+   no MFA. Not a new regression (PR #90 already put these values in
+   Komodo Variables; the old path had them in `install/.env` on the same
+   host either way), but this design newly routes production call-path
+   credentials through that surface and that trade should be explicit, not
+   implicit.
+
+### 3. Image-tag injection (`render-image-tag.sh`, new)
+
+`render-image-tag.sh <compose-file> <tag>`:
+- `grep -q '__IMAGE_TAG__' "$compose_file" || { echo "placeholder not found"; exit 1; }`
+- In-place substitute `__IMAGE_TAG__` → `<tag>` (`$CIRCLE_SHA1`).
+- Touches nothing else in the file.
+
+### 4. CI wiring
+
+`bin-call-manager-deploy` job body changes from:
+```
+command: .circleci/scripts/ssh-deploy.sh voipbin/bin-call-manager call-manager
+```
+to:
+```
+command: |
+  .circleci/scripts/render-image-tag.sh bin-call-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+  .circleci/scripts/komodo-api-deploy.sh bin-call-manager bin-call-manager/komodo/docker-compose.yml
+```
+Requires `CC_KOMODO_API_KEY`/`CC_KOMODO_API_SECRET` in the `production`
+context — already present (verify not rotated since PR #90, don't assume).
+
+**Poll timeout, set explicitly** (round 1 MEDIUM finding): default
+30×2s=60s may not cover a cold image pull for this service's actual image
+size. Measure during implementation/testing and set
+`CC_KOMODO_POLL_ATTEMPTS`/`CC_KOMODO_POLL_INTERVAL_S` explicitly for this
+job rather than relying on the library default. On `DEPLOY_TIMEOUT`,
+document that the deploy may still land after CI gives up — an operator
+must check Komodo directly (§2's log-leakage guard is why CI's own output
+isn't the source of truth here) before assuming failure and retrying.
+
+### 5. Deploy-success gate
+
+Two layers, neither fully sufficient alone (round 1 CRITICAL finding: a
+"container is running" gate cannot by itself distinguish a healthy
+call-manager from one that booted with an empty/broken DSN):
+
+**a. Automated, every deploy (routine CI runs):** Komodo's own
+`GetUpdate` `Complete`+`success` (started, not necessarily healthy) plus a
+poll of Komodo's Stack/service-status read for 3 consecutive `running`
+samples ~6s apart — same numeric gate `ssh-deploy.sh` already uses, read
+via Komodo's API instead of SSH `docker inspect`. **Open item to verify
+empirically during implementation:** confirm Komodo's read API actually
+exposes per-service container state in enough detail for this poll; if it
+doesn't, SSH may need to stay in the loop for this specific check (decide
+from the real response shape, not assumed here).
+
+**b. Manual, hard-blocking, cutover only (§7). Revised again per round 3
+(C1) — round 2's `call-control call get --id 00000000-...` fix does not
+work: `resolveUUID` rejects the nil UUID before any DB call
+(`cmd/call-control/main.go`), `Get` on a real-but-missing ID returns an
+*error* (`CALL_NOT_FOUND`, exit 1) rather than a "clean success" shape, and
+critically the CLI's `initHandler` connects to RabbitMQ too — with an
+**unbounded retry loop** (`rabbitmqhandler.connect()`), so if RabbitMQ is
+unreachable this command hangs forever instead of erroring. "Bypasses
+RabbitMQ entirely" was false. Two checks, both required, revised:
+
+```bash
+# (i) Negative gate — narrowed to boot-path failure strings (round 3 M2:
+# the earlier broader pattern would false-positive on unrelated transient
+# dial failures, e.g. Homer/asterisk-proxy, at DebugLevel log volume).
+# Must be empty.
+docker logs --since 2m voipbin-call-mgr | \
+  grep -Ei 'could not connect to the database|could not initialize the cache|could not connect to rabbitmq|panic:'
+
+# (ii) Positive gate — exercises DB connectivity via the control CLI,
+# bound to a timeout since the RabbitMQ leg of initHandler retries
+# unboundedly on failure rather than erroring (round 3 C1):
+timeout 30 docker exec voipbin-call-mgr /app/bin/call-control call list \
+  --customer-id 11111111-1111-1111-1111-111111111111 --limit 1
+```
+`initHandler` connects DB → Redis (both via a real `Ping`, per
+`databasehandler.Connect`/`cachehandler.Connect`) → RabbitMQ, in that
+order, so (ii) *does* exercise all three — just not by "bypassing"
+RabbitMQ, by racing against its retry loop under a timeout. Pass criterion
+for (ii): **exit 0** (an empty `[]` result for a customer ID with no calls
+is the expected, successful shape — `callHandler.List` returns an empty
+slice with nil error on no rows, not an error, unlike `Get`). A **non-zero
+exit** (DB/Redis connect failure surfaces as a returned error from
+`initHandler`) or a **timeout** (RabbitMQ unreachable) are both fail.
+**Open item to verify empirically before relying on this in production:**
+confirm `call list`'s exact exit code and output shape on an empty result
+against a real bm-nyc-01 Komodo-deployed container — this reasoning is
+derived from reading `pkg/callhandler/db.go`/`cmd/call-control/main.go`,
+not yet observed live.
+Either check failing is a hard abort trigger, not a judgment call. Both
+are manual (SSH-based observability/exec, not a deploy mechanism) and
+apply only to the cutover itself; routine subsequent deploys rely on gate
+(a) plus whatever monitoring/alerting already watches this service in
+production (unchanged by this design).
+
+### 6. Pre-cutover verification (round 1 HIGH; expanded round 2 — H2, H3)
+
+Before touching anything, on bm-nyc-01, capture both the network/project
+identity and the full live env in one pass:
+```bash
+docker inspect voipbin-call-mgr --format \
+  '{{index .Config.Labels "com.docker.compose.project"}} {{json .NetworkSettings.Networks}}'
+docker inspect voipbin-call-mgr --format '{{json .Config.Env}}' > pre-cutover-env.json
+```
+- The `com.docker.compose.project` label is the **single source of truth**
+  for the `-p` value used everywhere in §7 (step 3, rollback) — round 2
+  (H2) found the design asserting `-p install` in the same document that
+  refuses to assert the network name, which is inconsistent: a wrong `-p`
+  on step 3 makes the `rm` a silent no-op (conflict surfaces mid-cutover
+  at step 6 instead), and a wrong `-p` on rollback creates a *second*,
+  differently-projected container during an incident. Use the captured
+  value, not `install`, in every command below.
+- The network name fills `__NETWORK_NAME__` in §1. Do not assume
+  `install_default`; a stale, empty, differently-named network would
+  attach successfully (defeating the `external: true` fail-closed
+  property) while leaving `db`/`redis`/`rabbitmq` unreachable.
+- `pre-cutover-env.json` is the **authoritative source for §1's final env
+  list** (round 2 H3) — reconcile every `KEY=value` in it against §1's
+  draft list before cutover: every key present live must appear in §1
+  (add `REDIS_PASSWORD` if it's actually set), and every key in §1 must
+  correspond to something the live container actually has. Treat
+  "zero unexpected diff between this capture and §1's final list" as a
+  **pre-swap** gate — this replaces relying solely on the **post**-swap
+  diff (§7 step 7) to discover a missing/extra variable, which only finds
+  the problem after the outage window has already opened.
+
+### 7. Cutover sequencing
+
+(Below, `$LIVE_PROJECT` is the `com.docker.compose.project` value captured
+in §6, and `$LIVE_NETWORK` is the network name captured there — not
+hardcoded as `install`/`install_default`.)
+
+**Round 4 correction (CRITICAL, supersedes round 3's H1 fix):**
+`build-approval` in `.circleci/config_work.yml` gates the **entire**
+`test → build → deploy` chain, upstream of all three — not a pause point
+between build and deploy (the config's own comment: "Single approval gate
+... covers the whole pipeline including this deploy... A second
+deploy-specific approval was tried and doubles as staging, and requiring
+two clicks per deploy added [friction]"). Round 3's "merge, let build run,
+then approve before deploy" sequencing is not executable against this
+topology: not approving means no image ever gets pushed (step 4's pre-pull
+would have nothing to pull); approving runs straight through to deploy
+with no pause, hitting the exact `container_name` conflict steps 5-6
+existed to prevent, unattended.
+
+**Fix: decouple the risky swap from CI's pipeline entirely for this one,
+first cutover deploy.** The swap is inherently a manual, watched operation
+regardless (this design has said so throughout) — the correction is to
+stop trying to route it through CI's single-gate topology at all, and
+instead do the actual cutover by hand, with the CI wiring merged
+separately, once Komodo already owns the container and no name conflict
+exists to protect against.
+
+1. **Pre-swap checkpoint:** §6's captures (project/network identity,
+   `pre-cutover-env.json`), plus the current image ref
+   (`docker inspect voipbin-call-mgr --format '{{.Image}}'`) — all done
+   first, well before anything below.
+2. **Manual Stack bootstrap** (watched, on bm-nyc-01 or via API by hand —
+   not CI-automated, §2 item 1): create the Komodo Stack `bin-call-manager`
+   (`server_id`=bm-nyc-01, `file_contents` mode, `poll_for_updates: false`,
+   `auto_update: false`, `webhook_enabled: false` — Komodo does nothing on
+   its own; CI is the only trigger).
+3. **Build and push the image by hand**, from a workstation (not via CI,
+   and not tied to a `main` merge SHA — any clear, traceable tag works,
+   e.g. the feature branch's current commit). Matches what CI's
+   `docker-build` command does — repo root context, not the service
+   subdirectory (the Dockerfile's `COPY ./ .` then `cd bin-call-manager`
+   depends on it):
+   ```bash
+   docker build --tag voipbin/bin-call-manager:<manual-tag> \
+     -f bin-call-manager/Dockerfile .
+   docker push voipbin/bin-call-manager:<manual-tag>
+   ```
+4. **Pre-pull that exact tag** on bm-nyc-01:
+   `docker pull voipbin/bin-call-manager:<manual-tag>` — moves the cold
+   pull outside the outage window that opens at step 5.
+5. **Remove the old instance:**
+   `cd /opt/voipbin/install && docker compose -p "$LIVE_PROJECT" rm -sf call-manager`
+   (not `down` — preserves the shared network, now cross-project-owned;
+   `-p "$LIVE_PROJECT"` per round 2 H2 — never hardcode `install`). The
+   outage window starts here.
+6. **Comment out** (never delete) call-manager's block in **both**
+   `voipbin/voipbin install/docker-compose.yml` (the live host file) **and
+   note in `install/README.md`** that `docker-compose.yml.dist` still
+   contains this block too (round 1 finding: a host rebuild/fresh install
+   regenerates live from `.dist` and reintroduces the exact
+   `container_name` conflict this step exists to prevent — `.dist` itself
+   is out of scope to edit here since it's the external self-hosting
+   template, but the risk must be recorded where an operator will see it).
+   This step is manual SSH — outside Komodo's API surface entirely, since
+   this file belongs to a different, non-Komodo-managed system. One-time.
+   **Between this step and step 10 (CI wiring merge), `bin-call-manager-deploy`
+   still runs the old `ssh-deploy.sh` if some unrelated merge gets
+   approved** — it would hit a commented-out service and fail loudly
+   (`bump-image-digest.sh`/`docker compose pull` against a service Compose
+   no longer knows about) without touching the Komodo-managed container.
+   Fail-closed, not a production hazard, but keep this window short and
+   expect a red CI build as the (harmless) symptom if it happens.
+7. **Run `render-image-tag.sh` + `komodo-api-deploy.sh` by hand** from a
+   workstation with `CC_KOMODO_API_KEY`/`CC_KOMODO_API_SECRET` available
+   locally, targeting the manually-pushed tag from step 3 — watched, not
+   queued through CI. This is the actual cutover trigger; the image is
+   already local from step 4, so it should not need to pull.
+8. **Confirm (all of, not any of):** container up, gate 5a's
+   3-consecutive-running check passed (checked by hand here, same
+   criteria), env diff against `pre-cutover-env.json` (zero unexpected
+   differences — confirming §6's pre-swap reconciliation), **and** gate
+   5b's two checks (narrowed negative-log-grep empty, `call-control call
+   list` exits 0 within its timeout) both pass.
+9. **Abort criterion:** any of step 8's checks fails → stop immediately,
+   roll back (below) — do not retry blindly or debug live in production.
+10. **Only after step 8 confirms success:** merge the CI wiring change
+    (§4) to `main` through the normal, unmodified `build-approval` gate.
+    This is no longer a risky moment — Komodo already owns
+    `voipbin-call-mgr`, so the next CI-triggered deploy is an ordinary
+    image update on an already-Komodo-managed Stack, not a name-conflict
+    situation. `bin-call-manager-build` will rebuild and re-push the same
+    source at a new (`main`-merge) SHA — redundant with step 3's manual
+    build but harmless — and `bin-call-manager-deploy` runs normally from
+    then on.
+
+**Traffic-gap impact (round 1 MEDIUM finding — expanded, not just async
+queuing; step numbers corrected round 3 M1):** `bin-call-manager` is a
+**synchronous RabbitMQ RPC target** for the rest of the monorepo, not only
+an async event consumer. During the gap between steps 5 and 7, RPC callers
+(api-manager creating a call,
+flow-manager, hangup paths) block until their own RPC timeouts expire —
+user-visible failures during the gap, not just delayed background work.
+ARI events for calls already in progress (hangup, bridge changes) are also
+delayed, risking channel-state desync and billing-timing drift for calls
+active at swap time. **Maximum acceptable gap: state a concrete number
+before executing this in production** (not defined in this design — a
+production-operations judgment call for 대표님, informed by current call
+volume at the chosen swap window) and treat exceeding it as an independent
+abort trigger, not just "reconnect and move on." Schedule the swap in the
+lowest-traffic window available.
+
+**Rollback — ordered, CI-wiring-first (round 1 HIGH finding: the original
+draft's rollback left the merged CI change live, so the next unrelated
+merge touching bin-call-manager would silently re-run the new path over a
+rolled-back container):**
+**If aborting at §7 step 9 (before step 10's CI merge):** the CI wiring
+was never merged — there is nothing to revert, simply don't do step 10.
+Steps 2-3 below still apply.
+
+**If aborting after step 10 has already merged:**
+```bash
+# 1. FIRST: revert/disable the CI wiring change (§4) so no subsequent
+#    merge re-triggers komodo-api-deploy.sh against this service.
+# 2. Destroy the Komodo Stack (round 2 M1 — otherwise ANY later Deploy
+#    action against it, UI click or otherwise, recreates the
+#    container_name conflict against the container step 3 below brings
+#    back):
+#    DestroyStack(bin-call-manager) via the Komodo API/UI.
+# 3. On bm-nyc-01:
+docker rm -f voipbin-call-mgr 2>/dev/null || true
+# Un-comment call-manager's block in install/docker-compose.yml
+cd /opt/voipbin/install && docker compose -p "$LIVE_PROJECT" up -d call-manager
+```
+
+**`install_default` (or whatever §6 confirms the real name is) becomes a
+shared, cross-project network as of this cutover** — `docker compose -p
+install down` (full teardown) would now conflict with the Komodo-managed
+container still attached to it. Document this in `install/README.md` as a
+standing constraint, not a one-time migration note (same place as the
+`.dist` landmine note above).
+
+**Auditability (round 1 MEDIUM finding):** dropping `versions.lock` means
+git no longer records what's running on bm-nyc-01 for this service. State
+plainly: that answer now lives in Komodo's stored `file_contents` for the
+`bin-call-manager` Stack (queryable via `GetStack`), and the stale
+`bin-call-manager` entry left behind in the live `versions.lock` after
+cutover is intentional rollback ballast, not drift to be cleaned up.
+
+## Testing
+
+- **Existing `.circleci/tests/komodo-api-deploy.bats` is renamed to
+  `komodo-api-deploy-ssh-fallback.bats`** (paths/references updated to
+  match the §2 script rename), preserving its coverage of the retained
+  SSH-tunnel fallback script rather than silently losing it or having it
+  retarget the new HTTPS script by accident (round 2 M4). Note: as of this
+  writing, bats isn't wired into any `.circleci/*.yml` pipeline stage
+  (developer-run only) — this rename doesn't change CI behavior, only
+  keeps the test suite honest about what it covers.
+- New bats suite for the rewritten `komodo-api-deploy.sh` (stub `curl`,
+  assert on request bodies/headers, the 404/502 special-casing, and the
+  log-redaction-on-failure behavior) and for `render-image-tag.sh`.
+- Step 0's empirical spike (above) — required, not optional, before any of
+  the above is trusted in production.
+- Manual/watched verification of the actual cutover on bm-nyc-01 per §7 —
+  a production step, not something CI verifies unattended the first time.
+
+## Explicitly out of scope
+
+- Migrating any service other than bin-call-manager.
+- Decomposing the rest of the monolithic `docker-compose.yml`.
+- Fixing the pre-existing broken `wget`-based healthcheck on the *old*
+  path (moot for the new path, which drops the healthcheck — §1).
+- Migrating the shared network to a project-agnostic name/ownership.
+- Changing anything in `voipbin/voipbin`'s tracked `install/` files beyond
+  documentation (`install/README.md`) — no code/compose changes there.
+
+## Review corrections log
+
+**Round 1** (3 CRITICAL, 4 HIGH, 5 MEDIUM):
+- CRITICAL 1 (unverified `[[VAR]]` interpolation cited as confirmed) →
+  Step 0 added; claim downgraded throughout.
+- CRITICAL 2 (dead healthcheck copied forward; gate can't detect broken-but-running) →
+  healthcheck dropped from new file (§1); two-layer gate added (§5) —
+  further revised in round 2, see H1 below.
+- CRITICAL 3 (routine 404/502 fragility unaddressed; no break-glass path) →
+  §2 (special-casing) and the SSH-tunnel script kept as fallback.
+- HIGH 4 (rollback doesn't stop CI re-deploying over it; missing `cd`) →
+  rollback reordered CI-wiring-first, `cd` added (§7) — `cd` also added to
+  the forward path in round 2 (M5).
+- HIGH 5 (network name asserted, not verified) → §6 added; compose
+  fragment uses a placeholder instead of hardcoding `install_default`.
+- HIGH 6 (CI auto-creates Stacks, reversing VOIP-1341's own design intent) →
+  dropped; Stack creation is manual-only (§2 item 1, §7 step 2).
+- HIGH 7 (PATCH-style `UpdateStack` claim mis-cited) → citation corrected;
+  re-verification folded into Step 0.
+- MEDIUM 8 (traffic-gap analysis understated sync-RPC impact) → expanded
+  in §7.
+- MEDIUM 9 (Komodo update logs could leak secrets into CI logs) → §2 added
+  (later renumbered to item 7 by round-3's M3 insertion).
+- MEDIUM 10 (`.dist` file still a landmine) → noted in §7.
+- MEDIUM 11 (loss of git-based deployed-version auditability unstated) →
+  noted in §7.
+- MEDIUM 12 (poll timeout budget unstated) → §4 addresses explicitly.
+
+**Round 2** (3 HIGH, 6 MEDIUM — round 1's fixes verified correct except
+where noted):
+- H1 (gate 5b's `ContactStatusChange` grep unreliable and doesn't exercise
+  DB/Redis) → replaced with a two-part negative-log-grep +
+  `call-control call get` DB round-trip check (§5).
+- H2 (`-p install` hardcoded in the same doc that refuses to assert the
+  network name) → §6 now captures the real compose-project label
+  alongside the network name; §7 and rollback use `$LIVE_PROJECT`
+  throughout instead of a literal `install`.
+- H3 (new file's env list authored from `.dist`, divergence discovered
+  only post-swap) → §1 marks the env list as a non-authoritative draft;
+  §6 now captures the live container's actual env pre-cutover and makes
+  reconciliation a pre-swap gate.
+- M1 (rollback leaves the Komodo Stack live, re-deployable into a
+  conflict) → `DestroyStack` added as an explicit rollback step.
+- M2 (cold image pull sits inside the outage window) → pre-pull step
+  added between Stack bootstrap and container removal (§7).
+- M3 (Step 0 item 4 shape-checked only one variable) → generalized to all
+  referenced `BIN_MANAGER__*` variables.
+- M4 (rename breaks/silently retargets the existing bats suite) →
+  existing suite explicitly renamed alongside the script; new suite
+  created for the new script (Testing).
+- M5 (missing `cd` in the forward path, only fixed in rollback) → added.
+- M6 (secrets-at-rest exposure via Komodo's admin surface unstated) → §2
+  item 8 added.
+
+**Round 3** (1 CRITICAL, 1 HIGH, 3 MEDIUM):
+- C1 (gate 5b(ii) cannot pass as written — nil UUID rejected pre-DB-call,
+  `Get`'s not-found is an error not a success shape, and the CLI's
+  RabbitMQ dial retries unboundedly rather than erroring, so "bypasses
+  RabbitMQ" was false and a RabbitMQ-down state would hang the check
+  forever) → replaced with `call list --customer-id <random-non-nil-uuid>`
+  under `timeout 30`, pass-on-exit-0 (empty-list is a real List-vs-Get
+  behavior difference), explicitly flagged for empirical confirmation
+  against a live container (§5).
+- H1 (pre-pull in the old step 3 pulled a tag that didn't correspond to
+  what step 6 actually deployed, since the merge commit's image didn't
+  exist yet — no real outage-window reduction) → cutover reordered: merge
+  CI wiring first (build pushes the real SHA, deploy stays behind
+  `build-approval`), pre-pull *that* SHA, then remove the old container,
+  then approve the deploy (§7).
+- M1 (traffic-gap paragraph referenced stale step numbers after M2's
+  insertion) → corrected to match the reordered steps.
+- M2 (negative-log-grep patterns too broad for a mandatory-abort gate,
+  would false-positive on unrelated transient dial failures at DebugLevel
+  log volume) → narrowed to the specific boot-path failure strings (§5).
+- M3 (nothing guards against `__NETWORK_NAME__` shipping unfilled) →
+  generic `__[A-Z_]+__` placeholder guard added to `komodo-api-deploy.sh`
+  before every `UpdateStack` call (§2).
+
+**Round 4** (1 CRITICAL, plus 3 stale-reference cleanups):
+- CRITICAL (round 3's H1 fix doesn't execute against the real CI
+  topology — `build-approval` gates the entire `test → build → deploy`
+  chain, not a pause point between build and deploy; approving to get a
+  build also runs the deploy straight through with no room for the
+  manual old-container-removal/comment-out steps in between) → the risky
+  swap is decoupled from CI's single-gate pipeline entirely: build/push
+  the image by hand, do the removal/comment-out/deploy by hand
+  (watched), confirm success, and only then merge the CI wiring change
+  for *future* ordinary deploys, which no longer have a name conflict to
+  worry about (§7, fully restructured).
+- Stale cross-references cleaned up: the round-1 corrections log's "§2
+  item 5/6" citations (renumbered by round-3's M3 insertion), the
+  rollback's `DestroyStack` comment (referenced "step 4", the list only
+  has 3 steps), and `bin-call-manager/CLAUDE.md`'s command table, which
+  still claimed `call-control call get` "(bypasses RabbitMQ)" — corrected
+  in the same PR since round-3's C1 established `initHandler` does dial
+  RabbitMQ (with an unbounded retry loop), and gate 5b now depends on
+  that corrected understanding.

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -816,3 +816,17 @@ idempotently, reversing round-1's "does not create Stacks" finding — see
 mechanism (Komodo returns HTTP 500, not 404, for "Stack not found").
 §7 step 2's separate manual bootstrap is removed accordingly — folded into
 step 7's own first run.
+
+**Follow-up dependency, not in this PR's scope (대표님, 2026-08-16):** a
+neutral shared network (tentatively named `production`), owned by neither
+the `install` compose project nor any Komodo Stack, is being built out in
+a separate session — this is the same "network genuinely owned by neither
+compose project" follow-up this document already flagged (see the
+`install_default` shared-network note above). Once that network exists
+and `db`/`redis`/`rabbitmq` are attached to it, `bin-call-manager/komodo/docker-compose.yml`'s
+`networks.default.name` should move from `install_default` to
+`production` — but not before, and not as part of this pilot's cutover.
+Sequencing matters: that network must exist and carry the shared infra
+containers *before* any service tries to attach to it, so this is a
+prerequisite for the *next* service's Komodo migration at the earliest,
+not a same-day follow-up to this one.

--- a/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
+++ b/docs/plans/2026-08-16-komodo-call-manager-cutover-design.md
@@ -1,9 +1,26 @@
 # Design: cut bin-call-manager over to Komodo-managed deploy (VOIP-1342)
 
-Revision 5 — incorporates round-1 (3 CRITICAL, 4 HIGH, 5 MEDIUM), round-2
+Revision 6 — incorporates round-1 (3 CRITICAL, 4 HIGH, 5 MEDIUM), round-2
 (3 HIGH, 6 MEDIUM), round-3 (1 CRITICAL, 1 HIGH, 3 MEDIUM), and round-4
-(1 CRITICAL + reference cleanups) architect review findings. See "Review
-corrections log" at the end for the full mapping.
+(1 CRITICAL + reference cleanups) architect review findings, plus a
+post-approval naming change (below). See "Review corrections log" at the
+end for the full architect-review mapping.
+
+**Naming decision (2026-08-16, post-merge-review, 대표님):** the new
+container's name is `voipbin-call-manager` — matching GKE's `call-manager`
+app name/label (verified in `bin-call-manager/k8s/deployment.yml`) rather
+than `install/`'s host-wide `voipbin-<service>-mgr` abbreviation. This is
+**deliberately different from the old container's name**,
+`voipbin-call-mgr` (unchanged, still the live pre-cutover container's real
+name throughout this document). The other 31 `bin-*-manager` services'
+eventual Komodo cutover will follow the same `voipbin-<service>-manager`
+convention, not `-mgr`, as a follow-up. **Consequence, not a footnote:**
+because the two names differ, Docker no longer refuses to run both
+containers at once the way it would if they shared a name — the
+mutual-exclusion safety net earlier revisions of this design leaned on is
+gone. §7's ordering (old removed before new deployed) still holds, but is
+now enforced only by *procedure*, not by Docker itself — §7 adds an
+explicit verification step for this.
 
 ## Goal
 
@@ -361,13 +378,13 @@ RabbitMQ entirely" was false. Two checks, both required, revised:
 # the earlier broader pattern would false-positive on unrelated transient
 # dial failures, e.g. Homer/asterisk-proxy, at DebugLevel log volume).
 # Must be empty.
-docker logs --since 2m voipbin-call-mgr | \
+docker logs --since 2m voipbin-call-manager | \
   grep -Ei 'could not connect to the database|could not initialize the cache|could not connect to rabbitmq|panic:'
 
 # (ii) Positive gate — exercises DB connectivity via the control CLI,
 # bound to a timeout since the RabbitMQ leg of initHandler retries
 # unboundedly on failure rather than erroring (round 3 C1):
-timeout 30 docker exec voipbin-call-mgr /app/bin/call-control call list \
+timeout 30 docker exec voipbin-call-manager /app/bin/call-control call list \
   --customer-id 11111111-1111-1111-1111-111111111111 --limit 1
 ```
 `initHandler` connects DB → Redis (both via a real `Ping`, per
@@ -505,6 +522,17 @@ exists to protect against.
    no longer knows about) without touching the Komodo-managed container.
    Fail-closed, not a production hazard, but keep this window short and
    expect a red CI build as the (harmless) symptom if it happens.
+   **Mandatory check before step 7 (naming decision, 대표님, 2026-08-16):**
+   confirm the old container is actually gone —
+   `docker ps -a --filter "name=^/voipbin-call-mgr$" --format '{{.Names}}'`
+   must return nothing. Because the new container's name
+   (`voipbin-call-manager`) deliberately differs from the old one
+   (`voipbin-call-mgr`), Docker will **not** refuse to start the new
+   container even if the old one is somehow still running — the
+   mutual-exclusion this design originally relied on (same name = OS-level
+   refusal to double-run) no longer applies. This check is what replaces
+   it; do not skip it because step 5 "already removed" the old container —
+   confirm, don't assume.
 7. **Run `render-image-tag.sh` + `komodo-api-deploy.sh` by hand** from a
    workstation with `CC_KOMODO_API_KEY`/`CC_KOMODO_API_SECRET` available
    locally, targeting the manually-pushed tag from step 3 — watched, not
@@ -521,7 +549,7 @@ exists to protect against.
 10. **Only after step 8 confirms success:** merge the CI wiring change
     (§4) to `main` through the normal, unmodified `build-approval` gate.
     This is no longer a risky moment — Komodo already owns
-    `voipbin-call-mgr`, so the next CI-triggered deploy is an ordinary
+    `voipbin-call-manager`, so the next CI-triggered deploy is an ordinary
     image update on an already-Komodo-managed Stack, not a name-conflict
     situation. `bin-call-manager-build` will rebuild and re-push the same
     source at a new (`main`-merge) SHA — redundant with step 3's manual
@@ -544,6 +572,16 @@ volume at the chosen swap window) and treat exceeding it as an independent
 abort trigger, not just "reconnect and move on." Schedule the swap in the
 lowest-traffic window available.
 
+**Monitoring continuity (naming decision, 대표님, 2026-08-16 — new
+concern, didn't exist while the name was unchanged):** whatever scrapes
+`:2112/metrics` for Prometheus and whatever dashboards/alerts reference
+this service by container name both need to be checked for whether they
+key on `voipbin-call-mgr` specifically (breaks at cutover, needs updating
+to `voipbin-call-manager`) or on something name-independent (compose
+service label, a static target list keyed by IP/port, etc. — unaffected).
+**Not yet checked in this design** — confirm before or immediately after
+the cutover, not as an afterthought if alerts go quiet.
+
 **Rollback — ordered, CI-wiring-first (round 1 HIGH finding: the original
 draft's rollback left the merged CI change live, so the next unrelated
 merge touching bin-call-manager would silently re-run the new path over a
@@ -558,12 +596,13 @@ Steps 2-3 below still apply.
 #    merge re-triggers komodo-api-deploy.sh against this service.
 # 2. Destroy the Komodo Stack (round 2 M1 — otherwise ANY later Deploy
 #    action against it, UI click or otherwise, recreates the
-#    container_name conflict against the container step 3 below brings
-#    back):
+#    voipbin-call-manager container step 3 below removes):
 #    DestroyStack(bin-call-manager) via the Komodo API/UI.
-# 3. On bm-nyc-01:
-docker rm -f voipbin-call-mgr 2>/dev/null || true
-# Un-comment call-manager's block in install/docker-compose.yml
+# 3. On bm-nyc-01, remove the NEW (Komodo-managed) container - note the
+#    name difference from the old one (naming decision, 대표님, 2026-08-16):
+docker rm -f voipbin-call-manager 2>/dev/null || true
+# Un-comment call-manager's block in install/docker-compose.yml, which
+# recreates the OLD container under its original name (voipbin-call-mgr):
 cd /opt/voipbin/install && docker compose -p "$LIVE_PROJECT" up -d call-manager
 ```
 
@@ -706,3 +745,25 @@ where noted):
   in the same PR since round-3's C1 established `initHandler` does dial
   RabbitMQ (with an unbounded retry loop), and gate 5b now depends on
   that corrected understanding.
+
+**Post-approval naming revision** (대표님, 2026-08-16, after PR #1188 was
+opened — not an architect-review round, but logged here for the same
+reason):
+- New container renamed `voipbin-call-mgr` → `voipbin-call-manager`,
+  matching GKE's `call-manager` app name rather than `install/`'s
+  `-mgr`-abbreviated convention (verified against
+  `bin-call-manager/k8s/deployment.yml` before accepting the change, not
+  taken on faith — GKE's actual name has no `voipbin-` prefix at all,
+  which was surfaced and 대표님 chose `voipbin-call-manager` explicitly
+  over matching GKE exactly).
+- Consequence handled: the old/new name match this design leaned on for
+  automatic Docker-level mutual exclusion no longer holds. §7 gained an
+  explicit "confirm the old container is actually gone" check before
+  deploying the new one, and a monitoring-continuity flag (container-name-keyed
+  scrape configs/dashboards/alerts, not yet checked).
+- `bin-call-manager/komodo/docker-compose.yml`, and every design-doc
+  reference to the *new* container (gate 5b's commands, the post-cutover
+  "Komodo already owns..." note, and the rollback's `docker rm`) updated
+  accordingly. References to the *old* container (pre-cutover checkpoint,
+  §6's live-host captures) correctly stay `voipbin-call-mgr` — that
+  container's real name is unchanged by this decision.


### PR DESCRIPTION
Cut bin-call-manager's deploy path over to Komodo-managed deployment,
replacing SSH+versions.lock, as the first pilot service off
voipbin/voipbin's install/ mechanism. install/ stays unchanged for
external self-hosting users; this only affects bm-nyc-01 production.

Design went through 6 rounds of architect review (3 CRITICAL, 8 HIGH, 14
MEDIUM found and fixed across rounds) and this implementation through 4
rounds of code review (2 HIGH + 1 MEDIUM security finding fixed, final 2
rounds clean). Full design doc with the complete review trail:
docs/plans/2026-08-16-komodo-call-manager-cutover-design.md.

- monorepo: rewrite komodo-api-deploy.sh for direct HTTPS to
  komodo.voipbin.net (no SSH hop, now that Komodo's public API access
  exists) - GetStack precondition check, __PLACEHOLDER__ guard, 404/502
  special-casing (routine Caddy-route/network-attachment failure modes),
  log-leakage guard on deploy failure, and a 3-consecutive-running
  follow-up gate via ListStackServices
- monorepo: rename the original SSH-tunnel script to
  komodo-api-deploy-ssh-fallback.sh, kept as the break-glass path for a
  komodo.voipbin.net outage; fixed a log-leakage gap in its own
  deploy-failure path to match the primary script's guard
- monorepo: add render-image-tag.sh - substitutes a plain image tag
  ($CIRCLE_SHA1) into a Komodo compose fragment's __IMAGE_TAG__
  placeholder, replacing bump-image-digest.sh/versions.lock for services
  on this deploy path
- bin-call-manager: add komodo/docker-compose.yml - single-service Komodo
  Stack definition referencing already-synced BIN_MANAGER__* Komodo
  Variables via [[NAMESPACE__KEY]] interpolation, no secrets committed,
  no healthcheck (image is distroless, the old wget-based check could
  never pass on it)
- bin-call-manager: correct CLAUDE.md's call-control command table entry
  (it does dial RabbitMQ on startup with an unbounded retry loop, does
  not bypass it - caught during design review, gate 5b depends on this)
- bin-call-manager: document the Komodo deploy path in docs/operations.md
  (Stack definition, CI path, break-glass fallback, design doc pointer)
- bin-call-manager: switch the Komodo Stack's network from
  install_default to production (VOIP-1343) - production is the
  Komodo-managed shared backbone network and the intended default for new
  bm-nyc-01 services going forward
- monorepo: wire bin-call-manager-deploy's CI job to the new scripts,
  replacing ssh-deploy.sh, with an explicit poll-timeout budget
- monorepo: add/rename bats coverage for both scripts and
  render-image-tag.sh (95 tests total, all passing)

Empirically verified against the live bm-nyc-01/Komodo instance in this
session, via two real end-to-end CI-triggered deploys (not simulated):
- [[BIN_MANAGER__*]] Variable interpolation resolves correctly into the
  deployed container's env (DATABASE_DSN/RABBITMQ_ADDRESS/etc. all
  connected successfully).
- UpdateStack's file_contents-only PATCH semantics behave as designed.
- The 3-consecutive-running gate (ListStackServices) correctly reports
  running state on bm-nyc-01's actual Komodo instance - confirmed on
  both deploys (install_default network, then production network after
  the fix).
- Stack auto-creation (idempotent CreateStack) worked on first deploy.
- production network connectivity to db/redis/rabbitmq (via
  infra-komodo's backfill-install-default.sh) confirmed working - the
  second deploy's running-gate passed cleanly after the network switch.

The actual traffic cutover (design doc §7 - removing the old
voipbin-call-mgr container and pointing traffic at the new
Komodo-managed one) is still a separate, manual, watched procedure run
against bm-nyc-01 directly, not part of this PR. Two items called out in
the design doc still need a decision/check before that cutover runs:
acceptable downtime window (production-operations judgment call) and
whether monitoring/alerting is keyed on the old container name.
