### PR TITLE
VOIP-1347-Roll-out-tier1-bin-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -206,6 +206,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-agent-manager-test
+      - bin-agent-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-agent-manager-build
   bin-api-manager:
     when:
       or: [<< pipeline.parameters.run-bin-api-manager >>, << pipeline.parameters.run-bin-openapi-manager >>]
@@ -231,6 +235,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-billing-manager-test
+      - bin-billing-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-billing-manager-build
   bin-call-manager:
     when: << pipeline.parameters.run-bin-call-manager >>
     jobs:
@@ -269,6 +277,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-campaign-manager-test
+      - bin-campaign-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-campaign-manager-build
   bin-ai-manager:
     when: << pipeline.parameters.run-bin-ai-manager >>
     jobs:
@@ -302,6 +314,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-contact-manager-test
+      - bin-contact-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-contact-manager-build
   bin-conference-manager:
     when: << pipeline.parameters.run-bin-conference-manager >>
     jobs:
@@ -314,6 +330,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-conference-manager-test
+      - bin-conference-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-conference-manager-build
   bin-conversation-manager:
     when: << pipeline.parameters.run-bin-conversation-manager >>
     jobs:
@@ -326,6 +346,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-conversation-manager-test
+      - bin-conversation-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-conversation-manager-build
   bin-customer-manager:
     when: << pipeline.parameters.run-bin-customer-manager >>
     jobs:
@@ -384,6 +408,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-direct-manager-test
+      - bin-direct-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-direct-manager-build
   bin-email-manager:
     when: << pipeline.parameters.run-bin-email-manager >>
     jobs:
@@ -408,6 +436,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-flow-manager-test
+      - bin-flow-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-flow-manager-build
   bin-hook-manager:
     when: << pipeline.parameters.run-bin-hook-manager >>
     jobs:
@@ -465,6 +497,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-outdial-manager-test
+      - bin-outdial-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-outdial-manager-build
   bin-pipecat-manager:
     when: << pipeline.parameters.run-bin-pipecat-manager >>
     jobs:
@@ -489,6 +525,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-queue-manager-test
+      - bin-queue-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-queue-manager-build
   bin-rag-manager:
     when: << pipeline.parameters.run-bin-rag-manager >>
     jobs:
@@ -525,6 +565,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-route-manager-test
+      - bin-route-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-route-manager-build
   bin-schedule-manager:
     when: << pipeline.parameters.run-bin-schedule-manager >>
     jobs:
@@ -586,6 +630,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-tag-manager-test
+      - bin-tag-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-tag-manager-build
   bin-talk-manager:
     when: << pipeline.parameters.run-bin-talk-manager >>
     jobs:
@@ -598,6 +646,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-talk-manager-test
+      - bin-talk-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-talk-manager-build
   bin-timeline-manager:
     when: << pipeline.parameters.run-bin-timeline-manager >>
     jobs:
@@ -634,6 +686,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-transfer-manager-test
+      - bin-transfer-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-transfer-manager-build
   bin-trigger-sender:
     when: << pipeline.parameters.run-bin-trigger-sender >>
     jobs:
@@ -673,6 +729,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-webchat-manager-test
+      - bin-webchat-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-webchat-manager-build
   bin-webhook-manager:
     when: << pipeline.parameters.run-bin-webhook-manager >>
     jobs:
@@ -685,6 +745,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-webhook-manager-test
+      - bin-webhook-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-webhook-manager-build
   ############################################
   # namespace: voip
   ############################################
@@ -755,6 +819,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-agent-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-agent-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-agent-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-agent-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-agent-manager bin-agent-manager/komodo/docker-compose.yml
+
   # bin-api-manager
   bin-api-manager-test:
     docker: *go_image
@@ -788,6 +870,24 @@ jobs:
           source-directory: bin-billing-manager
           project-id: voipbin
           project-repository: bin-billing-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-billing-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-billing-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-billing-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-billing-manager bin-billing-manager/komodo/docker-compose.yml
 
   # bin-call-manager
   bin-call-manager-test:
@@ -853,6 +953,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-campaign-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-campaign-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-campaign-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-campaign-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-campaign-manager bin-campaign-manager/komodo/docker-compose.yml
+
   # bin-ai-manager
   bin-ai-manager-test:
     docker: *go_image
@@ -895,6 +1013,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-contact-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-contact-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-contact-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-contact-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-contact-manager bin-contact-manager/komodo/docker-compose.yml
+
   # bin-conference-manager
   bin-conference-manager-test:
     docker: *go_image
@@ -912,6 +1048,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-conference-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-conference-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-conference-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-conference-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-conference-manager bin-conference-manager/komodo/docker-compose.yml
+
   # bin-conversation-manager
   bin-conversation-manager-test:
     docker: *go_image
@@ -928,6 +1082,24 @@ jobs:
           source-directory: bin-conversation-manager
           project-id: voipbin
           project-repository: bin-conversation-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-conversation-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-conversation-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-conversation-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-conversation-manager bin-conversation-manager/komodo/docker-compose.yml
 
   # bin-customer-manager
   bin-customer-manager-test:
@@ -1013,6 +1185,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-direct-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-direct-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-direct-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-direct-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-direct-manager bin-direct-manager/komodo/docker-compose.yml
+
   # bin-email-manager
   bin-email-manager-test:
     docker: *go_image
@@ -1046,6 +1236,24 @@ jobs:
           source-directory: bin-flow-manager
           project-id: voipbin
           project-repository: bin-flow-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-flow-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-flow-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-flow-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-flow-manager bin-flow-manager/komodo/docker-compose.yml
 
   # bin-hook-manager
   bin-hook-manager-test:
@@ -1143,6 +1351,24 @@ jobs:
           project-repository: bin-outdial-manager
           source-directory: bin-outdial-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-outdial-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-outdial-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-outdial-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-outdial-manager bin-outdial-manager/komodo/docker-compose.yml
+
   # bin-pipecat-manager
   bin-pipecat-manager-test:
     docker: *go_image
@@ -1176,6 +1402,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-queue-manager
           source-directory: bin-queue-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-queue-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-queue-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-queue-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-queue-manager bin-queue-manager/komodo/docker-compose.yml
 
   # bin-rag-manager
   bin-rag-manager-test:
@@ -1227,6 +1471,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-route-manager
           source-directory: bin-route-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-route-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-route-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-route-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-route-manager bin-route-manager/komodo/docker-compose.yml
 
   # bin-schedule-manager
   bin-schedule-manager-test:
@@ -1306,6 +1568,24 @@ jobs:
           project-repository: bin-tag-manager
           source-directory: bin-tag-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-tag-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-tag-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-tag-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-tag-manager bin-tag-manager/komodo/docker-compose.yml
+
   # bin-talk-manager
   bin-talk-manager-test:
     docker: *go_image
@@ -1322,6 +1602,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-talk-manager
           source-directory: bin-talk-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-talk-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-talk-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-talk-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-talk-manager bin-talk-manager/komodo/docker-compose.yml
 
   # bin-timeline-manager
   bin-timeline-manager-test:
@@ -1374,6 +1672,24 @@ jobs:
           project-repository: bin-transfer-manager
           source-directory: bin-transfer-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-transfer-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-transfer-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-transfer-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-transfer-manager bin-transfer-manager/komodo/docker-compose.yml
+
   # bin-trigger-sender
   bin-trigger-sender-test:
     docker: *go_image
@@ -1425,6 +1741,24 @@ jobs:
           project-repository: bin-webchat-manager
           source-directory: bin-webchat-manager
 
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-webchat-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-webchat-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-webchat-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-webchat-manager bin-webchat-manager/komodo/docker-compose.yml
+
   # bin-webhook-manager
   bin-webhook-manager-test:
     docker: *go_image
@@ -1441,6 +1775,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-webhook-manager
           source-directory: bin-webhook-manager
+
+  # VOIP-1347 Tier 1 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md.
+  bin-webhook-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-webhook-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-webhook-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-webhook-manager bin-webhook-manager/komodo/docker-compose.yml
 
   ############################################
   # namespace: voip

--- a/bin-agent-manager/README.md
+++ b/bin-agent-manager/README.md
@@ -82,8 +82,7 @@ Represents agent's skills and groups.
 
 # Deploy
 
-`bin-agent-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-agent-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-agent-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-agent-manager/docs/operations.md
+++ b/bin-agent-manager/docs/operations.md
@@ -57,6 +57,23 @@ kubectl exec -n voipbin deploy/bin-agent-manager -- curl -s localhost:9090/metri
 kubectl exec -n voipbin deploy/bin-agent-manager -- curl -s localhost:9090/metrics | grep db_operation_duration
 ```
 
+## Deployment
+
+bin-agent-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-agent-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-agent-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Env Var | Default | Description |

--- a/bin-agent-manager/komodo/docker-compose.yml
+++ b/bin-agent-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-agent-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  agent-manager:
+    image: voipbin/bin-agent-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-agent-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./agent-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-billing-manager/README.md
+++ b/bin-billing-manager/README.md
@@ -112,8 +112,7 @@ Usage of ./billing-manager:
 
 # Deploy
 
-`bin-billing-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-billing-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-billing-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-billing-manager/docs/operations.md
+++ b/bin-billing-manager/docs/operations.md
@@ -50,6 +50,23 @@ REDIS_DATABASE=1 \
 - Paddle dashboard → Notifications → Event log
 - Look for events with status `failed` and check the response body
 
+## Deployment
+
+bin-billing-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-billing-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-billing-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags can also be set via environment variable (uppercase, underscores). No defaults shown means the flag is required.

--- a/bin-billing-manager/komodo/docker-compose.yml
+++ b/bin-billing-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-billing-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  billing-manager:
+    image: voipbin/bin-billing-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-billing-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./billing-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-call-manager/docs/operations.md
+++ b/bin-call-manager/docs/operations.md
@@ -74,9 +74,9 @@ All output is JSON (stdout); logs go to stderr.
 
 bin-call-manager is the Komodo-managed deploy pilot (VOIP-1342) — the first
 `bin-*-manager` service to move off `voipbin/voipbin`'s `install/`
-(`versions.lock`/`ssh-deploy.sh`) mechanism. The other 31 `bin-*-manager`
-services still deploy via `ssh-deploy.sh` until this pilot is verified in
-production and a follow-up ticket rolls the pattern out.
+(`versions.lock`/`ssh-deploy.sh`) mechanism. VOIP-1347 (Tier 1 rollout)
+followed with 16 more services on the same pattern; the remaining
+`bin-*-manager` services will migrate in future follow-up rollouts.
 
 - **Stack definition:** `bin-call-manager/komodo/docker-compose.yml` (git
   is the source of truth for structure; Komodo only executes it on

--- a/bin-call-manager/komodo/docker-compose.yml
+++ b/bin-call-manager/komodo/docker-compose.yml
@@ -43,8 +43,10 @@
 # container_name is `voipbin-call-manager`, deliberately DIFFERENT from
 # the old container's name `voipbin-call-mgr` (대표님's explicit naming
 # decision, 2026-08-16 - matches GKE's `call-manager` app label rather
-# than install/'s host-wide `-mgr`-abbreviated convention; the other 31
-# bin-*-manager services stay on the old convention until they migrate).
+# than install/'s host-wide `-mgr`-abbreviated convention; VOIP-1347 (Tier 1
+# rollout) applied the same `voipbin-<short>-manager` convention to 16 more
+# services, the remaining bin-*-manager services stay on the old convention
+# until they migrate too).
 # Because the names differ, Docker will NOT refuse to run both containers
 # at once the way it would if they shared a name - the mutual-exclusion
 # safety net the original cutover design relied on is gone. §7's ordering

--- a/bin-campaign-manager/README.md
+++ b/bin-campaign-manager/README.md
@@ -65,8 +65,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 # Deploy
 
-`bin-campaign-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-campaign-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-campaign-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-campaign-manager/docs/operations.md
+++ b/bin-campaign-manager/docs/operations.md
@@ -58,6 +58,23 @@ The `campaign-control` binary provides direct DB/cache access for inspection:
 
 All output is JSON (stdout); logs go to stderr.
 
+## Deployment
+
+bin-campaign-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-campaign-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-campaign-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Env Var | Default | Description |

--- a/bin-campaign-manager/komodo/docker-compose.yml
+++ b/bin-campaign-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-campaign-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  campaign-manager:
+    image: voipbin/bin-campaign-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-campaign-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./campaign-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-conference-manager/README.md
+++ b/bin-conference-manager/README.md
@@ -59,8 +59,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 # Deploy
 
-`bin-conference-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-conference-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-conference-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-conference-manager/docs/operations.md
+++ b/bin-conference-manager/docs/operations.md
@@ -55,6 +55,23 @@ kubectl exec -n voipbin deploy/bin-conference-manager -- curl -s localhost:9090/
 kubectl exec -n voipbin deploy/bin-conference-manager -- curl -s localhost:9090/metrics | grep conference_join_total
 ```
 
+## Deployment
+
+bin-conference-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-conference-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-conference-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Env Var | Default | Description |

--- a/bin-conference-manager/komodo/docker-compose.yml
+++ b/bin-conference-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-conference-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  conference-manager:
+    image: voipbin/bin-conference-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-conference-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./conference-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-contact-manager/README.md
+++ b/bin-contact-manager/README.md
@@ -4,8 +4,7 @@
 
 # Deploy
 
-`bin-contact-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-contact-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-contact-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-contact-manager/docs/operations.md
+++ b/bin-contact-manager/docs/operations.md
@@ -47,6 +47,23 @@ SELECT id, type, target, is_primary FROM contact_addresses
 WHERE contact_id = '<uuid>';
 ```
 
+## Deployment
+
+bin-contact-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-contact-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-contact-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Environment Variable | Default | Description |

--- a/bin-contact-manager/komodo/docker-compose.yml
+++ b/bin-contact-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-contact-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  contact-manager:
+    image: voipbin/bin-contact-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-contact-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./contact-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-conversation-manager/README.md
+++ b/bin-conversation-manager/README.md
@@ -6,8 +6,7 @@ Manages multi-channel conversations (SMS/MMS, LINE, WhatsApp) and their messages
 
 # Deploy
 
-`bin-conversation-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-conversation-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-conversation-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-conversation-manager/docs/operations.md
+++ b/bin-conversation-manager/docs/operations.md
@@ -1,5 +1,22 @@
 # bin-conversation-manager Operations
 
+## Deployment
+
+bin-conversation-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-conversation-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-conversation-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags support equivalent `UPPER_SNAKE_CASE` environment variables.

--- a/bin-conversation-manager/komodo/docker-compose.yml
+++ b/bin-conversation-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-conversation-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  conversation-manager:
+    image: voipbin/bin-conversation-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-conversation-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./conversation-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-direct-manager/README.md
+++ b/bin-direct-manager/README.md
@@ -139,8 +139,7 @@ The CLI uses the same configuration flags and environment variables as `direct-m
 
 # Deploy
 
-`bin-direct-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-direct-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-direct-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-direct-manager/docs/operations.md
+++ b/bin-direct-manager/docs/operations.md
@@ -45,6 +45,23 @@ SELECT id, customer_id, resource_type, resource_id FROM direct_manager_direct
 WHERE hash = '<hash>' AND tm_delete = '9999-01-01 00:00:00.000000';
 ```
 
+## Deployment
+
+bin-direct-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-direct-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-direct-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Environment Variable | Default | Description |

--- a/bin-direct-manager/komodo/docker-compose.yml
+++ b/bin-direct-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-direct-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  direct-manager:
+    image: voipbin/bin-direct-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-direct-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./direct-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-flow-manager/README.md
+++ b/bin-flow-manager/README.md
@@ -242,8 +242,7 @@ $ go build ./cmd/...
 
 # Deploy
 
-`bin-flow-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-flow-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-flow-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-flow-manager/docs/operations.md
+++ b/bin-flow-manager/docs/operations.md
@@ -59,6 +59,23 @@ kubectl exec -n voipbin deploy/bin-flow-manager -- curl -s localhost:9090/metric
 kubectl exec -n voipbin deploy/bin-flow-manager -- curl -s localhost:9090/metrics | grep action_error_total
 ```
 
+## Deployment
+
+bin-flow-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-flow-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-flow-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Env Var | Default | Description |

--- a/bin-flow-manager/komodo/docker-compose.yml
+++ b/bin-flow-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-flow-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  flow-manager:
+    image: voipbin/bin-flow-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-flow-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./flow-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-outdial-manager/README.md
+++ b/bin-outdial-manager/README.md
@@ -58,8 +58,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 # Deploy
 
-`bin-outdial-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-outdial-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-outdial-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-outdial-manager/docs/operations.md
+++ b/bin-outdial-manager/docs/operations.md
@@ -51,6 +51,23 @@ WHERE status = 'processing' AND tm_update < NOW() - INTERVAL 30 MINUTE
 curl -X PUT .../v1/outdialtargets/<id>/status -d '{"status": "idle"}'
 ```
 
+## Deployment
+
+bin-outdial-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-outdial-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-outdial-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Environment Variable | Default | Description |

--- a/bin-outdial-manager/komodo/docker-compose.yml
+++ b/bin-outdial-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-outdial-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  outdial-manager:
+    image: voipbin/bin-outdial-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-outdial-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./outdial-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-queue-manager/README.md
+++ b/bin-queue-manager/README.md
@@ -59,8 +59,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 # Deploy
 
-`bin-queue-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-queue-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-queue-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-queue-manager/docs/operations.md
+++ b/bin-queue-manager/docs/operations.md
@@ -57,6 +57,23 @@ kubectl exec -n voipbin deploy/bin-queue-manager -- curl -s localhost:9090/metri
 kubectl exec -n voipbin deploy/bin-queue-manager -- curl -s localhost:9090/metrics | grep queuecall_waiting_duration_seconds
 ```
 
+## Deployment
+
+bin-queue-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-queue-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-queue-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Env Var | Default | Description |

--- a/bin-queue-manager/komodo/docker-compose.yml
+++ b/bin-queue-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-queue-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  queue-manager:
+    image: voipbin/bin-queue-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-queue-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./queue-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-route-manager/README.md
+++ b/bin-route-manager/README.md
@@ -35,8 +35,7 @@ circuit breaker protects against downstream failure.
 
 # Deploy
 
-`bin-route-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-route-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-route-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-route-manager/docs/operations.md
+++ b/bin-route-manager/docs/operations.md
@@ -61,6 +61,31 @@ WHERE r.customer_id = '00000000-0000-0000-0000-000000000001'
 ORDER BY r.priority;
 ```
 
+## Deployment
+
+bin-route-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-route-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-route-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+- **Route-manager-specific deviation:** this service runs a background
+  health-check ticker (`pkg/healthcheckhandler`) that probes every
+  configured carrier via outbound SIP OPTIONS on an interval. During
+  old/new container overlap this doubles outbound probe traffic to
+  carriers, so — unlike the other Tier 1 services — cut over **promptly**
+  once the new container is confirmed healthy at the log level; do not
+  leave both containers running for an extended soak. See the design doc's
+  cutover section for the full rationale.
+
 ## Configuration
 
 | Flag | Environment Variable | Default | Description |

--- a/bin-route-manager/komodo/docker-compose.yml
+++ b/bin-route-manager/komodo/docker-compose.yml
@@ -1,0 +1,32 @@
+# Komodo Stack definition for bin-route-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager). NOTE:
+# route-manager runs a background health-check ticker
+# (pkg/healthcheckhandler) that probes carriers on an interval - the
+# design doc's cutover section calls out a shorter old/new overlap window
+# for this service specifically (do not leave both containers running for
+# an extended soak like the other Tier 1 services).
+services:
+  route-manager:
+    image: voipbin/bin-route-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-route-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./route-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-tag-manager/README.md
+++ b/bin-tag-manager/README.md
@@ -52,8 +52,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 # Deploy
 
-`bin-tag-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-tag-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-tag-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-tag-manager/docs/operations.md
+++ b/bin-tag-manager/docs/operations.md
@@ -45,6 +45,23 @@ golangci-lint run -v --timeout 5m
 go generate ./...
 ```
 
+## Deployment
+
+bin-tag-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-tag-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-tag-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag / Env | Description | Default |

--- a/bin-tag-manager/komodo/docker-compose.yml
+++ b/bin-tag-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-tag-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  tag-manager:
+    image: voipbin/bin-tag-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-tag-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./tag-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-talk-manager/README.md
+++ b/bin-talk-manager/README.md
@@ -4,8 +4,7 @@
 
 # Deploy
 
-`bin-talk-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-talk-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-talk-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-talk-manager/docs/operations.md
+++ b/bin-talk-manager/docs/operations.md
@@ -39,6 +39,23 @@ SELECT id, metadata FROM talk_messages WHERE JSON_VALID(metadata) = 0;
 ./bin/talk-control message list --chat-id <uuid>
 ```
 
+## Deployment
+
+bin-talk-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-talk-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-talk-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag / Env Var | Description | Default |

--- a/bin-talk-manager/komodo/docker-compose.yml
+++ b/bin-talk-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-talk-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  talk-manager:
+    image: voipbin/bin-talk-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-talk-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./talk-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-transfer-manager/README.md
+++ b/bin-transfer-manager/README.md
@@ -52,8 +52,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 # Deploy
 
-`bin-transfer-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-transfer-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-transfer-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-transfer-manager/docs/operations.md
+++ b/bin-transfer-manager/docs/operations.md
@@ -40,6 +40,23 @@ kubectl exec -n voipbin deploy/redis -- redis-cli keys "*transfer*"
 ./bin/transfer-control transfer cancel --id <transfer-uuid>
 ```
 
+## Deployment
+
+bin-transfer-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-transfer-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-transfer-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag / Env Var | Description | Default |

--- a/bin-transfer-manager/komodo/docker-compose.yml
+++ b/bin-transfer-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-transfer-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  transfer-manager:
+    image: voipbin/bin-transfer-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-transfer-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./transfer-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-webchat-manager/README.md
+++ b/bin-webchat-manager/README.md
@@ -1,9 +1,24 @@
 # webchat-manager
 
-# Deploy
+## Deployment
 
-`bin-webchat-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-webchat-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-webchat-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-webchat-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes the built
+  image tag, then `.circleci/scripts/komodo-api-deploy.sh` pushes the file's
+  content to Komodo and triggers a deploy, gated by the
+  `bin-webchat-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
+Note: bin-webchat-manager does not have a `docs/operations.md` file (only
+`docs/plans/`) — see [VOIP-1352](https://voipbin.atlassian.net/browse/VOIP-1352)
+for generating the full architecture/operations/domain/dependencies doc
+suite that `docs/reference/extractor.sh` produces for other services. Once
+that ticket lands, this `## Deployment` section should move to the new
+`docs/operations.md` and be removed from here.

--- a/bin-webchat-manager/komodo/docker-compose.yml
+++ b/bin-webchat-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-webchat-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  webchat-manager:
+    image: voipbin/bin-webchat-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-webchat-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./webchat-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-webhook-manager/README.md
+++ b/bin-webhook-manager/README.md
@@ -33,8 +33,7 @@ go test ./...
 
 # Deploy
 
-`bin-webhook-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-webhook-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+bin-webhook-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern). See
+[docs/operations.md](docs/operations.md#deployment) for the Stack
+definition, CI path, and full design/cutover procedure.

--- a/bin-webhook-manager/docs/operations.md
+++ b/bin-webhook-manager/docs/operations.md
@@ -1,5 +1,22 @@
 # bin-webhook-manager Operations
 
+## Deployment
+
+bin-webhook-manager deploys via Komodo (VOIP-1347 Tier 1 rollout, following the
+VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
+`versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-webhook-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-webhook-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags support equivalent `UPPER_SNAKE_CASE` environment variables.

--- a/bin-webhook-manager/komodo/docker-compose.yml
+++ b/bin-webhook-manager/komodo/docker-compose.yml
@@ -1,0 +1,27 @@
+# Komodo Stack definition for bin-webhook-manager (VOIP-1347, Tier 1 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager).
+services:
+  webhook-manager:
+    image: voipbin/bin-webhook-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-webhook-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./webhook-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md
+++ b/docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md
@@ -1,0 +1,188 @@
+# Design: roll out Komodo-managed deploy to 16 Tier 1 bin-*-manager services (VOIP-1347)
+
+## Goal
+
+Extend the Komodo-managed deploy pattern proven by VOIP-1342 (bin-call-manager,
+merged in PR #1188) to 16 additional services:
+
+agent, billing, campaign, conference, conversation, direct, flow, outdial,
+queue, route, tag, talk, transfer, webhook, contact, webchat
+(`bin-<short>-manager` for each).
+
+This is an **application of an already-verified pattern**, not new discovery
+work — see [2026-08-16-komodo-call-manager-cutover-design.md](2026-08-16-komodo-call-manager-cutover-design.md)
+for the original spike, empirical verification, and rationale. This doc only
+covers what differs for Tier 1: the things that are identical are stated
+once and not re-derived.
+
+## What's identical to bin-call-manager
+
+- **Compose file shape:** `<service>/komodo/docker-compose.yml`, one service
+  block, `image: voipbin/bin-<short>-manager:__IMAGE_TAG__`, `json-file`
+  logging (10m/3 files), `container_name: voipbin-<short>-manager`,
+  `restart: always`, `command: ./<short>-manager`, attached to the shared
+  `production` network (`external: true`).
+- **No healthcheck:** all 16 services build on
+  `gcr.io/distroless/static-debian12` (confirmed per-service Dockerfile) —
+  same as bin-call-manager, no shell/wget available for a Docker healthcheck.
+- **Binary name convention:** `./<short>-manager` confirmed per service via
+  each `Dockerfile`'s `go build -o /app/bin/ ./cmd/...` and each `cmd/`
+  directory listing — all 16 follow the same `<short>-manager` binary name
+  as `call-manager` does. No exceptions found.
+- **Env block:** `DATABASE_DSN`, `RABBITMQ_ADDRESS`, `REDIS_ADDRESS`,
+  `REDIS_DATABASE=1`, `PROMETHEUS_ENDPOINT`, `PROMETHEUS_LISTEN_ADDRESS` —
+  byte-identical across all 16 in `voipbin/install/docker-compose.yml.dist`.
+  `REDIS_PASSWORD` is absent for all 16, same as bin-call-manager — omitted
+  entirely rather than left commented out.
+  - **Tier 1's env list is simpler than bin-call-manager's.** bin-call-manager
+    additionally sets `PROJECT_BASE_DOMAIN`, `PROJECT_BUCKET_NAME`, and the
+    three `HOMER_*` vars (media storage + SIP capture integration specific to
+    call-manager). None of the 16 Tier 1 services have those envs in
+    `install/docker-compose.yml.dist`, so they are correctly omitted here —
+    not an oversight.
+- **CI mechanics reused as-is, unmodified:** `.circleci/scripts/render-image-tag.sh`
+  and `.circleci/scripts/komodo-api-deploy.sh` are already generic (operate
+  on a `komodo/docker-compose.yml` path and a service name passed as
+  arguments) and already exercised in production by bin-call-manager. The
+  16 new `<service>-deploy` CI jobs call them exactly as
+  `bin-call-manager-deploy` does, with the same
+  `CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3` budget.
+- **These 16 services had no deploy job at all before this PR** (only
+  `-test`/`-build`) — the old SSH `ssh-deploy.sh` wiring was removed for all
+  non-call-manager services in a prior cleanup
+  (`817c24db6 NOJIRA-Remove-ssh-deploy-bm-nyc-01 (#1189)`, immediately after
+  the bin-call-manager cutover). This PR adds new `-deploy` jobs; it does
+  not replace or conflict with anything currently running.
+- **Komodo Variables (`[[BIN_MANAGER__*]]`):** resolved by Komodo itself from
+  its global Variables store, already synced from infra-secret. Nothing in
+  this PR or CI supplies these values — same as bin-call-manager.
+
+## Decision: start on `production`, skip the `install_default` detour
+
+bin-call-manager's Stack originally targeted `install_default` and was
+corrected to the shared `production` network later (VOIP-1343, filed
+alongside VOIP-1342) once that Komodo-managed backbone network existed. All
+16 Tier 1 compose files here are written directly against `production` from
+the start — there is no interim `install_default` step to migrate away from.
+Precondition (same as bin-call-manager, already satisfied on bm-nyc-01):
+db/redis/rabbitmq must be reachable from `production`, which
+`monorepo-etc/infra-komodo/komodo/backfill-install-default.sh --apply` has
+already bridged.
+
+## Cutover procedure (standard, 15 of 16 services)
+
+Per service, after this PR merges and its `-deploy` job runs for the first
+time:
+
+1. **Deploy via CI** — the new `<service>-deploy` job pushes the compose
+   file to Komodo and triggers a deploy. Because the new container's name
+   (`voipbin-<short>-manager`) differs from the old install-managed
+   container's name, Docker does not refuse to run both at once. The new
+   container joins as an **additional** RabbitMQ competing consumer
+   alongside the old one — confirmed zero-gap-safe by the bin-call-manager
+   pilot (VOIP-1342): RabbitMQ delivers each message to exactly one
+   competing consumer, so having two consumers briefly overlap causes no
+   duplicate processing or dropped messages, only doubled idle
+   polling/heartbeat overhead for the overlap window.
+
+   **Old container name, per service — check before assuming
+   `voipbin-<short>-mgr`:** 14 of the 16 services have a pinned
+   `container_name: voipbin-<short>-mgr` in
+   `voipbin/install/docker-compose.yml.dist` (e.g.
+   `voipbin-route-mgr`, `voipbin-webhook-mgr`) — for those, step 3 below is
+   `docker rm voipbin-<short>-mgr` as expected. **`bin-contact-manager` and
+   `bin-webchat-manager` have no `container_name:` pinned** in that file, so
+   Compose auto-names their old containers (`install-<service>-1`-style,
+   scoped to the install project's working directory). For those two, do
+   not guess the name — run `docker compose -f
+   /opt/voipbin/install/docker-compose.yml ps <short>-manager` (or `docker
+   ps | grep <short>`) on bm-nyc-01 first to find the actual old container
+   before removing it.
+2. **Verify at the application log level, not just container running-state.**
+   VOIP-1342's false-positive lesson: the CI job's 3-consecutive-running
+   gate only checks Docker process state, not application health — a
+   container can be "running" while its app is crash-looping on a bad DB
+   connection (e.g. before the `production` network backfill was applied).
+   Before removing the old container, `docker logs` the **new** container
+   and confirm:
+   - a connection-success line for RabbitMQ/DB/Redis, and
+   - the absence of `CRITICAL`/`Error`-level lines from the boot path.
+3. **Remove the old container** once the new one is confirmed healthy at the
+   log level.
+4. **Comment out the removed service's block** in bm-nyc-01's live
+   `/opt/voipbin/install/docker-compose.yml` (SSH), matching VOIP-1342's
+   step 6 — prevents the install-managed compose project from recreating the
+   old container on its next `docker compose up`.
+5. **Confirm a single RabbitMQ consumer** remains for the service's queues
+   (via the RabbitMQ management UI/API) — the overlap window is closed.
+
+For 15 of the 16 services, there is no urgency forcing step 3 to happen
+quickly — "leave both running, verify at leisure, then cut over" is safe
+because none of them have a background loop that would compound the
+overlap's cost beyond doubled idle consumer overhead.
+
+## Deviation: bin-route-manager needs a short overlap window
+
+`bin-route-manager` runs a background health-check ticker
+(`pkg/healthcheckhandler/health.go`, `Run()`, started from
+`cmd/route-manager/main.go`) that sends outbound SIP OPTIONS probes to every
+configured carrier on an interval and writes `ProviderUpdateHealthStatus` to
+the DB. During old+new container overlap, **both** containers run this
+ticker independently, which:
+
+- **Doubles outbound SIP OPTIONS probe traffic** to every configured
+  carrier for the duration of the overlap — carriers may rate-limit or flag
+  this, unlike the other 15 services' pure idle-consumer overhead.
+- **Produces concurrent, non-corrupting but wasteful DB writes**
+  (`ProviderUpdateHealthStatus` from both containers, last-write-wins on the
+  same rows — no data corruption, just redundant writes).
+
+This was verified to be unique to route-manager: a grep for
+`time.NewTicker`/`time.Tick`/`cron\.` across all 16 Tier 1 services' source
+trees found this loop only in bin-route-manager.
+
+**Deviation from the standard flow:** for bin-route-manager specifically,
+after confirming the new container is healthy at the application log level
+(cutover step 2 above), remove the old container **promptly** — do not leave
+both running for an extended soak the way the other 15 services can. The
+verification step itself (log-level health check) is unchanged; only the
+old-container removal timing is tightened for this one service.
+
+## Doc gap: bin-webchat-manager
+
+`bin-webchat-manager` has no `docs/operations.md` (only `docs/plans/`), so
+its `## Deployment` section was added to `bin-webchat-manager/README.md`
+instead. It is missing the standard architecture/operations/domain/dependencies
+doc suite that `docs/reference/extractor.sh` produces for other services —
+[VOIP-1352](https://voipbin.atlassian.net/browse/VOIP-1352) tracks
+generating that suite; it is out of scope for this PR.
+
+## Testing
+
+No Go source changes — this PR only touches `komodo/docker-compose.yml`
+files (new), `.circleci/config_work.yml` (CI wiring), and doc files. The
+5-step Go verification workflow (`go mod tidy && go mod vendor && go
+generate && go test && golangci-lint`) is a no-op here and was not run
+against all 16 services' source trees. What was verified instead:
+
+- `.circleci/config_work.yml` parses as valid YAML
+  (`python3 -c "import yaml; yaml.safe_load(open(...))"`).
+- Each of the 16 new `-deploy` jobs is present under `jobs:` and wired into
+  its service's workflow block with `requires: [<service>-build]`, matching
+  `bin-call-manager-deploy`'s pattern.
+- `git status` confirms only `komodo/` (16 new compose files), 15
+  services' `docs/operations.md` (webchat has none — see the Doc gap
+  section above), all 16 `README.md` files, two small stale-count fixes in
+  `bin-call-manager`'s own `docs/operations.md` and
+  `komodo/docker-compose.yml` (its "other 31 services" framing was
+  falsified by this PR the moment it merges — see below), this design doc,
+  and `.circleci/config_work.yml` changed — no `.go` files touched.
+
+## Explicitly out of scope
+
+- Running any of the 16 new `-deploy` jobs, or performing any cutover step,
+  is **not** part of this PR. This PR ends at an open, reviewable PR — the
+  actual deploy/cutover for each service is a separate follow-up step after
+  human review, same as VOIP-1342.
+- Generating bin-webchat-manager's missing doc suite (tracked in
+  [VOIP-1352](https://voipbin.atlassian.net/browse/VOIP-1352)).


### PR DESCRIPTION
Extend the Komodo-managed deploy pattern proven by VOIP-1342 (bin-call-manager,
merged in PR #1188) to 16 more bin-*-manager services, adding new
`<service>-deploy` CI jobs where none existed before (these 16 services'
old ssh-deploy.sh wiring was already fully removed in a prior cleanup, so
this PR is additive, not a replacement).

- bin-agent-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-billing-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-campaign-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-conference-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-conversation-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-direct-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-flow-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-outdial-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-queue-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-route-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section with health-check-ticker cutover carve-out
- bin-tag-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-talk-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-transfer-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-webhook-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-contact-manager: Add komodo/docker-compose.yml, CI deploy job, docs/operations.md Deployment section
- bin-webchat-manager: Add komodo/docker-compose.yml, CI deploy job, README.md Deployment section (no docs/operations.md yet, tracked in VOIP-1352)
- bin-call-manager: Update docs/operations.md and komodo/docker-compose.yml to reference VOIP-1347 instead of the stale VOIP-1342-era "other 31 services" framing
- monorepo: Update all 16 Tier 1 services' README.md to point at the new Deployment section instead of the stale "deploys are manual" text
- monorepo: Add docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md covering the shared design, the production-network-from-the-start decision, the standard cutover procedure, and the bin-route-manager-specific short-overlap-window deviation

No Go source was changed. Deploy/cutover for each service is a separate,
manual follow-up step after human review of this PR, same as VOIP-1342 --
this PR does not run any deploy job or touch bm-nyc-01.
