### PR TITLE
VOIP-1348-Roll-out-tier2-bin-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -293,6 +293,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-ai-manager-test
+      - bin-ai-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-ai-manager-build
   bin-common-handler:
     when: << pipeline.parameters.run-bin-common-handler >>
     jobs:
@@ -362,6 +366,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-customer-manager-test
+      - bin-customer-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-customer-manager-build
   # bin-dbscheme-manager: CI does not apply migrations. The production
   # bin_manager / asterisk databases are not reachable from CircleCI's
   # executors (confirmed 2026-07-11, VOIP-1246: a read-only DSN probe on
@@ -424,6 +432,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-email-manager-test
+      - bin-email-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-email-manager-build
   bin-flow-manager:
     when: << pipeline.parameters.run-bin-flow-manager >>
     jobs:
@@ -464,6 +476,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-message-manager-test
+      - bin-message-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-message-manager-build
   bin-number-manager:
     when: << pipeline.parameters.run-bin-number-manager >>
     jobs:
@@ -476,6 +492,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-number-manager-test
+      - bin-number-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-number-manager-build
   bin-openapi-manager:
     when: << pipeline.parameters.run-bin-openapi-manager >>
     jobs:
@@ -553,6 +573,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-registrar-manager-test
+      - bin-registrar-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-registrar-manager-build
   bin-route-manager:
     when: << pipeline.parameters.run-bin-route-manager >>
     jobs:
@@ -717,6 +741,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-tts-manager-test
+      - bin-tts-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-tts-manager-build
   bin-webchat-manager:
     when: << pipeline.parameters.run-bin-webchat-manager >>
     jobs:
@@ -988,6 +1016,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-ai-manager
 
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-ai-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-ai-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-ai-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-ai-manager bin-ai-manager/komodo/docker-compose.yml
+
   # bin-common-handler
   bin-common-handler-test:
     docker: *go_image
@@ -1118,6 +1164,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-customer-manager
 
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-customer-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-customer-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-customer-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-customer-manager bin-customer-manager/komodo/docker-compose.yml
+
   # bin-dbscheme-manager has no build/deploy job -- production DB is not
   # reachable from CircleCI, so all migration application is manual/VPN.
   # See bin-dbscheme-manager/docs/operations.md for why, and
@@ -1220,6 +1284,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-email-manager
 
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-email-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-email-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-email-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-email-manager bin-email-manager/komodo/docker-compose.yml
+
   # bin-flow-manager
   bin-flow-manager-test:
     docker: *go_image
@@ -1289,6 +1371,24 @@ jobs:
           project-repository: bin-message-manager
           source-directory: bin-message-manager
 
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-message-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-message-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-message-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-message-manager bin-message-manager/komodo/docker-compose.yml
+
   # bin-number-manager
   bin-number-manager-test:
     docker: *go_image
@@ -1305,6 +1405,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-number-manager
           source-directory: bin-number-manager
+
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-number-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-number-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-number-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-number-manager bin-number-manager/komodo/docker-compose.yml
 
   # bin-openapi-manager
   bin-openapi-manager-validate:
@@ -1454,6 +1572,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-registrar-manager
           source-directory: bin-registrar-manager
+
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-registrar-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-registrar-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-registrar-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-registrar-manager bin-registrar-manager/komodo/docker-compose.yml
 
   # bin-route-manager
   bin-route-manager-test:
@@ -1723,6 +1859,24 @@ jobs:
           project-id: voipbin
           project-repository: bin-tts-manager
           source-directory: bin-tts-manager
+
+  # VOIP-1348 Tier 2 rollout: Komodo-managed deploy, following the
+  # VOIP-1342/bin-call-manager and VOIP-1347/Tier 1 pattern. See
+  # docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md.
+  bin-tts-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-tts-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-tts-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-tts-manager bin-tts-manager/komodo/docker-compose.yml
 
   # bin-webchat-manager
   bin-webchat-manager-test:

--- a/bin-ai-manager/docs/operations.md
+++ b/bin-ai-manager/docs/operations.md
@@ -1,5 +1,22 @@
 # bin-ai-manager Operations
 
+## Deployment
+
+bin-ai-manager deploys via Komodo (VOIP-1348 Tier 2 rollout, following the
+VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1 pattern) instead of
+the older SSH + `versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-ai-manager/komodo/docker-compose.yml` (git is
+  the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-ai-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags support equivalent `UPPER_SNAKE_CASE` environment variables.

--- a/bin-ai-manager/komodo/docker-compose.yml
+++ b/bin-ai-manager/komodo/docker-compose.yml
@@ -1,0 +1,29 @@
+# Komodo Stack definition for bin-ai-manager (VOIP-1348, Tier 2 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1).
+services:
+  ai-manager:
+    image: voipbin/bin-ai-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-ai-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - ENGINE_KEY_CHATGPT=[[BIN_MANAGER__ENGINE_KEY_CHATGPT]]
+    command: ./ai-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-customer-manager/docs/operations.md
+++ b/bin-customer-manager/docs/operations.md
@@ -54,6 +54,24 @@ PROMETHEUS_LISTEN_ADDRESS=":2112" \
 ./bin/customer-manager
 ```
 
+## Deployment
+
+bin-customer-manager deploys via Komodo (VOIP-1348 Tier 2 rollout,
+following the VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1
+pattern) instead of the older SSH + `versions.lock` (`ssh-deploy.sh`)
+path.
+
+- **Stack definition:** `bin-customer-manager/komodo/docker-compose.yml`
+  (git is the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-customer-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags can also be set via environment variable (uppercase, underscores).

--- a/bin-customer-manager/komodo/docker-compose.yml
+++ b/bin-customer-manager/komodo/docker-compose.yml
@@ -1,0 +1,35 @@
+# Komodo Stack definition for bin-customer-manager (VOIP-1348, Tier 2 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1).
+#
+# EMAIL_VERIFY_BASE_URL is a plain literal, not a Komodo Variable reference:
+# it is a public-facing base URL (not a credential), and its production
+# value already matches the Go binary's own built-in default
+# (internal/config/main.go, email_verify_base_url flag default
+# "https://api.voipbin.net").
+services:
+  customer-manager:
+    image: voipbin/bin-customer-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-customer-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - EMAIL_VERIFY_BASE_URL=https://api.voipbin.net
+    command: ./customer-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-email-manager/docs/operations.md
+++ b/bin-email-manager/docs/operations.md
@@ -45,6 +45,23 @@ MAILGUN_API_KEY="xxx" \
 **Check email delivery via SendGrid Activity Feed:**
 - SendGrid dashboard → Activity → search by recipient email or `provider_reference_id`
 
+## Deployment
+
+bin-email-manager deploys via Komodo (VOIP-1348 Tier 2 rollout, following
+the VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1 pattern)
+instead of the older SSH + `versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-email-manager/komodo/docker-compose.yml`
+  (git is the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-email-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags can also be set via environment variable (uppercase, underscores).

--- a/bin-email-manager/komodo/docker-compose.yml
+++ b/bin-email-manager/komodo/docker-compose.yml
@@ -1,0 +1,30 @@
+# Komodo Stack definition for bin-email-manager (VOIP-1348, Tier 2 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1).
+services:
+  email-manager:
+    image: voipbin/bin-email-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-email-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - SENDGRID_API_KEY=[[BIN_MANAGER__SENDGRID_API_KEY]]
+      - MAILGUN_API_KEY=[[BIN_MANAGER__MAILGUN_API_KEY]]
+    command: ./email-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-message-manager/docs/operations.md
+++ b/bin-message-manager/docs/operations.md
@@ -48,6 +48,24 @@ AUTHTOKEN_TELNYX="your-token" \
 ./bin/message-manager
 ```
 
+## Deployment
+
+bin-message-manager deploys via Komodo (VOIP-1348 Tier 2 rollout,
+following the VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1
+pattern) instead of the older SSH + `versions.lock` (`ssh-deploy.sh`)
+path.
+
+- **Stack definition:** `bin-message-manager/komodo/docker-compose.yml`
+  (git is the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-message-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags can also be set via environment variable (uppercase, underscores).

--- a/bin-message-manager/komodo/docker-compose.yml
+++ b/bin-message-manager/komodo/docker-compose.yml
@@ -1,0 +1,30 @@
+# Komodo Stack definition for bin-message-manager (VOIP-1348, Tier 2 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1).
+services:
+  message-manager:
+    image: voipbin/bin-message-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-message-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - AUTHTOKEN_MESSAGEBIRD=[[BIN_MANAGER__AUTHTOKEN_MESSAGEBIRD]]
+      - AUTHTOKEN_TELNYX=[[BIN_MANAGER__AUTHTOKEN_TELNYX]]
+    command: ./message-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-number-manager/docs/operations.md
+++ b/bin-number-manager/docs/operations.md
@@ -49,6 +49,24 @@ TELNYX_PROFILE_ID="<profile-id>" \
 ./bin/number-manager
 ```
 
+## Deployment
+
+bin-number-manager deploys via Komodo (VOIP-1348 Tier 2 rollout,
+following the VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1
+pattern) instead of the older SSH + `versions.lock` (`ssh-deploy.sh`)
+path.
+
+- **Stack definition:** `bin-number-manager/komodo/docker-compose.yml`
+  (git is the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-number-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 All flags can also be set via environment variable (uppercase, underscores).

--- a/bin-number-manager/komodo/docker-compose.yml
+++ b/bin-number-manager/komodo/docker-compose.yml
@@ -1,0 +1,33 @@
+# Komodo Stack definition for bin-number-manager (VOIP-1348, Tier 2 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1).
+services:
+  number-manager:
+    image: voipbin/bin-number-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-number-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - TWILIO_SID=[[BIN_MANAGER__TWILIO_SID]]
+      - TWILIO_TOKEN=[[BIN_MANAGER__TWILIO_TOKEN]]
+      - TELNYX_CONNECTION_ID=[[BIN_MANAGER__TELNYX_CONNECTION_ID]]
+      - TELNYX_PROFILE_ID=[[BIN_MANAGER__TELNYX_PROFILE_ID]]
+      - TELNYX_TOKEN=[[BIN_MANAGER__TELNYX_TOKEN]]
+    command: ./number-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-registrar-manager/docs/operations.md
+++ b/bin-registrar-manager/docs/operations.md
@@ -49,6 +49,26 @@ rabbitmqctl list_queues name messages consumers | grep registrar
 redis-cli -n 1 keys "registrar:contact:*" | head -10
 ```
 
+## Deployment
+
+bin-registrar-manager deploys via Komodo (VOIP-1348 Tier 2 rollout,
+following the VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1
+pattern) instead of the older SSH + `versions.lock` (`ssh-deploy.sh`)
+path. Its Komodo Stack definition sets **both** `DATABASE_DSN_BIN` and
+`DATABASE_DSN_ASTERISK` (the only Tier 2 service with two database
+DSNs).
+
+- **Stack definition:** `bin-registrar-manager/komodo/docker-compose.yml`
+  (git is the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-registrar-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag | Environment Variable | Default | Description |

--- a/bin-registrar-manager/komodo/docker-compose.yml
+++ b/bin-registrar-manager/komodo/docker-compose.yml
@@ -1,0 +1,35 @@
+# Komodo Stack definition for bin-registrar-manager (VOIP-1348, Tier 2
+# rollout). See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md
+# for the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1).
+#
+# NOTE: registrar-manager is the only Tier 2 service with two database DSNs
+# (bin_manager + asterisk) -- both already exist as separate Komodo
+# Variables.
+services:
+  registrar-manager:
+    image: voipbin/bin-registrar-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-registrar-manager
+    restart: always
+    environment:
+      - DATABASE_DSN_BIN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - DATABASE_DSN_ASTERISK=[[BIN_MANAGER__DATABASE_DSN_ASTERISK]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - DOMAIN_NAME_EXTENSION=[[BIN_MANAGER__DOMAIN_NAME_EXTENSION]]
+      - DOMAIN_NAME_TRUNK=[[BIN_MANAGER__DOMAIN_NAME_TRUNK]]
+    command: ./registrar-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-tts-manager/docs/operations.md
+++ b/bin-tts-manager/docs/operations.md
@@ -45,6 +45,23 @@ kubectl exec -n voipbin deploy/rabbitmq -- rabbitmqctl list_queues name messages
 kubectl logs -n voipbin -l app=tts-manager -c tts-manager --tail=200 | grep -E "ERROR|streaming|elevenlabs"
 ```
 
+## Deployment
+
+bin-tts-manager deploys via Komodo (VOIP-1348 Tier 2 rollout, following
+the VOIP-1342/bin-call-manager pilot and VOIP-1347/Tier 1 pattern)
+instead of the older SSH + `versions.lock` (`ssh-deploy.sh`) path.
+
+- **Stack definition:** `bin-tts-manager/komodo/docker-compose.yml` (git
+  is the source of truth for structure; Komodo only executes it on
+  request).
+- **CI path:** `.circleci/scripts/render-image-tag.sh` substitutes
+  the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
+  pushes the file's content to Komodo and triggers a deploy, gated
+  by the `bin-tts-manager-deploy` job's poll/running checks.
+- **Full design and cutover procedure:**
+  [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
+  (in the monorepo root, not this service's own `docs/`).
+
 ## Configuration
 
 | Flag / Env Var | Description | Default |

--- a/bin-tts-manager/komodo/docker-compose.yml
+++ b/bin-tts-manager/komodo/docker-compose.yml
@@ -1,0 +1,34 @@
+# Komodo Stack definition for bin-tts-manager (VOIP-1348, Tier 2 rollout).
+# See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for
+# the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/Tier 1). Per-connection time.NewTicker usages in
+# pkg/streaminghandler (websocket keepalive/write pacing) are scoped to
+# individual streaming sessions, not a global background loop -- see the
+# design doc's ticker/cron audit.
+services:
+  tts-manager:
+    image: voipbin/bin-tts-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-tts-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - AWS_ACCESS_KEY=[[BIN_MANAGER__AWS_ACCESS_KEY]]
+      - AWS_SECRET_KEY=[[BIN_MANAGER__AWS_SECRET_KEY]]
+      - ELEVENLABS_API_KEY=[[BIN_MANAGER__ELEVENLABS_API_KEY]]
+    command: ./tts-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md
+++ b/docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md
@@ -1,0 +1,168 @@
+# Design: roll out Komodo-managed deploy to 7 Tier 2 bin-*-manager services (VOIP-1348)
+
+## Goal
+
+Extend the Komodo-managed deploy pattern proven by VOIP-1342
+(bin-call-manager, PR #1188) and applied to 16 services by VOIP-1347
+(Tier 1, PR #1190) to 7 more services:
+
+ai, customer, number, tts, email, message, registrar
+(`bin-<short>-manager` for each).
+
+This is the **third application of an already-verified pattern** — see
+[2026-08-16-komodo-call-manager-cutover-design.md](2026-08-16-komodo-call-manager-cutover-design.md)
+for the original spike and
+[2026-08-18-bin-manager-komodo-rollout-tier1-design.md](2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
+for the Tier 1 rollout. This doc only covers what is new for Tier 2.
+
+## Excluded: bin-hook-manager
+
+`bin-hook-manager` is explicitly **out of scope** for this PR. It needs
+`SSL_CERT_BASE64`/`SSL_PRIVKEY_BASE64` Komodo Variables that do not exist
+yet — confirmed absent from the known `[[BIN_MANAGER__*]]` set, and the
+live GKE/install container uses real non-empty certificate values
+(~7600/2272 chars) that cannot be reconstructed or guessed. Tracked
+separately as [VOIP-1353](https://voipbin.atlassian.net/browse/VOIP-1353)
+(infra-secret work, different repo). No `bin-hook-manager/` files are
+touched by this PR.
+
+## What's new for Tier 2: provider-secret env vars
+
+Unlike Tier 1 (whose 16 services shared one identical, secret-free env
+block), all 7 Tier 2 services carry one or more extra
+provider/integration secrets on top of the common
+`DATABASE_DSN`/`RABBITMQ_ADDRESS`/`REDIS_ADDRESS`/`REDIS_DATABASE`/
+`PROMETHEUS_*` block. Every one of them was already confirmed present in
+Komodo's `[[BIN_MANAGER__*]]` Variables store (synced from
+`infra-secret/secrets-source/bin-manager`) — nothing new needed to be
+provisioned:
+
+| Service | Extra env vars | Komodo Variable(s) |
+|---|---|---|
+| bin-ai-manager | `ENGINE_KEY_CHATGPT` | `[[BIN_MANAGER__ENGINE_KEY_CHATGPT]]` |
+| bin-customer-manager | `EMAIL_VERIFY_BASE_URL` | plain literal (not a secret — see below) |
+| bin-number-manager | `TWILIO_SID`, `TWILIO_TOKEN`, `TELNYX_CONNECTION_ID`, `TELNYX_PROFILE_ID`, `TELNYX_TOKEN` | `[[BIN_MANAGER__TWILIO_SID]]`, `[[BIN_MANAGER__TWILIO_TOKEN]]`, `[[BIN_MANAGER__TELNYX_CONNECTION_ID]]`, `[[BIN_MANAGER__TELNYX_PROFILE_ID]]`, `[[BIN_MANAGER__TELNYX_TOKEN]]` |
+| bin-tts-manager | `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `ELEVENLABS_API_KEY` | `[[BIN_MANAGER__AWS_ACCESS_KEY]]`, `[[BIN_MANAGER__AWS_SECRET_KEY]]`, `[[BIN_MANAGER__ELEVENLABS_API_KEY]]` |
+| bin-email-manager | `SENDGRID_API_KEY`, `MAILGUN_API_KEY` | `[[BIN_MANAGER__SENDGRID_API_KEY]]`, `[[BIN_MANAGER__MAILGUN_API_KEY]]` |
+| bin-message-manager | `AUTHTOKEN_MESSAGEBIRD`, `AUTHTOKEN_TELNYX` | `[[BIN_MANAGER__AUTHTOKEN_MESSAGEBIRD]]`, `[[BIN_MANAGER__AUTHTOKEN_TELNYX]]` |
+| bin-registrar-manager | `DATABASE_DSN_ASTERISK` (in addition to the renamed `DATABASE_DSN_BIN`), `DOMAIN_NAME_EXTENSION`, `DOMAIN_NAME_TRUNK` | `[[BIN_MANAGER__DATABASE_DSN_ASTERISK]]`, `[[BIN_MANAGER__DOMAIN_NAME_EXTENSION]]`, `[[BIN_MANAGER__DOMAIN_NAME_TRUNK]]` |
+
+All values were read directly from each service's own block in
+`voipbin/install/docker-compose.yml.dist` (not a secondhand summary), then
+mapped by key name to the confirmed-existing Komodo Variable set.
+
+### bin-customer-manager's `EMAIL_VERIFY_BASE_URL` is a plain literal, not a secret
+
+`EMAIL_VERIFY_BASE_URL` is not in the known `[[BIN_MANAGER__*]]` set. It
+was checked and found to be a public-facing base URL used to build
+email-verification links, not a credential — and its default is already
+hardcoded in the Go binary itself
+(`bin-customer-manager/internal/config/main.go`, the
+`email_verify_base_url` flag defaults to `"https://api.voipbin.net"`,
+VoIPbin's real production API host). The Komodo compose file sets it as a
+plain literal (`EMAIL_VERIFY_BASE_URL=https://api.voipbin.net`), matching
+that code default — not a `[[BIN_MANAGER__...]]` reference, and not a
+guess.
+
+### bin-registrar-manager: dual database DSN
+
+`bin-registrar-manager` is the only Tier 2 service with two database
+connections: `DATABASE_DSN_BIN` (the shared `bin_manager` schema) and
+`DATABASE_DSN_ASTERISK` (the Asterisk realtime schema, for SIP
+registration state). Both map to already-existing, separate Komodo
+Variables (`[[BIN_MANAGER__DATABASE_DSN_BIN]]` and
+`[[BIN_MANAGER__DATABASE_DSN_ASTERISK]]`) — no new provisioning needed.
+
+## What's identical to Tier 1 / bin-call-manager
+
+- **Compose file shape:** `<service>/komodo/docker-compose.yml`, one
+  service block, `image: voipbin/bin-<short>-manager:__IMAGE_TAG__`,
+  `json-file` logging (10m/3 files), `container_name:
+  voipbin-<short>-manager`, `restart: always`, `command:
+  ./<short>-manager`, attached to the shared `production` network
+  (`external: true`), no `install_default` detour.
+- **No healthcheck:** all 7 services build on
+  `gcr.io/distroless/static-debian12` (confirmed per-service Dockerfile
+  `FROM` line) — no shell/wget available for a Docker healthcheck.
+- **Binary name convention:** `./<short>-manager` confirmed per service
+  via each `Dockerfile` and `cmd/` directory listing (each `cmd/` also
+  has a `<short>-control` CLI binary, not used here). No exceptions.
+- **CI mechanics reused as-is, unmodified:**
+  `.circleci/scripts/render-image-tag.sh` and
+  `.circleci/scripts/komodo-api-deploy.sh` are already generic. The 7 new
+  `<service>-deploy` CI jobs call them exactly as `bin-call-manager-deploy`
+  and the Tier 1 jobs do, with the same
+  `CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3` budget.
+- **These 7 services had no deploy job at all before this PR** (only
+  `-test`/`-build`) — same as Tier 1. This PR adds new `-deploy` jobs; it
+  does not replace or conflict with anything currently running.
+- **Komodo Variables (`[[BIN_MANAGER__*]]`):** resolved by Komodo itself
+  from its global Variables store, already synced from infra-secret.
+  Nothing in this PR or CI supplies these values.
+
+## Background-loop audit
+
+Grepped all 7 services' source trees for `time.NewTicker`,
+`time.Tick(`, and `cron\.` (the same check that caught
+`bin-route-manager`'s carrier health-check ticker in Tier 1). Only
+`bin-tts-manager` has hits, all in `pkg/streaminghandler/` (websocket
+write-pacing and provider keepalive tickers for GCP and ElevenLabs
+streaming sessions). These are scoped to individual per-connection
+streaming sessions, not a global background scheduler — an old/new
+container overlap does not compound their cost the way route-manager's
+provider-wide health-check loop did (that loop runs continuously and
+probes every configured carrier regardless of active traffic). No
+service in this batch needs a shortened cutover overlap window.
+
+## Cutover procedure
+
+Identical to Tier 1's standard flow — see
+[2026-08-18-bin-manager-komodo-rollout-tier1-design.md](2026-08-18-bin-manager-komodo-rollout-tier1-design.md#cutover-procedure-standard-15-of-16-services)
+for the full step-by-step. Summary, per service, after this PR merges and
+its `-deploy` job runs for the first time:
+
+1. Deploy via CI — the new container joins as an **additional** RabbitMQ
+   competing consumer alongside the old one (zero-gap-safe, confirmed by
+   the VOIP-1342 pilot).
+2. Verify at the **application log level**, not just Docker
+   running-state — `docker logs` the new container and confirm a
+   connection-success line for RabbitMQ/DB/Redis and no
+   `CRITICAL`/`Error`-level lines from the boot path (VOIP-1342's
+   false-positive lesson: "running" state alone does not mean the app is
+   healthy).
+3. Remove the old container once the new one is confirmed healthy at the
+   log level. Check the old container's actual name first — some
+   services in `voipbin/install/docker-compose.yml.dist` pin
+   `container_name: voipbin-<short>-mgr`, others leave it
+   Compose-assigned.
+4. Comment out the removed service's block in bm-nyc-01's live
+   `/opt/voipbin/install/docker-compose.yml` (SSH), preventing the
+   install-managed compose project from recreating the old container.
+5. Confirm a single RabbitMQ consumer remains for the service's queues.
+
+## Testing
+
+No Go source changes — this PR only touches `komodo/docker-compose.yml`
+files (new, 7), `.circleci/config_work.yml` (CI wiring), 7 services'
+`docs/operations.md`, and this design doc. The 5-step Go verification
+workflow (`go mod tidy && go mod vendor && go generate && go test &&
+golangci-lint`) is a no-op here and was not run. What was verified
+instead:
+
+- `.circleci/config_work.yml` parses as valid YAML
+  (`python3 -c "import yaml; yaml.safe_load(open(...))"`).
+- Each of the 7 new `-deploy` jobs is present under `jobs:` and wired
+  into its service's workflow block with `requires: [<service>-build]`,
+  matching the Tier 1/bin-call-manager pattern.
+- `git status` confirms only `komodo/` (7 new compose files), 7
+  services' `docs/operations.md`, this design doc, and
+  `.circleci/config_work.yml` changed — no `.go` files touched, and
+  nothing under `bin-hook-manager/`.
+
+## Explicitly out of scope
+
+- `bin-hook-manager` (see above — VOIP-1353 dependency).
+- Running any of the 7 new `-deploy` jobs, or performing any cutover
+  step, is **not** part of this PR. This PR ends at an open, reviewable
+  PR — the actual deploy/cutover for each service is a separate
+  follow-up step after human review, same as VOIP-1342 and VOIP-1347.


### PR DESCRIPTION
Extend the Komodo-managed deploy pattern (VOIP-1342 pilot, PR #1188; VOIP-1347 Tier 1, PR #1190) to 7 Tier 2 bin-*-manager services. bin-hook-manager is explicitly excluded from this PR — it needs SSL_CERT_BASE64/SSL_PRIVKEY_BASE64 Komodo Variables that do not exist yet (confirmed absent from infra-secret/secrets-source/bin-manager; the live container uses real non-empty certificate values that cannot be reconstructed), tracked separately as VOIP-1353 (infra-secret work, different repo).

- bin-ai-manager: Add komodo/docker-compose.yml, bin-ai-manager-deploy CI job, docs/operations.md Deployment section (extra secret: ENGINE_KEY_CHATGPT)
- bin-customer-manager: Add komodo/docker-compose.yml, bin-customer-manager-deploy CI job, docs/operations.md Deployment section (EMAIL_VERIFY_BASE_URL set as a plain literal, not a secret — matches the Go binary's own production default)
- bin-number-manager: Add komodo/docker-compose.yml, bin-number-manager-deploy CI job, docs/operations.md Deployment section (extra secrets: TWILIO_SID, TWILIO_TOKEN, TELNYX_CONNECTION_ID, TELNYX_PROFILE_ID, TELNYX_TOKEN)
- bin-tts-manager: Add komodo/docker-compose.yml, bin-tts-manager-deploy CI job, docs/operations.md Deployment section (extra secrets: AWS_ACCESS_KEY, AWS_SECRET_KEY, ELEVENLABS_API_KEY)
- bin-email-manager: Add komodo/docker-compose.yml, bin-email-manager-deploy CI job, docs/operations.md Deployment section (extra secrets: SENDGRID_API_KEY, MAILGUN_API_KEY)
- bin-message-manager: Add komodo/docker-compose.yml, bin-message-manager-deploy CI job, docs/operations.md Deployment section (extra secrets: AUTHTOKEN_MESSAGEBIRD, AUTHTOKEN_TELNYX)
- bin-registrar-manager: Add komodo/docker-compose.yml, bin-registrar-manager-deploy CI job, docs/operations.md Deployment section (dual DATABASE_DSN_BIN/DATABASE_DSN_ASTERISK, plus DOMAIN_NAME_EXTENSION/DOMAIN_NAME_TRUNK)
- monorepo: Add docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md covering the extra provider secrets, the registrar-manager dual-DSN detail, the ticker/cron background-loop audit (only bin-tts-manager has tickers, scoped to per-connection streaming sessions, not a global loop), and a pointer back to the Tier 1/VOIP-1342 docs for the cutover procedure

No Go source changes. Only komodo/docker-compose.yml (7 new files), .circleci/config_work.yml, 7 services' docs/operations.md, and this design doc changed — verified via git status. This PR does not run any deploy job or perform any cutover; that is a separate follow-up step after review, same as VOIP-1342 and VOIP-1347.