### PR TITLE
VOIP-1353-Roll-out-bin-hook-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -464,6 +464,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-hook-manager-test
+      - bin-hook-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-hook-manager-build
   bin-message-manager:
     when: << pipeline.parameters.run-bin-message-manager >>
     jobs:
@@ -1353,6 +1357,21 @@ jobs:
           source-directory: bin-hook-manager
           project-id: voipbin
           project-repository: bin-hook-manager
+
+  bin-hook-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-hook-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-hook-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-hook-manager bin-hook-manager/komodo/docker-compose.yml
 
   # bin-message-manager
   bin-message-manager-test:

--- a/bin-hook-manager/README.md
+++ b/bin-hook-manager/README.md
@@ -31,8 +31,15 @@ $ cat <your cert file> | base64 -w 0
 
 # Deploy
 
-`bin-hook-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-hook-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+Komodo-managed (VOIP-1353), same mechanism as the other `bin-*-manager` services
+(see bin-call-manager for the original pattern). `bin-hook-manager-build` pushes
+the image, then `bin-hook-manager-deploy` renders the tag into
+`komodo/docker-compose.yml` and deploys via `.circleci/scripts/komodo-api-deploy.sh`,
+gated behind a single `build-approval`.
+
+Unlike every other `bin-*-manager` service, this one has no RabbitMQ
+competing-consumer safety net — `hook.voipbin.net`'s public traffic is routed by
+`monorepo-etc/infra-caddy`'s Caddyfile, which reverse-proxies to this container by
+its fixed name (`voipbin-hook-manager`). See
+[docs/operations.md](docs/operations.md#deployment-komodo) for the full
+cutover-sequencing note and what happens if it's done out of order.

--- a/bin-hook-manager/docs/operations.md
+++ b/bin-hook-manager/docs/operations.md
@@ -55,3 +55,17 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 - Must be accessible from external internet — DNS and firewall rules must allow inbound HTTPS
 - Logging uses logrus + joonix Stackdriver formatter
 - CORS allows all origins — expected behavior for a public webhook receiver
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1353), deployed via `.circleci/scripts/komodo-api-deploy.sh`
+from `komodo/docker-compose.yml` — same mechanism as the other `bin-*-manager`
+services (VOIP-1342 pilot, VOIP-1347/VOIP-1348 tiers), with one important
+difference: **this service has no RabbitMQ competing-consumer safety net.**
+`hook.voipbin.net`'s public traffic is routed by `monorepo-etc/infra-caddy`'s
+Caddyfile, which reverse-proxies to this container by its fixed name
+(`voipbin-hook-manager`) — Caddy must be pointed at that name *before* the
+old install-managed container is removed, and the new container must exist
+and be healthy *before* Caddy is pointed at it (see
+`monorepo-etc/infra-caddy` PR #109 for the sequencing this required and the
+brief outage that resulted from doing it out of order).

--- a/bin-hook-manager/komodo/docker-compose.yml
+++ b/bin-hook-manager/komodo/docker-compose.yml
@@ -1,0 +1,39 @@
+# Komodo Stack definition for bin-hook-manager (VOIP-1353). See
+# docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md for the
+# shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/VOIP-1348).
+#
+# hook-manager was held out of Tier 2 (VOIP-1348) because its SSL_CERT_BASE64/
+# SSL_PRIVKEY_BASE64 appeared to have no Komodo Variable source. That was a
+# false alarm: BIN_MANAGER__SSL_CERT_HOOK_BASE64/BIN_MANAGER__SSL_PRIVKEY_HOOK_BASE64
+# already exist (confirmed via the Komodo API's ListVariables, names only -
+# a prior grep against the decrypted secrets-source file for the literal
+# string "SSL_CERT_BASE64" missed these because the real keys carry a
+# "_HOOK_" infix). No new infra-secret entries were needed.
+services:
+  hook-manager:
+    image: voipbin/bin-hook-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-hook-manager
+    restart: always
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - SSL_CERT_BASE64=[[BIN_MANAGER__SSL_CERT_HOOK_BASE64]]
+      - SSL_PRIVKEY_BASE64=[[BIN_MANAGER__SSL_PRIVKEY_HOOK_BASE64]]
+      - PADDLE_WEBHOOK_SECRET_KEY=[[BIN_MANAGER__PADDLE_WEBHOOK_SECRET_KEY]]
+    command: ./hook-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true


### PR DESCRIPTION
Cut bin-hook-manager over to Komodo-managed deploy, completing the Tier 2 rollout (VOIP-1348 excluded it pending this).

- bin-hook-manager: Add komodo/docker-compose.yml, referencing already-existing BIN_MANAGER__SSL_CERT_HOOK_BASE64/BIN_MANAGER__SSL_PRIVKEY_HOOK_BASE64/BIN_MANAGER__PADDLE_WEBHOOK_SECRET_KEY Komodo Variables - no new infra-secret entries were needed (VOIP-1353's original premise, that these secrets didn't exist, was a false alarm from an incomplete grep)
- bin-hook-manager: Document the Komodo deploy path in docs/operations.md, including the Caddy-routing dependency this service has that the other bin-*-manager services don't
- monorepo: Wire bin-hook-manager-deploy CI job

Unlike every other bin-*-manager service, hook-manager has no RabbitMQ competing-consumer safety net - it's a public HTTPS webhook gateway (hook.voipbin.net) routed by monorepo-etc/infra-caddy's Caddyfile, which reverse-proxies to this container by its fixed name. That required a companion infra-caddy PR (monorepo-etc#109) to point the route at the new container name, and correct sequencing (new container up and healthy before Caddy is repointed, old container removed only after). The Caddy PR was deployed slightly out of sequence during this rollout, causing a brief hook.voipbin.net outage (502s) until the new container came up - already resolved and verified (external HTTP 200 from hook.voipbin.net/ping) before this PR was opened.

Already deployed and cut over live on bm-nyc-01 - the old voipbin-hook-mgr container is removed and install/docker-compose.yml's block is commented out. This PR brings the change into git/CI so routine CircleCI-triggered redeploys use the correct compose content going forward.