### PR TITLE
VOIP-1349-Roll-out-timeline-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -690,6 +690,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-timeline-manager-test
+      - bin-timeline-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-timeline-manager-build
   bin-transcribe-manager:
     when: << pipeline.parameters.run-bin-transcribe-manager >>
     jobs:
@@ -1792,6 +1796,21 @@ jobs:
           project-id: voipbin
           project-repository: bin-timeline-manager
           source-directory: bin-timeline-manager
+
+  bin-timeline-manager-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-timeline-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-timeline-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-timeline-manager bin-timeline-manager/komodo/docker-compose.yml
 
   # bin-transcribe-manager
   bin-transcribe-manager-test:

--- a/bin-timeline-manager/docs/operations.md
+++ b/bin-timeline-manager/docs/operations.md
@@ -72,3 +72,16 @@ Metrics exposed at `PROMETHEUS_LISTEN_ADDRESS` (default `:2112/metrics`):
 | `timeline_manager_receive_request_process_time` | Histogram | `type`, `method` | RPC request processing duration |
 | `timeline_manager_subscribe_batch_insert_time` | Histogram | — | ClickHouse batch insert duration |
 | `timeline_manager_subscribe_batch_size` | Histogram | — | Number of events per batch insert |
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1349), same mechanism as the other `bin-*-manager` services
+(see bin-call-manager for the original pattern, bin-agent-manager for the Tier 1
+template this one extends). Deployed via `.circleci/scripts/render-image-tag.sh`
++ `.circleci/scripts/komodo-api-deploy.sh` from `komodo/docker-compose.yml`.
+
+Unlike most `bin-*-manager` services, timeline-manager does not use MySQL/Redis
+at all — its Komodo Variables are `RABBITMQ_ADDRESS`, `CLICKHOUSE_ADDRESS`,
+`CLICKHOUSE_DATABASE`, `HOMER_API_ADDRESS`, `HOMER_AUTH_TOKEN`. `GCS_BUCKET_NAME`
+(PCAP archival) is optional and not currently set in production, so it is
+omitted from the Komodo compose file too.

--- a/bin-timeline-manager/komodo/docker-compose.yml
+++ b/bin-timeline-manager/komodo/docker-compose.yml
@@ -1,0 +1,31 @@
+# Komodo Stack definition for bin-timeline-manager (VOIP-1349, Tier 3
+# rollout). See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md
+# for the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/VOIP-1348). NOTE: unlike every other bin-*-manager service,
+# timeline-manager depends on clickhouse, not db/redis - no DATABASE_DSN
+# or REDIS_ADDRESS here.
+services:
+  timeline-manager:
+    image: voipbin/bin-timeline-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-timeline-manager
+    restart: always
+    environment:
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - CLICKHOUSE_ADDRESS=[[BIN_MANAGER__CLICKHOUSE_ADDRESS]]
+      - CLICKHOUSE_DATABASE=[[BIN_MANAGER__CLICKHOUSE_DATABASE]]
+      - HOMER_API_ADDRESS=[[BIN_MANAGER__HOMER_API_ADDRESS]]
+      - HOMER_AUTH_TOKEN=[[BIN_MANAGER__HOMER_AUTH_TOKEN]]
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    command: ./timeline-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true


### PR DESCRIPTION
Cut bin-timeline-manager over to Komodo-managed deploy (Tier 3, the sole service that depends on clickhouse instead of db/redis).

- bin-timeline-manager: Add komodo/docker-compose.yml - no DATABASE_DSN/REDIS_ADDRESS, uses RABBITMQ_ADDRESS/CLICKHOUSE_ADDRESS/CLICKHOUSE_DATABASE/HOMER_API_ADDRESS/HOMER_AUTH_TOKEN, all already-existing BIN_MANAGER__* Komodo Variables - no new infra-secret entries needed
- bin-timeline-manager: Wire bin-timeline-manager-deploy CI job, same pattern as VOIP-1347/VOIP-1348
- bin-timeline-manager: Document the Komodo deploy path in docs/operations.md, including the optional GCS_BUCKET_NAME (PCAP archival) field that's not currently set in production and is therefore omitted from the Komodo compose file too

Same cutover procedure as prior rounds: deploy via CI -> new container joins as an additional RabbitMQ competing consumer alongside the old one -> verify at application log level -> remove old container -> comment out its block in bm-nyc-01's live install/docker-compose.yml.