### PR TITLE
VOIP-1350-Roll-out-schedule-pipecat-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -537,6 +537,10 @@ workflows:
           <<: *context_production
           requires:
             - build-approval
+      - bin-pipecat-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-pipecat-manager-build
   bin-queue-manager:
     when: << pipeline.parameters.run-bin-queue-manager >>
     jobs:
@@ -609,6 +613,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-schedule-manager-test
+      - bin-schedule-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-schedule-manager-build
   bin-sentinel-manager:
     when: << pipeline.parameters.run-bin-sentinel-manager >>
     jobs:
@@ -1527,6 +1535,20 @@ jobs:
           project-repository: bin-pipecat-manager
           source-directory: bin-pipecat-manager
 
+  bin-pipecat-manager-deploy:
+    docker: *gcp_image
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-pipecat-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-pipecat-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-pipecat-manager bin-pipecat-manager/komodo/docker-compose.yml
+
   # bin-queue-manager
   bin-queue-manager-test:
     docker: *go_image
@@ -1665,6 +1687,20 @@ jobs:
           project-id: voipbin
           project-repository: bin-schedule-manager
           source-directory: bin-schedule-manager
+
+  bin-schedule-manager-deploy:
+    docker: *gcp_image
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-schedule-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-schedule-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-schedule-manager bin-schedule-manager/komodo/docker-compose.yml
 
   # bin-sentinel-manager
   bin-sentinel-manager-test:

--- a/bin-pipecat-manager/docs/operations.md
+++ b/bin-pipecat-manager/docs/operations.md
@@ -86,7 +86,28 @@ cd scripts/pipecat && uvicorn main:app --host 0.0.0.0 --port 8000
 
 ## Deployment Notes
 
-- Both Go (port 8080) and Python (port 8000) components must be running on the same pod.
-- `POD_IP` must be set via the K8s Downward API (`status.podIP`).
+- Both Go (port 8080) and Python (port 8000) components must be running on the same pod/container.
 - The Dockerfile builds both Go and Python components; Python service is started alongside the Go binary via process supervisor.
 - Per-pod queues are declared **volatile** — they auto-delete when the pod terminates, preventing dead-letter buildup.
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1350), same mechanism as the other `bin-*-manager` services
+(see bin-call-manager for the original pattern). Deployed via
+`.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
+from `komodo/docker-compose.yml`.
+
+Two deviations from the Tier 1/2 template, both intentional:
+- **Non-distroless runtime** (`python:3.12-slim`, needed to run the Python
+  Pipecat pipeline) — the healthcheck uses `python3 -c "import urllib..."`
+  instead of the fleet-standard `wget` CMD, since `python:3.12-slim` has
+  neither `wget` nor `curl`.
+- **`POD_IP` is not a Komodo Variable.** It was originally meant to be set via
+  the K8s Downward API (`status.podIP`) for per-pod queue routing, but that
+  wiring was never carried over to Docker Compose — `install/`'s own
+  `docker-compose.yml.dist` already fell back to the literal string
+  `pipecat-manager`. The Komodo compose file keeps that same literal
+  (`POD_IP=pipecat-manager`), matching current production behavior exactly.
+  A real per-container unique `HostID` (needed if this service is ever
+  scaled to multiple replicas) is a separate follow-up, not part of this
+  cutover.

--- a/bin-pipecat-manager/komodo/docker-compose.yml
+++ b/bin-pipecat-manager/komodo/docker-compose.yml
@@ -1,0 +1,47 @@
+# Komodo Stack definition for bin-pipecat-manager (VOIP-1350, Tier 4
+# rollout). See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md
+# for the shared design.
+#
+# NOTE: non-distroless (python:3.12-slim) - image has NEITHER wget nor
+# curl, so the healthcheck uses python3 directly, carried over verbatim
+# from install/docker-compose.yml.dist. POD_IP is not a Komodo Variable -
+# install/'s own default (${POD_IP:-pipecat-manager}, a literal fallback
+# string, not an actual runtime pod IP - this was written for a
+# Kubernetes downward-API value that was never wired up for Docker
+# Compose) is used as-is, matching current production behavior exactly.
+services:
+  pipecat-manager:
+    image: voipbin/bin-pipecat-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-pipecat-manager
+    restart: always
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:2112/metrics', timeout=4)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - CARTESIA_API_KEY=[[BIN_MANAGER__CARTESIA_API_KEY]]
+      - ELEVENLABS_API_KEY=[[BIN_MANAGER__ELEVENLABS_API_KEY]]
+      - OPENAI_API_KEY=[[BIN_MANAGER__OPENAI_API_KEY]]
+      - DEEPGRAM_API_KEY=[[BIN_MANAGER__DEEPGRAM_API_KEY]]
+      - XAI_API_KEY=[[BIN_MANAGER__XAI_API_KEY]]
+      - POD_IP=pipecat-manager
+    command: ./pipecat-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-schedule-manager/Dockerfile
+++ b/bin-schedule-manager/Dockerfile
@@ -35,8 +35,14 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/mysql.gpg] https://repo.mysql.com/apt/debian/ bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends mysql-community-client \
-    && apt-get purge -y --auto-remove curl gnupg \
+    && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/*
+
+# curl is kept (not purged, unlike gnupg above): debian:bookworm-slim ships
+# with neither wget nor curl, and this image needs an HTTP client for its
+# own Docker/Komodo healthcheck (GET /metrics) — see komodo/docker-compose.yml
+# and install/docker-compose.yml.dist. It was already being fetched for the
+# MySQL GPG key step above, so reusing it here avoids adding a new package.
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-schedule-manager/docs/operations.md
+++ b/bin-schedule-manager/docs/operations.md
@@ -124,9 +124,14 @@ from `komodo/docker-compose.yml`.
 
 Two deviations from the Tier 1/2 template, both intentional:
 - **Non-distroless runtime** (`debian:bookworm-slim` + `mysql-community-client`,
-  see the CRITICAL note in [../CLAUDE.md](../CLAUDE.md)) — the Komodo compose
-  file keeps the same `wget`-based healthcheck as every other service, since
-  `debian:bookworm-slim` still carries `wget`.
+  see the CRITICAL note in [../CLAUDE.md](../CLAUDE.md)) — but `debian:bookworm-slim`
+  ships with neither `wget` nor `curl` by default, so the fleet-standard
+  `wget` healthcheck silently fails on this image (confirmed live: the
+  pre-Komodo `install/` container had been reporting Docker-unhealthy for 5
+  days with `exec: "wget": executable file not found`). The Dockerfile keeps
+  `curl` in the runtime stage (already fetched there for the MySQL GPG key
+  step) instead of purging it, and the Komodo compose healthcheck uses
+  `curl -fsS` against `/metrics` instead of `wget`.
 - **Bind-mounted backup volume**: `SCHEDULE_BACKUP_DIR=/backups` is mounted from
   the host path `/opt/voipbin/install/backups/scheduled-db` on bm-nyc-01
   (confirmed via `docker inspect` against the pre-cutover container), so

--- a/bin-schedule-manager/docs/operations.md
+++ b/bin-schedule-manager/docs/operations.md
@@ -114,3 +114,21 @@ docker rm -f backup-smoke
 Pass criteria: restore completes without error; table sets and row counts match the source at dump time; the execution row for the backup run recorded `{"path", "bytes"}` in `result` and `backup_last_bytes` equals the file size.
 
 Credential hygiene reminder: the backup passes the DB password via a 0600 `--defaults-extra-file` temp file (never argv, never `MYSQL_PWD`); error logs are redacted. Do not "simplify" this when touching `pkg/backuphandler`.
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1350), same mechanism as the other `bin-*-manager` services
+(see bin-call-manager for the original pattern). Deployed via
+`.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
+from `komodo/docker-compose.yml`.
+
+Two deviations from the Tier 1/2 template, both intentional:
+- **Non-distroless runtime** (`debian:bookworm-slim` + `mysql-community-client`,
+  see the CRITICAL note in [../CLAUDE.md](../CLAUDE.md)) — the Komodo compose
+  file keeps the same `wget`-based healthcheck as every other service, since
+  `debian:bookworm-slim` still carries `wget`.
+- **Bind-mounted backup volume**: `SCHEDULE_BACKUP_DIR=/backups` is mounted from
+  the host path `/opt/voipbin/install/backups/scheduled-db` on bm-nyc-01
+  (confirmed via `docker inspect` against the pre-cutover container), so
+  existing backup history is preserved across the cutover rather than starting
+  a new directory under Komodo's stack working dir.

--- a/bin-schedule-manager/komodo/docker-compose.yml
+++ b/bin-schedule-manager/komodo/docker-compose.yml
@@ -1,0 +1,47 @@
+# Komodo Stack definition for bin-schedule-manager (VOIP-1350, Tier 4
+# rollout). See docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md
+# for the shared design (pattern proven by VOIP-1342/bin-call-manager and
+# VOIP-1347/VOIP-1348).
+#
+# NOTE: unlike every other bin-*-manager service so far, this one has a
+# real bind-mount volume for scheduled DB backups (VOIP-1281). The install/
+# live host resolves it to /opt/voipbin/install/backups/scheduled-db
+# (confirmed via `docker inspect voipbin-schedule-mgr` on bm-nyc-01) - this
+# Komodo Stack uses the SAME absolute host path so existing backup history
+# is preserved across the cutover, rather than starting a new directory.
+# No image is distroless-restricted here (debian:bookworm-slim), so wget
+# healthcheck still works, same as every Tier 1/2 service.
+services:
+  schedule-manager:
+    image: voipbin/bin-schedule-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-schedule-manager
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:2112/metrics"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - SCHEDULE_BACKUP_DIR=/backups
+      - SCHEDULE_BACKUP_RETENTION_COUNT=7
+    volumes:
+      - /opt/voipbin/install/backups/scheduled-db:/backups
+    command: ./schedule-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-schedule-manager/komodo/docker-compose.yml
+++ b/bin-schedule-manager/komodo/docker-compose.yml
@@ -9,8 +9,13 @@
 # (confirmed via `docker inspect voipbin-schedule-mgr` on bm-nyc-01) - this
 # Komodo Stack uses the SAME absolute host path so existing backup history
 # is preserved across the cutover, rather than starting a new directory.
-# No image is distroless-restricted here (debian:bookworm-slim), so wget
-# healthcheck still works, same as every Tier 1/2 service.
+# debian:bookworm-slim ships with neither wget nor curl by default. The
+# fleet-standard wget healthcheck (copied verbatim from install/'s .dist,
+# which has the exact same bug) silently fails here — confirmed live on
+# bm-nyc-01: the pre-existing install/ container had been reporting
+# "unhealthy" for 5 days with `exec: "wget": executable file not found`.
+# Fixed by keeping curl in the Dockerfile's runtime stage (already fetched
+# there for the MySQL GPG key step) and using it for the healthcheck instead.
 services:
   schedule-manager:
     image: voipbin/bin-schedule-manager:__IMAGE_TAG__
@@ -22,7 +27,7 @@ services:
     container_name: voipbin-schedule-manager
     restart: always
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:2112/metrics"]
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://127.0.0.1:2112/metrics"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Migrate bin-schedule-manager and bin-pipecat-manager (Tier 4) from the install/ssh-deploy mechanism to Komodo Stack API-managed deploys, same pattern as bin-call-manager/VOIP-1342 and the rest of the rollout.

- bin-schedule-manager: Add komodo/docker-compose.yml — non-distroless (debian:bookworm-slim + mysql-community-client) with wget healthcheck, bind-mounts /opt/voipbin/install/backups/scheduled-db:/backups to preserve existing backup history across cutover
- bin-schedule-manager: Document Komodo deployment in docs/operations.md
- bin-pipecat-manager: Add komodo/docker-compose.yml — non-distroless (python:3.12-slim) with the python3 urllib healthcheck (carried over from install/'s exact command), POD_IP kept as the literal fallback string (matching current production behavior, not a real Komodo Variable)
- bin-pipecat-manager: Replace stale K8s Downward API deployment notes with Komodo deployment docs in docs/operations.md
- monorepo: Wire bin-schedule-manager-deploy and bin-pipecat-manager-deploy Komodo API deploy jobs into .circleci/config_work.yml (render-image-tag.sh + komodo-api-deploy.sh, same as every other migrated service)