### PR TITLE
VOIP-1358-Roll-out-storage-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -654,6 +654,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-storage-manager-test
+      - bin-storage-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-storage-manager-build
   bin-tag-manager:
     when: << pipeline.parameters.run-bin-tag-manager >>
     jobs:
@@ -1745,6 +1749,20 @@ jobs:
           project-id: voipbin
           project-repository: bin-storage-manager
           source-directory: bin-storage-manager
+
+  bin-storage-manager-deploy:
+    docker: *gcp_image
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-storage-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-storage-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-storage-manager bin-storage-manager/komodo/docker-compose.yml bin-storage-manager/komodo/environment.env
 
   # bin-tag-manager
   bin-tag-manager-test:

--- a/.circleci/scripts/komodo-api-deploy.sh
+++ b/.circleci/scripts/komodo-api-deploy.sh
@@ -38,8 +38,9 @@
 #   6. Exits 0 only if the Update's terminal status is Complete+success.
 #
 # What this does NOT do:
-#   - Does NOT touch an EXISTING Stack's config beyond `file_contents`
-#     (UpdateStack, step 3 below, is PATCH-style) - the ensure-exists check
+#   - Does NOT touch an EXISTING Stack's config beyond `file_contents` (and,
+#     when a 3rd argument is given, `environment` - see Usage below) -
+#     UpdateStack (step 3 below) is PATCH-style - the ensure-exists check
 #     in step 1 only ever creates a Stack that doesn't exist yet; it never
 #     modifies one that's already there.
 #   - Does NOT enable Komodo's own polling/webhook auto-deploy for the
@@ -56,7 +57,7 @@
 #
 # Usage:
 #   CC_KOMODO_API_KEY=<key> CC_KOMODO_API_SECRET=<secret> \
-#     ./.circleci/scripts/komodo-api-deploy.sh <stack-name> <local-compose-file>
+#     ./.circleci/scripts/komodo-api-deploy.sh <stack-name> <local-compose-file> [local-environment-file]
 #
 #   <stack-name>          The Komodo Stack resource's name (or id). Must
 #                         already exist - see Preconditions below. Must
@@ -67,6 +68,21 @@
 #                         - this is what makes the model "kustomize-style":
 #                         git is the only source of truth for deployed
 #                         content, Komodo just executes it on request.
+#   [local-environment-file]  Optional. Path to a plain KEY=VALUE env file
+#                         IN THE CI CHECKOUT (e.g. komodo/environment.env).
+#                         Its content is PATCHed into the Stack's own
+#                         `environment` config field (distinct from
+#                         file_contents' service-level `environment:`
+#                         blocks) - Komodo writes this into the Stack's
+#                         run-directory .env file before `docker compose up`
+#                         runs, which Compose can then read via `${VAR}`
+#                         substitution or (VOIP-1351) an
+#                         environment-sourced `secrets:` block. Supports the
+#                         same `[[VARIABLE]]` interpolation as
+#                         file_contents. Omit this argument entirely for a
+#                         service with no Stack-level environment need -
+#                         this preserves the exact previous behavior/request
+#                         shape for every existing call site.
 #
 # Environment:
 #   CC_KOMODO_API_KEY      Komodo API key for the 'circleci' Service User.
@@ -122,13 +138,14 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -ne 2 && $# -ne 3 ]]; then
   usage
   exit 1
 fi
 
 STACK_NAME="$1"
 LOCAL_COMPOSE_FILE="$2"
+LOCAL_ENV_FILE="${3:-}"
 
 if [[ ! "$STACK_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
   log_error "stack-name must match ^[A-Za-z0-9._-]+\$ (got: $STACK_NAME)"
@@ -137,6 +154,11 @@ fi
 
 if [[ ! -f "$LOCAL_COMPOSE_FILE" ]]; then
   log_error "local-compose-file does not exist: $LOCAL_COMPOSE_FILE"
+  exit 1
+fi
+
+if [[ -n "$LOCAL_ENV_FILE" && ! -f "$LOCAL_ENV_FILE" ]]; then
+  log_error "local-environment-file does not exist: $LOCAL_ENV_FILE"
   exit 1
 fi
 
@@ -211,8 +233,17 @@ if grep -Eq '__[A-Z_]+__' "$LOCAL_COMPOSE_FILE"; then
   grep -En '__[A-Z_]+__' "$LOCAL_COMPOSE_FILE" >&2
   exit 1
 fi
+if [[ -n "$LOCAL_ENV_FILE" ]] && grep -Eq '__[A-Z_]+__' "$LOCAL_ENV_FILE"; then
+  log_error "environment file still contains an unfilled __PLACEHOLDER__ token - refusing to deploy:"
+  grep -En '__[A-Z_]+__' "$LOCAL_ENV_FILE" >&2
+  exit 1
+fi
 
 COMPOSE_CONTENT="$(cat "$LOCAL_COMPOSE_FILE")"
+ENV_CONTENT=""
+if [[ -n "$LOCAL_ENV_FILE" ]]; then
+  ENV_CONTENT="$(cat "$LOCAL_ENV_FILE")"
+fi
 
 # Shared helper so all API calls get identical error handling: on a
 # non-2xx or a curl-level (connection) failure, print the request type and
@@ -283,8 +314,8 @@ get_stack_body="$(jq -n --arg stack "$STACK_NAME" '{type:"GetStack",params:{stac
 if ! call_api read "$get_stack_body" >/dev/null; then
   if [[ "$LAST_ERROR_BODY" == *"Did not find any Stack matching"* ]]; then
     log_info "Stack '$STACK_NAME' does not exist yet - creating it (idempotent bootstrap, server=$KOMODO_SERVER_NAME)."
-    create_body="$(jq -n --arg name "$STACK_NAME" --arg server "$KOMODO_SERVER_NAME" \
-      '{type:"CreateStack",params:{name:$name,config:{server_id:$server,file_contents:"",poll_for_updates:false,auto_update:false,webhook_enabled:false}}}')"
+    create_body="$(jq -n --arg name "$STACK_NAME" --arg server "$KOMODO_SERVER_NAME" --arg env "$ENV_CONTENT" \
+      '{type:"CreateStack",params:{name:$name,config:{server_id:$server,file_contents:"",environment:$env,poll_for_updates:false,auto_update:false,webhook_enabled:false}}}')"
     call_api write "$create_body" >/dev/null
     log_info "Stack '$STACK_NAME' created."
   else
@@ -295,8 +326,17 @@ fi
 
 log_info "Deploying Stack '$STACK_NAME' from local file $LOCAL_COMPOSE_FILE (content pushed via Komodo API, direct HTTPS)..."
 
-update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$COMPOSE_CONTENT" \
-  '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents}}}')"
+# environment is only included in the PATCH when a 3rd argument was given -
+# an existing call site that never passes one gets the exact same request
+# shape as before this option existed (see this script's "What this does
+# NOT do" header note).
+if [[ -n "$LOCAL_ENV_FILE" ]]; then
+  update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$COMPOSE_CONTENT" --arg env "$ENV_CONTENT" \
+    '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents,environment:$env}}}')"
+else
+  update_body="$(jq -n --arg id "$STACK_NAME" --arg contents "$COMPOSE_CONTENT" \
+    '{type:"UpdateStack",params:{id:$id,config:{file_contents:$contents}}}')"
+fi
 call_api write "$update_body" >/dev/null
 
 deploy_body="$(jq -n --arg stack "$STACK_NAME" \

--- a/.circleci/tests/komodo-api-deploy.bats
+++ b/.circleci/tests/komodo-api-deploy.bats
@@ -295,3 +295,72 @@ queue_running_samples() {
     [[ "$output" == *"DEPLOY_TIMEOUT"* ]]
     [[ "$output" == *"may still land after this script gives up"* ]]
 }
+
+# --- VOIP-1358: optional 3rd argument (Stack-level environment file) ---
+
+@test "usage: exits 1 with 4+ args" {
+    run run_deploy bin-call-manager "$COMPOSE_FILE" extra1 extra2
+    [ "$status" -eq 1 ]
+}
+
+@test "validation: rejects a nonexistent environment file" {
+    run run_deploy bin-call-manager "$COMPOSE_FILE" /nonexistent/env.env
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"local-environment-file does not exist"* ]]
+}
+
+@test "placeholder guard: refuses to deploy with an unfilled __PLACEHOLDER__ token in the environment file" {
+    ENV_FILE="$TEST_TEMP_DIR/environment.env"
+    echo 'GCP_SA_JSON=__NOT_YET_RENDERED__' > "$ENV_FILE"
+    run run_deploy bin-call-manager "$COMPOSE_FILE" "$ENV_FILE"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unfilled __PLACEHOLDER__ token"* ]]
+    [[ "$output" == *"__NOT_YET_RENDERED__"* ]]
+    [ "$(curl_call_count)" -eq 0 ]
+}
+
+@test "environment file omitted: UpdateStack body has no 'environment' key at all (existing call sites unchanged)" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    queue_curl_response 200 '{"id":"bin-call-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-call-manager "$COMPOSE_FILE"
+    [ "$status" -eq 0 ]
+    body="$(curl_call_body 2)"  # UpdateStack is the 2nd call
+    [[ "$body" != *'"environment"'* ]]
+}
+
+@test "environment file given: UpdateStack body carries its content under 'environment'" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    ENV_FILE="$TEST_TEMP_DIR/environment.env"
+    echo 'GCP_SA_JSON=rendered-value' > "$ENV_FILE"
+    queue_curl_response 200 '{"id":"bin-storage-manager"}'
+    queue_curl_response 200 '{}'
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-storage-manager "$COMPOSE_FILE" "$ENV_FILE"
+    [ "$status" -eq 0 ]
+    body="$(curl_call_body 2)"  # UpdateStack is the 2nd call
+    [[ "$body" == *'"environment"'* ]]
+    [[ "$body" == *"GCP_SA_JSON=rendered-value"* ]]
+}
+
+@test "environment file given on ensure-exists path: CreateStack body also carries the environment content" {
+    export CC_KOMODO_POLL_INTERVAL_S=1 CC_KOMODO_RUNNING_CHECK_INTERVAL_S=1
+    ENV_FILE="$TEST_TEMP_DIR/environment.env"
+    echo 'GCP_SA_JSON=rendered-value' > "$ENV_FILE"
+    queue_curl_response 500 '{"error":"Did not find any Stack matching bin-storage-manager","trace":[]}'  # GetStack
+    queue_curl_response 200 '{"name":"bin-storage-manager"}'  # CreateStack
+    queue_curl_response 200 '{}'                               # UpdateStack
+    queue_curl_response 200 '{"_id":{"$oid":"update-123"}}'    # DeployStack
+    queue_curl_response 200 '{"status":"Complete","success":true}'
+    queue_running_samples 3
+    run run_deploy bin-storage-manager "$COMPOSE_FILE" "$ENV_FILE"
+    [ "$status" -eq 0 ]
+    body="$(curl_call_body 2)"  # CreateStack is the 2nd call
+    [[ "$body" == *'"CreateStack"'* ]]
+    [[ "$body" == *"GCP_SA_JSON=rendered-value"* ]]
+}

--- a/bin-storage-manager/docs/operations.md
+++ b/bin-storage-manager/docs/operations.md
@@ -95,3 +95,47 @@ Recovery: configure a valid `GOOGLE_APPLICATION_CREDENTIALS`, restart, then call
 | `storage_manager_receive_subscribe_event_process_time` | Histogram | `publisher`, `type` | Event processing duration |
 | `storage_manager_signing_available` | Gauge | — | `1` when a GCS signing credential was loaded at startup, `0` when signed download URLs are unavailable |
 | `storage_manager_download_uri_failure_total` | Counter | `reason` | File creations persisted without a download URI. `reason=not_configured` (no credential) or `reason=signer_error` (credential present but rejected) |
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1358, Tier 5 - first of the 4 GCP-credential-file
+services). Deployed via `.circleci/scripts/render-image-tag.sh` +
+`.circleci/scripts/komodo-api-deploy.sh` from `komodo/docker-compose.yml`,
+same as every other migrated `bin-*-manager` service.
+
+**GCP credential file (VOIP-1351 spike conclusion)**: distroless has no
+shell, so the classic install/-style bind-mount-a-host-path trick has no
+Komodo equivalent (no host-setup-script step). Solved with Docker Compose's
+native environment-sourced `secrets:` block instead of an init container or
+an app code change:
+
+```yaml
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+services:
+  storage-manager:
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json   # -> /run/secrets/google_service_account.json
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
+```
+
+`GCP_SA_JSON`'s value comes from `komodo/environment.env`
+(`GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]`), passed
+as `komodo-api-deploy.sh`'s new optional 3rd argument. Komodo writes this
+into the Stack's own `environment` config field (distinct from the compose
+file's service-level `environment:` blocks), materializing it into a
+`.env` file in the run directory before `docker compose up` - Compose then
+resolves `GCP_SA_JSON` and creates `/run/secrets/google_service_account.json`
+entirely on the Docker Engine side, no in-container tool needed. The
+`GOOGLE_APPLICATION_CREDENTIALS_JSON` secret itself already existed in
+`infra-secret`/Komodo (migrated wholesale from the old vault system) -
+no new secret had to be added for this cutover.
+
+No healthcheck block: same as every other distroless `bin-*-manager`
+service (the fleet-standard `wget` healthcheck can never pass on
+`gcr.io/distroless/static-debian12` - no `wget` binary - established by
+the VOIP-1342 pilot). Deploy success is gated by CI/the cutover procedure,
+not a Docker health check.

--- a/bin-storage-manager/komodo/docker-compose.yml
+++ b/bin-storage-manager/komodo/docker-compose.yml
@@ -1,0 +1,62 @@
+# Komodo Stack definition for bin-storage-manager (VOIP-1358, Tier 5 -
+# first of the 4 GCP-credential-file services). See VOIP-1351's spike
+# conclusion and docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md
+# for the shared design.
+#
+# GCP service-account credential materialization (VOIP-1351): distroless
+# images have no shell, so the container itself cannot write a file from
+# an env var at startup - the classic bind-mount-a-host-path trick (used
+# by install/'s ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/...:ro) also has no
+# equivalent host-setup step under Komodo. Solved with Docker Compose's
+# native environment-sourced secret instead: the `secrets:` block below
+# pulls its content from the GCP_SA_JSON env var, which Komodo itself
+# writes into this Stack's run-directory .env file (via the Stack's own
+# `environment` config field - see komodo/environment.env in this same
+# directory, passed as komodo-api-deploy.sh's 3rd argument) BEFORE
+# `docker compose up` runs. Docker Compose then materializes the file at
+# /run/secrets/google_service_account.json entirely on the host side - no
+# shell/tool needed inside the distroless container, no init container,
+# no app code change.
+#
+# distroless (gcr.io/distroless/static-debian12): no healthcheck block,
+# same as every other distroless bin-*-manager service (VOIP-1342 pilot
+# already established that the fleet-standard wget healthcheck can never
+# pass on this image - there is no wget - so these services simply omit
+# healthcheck and rely on CI/cutover verification instead, not a Docker
+# health gate).
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+
+services:
+  storage-manager:
+    image: voipbin/bin-storage-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-storage-manager
+    restart: always
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - GCP_PROJECT_ID=[[BIN_MANAGER__GCP_PROJECT_ID]]
+      - GCP_BUCKET_NAME_TMP=[[BIN_MANAGER__GCP_BUCKET_NAME_TMP]]
+      - GCP_BUCKET_NAME_MEDIA=[[BIN_MANAGER__GCP_BUCKET_NAME_MEDIA]]
+      - JWT_KEY=[[BIN_MANAGER__JWT_KEY]]
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
+    command: ./storage-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-storage-manager/komodo/environment.env
+++ b/bin-storage-manager/komodo/environment.env
@@ -1,0 +1,13 @@
+# Komodo Stack-level environment (VOIP-1351/VOIP-1358) - distinct from
+# docker-compose.yml's own `environment:` blocks (service-level, baked
+# into file_contents). This file is passed as komodo-api-deploy.sh's
+# optional 3rd argument and PATCHed into the Stack's own `environment`
+# config field, which Komodo writes into this Stack's run-directory .env
+# file before `docker compose up` runs. docker-compose.yml's
+# `secrets.gcp_sa_json.environment: "GCP_SA_JSON"` reads this value at
+# that point to materialize the credential file - see the comment at the
+# top of docker-compose.yml for the full mechanism.
+#
+# [[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]] is interpolated by
+# Komodo the same way as any [[VAR]] reference inside file_contents.
+GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]


### PR DESCRIPTION
Migrate bin-storage-manager (Tier 5, first of the 4 GCP-credential-file services) from the install/ssh-deploy mechanism to Komodo Stack API-managed deploys.

- bin-storage-manager: Add komodo/docker-compose.yml — distroless (no healthcheck, same as every other migrated distroless service), uses a Docker Compose native environment-sourced secrets block to materialize /run/secrets/google_service_account.json without an init container or app code change (VOIP-1351 spike conclusion)
- bin-storage-manager: Add komodo/environment.env carrying GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]] — this secret already existed in infra-secret/Komodo (migrated wholesale from the old vault system), no new secret needed
- bin-storage-manager: Document the Komodo deployment and GCP credential mechanism in docs/operations.md
- monorepo: Extend .circleci/scripts/komodo-api-deploy.sh with an optional 3rd argument (local-environment-file) that PATCHes a Stack's own environment config field — backward compatible, existing call sites that never pass this argument get the exact same request shape as before
- monorepo: Add bats coverage for the new optional argument (5 new tests, all 30 tests in the suite pass)
- monorepo: Wire bin-storage-manager-deploy into .circleci/config_work.yml (render-image-tag.sh + komodo-api-deploy.sh, same as every other migrated service)