### PR TITLE
VOIP-1359-Roll-out-rag-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -569,6 +569,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-rag-manager-test
+      - bin-rag-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-rag-manager-build
   bin-registrar-manager:
     when: << pipeline.parameters.run-bin-registrar-manager >>
     jobs:
@@ -1604,6 +1608,20 @@ jobs:
           source-directory: bin-rag-manager
           project-id: voipbin
           project-repository: bin-rag-manager
+
+  bin-rag-manager-deploy:
+    docker: *gcp_image
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-rag-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-rag-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-rag-manager bin-rag-manager/komodo/docker-compose.yml bin-rag-manager/komodo/environment.env
 
   # bin-registrar-manager
   bin-registrar-manager-test:

--- a/bin-rag-manager/docs/operations.md
+++ b/bin-rag-manager/docs/operations.md
@@ -59,3 +59,25 @@ Metrics are served at `PROMETHEUS_LISTEN_ADDRESS` (default `:2112`) on `PROMETHE
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `rag_manager_receive_request_process_time` | Histogram | `type`, `method` | RPC request processing duration |
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1359, Tier 5 - second of the 4 GCP-credential-file
+services, same pattern as bin-storage-manager/VOIP-1358). Deployed via
+`.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
+from `komodo/docker-compose.yml`.
+
+**GCP credential file**: same Docker Compose environment-sourced `secrets:`
+block as bin-storage-manager - see that service's docs/operations.md for
+the full mechanism. `GCP_SA_JSON` comes from `komodo/environment.env`,
+passed as `komodo-api-deploy.sh`'s 3rd argument.
+
+**PostgreSQL, not MySQL**: `POSTGRESQL_DSN=[[BIN_MANAGER__DATABASE_DSN_POSTGRES]]`,
+not the `DATABASE_DSN`/`DATABASE_DSN_BIN` most other services use.
+`RAG_TOP_K` is a plain literal (`5`) in the compose file, not a Komodo
+Variable - it is non-secret config, not a credential.
+
+No healthcheck block: distroless (`gcr.io/distroless/static-debian12`),
+same as every other distroless `bin-*-manager` service (VOIP-1342 pilot
+established the fleet-standard `wget` healthcheck can never pass on this
+image).

--- a/bin-rag-manager/komodo/docker-compose.yml
+++ b/bin-rag-manager/komodo/docker-compose.yml
@@ -1,0 +1,58 @@
+# Komodo Stack definition for bin-rag-manager (VOIP-1359, Tier 5). See
+# VOIP-1351's spike conclusion and VOIP-1358 (bin-storage-manager, the
+# first service to use this pattern) for the shared design.
+#
+# GCP service-account credential materialization: same mechanism as
+# bin-storage-manager - see the comment at the top of that service's
+# komodo/docker-compose.yml for the full explanation. In short: Docker
+# Compose's environment-sourced `secrets:` block below reads GCP_SA_JSON
+# from this Stack's own `environment` config field (komodo/environment.env
+# in this same directory, passed as komodo-api-deploy.sh's 3rd argument),
+# which Komodo writes into the run directory's .env file before
+# `docker compose up` - no init container, no app code change, no shell
+# needed inside this distroless image.
+#
+# PostgreSQL, not MySQL: unlike most bin-*-manager services, rag-manager's
+# database is PostgreSQL/pgvector (POSTGRESQL_DSN, not DATABASE_DSN) -
+# references the already-correct [[BIN_MANAGER__DATABASE_DSN_POSTGRES]]
+# Komodo Variable. RAG_TOP_K is a plain non-secret config value (a literal
+# here, not a [[VAR]] reference).
+#
+# distroless (gcr.io/distroless/static-debian12): no healthcheck block,
+# same as every other distroless bin-*-manager service (VOIP-1342 pilot
+# already established the fleet-standard wget healthcheck can never pass
+# on this image).
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+
+services:
+  rag-manager:
+    image: voipbin/bin-rag-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-rag-manager
+    restart: always
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
+    environment:
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - GCP_PROJECT_ID=[[BIN_MANAGER__GCP_PROJECT_ID]]
+      - GCP_REGION=[[BIN_MANAGER__GCP_REGION]]
+      - GCP_BUCKET_NAME_MEDIA=[[BIN_MANAGER__GCP_BUCKET_NAME_MEDIA]]
+      - POSTGRESQL_DSN=[[BIN_MANAGER__DATABASE_DSN_POSTGRES]]
+      - RAG_TOP_K=5
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
+    command: ./rag-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-rag-manager/komodo/environment.env
+++ b/bin-rag-manager/komodo/environment.env
@@ -1,0 +1,5 @@
+# Komodo Stack-level environment (VOIP-1351/VOIP-1358 pattern, reused
+# here). See bin-storage-manager/komodo/environment.env for the full
+# explanation - this file is passed as komodo-api-deploy.sh's optional 3rd
+# argument and PATCHed into the Stack's own `environment` config field.
+GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]


### PR DESCRIPTION
Migrate bin-rag-manager (Tier 5, second of the 4 GCP-credential-file services) from the install/ssh-deploy mechanism to Komodo Stack API-managed deploys, same pattern as bin-storage-manager/VOIP-1358.

- bin-rag-manager: Add komodo/docker-compose.yml — distroless (no healthcheck), reuses the same Docker Compose environment-sourced secrets block as bin-storage-manager to materialize /run/secrets/google_service_account.json
- bin-rag-manager: Add komodo/environment.env carrying GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]] (same already-existing secret VOIP-1358 uses)
- bin-rag-manager: Document the Komodo deployment, PostgreSQL DSN (POSTGRESQL_DSN, not the MySQL DATABASE_DSN most services use), and GCP credential mechanism in docs/operations.md
- monorepo: Wire bin-rag-manager-deploy into .circleci/config_work.yml (render-image-tag.sh + komodo-api-deploy.sh with the environment.env 3rd argument, same as bin-storage-manager)