### PR TITLE
VOIP-1360-Roll-out-transcribe-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -722,6 +722,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-transcribe-manager-test
+      - bin-transcribe-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-transcribe-manager-build
   bin-transfer-manager:
     when: << pipeline.parameters.run-bin-transfer-manager >>
     jobs:
@@ -1900,6 +1904,20 @@ jobs:
           project-id: voipbin
           project-repository: bin-transcribe-manager
           source-directory: bin-transcribe-manager
+
+  bin-transcribe-manager-deploy:
+    docker: *gcp_image
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-transcribe-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-transcribe-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-transcribe-manager bin-transcribe-manager/komodo/docker-compose.yml bin-transcribe-manager/komodo/environment.env
 
   # bin-transfer-manager
   bin-transfer-manager-test:

--- a/bin-transcribe-manager/docs/operations.md
+++ b/bin-transcribe-manager/docs/operations.md
@@ -78,3 +78,30 @@ Metrics registered in handler `init()` functions, exposed at `PROMETHEUS_LISTEN_
 | `transcribe_manager_ari_event_listen_total` | Counter | — | Total ARI events received |
 | `transcribe_manager_transcribe_create_total` | Counter | `type` | Transcription sessions created (by provider) |
 | `transcribe_manager_transcript_transcript_create_total` | Counter | — | Transcript segments created |
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1360, Tier 5 - third of the 4 GCP-credential-file
+services, same pattern as bin-storage-manager/VOIP-1358 and
+bin-rag-manager/VOIP-1359). Deployed via
+`.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
+from `komodo/docker-compose.yml`.
+
+**GCP credential file**: same Docker Compose environment-sourced `secrets:`
+block as bin-storage-manager. `GCP_SA_JSON` comes from
+`komodo/environment.env`, passed as `komodo-api-deploy.sh`'s 3rd argument.
+
+**`POD_IP`**: not a real Komodo Variable, same as bin-pipecat-manager.
+`install/`'s own `docker-compose.yml.dist` already falls back to a
+literal (`${POD_IP:-127.0.0.1}`) since the K8s Downward API wiring this
+was meant for was never carried over to Docker Compose - the Komodo
+compose file keeps that same literal, matching current production
+behavior exactly. This service's per-pod queue routing
+(`bin-manager.transcribe-manager.request.<POD_IP>`, see this service's
+CLAUDE.md) is therefore unaffected by the cutover - it already runs as a
+single instance with this same fixed value today.
+
+No healthcheck block: distroless (`gcr.io/distroless/static-debian12`),
+same as every other distroless `bin-*-manager` service (VOIP-1342 pilot
+established the fleet-standard `wget` healthcheck can never pass on this
+image).

--- a/bin-transcribe-manager/komodo/docker-compose.yml
+++ b/bin-transcribe-manager/komodo/docker-compose.yml
@@ -1,0 +1,54 @@
+# Komodo Stack definition for bin-transcribe-manager (VOIP-1360, Tier 5 -
+# third of the 4 GCP-credential-file services, api-manager excepted). See
+# VOIP-1351's spike conclusion and VOIP-1358 (bin-storage-manager, the
+# first service to use this pattern) for the shared design.
+#
+# GCP service-account credential materialization: same mechanism as
+# bin-storage-manager - see the comment at the top of that service's
+# komodo/docker-compose.yml for the full explanation.
+#
+# POD_IP: like bin-pipecat-manager, this is not a real Komodo Variable -
+# install/'s own docker-compose.yml.dist already falls back to a literal
+# (${POD_IP:-127.0.0.1}) since the K8s Downward API wiring this was
+# originally meant for was never carried over to Docker Compose. Kept as
+# the same literal here, matching current production behavior exactly.
+#
+# distroless (gcr.io/distroless/static-debian12): no healthcheck block,
+# same as every other distroless bin-*-manager service (VOIP-1342 pilot
+# already established the fleet-standard wget healthcheck can never pass
+# on this image).
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+
+services:
+  transcribe-manager:
+    image: voipbin/bin-transcribe-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-transcribe-manager
+    restart: always
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - AWS_ACCESS_KEY=[[BIN_MANAGER__AWS_ACCESS_KEY]]
+      - AWS_SECRET_KEY=[[BIN_MANAGER__AWS_SECRET_KEY]]
+      - POD_IP=127.0.0.1
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
+    command: ./transcribe-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-transcribe-manager/komodo/environment.env
+++ b/bin-transcribe-manager/komodo/environment.env
@@ -1,0 +1,5 @@
+# Komodo Stack-level environment (VOIP-1351/VOIP-1358 pattern, reused
+# here). See bin-storage-manager/komodo/environment.env for the full
+# explanation - this file is passed as komodo-api-deploy.sh's optional 3rd
+# argument and PATCHed into the Stack's own `environment` config field.
+GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]


### PR DESCRIPTION
Migrate bin-transcribe-manager (Tier 5, third of the 4 GCP-credential-file services) from the install/ssh-deploy mechanism to Komodo Stack API-managed deploys, same pattern as bin-storage-manager/VOIP-1358 and bin-rag-manager/VOIP-1359.

- bin-transcribe-manager: Add komodo/docker-compose.yml — distroless (no healthcheck), reuses the same Docker Compose environment-sourced secrets block as bin-storage-manager to materialize /run/secrets/google_service_account.json
- bin-transcribe-manager: Add komodo/environment.env carrying GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]] (same already-existing secret the other two Tier 5 services use)
- bin-transcribe-manager: Document the Komodo deployment, the POD_IP literal fallback (same non-Variable pattern as bin-pipecat-manager), and GCP credential mechanism in docs/operations.md
- monorepo: Wire bin-transcribe-manager-deploy into .circleci/config_work.yml (render-image-tag.sh + komodo-api-deploy.sh with the environment.env 3rd argument)