### PR TITLE
VOIP-1362-Roll-out-api-manager-komodo-deploy

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -223,6 +223,10 @@ workflows:
           <<: *context_production
           requires:
             - bin-api-manager-test
+      - bin-api-manager-deploy:
+          <<: *context_production
+          requires:
+            - bin-api-manager-build
   bin-billing-manager:
     when: << pipeline.parameters.run-bin-billing-manager >>
     jobs:
@@ -909,6 +913,20 @@ jobs:
           source-directory: bin-api-manager
           project-id: voipbin
           project-repository: bin-api-manager
+
+  bin-api-manager-deploy:
+    docker: *gcp_image
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh bin-api-manager/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy bin-api-manager via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh bin-api-manager bin-api-manager/komodo/docker-compose.yml bin-api-manager/komodo/environment.env
 
   # bin-billing-manager
   bin-billing-manager-test:

--- a/bin-api-manager/docs/operations.md
+++ b/bin-api-manager/docs/operations.md
@@ -15,7 +15,7 @@ Runtime configuration is provided via CLI flags and/or environment variables, de
 | `-gcp_project_id` | `GCP_PROJECT_ID` | No | — | GCP project for storage |
 | `-gcp_bucket_name` | `GCP_BUCKET_NAME` | No | — | GCS bucket for media/recordings |
 | `-ssl_cert_base64` | `SSL_CERT_BASE64` | No | — | Base64-encoded SSL certificate |
-| `-ssl_privkey_base64` | `SSL_PRIVATE_BASE64` | No | — | Base64-encoded SSL private key |
+| `-ssl_privkey_base64` | `SSL_PRIVKEY_BASE64` | No | — | Base64-encoded SSL private key |
 | `-listen_ip_audiosock` | `LISTEN_IP_AUDIOSOCK` | No | `""` | Audiosocket listener IP (AI audio streaming) |
 | `-prometheus_endpoint` | `PROMETHEUS_ENDPOINT` | No | `/metrics` | Prometheus metrics path |
 | `-prometheus_listen_address` | `PROMETHEUS_LISTEN_ADDRESS` | No | `:2112` | Prometheus listen address |
@@ -209,3 +209,71 @@ echo "<jwt_token>" | cut -d. -f2 | base64 -d | jq .
 ### System prerequisites
 
 None. The service is pure Go (no cgo); the internal pub/sub is the in-process `pkg/pubsubhandler` package.
+
+---
+
+## Deployment (Komodo)
+
+Komodo-managed (VOIP-1362, Tier 5 — final service in the install/→Komodo
+rollout, migrated last per plan given this service's blast radius: the
+sole public HTTP/WebSocket entry point, JWT auth). Deployed via
+`.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
+from `komodo/docker-compose.yml`.
+
+**Fundamentally different cutover from every other `bin-*-manager`
+service in this rollout**: every other service communicates purely over
+RabbitMQ RPC, so a new Komodo container and the old `install/` container
+could both run as competing consumers on the same queue simultaneously —
+zero-downtime overlap. `bin-api-manager` instead serves public HTTPS
+traffic directly; `install/`'s `docker-compose.yml.dist` publishes it to
+the host at `0.0.0.0:8443:443`. Two containers cannot both bind the same
+host port, so the RabbitMQ-style overlap trick does not apply here.
+
+**Resolution — route through Caddy instead of publishing a host port**:
+`monorepo-etc`'s `infra-caddy` already reverse-proxies `api.voipbin.net`
+to this service over the `production` network (`infra-caddy/config/Caddyfile`'s
+`reverse_proxy https://voipbin-api-mgr:443`, confirmed live). The Komodo
+compose file below therefore:
+- Has **no `ports:` block at all** — reachable only via Caddy inside
+  `production`, never a host-published port.
+- Still self-terminates TLS (`SSL_CERT_BASE64`/`SSL_PRIVKEY_BASE64` from
+  the already-existing `[[BIN_MANAGER__SSL_CERT_API_BASE64]]`/
+  `[[BIN_MANAGER__SSL_PRIVKEY_API_BASE64]]` secrets) — Caddy connects to
+  it over HTTPS, same as it already does for `voipbin-hook-manager`.
+- Uses `container_name: voipbin-api-manager` (the fleet's new-service
+  naming convention), not the old `voipbin-api-mgr` — `infra-caddy`'s
+  Caddyfile target must be updated to match in a companion
+  `monorepo-etc` PR.
+
+**Cutover sequence (short downtime, by design — see VOIP-1362)**:
+1. Deploy this Stack via CI. The new `voipbin-api-manager` container
+   starts and can be fully verified (DB/Redis/RabbitMQ connectivity, TLS
+   cert load, GCP credential load) **with zero live-traffic impact** —
+   Caddy is still pointed at the old `voipbin-api-mgr` the whole time.
+2. Once verified, get explicit go-ahead for the actual cutover window,
+   then: stop/remove the old `voipbin-api-mgr` container → merge/deploy
+   the companion `monorepo-etc` Caddyfile PR (new target
+   `voipbin-api-manager`) → confirm `api.voipbin.net` responds again.
+   The downtime window is exactly the gap between those two steps, not
+   the whole migration.
+3. Comment out (not delete) the `api-manager` block in the live
+   `install/docker-compose.yml` on bm-nyc-01, same as every other
+   migrated service, to prevent a `container_name`/host-port collision on
+   a future host rebuild.
+
+**GCP credential file**: same Docker Compose environment-sourced
+`secrets:` block as `bin-storage-manager` — see that service's
+`docs/operations.md` for the full mechanism. `GCP_SA_JSON` comes from
+`komodo/environment.env`, passed as `komodo-api-deploy.sh`'s 3rd
+argument.
+
+**`SSL_PRIVKEY_BASE64` env var name note**: the Configuration table above
+lists `SSL_PRIVATE_BASE64` — that is stale/incorrect. The actual env var
+`internal/config/main.go` binds via viper is `SSL_PRIVKEY_BASE64`,
+matching `install/`'s own `docker-compose.yml.dist`. The Komodo compose
+file uses the correct (source-verified) name.
+
+No healthcheck block: distroless (`gcr.io/distroless/static-debian12`),
+same as every other distroless `bin-*-manager` service (VOIP-1342 pilot
+established the fleet-standard `wget` healthcheck can never pass on this
+image).

--- a/bin-api-manager/komodo/docker-compose.yml
+++ b/bin-api-manager/komodo/docker-compose.yml
@@ -1,0 +1,87 @@
+# Komodo Stack definition for bin-api-manager (VOIP-1362, Tier 5 - final
+# service, migrated last per the plan's explicit "highest blast radius,
+# always last" instruction). See VOIP-1351's spike conclusion and
+# VOIP-1358 (bin-storage-manager, the first service to use the GCP
+# credential pattern) for the shared design.
+#
+# CRITICAL DIFFERENCE FROM EVERY OTHER bin-*-manager SERVICE: this is the
+# only one that serves public HTTPS traffic directly (JWT auth, WebSocket
+# fan-out - see this service's own CLAUDE.md). install/'s
+# docker-compose.yml.dist publishes it to the HOST at 0.0.0.0:8443:443.
+# Deliberately NOT replicated here - Caddy (monorepo-etc's infra-caddy)
+# already reverse-proxies api.voipbin.net to this container over the
+# `production` network (confirmed live: infra-caddy's Caddyfile already
+# targets `voipbin-api-mgr:443`, the install/ container's name, and
+# infra-caddy's own compose file documents this container as one of its
+# 5 reverse-proxy targets already reachable via `production`). This
+# means:
+#   - No `ports:` block here at all - the container is reachable ONLY via
+#     Caddy inside `production`, never a host-published port.
+#   - TLS is still self-terminated by this container (SSL_CERT_BASE64/
+#     SSL_PRIVKEY_BASE64 below) - Caddy's reverse_proxy connects to it
+#     over HTTPS (see infra-caddy's Caddyfile), same as it already does
+#     for voipbin-hook-manager.
+#   - The container_name here is `voipbin-api-manager` (the new-service
+#     naming convention every other migrated service uses), NOT the old
+#     `voipbin-api-mgr` - monorepo-etc's Caddyfile reverse_proxy target
+#     must be updated to match in lockstep (separate PR) BEFORE traffic
+#     can flow to this container. Until that Caddy PR deploys, this
+#     container can run fully verified and healthy with zero live traffic
+#     impact - Caddy keeps talking to the old `voipbin-api-mgr` the whole
+#     time. See docs/operations.md's "Deployment (Komodo)" section for
+#     the full cutover sequence and why a brief downtime window (not a
+#     zero-downtime overlap like every RabbitMQ-only service in this
+#     rollout) is unavoidable here: two containers cannot both hold a
+#     unique reverse-proxy target name at once the way two RabbitMQ
+#     consumers can share one queue.
+#
+# GOOGLE_APPLICATION_CREDENTIALS: same Docker Compose environment-sourced
+# `secrets:` mechanism as bin-storage-manager - see that service's
+# komodo/docker-compose.yml for the full explanation.
+#
+# SSL_PRIVKEY_BASE64 (not the docs/operations.md table's "SSL_PRIVATE_
+# BASE64" - that table has a stale env var name; confirmed against
+# internal/config/main.go's actual viper binding: the real env var is
+# SSL_PRIVKEY_BASE64, matching install/'s own docker-compose.yml.dist).
+#
+# distroless (gcr.io/distroless/static-debian12): no healthcheck block,
+# same as every other distroless bin-*-manager service (VOIP-1342 pilot
+# already established the fleet-standard wget healthcheck can never pass
+# on this image).
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+
+services:
+  api-manager:
+    image: voipbin/bin-api-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-api-manager
+    restart: always
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
+    environment:
+      - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - REDIS_ADDRESS=[[BIN_MANAGER__REDIS_ADDRESS]]
+      - REDIS_DATABASE=1
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+      - SSL_CERT_BASE64=[[BIN_MANAGER__SSL_CERT_API_BASE64]]
+      - SSL_PRIVKEY_BASE64=[[BIN_MANAGER__SSL_PRIVKEY_API_BASE64]]
+      - GCP_PROJECT_ID=[[BIN_MANAGER__GCP_PROJECT_ID]]
+      - GCP_BUCKET_NAME=[[BIN_MANAGER__GCP_BUCKET_NAME_TMP]]
+      - JWT_KEY=[[BIN_MANAGER__JWT_KEY]]
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
+    command: ./api-manager
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/bin-api-manager/komodo/environment.env
+++ b/bin-api-manager/komodo/environment.env
@@ -1,0 +1,5 @@
+# Komodo Stack-level environment (VOIP-1351/VOIP-1358 pattern, reused
+# here). See bin-storage-manager/komodo/environment.env for the full
+# explanation - this file is passed as komodo-api-deploy.sh's optional 3rd
+# argument and PATCHed into the Stack's own `environment` config field.
+GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]


### PR DESCRIPTION
Migrate bin-api-manager (Tier 5, final service in the install/->Komodo rollout) from the install/ssh-deploy mechanism to Komodo Stack API-managed deploys.

This is the highest-blast-radius service in the rollout (sole public HTTP/WebSocket API entry point, JWT auth) and is deliberately migrated last. It also differs fundamentally from every other bin-*-manager service migrated so far: it serves public HTTPS traffic directly rather than only RabbitMQ RPC, so the zero-downtime competing-consumer overlap trick used for every prior service does not apply (two containers cannot both hold a host-published port).

- bin-api-manager: Add komodo/docker-compose.yml - no host port published (unlike install/'s 0.0.0.0:8443:443); reachable only via Caddy's already-existing reverse-proxy to this service over the production network. TLS is still self-terminated by the container. GCP credential via the same Docker Compose environment-sourced secrets block as bin-storage-manager/VOIP-1358.
- bin-api-manager: Add komodo/environment.env carrying GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]
- bin-api-manager: Document the Komodo deployment and the Caddy-routed cutover sequence (short downtime by design, not zero-downtime) in docs/operations.md; also fix a stale SSL_PRIVATE_BASE64 env var name in the Configuration table (source-verified actual name is SSL_PRIVKEY_BASE64)
- monorepo: Wire bin-api-manager-deploy into .circleci/config_work.yml

Deploying this Stack has ZERO live-traffic impact by itself - Caddy stays pointed at the old voipbin-api-mgr container until a companion monorepo-etc PR (updating infra-caddy's Caddyfile reverse-proxy target) is merged and deployed. That companion PR and the actual cutover will follow after this one is verified live.