### PR TITLE
NOJIRA-Fix-tts-manager-gcp-credentials

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -2022,7 +2022,7 @@ jobs:
           name: Deploy bin-tts-manager via Komodo API
           command: |
             CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
-              .circleci/scripts/komodo-api-deploy.sh bin-tts-manager bin-tts-manager/komodo/docker-compose.yml
+              .circleci/scripts/komodo-api-deploy.sh bin-tts-manager bin-tts-manager/komodo/docker-compose.yml bin-tts-manager/komodo/environment.env
 
   # bin-webchat-manager
   bin-webchat-manager-test:

--- a/bin-tts-manager/CLAUDE.md
+++ b/bin-tts-manager/CLAUDE.md
@@ -36,7 +36,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 **Per-pod queue routing uses `HOSTNAME`** (not `POD_IP`): The `HostID` for the per-pod queue is `HOSTNAME` (Kubernetes pod name). Streaming control RPCs (`say_init`, `say_add`, `say_stop`, `say_finish`) must be routed to `bin-manager.tts-manager.request.<HOSTNAME>`.
 
-**`POD_IP` is for AudioSocket advertising**: `POD_IP` (Kubernetes Downward API) is used to tell Asterisk where to dial for audio frames — it is NOT the queue host ID.
+**`POD_IP` is the batch-TTS media URL host**: `POD_IP` feeds `buckethandler`'s media URL (`http://<host>/<file>`, fetched by Asterisk) — it is NOT the queue host ID. On GKE it is the pod IP (Downward API), rewritten to the pod-DNS form; on Docker Compose (bm-nyc-01) it is the media http sidecar's container name (`voipbin-tts-manager-http`), used verbatim. It is the only `POD_IP` consumer in this service (`cmd/tts-manager/main.go`).
 
 **Provider fallback order**: GCP Cloud TTS (primary) → AWS Polly (fallback). GCP uses ADC; fallback is tracked by `speech_fallback_total` metric.
 

--- a/bin-tts-manager/cmd/tts-manager/main.go
+++ b/bin-tts-manager/cmd/tts-manager/main.go
@@ -126,6 +126,14 @@ func run(db *sql.DB) error {
 	podID := os.Getenv("HOSTNAME")
 
 	ttsHandler := ttshandler.NewTTSHandler(config.Get().AWSAccessKey, config.Get().AWSSecretKey, config.Get().GCPTTSEndpoint, "/shared-data", localAddress, reqHandler, notifyHandler)
+	if ttsHandler == nil {
+		// Fail fast: a nil handler would otherwise sit in the listener and
+		// nil-panic on the first /v1/speeches request (the 2026-08-22
+		// missing-GCP-credentials incident surfaced exactly this way -
+		// 10s RPC timeouts on every TTS request while the container
+		// crash-looped per request instead of failing at startup).
+		logrus.Fatalf("Could not create the tts handler. Check TTS provider credentials (e.g. GOOGLE_APPLICATION_CREDENTIALS).")
+	}
 	streamingHandler := streaminghandler.NewStreamingHandler(reqHandler, notifyHandler, podID, config.Get().ElevenlabsAPIKey, config.Get().AWSAccessKey, config.Get().AWSSecretKey)
 
 	// initialize cache and db handlers

--- a/bin-tts-manager/docs/operations.md
+++ b/bin-tts-manager/docs/operations.md
@@ -4,14 +4,16 @@
 
 | Symptom | Likely Cause | Resolution |
 |---------|-------------|------------|
-| Batch TTS returns no audio URL | GCP ADC credentials not available | Check `GOOGLE_APPLICATION_CREDENTIALS` points to a valid mounted service account key file; check `speech_fallback_total` metric |
+| Service exits at startup ("Could not create the tts handler") | GCP ADC credentials not available — the daemon fails fast instead of nil-panicking on the first `/v1/speeches` request | Check `GOOGLE_APPLICATION_CREDENTIALS` points to a valid credential file (`/run/secrets/google_service_account.json`, materialized by the Komodo compose `secrets:` block); verify the `BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON` Komodo Variable is synced |
+| Batch TTS returns no audio URL | GCP request failing at runtime (quota, endpoint), or `/shared-data` not writable (volume missing from the compose stack) | Check `speech_fallback_total` metric (AWS Polly is the fallback provider); verify the `shared-data` volume is mounted in `komodo/docker-compose.yml` |
+| Call connects but TTS audio is silent while `/v1/speeches` succeeds | Asterisk cannot fetch the media URL — `voipbin-tts-manager-http` sidecar down, or `POD_IP` missing/wrong so the URL host does not resolve | Check the `tts-manager-http` container is running on the `production` network; verify `POD_IP=voipbin-tts-manager-http` in the compose stack |
 | AWS Polly fallback failing | Missing `aws_access_key` / `aws_secret_key` | Verify credentials in environment; check AWS Polly quotas |
 | Streaming session RPC timeout | RPC routed to wrong pod (wrong per-pod queue) | Verify `host_id` matches `HOSTNAME` of target pod; check per-pod queue binding |
 | AudioSocket connection refused | Go service port 8080 not listening | Check pod readiness; verify no port conflict with Python sidecar |
 | Audio file not served by sidecar | `/shared-data` volume not mounted or empty | Check pod volume mount; verify Go service wrote the file before sidecar serves it |
 | ElevenLabs WebSocket disconnect | Rate limit or API key invalid | Check `streaming_error_total` metric; verify `ELEVENLABS_API_KEY` |
 | Keep-alive timeout | Network issue between pod and ElevenLabs | Check `streaming_error_total`; session is cleaned up automatically |
-| `POD_IP` not set | Missing Kubernetes Downward API configuration | Verify `k8s/deployment.yml` injects `status.podIP` as `POD_IP` |
+| `POD_IP` not set | GKE: missing Downward API configuration. Compose: env dropped from the stack | GKE: verify `k8s/deployment.yml` injects `status.podIP` as `POD_IP`. Compose: verify `POD_IP=voipbin-tts-manager-http` in `komodo/docker-compose.yml` |
 
 ## Debugging Guide
 
@@ -58,6 +60,26 @@ instead of the older SSH + `versions.lock` (`ssh-deploy.sh`) path.
   the built image tag, then `.circleci/scripts/komodo-api-deploy.sh`
   pushes the file's content to Komodo and triggers a deploy, gated
   by the `bin-tts-manager-deploy` job's poll/running checks.
+- **GCP credential file:** same Docker Compose environment-sourced
+  `secrets:` block as bin-storage-manager/bin-transcribe-manager.
+  `GCP_SA_JSON` comes from `komodo/environment.env`, passed as
+  `komodo-api-deploy.sh`'s 3rd argument, and is materialized inside the
+  container at `/run/secrets/google_service_account.json`
+  (`GOOGLE_APPLICATION_CREDENTIALS` points there). tts-manager was missed
+  in the original GCP-credential-file rollout — on GKE this worked
+  implicitly via workload-identity ADC, so the gap only surfaced on
+  bm-nyc-01 (see NOJIRA-Fix-tts-manager-gcp-credentials).
+- **Batch-TTS media delivery:** the stack runs two containers sharing a
+  named `shared-data` volume — the Go service writes wav files to
+  `/shared-data`, and the `tts-manager-http` sidecar
+  (`voipbin-tts-manager-http`, `python3 -m http.server 80`) serves them,
+  mirroring the GKE pod's http-server container. `POD_IP` is set to the
+  sidecar's container name so the media URL host resolves via Docker DNS
+  on the `production` network (Asterisk fetches the wav from that URL).
+  All three pieces (volume, sidecar, `POD_IP`) were dropped in the
+  original Komodo migration, so batch TTS was silent on bm-nyc-01 even
+  with working credentials (same NOJIRA-Fix-tts-manager-gcp-credentials
+  incident).
 - **Full design and cutover procedure:**
   [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier2-design.md)
   (in the monorepo root, not this service's own `docs/`).
@@ -75,12 +97,12 @@ instead of the older SSH + `versions.lock` (`ssh-deploy.sh`) path.
 | `redis_address` / `REDIS_ADDRESS` | Redis server address | required |
 | `redis_password` / `REDIS_PASSWORD` | Redis authentication | optional |
 | `redis_db` / `REDIS_DB` | Redis DB index | optional |
-| `POD_IP` | Pod IP (Kubernetes Downward API) — AudioSocket advertise address | required |
+| `POD_IP` | Media URL host for batch TTS. On GKE: pod IP (Downward API), rewritten to the pod-DNS form. On Docker Compose: the media http sidecar's container name (`voipbin-tts-manager-http`), used verbatim | required |
 | `HOSTNAME` | Pod hostname (Kubernetes) — used as `HostID` for per-pod queue | required |
 | `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics HTTP path | `/metrics` |
 | `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics listen address | `:2112` |
 
-GCP authentication uses Application Default Credentials via `GOOGLE_APPLICATION_CREDENTIALS` (mounted service account key file from `Secret/voipbin` key `GOOGLE_APPLICATION_CREDENTIALS_JSON`).
+GCP authentication uses Application Default Credentials via `GOOGLE_APPLICATION_CREDENTIALS`, pointing at `/run/secrets/google_service_account.json` — materialized by the Komodo compose `secrets:` block from the `BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON` Komodo Variable (see the Deployment section above). If the credential file is missing or invalid, the daemon fails fast at startup instead of serving requests.
 
 ## Prometheus Metrics
 

--- a/bin-tts-manager/komodo/docker-compose.yml
+++ b/bin-tts-manager/komodo/docker-compose.yml
@@ -5,6 +5,35 @@
 # pkg/streaminghandler (websocket keepalive/write pacing) are scoped to
 # individual streaming sessions, not a global background loop -- see the
 # design doc's ticker/cron audit.
+#
+# GCP service-account credential materialization: same mechanism as
+# bin-storage-manager (VOIP-1358, first user of the pattern) - see the
+# comment at the top of that service's komodo/docker-compose.yml for the
+# full explanation. tts-manager was missed in the original "GCP
+# credential file services" rollout (its GCP Cloud TTS client relied on
+# GKE workload-identity ADC, which does not exist on bm-nyc-01), so
+# every TTS request nil-panicked until this was added - see
+# NOJIRA-Fix-tts-manager-gcp-credentials.
+#
+# Batch-TTS media delivery (shared-data volume + tts-manager-http +
+# POD_IP): the GKE pod ran the Go service next to a python http.server
+# sidecar over a shared emptyDir (k8s/deployment.yml), and Asterisk
+# fetched the generated wav from
+# http://<pod-ip-dashed>.bin-manager.pod.cluster.local/<file>. None of
+# that survived the Komodo migration - no /shared-data volume (both TTS
+# providers ENOENT'd on write), no http sidecar, and no POD_IP (the
+# media URL degenerated to an empty-host GKE DNS name). Here the two
+# containers share a named volume, and POD_IP carries the sidecar's
+# container name, which buckethandler now uses verbatim as the media URL
+# host (Docker's embedded DNS resolves it for every container on the
+# `production` network, including Asterisk).
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+
+volumes:
+  shared-data: {}
+
 services:
   tts-manager:
     image: voipbin/bin-tts-manager:__IMAGE_TAG__
@@ -15,6 +44,11 @@ services:
         max-file: "3"
     container_name: voipbin-tts-manager
     restart: always
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
+    volumes:
+      - shared-data:/shared-data
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
@@ -25,7 +59,28 @@ services:
       - AWS_ACCESS_KEY=[[BIN_MANAGER__AWS_ACCESS_KEY]]
       - AWS_SECRET_KEY=[[BIN_MANAGER__AWS_SECRET_KEY]]
       - ELEVENLABS_API_KEY=[[BIN_MANAGER__ELEVENLABS_API_KEY]]
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
+      - POD_IP=voipbin-tts-manager-http
     command: ./tts-manager
+    networks:
+      default: {}
+
+  # Media http sidecar: serves the batch-TTS wav files the Go service
+  # writes into /shared-data. Same image and command as the GKE pod's
+  # http-server container (k8s/deployment.yml). bin-tts-manager/CLAUDE.md:
+  # "Do not serve files directly from the Go service."
+  tts-manager-http:
+    image: python:3.9-bookworm
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-tts-manager-http
+    restart: always
+    volumes:
+      - shared-data:/shared-data
+    command: ["sh", "-c", "python3 -m http.server 80 -d /shared-data 2>&1"]
     networks:
       default: {}
 networks:

--- a/bin-tts-manager/komodo/environment.env
+++ b/bin-tts-manager/komodo/environment.env
@@ -1,0 +1,5 @@
+# Komodo Stack-level environment (VOIP-1351/VOIP-1358 pattern, reused
+# here). See bin-storage-manager/komodo/environment.env for the full
+# explanation - this file is passed as komodo-api-deploy.sh's optional 3rd
+# argument and PATCHed into the Stack's own `environment` config field.
+GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]

--- a/bin-tts-manager/pkg/buckethandler/main.go
+++ b/bin-tts-manager/pkg/buckethandler/main.go
@@ -5,6 +5,7 @@ package buckethandler
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -65,8 +66,18 @@ func NewBucketHandler(osMediaBucketDirectory string, osAddress string) BucketHan
 	})
 	log.Debugf("Creating a new bucket handler.")
 
-	tmpAddress := strings.ReplaceAll(osAddress, ".", "-")
-	osLocalAddress := fmt.Sprintf("%s.bin-manager.pod.cluster.local", tmpAddress)
+	// osAddress is the address other services use to fetch the generated
+	// media over HTTP (the media http sidecar). On Kubernetes it is the
+	// pod IP (Downward API) and must be converted to the GKE pod DNS
+	// form. On Docker Compose deployments (bm-nyc-01) it is already a
+	// resolvable hostname - the media http sidecar's container name on
+	// the shared Docker network - so it is used verbatim; appending the
+	// GKE suffix there would produce a hostname that resolves nowhere.
+	osLocalAddress := osAddress
+	if ip := net.ParseIP(osAddress); ip != nil {
+		tmpAddress := strings.ReplaceAll(osAddress, ".", "-")
+		osLocalAddress = fmt.Sprintf("%s.bin-manager.pod.cluster.local", tmpAddress)
+	}
 	log.Debugf("Generated os local address. os_local_address: %s", osLocalAddress)
 
 	h := &bucketHandler{

--- a/bin-tts-manager/pkg/buckethandler/main_test.go
+++ b/bin-tts-manager/pkg/buckethandler/main_test.go
@@ -26,6 +26,30 @@ func Test_NewBucketHandler(t *testing.T) {
 			expectedOsBucketDir:     "/var/media",
 			expectedOsLocalAddress:  "192-168-1-100.bin-manager.pod.cluster.local",
 		},
+		{
+			// Docker Compose deployments (bm-nyc-01) set POD_IP to the media
+			// http sidecar's container name - a hostname must be used
+			// verbatim, never rewritten into the GKE pod DNS form.
+			name:                    "hostname is used verbatim",
+			osMediaBucketDirectory:  "/shared-data",
+			osAddress:               "voipbin-tts-manager-http",
+			expectedOsBucketDir:     "/shared-data",
+			expectedOsLocalAddress:  "voipbin-tts-manager-http",
+		},
+		{
+			name:                    "empty address stays empty",
+			osMediaBucketDirectory:  "/shared-data",
+			osAddress:               "",
+			expectedOsBucketDir:     "/shared-data",
+			expectedOsLocalAddress:  "",
+		},
+		{
+			name:                    "ipv6 address gets the gke pod dns form",
+			osMediaBucketDirectory:  "/shared-data",
+			osAddress:               "fd00::1",
+			expectedOsBucketDir:     "/shared-data",
+			expectedOsLocalAddress:  "fd00::1.bin-manager.pod.cluster.local",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix silent TTS calls on bm-nyc-01: bin-tts-manager was missed in the GCP-credential-file rollout and the Komodo migration also dropped the entire batch-TTS media delivery chain, so every talk action produced 10 seconds of silence (per-request nil panic, then ENOENT and an unresolvable media URL even with credentials).

- bin-tts-manager: Wire the GCP service-account credential into the Komodo stack using the established bin-storage-manager/bin-transcribe-manager environment-sourced secrets pattern (komodo/docker-compose.yml, new komodo/environment.env)
- bin-tts-manager: Fail fast at startup when NewTTSHandler returns nil instead of nil-panicking on the first /v1/speeches request
- bin-tts-manager: Restore the batch-TTS media delivery chain dropped in the Komodo migration - shared-data volume, tts-manager-http sidecar (python http.server, same image and command as the GKE pod's http-server container), and POD_IP set to the sidecar's container name
- bin-tts-manager: buckethandler applies the GKE pod-DNS rewrite only when POD_IP is an IP address; a hostname (the Compose sidecar's container name) is used verbatim as the media URL host, with unit tests for both paths
- bin-tts-manager: Sync docs/operations.md and CLAUDE.md (deployment credential and media-delivery sections, failure-modes table, POD_IP description) with the new deployment shape
- .circleci: bin-tts-manager-deploy passes komodo/environment.env as komodo-api-deploy.sh's 3rd argument, same as the other GCP-credential services