### PR TITLE
NOJIRA-Fix-pipecat-runner-sidecar

### DIFF
--- a/bin-pipecat-manager/docs/operations.md
+++ b/bin-pipecat-manager/docs/operations.md
@@ -86,8 +86,8 @@ cd scripts/pipecat && uvicorn main:app --host 0.0.0.0 --port 8000
 
 ## Deployment Notes
 
-- Both Go (port 8080) and Python (port 8000) components must be running on the same pod/container.
-- The Dockerfile builds both Go and Python components; Python service is started alongside the Go binary via process supervisor.
+- Both Go (port 8080) and Python (port 8000) components must be running in the same network namespace — the Go side drives the Python runner at `http://localhost:8000/run`.
+- The Dockerfile builds one image carrying both the Go binary and the Python pipeline (deps preinstalled); each deployment runs it twice — once as the Go service, once as the Python runner. On GKE these were two containers in one pod (`k8s/deployment.yml`); on Komodo/Compose they are the `pipecat-manager` and `pipecat-script-runner` services, the latter joined via `network_mode: "service:pipecat-manager"`.
 - Per-pod queues are declared **volatile** — they auto-delete when the pod terminates, preventing dead-letter buildup.
 
 ## Deployment (Komodo)
@@ -97,7 +97,7 @@ Komodo-managed (VOIP-1350), same mechanism as the other `bin-*-manager` services
 `.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
 from `komodo/docker-compose.yml`.
 
-Two deviations from the Tier 1/2 template, both intentional:
+Three deviations from the Tier 1/2 template, all intentional:
 - **Non-distroless runtime** (`python:3.12-slim`, needed to run the Python
   Pipecat pipeline) — the healthcheck uses `python3 -c "import urllib..."`
   instead of the fleet-standard `wget` CMD, since `python:3.12-slim` has
@@ -111,3 +111,12 @@ Two deviations from the Tier 1/2 template, both intentional:
   A real per-container unique `HostID` (needed if this service is ever
   scaled to multiple replicas) is a separate follow-up, not part of this
   cutover.
+- **`pipecat-script-runner` sidecar** (added 2026-08-22,
+  NOJIRA-Fix-pipecat-runner-sidecar): the Python Pipecat pipeline runs as
+  a second service from the same image (`python /app/scripts/pipecat/main.py`,
+  uvicorn on 0.0.0.0:8000), sharing the Go container's network namespace
+  via `network_mode: "service:pipecat-manager"` so localhost:8000 works
+  exactly as it did in the GKE pod. It was dropped in the original Komodo
+  cutover, which made every `ai_talk` action fail with connection-refused
+  on localhost:8000 and tear the call down. It receives the same six
+  STT/LLM/TTS API-key env vars the GKE runner container had.

--- a/bin-pipecat-manager/komodo/docker-compose.yml
+++ b/bin-pipecat-manager/komodo/docker-compose.yml
@@ -9,6 +9,16 @@
 # string, not an actual runtime pod IP - this was written for a
 # Kubernetes downward-API value that was never wired up for Docker
 # Compose) is used as-is, matching current production behavior exactly.
+#
+# pipecat-script-runner: the Python Pipecat pipeline sidecar (FastAPI/
+# uvicorn on 0.0.0.0:8000) the Go service drives via
+# http://localhost:8000/run. On GKE this was a second container in the
+# same pod (k8s/deployment.yml's pipecat-script-runner); it was dropped
+# in the Komodo migration, so every ai_talk action failed with
+# "connection refused" on localhost:8000 and the flow tore the call
+# down (2026-08-22 incident, NOJIRA-Fix-pipecat-runner-sidecar). Same
+# image (all Python deps are baked in), network_mode
+# "service:pipecat-manager" reproduces the GKE pod's shared localhost.
 services:
   pipecat-manager:
     image: voipbin/bin-pipecat-manager:__IMAGE_TAG__
@@ -41,6 +51,33 @@ services:
     command: ./pipecat-manager
     networks:
       default: {}
+
+  pipecat-script-runner:
+    image: voipbin/bin-pipecat-manager:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: voipbin-pipecat-script-runner
+    restart: always
+    # Shares the Go service's network namespace so the Go side reaches
+    # uvicorn at localhost:8000, exactly like the GKE pod. A container in
+    # another container's netns cannot declare its own networks/ports.
+    network_mode: "service:pipecat-manager"
+    depends_on:
+      - pipecat-manager
+    # Same env set the GKE pipecat-script-runner container received
+    # (k8s/deployment.yml) - the Python side calls the STT/LLM/TTS APIs
+    # directly.
+    environment:
+      - CARTESIA_API_KEY=[[BIN_MANAGER__CARTESIA_API_KEY]]
+      - ELEVENLABS_API_KEY=[[BIN_MANAGER__ELEVENLABS_API_KEY]]
+      - OPENAI_API_KEY=[[BIN_MANAGER__OPENAI_API_KEY]]
+      - DEEPGRAM_API_KEY=[[BIN_MANAGER__DEEPGRAM_API_KEY]]
+      - XAI_API_KEY=[[BIN_MANAGER__XAI_API_KEY]]
+      - GOOGLE_API_KEY=[[BIN_MANAGER__GOOGLE_API_KEY]]
+    command: ["python", "/app/scripts/pipecat/main.py"]
 networks:
   default:
     name: production


### PR DESCRIPTION
Restore the Python Pipecat runner dropped in the Komodo migration - without it every ai_talk flow action failed with connection-refused on localhost:8000 and tore the call down (2026-08-22 incident).

- bin-pipecat-manager: Add the pipecat-script-runner sidecar service to the Komodo stack - the Python Pipecat pipeline (uvicorn on 0.0.0.0:8000) runs from the same image via python /app/scripts/pipecat/main.py, joined to the Go service's network namespace with network_mode service:pipecat-manager so localhost:8000 works exactly as in the GKE pod (mirrors k8s/deployment.yml's pipecat-script-runner container)
- bin-pipecat-manager: The sidecar receives the same six STT/LLM/TTS API-key env vars the GKE runner container had (CARTESIA/ELEVENLABS/OPENAI/DEEPGRAM/XAI/GOOGLE)
- bin-pipecat-manager: Sync docs/operations.md - correct the stale process-supervisor claim, document the two-service topology, and add the sidecar to the Komodo deviations list