### PR TITLE
VOIP-1386-Add-column-statistics-flag-to-schedule-backup

### DIFF
--- a/bin-schedule-manager/CLAUDE.md
+++ b/bin-schedule-manager/CLAUDE.md
@@ -85,10 +85,10 @@ golangci-lint run -v --timeout 5m
 The fleet standard runtime image is distroless static. This service's runtime stage is **`debian:bookworm-slim` + `mysql-community-client` 8.0 from MySQL's official APT repo** — a sanctioned deviation (design §7, same status as bin-call-manager's raw-SQL exception):
 
 - The scheduled DB backup executes `mysqldump` as a subprocess, which needs a binary-carrying base image.
-- The client must be **genuine MySQL 8.0**, not MariaDB: alpine's `mysql-client` and debian's `default-mysql-client` are MariaDB aliases, an unsupported pairing against the MySQL 8.0 platform DB (`caching_sha2_password` auth, incompatible dump output).
-- Client pin follows the platform DB server version. When the platform migrates to MySQL 8.4/9.x, bumping this package is part of that migration's checklist.
+- The platform DB is migrating from MySQL 8.0 to **MariaDB 12.3 LTS (VOIP-1386)**. The `mysqldump` 8.0 client is kept through that migration: with `--column-statistics=0` (set in `backuphandler`) it is empirically validated against BOTH server states — MySQL 8.0 (flag is a no-op) and MariaDB 12.3 (without the flag the dump aborts with `Unknown table 'COLUMN_STATISTICS'`, error 1109). This makes the backup deploy-order-independent of the cutover.
+- Do not swap in debian's `default-mysql-client`/alpine's `mysql-client` (MariaDB alias clients) as a drive-by "fix": switching to `mariadb-dump` requires reworking the flag set (`--set-gtid-purged` is MySQL-only) and is tracked as a separate follow-up ticket after the VOIP-1386 cutover stabilizes.
 
-Do NOT "fix" the Dockerfile back to distroless or swap in a MariaDB client.
+Do NOT "fix" the Dockerfile back to distroless. The mariadb-client switch happens only in its own dedicated change, not opportunistically.
 
 ## CRITICAL: DB-driven `target_queue` — sanctioned exception to two conventions
 

--- a/bin-schedule-manager/Dockerfile
+++ b/bin-schedule-manager/Dockerfile
@@ -12,12 +12,14 @@ RUN cd bin-schedule-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/b
 #
 # Deviation from the fleet-standard distroless static runtime (design §7,
 # documented in this service's CLAUDE.md): the scheduled DB backup runs
-# genuine mysqldump 8.0 as a subprocess against the MySQL 8.0 platform
-# database, so the runtime image must carry the MySQL client binaries.
-# mysql-community-client comes from MySQL's official APT repository —
-# alpine/debian "mysql-client"/"default-mysql-client" are MariaDB aliases,
-# an unsupported pairing against MySQL 8.0 (caching_sha2_password auth,
-# incompatible dump output).
+# mysqldump 8.0 as a subprocess against the platform database, so the
+# runtime image must carry the client binaries. The platform DB is
+# migrating from MySQL 8.0 to MariaDB 12.3 (VOIP-1386); this client is
+# validated against both server states via --column-statistics=0 set in
+# backuphandler (see CLAUDE.md "Runtime image deviation"). Switching to
+# mariadb-client is a separate post-cutover follow-up, not a drive-by
+# edit here. mysql-community-client comes from MySQL's official APT
+# repository.
 FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
 # Key integrity: fetch MySQL's signing key over HTTPS from repo.mysql.com

--- a/bin-schedule-manager/pkg/backuphandler/backup.go
+++ b/bin-schedule-manager/pkg/backuphandler/backup.go
@@ -73,6 +73,12 @@ func (h *backupHandler) Backup(ctx context.Context) (*Result, error) {
 		"--routines",
 		"--triggers",
 		"--set-gtid-purged=OFF",
+		// mysqldump 8.0 defaults to querying
+		// information_schema.COLUMN_STATISTICS, which does not exist on
+		// MariaDB (the platform DB as of VOIP-1386) and aborts the dump
+		// with error 1109. Disabling it is a no-op against MySQL 8, so
+		// this flag is safe in both server states.
+		"--column-statistics=0",
 		cfg.DBName,
 	}
 

--- a/bin-schedule-manager/pkg/backuphandler/backup_test.go
+++ b/bin-schedule-manager/pkg/backuphandler/backup_test.go
@@ -111,6 +111,7 @@ func Test_Backup(t *testing.T) {
 		"--routines",
 		"--triggers",
 		"--set-gtid-purged=OFF",
+		"--column-statistics=0",
 		"voipbin",
 	}
 	if !reflect.DeepEqual(runner.capturedArgs[1:], expectArgs) {


### PR DESCRIPTION
Keep the nightly platform-DB backup working across the MySQL 8.0 to MariaDB 12.3 migration (VOIP-1386, companion PR: voipbin/monorepo-etc#146). mysqldump 8.0 queries information_schema.COLUMN_STATISTICS by default, which does not exist on MariaDB and aborts the dump with error 1109 (empirically reproduced against mariadb:12.3); disabling it is a no-op against MySQL 8.0 (also empirically verified), so this PR is safe to merge and deploy any time before the cutover - and MUST be deployed before it.

- bin-schedule-manager: add --column-statistics=0 to the mysqldump argv in backuphandler
- bin-schedule-manager: extend the backup args regression test with the new flag
- bin-schedule-manager: rewrite the CLAUDE.md runtime-image-deviation rationale for the MariaDB migration (client stays mysqldump 8.0, validated against both server states; mariadb-client switch deferred to a dedicated follow-up)
- bin-schedule-manager: update the Dockerfile comment to match

Test results: go test 260 passed in 14 packages, golangci-lint clean (full 5-step verification workflow)