### PR TITLE
VOIP-1387-Fix-mariadb-generated-column-not-null

### DIFF
--- a/bin-dbscheme-manager/bin-manager/main/versions/167bebb7c46f_contact_cases_peer_local_address_json.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/167bebb7c46f_contact_cases_peer_local_address_json.py
@@ -101,20 +101,34 @@ def upgrade():
             DROP COLUMN peer_target;
     """)
 
+    # peer_type/peer_target are STORED (not "STORED NOT NULL"): MariaDB
+    # rejects NOT NULL on a generated column outright (error 1064, no
+    # valid clause order) -- MySQL 8 accepted it, which is how this
+    # shipped originally, but it broke bin-dbscheme-manager's Docker
+    # build once that build's builder stage moved to MariaDB (VOIP-1386
+    # investigation; VOIP-1387). The NOT NULL guarantee is restored via
+    # explicit CHECK constraints in the same statement instead --
+    # MariaDB has supported CHECK since 10.2.1, and this exact
+    # STORED+CHECK pattern was empirically validated (create + enforce)
+    # against MariaDB 12.3 during VOIP-1386's production cutover.
     op.execute("""
         ALTER TABLE contact_cases
             ADD COLUMN peer_type VARCHAR(255)
-                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.type'))) STORED NOT NULL
+                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.type'))) STORED
                 AFTER peer,
             ADD COLUMN peer_target VARCHAR(255)
-                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.target'))) STORED NOT NULL
+                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.target'))) STORED
                 AFTER peer_type,
             ADD COLUMN local_type VARCHAR(255)
                 GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(local, '$.type'))) STORED
                 AFTER local,
             ADD COLUMN local_target VARCHAR(255)
                 GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(local, '$.target'))) STORED
-                AFTER local_type;
+                AFTER local_type,
+            ADD CONSTRAINT chk_contact_cases_peer_type_not_null
+                CHECK (peer_type IS NOT NULL),
+            ADD CONSTRAINT chk_contact_cases_peer_target_not_null
+                CHECK (peer_target IS NOT NULL);
     """)
 
     # Recreate open_peer_uk/uq_case_open_peer now that peer_type/peer_target
@@ -159,6 +173,15 @@ def downgrade():
         UPDATE contact_cases
         SET peer_type_plain = peer_type,
             peer_target_plain = peer_target;
+    """)
+
+    # DROP CONSTRAINT before DROP COLUMN: MariaDB refuses to drop a
+    # column referenced by a CHECK constraint (same requirement 99e7e955a149
+    # already documents for chk_resolution_case_or_interaction / case_id).
+    op.execute("""
+        ALTER TABLE contact_cases
+            DROP CONSTRAINT chk_contact_cases_peer_type_not_null,
+            DROP CONSTRAINT chk_contact_cases_peer_target_not_null;
     """)
 
     op.execute("""

--- a/bin-dbscheme-manager/bin-manager/main/versions/b41d1b2317af_contact_interactions_peer_local_address_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/b41d1b2317af_contact_interactions_peer_local_address_.py
@@ -116,20 +116,29 @@ def upgrade():
             DROP COLUMN local_target;
     """)
 
+    # peer_type/peer_target are STORED (not "STORED NOT NULL") -- MariaDB
+    # rejects NOT NULL on a generated column outright (error 1064). See
+    # 167bebb7c46f's identical fix comment (VOIP-1386/VOIP-1387) for the
+    # full rationale; the NOT NULL guarantee is restored via CHECK
+    # constraints in the same statement.
     op.execute("""
         ALTER TABLE contact_interactions
             ADD COLUMN peer_type VARCHAR(255)
-                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.type'))) STORED NOT NULL
+                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.type'))) STORED
                 AFTER peer,
             ADD COLUMN peer_target VARCHAR(255)
-                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.target'))) STORED NOT NULL
+                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.target'))) STORED
                 AFTER peer_type,
             ADD COLUMN local_type VARCHAR(255)
                 GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(local, '$.type'))) STORED
                 AFTER local,
             ADD COLUMN local_target VARCHAR(255)
                 GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(local, '$.target'))) STORED
-                AFTER local_type;
+                AFTER local_type,
+            ADD CONSTRAINT chk_contact_interactions_peer_type_not_null
+                CHECK (peer_type IS NOT NULL),
+            ADD CONSTRAINT chk_contact_interactions_peer_target_not_null
+                CHECK (peer_target IS NOT NULL);
     """)
 
     # Restore idx_contact_interactions_idem/idx_contact_interactions_peer to
@@ -194,6 +203,15 @@ def downgrade():
             peer_target_plain = peer_target,
             local_type_plain = IFNULL(local_type, ''),
             local_target_plain = IFNULL(local_target, '');
+    """)
+
+    # DROP CONSTRAINT before DROP COLUMN: MariaDB refuses to drop a
+    # column referenced by a CHECK constraint (same requirement 99e7e955a149
+    # already documents for chk_resolution_case_or_interaction / case_id).
+    op.execute("""
+        ALTER TABLE contact_interactions
+            DROP CONSTRAINT chk_contact_interactions_peer_type_not_null,
+            DROP CONSTRAINT chk_contact_interactions_peer_target_not_null;
     """)
 
     op.execute("""

--- a/bin-dbscheme-manager/bin-manager/main/versions/d8b04ef3ddd0_contact_drop_legacy_interaction_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/d8b04ef3ddd0_contact_drop_legacy_interaction_.py
@@ -86,9 +86,9 @@ def downgrade():
             local JSON NULL,
 
             peer_type VARCHAR(255)
-                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.type'))) STORED NOT NULL,
+                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.type'))) STORED,
             peer_target VARCHAR(255)
-                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.target'))) STORED NOT NULL,
+                GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(peer, '$.target'))) STORED,
             local_type VARCHAR(255)
                 GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(local, '$.type'))) STORED,
             local_target VARCHAR(255)
@@ -101,6 +101,15 @@ def downgrade():
             tm_create      DATETIME(6),
 
             PRIMARY KEY (id),
+            -- peer_type/peer_target are STORED, not "STORED NOT NULL" --
+            -- MariaDB rejects NOT NULL on a generated column outright
+            -- (error 1064). See 167bebb7c46f's identical fix comment
+            -- (VOIP-1386/VOIP-1387). The NOT NULL guarantee is restored
+            -- via explicit CHECK constraints below.
+            CONSTRAINT chk_contact_interactions_peer_type_not_null
+                CHECK (peer_type IS NOT NULL),
+            CONSTRAINT chk_contact_interactions_peer_target_not_null
+                CHECK (peer_target IS NOT NULL),
             UNIQUE INDEX idx_contact_interactions_idem (reference_type, reference_id, peer_target),
             INDEX        idx_contact_interactions_peer (customer_id, peer_type, peer_target),
             INDEX        idx_contact_interactions_cursor (customer_id, tm_create)


### PR DESCRIPTION
Fix bin-dbscheme-manager's Docker build, which fails at the builder stage's `alembic upgrade head` against a fresh MariaDB 10.11 instance: MariaDB rejects `GENERATED ALWAYS AS (...) STORED NOT NULL` outright (error 1064, no valid clause order accepts it), a defect discovered during VOIP-1386's MySQL-to-MariaDB migration validation (VOIP-1387). Restore the NOT NULL guarantee via a separate CHECK constraint instead, mirroring the exact pattern VOIP-1386 already validated (create + enforce) against MariaDB 12.3 in production.

- bin-dbscheme-manager: 167bebb7c46f (contact_cases.peer_type/peer_target) - STORED NOT NULL to STORED + CHECK in upgrade(), DROP CONSTRAINT before DROP COLUMN in downgrade()
- bin-dbscheme-manager: b41d1b2317af (contact_interactions.peer_type/peer_target) - same fix in upgrade()/downgrade()
- bin-dbscheme-manager: d8b04ef3ddd0 (contact_interactions recreate) - same fix in downgrade()'s CREATE TABLE, the only path that executes this file's affected DDL (upgrade() only drops the table)

Verification: local throwaway MariaDB 10.11 (matching the Docker builder) - alembic upgrade head clean, CHECK constraint rejects a NULL-inducing insert while accepting a valid one, alembic downgrade a1dca1dc6e67 followed by upgrade head round-trips all three files' both directions with zero errors, and the actual bin-dbscheme-manager Dockerfile build (docker build -f bin-dbscheme-manager/Dockerfile .) now completes successfully end to end, exporting the final image.