### PR TITLE
VOIP-1397-Switch-schedule-manager-backup-to-mariadb-dump

### DIFF
--- a/bin-schedule-manager/CLAUDE.md
+++ b/bin-schedule-manager/CLAUDE.md
@@ -26,7 +26,7 @@ Platform-internal cron scheduler (VOIP-1283). Absorbs external cron surfaces (th
 | `pkg/subscribehandler` | Event consumer (`customer_deleted`) |
 | `pkg/schedulehandler` | Schedule CRUD, validation, next-run computation, name uniqueness |
 | `pkg/dispatchhandler` | Tick loop, claim (lock + CAS), dispatch, record, reaper, manual execute |
-| `pkg/backuphandler` | mysqldump subprocess + gzip + retention pruning (design §7) |
+| `pkg/backuphandler` | mariadb-dump subprocess + gzip + retention pruning (design §7) |
 | `pkg/dbhandler` | MySQL via squirrel; sqlite test harness |
 | `pkg/cachehandler` | Redis + redsync claim locks |
 
@@ -80,15 +80,15 @@ golangci-lint run -v --timeout 5m
 | `SCHEDULE_BACKUP_DIR` | Backup dump directory. **No default — deliberately.** A default would let a surface that forgot to mount the shared volume "succeed" into ephemeral container disk (silent backup loss). Unset ⇒ the backup job fails loudly; nothing else breaks. | (none) |
 | `SCHEDULE_BACKUP_RETENTION_COUNT` | Newest backup files to keep | `7` |
 
-## CRITICAL: Runtime image deviation (debian-slim + mysql-community-client)
+## CRITICAL: Runtime image deviation (debian-slim + mariadb-client)
 
-The fleet standard runtime image is distroless static. This service's runtime stage is **`debian:bookworm-slim` + `mysql-community-client` 8.0 from MySQL's official APT repo** — a sanctioned deviation (design §7, same status as bin-call-manager's raw-SQL exception):
+The fleet standard runtime image is distroless static. This service's runtime stage is **`debian:bookworm-slim` + `default-mysql-client`(→ mariadb-client) from Debian's own repo** — a sanctioned deviation (design §7, same status as bin-call-manager's raw-SQL exception):
 
-- The scheduled DB backup executes `mysqldump` as a subprocess, which needs a binary-carrying base image.
-- The platform DB is migrating from MySQL 8.0 to **MariaDB 12.3 LTS (VOIP-1386)**. The `mysqldump` 8.0 client is kept through that migration: with `--column-statistics=0` (set in `backuphandler`) it is empirically validated against BOTH server states — MySQL 8.0 (flag is a no-op) and MariaDB 12.3 (without the flag the dump aborts with `Unknown table 'COLUMN_STATISTICS'`, error 1109). This makes the backup deploy-order-independent of the cutover.
-- Do not swap in debian's `default-mysql-client`/alpine's `mysql-client` (MariaDB alias clients) as a drive-by "fix": switching to `mariadb-dump` requires reworking the flag set (`--set-gtid-purged` is MySQL-only) and is tracked as a separate follow-up ticket after the VOIP-1386 cutover stabilizes.
+- The scheduled DB backup executes `mariadb-dump` as a subprocess, which needs a binary-carrying base image.
+- The platform DB is MariaDB 12.3 LTS (VOIP-1386). The client was originally kept at mysqldump 8.0 through the cutover with `--column-statistics=0`/`--set-gtid-purged=OFF` as MySQL-8-only compatibility shims (VOIP-1387); VOIP-1397 completed the switch to `mariadb-dump` once the cutover stabilized, dropping both flags (mariadb-dump doesn't recognize either) and installing the client straight from Debian bookworm's own repository — no external repo or GPG key needed, unlike the `mysql-community-client` package this replaced.
+- `mysqldump` still works as an invocation name (Debian's `default-mysql-client` ships it as a compat symlink to the real `mariadb-dump` binary), but the code and this Dockerfile call the binary `mariadb-dump` directly for clarity.
 
-Do NOT "fix" the Dockerfile back to distroless. The mariadb-client switch happens only in its own dedicated change, not opportunistically.
+Do NOT "fix" the Dockerfile back to distroless — the mysqldump/mariadb-dump subprocess requirement is a real, permanent constraint, not a stopgap.
 
 ## CRITICAL: DB-driven `target_queue` — sanctioned exception to two conventions
 

--- a/bin-schedule-manager/Dockerfile
+++ b/bin-schedule-manager/Dockerfile
@@ -12,39 +12,23 @@ RUN cd bin-schedule-manager && go mod vendor && CGO_ENABLED=0 go build -o /app/b
 #
 # Deviation from the fleet-standard distroless static runtime (design §7,
 # documented in this service's CLAUDE.md): the scheduled DB backup runs
-# mysqldump 8.0 as a subprocess against the platform database, so the
-# runtime image must carry the client binaries. The platform DB is
-# migrating from MySQL 8.0 to MariaDB 12.3 (VOIP-1386); this client is
-# validated against both server states via --column-statistics=0 set in
-# backuphandler (see CLAUDE.md "Runtime image deviation"). Switching to
-# mariadb-client is a separate post-cutover follow-up, not a drive-by
-# edit here. mysql-community-client comes from MySQL's official APT
-# repository.
+# mariadb-dump as a subprocess against the platform database, so the
+# runtime image must carry the client binaries. The platform DB moved to
+# MariaDB 12.3 in VOIP-1386; this switches the client to match (VOIP-1397,
+# following VOIP-1387's interim mysqldump-8.0-with-compatibility-flags
+# workaround). default-mysql-client comes straight from Debian bookworm's
+# own repository (resolves to mariadb-client) — no external repo or GPG
+# key needed, unlike the mysql-community-client this replaces.
 FROM public.ecr.aws/docker/library/debian:bookworm-slim
 
-# Key integrity: fetch MySQL's signing key over HTTPS from repo.mysql.com
-# itself (not an HKP keyserver lookup by short key id, which is spoofable),
-# verify its fingerprint before trusting it, and use the HTTPS repo URL —
-# closing the MITM window on both the key and the packages.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 -o /tmp/mysql-key.asc \
-    && gpg --import /tmp/mysql-key.asc \
-    && gpg --fingerprint --with-colons | grep -q "^fpr:::::::::BCA43417C3B485DD128EC6D4B7B3B788A8D3785C:$" \
-    && gpg --export B7B3B788A8D3785C > /usr/share/keyrings/mysql.gpg \
-    && rm -rf "$GNUPGHOME" /tmp/mysql-key.asc \
-    && echo "deb [signed-by=/usr/share/keyrings/mysql.gpg] https://repo.mysql.com/apt/debian/ bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends mysql-community-client \
-    && apt-get purge -y --auto-remove gnupg \
+    && apt-get install -y --no-install-recommends curl default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 
-# curl is kept (not purged, unlike gnupg above): debian:bookworm-slim ships
-# with neither wget nor curl, and this image needs an HTTP client for its
-# own Docker/Komodo healthcheck (GET /metrics) — see komodo/docker-compose.yml
-# and install/docker-compose.yml.dist. It was already being fetched for the
-# MySQL GPG key step above, so reusing it here avoids adding a new package.
+# curl: debian:bookworm-slim ships with neither wget nor curl, and this
+# image needs an HTTP client for its own Docker/Komodo healthcheck
+# (GET /metrics) — see komodo/docker-compose.yml and
+# install/docker-compose.yml.dist.
 
 WORKDIR /app/bin/
 COPY --from=build /app/bin /app/bin

--- a/bin-schedule-manager/README.md
+++ b/bin-schedule-manager/README.md
@@ -20,11 +20,11 @@ Platform-internal cron scheduler for VoIPbin. Stores schedules in MySQL, scans t
 | `POST /v1/schedules/<id>/execute` | Manual fire-now (never consumes the cron slot) |
 | `GET /v1/executions` | Execution audit trail |
 | `POST /v1/executions/prune` | Retention pruning (internal; fired by the `execution-retention` schedule) |
-| `POST /v1/backups` | Database backup via mysqldump (internal; fired by the `database-backup` schedule) |
+| `POST /v1/backups` | Database backup via mariadb-dump (internal; fired by the `database-backup` schedule) |
 
 ## Dependencies
 
-- **MySQL** — `schedule_schedules`, `schedule_executions` (soft-delete via `tm_delete`); also the backup target for mysqldump
+- **MySQL** — `schedule_schedules`, `schedule_executions` (soft-delete via `tm_delete`); also the backup target for mariadb-dump
 - **Redis** — per-schedule claim locks (redsync)
 - **RabbitMQ** — listen queue `bin-manager.schedule-manager.request`; subscribes to `bin-manager.customer-manager.event`; publishes internal events on `bin-manager.schedule-manager.event`
 

--- a/bin-schedule-manager/docs/architecture.md
+++ b/bin-schedule-manager/docs/architecture.md
@@ -23,7 +23,7 @@ graph TD
 
     DH -- "SendRequest(target_queue, ...)" --> MQ[(RabbitMQ)]
     SCH -- "PublishEvent (internal)" --> MQ
-    BH -- "mysqldump subprocess" --> MYSQL[(MySQL 8.0)]
+    BH -- "mariadb-dump subprocess" --> MYSQL[(MariaDB 12.3)]
     DB --> MYSQL
     CACHE --> REDIS[(Redis / redsync locks)]
 ```
@@ -39,7 +39,7 @@ graph TD
 | `pkg/subscribehandler` | Subscribes `bin-manager.customer-manager.event`; `customer_deleted` cascade | `SubscribeHandler` |
 | `pkg/schedulehandler` | Schedule CRUD, cron/method/target-queue validation, name uniqueness, next-run computation, internal event publishing | `ScheduleHandler` |
 | `pkg/dispatchhandler` | Tick loop: reap abandoned → refresh gauges → init `tm_next_run` → claim + dispatch due slots; manual execute | `DispatchHandler` |
-| `pkg/backuphandler` | `mysqldump --single-transaction` subprocess, gzip to `SCHEDULE_BACKUP_DIR`, retention pruning | `BackupHandler` |
+| `pkg/backuphandler` | `mariadb-dump --single-transaction` subprocess, gzip to `SCHEDULE_BACKUP_DIR`, retention pruning | `BackupHandler` |
 | `pkg/dbhandler` | MySQL via squirrel; CAS claim transaction; sqlite-backed tests | `DBHandler` |
 | `pkg/cachehandler` | Redis + redsync try-once claim locks (`schedule:lock:<id>`) | `CacheHandler` |
 | `models/schedule` | Schedule entity, cron helpers, filters, internal event type constants | `schedule.Schedule` |

--- a/bin-schedule-manager/docs/operations.md
+++ b/bin-schedule-manager/docs/operations.md
@@ -48,7 +48,7 @@ Tracing a run: find the execution row (`execution list` or `GET /v1/executions?f
 | `rabbitmq_address` | `RABBITMQ_ADDRESS` | (required) | RabbitMQ server address |
 | `prometheus_endpoint` | `PROMETHEUS_ENDPOINT` | `/metrics` | Prometheus metrics endpoint path |
 | `prometheus_listen_address` | `PROMETHEUS_LISTEN_ADDRESS` | `:2112` | Prometheus metrics listen address |
-| `database_dsn` | `DATABASE_DSN` | (required) | MySQL connection DSN (also the mysqldump target) |
+| `database_dsn` | `DATABASE_DSN` | (required) | MySQL connection DSN (also the mariadb-dump target) |
 | `redis_address` | `REDIS_ADDRESS` | (required) | Redis server address |
 | `redis_password` | `REDIS_PASSWORD` | empty | Redis password |
 | `redis_database` | `REDIS_DATABASE` | `1` | Redis logical database index |
@@ -79,7 +79,7 @@ Label-cardinality note: `schedule_name` labels are acceptable while all schedule
 
 ## Backup Runbook — dump-and-restore smoke test
 
-Verifies that a dump produced by the backup job actually restores. Run against a scratch MySQL 8.0 (never production). Automated as part of VOIP-1281's sandbox onboarding; manual procedure:
+Verifies that a dump produced by the backup job actually restores. Run against a scratch MariaDB 12.3 (never production) — matches the platform DB engine since VOIP-1386, and the client since VOIP-1397. Automated as part of VOIP-1281's sandbox onboarding; manual procedure:
 
 ```bash
 # 0. Fire the backup now (or take the newest existing dump)
@@ -89,21 +89,21 @@ Verifies that a dump produced by the backup job actually restores. Run against a
 DUMP=$(ls -t "$SCHEDULE_BACKUP_DIR"/voipbin-*.sql.gz | head -1)
 echo "testing: $DUMP"
 
-# 1. Scratch MySQL 8.0
-docker run -d --name backup-smoke -e MYSQL_ROOT_PASSWORD=smoke \
-  -p 33061:3306 mysql:8.0
-until docker exec backup-smoke mysqladmin ping -uroot -psmoke --silent; do sleep 2; done
+# 1. Scratch MariaDB 12.3
+docker run -d --name backup-smoke -e MARIADB_ROOT_PASSWORD=smoke \
+  -p 33061:3306 mariadb:12.3
+until docker exec backup-smoke mariadb-admin ping -uroot -psmoke --silent; do sleep 2; done
 
 # 2. Restore
-gunzip -c "$DUMP" | docker exec -i backup-smoke mysql -uroot -psmoke
+gunzip -c "$DUMP" | docker exec -i backup-smoke mariadb -uroot -psmoke
 
 # 3. Diff table counts against the source (spot-check the schedule tables
 #    plus a few high-traffic tables)
-docker exec backup-smoke mysql -uroot -psmoke -e \
+docker exec backup-smoke mariadb -uroot -psmoke -e \
   "SELECT table_schema, COUNT(*) AS tables FROM information_schema.tables
    WHERE table_schema NOT IN ('mysql','sys','information_schema','performance_schema')
    GROUP BY table_schema;"
-docker exec backup-smoke mysql -uroot -psmoke -e \
+docker exec backup-smoke mariadb -uroot -psmoke -e \
   "SELECT COUNT(*) FROM voipbin.schedule_schedules; SELECT COUNT(*) FROM voipbin.schedule_executions;"
 # Compare with the same queries on the source DB — counts must match the dump time.
 
@@ -123,15 +123,15 @@ Komodo-managed (VOIP-1350), same mechanism as the other `bin-*-manager` services
 from `komodo/docker-compose.yml`.
 
 Two deviations from the Tier 1/2 template, both intentional:
-- **Non-distroless runtime** (`debian:bookworm-slim` + `mysql-community-client`,
-  see the CRITICAL note in [../CLAUDE.md](../CLAUDE.md)) — but `debian:bookworm-slim`
-  ships with neither `wget` nor `curl` by default, so the fleet-standard
-  `wget` healthcheck silently fails on this image (confirmed live: the
-  pre-Komodo `install/` container had been reporting Docker-unhealthy for 5
-  days with `exec: "wget": executable file not found`). The Dockerfile keeps
-  `curl` in the runtime stage (already fetched there for the MySQL GPG key
-  step) instead of purging it, and the Komodo compose healthcheck uses
-  `curl -fsS` against `/metrics` instead of `wget`.
+- **Non-distroless runtime** (`debian:bookworm-slim` + `default-mysql-client`
+  (→ mariadb-client, VOIP-1397), see the CRITICAL note in
+  [../CLAUDE.md](../CLAUDE.md)) — but `debian:bookworm-slim` ships with
+  neither `wget` nor `curl` by default, so the fleet-standard `wget`
+  healthcheck silently fails on this image (confirmed live: the pre-Komodo
+  `install/` container had been reporting Docker-unhealthy for 5 days with
+  `exec: "wget": executable file not found`). The Dockerfile keeps `curl`
+  in the runtime stage instead of purging it, and the Komodo compose
+  healthcheck uses `curl -fsS` against `/metrics` instead of `wget`.
 - **Bind-mounted backup volume**: `SCHEDULE_BACKUP_DIR=/backups` is mounted from
   the host path `/opt/voipbin/install/backups/scheduled-db` on bm-nyc-01
   (confirmed via `docker inspect` against the pre-cutover container), so

--- a/bin-schedule-manager/komodo/docker-compose.yml
+++ b/bin-schedule-manager/komodo/docker-compose.yml
@@ -14,8 +14,9 @@
 # which has the exact same bug) silently fails here — confirmed live on
 # bm-nyc-01: the pre-existing install/ container had been reporting
 # "unhealthy" for 5 days with `exec: "wget": executable file not found`.
-# Fixed by keeping curl in the Dockerfile's runtime stage (already fetched
-# there for the MySQL GPG key step) and using it for the healthcheck instead.
+# Fixed by keeping curl in the Dockerfile's runtime stage (installed
+# alongside the mariadb-dump client, VOIP-1397) and using it for the
+# healthcheck instead.
 services:
   schedule-manager:
     image: voipbin/bin-schedule-manager:__IMAGE_TAG__

--- a/bin-schedule-manager/pkg/backuphandler/backup.go
+++ b/bin-schedule-manager/pkg/backuphandler/backup.go
@@ -23,12 +23,12 @@ const (
 	backupFileSuffix = ".sql.gz"
 	backupTimeLayout = "20060102T150405Z"
 
-	// stderrLimitBytes bounds the captured mysqldump stderr carried in error
+	// stderrLimitBytes bounds the captured mariadb-dump stderr carried in error
 	// messages.
 	stderrLimitBytes = 4096
 )
 
-// Backup runs mysqldump against the DSN's database, gzips the dump into the
+// Backup runs mariadb-dump against the DSN's database, gzips the dump into the
 // backup directory, prunes old dumps to the retention count, and returns the
 // produced file's path and size (design §7).
 //
@@ -63,7 +63,18 @@ func (h *backupHandler) Backup(ctx context.Context) (*Result, error) {
 	}()
 
 	// --defaults-extra-file MUST be the first argument (mysql client
-	// requirement); host/port/user/dbname go as flags (design §7)
+	// requirement); host/port/user/dbname go as flags (design §7).
+	//
+	// mariadb-dump (VOIP-1397, switched from mysqldump 8.0 now that the
+	// platform DB is MariaDB 12.3 per VOIP-1386): --single-transaction/
+	// --routines/--triggers/--events are all supported. --set-gtid-purged
+	// and --column-statistics were MySQL-8-only flags used as temporary
+	// compatibility shims during the VOIP-1386 cutover (VOIP-1387) —
+	// mariadb-dump doesn't recognize either (empirically confirmed via
+	// `mariadb-dump --help`, would fail as unknown options), so both are
+	// dropped here. --events is new: it was missing even under mysqldump
+	// (a pre-existing gap, unrelated to the client switch) and is added
+	// now while the arg list is already being normalized.
 	args := []string{
 		"--defaults-extra-file=" + defaultsPath,
 		"-h", host,
@@ -72,13 +83,7 @@ func (h *backupHandler) Backup(ctx context.Context) (*Result, error) {
 		"--single-transaction",
 		"--routines",
 		"--triggers",
-		"--set-gtid-purged=OFF",
-		// mysqldump 8.0 defaults to querying
-		// information_schema.COLUMN_STATISTICS, which does not exist on
-		// MariaDB (the platform DB as of VOIP-1386) and aborts the dump
-		// with error 1109. Disabling it is a no-op against MySQL 8, so
-		// this flag is safe in both server states.
-		"--column-statistics=0",
+		"--events",
 		cfg.DBName,
 	}
 
@@ -104,8 +109,8 @@ func (h *backupHandler) Backup(ctx context.Context) (*Result, error) {
 	return &Result{Path: outPath, Bytes: size}, nil
 }
 
-// runDump executes mysqldump with the given args, gzip-compressing its stdout
-// into outPath. Returns the produced file's size in bytes.
+// runDump executes mariadb-dump with the given args, gzip-compressing its
+// stdout into outPath. Returns the produced file's size in bytes.
 func (h *backupHandler) runDump(ctx context.Context, outPath string, args []string) (int64, error) {
 	// 0600: the dump is the full platform database (PII, credentials) and the
 	// backup dir may be a volume shared across replicas — same hygiene as the
@@ -117,13 +122,13 @@ func (h *backupHandler) runDump(ctx context.Context, outPath string, args []stri
 
 	gz := gzip.NewWriter(f)
 
-	stderr, errRun := h.runner.Run(ctx, gz, "mysqldump", args...)
+	stderr, errRun := h.runner.Run(ctx, gz, "mariadb-dump", args...)
 	if errRun != nil {
 		_ = gz.Close()
 		_ = f.Close()
 		// args carry no password material (defaults-extra-file), so the argv
 		// is safe to include
-		return 0, errors.Wrapf(errRun, "mysqldump failed. argv: mysqldump %s, stderr: %s", strings.Join(args, " "), truncateStderr(stderr))
+		return 0, errors.Wrapf(errRun, "mariadb-dump failed. argv: mariadb-dump %s, stderr: %s", strings.Join(args, " "), truncateStderr(stderr))
 	}
 
 	if errClose := gz.Close(); errClose != nil {

--- a/bin-schedule-manager/pkg/backuphandler/backup_test.go
+++ b/bin-schedule-manager/pkg/backuphandler/backup_test.go
@@ -49,7 +49,7 @@ func (r *fakeRunner) Run(_ context.Context, stdout io.Writer, name string, args 
 func Test_Backup(t *testing.T) {
 	dir := t.TempDir()
 
-	payload := []byte("-- fake mysqldump output\nCREATE TABLE t (id INT);\n")
+	payload := []byte("-- fake mariadb-dump output\nCREATE TABLE t (id INT);\n")
 
 	var defaultsPathSeen string
 	var defaultsContentSeen []byte
@@ -86,8 +86,8 @@ func Test_Backup(t *testing.T) {
 	}
 
 	// command name
-	if runner.capturedName != "mysqldump" {
-		t.Errorf("Wrong match. expect: mysqldump, got: %v", runner.capturedName)
+	if runner.capturedName != "mariadb-dump" {
+		t.Errorf("Wrong match. expect: mariadb-dump, got: %v", runner.capturedName)
 	}
 
 	// --defaults-extra-file MUST be the first argument
@@ -110,8 +110,7 @@ func Test_Backup(t *testing.T) {
 		"--single-transaction",
 		"--routines",
 		"--triggers",
-		"--set-gtid-purged=OFF",
-		"--column-statistics=0",
+		"--events",
 		"voipbin",
 	}
 	if !reflect.DeepEqual(runner.capturedArgs[1:], expectArgs) {
@@ -207,16 +206,16 @@ func Test_Backup_error(t *testing.T) {
 			expectNotContains: "secretpw",
 		},
 		{
-			name: "mysqldump failure carries stderr but no password",
+			name: "mariadb-dump failure carries stderr but no password",
 
 			dsn:       "testuser:testpass@tcp(127.0.0.1:3306)/voipbin",
 			backupDir: "PLACEHOLDER_TMPDIR",
 			runner: &fakeRunner{
-				stderr: "mysqldump: Got error: 2003",
+				stderr: "mariadb-dump: Got error: 2003",
 				runErr: stderrors.New("exit status 2"),
 			},
 
-			expectContains:    "mysqldump: Got error: 2003",
+			expectContains:    "mariadb-dump: Got error: 2003",
 			expectNotContains: "testpass",
 		},
 	}

--- a/bin-schedule-manager/pkg/backuphandler/main.go
+++ b/bin-schedule-manager/pkg/backuphandler/main.go
@@ -21,7 +21,7 @@ type BackupHandler interface {
 
 // commandRunner abstracts subprocess execution so unit tests can assert the
 // exact argv (incl. the no-password-in-argv guarantee) without running
-// mysqldump.
+// mariadb-dump.
 type commandRunner interface {
 	Run(ctx context.Context, stdout io.Writer, name string, args ...string) (stderr string, err error)
 }


### PR DESCRIPTION
Complete the mariadb-dump client switch that VOIP-1387 deferred as a post-cutover follow-up. The nightly backup previously ran mysqldump 8.0 with --set-gtid-purged=OFF/--column-statistics=0 as temporary MySQL-8-only compatibility shims (neither flag exists in mariadb-dump, empirically confirmed via --help); both are dropped now that the switch is complete. The runtime image simplifies from an Oracle-repo GPG-key-fetch dance to a single Debian bookworm default-mysql-client install (resolves to mariadb-client, no external repo or ca-certificates needed).

- bin-schedule-manager: drop --set-gtid-purged/--column-statistics from the mariadb-dump argv in backuphandler, rename the subprocess binary from mysqldump to mariadb-dump
- bin-schedule-manager: add --events to the dump argv (a pre-existing gap unrelated to the client switch, bundled while the arg list was already being normalized)
- bin-schedule-manager: extend the backup args regression test for the new binary name/argv, and its fake-output/error-message strings
- bin-schedule-manager: replace the Dockerfile's Oracle mysql-8.0 APT repo + GPG key verification block with a single default-mysql-client install from Debian's own repository, dropping the now-unneeded ca-certificates package too
- bin-schedule-manager: update CLAUDE.md (Runtime image deviation section rewritten for the completed switch, package-layout table row), README.md, docs/architecture.md (mermaid diagram + package table), docs/operations.md (backup runbook rewritten for mariadb:12.3 + mariadb/mariadb-admin commands, Deployment/Komodo section, config table), and komodo/docker-compose.yml's curl-rationale comment to stop describing mysqldump/mysql-community-client/the now-removed GPG step

Verification: Dockerfile builds clean; the built image's mariadb-dump/mysqldump(symlink)/curl binaries all confirmed present and ca-certificates confirmed absent and unneeded (healthcheck is plain HTTP); a real mariadb-dump with the final argv against mariadb:12.3 dumps with zero errors (captures CREATE EVENT correctly) and the dump restores into a fresh mariadb:12.3 with matching row/event data; go test 260 passed in 14 packages; golangci-lint clean.