### PR TITLE
NOJIRA-Fix-api-manager-audiosocket-advertise-address

### DIFF
--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	swaggerFiles "github.com/swaggo/files"
@@ -29,6 +31,7 @@ import (
 	// gin-swagger middleware
 	"monorepo/bin-api-manager/gens/openapi_server"
 	"monorepo/bin-api-manager/internal/config"
+	"monorepo/bin-api-manager/internal/nethandler"
 	"monorepo/bin-api-manager/lib/middleware"
 	"monorepo/bin-api-manager/lib/service"
 	"monorepo/bin-api-manager/models/common"
@@ -149,12 +152,30 @@ func run(
 	log := logrus.WithField("func", "run")
 
 	cfg := config.Get()
-	addressListenStream := getAddressListenAudiosock()
+	addressAdvertiseStream, err := getAddressAdvertiseAudiosock()
+	if err != nil {
+		// Fail fast: an empty/unresolvable advertise address would be
+		// silently handed to Asterisk, which would then be unable to dial
+		// back for AudioSocket/ExternalMedia streaming.
+		log.Fatalf("Could not resolve the audiosocket advertise address. err: %v", err)
+	}
+
+	// Observability: the advertise address is resolved once at startup and
+	// never logged afterward, so a misconfigured deployment (e.g. POD_IP
+	// pointing at the wrong interface) is otherwise invisible until a
+	// dial-back actually fails. addressSource is informational only -- it
+	// does not affect resolution, which always goes through
+	// nethandler.AdvertiseIP() above.
+	addressSource := "auto-detected network interface"
+	if os.Getenv(nethandler.EnvPodIP) != "" {
+		addressSource = "POD_IP override"
+	}
+	log.Infof("Resolved the audiosocket advertise address. address: %s, source: %s", addressAdvertiseStream, addressSource)
 
 	// create handlers
 	requestHandler := requesthandler.NewRequestHandler(sockHandler, "api_manager")
 	pubsubBroker := pubsubhandler.NewBrokerHandler()
-	streamHandler := streamhandler.NewStreamHandler(requestHandler, addressListenStream)
+	streamHandler := streamhandler.NewStreamHandler(requestHandler, addressAdvertiseStream)
 
 	// per-pod subscribe queue name -- constructed here (before websockHandler) so it can be
 	// shared with websockhandler's scopeRefCount for dynamic AMQP bind/unbind (VOIP-1258 §9).
@@ -390,8 +411,7 @@ func runListenStreamsock(ctx context.Context, streamHandler streamhandler.Stream
 		"func": "runListenAudiosock",
 	})
 
-	cfg := config.Get()
-	listenAddress := fmt.Sprintf("%s:%d", cfg.ListenIPAudiosock, defaultAudiosockPort)
+	listenAddress := getAddressListenAudiosock()
 	log.Debugf("Listening audiosock address. address: %s", listenAddress)
 
 	addr, err := net.ResolveTCPAddr("tcp", listenAddress)
@@ -424,9 +444,49 @@ func runListenStreamsock(ctx context.Context, streamHandler streamhandler.Stream
 	}
 }
 
+// getAddressListenAudiosock returns the address the AudioSocket listener
+// binds to. This is deliberately NOT derived from the advertise address
+// (see getAddressAdvertiseAudiosock): the socket must accept connections on
+// every interface, while the advertise address handed to Asterisk must be a
+// concrete, routable host. An empty host in "host:port" binds to all
+// interfaces (equivalent to 0.0.0.0:<port>).
 func getAddressListenAudiosock() string {
-	cfg := config.Get()
-	res := fmt.Sprintf("%s:%d", cfg.ListenIPAudiosock, defaultAudiosockPort)
+	return fmt.Sprintf(":%d", defaultAudiosockPort)
+}
 
-	return res
+// getAddressAdvertiseAudiosock returns the host:port that this process
+// hands to Asterisk (via CallV1ExternalMediaStart) so it can dial back for
+// AudioSocket/ExternalMedia streaming. This is intentionally separate from
+// the AudioSocket listen address (see runListenStreamsock), which always
+// binds to all interfaces.
+//
+// nethandler.AdvertiseIP() itself does not validate that the POD_IP
+// override is a well-formed IP address -- it returns that value verbatim so
+// it stays reusable if this package is ever promoted to serve other
+// consumers that may legitimately advertise a hostname. AudioSocket
+// specifically needs a real, dialable IP for Asterisk's dial-back, so that
+// validation belongs here, at the consumer that actually requires it.
+func getAddressAdvertiseAudiosock() (string, error) {
+	ip, err := nethandler.AdvertiseIP()
+	if err != nil {
+		return "", errors.Wrapf(err, "could not resolve the audiosocket advertise ip")
+	}
+
+	if net.ParseIP(ip) == nil {
+		// Fail fast: a non-IP POD_IP value (e.g. a hostname, as some other
+		// services set for their own advertise-style env vars) would be
+		// silently handed to Asterisk, reproducing the same dial-back
+		// failure this fix addresses.
+		return "", errors.Errorf("the resolved audiosocket advertise address is not a valid ip. ip: %s", ip)
+	}
+
+	// net.JoinHostPort (not fmt.Sprintf("%s:%d", ...)) is mandatory here:
+	// net.ParseIP above accepts IPv6 as well as IPv4, and a bare "%s:%d"
+	// join produces an unparseable string for an IPv6 host (e.g.
+	// "2001:db8::1:9000", which net.SplitHostPort/net.ResolveTCPAddr both
+	// reject as a malformed address). JoinHostPort brackets an IPv6 host
+	// automatically (e.g. "[2001:db8::1]:9000").
+	res := net.JoinHostPort(ip, strconv.Itoa(defaultAudiosockPort))
+
+	return res, nil
 }

--- a/bin-api-manager/cmd/api-manager/main_test.go
+++ b/bin-api-manager/cmd/api-manager/main_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+// Test_getAddressListenAudiosock verifies the AudioSocket listener always
+// binds to all interfaces (an empty host in "host:port"), regardless of any
+// environment configuration -- it must never be derived from the advertise
+// address.
+func Test_getAddressListenAudiosock(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		expectRes string
+	}{
+		{
+			name: "normal",
+
+			expectRes: fmt.Sprintf(":%d", defaultAudiosockPort),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// POD_IP must have zero effect on the listen address.
+			t.Setenv("POD_IP", "203.0.113.5")
+
+			res := getAddressListenAudiosock()
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %s, got: %s", tt.expectRes, res)
+			}
+		})
+	}
+}
+
+// Test_getAddressAdvertiseAudiosock verifies the advertise address is
+// resolved via nethandler.AdvertiseIP() (POD_IP override path here, since
+// the auto-detect fallback depends on the host's real network interfaces
+// and is already covered by nethandler's own unit tests).
+func Test_getAddressAdvertiseAudiosock(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		podIP string
+
+		expectRes string
+	}{
+		{
+			name: "normal ipv4",
+
+			podIP: "203.0.113.5",
+
+			expectRes: fmt.Sprintf("203.0.113.5:%d", defaultAudiosockPort),
+		},
+		{
+			// Regression test: a bare fmt.Sprintf("%s:%d", ip, port) join
+			// (the previous implementation) produces an unparseable string
+			// for an IPv6 host -- net.JoinHostPort must be used so the
+			// IPv6 host is bracketed correctly.
+			name: "ipv6",
+
+			podIP: "2001:db8::1",
+
+			expectRes: fmt.Sprintf("[2001:db8::1]:%d", defaultAudiosockPort),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("POD_IP", tt.podIP)
+
+			res, err := getAddressAdvertiseAudiosock()
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %s, got: %s", tt.expectRes, res)
+			}
+
+			// Empirical proof the result is actually a dialable host:port,
+			// not just a string that happens to match expectRes -- this is
+			// what net.SplitHostPort/net.ResolveTCPAddr rejected before the
+			// net.JoinHostPort fix for an IPv6 host.
+			host, port, errSplit := net.SplitHostPort(res)
+			if errSplit != nil {
+				t.Fatalf("Wrong match. expect: parseable host:port, got err: %v (res: %s)", errSplit, res)
+			}
+			if host != tt.podIP {
+				t.Errorf("Wrong match. expect host: %s, got: %s", tt.podIP, host)
+			}
+			if port != fmt.Sprintf("%d", defaultAudiosockPort) {
+				t.Errorf("Wrong match. expect port: %d, got: %s", defaultAudiosockPort, port)
+			}
+			if _, errResolve := net.ResolveTCPAddr("tcp", res); errResolve != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", errResolve)
+			}
+		})
+	}
+}
+
+// Test_getAddressAdvertiseAudiosock_InvalidPodIP verifies that a POD_IP
+// value which is not a well-formed IP address (e.g. a hostname, the shape
+// several other services already use for their own advertise-style env
+// vars) is rejected with an error instead of being silently handed to
+// Asterisk. nethandler.AdvertiseIP() itself does not validate the POD_IP
+// override's format (it must also serve future non-IP consumers), so this
+// validation lives here, at the AudioSocket-specific consumer that requires
+// a real IP for dial-back -- this is the fail-fast guard the previous
+// version of this fix was missing on the POD_IP override path.
+func Test_getAddressAdvertiseAudiosock_InvalidPodIP(t *testing.T) {
+
+	tests := []struct {
+		name string
+
+		podIP string
+	}{
+		{
+			name: "hostname instead of ip",
+
+			podIP: "api-manager.production.svc.cluster.local",
+		},
+		{
+			name: "garbage value",
+
+			podIP: "not-an-ip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("POD_IP", tt.podIP)
+
+			res, err := getAddressAdvertiseAudiosock()
+			if err == nil {
+				t.Fatalf("Wrong match. expect: error, got: nil (res: %s)", res)
+			}
+			if res != "" {
+				t.Errorf("Wrong match. expect: empty string, got: %s", res)
+			}
+		})
+	}
+}
+
+// Test_getAddressListenAudiosock_and_Advertise_are_independent verifies the
+// listen and advertise addresses never collapse into the same config value
+// -- the regression this whole fix addresses (VOIP audiosocket dial-back
+// bug: both used to come from the same cfg.ListenIPAudiosock field).
+func Test_ListenAndAdvertiseAudiosockAddresses_areIndependent(t *testing.T) {
+	t.Setenv("POD_IP", "203.0.113.5")
+
+	listenAddress := getAddressListenAudiosock()
+	advertiseAddress, err := getAddressAdvertiseAudiosock()
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	if listenAddress == advertiseAddress {
+		t.Errorf("Wrong match. listen and advertise addresses must not be equal, got: %s", listenAddress)
+	}
+
+	expectedListen := fmt.Sprintf(":%d", defaultAudiosockPort)
+	if listenAddress != expectedListen {
+		t.Errorf("Wrong match. expect: %s, got: %s", expectedListen, listenAddress)
+	}
+
+	expectedAdvertise := fmt.Sprintf("203.0.113.5:%d", defaultAudiosockPort)
+	if advertiseAddress != expectedAdvertise {
+		t.Errorf("Wrong match. expect: %s, got: %s", expectedAdvertise, advertiseAddress)
+	}
+}

--- a/bin-api-manager/docs/operations.md
+++ b/bin-api-manager/docs/operations.md
@@ -16,7 +16,6 @@ Runtime configuration is provided via CLI flags and/or environment variables, de
 | `-gcp_bucket_name` | `GCP_BUCKET_NAME` | No | — | GCS bucket for media/recordings |
 | `-ssl_cert_base64` | `SSL_CERT_BASE64` | No | — | Base64-encoded SSL certificate |
 | `-ssl_privkey_base64` | `SSL_PRIVKEY_BASE64` | No | — | Base64-encoded SSL private key |
-| `-listen_ip_audiosock` | `LISTEN_IP_AUDIOSOCK` | No | `""` | Audiosocket listener IP (AI audio streaming) |
 | `-prometheus_endpoint` | `PROMETHEUS_ENDPOINT` | No | `/metrics` | Prometheus metrics path |
 | `-prometheus_listen_address` | `PROMETHEUS_LISTEN_ADDRESS` | No | `:2112` | Prometheus listen address |
 | — (env var only) | `RATE_LIMIT_AUTH_PUBLIC_RPS` | No | `10` | Rate limit, requests/second per IP, for unauthenticated `/auth/*` routes. `<=0` disables the tier. |
@@ -37,6 +36,18 @@ Runtime configuration is provided via CLI flags and/or environment variables, de
 | — (env var only) | `RATE_LIMIT_CUSTOMER_REDIS_TIMEOUT_MS` | No | `50` | Timeout budget, in milliseconds, for the customer rate limiter's Redis round trip. On timeout the request fails open (proceeds). This is a jitter-tolerant starting value, not a measured p99 — tune after observing production latency. |
 
 SSL certificates are passed as base64-encoded values to allow injection via Kubernetes secrets without multi-line PEM issues.
+
+### AudioSocket listen vs. advertise address
+
+The AudioSocket/ExternalMedia listener (port 9000, `pkg/streamhandler/`, `cmd/api-manager/main.go`) binds to all interfaces unconditionally (`:9000`) -- this is no longer configurable and is not part of the `Config` struct above. Separately, the *advertise* address -- the host:port handed to Asterisk via `CallV1ExternalMediaStart` so it can dial back -- is resolved by `internal/nethandler.AdvertiseIP()` (a package internal to this service -- see the bin-common-handler admission rule in the root CLAUDE.md for why it is not a shared library package):
+
+1. `POD_IP` env var, if set -- returned verbatim (Kubernetes Downward API `status.podIP`, or an explicit Docker Compose override).
+2. Otherwise, auto-detected as the first non-loopback IPv4 address found on the host's network interfaces (in Komodo/Compose deployments, the container's `production` network interface).
+3. If neither resolves, the service fails fast at startup (`log.Fatalf`) rather than advertising an empty/unusable host.
+
+`cmd/api-manager/main.go`'s `getAddressAdvertiseAudiosock()` additionally validates the resolved value is a well-formed IP (`net.ParseIP`) and joins it with the port via `net.JoinHostPort` -- not a bare `fmt.Sprintf("%s:%d", ...)` -- so an IPv6 `POD_IP` is bracketed correctly (e.g. `[2001:db8::1]:9000`) instead of producing an unparseable string.
+
+This replaces the old `listen_ip_audiosock` flag (bound to `POD_IP`), which incorrectly fed the same value into both the listen and advertise addresses -- see `pkg/streamhandler/main.go`'s `advertiseAddress` field and `cmd/api-manager/main.go`'s `getAddressListenAudiosock`/`getAddressAdvertiseAudiosock`.
 
 The per-customer rate limiter uses a dedicated `*redis.Client` (`cmd/api-manager/main.go`, `runDaemon`), constructed from the same `REDIS_ADDRESS`/`REDIS_PASSWORD`/`REDIS_DATABASE` values as the cache client but connected separately — `pkg/cachehandler` is intentionally not reused for this (see `pkg/ratelimithandler`). On Kubernetes, ensure the Redis instance's `maxmemory-policy` is `noeviction` or `volatile-*`; an `allkeys-lru` policy can cause rate-limit keys to be evicted under memory pressure, which degrades to the same fail-open behavior as a Redis timeout.
 
@@ -60,6 +71,20 @@ Circuit-breaker metrics for each RabbitMQ RPC target are also registered under t
 ---
 
 ## Common Failure Modes
+
+### AudioSocket Advertise Address Resolution Failure (startup crash loop)
+
+**Symptom:** The container crashes immediately after starting and enters a restart/crash loop -- it never reaches a healthy state, so no other failure mode below applies.
+
+**Cause:** `POD_IP` is set to a value that is not a valid IP address (e.g. a hostname string), or (with `POD_IP` unset) no non-loopback IPv4 address could be auto-detected on any network interface. Either way, `internal/nethandler.AdvertiseIP()` / `cmd/api-manager/main.go`'s `getAddressAdvertiseAudiosock()` cannot resolve a usable AudioSocket advertise address, and the service fails fast rather than silently handing Asterisk an empty or unusable host (see the "AudioSocket listen vs. advertise address" subsection above).
+
+**Log signal:** `log.Fatalf` in `cmd/api-manager/main.go`'s `run()` prints, then the process exits:
+```
+Could not resolve the audiosocket advertise address. err: the resolved audiosocket advertise address is not a valid ip. ip: <value>
+```
+(or, when no address could be auto-detected at all: `err: could not resolve the audiosocket advertise ip: could not auto-detect advertise ip: no non-loopback ipv4 address found on any network interface`)
+
+**Resolution:** Either unset `POD_IP` so the service auto-detects an address from the container's network interfaces, or set `POD_IP` to a valid, routable IPv4/IPv6 address (not a hostname).
 
 ### Backend Service Unavailable
 

--- a/bin-api-manager/internal/config/main.go
+++ b/bin-api-manager/internal/config/main.go
@@ -40,8 +40,17 @@ type Config struct {
 	GCPBucketName           string // GCPBucketName is the name of the GCP storage bucket for temporary storage.
 	SSLCertBase64           string // SSLCertBase64 is the base64-encoded SSL certificate for HTTPS connections.
 	SSLPrivKeyBase64        string // SSLPrivKeyBase64 is the base64-encoded SSL private key for HTTPS connections.
-	ListenIPAudiosock       string // ListenIPAudiosock is the IP address for audiosocket connection listening.
 	PublicBaseURL           string // PublicBaseURL is the public base URL of this API (e.g. "https://api.voipbin.net"), used to build absolute URLs handed to external clients (extension provisioning). Env var only (API_PUBLIC_BASE_URL) -- see the NOTE below about inert CLI flags.
+
+	// NOTE: there used to be a "ListenIPAudiosock" field here, bound to the
+	// POD_IP env var, that was shared by BOTH the AudioSocket listener's
+	// bind address and the advertise address handed to Asterisk for
+	// dial-back. That conflation was a bug: the listen socket now always
+	// binds to all interfaces (a hardcoded ":9000" in cmd/api-manager), and
+	// the advertise address is resolved separately via
+	// internal/nethandler.AdvertiseIP() (POD_IP override,
+	// falling back to auto-detecting a non-loopback IPv4 address, and
+	// failing fast if neither is available) -- see cmd/api-manager/main.go.
 
 	// Rate limiting (per-IP, in-memory token bucket -- see lib/middleware/ratelimit.go).
 	// Each pair is (requests/second, burst). A tier is disabled (unlimited
@@ -120,7 +129,6 @@ func bindConfig(cmd *cobra.Command) error {
 	f.String("gcp_bucket_name", "", "GCP bucket name for temporary storage")
 	f.String("ssl_cert_base64", "", "Base64 encoded SSL certificate")
 	f.String("ssl_privkey_base64", "", "Base64 encoded SSL private key")
-	f.String("listen_ip_audiosock", "", "Listen IP address for audiosocket connection")
 	f.String("public_base_url", "https://api.voipbin.net", "Public base URL of this API, used to build absolute URLs handed to external clients. Env var only, see API_PUBLIC_BASE_URL.")
 	f.Float64("rate_limit_auth_public_rps", 10, "Rate limit (requests/second per IP) for unauthenticated /auth/* routes. <=0 disables this tier. Env var only, see RATE_LIMIT_AUTH_PUBLIC_RPS.")
 	f.Int("rate_limit_auth_public_burst", 20, "Rate limit burst size for the unauthenticated /auth/* routes. <=0 disables this tier. Env var only, see RATE_LIMIT_AUTH_PUBLIC_BURST.")
@@ -151,7 +159,6 @@ func bindConfig(cmd *cobra.Command) error {
 		"gcp_bucket_name":           "GCP_BUCKET_NAME",
 		"ssl_cert_base64":           "SSL_CERT_BASE64",
 		"ssl_privkey_base64":        "SSL_PRIVKEY_BASE64",
-		"listen_ip_audiosock":       "POD_IP",
 		"public_base_url":           "API_PUBLIC_BASE_URL",
 
 		"rate_limit_auth_public_rps":           "RATE_LIMIT_AUTH_PUBLIC_RPS",
@@ -207,7 +214,6 @@ func LoadGlobalConfig() {
 			GCPBucketName:           viper.GetString("gcp_bucket_name"),
 			SSLCertBase64:           viper.GetString("ssl_cert_base64"),
 			SSLPrivKeyBase64:        viper.GetString("ssl_privkey_base64"),
-			ListenIPAudiosock:       viper.GetString("listen_ip_audiosock"),
 			PublicBaseURL:           viper.GetString("public_base_url"),
 
 			RateLimitAuthPublicRPS:      viper.GetFloat64("rate_limit_auth_public_rps"),

--- a/bin-api-manager/internal/config/main_test.go
+++ b/bin-api-manager/internal/config/main_test.go
@@ -44,7 +44,6 @@ func TestBootstrap(t *testing.T) {
 		{"gcp_bucket_name", "gcp_bucket_name"},
 		{"ssl_cert_base64", "ssl_cert_base64"},
 		{"ssl_privkey_base64", "ssl_privkey_base64"},
-		{"listen_ip_audiosock", "listen_ip_audiosock"},
 	}
 
 	for _, tt := range tests {
@@ -54,6 +53,14 @@ func TestBootstrap(t *testing.T) {
 				t.Errorf("Flag %s was not registered", tt.flagName)
 			}
 		})
+	}
+
+	// The AudioSocket listener now always binds to all interfaces and the
+	// advertise address is resolved via internal/nethandler.AdvertiseIP(),
+	// so the old listen_ip_audiosock flag (bound to POD_IP)
+	// must not be registered anymore.
+	if flag := flags.Lookup("listen_ip_audiosock"); flag != nil {
+		t.Errorf("Flag listen_ip_audiosock should no longer be registered, got: %v", flag)
 	}
 }
 
@@ -71,7 +78,6 @@ func TestConfigStruct(t *testing.T) {
 		GCPBucketName:           "test-bucket",
 		SSLCertBase64:           "dGVzdA==",
 		SSLPrivKeyBase64:        "dGVzdA==",
-		ListenIPAudiosock:       "0.0.0.0",
 	}
 
 	tests := []struct {
@@ -91,7 +97,6 @@ func TestConfigStruct(t *testing.T) {
 		{"GCPBucketName", cfg.GCPBucketName, "test-bucket"},
 		{"SSLCertBase64", cfg.SSLCertBase64, "dGVzdA=="},
 		{"SSLPrivKeyBase64", cfg.SSLPrivKeyBase64, "dGVzdA=="},
-		{"ListenIPAudiosock", cfg.ListenIPAudiosock, "0.0.0.0"},
 	}
 
 	for _, tt := range tests {

--- a/bin-api-manager/internal/nethandler/advertise.go
+++ b/bin-api-manager/internal/nethandler/advertise.go
@@ -1,0 +1,135 @@
+// Package nethandler provides helpers for resolving network addresses that
+// a process should advertise to peers, as opposed to the address it binds
+// its listening socket to.
+//
+// The distinction matters for bin-api-manager's AudioSocket/ExternalMedia
+// listener, which binds a socket to all interfaces (0.0.0.0:<port>) but
+// must hand a dialable host:port to a remote peer (Asterisk) so it can
+// connect back. Binding and advertising must never share a single
+// "listen IP" config value: an advertise address needs a real, routable
+// host, while a listen address is free to be the wildcard.
+//
+// This package is internal to bin-api-manager (see the bin-common-handler
+// admission rule in the root CLAUDE.md: a package may only live in
+// bin-common-handler if it is used by 3+ services). Should
+// bin-pipecat-manager, bin-tts-manager, or bin-transcribe-manager later need
+// the same POD_IP-for-advertise-address resolution, promoting this package
+// to bin-common-handler at that time is the correct procedure.
+package nethandler
+
+import (
+	"net"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// EnvPodIP is the environment variable that, when set, overrides the
+// auto-detected advertise IP. This is how Kubernetes' Downward API
+// (fieldRef: status.podIP) and any Docker Compose deployment that sets it
+// explicitly communicate the pod/container's externally-reachable address.
+//
+// Exported so callers that need to know (e.g. for a startup log line
+// describing which resolution path was used) can reference the same
+// constant AdvertiseIP() consults, instead of re-declaring the literal.
+const EnvPodIP = "POD_IP"
+
+// Test seams. Production code always uses the real os/net implementations;
+// tests override these package vars to make interface enumeration and
+// environment lookups deterministic.
+var (
+	osGetenv         = os.Getenv
+	netInterfacesFn  = net.Interfaces
+	interfaceAddrsFn = func(iface net.Interface) ([]net.Addr, error) { return iface.Addrs() }
+)
+
+// AdvertiseIP returns the IP address other hosts (e.g. Asterisk dialing back
+// for AudioSocket/ExternalMedia streaming) should use to reach this process.
+//
+// This is deliberately distinct from a listen address: a listen address may
+// be the wildcard (0.0.0.0) so the process accepts connections on every
+// interface, but an advertise address must be a concrete, routable host.
+//
+// Resolution order:
+//  1. POD_IP environment variable, if set -- returned verbatim. This is the
+//     explicit override path (Kubernetes Downward API, or an operator-set
+//     Docker Compose environment variable).
+//  2. Auto-detected non-loopback IPv4 address from the host's network
+//     interfaces (e.g. the container's `production` Docker network
+//     interface in Komodo/Compose deployments that do not set POD_IP).
+//
+// If neither source yields an address, AdvertiseIP returns an error so
+// callers fail fast instead of silently advertising an empty/unusable host.
+func AdvertiseIP() (string, error) {
+	if podIP := osGetenv(EnvPodIP); podIP != "" {
+		return podIP, nil
+	}
+
+	ip, err := autoDetectIP()
+	if err != nil {
+		return "", errors.Wrap(err, "could not auto-detect advertise ip")
+	}
+
+	return ip, nil
+}
+
+// autoDetectIP scans the host's network interfaces for the first
+// non-loopback, non-link-local IPv4 address.
+func autoDetectIP() (string, error) {
+	ifaces, err := netInterfacesFn()
+	if err != nil {
+		return "", errors.Wrap(err, "could not list network interfaces")
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
+		addrs, errAddrs := interfaceAddrsFn(iface)
+		if errAddrs != nil {
+			continue
+		}
+
+		if ip := firstUsableIPv4(addrs); ip != "" {
+			return ip, nil
+		}
+	}
+
+	return "", errors.New("no non-loopback ipv4 address found on any network interface")
+}
+
+// firstUsableIPv4 returns the first non-loopback, non-link-local IPv4
+// address string found in addrs, or "" if none qualify.
+func firstUsableIPv4(addrs []net.Addr) string {
+	for _, addr := range addrs {
+		ip := extractIP(addr)
+		if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			continue
+		}
+
+		ip4 := ip.To4()
+		if ip4 == nil {
+			// IPv6-only address -- not usable here.
+			continue
+		}
+
+		return ip4.String()
+	}
+
+	return ""
+}
+
+// extractIP pulls the net.IP out of the concrete net.Addr implementations
+// returned by net.Interface.Addrs (*net.IPNet in practice, *net.IPAddr for
+// completeness).
+func extractIP(addr net.Addr) net.IP {
+	switch v := addr.(type) {
+	case *net.IPNet:
+		return v.IP
+	case *net.IPAddr:
+		return v.IP
+	default:
+		return nil
+	}
+}

--- a/bin-api-manager/internal/nethandler/advertise_test.go
+++ b/bin-api-manager/internal/nethandler/advertise_test.go
@@ -1,0 +1,157 @@
+package nethandler
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+var errNetInterfaces = errors.New("boom: could not enumerate interfaces")
+
+// resetSeams restores the package-level test seams to values that will not
+// leak between test cases.
+func resetSeams(t *testing.T) {
+	t.Helper()
+
+	origGetenv := osGetenv
+	origInterfaces := netInterfacesFn
+	origAddrs := interfaceAddrsFn
+
+	t.Cleanup(func() {
+		osGetenv = origGetenv
+		netInterfacesFn = origInterfaces
+		interfaceAddrsFn = origAddrs
+	})
+}
+
+func Test_AdvertiseIP_PodIPOverride(t *testing.T) {
+	resetSeams(t)
+
+	osGetenv = func(key string) string {
+		if key == EnvPodIP {
+			return "203.0.113.10"
+		}
+		return ""
+	}
+
+	// Auto-detect must never be consulted when POD_IP is set -- force it to
+	// fail loudly if it is.
+	netInterfacesFn = func() ([]net.Interface, error) {
+		t.Fatal("netInterfacesFn should not be called when POD_IP is set")
+		return nil, nil
+	}
+
+	res, err := AdvertiseIP()
+	if err != nil {
+		t.Fatalf("Wrong match. expected: nil, got: %v", err)
+	}
+
+	if res != "203.0.113.10" {
+		t.Errorf("Wrong match. expected: 203.0.113.10, got: %s", res)
+	}
+}
+
+func Test_AdvertiseIP_AutoDetectSuccess(t *testing.T) {
+	resetSeams(t)
+
+	osGetenv = func(key string) string { return "" }
+
+	netInterfacesFn = func() ([]net.Interface, error) {
+		return []net.Interface{
+			{Name: "lo", Flags: net.FlagUp | net.FlagLoopback},
+			{Name: "eth0", Flags: net.FlagUp},
+		}, nil
+	}
+
+	interfaceAddrsFn = func(iface net.Interface) ([]net.Addr, error) {
+		switch iface.Name {
+		case "lo":
+			return []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}}, nil
+		case "eth0":
+			return []net.Addr{
+				// link-local address should be skipped before the real one
+				&net.IPNet{IP: net.ParseIP("169.254.1.5"), Mask: net.CIDRMask(16, 32)},
+				&net.IPNet{IP: net.ParseIP("172.20.0.5"), Mask: net.CIDRMask(24, 32)},
+			}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	res, err := AdvertiseIP()
+	if err != nil {
+		t.Fatalf("Wrong match. expected: nil, got: %v", err)
+	}
+
+	if res != "172.20.0.5" {
+		t.Errorf("Wrong match. expected: 172.20.0.5, got: %s", res)
+	}
+}
+
+func Test_AdvertiseIP_FailFast(t *testing.T) {
+
+	type test struct {
+		name             string
+		netInterfacesFn  func() ([]net.Interface, error)
+		interfaceAddrsFn func(net.Interface) ([]net.Addr, error)
+	}
+
+	tests := []test{
+		{
+			name: "no interfaces at all",
+			netInterfacesFn: func() ([]net.Interface, error) {
+				return []net.Interface{}, nil
+			},
+			interfaceAddrsFn: func(iface net.Interface) ([]net.Addr, error) {
+				return nil, nil
+			},
+		},
+		{
+			name: "only loopback and link-local addresses",
+			netInterfacesFn: func() ([]net.Interface, error) {
+				return []net.Interface{
+					{Name: "lo", Flags: net.FlagUp | net.FlagLoopback},
+					{Name: "eth0", Flags: net.FlagUp},
+				}, nil
+			},
+			interfaceAddrsFn: func(iface net.Interface) ([]net.Addr, error) {
+				switch iface.Name {
+				case "lo":
+					return []net.Addr{&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)}}, nil
+				case "eth0":
+					return []net.Addr{&net.IPNet{IP: net.ParseIP("169.254.3.9"), Mask: net.CIDRMask(16, 32)}}, nil
+				default:
+					return nil, nil
+				}
+			},
+		},
+		{
+			name: "interface enumeration itself errors",
+			netInterfacesFn: func() ([]net.Interface, error) {
+				return nil, errNetInterfaces
+			},
+			interfaceAddrsFn: func(iface net.Interface) ([]net.Addr, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetSeams(t)
+
+			osGetenv = func(key string) string { return "" }
+			netInterfacesFn = tt.netInterfacesFn
+			interfaceAddrsFn = tt.interfaceAddrsFn
+
+			res, err := AdvertiseIP()
+			if err == nil {
+				t.Fatalf("Wrong match. expected: error, got: nil (res: %s)", res)
+			}
+
+			if res != "" {
+				t.Errorf("Wrong match. expected: empty string, got: %s", res)
+			}
+		})
+	}
+}

--- a/bin-api-manager/komodo/docker-compose.yml
+++ b/bin-api-manager/komodo/docker-compose.yml
@@ -39,6 +39,19 @@
 # `secrets:` mechanism as bin-storage-manager - see that service's
 # komodo/docker-compose.yml for the full explanation.
 #
+# POD_IP is deliberately NOT set here (unlike bin-pipecat-manager/
+# bin-transcribe-manager/bin-tts-manager, which set it to a literal
+# hostname string for HTTP media URLs). This service's AudioSocket/
+# ExternalMedia advertise address - the host:port handed to Asterisk so it
+# can dial back for AI audio streaming - needs a real, routable IP, not a
+# Docker-DNS-resolvable hostname. internal/nethandler.AdvertiseIP()
+# (internal to this service) resolves it: POD_IP overrides if set, otherwise it
+# auto-detects the container's non-loopback IPv4 address on the
+# `production` network below (this container joins only that one network,
+# so auto-detection is unambiguous). If neither resolves, the service
+# fails fast at startup instead of silently advertising an empty host
+# (see cmd/api-manager/main.go's getAddressAdvertiseAudiosock).
+#
 # SSL_PRIVKEY_BASE64 (not the docs/operations.md table's "SSL_PRIVATE_
 # BASE64" - that table has a stale env var name; confirmed against
 # internal/config/main.go's actual viper binding: the real env var is

--- a/bin-api-manager/pkg/streamhandler/main.go
+++ b/bin-api-manager/pkg/streamhandler/main.go
@@ -40,18 +40,24 @@ type streamHandler struct {
 	utilHandler utilhandler.UtilHandler
 	reqHandler  requesthandler.RequestHandler
 
-	listenAddress string
+	// advertiseAddress is the host:port handed to Asterisk (via
+	// CallV1ExternalMediaStart) so it knows where to dial back for
+	// AudioSocket/ExternalMedia streaming. This is intentionally NOT the
+	// address this process binds its listening socket to -- the socket
+	// binds to all interfaces (see cmd/api-manager's runListenStreamsock),
+	// while this must be a concrete, routable host.
+	advertiseAddress string
 
 	streamLock sync.Mutex
 	streamData map[string]*stream.Stream
 }
 
-func NewStreamHandler(reqHandler requesthandler.RequestHandler, listenAddress string) StreamHandler {
+func NewStreamHandler(reqHandler requesthandler.RequestHandler, advertiseAddress string) StreamHandler {
 	return &streamHandler{
 		utilHandler: utilhandler.NewUtilHandler(),
 		reqHandler:  reqHandler,
 
-		listenAddress: listenAddress,
+		advertiseAddress: advertiseAddress,
 
 		streamData: make(map[string]*stream.Stream),
 	}

--- a/bin-api-manager/pkg/streamhandler/start.go
+++ b/bin-api-manager/pkg/streamhandler/start.go
@@ -39,7 +39,7 @@ func (h *streamHandler) Start(
 		tmp.ID,
 		referenceType,
 		referenceID,
-		h.listenAddress,
+		h.advertiseAddress,
 		defaultExternalMediaEncapsulation,
 		defaultExternalMediaTransport,
 		"", // transportData

--- a/bin-api-manager/pkg/streamhandler/start_test.go
+++ b/bin-api-manager/pkg/streamhandler/start_test.go
@@ -64,10 +64,10 @@ func Test_Start(t *testing.T) {
 			localhost := "127.0.0.1:9000"
 
 			h := &streamHandler{
-				reqHandler:    mockReq,
-				utilHandler:   mockUtil,
-				listenAddress: localhost,
-				streamData:    make(map[string]*stream.Stream),
+				reqHandler:       mockReq,
+				utilHandler:      mockUtil,
+				advertiseAddress: localhost,
+				streamData:       make(map[string]*stream.Stream),
 			}
 			ctx := context.Background()
 

--- a/bin-api-manager/pkg/websockhandler/endpoint_test.go
+++ b/bin-api-manager/pkg/websockhandler/endpoint_test.go
@@ -1,7 +1,6 @@
 package websockhandler
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -187,9 +186,7 @@ func Test_endpointLocalGet(t *testing.T) {
 			mc := gomock.NewController(t)
 			defer mc.Finish()
 
-			if err := os.Setenv("POD_IP", tt.podIP); err != nil {
-				t.Errorf("Wrong match. expect: ok, got: %v", err)
-			}
+			t.Setenv("POD_IP", tt.podIP)
 
 			res := endpointLocalGet(tt.callID)
 			if res != tt.expectRes {

--- a/docs/.docs-gen/bin-api-manager.extracted.json
+++ b/docs/.docs-gen/bin-api-manager.extracted.json
@@ -173,9 +173,6 @@
     },
     {
       "flag": "ssl_privkey_base64"
-    },
-    {
-      "flag": "listen_ip_audiosock"
     }
   ],
   "metrics": [


### PR DESCRIPTION
Fix api-manager audiosocket advertise address so Asterisk can dial back correctly for AI streaming. The advertise address (told to Asterisk for AudioSocket dial-back) was sharing a single unset POD_IP value with the listen address, causing it to become ":9000" with no usable host in the current Komodo deployment.

- bin-api-manager: Add AdvertiseIP() helper in internal/nethandler (POD_IP override -> auto-detect from network interfaces -> fail-fast on failure)
- bin-api-manager: Separate listen address (0.0.0.0:9000) from advertise address for AudioSocket/ExternalMedia
- bin-api-manager: Validate resolved advertise address is a real IP (net.ParseIP) and use net.JoinHostPort for correct IPv6 handling
- bin-api-manager: Add Common Failure Modes doc entry for advertise address resolution startup failure