### PR TITLE
NOJIRA-Fix-transcribe-zombie-session-invariant

### DIFF
--- a/bin-transcribe-manager/docs/operations.md
+++ b/bin-transcribe-manager/docs/operations.md
@@ -4,7 +4,7 @@
 
 | Symptom | Likely Cause | Resolution |
 |---------|-------------|------------|
-| Session stuck in `progressing` | `call_hangup` event not received or not processed | Check subscribe handler queue; manually stop via `POST /v1/transcribes/{id}/stop` |
+| Session stuck in `progressing` | `call_hangup` event not received or not processed. **Also**: the zombie-session invariant (see [Zombie-Session Invariant and Recovery](#zombie-session-invariant-and-recovery) below) deliberately refuses to move a transcribe to `done` while any of its streaming sessions genuinely failed to stop | Check subscribe handler queue; manually stop via `POST /v1/transcribes/{id}/stop`. See the section below for the full mitigation picture, including a current limitation that prevents automatic retry today |
 | STT RPC routed to wrong pod | Stale `host_id` after pod restart (Calico POD_IP recycle) | See [per-pod-queues.md](../../docs/patterns/per-pod-queues.md) for known limitation; session must be recreated |
 | No transcripts appearing | WebSocket to Asterisk not established | Check `streaming_handler` logs for dial errors; verify `MediaURI` from `ExternalMediaStart` |
 | GCP auth failure | ADC not configured | Check `GOOGLE_APPLICATION_CREDENTIALS` points to a valid mounted service account key file |
@@ -12,6 +12,23 @@
 | Session health-check failing | Pod hosting session is down | Session is lost; streaming cannot be resumed — client must recreate |
 | `customer_deleted` cascade not running | Subscribe handler not consuming customer-manager events | Check queue binding: `bin-manager.customer-manager.event` |
 | Transcribe start/stop returns a `STT_NOT_CONFIGURED` error (`*cerrors.VoipbinError`, status `Unavailable`) | Neither GCP nor AWS STT client initialized at startup, so the service is running with the disabled streaming handler. Common causes: an invalid or placeholder `GOOGLE_APPLICATION_CREDENTIALS` key file plus no AWS credentials | Fix the GCP key file or set `AWS_ACCESS_KEY` / `AWS_SECRET_KEY`, then restart the service. Confirm with the provider-initialization log check below — a healthy boot logs `GCP STT provider initialized` and/or `AWS STT provider initialized`; a degraded boot logs `No STT providers available. Streaming transcribe is disabled until GCP or AWS credentials are configured.` |
+
+## Zombie-Session Invariant and Recovery
+
+`pkg/transcribehandler/stop.go`'s zombie-session invariant deliberately refuses to move a transcribe to `done` while any of its streaming sessions genuinely failed to stop (e.g. a transient call-manager RPC failure). This correctly prevents an orphaned live session from being marked done, but leaves the transcribe in `progressing` until the stop actually succeeds.
+
+Current mitigations, and their limits:
+
+- `streamingHandler.Stop` removes the entry from the in-memory session map as soon as the external media is actually stopped, so a retried stop never re-attempts an already-stopped streaming.
+- `pkg/transcribehandler/health.go`'s `stopOrReschedule` will requeue another health check (up to `defaultStopRescheduleMaxRetryCount` attempts) when `Stop` fails with the specific `STREAMING_STOP_FAILED` error — any other failure (e.g. an invalid reference type) is treated as permanent and is not retried.
+- **This reschedule mechanism is currently dormant.** Nothing in the codebase schedules the *first* health check for a transcribe: `startLive` never calls `TranscribeV1TranscribeHealthCheck`, and no other service, `cmd`, or subscribe handler does either. The only callers of that RPC are `health.go`'s own reschedule calls. In practice, the periodic health check does **not** currently retry a stuck stop on its own — bootstrapping the first health check (e.g. scheduling one from `startLive`) is a separate follow-up that has not been implemented yet.
+- `Delete` on a non-`done` transcribe still proceeds even if `Stop` fails, so a stuck session never blocks the customer-deletion cascade — but this only means the record is removed; the streaming session itself may still be live on Asterisk with no VoIPbin record left to stop it (see the log line `Could not stop the transcribe before delete; streaming may still be active on Asterisk...`).
+
+**Until the health-check bootstrap lands, the only real recovery paths for a transcribe stuck in `progressing` after a genuine stop failure are:**
+1. A manual `POST /v1/transcribes/{id}/stop` retry.
+2. `Delete`, which proceeds regardless of stop failure (see above) — but does not itself confirm the streaming session was actually stopped, so treat it as record cleanup, not confirmed session teardown.
+
+**These recovery paths, and the manual-retry framing above, assume this service is running with `replicas: 1` (see `k8s/deployment.yml`).** `pkg/transcribehandler/stop.go`'s `isSafeToConsiderStopped` treats a `NotFound` from the in-memory session lookup as proof the session cannot possibly still be alive — which is only true when a single pod owns every session. `TranscribeV1TranscribeStop` and `TranscribeV1TranscribeHealthCheck` are both routed through the shared `QueueNameTranscribeRequest` queue rather than a per-pod queue, so if `replicas` is ever raised above 1 without first fixing that routing gap, a "manual stop RPC retry" against a non-owning pod would return `NotFound` and be treated as a confirmed stop instead of a recovery attempt — silently completing the zombie session rather than recovering it. See the comment on `isSafeToConsiderStopped` for the full explanation.
 
 ## Debugging Guide
 

--- a/bin-transcribe-manager/pkg/streaminghandler/disabled.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/disabled.go
@@ -13,21 +13,30 @@ import (
 	"monorepo/bin-transcribe-manager/models/transcript"
 )
 
-// errSTTNotConfiguredReason is the VoipbinError reason returned by the disabled streaming
+// ErrSTTNotConfiguredReason is the VoipbinError reason returned by the disabled streaming
 // handler's per-request methods when no STT provider (GCP or AWS) could be initialized at
 // startup. The service keeps running so that every other transcribe-manager capability
 // stays available; only the live-streaming transcribe path is unavailable. Matches this
 // codebase's structured-error convention (see pkg/transcribehandler/start.go's
 // TRANSCRIBE_ALREADY_PROGRESSING for another example) so API callers get a typed,
 // domain/reason-tagged error instead of an opaque 500.
-const errSTTNotConfiguredReason = "STT_NOT_CONFIGURED"
+//
+// Exported so that other packages can match on this specific reason instead of on
+// Status alone. In particular, pkg/transcribehandler/stop.go's isSafeToConsiderStopped
+// checks Status == StatusUnavailable && Reason == ErrSTTNotConfiguredReason before
+// treating a streamingHandler.Stop failure as "safe to consider already stopped" -
+// StatusUnavailable by itself is a general-purpose "transient, retry later" status
+// that other call paths (e.g. a future typed-error migration of call-manager's
+// CallV1ExternalMediaStop) could also return for genuinely transient failures, so the
+// Reason match is required to avoid misclassifying a live session as already gone.
+const ErrSTTNotConfiguredReason = "STT_NOT_CONFIGURED"
 
 // newErrSTTNotConfigured returns a fresh VoipbinError for the disabled handler's per-request
 // methods to return.
 func newErrSTTNotConfigured() error {
 	return cerrors.Unavailable(
 		commonoutline.ServiceNameTranscribeManager,
-		errSTTNotConfiguredReason,
+		ErrSTTNotConfiguredReason,
 		"No STT provider (GCP or AWS) is configured on this instance. Live-streaming transcribe is unavailable; all other transcribe-manager functionality is unaffected.",
 	)
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/main_test.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/main_test.go
@@ -90,13 +90,13 @@ func Test_NewDisabledStreamingHandler(t *testing.T) {
 
 	if _, err := handler.Start(context.Background(), uuid.Nil, uuid.Nil, transcribe.ReferenceTypeCall, uuid.Nil, "en-US", transcript.DirectionIn, transcribe.ProviderEmpty); err == nil {
 		t.Error("Expected an STT-not-configured error from Start(), got nil")
-	} else if ve, ok := err.(*cerrors.VoipbinError); !ok || ve.Reason != errSTTNotConfiguredReason {
-		t.Errorf("Wrong error type/reason. expect reason: %s, got: %v", errSTTNotConfiguredReason, err)
+	} else if ve, ok := err.(*cerrors.VoipbinError); !ok || ve.Reason != ErrSTTNotConfiguredReason {
+		t.Errorf("Wrong error type/reason. expect reason: %s, got: %v", ErrSTTNotConfiguredReason, err)
 	}
 
 	if _, err := handler.Stop(context.Background(), uuid.Nil); err == nil {
 		t.Error("Expected an STT-not-configured error from Stop(), got nil")
-	} else if ve, ok := err.(*cerrors.VoipbinError); !ok || ve.Reason != errSTTNotConfiguredReason {
-		t.Errorf("Wrong error type/reason. expect reason: %s, got: %v", errSTTNotConfiguredReason, err)
+	} else if ve, ok := err.(*cerrors.VoipbinError); !ok || ve.Reason != ErrSTTNotConfiguredReason {
+		t.Errorf("Wrong error type/reason. expect reason: %s, got: %v", ErrSTTNotConfiguredReason, err)
 	}
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/stop.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/stop.go
@@ -35,5 +35,13 @@ func (h *streamingHandler) Stop(ctx context.Context, id uuid.UUID) (*streaming.S
 		_ = st.ConnAst.Close()
 	}
 
+	// Remove the entry from the in-memory session map now that the external
+	// media has actually been stopped. Without this, a retried Stop (e.g. after
+	// a sibling streaming in the same transcribe failed and the caller retries
+	// the whole transcribe stop) would call CallV1ExternalMediaStop again for an
+	// external media that call-manager no longer has any record of, turning a
+	// once-successful stop into a permanent failure on every subsequent retry.
+	h.Delete(ctx, st.ID)
+
 	return st, nil
 }

--- a/bin-transcribe-manager/pkg/streaminghandler/stop_test.go
+++ b/bin-transcribe-manager/pkg/streaminghandler/stop_test.go
@@ -12,6 +12,8 @@ import (
 
 	cmexternalmedia "monorepo/bin-call-manager/models/externalmedia"
 
+	stderrors "errors"
+
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -73,6 +75,11 @@ func Test_Stop(t *testing.T) {
 			h.mapStreaming[tt.streaming.ID] = tt.streaming
 
 			mockReq.EXPECT().CallV1ExternalMediaStop(ctx, tt.expectExternalMediaID).Return(tt.responseExternalMedia, nil)
+			// a successful stop must clear the map entry(and emit the stopped
+			// event via Delete), otherwise a retried Stop for this same
+			// streaming id would call CallV1ExternalMediaStop again for media
+			// call-manager no longer knows about.
+			mockNotify.EXPECT().PublishEvent(ctx, streaming.EventTypeStreamingStopped, tt.streaming)
 
 			res, err := h.Stop(ctx, tt.id)
 			if err != nil {
@@ -82,6 +89,49 @@ func Test_Stop(t *testing.T) {
 			if !reflect.DeepEqual(res, tt.expectRes) {
 				t.Errorf("Wrong match. expected: %v, got: %v", tt.expectRes, res)
 			}
+
+			if _, ok := h.mapStreaming[tt.id]; ok {
+				t.Errorf("Wrong match. expected the streaming to be removed from mapStreaming after a successful stop, but it is still present. streaming_id: %s", tt.id)
+			}
 		})
+	}
+}
+
+// Test_Stop_externalMediaStopFails verifies that when the call-manager RPC
+// fails, Stop returns the error and leaves the map entry in place(so a retry
+// can still find and re-attempt stopping it).
+func Test_Stop_externalMediaStopFails(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	id := uuid.FromStringOrNil("2f5b6f8c-2a52-4c1c-9f1a-1a0f8c8f6b21")
+	st := &streaming.Streaming{
+		Identity: commonidentity.Identity{ID: id},
+	}
+
+	h := &streamingHandler{
+		utilHandler:   mockUtil,
+		reqHandler:    mockReq,
+		notifyHandler: mockNotify,
+		mapStreaming:  map[uuid.UUID]*streaming.Streaming{id: st},
+	}
+	ctx := context.Background()
+
+	mockReq.EXPECT().CallV1ExternalMediaStop(ctx, id).Return(nil, stderrors.New("could not stop the external media"))
+
+	res, err := h.Stop(ctx, id)
+	if err == nil {
+		t.Errorf("Wrong match. expected: error, got: ok, res: %v", res)
+	}
+	if res != nil {
+		t.Errorf("Wrong match. expected: nil, got: %v", res)
+	}
+
+	if _, ok := h.mapStreaming[id]; !ok {
+		t.Errorf("Wrong match. expected the streaming to remain in mapStreaming after a failed stop so a retry can find it, but it was removed. streaming_id: %s", id)
 	}
 }

--- a/bin-transcribe-manager/pkg/transcribehandler/health.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/health.go
@@ -2,9 +2,11 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"monorepo/bin-call-manager/models/call"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-transcribe-manager/models/transcribe"
 
 	"github.com/gofrs/uuid"
@@ -20,20 +22,26 @@ func (h *transcribeHandler) HealthCheck(ctx context.Context, id uuid.UUID, retry
 		"retry_count":   retryCount,
 	})
 
-	if retryCount > defaultHealthMaxRetryCount {
-		log.Errorf("The health check exceeded max retry count. Stopping the transcribe. retry_count: %d", retryCount)
-		_, _ = h.Stop(ctx, id)
-		return
-	}
-
-	// validate the transcribe.
+	// validate the transcribe. This guard must run unconditionally, before the
+	// max-retry-exceeded branch below, so that a transcribe that is already
+	// StatusDone or soft-deleted (TMDelete != nil) never enters
+	// stopOrReschedule in the first place. TranscribeGet does not filter out
+	// soft-deleted rows, so without this ordering a soft-deleted transcribe
+	// with Status still "progressing" could be rescheduled by this health
+	// check forever.
 	tr, err := h.Get(ctx, id)
 	if err != nil {
 		log.Errorf("Could not get transcribe info. err: %v", err)
 		return
 	}
 	if tr.Status == transcribe.StatusDone || tr.TMDelete != nil {
-		// the call is done already. no need to check the health anymore.
+		// the transcribe is done or deleted already. no need to check the health anymore.
+		return
+	}
+
+	if retryCount > defaultHealthMaxRetryCount {
+		log.Errorf("The health check exceeded max retry count. Stopping the transcribe. retry_count: %d", retryCount)
+		h.stopOrReschedule(ctx, tr, retryCount, log)
 		return
 	}
 
@@ -43,7 +51,7 @@ func (h *transcribeHandler) HealthCheck(ctx context.Context, id uuid.UUID, retry
 		c, err := h.reqHandler.CallV1CallGet(ctx, tr.ReferenceID)
 		if err != nil {
 			log.Errorf("Could not get reference call info. Stopping the transcribe. err: %v", err)
-			_, _ = h.Stop(ctx, id)
+			h.stopOrReschedule(ctx, tr, retryCount, log)
 			return
 		}
 
@@ -58,7 +66,7 @@ func (h *transcribeHandler) HealthCheck(ctx context.Context, id uuid.UUID, retry
 		cb, err := h.reqHandler.CallV1ConfbridgeGet(ctx, tr.ReferenceID)
 		if err != nil {
 			log.Errorf("Could not get reference confbridge info. Stopping the transcribe. err: %v", err)
-			_, _ = h.Stop(ctx, id)
+			h.stopOrReschedule(ctx, tr, retryCount, log)
 			return
 		}
 
@@ -71,5 +79,75 @@ func (h *transcribeHandler) HealthCheck(ctx context.Context, id uuid.UUID, retry
 
 	go func() {
 		_ = h.reqHandler.TranscribeV1TranscribeHealthCheck(ctx, id, defaultHealthDelay, retryCount)
+	}()
+}
+
+// stopOrReschedule attempts to stop the transcribe. Stop() only fails when at
+// least one streaming session could not genuinely be stopped (a
+// cerrors.VoipbinError{Status: StatusFailedPrecondition, Reason:
+// reasonStreamingStopFailed} - see pkg/transcribehandler/stop.go's
+// zombie-session invariant) - in that case the transcribe is deliberately
+// left in StatusProgressing rather than forced to StatusDone.
+//
+// IMPORTANT - this mechanism is currently dormant: as of this writing, nothing
+// in the codebase schedules the *first* health check for a transcribe.
+// `startLive` (pkg/transcribehandler/start.go) never calls
+// TranscribeV1TranscribeHealthCheck, and no other service, cmd, or
+// subscribehandler does either - the only callers of
+// TranscribeV1TranscribeHealthCheck are this function's own reschedule call
+// below and HealthCheck's own reschedule call. In other words, this reschedule
+// loop only ever runs once some other change explicitly triggers the first
+// health-check RPC for a transcribe; today it never fires on its own. Until
+// that bootstrapping work happens (tracked separately - it is a distinct
+// feature addition, not a safety fix, and is out of scope here), the only
+// real recovery paths for a transcribe stuck in StatusProgressing after a
+// genuine stop failure are (1) a manual POST /v1/transcribes/{id}/stop retry,
+// or (2) Delete, which proceeds even if Stop fails (see transcribe.go's
+// Delete). This function is still kept safe-by-construction below (narrow
+// error match, bounded retries) so it is safe to wire up later without
+// re-litigating this logic - PROVIDED this service is still running with
+// replicas: 1 (see k8s/deployment.yml) when that wiring happens. Stop()'s
+// isSafeToConsiderStopped (pkg/transcribehandler/stop.go) has a NotFound
+// branch that is only correct under that single-replica assumption, because
+// TranscribeV1TranscribeStop and TranscribeV1TranscribeHealthCheck are both
+// routed through the shared commonoutline.QueueNameTranscribeRequest queue
+// rather than a per-pod queue. If replicas is ever raised above 1, that
+// NotFound branch must be re-examined first - see the detailed comment on
+// isSafeToConsiderStopped for why.
+//
+// If/when the first health check does get scheduled and this reschedule loop
+// runs, ending it here on a genuine stop failure would leave that transcribe
+// stuck in `progressing` forever with no remaining path to clean it up.
+// Instead, reschedule another health check - but only:
+//   - when the failure is specifically reasonStreamingStopFailed. Any other
+//     error (e.g. an invalid reference type, a permanent DB failure, etc.)
+//     cannot be fixed by retrying the exact same stop again, so we log and
+//     give up instead of rescheduling forever.
+//   - up to defaultStopRescheduleMaxRetryCount attempts, so a persistent
+//     failure (e.g. call-manager unreachable indefinitely) eventually stops
+//     rescheduling instead of looping forever.
+func (h *transcribeHandler) stopOrReschedule(ctx context.Context, tr *transcribe.Transcribe, retryCount int, log *logrus.Entry) {
+	_, err := h.Stop(ctx, tr.ID)
+	if err == nil {
+		return
+	}
+
+	var ve *cerrors.VoipbinError
+	isRetryable := stderrors.As(err, &ve) && ve.Status == cerrors.StatusFailedPrecondition && ve.Reason == reasonStreamingStopFailed
+	if !isRetryable {
+		// a permanent failure: retrying the same stop again will never
+		// succeed, so do not reschedule.
+		log.Errorf("Could not stop the transcribe with a non-retryable error. Giving up without rescheduling. transcribe_id: %s, err: %v", tr.ID, err)
+		return
+	}
+
+	if retryCount >= defaultStopRescheduleMaxRetryCount {
+		log.Errorf("Could not stop the transcribe after %d attempts. Giving up; the transcribe remains in progressing and needs manual intervention (see docs/operations.md). transcribe_id: %s, err: %v", retryCount, tr.ID, err)
+		return
+	}
+
+	log.Errorf("Could not stop the transcribe. Will retry via a future health check. transcribe_id: %s, err: %v", tr.ID, err)
+	go func() {
+		_ = h.reqHandler.TranscribeV1TranscribeHealthCheck(ctx, tr.ID, defaultHealthDelay, retryCount+1)
 	}()
 }

--- a/bin-transcribe-manager/pkg/transcribehandler/health_test.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/health_test.go
@@ -2,6 +2,7 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 	"time"
 
@@ -13,8 +14,10 @@ import (
 	"monorepo/bin-common-handler/pkg/requesthandler"
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
+	"monorepo/bin-transcribe-manager/models/streaming"
 	"monorepo/bin-transcribe-manager/models/transcribe"
 	"monorepo/bin-transcribe-manager/pkg/dbhandler"
+	"monorepo/bin-transcribe-manager/pkg/streaminghandler"
 
 	"github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -168,4 +171,299 @@ func Test_HealthCheck(t *testing.T) {
 			time.Sleep(time.Millisecond * 100)
 		})
 	}
+}
+
+// Test_HealthCheck_maxRetryExceeded_stopFails_reschedules verifies that when
+// the retry count is exceeded and the resulting Stop() genuinely fails(a
+// streaming session could not be stopped), HealthCheck does not just give up:
+// it reschedules another health check at the same retryCount so the existing
+// periodic health-check mechanism keeps retrying, instead of leaving the
+// transcribe stuck in progressing forever with nothing left to ever retry it.
+func Test_HealthCheck_maxRetryExceeded_stopFails_reschedules(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockStreaming := streaminghandler.NewMockStreamingHandler(mc)
+
+	id := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000001")
+	stID := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000002")
+	retryCount := defaultHealthMaxRetryCount + 1
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		ReferenceType: transcribe.ReferenceTypeCall,
+		Status:        transcribe.StatusProgressing,
+		StreamingIDs:  []uuid.UUID{stID},
+	}
+
+	h := &transcribeHandler{
+		reqHandler:       mockReq,
+		db:               mockDB,
+		notifyHandler:    mockNotify,
+		streamingHandler: mockStreaming,
+	}
+	ctx := context.Background()
+
+	// Get is called twice: once by HealthCheck's own unconditional
+	// done/deleted guard (which now runs before the max-retry branch), and
+	// once more inside the nested h.Stop() call triggered by
+	// stopOrReschedule.
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(2)
+	mockStreaming.EXPECT().Stop(ctx, stID).Return(nil, stderrors.New("could not stop the external media"))
+	// stopLive wraps this into a reasonStreamingStopFailed
+	// FailedPrecondition error, which is the one retryable case - so
+	// stopOrReschedule reschedules at retryCount+1.
+	mockReq.EXPECT().TranscribeV1TranscribeHealthCheck(ctx, id, defaultHealthDelay, retryCount+1).Return(nil)
+
+	h.HealthCheck(ctx, id, retryCount)
+
+	time.Sleep(time.Millisecond * 100)
+}
+
+// Test_HealthCheck_maxRetryExceeded_stopSucceeds_noReschedule verifies that
+// when Stop() succeeds, HealthCheck does not reschedule another health check
+// (the transcribe is now done, so there is nothing left to check).
+func Test_HealthCheck_maxRetryExceeded_stopSucceeds_noReschedule(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockStreaming := streaminghandler.NewMockStreamingHandler(mc)
+
+	id := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000003")
+	stID := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000004")
+	retryCount := defaultHealthMaxRetryCount + 1
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		ReferenceType: transcribe.ReferenceTypeCall,
+		Status:        transcribe.StatusProgressing,
+		StreamingIDs:  []uuid.UUID{stID},
+	}
+
+	h := &transcribeHandler{
+		reqHandler:       mockReq,
+		db:               mockDB,
+		notifyHandler:    mockNotify,
+		streamingHandler: mockStreaming,
+	}
+	ctx := context.Background()
+
+	// Get is called twice with the exact (ctx, id) matcher: once by
+	// HealthCheck's own unconditional done/deleted guard, and once more
+	// inside the nested h.Stop() call triggered by stopOrReschedule. A third,
+	// separate Get (matched via gomock.Any() below) happens inside
+	// UpdateStatus's post-update refetch.
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(2)
+	mockStreaming.EXPECT().Stop(ctx, stID).Return(&streaming.Streaming{}, nil)
+	mockDB.EXPECT().TranscribeUpdate(ctx, id, map[transcribe.Field]any{
+		transcribe.FieldStatus: transcribe.StatusDone,
+	}).Return(nil)
+	mockDB.EXPECT().TranscribeGet(gomock.Any(), id).Return(tr, nil)
+	mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tr.CustomerID, transcribe.EventTypeTranscribeDone, tr)
+	// deliberately no mockReq.EXPECT().TranscribeV1TranscribeHealthCheck(...): a
+	// successful stop must not reschedule another health check.
+
+	h.HealthCheck(ctx, id, retryCount)
+
+	time.Sleep(time.Millisecond * 100)
+}
+
+// Test_HealthCheck_referenceGetError_stopFails_reschedules verifies the same
+// reschedule-on-genuine-stop-failure behavior for the "could not get
+// reference call info" branch, not just the max-retry-exceeded branch.
+func Test_HealthCheck_referenceGetError_stopFails_reschedules(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockStreaming := streaminghandler.NewMockStreamingHandler(mc)
+
+	id := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000005")
+	stID := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000006")
+	referenceID := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000007")
+	retryCount := 0
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		ReferenceType: transcribe.ReferenceTypeCall,
+		ReferenceID:   referenceID,
+		Status:        transcribe.StatusProgressing,
+		StreamingIDs:  []uuid.UUID{stID},
+	}
+
+	h := &transcribeHandler{
+		reqHandler:       mockReq,
+		db:               mockDB,
+		notifyHandler:    mockNotify,
+		streamingHandler: mockStreaming,
+	}
+	ctx := context.Background()
+
+	// once for HealthCheck's own validation Get, once more inside the nested
+	// h.Stop() call triggered by the reference-lookup failure.
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(2)
+	mockReq.EXPECT().CallV1CallGet(ctx, referenceID).Return(nil, stderrors.New("call not found"))
+	mockStreaming.EXPECT().Stop(ctx, stID).Return(nil, stderrors.New("could not stop the external media"))
+	// stopLive wraps this into a reasonStreamingStopFailed FailedPrecondition
+	// error, which is the one retryable case - so stopOrReschedule
+	// reschedules at retryCount+1.
+	mockReq.EXPECT().TranscribeV1TranscribeHealthCheck(ctx, id, defaultHealthDelay, retryCount+1).Return(nil)
+
+	h.HealthCheck(ctx, id, retryCount)
+
+	time.Sleep(time.Millisecond * 100)
+}
+
+// Test_HealthCheck_maxRetryExceeded_permanentStopFailure_noReschedule verifies
+// that when Stop() fails with a non-retryable error (i.e. anything other than
+// the specific reasonStreamingStopFailed FailedPrecondition), stopOrReschedule
+// gives up instead of rescheduling - retrying the exact same permanent
+// failure (e.g. an invalid reference type) on a later health check could
+// never succeed, so it must not loop forever.
+func Test_HealthCheck_maxRetryExceeded_permanentStopFailure_noReschedule(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	id := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000008")
+	retryCount := defaultHealthMaxRetryCount + 1
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		// Not ReferenceTypeCall/ReferenceTypeConfbridge, so Stop()'s switch
+		// default branch returns a permanent
+		// cerrors.InvalidArgument("INVALID_REFERENCE_TYPE") error - not the
+		// retryable reasonStreamingStopFailed - without needing a streaming
+		// handler mock at all.
+		ReferenceType: transcribe.ReferenceTypeRecording,
+		Status:        transcribe.StatusProgressing,
+	}
+
+	h := &transcribeHandler{
+		reqHandler:    mockReq,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(2)
+	// deliberately no mockReq.EXPECT().TranscribeV1TranscribeHealthCheck(...):
+	// a permanent failure must not be rescheduled.
+
+	h.HealthCheck(ctx, id, retryCount)
+
+	time.Sleep(time.Millisecond * 100)
+}
+
+// Test_HealthCheck_maxRetryExceeded_softDeleted_noReschedule verifies that a
+// soft-deleted transcribe (TMDelete != nil) never reaches stopOrReschedule,
+// even when retryCount has already exceeded the max. The done/deleted guard
+// at the top of HealthCheck must run unconditionally, before the max-retry
+// branch: TranscribeGet does not filter out soft-deleted rows, so without
+// this ordering a soft-deleted-but-still-"progressing" transcribe could be
+// rescheduled by this health check forever.
+func Test_HealthCheck_maxRetryExceeded_softDeleted_noReschedule(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+
+	id := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-000000000009")
+	retryCount := defaultHealthMaxRetryCount + 1
+	deletedAt := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		ReferenceType: transcribe.ReferenceTypeCall,
+		Status:        transcribe.StatusProgressing,
+		TMDelete:      &deletedAt,
+	}
+
+	h := &transcribeHandler{
+		reqHandler:    mockReq,
+		db:            mockDB,
+		notifyHandler: mockNotify,
+	}
+	ctx := context.Background()
+
+	// Only the single top-level guard Get - Stop() must never be reached
+	// (no streamingHandler is even wired up on this handler), so there must
+	// be no second Get from inside it.
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(1)
+	// deliberately no CallV1CallGet and no
+	// TranscribeV1TranscribeHealthCheck expectations: a soft-deleted
+	// transcribe must short-circuit before ever reaching stopOrReschedule.
+
+	h.HealthCheck(ctx, id, retryCount)
+
+	time.Sleep(time.Millisecond * 100)
+}
+
+// Test_HealthCheck_stopReschedule_capEnforced verifies that stopOrReschedule
+// stops rescheduling once defaultStopRescheduleMaxRetryCount is reached, even
+// though Stop() keeps failing with the retryable reasonStreamingStopFailed
+// error - otherwise a persistent stop failure (e.g. call-manager unreachable
+// indefinitely) would reschedule forever.
+func Test_HealthCheck_stopReschedule_capEnforced(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockStreaming := streaminghandler.NewMockStreamingHandler(mc)
+
+	id := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-00000000000a")
+	stID := uuid.FromStringOrNil("a1b2c3d4-0000-4000-8000-00000000000b")
+	retryCount := defaultStopRescheduleMaxRetryCount
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		ReferenceType: transcribe.ReferenceTypeCall,
+		Status:        transcribe.StatusProgressing,
+		StreamingIDs:  []uuid.UUID{stID},
+	}
+
+	h := &transcribeHandler{
+		reqHandler:       mockReq,
+		db:               mockDB,
+		notifyHandler:    mockNotify,
+		streamingHandler: mockStreaming,
+	}
+	ctx := context.Background()
+
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(2)
+	mockStreaming.EXPECT().Stop(ctx, stID).Return(nil, stderrors.New("could not stop the external media"))
+	// deliberately no mockReq.EXPECT().TranscribeV1TranscribeHealthCheck(...):
+	// retryCount has already reached the cap, so no further reschedule
+	// should be requested.
+
+	h.HealthCheck(ctx, id, retryCount)
+
+	time.Sleep(time.Millisecond * 100)
 }

--- a/bin-transcribe-manager/pkg/transcribehandler/main.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/main.go
@@ -81,6 +81,17 @@ var (
 const (
 	defaultHealthMaxRetryCount = 2
 	defaultHealthDelay         = 10000 // 10 seconds
+
+	// defaultStopRescheduleMaxRetryCount bounds how many times
+	// health.go's stopOrReschedule will requeue itself after Stop() keeps
+	// failing with the one specific retryable error
+	// (reasonStreamingStopFailed). It is independent of
+	// defaultHealthMaxRetryCount, which only gates how long the
+	// reference-liveness loop runs before HealthCheck ever reaches
+	// stopOrReschedule. This bound exists purely so a persistent stop
+	// failure (e.g. call-manager unreachable indefinitely) eventually stops
+	// rescheduling instead of retrying forever.
+	defaultStopRescheduleMaxRetryCount = defaultHealthMaxRetryCount + 5
 )
 
 const (

--- a/bin-transcribe-manager/pkg/transcribehandler/stop.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/stop.go
@@ -2,15 +2,28 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/requesthandler"
 	fmactiveflow "monorepo/bin-flow-manager/models/activeflow"
 	"monorepo/bin-transcribe-manager/models/transcribe"
+	"monorepo/bin-transcribe-manager/pkg/streaminghandler"
 )
+
+// reasonStreamingStopFailed is the VoipbinError reason stopLive uses when at
+// least one streaming session could not be confirmed stopped (the
+// zombie-session invariant below). health.go's stopOrReschedule matches on
+// this exact reason to decide whether a Stop() failure is worth retrying via
+// another scheduled health check, as opposed to a permanent failure (e.g. an
+// invalid reference type) that retrying can never fix.
+const reasonStreamingStopFailed = "STREAMING_STOP_FAILED"
 
 // Stop stops the progressing transcribe process.
 func (h *transcribeHandler) Stop(ctx context.Context, id uuid.UUID) (*transcribe.Transcribe, error) {
@@ -39,7 +52,11 @@ func (h *transcribeHandler) Stop(ctx context.Context, id uuid.UUID) (*transcribe
 
 	default:
 		log.Errorf("Invalid reference type. reference_type: %s", tr.ReferenceType)
-		return nil, fmt.Errorf("invalid reference type")
+		return nil, cerrors.InvalidArgument(
+			commonoutline.ServiceNameTranscribeManager,
+			"INVALID_REFERENCE_TYPE",
+			fmt.Sprintf("invalid reference type: %s", tr.ReferenceType),
+		)
 	}
 
 	if err != nil {
@@ -80,14 +97,38 @@ func (h *transcribeHandler) stopLive(ctx context.Context, tr *transcribe.Transcr
 		"transcribe_id": tr.ID,
 	})
 
+	var failedStreamingIDs []uuid.UUID
 	for _, streamingID := range tr.StreamingIDs {
 		st, err := h.streamingHandler.Stop(ctx, streamingID)
 		if err != nil {
-			// could not stop the streaming, but continue to stop the other streamings
-			log.Infof("Could not stop the streaming. But consider already stopped. streaming_id: %s, err: %v", streamingID, err)
+			if isSafeToConsiderStopped(err) {
+				// the streaming session no longer exists (e.g., it already finished and was
+				// cleaned up, or the external media was already stopped elsewhere), or it
+				// cannot logically be alive (e.g., no STT provider is configured on this
+				// instance, so nothing could ever have started it). Either way there is
+				// nothing left to stop here. Safe to consider it already stopped and
+				// continue with the other streamings.
+				log.Infof("Could not stop the streaming. But consider already stopped. streaming_id: %s, err: %v", streamingID, err)
+				continue
+			}
+
+			// a genuine stop failure: the streaming session may still be running. Do not
+			// continue to mark the transcribe done for this, or the session becomes a
+			// zombie that nothing can ever stop again. Keep trying the remaining
+			// streamings so we stop as many as we can, but track the failure.
+			log.Errorf("Could not stop the streaming. streaming_id: %s, err: %v", streamingID, err)
+			failedStreamingIDs = append(failedStreamingIDs, streamingID)
 			continue
 		}
 		log.WithField("streaming", st).Debugf("Stopped streaming. streaming_id: %s", st.ID)
+	}
+
+	if len(failedStreamingIDs) > 0 {
+		return nil, cerrors.FailedPrecondition(
+			commonoutline.ServiceNameTranscribeManager,
+			reasonStreamingStopFailed,
+			fmt.Sprintf("could not stop %d of %d streaming session(s). transcribe_id: %s, failed streaming_ids: %v", len(failedStreamingIDs), len(tr.StreamingIDs), tr.ID, failedStreamingIDs),
+		)
 	}
 
 	res, err := h.UpdateStatus(ctx, tr.ID, transcribe.StatusDone)
@@ -97,4 +138,85 @@ func (h *transcribeHandler) stopLive(ctx context.Context, tr *transcribe.Transcr
 	log.WithField("transcribe", res).Debugf("Updated transcribe status done. transcribe_id: %s", res.ID)
 
 	return res, nil
+}
+
+// isSafeToConsiderStopped decides whether an error returned from
+// streamingHandler.Stop means the streaming session cannot possibly still be
+// alive, so it is safe to treat the stop as having already happened and
+// proceed to mark the transcribe done.
+//
+// This must recognize every error shape streamingHandler.Stop can actually
+// produce, not just the typed one:
+//
+//   - typed cerrors.VoipbinError{Status: StatusNotFound}: the in-memory
+//     streaming.Get() lookup missed (see streaminghandler/streaming.go's Get),
+//     i.e. the session was already cleaned up locally.
+//
+//     IMPORTANT - deployment dependency: this branch is only safe to treat as
+//     "session cannot possibly be alive" as long as this service runs with
+//     replicas: 1 (see k8s/deployment.yml). The in-memory session map
+//     (mapStreaming) is per-pod, and a genuinely live session only exists in
+//     the memory of the one pod that owns it. With a single replica, any
+//     control RPC necessarily reaches that one pod, so a NotFound here really
+//     does mean "no such session anywhere." However, TranscribeV1TranscribeStop
+//     and TranscribeV1TranscribeHealthCheck are both sent to the shared
+//     commonoutline.QueueNameTranscribeRequest queue rather than a per-pod
+//     queue (contrast this with the per-pod request queue that does exist,
+//     bin-manager.transcribe-manager-<hostID>.request, wired up in
+//     cmd/transcribe-manager/main.go) - control RPCs are not yet routed to the
+//     owning pod the way this service's own CLAUDE.md says they must be (a
+//     known, separately tracked architecture gap, out of scope for this file).
+//     If replicas is ever raised above 1 without first fixing that routing
+//     gap, a stop/health-check request can land on a pod that does not own the
+//     session; streaming.Get() would miss on that non-owning pod and return
+//     NotFound even though the session is genuinely alive on another pod, and
+//     this branch would then misclassify a live session as already stopped -
+//     reintroducing the exact zombie-session bug this file exists to prevent.
+//     Any change to replicas in k8s/deployment.yml must re-examine this branch
+//     first.
+//   - legacy requesthandler.ErrNotFound sentinel: the call-manager RPC
+//     (CallV1ExternalMediaStop) surfaces a 404 through the older,
+//     pre-VoipbinError sentinel path instead of a typed error (call-manager's
+//     external-media error responses are not yet migrated to typed errors).
+//     Mirrors the same dual-check pattern used by
+//     bin-call-manager/pkg/channelhandler/hangup.go's HangingUpWithAsteriskID.
+//   - typed cerrors.VoipbinError{Status: StatusUnavailable, Reason:
+//     streaminghandler.ErrSTTNotConfiguredReason}: returned by
+//     streaminghandler's disabledStreamingHandler.Stop (see
+//     pkg/streaminghandler/disabled.go) when no STT provider is configured on
+//     this instance. Start always fails in that state too, so no live session
+//     could ever have existed to begin with — treating this as a genuine
+//     failure would permanently block the StatusDone transition for an
+//     instance that structurally can never have a real session to stop.
+//
+//     IMPORTANT: this branch intentionally checks Status AND Reason together,
+//     unlike the NotFound branch above (which is a genuine dual-check mirror
+//     of hangup.go's pattern and only needs Status). StatusUnavailable by
+//     itself is a general-purpose "transient failure, safe to retry later"
+//     status - if bin-call-manager's ARI/Asterisk error responses are ever
+//     migrated to typed errors, a genuinely-alive session could plausibly
+//     surface StatusUnavailable too (e.g. Asterisk temporarily unreachable).
+//     Matching on Status alone would then misclassify a live session as
+//     already stopped and reintroduce the exact zombie-session bug this file
+//     exists to prevent. Narrowing to the specific STT_NOT_CONFIGURED reason
+//     keeps this branch scoped to the one situation where "no session could
+//     possibly exist" is actually true. This Reason-scoped check is a local
+//     extension of the dual-check pattern, not something hangup.go's pattern
+//     itself does.
+func isSafeToConsiderStopped(err error) bool {
+	var ve *cerrors.VoipbinError
+	if stderrors.As(err, &ve) {
+		if ve.Status == cerrors.StatusNotFound {
+			return true
+		}
+		if ve.Status == cerrors.StatusUnavailable && ve.Reason == streaminghandler.ErrSTTNotConfiguredReason {
+			return true
+		}
+	}
+
+	if stderrors.Is(err, requesthandler.ErrNotFound) {
+		return true
+	}
+
+	return false
 }

--- a/bin-transcribe-manager/pkg/transcribehandler/stop_test.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/stop_test.go
@@ -2,6 +2,7 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 	reflect "reflect"
 	"testing"
 
@@ -11,8 +12,11 @@ import (
 	"monorepo/bin-common-handler/pkg/utilhandler"
 
 	"github.com/gofrs/uuid"
+	pkgerrors "github.com/pkg/errors"
 	gomock "go.uber.org/mock/gomock"
 
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 	"monorepo/bin-transcribe-manager/models/streaming"
 	"monorepo/bin-transcribe-manager/models/transcribe"
 	"monorepo/bin-transcribe-manager/pkg/dbhandler"
@@ -94,25 +98,88 @@ func Test_TranscribingStop_call(t *testing.T) {
 	}
 }
 
+// newStopLiveTestTranscribe returns a fresh transcribe for each subtest so
+// subtests never share a pointer(a shared pointer risks one subtest's
+// mutations leaking into another when run in parallel or in sequence).
+func newStopLiveTestTranscribe() *transcribe.Transcribe {
+	return &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: uuid.FromStringOrNil("58ad260c-8789-11ec-87ad-63d573434c69"),
+		},
+		StreamingIDs: []uuid.UUID{
+			uuid.FromStringOrNil("d5824a14-8788-11ec-9e71-a7cedf6ca3e1"),
+			uuid.FromStringOrNil("df402f8a-8788-11ec-a14b-af9efb78ed6a"),
+		},
+	}
+}
+
 func Test_stopLive(t *testing.T) {
 
 	tests := []struct {
 		name string
 
-		transcribe *transcribe.Transcribe
+		// streamingErrs holds the error h.streamingHandler.Stop should return for the
+		// streaming id at the same index of transcribe.StreamingIDs. nil means success.
+		streamingErrs []error
+
+		expectDone bool
 	}{
 		{
-			"normal",
+			"all streamings stop successfully, transcribe becomes done",
 
-			&transcribe.Transcribe{
-				Identity: commonidentity.Identity{
-					ID: uuid.FromStringOrNil("58ad260c-8789-11ec-87ad-63d573434c69"),
-				},
-				StreamingIDs: []uuid.UUID{
-					uuid.FromStringOrNil("d5824a14-8788-11ec-9e71-a7cedf6ca3e1"),
-					uuid.FromStringOrNil("df402f8a-8788-11ec-a14b-af9efb78ed6a"),
-				},
+			[]error{nil, nil},
+
+			true,
+		},
+		{
+			"a streaming is already gone(typed not found), still becomes done",
+
+			[]error{
+				cerrors.NotFound(commonoutline.ServiceNameTranscribeManager, "STREAMING_NOT_FOUND", "The streaming was not found."),
+				nil,
 			},
+
+			true,
+		},
+		{
+			"a streaming is already gone via the legacy call-manager sentinel, still becomes done",
+
+			[]error{
+				nil,
+				pkgerrors.Wrap(requesthandler.ErrNotFound, "could not stop the external media"),
+			},
+
+			true,
+		},
+		{
+			"a streaming reports STT not configured(Unavailable), still becomes done",
+
+			[]error{
+				cerrors.Unavailable(commonoutline.ServiceNameTranscribeManager, streaminghandler.ErrSTTNotConfiguredReason, "No STT provider is configured."),
+				nil,
+			},
+
+			true,
+		},
+		{
+			"a streaming genuinely fails to stop, must not become done(zombie session invariant)",
+
+			[]error{
+				nil,
+				stderrors.New("could not stop the external media"),
+			},
+
+			false,
+		},
+		{
+			"all streamings genuinely fail to stop, must not become done",
+
+			[]error{
+				stderrors.New("could not stop the external media 1"),
+				stderrors.New("could not stop the external media 2"),
+			},
+
+			false,
 		},
 	}
 
@@ -120,6 +187,8 @@ func Test_stopLive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mc := gomock.NewController(t)
 			defer mc.Finish()
+
+			tr := newStopLiveTestTranscribe()
 
 			mockReq := requesthandler.NewMockRequestHandler(mc)
 			mockDB := dbhandler.NewMockDBHandler(mc)
@@ -137,23 +206,117 @@ func Test_stopLive(t *testing.T) {
 
 			ctx := context.Background()
 
-			for _, stID := range tt.transcribe.StreamingIDs {
-				mockStreaming.EXPECT().Stop(ctx, stID).Return(&streaming.Streaming{}, nil)
+			for i, stID := range tr.StreamingIDs {
+				if tt.streamingErrs[i] != nil {
+					mockStreaming.EXPECT().Stop(ctx, stID).Return(nil, tt.streamingErrs[i])
+				} else {
+					mockStreaming.EXPECT().Stop(ctx, stID).Return(&streaming.Streaming{}, nil)
+				}
 			}
 
-			mockDB.EXPECT().TranscribeUpdate(ctx, tt.transcribe.ID, map[transcribe.Field]any{
-				transcribe.FieldStatus: transcribe.StatusDone,
-			}).Return(nil)
-			mockDB.EXPECT().TranscribeGet(gomock.Any(), tt.transcribe.ID).Return(tt.transcribe, nil)
-			mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tt.transcribe.CustomerID, transcribe.EventTypeTranscribeDone, tt.transcribe)
+			if tt.expectDone {
+				mockDB.EXPECT().TranscribeUpdate(ctx, tr.ID, map[transcribe.Field]any{
+					transcribe.FieldStatus: transcribe.StatusDone,
+				}).Return(nil)
+				mockDB.EXPECT().TranscribeGet(gomock.Any(), tr.ID).Return(tr, nil)
+				mockNotify.EXPECT().PublishWebhookEvent(gomock.Any(), tr.CustomerID, transcribe.EventTypeTranscribeDone, tr)
+			}
 
-			res, err := h.stopLive(ctx, tt.transcribe)
+			res, err := h.stopLive(ctx, tr)
+
+			if !tt.expectDone {
+				if err == nil {
+					t.Errorf("Wrong match. expect: error, got: ok, res: %v", res)
+				}
+				if res != nil {
+					t.Errorf("Wrong match. expect: nil, got: %v", res)
+				}
+
+				// verify error identity: callers(pkg/transcribehandler/stop.go's
+				// CLAUDE.md structured-error convention) rely on a typed
+				// *cerrors.VoipbinError, not an opaque fmt.Errorf.
+				var ve *cerrors.VoipbinError
+				if !stderrors.As(err, &ve) {
+					t.Fatalf("Wrong match. expect: a *cerrors.VoipbinError, got: %T (%v)", err, err)
+				}
+				if ve.Status != cerrors.StatusFailedPrecondition {
+					t.Errorf("Wrong match. expect status: %s, got: %s", cerrors.StatusFailedPrecondition, ve.Status)
+				}
+				if ve.Reason != "STREAMING_STOP_FAILED" {
+					t.Errorf("Wrong match. expect reason: STREAMING_STOP_FAILED, got: %s", ve.Reason)
+				}
+				return
+			}
+
 			if err != nil {
 				t.Errorf("Wrong match. expect: ok, got: %v", err)
 			}
 
-			if reflect.DeepEqual(tt.transcribe, res) == false {
-				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tt.transcribe, res)
+			if reflect.DeepEqual(tr, res) == false {
+				t.Errorf("Wrong match.\nexpect: %v\ngot: %v\n", tr, res)
+			}
+		})
+	}
+}
+
+func Test_isSafeToConsiderStopped(t *testing.T) {
+
+	tests := []struct {
+		name string
+		err  error
+
+		expectRes bool
+	}{
+		{
+			"typed not found",
+			cerrors.NotFound(commonoutline.ServiceNameTranscribeManager, "STREAMING_NOT_FOUND", "The streaming was not found."),
+			true,
+		},
+		{
+			"typed unavailable(STT not configured)",
+			cerrors.Unavailable(commonoutline.ServiceNameTranscribeManager, streaminghandler.ErrSTTNotConfiguredReason, "No STT provider is configured."),
+			true,
+		},
+		{
+			// HIGH-1 regression test: StatusUnavailable alone must not be
+			// treated as "safe to consider stopped". Only the specific
+			// STT_NOT_CONFIGURED reason is safe; any other Unavailable
+			// reason (e.g. a future typed-error migration of call-manager's
+			// CallV1ExternalMediaStop surfacing a transient failure as
+			// Unavailable) must still be treated as a genuine failure, or a
+			// live streaming session could be misclassified as already
+			// stopped.
+			"typed unavailable with a different reason is a genuine failure",
+			cerrors.Unavailable(commonoutline.ServiceNameTranscribeManager, "SOME_OTHER_TRANSIENT_FAILURE", "a transient failure unrelated to STT configuration"),
+			false,
+		},
+		{
+			"legacy sentinel wrapped",
+			pkgerrors.Wrap(requesthandler.ErrNotFound, "could not stop the external media"),
+			true,
+		},
+		{
+			"legacy sentinel bare",
+			requesthandler.ErrNotFound,
+			true,
+		},
+		{
+			"typed failed precondition is not safe to consider stopped",
+			cerrors.FailedPrecondition(commonoutline.ServiceNameTranscribeManager, "SOME_OTHER_REASON", "some other failure"),
+			false,
+		},
+		{
+			"generic error is not safe to consider stopped",
+			stderrors.New("could not stop the external media"),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := isSafeToConsiderStopped(tt.err)
+			if res != tt.expectRes {
+				t.Errorf("Wrong match. expect: %v, got: %v", tt.expectRes, res)
 			}
 		})
 	}

--- a/bin-transcribe-manager/pkg/transcribehandler/transcribe.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/transcribe.go
@@ -146,12 +146,24 @@ func (h *transcribeHandler) Delete(ctx context.Context, id uuid.UUID) (*transcri
 	}
 
 	if tr.Status != transcribe.StatusDone {
-		// transcribe is ongoing. need to stop the first.
+		// transcribe is ongoing. try to stop it first, but do not let a stop
+		// failure block the delete: Stop() deliberately refuses to mark a
+		// transcribe done when a streaming session could not genuinely be
+		// stopped(see pkg/transcribehandler/stop.go's zombie-session
+		// invariant), and if we returned here on that error, this transcribe
+		// could never be deleted at all - which would turn every genuine stop
+		// failure into a permanently undeletable record (e.g. a new source of
+		// orphaned data in the customer-deletion cascade). Deletion integrity
+		// takes priority over this one field's consistency, so log loudly and
+		// proceed with delete regardless. This exception is intentionally
+		// scoped to the delete path; HealthCheck and the explicit stop RPC
+		// must still surface Stop failures normally.
 		tmp, err := h.Stop(ctx, tr.ID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not stop the transcribing. transcribe_id: %s", tr.ID)
+			log.Errorf("Could not stop the transcribe before delete; streaming may still be active on Asterisk and external media was not confirmed stopped. Proceeding with delete anyway so the deletion cascade is not blocked, but this may leave a live streaming session with no VoIPbin record to stop it. transcribe_id: %s, err: %v", tr.ID, err)
+		} else {
+			log.WithField("transcribe", tmp).Debugf("Stopped transcribe. transcribe_id: %s", tr.ID)
 		}
-		log.WithField("transcribe", tmp).Debugf("Stopped transcribe. transcribe_id: %s", tr.ID)
 	}
 
 	// delete transcripts

--- a/bin-transcribe-manager/pkg/transcribehandler/transcribe_test.go
+++ b/bin-transcribe-manager/pkg/transcribehandler/transcribe_test.go
@@ -2,6 +2,7 @@ package transcribehandler
 
 import (
 	"context"
+	stderrors "errors"
 	"reflect"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"monorepo/bin-transcribe-manager/models/transcribe"
 	"monorepo/bin-transcribe-manager/models/transcript"
 	"monorepo/bin-transcribe-manager/pkg/dbhandler"
+	"monorepo/bin-transcribe-manager/pkg/streaminghandler"
 	"monorepo/bin-transcribe-manager/pkg/transcripthandler"
 )
 
@@ -369,6 +371,62 @@ func Test_Delete(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+// Test_Delete_stopFailsButDeleteProceeds verifies the HIGH-2 mitigation:
+// deletion must not be blocked forever just because Stop() genuinely could
+// not stop a live streaming session. Otherwise a transient stop failure would
+// turn this transcribe into a permanently undeletable record and a new
+// source of orphaned data in the customer-deletion cascade.
+func Test_Delete_stopFailsButDeleteProceeds(t *testing.T) {
+	id := uuid.FromStringOrNil("6e9f6f1e-2a2a-4a3a-9a1a-8c9a9a9a9a01")
+	stID := uuid.FromStringOrNil("6e9f6f1e-2a2a-4a3a-9a1a-8c9a9a9a9a02")
+
+	tr := &transcribe.Transcribe{
+		Identity: commonidentity.Identity{
+			ID: id,
+		},
+		Status:        transcribe.StatusProgressing,
+		ReferenceType: transcribe.ReferenceTypeCall,
+		StreamingIDs:  []uuid.UUID{stID},
+	}
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockNotify := notifyhandler.NewMockNotifyHandler(mc)
+	mockTranscript := transcripthandler.NewMockTranscriptHandler(mc)
+	mockStreaming := streaminghandler.NewMockStreamingHandler(mc)
+
+	h := &transcribeHandler{
+		reqHandler:        mockReq,
+		db:                mockDB,
+		notifyHandler:     mockNotify,
+		transcriptHandler: mockTranscript,
+		streamingHandler:  mockStreaming,
+	}
+	ctx := context.Background()
+
+	// Delete's own Get, Stop's nested Get, and dbDelete's post-delete Get.
+	mockDB.EXPECT().TranscribeGet(ctx, id).Return(tr, nil).Times(3)
+
+	// the streaming genuinely fails to stop, so h.Stop returns an error.
+	mockStreaming.EXPECT().Stop(ctx, stID).Return(nil, stderrors.New("could not stop the external media"))
+
+	// deletion must still proceed despite the stop failure.
+	mockTranscript.EXPECT().List(ctx, uint64(1000), "", gomock.Any()).Return([]*transcript.Transcript{}, nil)
+	mockDB.EXPECT().TranscribeDelete(ctx, id).Return(nil)
+	mockNotify.EXPECT().PublishEvent(ctx, transcribe.EventTypeTranscribeDeleted, gomock.Any())
+
+	res, err := h.Delete(ctx, id)
+	if err != nil {
+		t.Errorf("Wrong match. expect: ok(delete proceeds despite stop failure), got: %v", err)
+	}
+	if res == nil {
+		t.Errorf("Wrong match. expect: non-nil deleted transcribe, got: nil")
 	}
 }
 


### PR DESCRIPTION
Fix a split-brain / zombie-session defect in transcribe stop handling. stopLive previously swallowed any error from streamingHandler.Stop (logging "consider already stopped") and then unconditionally transitioned the transcribe to StatusDone, so a genuine stop failure (session still owned by the caller, still live on Asterisk) got recorded as done in the database while the underlying streaming kept running with no way to stop it later.

- bin-transcribe-manager: Classify stop errors before deciding on StatusDone - typed NOT_FOUND and the legacy ErrNotFound sentinel (session already gone) are treated as safely stopped, matching the same dual-check pattern used in bin-call-manager/pkg/channelhandler/hangup.go; a narrowly-scoped STT_NOT_CONFIGURED case is also treated as safe since no session can exist there
- bin-transcribe-manager: Any other stop failure blocks the StatusDone transition and returns a structured FailedPrecondition/STREAMING_STOP_FAILED error instead of silently marking the transcribe done
- bin-transcribe-manager: streamingHandler.Stop now removes the in-memory session entry on success, fixing a pre-existing map leak and making retries converge instead of re-attempting an already-stopped session
- bin-transcribe-manager: Reorder health-check retry logic so the StatusDone/TMDelete guard always runs before the max-retry branch, cap the stop-failure reschedule count, and only reschedule for the specific retryable stop failure (not permanent errors)
- bin-transcribe-manager: Delete still proceeds when Stop fails, so customer-deletion cascades are not blocked by a stuck streaming session; the log now flags that the streaming may still be active on Asterisk
- bin-transcribe-manager: Document that the health-check reschedule loop is currently dormant (nothing bootstraps an initial health check) and that the NOT_FOUND classification's safety currently depends on this service running at replicas: 1, since stop/health-check requests are routed through the shared queue rather than the documented per-pod queue