### PR TITLE
NOJIRA-Fix-transcribe-claude-md-corrections

### DIFF
--- a/bin-transcribe-manager/CLAUDE.md
+++ b/bin-transcribe-manager/CLAUDE.md
@@ -36,9 +36,9 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 ## Critical Implementation Notes
 
-**Per-pod queue routing uses `POD_IP`**: The `HostID` for per-pod queue is `POD_IP` (Kubernetes Downward API `status.podIP`). Control RPCs targeting an active session (`stop`, `health-check`) must be routed to `bin-manager.transcribe-manager.request.<POD_IP>`. Contrast with `bin-tts-manager` which uses `HOSTNAME`.
+**Per-pod queue routing uses a random `HostID` UUID**: `cmd/transcribe-manager/main.go` generates `hostID := uuid.Must(uuid.NewV4())` once at process startup — it is not `POD_IP` or any other pod identity. Control RPCs targeting an active session (`stop`, `health-check`) must be routed to `bin-manager.transcribe-manager-<host_id>.request` (note the hyphen before the UUID and the `.request` suffix at the end, not a dot-suffixed `<host_id>` after `.request`). Contrast with `bin-tts-manager` which uses `HOSTNAME`.
 
-**Calico POD_IP recycle limitation**: If a pod restarts and gets a new IP, sessions from the old pod are orphaned. See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md).
+**HostID changes on every restart**: Because `hostID` is a fresh random UUID generated each time the process starts (not tied to pod IP or hostname), the per-pod queue name changes on every restart, not only when the underlying pod IP changes. Sessions from before a restart are orphaned — the old queue is gone and any caller still holding the old `host_id` must treat it as unreachable. See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the general per-pod queue pattern (used there with a `POD_IP`-based identity by other services; transcribe-manager instead uses a process-lifetime random UUID).
 
 **Session map locking**: Always lock/unlock `muStreaming` when accessing `mapStreaming`. Failure to lock causes data races under concurrent streaming session operations.
 

--- a/bin-transcribe-manager/docs/architecture.md
+++ b/bin-transcribe-manager/docs/architecture.md
@@ -54,13 +54,13 @@ This service uses two queues simultaneously:
 | GET | `/v1/transcribes/{uuid}` | `v1TranscribesIDGet` — get session by ID |
 | GET | `/v1/transcripts?` | `v1TranscriptsGet` — list transcript segments |
 
-**Per-pod queue** `bin-manager.transcribe-manager.request.<host_id>` — must reach the pod owning the session:
+**Per-pod queue** `bin-manager.transcribe-manager-<host_id>.request` — must reach the pod owning the session:
 
 | Method | URI Pattern | Handler |
 |--------|-------------|---------|
 | GET | `/v1/transcribes/{uuid}/health-check` | Session liveness check |
 | POST | `/v1/transcribes/{uuid}/stop` | Stop active streaming session |
 
-The `host_id` is `POD_IP` (from Kubernetes Downward API), stored on the session record. Callers route per-pod RPCs using this value.
+The `host_id` is a random UUID (`uuid.Must(uuid.NewV4())`) generated fresh in `cmd/transcribe-manager/main.go` each time the process starts — it is not `POD_IP` or any other pod identity. It is stored on the session record so callers can route per-pod RPCs using this value, but it changes on every process restart, not just when the underlying pod IP changes.
 
-See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical per-pod queue pattern (queue naming, identity source, Calico POD_IP recycle limitation).
+See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the general per-pod queue pattern (naming convention, volatile queue declaration). That doc's example identity source is `POD_IP`; this service instead uses a process-lifetime random UUID as its identity source.

--- a/bin-transcribe-manager/docs/domain.md
+++ b/bin-transcribe-manager/docs/domain.md
@@ -15,7 +15,7 @@ A transcription session associating a call/conference/recording with an STT prov
 | `language` | string | BCP47 language code (e.g., `en-US`, `ko-KR`) |
 | `direction` | enum | Audio direction: `in`, `out`, or `both` |
 | `status` | enum | `progressing` or `done` |
-| `host_id` | string | `POD_IP` of the owning pod — used for per-pod queue routing |
+| `host_id` | UUID | Random UUID generated at process startup (`uuid.NewV4()`), not `POD_IP` — used for per-pod queue routing; changes on every process restart |
 | `tm_create` | timestamp | Creation time |
 | `tm_update` | timestamp | Last update time |
 | `tm_delete` | timestamp | Soft-delete marker |
@@ -50,7 +50,7 @@ Both providers use 8 kHz, 16-bit mono signed linear PCM (slin) audio:
 
 ### Per-Pod Session Anchoring
 
-Streaming sessions live in memory on the pod that created them (`mapStreaming`, mutex-protected via `muStreaming`). The session's `host_id = POD_IP` is persisted to MySQL so follow-up RPCs (`stop`, `health-check`) can be routed to the correct pod.
+Streaming sessions live in memory on the pod that created them (`mapStreaming`, mutex-protected via `muStreaming`). The session's `host_id` — a random UUID generated once when the process starts, not `POD_IP` — is persisted to MySQL so follow-up RPCs (`stop`, `health-check`) can be routed to the correct process. Because `host_id` is regenerated on every restart, a restart invalidates routing to any of that process's prior sessions, independent of whether the pod's IP changed.
 
 Always lock/unlock the session map when accessing it. Implement proper cleanup in `Stop()` to prevent goroutine and WebSocket leaks.
 

--- a/bin-transcribe-manager/docs/operations.md
+++ b/bin-transcribe-manager/docs/operations.md
@@ -5,7 +5,7 @@
 | Symptom | Likely Cause | Resolution |
 |---------|-------------|------------|
 | Session stuck in `progressing` | `call_hangup` event not received or not processed. **Also**: the zombie-session invariant (see [Zombie-Session Invariant and Recovery](#zombie-session-invariant-and-recovery) below) deliberately refuses to move a transcribe to `done` while any of its streaming sessions genuinely failed to stop | Check subscribe handler queue; manually stop via `POST /v1/transcribes/{id}/stop`. See the section below for the full mitigation picture, including a current limitation that prevents automatic retry today |
-| STT RPC routed to wrong pod | Stale `host_id` after pod restart (Calico POD_IP recycle) | See [per-pod-queues.md](../../docs/patterns/per-pod-queues.md) for known limitation; session must be recreated |
+| STT RPC routed to wrong/nonexistent pod | Stale `host_id` after any process restart — `host_id` is a random UUID generated fresh at startup (not derived from `POD_IP` or pod identity), so it changes every time the process restarts, not only when the pod IP changes | Session must be recreated; see [docs/architecture.md](architecture.md) for per-pod queue naming |
 | No transcripts appearing | WebSocket to Asterisk not established | Check `streaming_handler` logs for dial errors; verify `MediaURI` from `ExternalMediaStart` |
 | GCP auth failure | ADC not configured | Check `GOOGLE_APPLICATION_CREDENTIALS` points to a valid mounted service account key file |
 | AWS auth failure | Missing credentials | Verify `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` env vars |
@@ -76,7 +76,7 @@ Service uses Cobra and Viper (`internal/config/main.go`). Configuration loaded o
 | `redis_database` / `REDIS_DATABASE` | Redis DB index | optional |
 | `aws_access_key` / `AWS_ACCESS_KEY` | AWS Transcribe access key | optional (if GCP configured) |
 | `aws_secret_key` / `AWS_SECRET_KEY` | AWS Transcribe secret key | optional (if GCP configured) |
-| `pod_ip` / `POD_IP` | Pod IP (Kubernetes Downward API) — used as `HostID` for per-pod queue | required |
+| `pod_ip` / `POD_IP` | Pod IP (Kubernetes Downward API); config field is intended for the AudioSocket streaming listener bind address — **not** the per-pod queue `host_id`, which is a random UUID generated at process startup independent of `POD_IP` | required |
 | `streaming_listen_port` / `STREAMING_LISTEN_PORT` | Port for WebSocket streaming connections | required |
 | `prometheus_endpoint` / `PROMETHEUS_ENDPOINT` | Metrics HTTP path | `/metrics` |
 | `prometheus_listen_address` / `PROMETHEUS_LISTEN_ADDRESS` | Metrics listen address | `:2112` |
@@ -113,10 +113,13 @@ block as bin-storage-manager. `GCP_SA_JSON` comes from
 literal (`${POD_IP:-127.0.0.1}`) since the K8s Downward API wiring this
 was meant for was never carried over to Docker Compose - the Komodo
 compose file keeps that same literal, matching current production
-behavior exactly. This service's per-pod queue routing
-(`bin-manager.transcribe-manager.request.<POD_IP>`, see this service's
-CLAUDE.md) is therefore unaffected by the cutover - it already runs as a
-single instance with this same fixed value today.
+behavior exactly. Note that this service's per-pod queue routing does
+not actually key off `POD_IP` at all - the per-pod queue name is
+`bin-manager.transcribe-manager-<host_id>.request`, where `<host_id>`
+is a random UUID generated fresh at each process start (see this
+service's CLAUDE.md), so the queue name already changes on every
+restart regardless of `POD_IP`. The Komodo cutover is therefore
+unaffected either way - it already runs as a single instance today.
 
 No healthcheck block: distroless (`gcr.io/distroless/static-debian12`),
 same as every other distroless `bin-*-manager` service (VOIP-1342 pilot

--- a/bin-tts-manager/CLAUDE.md
+++ b/bin-tts-manager/CLAUDE.md
@@ -48,4 +48,4 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 
 ## Per-Pod Queue Pattern
 
-See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical pattern. Note: `bin-tts-manager` differs from `bin-transcribe-manager` in that it uses `HOSTNAME` (not `POD_IP`) as the HostID.
+See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical pattern. Note: `bin-tts-manager` uses `HOSTNAME` as the HostID, while `bin-transcribe-manager` uses a random UUID generated fresh at each process start (not `POD_IP`).

--- a/bin-tts-manager/docs/architecture.md
+++ b/bin-tts-manager/docs/architecture.md
@@ -70,4 +70,4 @@ This service uses two queues simultaneously:
 
 Asterisk dials into the Go service on TCP port 8080 (AudioSocket protocol) for media delivery to active streaming sessions.
 
-See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical per-pod queue pattern. Note: `bin-tts-manager` uses `HOSTNAME` as `HostID`, while `bin-transcribe-manager` uses `POD_IP`.
+See [docs/patterns/per-pod-queues.md](../docs/patterns/per-pod-queues.md) for the canonical per-pod queue pattern. Note: `bin-tts-manager` uses `HOSTNAME` as `HostID`, while `bin-transcribe-manager` uses a random UUID generated fresh at each process start (not `POD_IP`).


### PR DESCRIPTION
Correct stale documentation in bin-transcribe-manager (and cross-references in bin-tts-manager) that described the per-pod HostID/queue mechanism inaccurately. The docs claimed HostID comes from POD_IP and the per-pod queue is dot-suffixed, but the actual code generates a random UUID at process startup and uses a hyphen-inserted queue name.

- bin-transcribe-manager: Correct CLAUDE.md, docs/architecture.md, docs/domain.md, docs/operations.md to state HostID is uuid.Must(uuid.NewV4()) generated at startup (not POD_IP), the per-pod queue is bin-manager.transcribe-manager-<host_id>.request (not the dot-suffixed form), and clarify that the pod_ip config field is unrelated (intended for the AudioSocket listener bind address)
- bin-tts-manager: Correct cross-references to transcribe-manager's HostID scheme in CLAUDE.md and docs/architecture.md