### PR TITLE
NOJIRA-Schedule-manager-scale-poc

### DIFF
--- a/bin-schedule-manager/docs/operations.md
+++ b/bin-schedule-manager/docs/operations.md
@@ -122,7 +122,7 @@ Komodo-managed (VOIP-1350), same mechanism as the other `bin-*-manager` services
 `.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
 from `komodo/docker-compose.yml`.
 
-Two deviations from the Tier 1/2 template, both intentional:
+Three deviations from the Tier 1/2 template, all intentional:
 - **Non-distroless runtime** (`debian:bookworm-slim` + `default-mysql-client`
   (→ mariadb-client, VOIP-1397), see the CRITICAL note in
   [../CLAUDE.md](../CLAUDE.md)) — but `debian:bookworm-slim` ships with
@@ -137,3 +137,55 @@ Two deviations from the Tier 1/2 template, both intentional:
   (confirmed via `docker inspect` against the pre-cutover container), so
   existing backup history is preserved across the cutover rather than starting
   a new directory under Komodo's stack working dir.
+- **`deploy: replicas: 2`, no `container_name`** (NOJIRA-Schedule-manager-scale-poc):
+  this service is the fleet's pilot for the bin-*-manager 1→2 replica
+  rollout. Compose rejects a fixed `container_name` together with
+  `deploy.replicas > 1` ("container name must be unique"), so
+  `container_name: voipbin-schedule-manager` was removed; Komodo is
+  expected to name the containers from the compose project/service (e.g.
+  `bin-schedule-manager-schedule-manager-1`/`-2`) — **not yet confirmed
+  against a live deploy on bm-nyc-01** (`komodo-api-deploy.sh` itself notes
+  its container-state read is unverified against the live instance). Update
+  this once the PoC actually deploys.
+  - **Backup path is the one genuinely new surface** (dispatch-loop replica
+    safety already ran on GKE; the bind-mounted backup path did not). It
+    remains safe: the mount is a host bind mount on a single bare-metal
+    node, which is exactly the ReadWriteMany semantics this doc already
+    requires ("any replica may run the job"), and double-execution is
+    prevented at two layers — `bin-manager.schedule-manager.request` is a
+    shared competing-consumer queue (only one replica receives the RPC),
+    and the design §5.3 claim (Redis lock + DB CAS + unique execution row)
+    prevents double-dispatch. `pkg/backuphandler` itself has no file-level
+    lock (writes straight to `outPath`, prunes by directory listing) — this
+    is fine only as long as the claim machinery above keeps two replicas
+    from running the backup job concurrently; do not weaken that guarantee
+    without revisiting this note.
+  - **CI deploy gate has a known blind spot with replicas > 1**:
+    `.circleci/scripts/komodo-api-deploy.sh`'s `check_stack_running` reads
+    `.container.state` per compose *service*, not per container. With 2
+    replicas it can report healthy on a 1-of-2 state — a green deploy does
+    not by itself prove both replicas are up. **Manual verification is
+    required after every deploy of this service until the gate is fixed
+    fleet-wide:**
+    ```bash
+    # On bm-nyc-01: expect exactly 2 running containers
+    docker ps --filter name=schedule-manager --format '{{.Names}}\t{{.Status}}'
+    ```
+    ```promql
+    # In Prometheus: expect 2 up series
+    count(up{job="voipbin-managers", service="schedule-manager"})
+    ```
+  - **Alerting blind spot**: `InstanceDown` (`up == 0`) cannot catch a lost
+    replica under DNS SD (the target goes stale, not to 0), and
+    `ManagerServiceGone` only fires at zero surviving replicas — a 1-of-2
+    degraded state is silently invisible today. No `count by (service)(up{...}) < 2`-style
+    alert exists yet; tracked as a follow-up for the fleet rollout, not
+    blocking this PoC.
+  - **Runbook naming drift**: alert runbooks in `monorepo-etc`'s
+    `alert-rules.yml` assume containers are named `voipbin-<service>` (used
+    for `docker ps --filter name=...` substring matching). This service no
+    longer has that name. The substring filter still happens to match
+    (`schedule-manager` is contained in the new Komodo-generated names), so
+    nothing breaks operationally, but this is an undocumented exception
+    that will multiply as more services join the rollout — flag it in the
+    fleet rollout design doc rather than fixing per-service.

--- a/bin-schedule-manager/komodo/docker-compose.yml
+++ b/bin-schedule-manager/komodo/docker-compose.yml
@@ -3,12 +3,31 @@
 # for the shared design (pattern proven by VOIP-1342/bin-call-manager and
 # VOIP-1347/VOIP-1348).
 #
-# NOTE: unlike every other bin-*-manager service so far, this one has a
-# real bind-mount volume for scheduled DB backups (VOIP-1281). The install/
-# live host resolves it to /opt/voipbin/install/backups/scheduled-db
-# (confirmed via `docker inspect voipbin-schedule-mgr` on bm-nyc-01) - this
-# Komodo Stack uses the SAME absolute host path so existing backup history
-# is preserved across the cutover, rather than starting a new directory.
+# NOJIRA-Schedule-manager-scale-poc: this is the fleet's PoC for the
+# bin-*-manager 1->2 replica rollout (the shared design/rollout plan for
+# that effort has not been committed to docs/plans/ yet - do not assume it
+# exists elsewhere). schedule-manager was chosen as the pilot because its
+# dispatch loop is already replica-safe by design (Redis lock + DB CAS
+# claim, see this service's own CLAUDE.md "replicas: 2 by design") and it
+# does not use a per-pod queue, so it cannot be affected by the
+# per-pod-queue-routing blocker tracked separately for
+# pipecat/api/transcribe-manager. `container_name` is removed below because
+# Compose rejects a fixed container_name together with `deploy.replicas > 1`
+# ("container name must be unique" - docker/compose#3722).
+#
+# Everything else this PoC touches - backup-path safety reasoning, the CI
+# deploy gate's single-container blind spot + manual verification
+# procedure, the alerting blind spot, and the container-naming/runbook
+# drift - is documented once in docs/operations.md#deployment-komodo
+# rather than duplicated here; read that section, not this comment, for
+# the full picture.
+#
+# NOTE: this one has a real bind-mount volume for scheduled DB backups
+# (VOIP-1281). The install/ live host resolves it to
+# /opt/voipbin/install/backups/scheduled-db (confirmed via `docker inspect
+# voipbin-schedule-mgr` on bm-nyc-01) - this Komodo Stack uses the SAME
+# absolute host path so existing backup history is preserved across the
+# cutover, rather than starting a new directory.
 # debian:bookworm-slim ships with neither wget nor curl by default. The
 # fleet-standard wget healthcheck (copied verbatim from install/'s .dist,
 # which has the exact same bug) silently fails here — confirmed live on
@@ -25,8 +44,13 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-schedule-manager
+    # container_name intentionally removed (was voipbin-schedule-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1 ("container name must be unique"). See the PoC
+    # note above the services: block.
     restart: always
+    deploy:
+      replicas: 2
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://127.0.0.1:2112/metrics"]
       interval: 30s


### PR DESCRIPTION
Remove the fixed container_name and add deploy.replicas: 2 to bin-schedule-manager's Komodo Stack, as the pilot for the fleet-wide bin-*-manager 1->2 replica rollout. schedule-manager was chosen because its dispatch loop is already replica-safe by design (Redis lock + DB CAS claim) and it does not use a per-pod queue, so it is unaffected by the per-pod-queue-routing blocker tracked separately for pipecat/api/transcribe-manager.

- bin-schedule-manager: Remove container_name (was voipbin-schedule-manager) and add deploy.replicas: 2 to komodo/docker-compose.yml - container_name and deploy.replicas > 1 cannot coexist (Docker Compose rejects it with "container name must be unique")
- bin-schedule-manager: Document the third Komodo deployment deviation (replicas:2, no container_name) in docs/operations.md - backup-path safety reasoning, the CI deploy gate's single-container blind spot with a manual verification procedure (docker ps / PromQL), the alerting blind spot for a 1-of-2 degraded state, and container-naming/runbook drift versus the voipbin-<service> convention