### PR TITLE
NOJIRA-Add-db-connection-pool-metrics

### DIFF
--- a/bin-agent-manager/cmd/agent-manager/main.go
+++ b/bin-agent-manager/cmd/agent-manager/main.go
@@ -69,6 +69,7 @@ func runDaemon() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	cache, err := initCache()

--- a/bin-ai-manager/cmd/ai-manager/main.go
+++ b/bin-ai-manager/cmd/ai-manager/main.go
@@ -80,6 +80,7 @@ func runDaemon() error {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -98,6 +98,7 @@ func runDaemon(cmd *cobra.Command, args []string) {
 		log.Errorf("Could not access to database. err: %v", err)
 		return
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-billing-manager/cmd/billing-manager/main.go
+++ b/bin-billing-manager/cmd/billing-manager/main.go
@@ -78,6 +78,7 @@ func runDaemon() error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-call-manager/cmd/call-manager/main.go
+++ b/bin-call-manager/cmd/call-manager/main.go
@@ -79,6 +79,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return errors.Wrapf(err, "could not connect to database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-campaign-manager/cmd/campaign-manager/main.go
+++ b/bin-campaign-manager/cmd/campaign-manager/main.go
@@ -128,6 +128,7 @@ func createDBHandler(cfg *config.Config) (dbhandler.DBHandler, error) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return nil, err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(db, "main")
 
 	// connect to cache
 	cache := cachehandler.NewHandler(cfg.RedisAddress, cfg.RedisPassword, cfg.RedisDatabase)

--- a/bin-common-handler/pkg/databasehandler/main.go
+++ b/bin-common-handler/pkg/databasehandler/main.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/squirrel"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -25,6 +28,34 @@ func Connect(dsn string) (*sql.DB, error) {
 	}
 
 	return res, nil
+}
+
+// registerDBStatsMu/registerDBStatsDone guard against duplicate MustRegister
+// panics when RegisterDBStatsCollector is called more than once for the same
+// dbName in one process (same pattern as notifyhandler's initPrometheusMu/
+// initPrometheusDone, VOIP-1258).
+var (
+	registerDBStatsMu   sync.Mutex
+	registerDBStatsDone = map[string]bool{}
+)
+
+// RegisterDBStatsCollector registers a Prometheus collector that exposes
+// db.Stats() (open/in-use/idle connections, wait count/duration) on the
+// default registry. Call once per *sql.DB after Connect() succeeds, from a
+// process that actually serves /metrics (bin-*-manager daemons, not
+// *-control CLIs). dbName distinguishes multiple DBs in one process (e.g.
+// registrar-manager's "bin"/"asterisk"). A duplicate call with the same
+// dbName is a silent no-op rather than a panic.
+func RegisterDBStatsCollector(db *sql.DB, dbName string) {
+	registerDBStatsMu.Lock()
+	defer registerDBStatsMu.Unlock()
+
+	if registerDBStatsDone[dbName] {
+		return
+	}
+	registerDBStatsDone[dbName] = true
+
+	prometheus.MustRegister(collectors.NewDBStatsCollector(db, dbName))
 }
 
 func Close(db *sql.DB) {

--- a/bin-conference-manager/cmd/conference-manager/main.go
+++ b/bin-conference-manager/cmd/conference-manager/main.go
@@ -80,6 +80,7 @@ func runMain(cmd *cobra.Command, args []string) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-contact-manager/cmd/contact-manager/main.go
+++ b/bin-contact-manager/cmd/contact-manager/main.go
@@ -92,6 +92,7 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-conversation-manager/cmd/conversation-manager/main.go
+++ b/bin-conversation-manager/cmd/conversation-manager/main.go
@@ -85,6 +85,7 @@ func runMain(cmd *cobra.Command, args []string) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-customer-manager/cmd/customer-manager/main.go
+++ b/bin-customer-manager/cmd/customer-manager/main.go
@@ -67,6 +67,7 @@ func runDaemon() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	cache, err := initCache()

--- a/bin-direct-manager/cmd/direct-manager/main.go
+++ b/bin-direct-manager/cmd/direct-manager/main.go
@@ -89,6 +89,7 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-email-manager/cmd/email-manager/main.go
+++ b/bin-email-manager/cmd/email-manager/main.go
@@ -115,6 +115,7 @@ func createDBHandler(cfg *config.Config) (dbhandler.DBHandler, error) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return nil, err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(db, "main")
 
 	// connect to cache
 	cache := cachehandler.NewHandler(cfg.RedisAddress, cfg.RedisPassword, cfg.RedisDatabase)

--- a/bin-email-manager/pkg/listenhandler/main_test.go
+++ b/bin-email-manager/pkg/listenhandler/main_test.go
@@ -59,7 +59,7 @@ func TestSimpleResponse(t *testing.T) {
 			resp := simpleResponse(tt.statusCode)
 
 			if resp == nil {
-				t.Errorf("Expected non-nil response")
+				t.Fatalf("Expected non-nil response")
 			}
 
 			if resp.StatusCode != tt.statusCode {

--- a/bin-flow-manager/cmd/flow-manager/main.go
+++ b/bin-flow-manager/cmd/flow-manager/main.go
@@ -71,6 +71,7 @@ func runDaemon() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	cache, err := initCache()

--- a/bin-hook-manager/cmd/hook-manager/main.go
+++ b/bin-hook-manager/cmd/hook-manager/main.go
@@ -102,6 +102,7 @@ func runService(cmd *cobra.Command, args []string) {
 		log.Errorf("Could not access to database. err: %v", err)
 		return
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to rabbitmq

--- a/bin-message-manager/cmd/message-manager/main.go
+++ b/bin-message-manager/cmd/message-manager/main.go
@@ -74,6 +74,7 @@ func runService() error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-number-manager/cmd/number-manager/main.go
+++ b/bin-number-manager/cmd/number-manager/main.go
@@ -99,6 +99,7 @@ func runDaemon() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	cache, err := initCache()

--- a/bin-outdial-manager/cmd/outdial-manager/main.go
+++ b/bin-outdial-manager/cmd/outdial-manager/main.go
@@ -104,6 +104,7 @@ func createDBHandler() (dbhandler.DBHandler, error) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return nil, err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(db, "main")
 
 	// connect to cache
 	cache := cachehandler.NewHandler(config.Get().RedisAddress, config.Get().RedisPassword, config.Get().RedisDatabase)

--- a/bin-outdial-manager/models/outdialtarget/outdialtarget_test.go
+++ b/bin-outdial-manager/models/outdialtarget/outdialtarget_test.go
@@ -66,17 +66,11 @@ func TestOutdialTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.target.ID != tt.target.ID {
-				t.Errorf("ID mismatch")
+			if tt.target == nil {
+				t.Fatalf("Expected non-nil target")
 			}
-			if tt.target.OutdialID != tt.target.OutdialID {
-				t.Errorf("OutdialID mismatch")
-			}
-			if tt.target.Name != tt.target.Name {
-				t.Errorf("Name mismatch")
-			}
-			if tt.target.Status != tt.target.Status {
-				t.Errorf("Status mismatch")
+			if tt.target.Status != StatusIdle {
+				t.Errorf("Status mismatch. expect: %v, got: %v", StatusIdle, tt.target.Status)
 			}
 		})
 	}

--- a/bin-outdial-manager/models/outdialtargetcall/outdialtargetcall_test.go
+++ b/bin-outdial-manager/models/outdialtargetcall/outdialtargetcall_test.go
@@ -63,20 +63,8 @@ func TestOutdialTargetCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.call.ID != tt.call.ID {
-				t.Errorf("ID mismatch")
-			}
-			if tt.call.CampaignID != tt.call.CampaignID {
-				t.Errorf("CampaignID mismatch")
-			}
-			if tt.call.OutdialID != tt.call.OutdialID {
-				t.Errorf("OutdialID mismatch")
-			}
-			if tt.call.OutdialTargetID != tt.call.OutdialTargetID {
-				t.Errorf("OutdialTargetID mismatch")
-			}
-			if tt.call.Status != tt.call.Status {
-				t.Errorf("Status mismatch")
+			if tt.call == nil {
+				t.Fatalf("Expected non-nil call")
 			}
 		})
 	}

--- a/bin-pipecat-manager/cmd/pipecat-manager/main.go
+++ b/bin-pipecat-manager/cmd/pipecat-manager/main.go
@@ -190,6 +190,7 @@ func createDBHandler() (dbhandler.DBHandler, error) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return nil, err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(db, "main")
 
 	// connect to cache
 	cache := cachehandler.NewHandler(config.Get().RedisAddress, config.Get().RedisPassword, config.Get().RedisDatabase)

--- a/bin-queue-manager/cmd/queue-manager/main.go
+++ b/bin-queue-manager/cmd/queue-manager/main.go
@@ -66,6 +66,7 @@ func runDaemon() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-registrar-manager/cmd/registrar-manager/main.go
+++ b/bin-registrar-manager/cmd/registrar-manager/main.go
@@ -82,12 +82,14 @@ func runDaemon() error {
 		return errors.Wrapf(err, "could not connect to the voipbin database")
 	}
 	defer commondatabasehandler.Close(sqlDBBin)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDBBin, "bin")
 
 	sqlDBAsterisk, err := commondatabasehandler.Connect(config.Get().DatabaseDSNAsterisk)
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to the asterisk database")
 	}
 	defer commondatabasehandler.Close(sqlDBAsterisk)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDBAsterisk, "asterisk")
 
 	cache, err := initCache()
 	if err != nil {

--- a/bin-route-manager/cmd/route-manager/main.go
+++ b/bin-route-manager/cmd/route-manager/main.go
@@ -87,6 +87,7 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-schedule-manager/cmd/schedule-manager/main.go
+++ b/bin-schedule-manager/cmd/schedule-manager/main.go
@@ -100,6 +100,7 @@ func runDaemon() error {
 	if err != nil {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	cache, err := initCache()

--- a/bin-storage-manager/cmd/storage-manager/main.go
+++ b/bin-storage-manager/cmd/storage-manager/main.go
@@ -124,6 +124,7 @@ func createDBHandler() (dbhandler.DBHandler, error) {
 		logrus.Errorf("Could not access to database. err: %v", err)
 		return nil, err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(db, "main")
 
 	// connect to cache
 	cache := cachehandler.NewHandler(cfg.RedisAddress, cfg.RedisPassword, cfg.RedisDatabase)

--- a/bin-tag-manager/cmd/tag-manager/main.go
+++ b/bin-tag-manager/cmd/tag-manager/main.go
@@ -89,6 +89,7 @@ func run(cmd *cobra.Command, args []string) error {
 		log.Errorf("Could not access to database. err: %v", err)
 		return err
 	}
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 	defer commondatabasehandler.Close(sqlDB)
 
 	// connect to cache

--- a/bin-talk-manager/cmd/talk-manager/main.go
+++ b/bin-talk-manager/cmd/talk-manager/main.go
@@ -70,6 +70,7 @@ func runDaemon() error {
 		logrus.Fatalf("Could not connect to the database: %v", err)
 	}
 	defer commondb.Close(db)
+	commondb.RegisterDBStatsCollector(db, "main")
 
 	// Initialize RabbitMQ
 	sockHandler := commonsock.NewSockHandler(sock.TypeRabbitMQ, cfg.RabbitMQAddress)

--- a/bin-timeline-manager/cmd/timeline-manager/main.go
+++ b/bin-timeline-manager/cmd/timeline-manager/main.go
@@ -199,6 +199,7 @@ func runServices(ctx context.Context) (<-chan struct{}, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not connect to analysis MySQL store")
 		}
+		commondatabasehandler.RegisterDBStatsCollector(sqlDB, "analysis")
 
 		analysisDB := analysisdbhandler.NewAnalysisDBHandler(sqlDB)
 		reqHandler := requesthandler.NewRequestHandler(sockHandler, commonoutline.ServiceNameTimelineManager)

--- a/bin-transcribe-manager/cmd/transcribe-manager/main.go
+++ b/bin-transcribe-manager/cmd/transcribe-manager/main.go
@@ -107,6 +107,7 @@ func runDaemon() error {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
 	defer commondatabasehandler.Close(sqlDB)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 
 	cache, err := initCache()
 	if err != nil {

--- a/bin-transfer-manager/cmd/transfer-manager/main.go
+++ b/bin-transfer-manager/cmd/transfer-manager/main.go
@@ -104,6 +104,7 @@ func runDaemon() error {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
 	defer commondatabasehandler.Close(sqlDB)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 
 	cache, err := initCache()
 	if err != nil {

--- a/bin-tts-manager/cmd/tts-manager/main.go
+++ b/bin-tts-manager/cmd/tts-manager/main.go
@@ -98,6 +98,7 @@ func runDaemon() error {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
 	defer commondatabasehandler.Close(sqlDB)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 
 	if errRun := run(sqlDB); errRun != nil {
 		return errors.Wrapf(errRun, "could not run tts-manager")

--- a/bin-webchat-manager/cmd/webchat-manager/main.go
+++ b/bin-webchat-manager/cmd/webchat-manager/main.go
@@ -67,6 +67,7 @@ func runDaemon() error {
 		return errors.Wrapf(err, "could not connect to database")
 	}
 	defer commondatabasehandler.Close(sqlDB)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 
 	// connect to cache
 	cache := cachehandler.NewHandler(config.Get().RedisAddress, config.Get().RedisPassword, config.Get().RedisDatabase)

--- a/bin-webhook-manager/cmd/webhook-manager/main.go
+++ b/bin-webhook-manager/cmd/webhook-manager/main.go
@@ -107,6 +107,7 @@ func runDaemon() error {
 		return errors.Wrapf(err, "could not connect to the database")
 	}
 	defer commondatabasehandler.Close(sqlDB)
+	commondatabasehandler.RegisterDBStatsCollector(sqlDB, "main")
 
 	cache, err := initCache()
 	if err != nil {


### PR DESCRIPTION
Add Prometheus DB connection pool metrics (open/in-use/idle/wait) to every MariaDB-backed bin-*-manager service, ahead of the app-side pool cap (SetMaxOpenConns). bin-common-handler's Connect() has never set a pool cap, so every service's connection pool is currently unbounded; before enforcing a cap, we first want real per-service usage data (the direction the CEO/CTO approved: monitor before capping).

- bin-common-handler: Add RegisterDBStatsCollector(db, dbName) to pkg/databasehandler, wrapping the official prometheus/collectors.NewDBStatsCollector (pull-read-only, no SetMaxOpenConns call - this does not enforce a cap). Guards duplicate registration for the same dbName with a mutex+map (same pattern as notifyhandler's initPrometheusMu/initPrometheusDone, VOIP-1258)
- bin-agent-manager, bin-ai-manager, bin-api-manager, bin-billing-manager, bin-call-manager, bin-campaign-manager, bin-conference-manager, bin-contact-manager, bin-conversation-manager, bin-customer-manager, bin-direct-manager, bin-email-manager, bin-flow-manager, bin-hook-manager, bin-message-manager, bin-number-manager, bin-outdial-manager, bin-pipecat-manager, bin-queue-manager, bin-route-manager, bin-schedule-manager, bin-storage-manager, bin-tag-manager, bin-talk-manager, bin-transcribe-manager, bin-transfer-manager, bin-tts-manager, bin-webchat-manager, bin-webhook-manager: Call RegisterDBStatsCollector(sqlDB, "main") right after Connect() succeeds (inside the createDBHandler() helper for campaign/email/outdial/storage/pipecat-manager, which wrap the raw *sql.DB before it leaves the function)
- bin-timeline-manager: Call RegisterDBStatsCollector(sqlDB, "analysis") inside the existing DatabaseDSN != "" conditional block - MySQL here is an optional secondary store behind the primary ClickHouse store, so this service's series is absent when DATABASE_DSN is unset
- bin-registrar-manager: Call RegisterDBStatsCollector twice ("bin"/"asterisk" dbName) for its two separate DB connections
- bin-email-manager, bin-outdial-manager: Fix three pre-existing self-comparison test bugs found by golangci-lint/staticcheck while verifying these services (tt.target.ID != tt.target.ID is always false, so the original assertions never checked anything) - unrelated to the metrics change but required to pass the mandatory lint gate