### PR TITLE
NOJIRA-Fix-extractor-empty-slice-awk-range

### DIFF
--- a/docs/.docs-gen/bin-ai-manager.extracted.json
+++ b/docs/.docs-gen/bin-ai-manager.extracted.json
@@ -340,9 +340,6 @@
   ],
   "metrics": [
     {
-      "name": "actions"
-    },
-    {
       "name": "aicall_backstop_reply_total"
     },
     {
@@ -370,157 +367,13 @@
       "name": "aicall_tool_execute_total"
     },
     {
-      "name": "ai_id"
-    },
-    {
       "name": "analysis_gateway_run_duration_seconds"
     },
     {
       "name": "analysis_gateway_run_total"
     },
     {
-      "name": "anonymous"
-    },
-    {
-      "name": "assistance_id"
-    },
-    {
-      "name": "assistance_type"
-    },
-    {
-      "name": "async"
-    },
-    {
-      "name": "attachments"
-    },
-    {
-      "name": "beep_start"
-    },
-    {
-      "name": "bool"
-    },
-    {
-      "name": "chained"
-    },
-    {
-      "name": "condition"
-    },
-    {
-      "name": "confbridge_id"
-    },
-    {
-      "name": "conference_id"
-    },
-    {
-      "name": "connect"
-    },
-    {
-      "name": "connection_type"
-    },
-    {
-      "name": "content"
-    },
-    {
-      "name": "conversation_id"
-    },
-    {
       "name": "conversation_reply_send_total"
-    },
-    {
-      "name": "data"
-    },
-    {
-      "name": "data_type"
-    },
-    {
-      "name": "day"
-    },
-    {
-      "name": "default_target_id"
-    },
-    {
-      "name": "destinations"
-    },
-    {
-      "name": "detail"
-    },
-    {
-      "name": "digits"
-    },
-    {
-      "name": "digits_handle"
-    },
-    {
-      "name": "direction"
-    },
-    {
-      "name": "direction_listen"
-    },
-    {
-      "name": "direction_speak"
-    },
-    {
-      "name": "duration"
-    },
-    {
-      "name": "early_execution"
-    },
-    {
-      "name": "early_media"
-    },
-    {
-      "name": "encapsulation"
-    },
-    {
-      "name": "end_of_key"
-    },
-    {
-      "name": "end_of_silence"
-    },
-    {
-      "name": "evaluation_response"
-    },
-    {
-      "name": "event_method"
-    },
-    {
-      "name": "event_url"
-    },
-    {
-      "name": "external_host"
-    },
-    {
-      "name": "false_target_id"
-    },
-    {
-      "name": "flow_id"
-    },
-    {
-      "name": "format"
-    },
-    {
-      "name": "hour"
-    },
-    {
-      "name": "int"
-    },
-    {
-      "name": "interval"
-    },
-    {
-      "name": "key"
-    },
-    {
-      "name": "language"
-    },
-    {
-      "name": "length"
-    },
-    {
-      "name": "loop_count"
-    },
-    {
-      "name": "machine_handle"
     },
     {
       "name": "message_create_total"
@@ -529,67 +382,7 @@
       "name": "message_delivery_status_update_failed_total"
     },
     {
-      "name": "message_send"
-    },
-    {
-      "name": "method"
-    },
-    {
-      "name": "minute"
-    },
-    {
-      "name": "month"
-    },
-    {
-      "name": "name"
-    },
-    {
-      "name": "note"
-    },
-    {
-      "name": "number"
-    },
-    {
-      "name": "on_end_flow_id"
-    },
-    {
-      "name": "proposal_response"
-    },
-    {
-      "name": "provider"
-    },
-    {
-      "name": "queue_id"
-    },
-    {
-      "name": "reason"
-    },
-    {
       "name": "receive_request_process_time"
-    },
-    {
-      "name": "reference_id"
-    },
-    {
-      "name": "reference_type"
-    },
-    {
-      "name": "relay_reason"
-    },
-    {
-      "name": "source"
-    },
-    {
-      "name": "status"
-    },
-    {
-      "name": "stream_urls"
-    },
-    {
-      "name": "string"
-    },
-    {
-      "name": "subject"
     },
     {
       "name": "subscribe_event_process_time"
@@ -599,54 +392,6 @@
     },
     {
       "name": "summary_start_total"
-    },
-    {
-      "name": "sync"
-    },
-    {
-      "name": "target_id"
-    },
-    {
-      "name": "target_ids"
-    },
-    {
-      "name": "text"
-    },
-    {
-      "name": "transport"
-    },
-    {
-      "name": "transport_data"
-    },
-    {
-      "name": "uri"
-    },
-    {
-      "name": "uuid"
-    },
-    {
-      "name": "value"
-    },
-    {
-      "name": "value_length"
-    },
-    {
-      "name": "value_number"
-    },
-    {
-      "name": "value_string"
-    },
-    {
-      "name": "value_type"
-    },
-    {
-      "name": "variable"
-    },
-    {
-      "name": "voice_id"
-    },
-    {
-      "name": "weekdays"
     }
   ],
   "missing_fields": []

--- a/docs/.docs-gen/bin-api-manager.extracted.json
+++ b/docs/.docs-gen/bin-api-manager.extracted.json
@@ -3,17 +3,7 @@
   "service_name": "bin-api-manager",
   "service_class": "B",
   "routing_table": [],
-  "events_subscribed": [
-    {
-      "queue_symbol": "bin-manager.webhook-manager.event"
-    },
-    {
-      "queue_symbol": "bin-manager.agent-manager.event"
-    },
-    {
-      "queue_symbol": "bin-manager.talk-manager.event"
-    }
-  ],
+  "events_subscribed": [],
   "events_published": [],
   "dependencies": [
     {
@@ -101,6 +91,10 @@
       "local_path": "../bin-route-manager"
     },
     {
+      "module_path": "monorepo/bin-schedule-manager",
+      "local_path": "../bin-schedule-manager"
+    },
+    {
       "module_path": "monorepo/bin-storage-manager",
       "local_path": "../bin-storage-manager"
     },
@@ -131,6 +125,10 @@
     {
       "module_path": "monorepo/bin-webhook-manager",
       "local_path": "../bin-webhook-manager"
+    },
+    {
+      "module_path": "monorepo/bin-webchat-manager",
+      "local_path": "../bin-webchat-manager"
     },
     {
       "module_path": "monorepo/bin-customer-manager",
@@ -173,9 +171,42 @@
     },
     {
       "flag": "ssl_privkey_base64"
+    },
+    {
+      "flag": "public_base_url"
+    },
+    {
+      "flag": "rate_limit_auth_public_burst"
+    },
+    {
+      "flag": "rate_limit_auth_protected_burst"
+    },
+    {
+      "flag": "rate_limit_v1_burst"
+    },
+    {
+      "flag": "rate_limit_provisioning_public_burst"
+    },
+    {
+      "flag": "rate_limit_customer_v1_burst"
+    },
+    {
+      "flag": "rate_limit_customer_v1_direct_burst"
+    },
+    {
+      "flag": "rate_limit_customer_v1_delegate_burst"
+    },
+    {
+      "flag": "rate_limit_customer_redis_timeout_ms"
     }
   ],
   "metrics": [
+    {
+      "name": "auth_delegate_token_issued_total"
+    },
+    {
+      "name": "pubsub_dropped_message_total"
+    },
     {
       "name": "receive_subscribe_event_process_time"
     }

--- a/docs/reference/extractor.sh
+++ b/docs/reference/extractor.sh
@@ -50,6 +50,39 @@ EVENTS_SUB="[]"
 SUB_MAIN_GO=$(grep -rl 'subscribeTargets' "$SVC_DIR/cmd/" 2>/dev/null | { grep 'main\.go' || true; } | head -1 || true)
 SUB_PKG_GO="$SVC_DIR/pkg/subscribehandler/main.go"
 
+# Extract a `{ ... }` block starting at the first line matching open_regex,
+# using brace-depth tracking instead of an awk range (`/open/,/close/`).
+# A range pattern can't close correctly on an inline/empty literal such as
+# `subscribeTargets := []string{}`: the opening pattern matches, but there is
+# no later line consisting only of `}` to match the closing pattern, so the
+# range never turns off and the scan spills into unrelated code (e.g. the
+# enclosing function's body) until it happens to hit some other line that
+# starts with `}`. Depth tracking closes on the same line when a literal
+# opens and closes inline, and still spans multiple lines correctly for the
+# non-empty case.
+# LIMITATION: depth is counted from raw text (gsub over `{`/`}`), not a real
+# parser, so an unbalanced brace inside a string literal or comment within
+# the block could still mis-close. Acceptable for this best-effort doc
+# extraction tool; the source patterns it targets (subscribeTargets slice
+# literals) don't contain such braces in practice.
+extract_brace_block() {
+  local file="$1" open_regex="$2"
+  # NOTE: the open regex is passed via the environment (ENVIRON), not `awk -v`.
+  # `awk -v var=value` runs C-style backslash-escape processing on `value`,
+  # which silently turns `\[`, `\]`, `\{` into `[`, `]`, `{` and produces an
+  # invalid dynamic regex (this was tried and broke the multi-line case).
+  # ENVIRON values are passed through verbatim.
+  EXTRACT_OPEN_RE="$open_regex" awk '
+    $0 ~ ENVIRON["EXTRACT_OPEN_RE"] { in_block = 1; depth = 0 }
+    in_block {
+      print
+      depth += gsub(/\{/, "{")
+      depth -= gsub(/\}/, "}")
+      if (depth <= 0) in_block = 0
+    }
+  ' "$file" 2>/dev/null || true
+}
+
 # Resolve QueueName constants to their string values
 resolve_const_names() {
   local const_names="$1"
@@ -67,7 +100,7 @@ resolve_const_names() {
 if [ -n "$SUB_MAIN_GO" ]; then
   # Pattern 1: subscribeTargets = []string{...} or []string{} — multi-event list
   CONST_NAMES=$(
-    { awk '/subscribeTargets.*:?=.*\[\]string\{/,/^\s*\}/' "$SUB_MAIN_GO" 2>/dev/null || true; } \
+    extract_brace_block "$SUB_MAIN_GO" 'subscribeTargets.*:?=.*\[\]string\{' \
     | { grep -oP 'QueueName\w+' || true; }
   )
   if [ -n "$CONST_NAMES" ]; then
@@ -79,7 +112,7 @@ if [ -n "$SUB_MAIN_GO" ]; then
   # Fallback: try raw string literals from []string{} block
   if [ "$EVENTS_SUB" = "[]" ]; then
     EVENTS_SUB=$(
-      { awk '/subscribeTargets.*:?=.*\[\]string\{/,/^\s*\}/' "$SUB_MAIN_GO" 2>/dev/null || true; } \
+      extract_brace_block "$SUB_MAIN_GO" 'subscribeTargets.*:?=.*\[\]string\{' \
       | { grep -oP '"[^"]*"' || true; } | tr -d '"' \
       | { grep -v '^$' || true; } \
       | jq -R '{queue_symbol: .}' | jq -s '.'
@@ -106,7 +139,7 @@ fi
 if [ "$EVENTS_SUB" = "[]" ] && [ -f "$SUB_PKG_GO" ]; then
   # Look for: var subscribeTargets = []commonoutline.QueueName{ ... } or []QueueName{ ... }
   CONST_NAMES=$(
-    { awk '/var\s+subscribeTargets\s*=\s*\[\](commonoutline\.)?QueueName\{/,/^\}/' "$SUB_PKG_GO" 2>/dev/null || true; } \
+    extract_brace_block "$SUB_PKG_GO" 'var\s+subscribeTargets\s*=\s*\[\](commonoutline\.)?QueueName\{' \
     | { grep -oP 'QueueName\w+' || true; }
   )
   if [ -n "$CONST_NAMES" ]; then
@@ -166,15 +199,28 @@ if [ -n "$CONFIG_SRC" ]; then
 fi
 
 # --- Prometheus metrics (Name: "..." in opts blocks near prometheus.New*) ---
+# Scoped to the prometheus.New*/promauto.New* constructor call itself (via
+# paren-depth tracking, same rationale and limitation as extract_brace_block
+# above) so an unrelated struct literal that happens to have a "Name" field
+# (e.g. a SIP provisioning XML entry list) doesn't get misattributed as a
+# metric name.
 METRICS="[]"
 METRIC_DIRS=""
 [ -d "$SVC_DIR/pkg" ] && METRIC_DIRS="${METRIC_DIRS:+$METRIC_DIRS }$SVC_DIR/pkg"
 [ -d "$SVC_DIR/internal" ] && METRIC_DIRS="${METRIC_DIRS:+$METRIC_DIRS }$SVC_DIR/internal"
 if [ -n "$METRIC_DIRS" ]; then
   METRICS=$(
-    { find $METRIC_DIRS -name "*.go" ! -name "*_test.go" 2>/dev/null \
-      | xargs grep -hn 'Name:\s*"[a-z]' 2>/dev/null || true; } \
-    | { grep -oP '"[a-z][a-z_0-9]+"' || true; } | tr -d '"' \
+    { find $METRIC_DIRS -name "*.go" ! -name "*_test.go" -print0 2>/dev/null \
+      | xargs -0 -I{} awk '
+          /(prometheus|promauto)\.New(Counter|Gauge|Histogram|Summary)(Vec)?\(/ { in_block = 1; depth = 0 }
+          in_block {
+            print
+            depth += gsub(/\(/, "(")
+            depth -= gsub(/\)/, ")")
+            if (depth <= 0) in_block = 0
+          }
+        ' {} 2>/dev/null || true; } \
+    | { grep -oP 'Name:\s*"\K[a-z][a-z_0-9]*(?=")' || true; } \
     | { grep -v '^$' || true; } \
     | sort -u \
     | jq -R '{name: .}' | jq -s '.'


### PR DESCRIPTION
Fix docs/reference/extractor.sh's awk range pattern (/subscribeTargets.*\[\]string\{/,/^\s*\}/) which failed to close on an inline/empty Go slice literal such as `subscribeTargets := []string{}` (bin-api-manager/cmd/api-manager/main.go:206). With no later line consisting only of `}`, the range never turned off and spilled into unrelated code, corrupting events_subscribed with a log format string and a stray "#". Also found and fixed a second, unrelated pre-existing bug in the same script's Prometheus METRICS scan (unscoped grep picking up unrelated struct fields as fake metric names), since leaving it would have failed the requested verification that regenerated output matches actual source content.

- docs: Replace the broken awk range with a brace-depth-tracking helper (extract_brace_block), applied at all 3 subscribeTargets call sites
- docs: Scope the METRICS grep to prometheus.New*/promauto.New* constructor call spans via paren-depth tracking, instead of matching any struct field named Name across the whole pkg/internal tree
- docs: Regenerate bin-api-manager.extracted.json and bin-ai-manager.extracted.json, the only 2 of 39 services whose output the fix actually changes (verified by diffing old-script vs new-script output across every service in the monorepo)

Verification: ran the pre-fix and post-fix script against all 39 services and diffed every output pair directly — confirmed the code change alters output for exactly bin-api-manager and bin-ai-manager, byte-identical elsewhere. Cross-validated bin-ai-manager's 18 extracted metrics against an independent grep-based check (18/18 exact match). Confirmed the fix works identically under gawk and mawk. Passed 3 rounds of independent code review (2 consecutive approvals) plus 2 rounds of issue-analysis/design review, per this repo's mandatory review-loop policy.