### PR TITLE
VOIP-1411-Fix-gawk-only-regex-subscribehandler-pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,8 @@ workflows:
             voip-asterisk-proxy/.*      run-voip-asterisk-proxy true
             voip-kamailio-proxy/.*      run-voip-kamailio-proxy true
             voip-rtpengine-proxy/.*     run-voip-rtpengine-proxy true
+
+            .circleci/scripts/.*        run-shell-tests true
+            .circleci/tests/.*          run-shell-tests true
+            docs/reference/extractor\.sh run-shell-tests true
+            docs/reference/tests/.*     run-shell-tests true

--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -185,6 +185,13 @@ parameters:
     type: boolean
     default: false
 
+  ############################################
+  # namespace: tooling
+  ############################################
+  run-shell-tests:
+    type: boolean
+    default: false
+
 
 #########################################################################################################################################################################
 # workflows
@@ -851,6 +858,18 @@ workflows:
           <<: *context_production
           requires:
             - voip-kamailio-proxy-test
+
+  ############################################
+  # namespace: tooling
+  ############################################
+
+  # Runs both bats suites in the repo (.circleci/tests/*.bats,
+  # docs/reference/tests/*.bats). No approval gate: this is a read-only
+  # test run, not a deploy.
+  shell-tests:
+    when: << pipeline.parameters.run-shell-tests >>
+    jobs:
+      - shell-tests
 
 
 #########################################################################################################################################################################
@@ -2141,6 +2160,30 @@ jobs:
           project-id: voipbin
           project-repository: voip-kamailio-proxy
           source-directory: voip-kamailio-proxy
+
+  ############################################
+  # namespace: tooling
+  ############################################
+
+  # Runs the repo's bats test suites (.circleci/tests/*.bats,
+  # docs/reference/tests/*.bats). Both suites are self-contained - they
+  # mock their own external dependencies (ssh/curl in .circleci/tests,
+  # awk/mawk PATH-shimming in docs/reference/tests) - so checkout plus
+  # installing bats and mawk is the only setup needed.
+  shell-tests:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Install bats and mawk
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y bats mawk
+      - run:
+          name: Run shell test suites
+          command: bats .circleci/tests/*.bats docs/reference/tests/*.bats
 
 
 #########################################################################################################################################################################

--- a/docs/reference/extractor.sh
+++ b/docs/reference/extractor.sh
@@ -139,7 +139,7 @@ fi
 if [ "$EVENTS_SUB" = "[]" ] && [ -f "$SUB_PKG_GO" ]; then
   # Look for: var subscribeTargets = []commonoutline.QueueName{ ... } or []QueueName{ ... }
   CONST_NAMES=$(
-    extract_brace_block "$SUB_PKG_GO" 'var\s+subscribeTargets\s*=\s*\[\](commonoutline\.)?QueueName\{' \
+    extract_brace_block "$SUB_PKG_GO" 'var[[:space:]]+subscribeTargets[[:space:]]*=[[:space:]]*\[\](commonoutline\.)?QueueName\{' \
     | { grep -oP 'QueueName\w+' || true; }
   )
   if [ -n "$CONST_NAMES" ]; then

--- a/docs/reference/tests/extractor.bats
+++ b/docs/reference/tests/extractor.bats
@@ -1,0 +1,431 @@
+#!/usr/bin/env bats
+# Regression + coverage tests for docs/reference/extractor.sh.
+#
+# extractor.sh had no test coverage at all before this file. It has been the
+# source of two real, silently-wrong-output bugs found via manual
+# investigation rather than an automated check:
+#   - PR #1215: an awk range pattern (`/open/,/close/`) never closes on an
+#     inline/empty Go slice literal (e.g. `subscribeTargets := []string{}`),
+#     scanning past it into unrelated code. Fixed via brace/paren-depth
+#     tracking (extract_brace_block, and the parallel METRICS section fix).
+#   - VOIP-1411 (this PR): the Pattern-3 open-regex used gawk-only `\s`
+#     whitespace shorthand, silently matching nothing under mawk.
+# Both failure modes share a signature: the script still exits 0 and still
+# prints "Written: ...json", but the JSON content is wrong. That's exactly
+# the kind of bug a human skimming a diff or a "did it run" CI check won't
+# catch - only asserting on the actual extracted values does. This suite
+# covers the extraction patterns that share that risk (any brace/paren-depth
+# scan, or any dynamic-regex-in-awk delivery), plus lighter smoke coverage
+# of the remaining sections for completeness.
+#
+# Not covered here: EVENTS_PUB event-type-symbol extraction, and every
+# combination of the class-exemption matrix in the "Missing fields" section
+# - those don't share the depth-tracking/dynamic-regex risk this suite
+# targets, and a couple of representative cases are enough to catch a
+# structural regression in that logic.
+
+load 'test_helper'
+
+setup() {
+    setup_extractor_test_env
+}
+
+teardown() {
+    teardown_extractor_test_env
+}
+
+# --- Pattern 1: cmd/*/main.go, subscribeTargets := []string{...} / {} ------
+
+@test "pattern 1: empty subscribeTargets literal produces an empty list, not garbage scraped from surrounding code (PR #1215 regression)" {
+    add_service_class "svc-empty" "B"
+    write_fixture_file "svc-empty/cmd/svc-empty/main.go" <<'EOF'
+package main
+
+func runSubscribe() {
+	subscribeTargets := []string{}
+	subHandler := subscribehandler.NewSubscribeHandler(
+		sockHandler,
+		reqHandler,
+		queueNamePod,
+		subscribeTargets,
+		pubHandler,
+	)
+
+	if errRun := subHandler.Run(); errRun != nil {
+		log.Errorf("Could not run the subscribe handler. err: %v", errRun)
+		return
+	}
+}
+EOF
+
+    run run_extractor "svc-empty"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-empty" '.events_subscribed')"
+    [ "$result" = "[]" ]
+}
+
+@test "pattern 1: empty subscribeTargets literal is also correct under mawk (ENVIRON-based regex delivery, not awk -v)" {
+    use_mawk
+    add_service_class "svc-empty-mawk" "B"
+    write_fixture_file "svc-empty-mawk/cmd/svc-empty-mawk/main.go" <<'EOF'
+package main
+
+func runSubscribe() {
+	subscribeTargets := []string{}
+	_ = subscribeTargets
+}
+EOF
+
+    run run_extractor "svc-empty-mawk"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-empty-mawk" '.events_subscribed')"
+    [ "$result" = "[]" ]
+}
+
+@test "pattern 1: multi-line QueueName const list resolves through queuename.go" {
+    add_service_class "svc-multi" "A"
+    add_queue_name "QueueNameCallEvent" "bin-manager.call-manager.event"
+    add_queue_name "QueueNameCustomerEvent" "bin-manager.customer-manager.event"
+    write_fixture_file "svc-multi/cmd/svc-multi/main.go" <<'EOF'
+package main
+
+func runSubscribe() {
+	subscribeTargets := []string{
+		string(commonoutline.QueueNameCallEvent),
+		string(commonoutline.QueueNameCustomerEvent),
+	}
+	_ = subscribeTargets
+}
+EOF
+
+    run run_extractor "svc-multi"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-multi" '[.events_subscribed[].queue_symbol] | sort')"
+    [ "$result" = '["bin-manager.call-manager.event","bin-manager.customer-manager.event"]' ]
+}
+
+@test "pattern 1: raw string literal fallback works when no QueueName consts are used" {
+    add_service_class "svc-raw" "A"
+    write_fixture_file "svc-raw/cmd/svc-raw/main.go" <<'EOF'
+package main
+
+func runSubscribe() {
+	subscribeTargets := []string{
+		"raw.queue.one",
+		"raw.queue.two",
+	}
+	_ = subscribeTargets
+}
+EOF
+
+    run run_extractor "svc-raw"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-raw" '[.events_subscribed[].queue_symbol] | sort')"
+    [ "$result" = '["raw.queue.one","raw.queue.two"]' ]
+}
+
+# --- Pattern 2: cmd/*/main.go, subscribeTargets := string(...) -------------
+
+@test "pattern 2: single-event string(commonoutline.QueueNameXxx) resolves correctly" {
+    add_service_class "svc-single" "A"
+    add_queue_name "QueueNameFlowEvent" "bin-manager.flow-manager.event"
+    write_fixture_file "svc-single/cmd/svc-single/main.go" <<'EOF'
+package main
+
+func runSubscribe() {
+	subscribeTargets := string(commonoutline.QueueNameFlowEvent)
+	_ = subscribeTargets
+}
+EOF
+
+    run run_extractor "svc-single"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-single" '.events_subscribed')"
+    [ "$result" = '[{"queue_symbol":"bin-manager.flow-manager.event"}]' ]
+}
+
+# --- Pattern 3: pkg/subscribehandler/main.go, var subscribeTargets = ... ---
+
+@test "pattern 3: empty var subscribeTargets literal produces an empty list" {
+    add_service_class "svc-pkg-empty" "A"
+    write_fixture_file "svc-pkg-empty/pkg/subscribehandler/main.go" <<'EOF'
+package subscribehandler
+
+var subscribeTargets = []commonoutline.QueueName{}
+
+func Run() error {
+	return nil
+}
+EOF
+
+    run run_extractor "svc-pkg-empty"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-pkg-empty" '.events_subscribed')"
+    [ "$result" = "[]" ]
+}
+
+@test "pattern 3: multi-line package-level var subscribeTargets resolves through queuename.go" {
+    add_service_class "svc-pkg-multi" "A"
+    add_queue_name "QueueNameAIEvent" "bin-manager.ai-manager.event"
+    add_queue_name "QueueNameAgentEvent" "bin-manager.agent-manager.event"
+    write_fixture_file "svc-pkg-multi/pkg/subscribehandler/main.go" <<'EOF'
+package subscribehandler
+
+var subscribeTargets = []commonoutline.QueueName{
+	commonoutline.QueueNameAIEvent,
+	commonoutline.QueueNameAgentEvent,
+}
+
+func Run() error {
+	return nil
+}
+EOF
+
+    run run_extractor "svc-pkg-multi"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-pkg-multi" '[.events_subscribed[].queue_symbol] | sort')"
+    [ "$result" = '["bin-manager.agent-manager.event","bin-manager.ai-manager.event"]' ]
+}
+
+@test "pattern 3: matches under mawk too (VOIP-1411 regression - gawk-only \\s previously matched nothing under mawk)" {
+    use_mawk
+    add_service_class "svc-pkg-mawk" "A"
+    add_queue_name "QueueNameCallEvent" "bin-manager.call-manager.event"
+    write_fixture_file "svc-pkg-mawk/pkg/subscribehandler/main.go" <<'EOF'
+package subscribehandler
+
+var subscribeTargets = []commonoutline.QueueName{
+	commonoutline.QueueNameCallEvent,
+}
+
+func Run() error {
+	return nil
+}
+EOF
+
+    run run_extractor "svc-pkg-mawk"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-pkg-mawk" '.events_subscribed')"
+    [ "$result" = '[{"queue_symbol":"bin-manager.call-manager.event"}]' ]
+}
+
+# --- Prometheus metrics: scoped to prometheus.New*/promauto.New* calls -----
+
+@test "metrics: Name inside a prometheus.NewCounterVec(...) call is captured" {
+    add_service_class "svc-metrics" "A"
+    write_fixture_file "svc-metrics/pkg/somehandler/metrics.go" <<'EOF'
+package somehandler
+
+var (
+	promCallCreateTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "call_create_total",
+			Help: "Total number of calls created.",
+		},
+		[]string{"status"},
+	)
+)
+EOF
+
+    run run_extractor "svc-metrics"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-metrics" '.metrics')"
+    [ "$result" = '[{"name":"call_create_total"}]' ]
+}
+
+@test "metrics: a Name field on an unrelated struct (not inside prometheus.New*) is NOT captured (false-positive regression)" {
+    add_service_class "svc-metrics-fp" "A"
+    write_fixture_file "svc-metrics-fp/pkg/somehandler/provisioning.go" <<'EOF'
+package somehandler
+
+type entry struct {
+	Name  string
+	Value string
+}
+
+var entries = []entry{
+	{Name: "domain", Value: "example.com"},
+	{Name: "username", Value: "1001"},
+}
+EOF
+
+    run run_extractor "svc-metrics-fp"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-metrics-fp" '.metrics')"
+    [ "$result" = "[]" ]
+}
+
+@test "metrics: a real metric and an unrelated Name-bearing struct in the same file only extracts the real metric (direct repro of the bin-api-manager bug)" {
+    add_service_class "svc-metrics-mixed" "A"
+    write_fixture_file "svc-metrics-mixed/pkg/somehandler/main.go" <<'EOF'
+package somehandler
+
+var (
+	promAuthDelegateTokenIssuedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "auth_delegate_token_issued_total",
+		Help: "Total number of delegate tokens issued.",
+	})
+)
+
+type provisioningEntry struct {
+	Name  string
+	Value string
+}
+
+var provisioningEntries = []provisioningEntry{
+	{Name: "passwd", Value: "secret"},
+	{Name: "realm", Value: "example.com"},
+}
+EOF
+
+    run run_extractor "svc-metrics-mixed"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-metrics-mixed" '.metrics')"
+    [ "$result" = '[{"name":"auth_delegate_token_issued_total"}]' ]
+}
+
+@test "metrics: multiple prometheus.New* calls across multiple files are all captured, deduped, and sorted" {
+    add_service_class "svc-metrics-multi" "A"
+    write_fixture_file "svc-metrics-multi/pkg/handlera/main.go" <<'EOF'
+package handlera
+
+var promB = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "b_total",
+})
+EOF
+    write_fixture_file "svc-metrics-multi/pkg/handlerb/main.go" <<'EOF'
+package handlerb
+
+var promA = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name: "a_duration_seconds",
+})
+EOF
+
+    run run_extractor "svc-metrics-multi"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-metrics-multi" '[.metrics[].name]')"
+    [ "$result" = '["a_duration_seconds","b_total"]' ]
+}
+
+# --- Lighter smoke coverage: routing / config / dependencies ---------------
+
+@test "routing: extracts regexp.MustCompile patterns from listenhandler, collapsing a + var + interpolation into {{UUID}}" {
+    add_service_class "svc-routing" "A"
+    write_fixture_file "svc-routing/pkg/listenhandler/main.go" <<'EOF'
+package listenhandler
+
+var regV1CallsGet = regexp.MustCompile("/v1/calls$")
+var regV1CallsIDGet = regexp.MustCompile("/v1/calls/" + id + "$")
+EOF
+
+    run run_extractor "svc-routing"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-routing" '[.routing_table[].pattern] | sort')"
+    [ "$result" = '["/v1/calls$","/v1/calls/{{UUID}}$"]' ]
+}
+
+@test "config: extracts pflag flag registrations from internal/config" {
+    add_service_class "svc-config" "A"
+    write_fixture_file "svc-config/internal/config/main.go" <<'EOF'
+package config
+
+func Init(f *pflag.FlagSet) {
+	f.String("database_dsn", "", "database DSN")
+	f.Int("redis_database", 0, "redis database index")
+}
+EOF
+
+    run run_extractor "svc-config"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-config" '[.config_vars[].flag] | sort')"
+    [ "$result" = '["database_dsn","redis_database"]' ]
+}
+
+@test "dependencies: extracts go.mod replace directives" {
+    add_service_class "svc-deps" "A"
+    write_fixture_file "svc-deps/go.mod" <<'EOF'
+module monorepo/svc-deps
+
+go 1.22
+
+require monorepo/bin-common-handler v0.0.0
+
+replace monorepo/bin-common-handler => ../bin-common-handler
+EOF
+
+    run run_extractor "svc-deps"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-deps" '.dependencies')"
+    [ "$result" = '[{"module_path":"monorepo/bin-common-handler","local_path":"../bin-common-handler"}]' ]
+}
+
+# --- Class lookup and missing_fields exemptions -----------------------------
+
+@test "class lookup: reads the service's class from the taxonomy table" {
+    add_service_class "svc-class-lookup" "A2" "event-driven worker"
+
+    run run_extractor "svc-class-lookup"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Class: A2"* ]]
+
+    result="$(extracted_json_field "svc-class-lookup" '.service_class')"
+    [ "$result" = '"A2"' ]
+}
+
+@test "missing_fields: Class A service with no routing table is flagged missing, and only that" {
+    add_service_class "svc-missing-routing" "A"
+    write_fixture_file "svc-missing-routing/go.mod" <<'EOF'
+module monorepo/svc-missing-routing
+go 1.22
+EOF
+    # Give the fixture a populated config_vars source so config_vars isn't
+    # ALSO flagged missing - otherwise a substring check on "routing_table"
+    # would still pass even if the routing_table exemption logic were
+    # broken and flagging everything, pinning nothing.
+    write_fixture_file "svc-missing-routing/internal/config/main.go" <<'EOF'
+package config
+
+func Init(f *pflag.FlagSet) {
+	f.String("database_dsn", "", "database DSN")
+}
+EOF
+
+    run run_extractor "svc-missing-routing"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-missing-routing" '.missing_fields')"
+    [ "$result" = '["routing_table"]' ]
+}
+
+@test "missing_fields: Class C (shared library) service is exempt from all missing-field checks" {
+    add_service_class "svc-shared-lib" "C"
+
+    run run_extractor "svc-shared-lib"
+    [ "$status" -eq 0 ]
+
+    result="$(extracted_json_field "svc-shared-lib" '.missing_fields')"
+    [ "$result" = "[]" ]
+}
+
+# --- Usage -------------------------------------------------------------------
+
+@test "usage: exits non-zero with no service-dir argument" {
+    run bash "$EXTRACTOR_SH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/docs/reference/tests/test_helper.bash
+++ b/docs/reference/tests/test_helper.bash
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Minimal, self-contained bats helper for docs/reference/extractor.sh tests.
+# Modeled on .circleci/tests/test_helper.bash - deliberately independent of
+# any other test harness in this monorepo.
+#
+# extractor.sh resolves two paths RELATIVE TO THE CURRENT WORKING DIRECTORY
+# (not relative to the script itself, and not relative to the service dir
+# it's asked to scan):
+#   docs/reference/service-taxonomy.md              (service name -> class)
+#   bin-common-handler/models/outline/queuename.go  (QueueName const -> string)
+# Its usage comment says "Run from monorepo root." for exactly this reason.
+# So every test builds a self-contained fake monorepo root under
+# TEST_TEMP_DIR with those two files plus a fixture service directory, cds
+# into it, and invokes the real extractor.sh (by its fixed absolute path,
+# captured below before any cd) against that fixture.
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(dirname "$TESTS_DIR")"
+EXTRACTOR_SH="$REFERENCE_DIR/extractor.sh"
+
+TEST_TEMP_DIR=""
+ORIGINAL_PATH="$PATH"
+ORIGINAL_PWD=""
+
+setup_extractor_test_env() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    ORIGINAL_PWD="$PWD"
+
+    mkdir -p "$TEST_TEMP_DIR/docs/reference"
+    mkdir -p "$TEST_TEMP_DIR/bin-common-handler/models/outline"
+
+    cat > "$TEST_TEMP_DIR/docs/reference/service-taxonomy.md" <<'EOF'
+# Service Taxonomy (test fixture - not the real one)
+| Service | Class | Notes |
+|---------|-------|-------|
+EOF
+
+    cat > "$TEST_TEMP_DIR/bin-common-handler/models/outline/queuename.go" <<'EOF'
+package outline
+
+// QueueName type define (test fixture - not the real one)
+type QueueName string
+
+const (
+EOF
+
+    export MOCK_BIN_DIR="$TEST_TEMP_DIR/mock_bin"
+    mkdir -p "$MOCK_BIN_DIR"
+    export PATH="$MOCK_BIN_DIR:$ORIGINAL_PATH"
+}
+
+teardown_extractor_test_env() {
+    cd "$ORIGINAL_PWD" 2>/dev/null || true
+    if [[ -n "$TEST_TEMP_DIR" && -d "$TEST_TEMP_DIR" ]]; then
+        rm -rf "$TEST_TEMP_DIR"
+    fi
+    export PATH="$ORIGINAL_PATH"
+}
+
+# Registers a service in the fake taxonomy table extractor.sh looks up the
+# service's class from. Args: service_name class [notes]
+add_service_class() {
+    local svc="$1" class="$2" notes="${3:-test fixture}"
+    printf '| %s | %s | %s |\n' "$svc" "$class" "$notes" \
+        >> "$TEST_TEMP_DIR/docs/reference/service-taxonomy.md"
+}
+
+# Registers a QueueName constant -> string value mapping, in the shape
+# resolve_const_names()'s `grep -E "^\s+${const_name}\s+"` expects.
+# Args: const_name value
+add_queue_name() {
+    local const_name="$1" value="$2"
+    printf '\t%s QueueName = "%s"\n' "$const_name" "$value" \
+        >> "$TEST_TEMP_DIR/bin-common-handler/models/outline/queuename.go"
+}
+
+# Writes stdin (use as `write_fixture_file "path" <<'EOF' ... EOF`) to a file
+# at $TEST_TEMP_DIR/<rel_path>, creating parent directories as needed.
+write_fixture_file() {
+    local rel_path="$1" full_path
+    full_path="$TEST_TEMP_DIR/$rel_path"
+    mkdir -p "$(dirname "$full_path")"
+    cat > "$full_path"
+}
+
+# Runs extractor.sh against a fixture service directory (given as a path
+# relative to TEST_TEMP_DIR, e.g. "fake-svc") from within the fake monorepo
+# root, capturing $status/$output the way bats' `run` normally would (this
+# must be called as `run run_extractor <svc>` from the test, same as any
+# other `run`-wrapped command, so bats' assertions work unchanged).
+run_extractor() {
+    local svc_dir="$1"
+    (cd "$TEST_TEMP_DIR" && bash "$EXTRACTOR_SH" "$svc_dir")
+}
+
+# The generated extracted.json for a fixture service, as a jq-queryable path.
+extracted_json_path() {
+    local svc="$1"
+    echo "$TEST_TEMP_DIR/docs/.docs-gen/${svc}.extracted.json"
+}
+
+# jq's compact output for a field of a fixture service's extracted.json.
+extracted_json_field() {
+    local svc="$1" query="$2"
+    jq -c "$query" "$(extracted_json_path "$svc")"
+}
+
+# Makes `awk` on PATH resolve to mawk (a non-gawk implementation) instead of
+# whatever it normally would (gawk, in this dev environment) so a test can
+# assert a fix behaves identically under both. Skips the calling test (via
+# bats' `skip`) if mawk isn't installed on this machine, rather than failing.
+use_mawk() {
+    local mawk_path
+    mawk_path="$(command -v mawk)" || skip "mawk not installed on this machine"
+    ln -sf "$mawk_path" "$MOCK_BIN_DIR/awk"
+}


### PR DESCRIPTION
docs/reference/extractor.sh's Pattern 3 (scans pkg/subscribehandler/main.go for a package-level `var subscribeTargets = []QueueName{...}` declaration, used by services like bin-timeline-manager) used gawk-only \s whitespace shorthand in its open-match regex. Under mawk (Debian/Ubuntu's default non-gawk awk), this silently fails to match, producing an empty events_subscribed list with no error. Replaced with POSIX [[:space:]] bracket expressions, which match identically under gawk and mawk.

Also adds bats regression coverage for extractor.sh, which had zero test coverage before this PR despite two real, silently-wrong-output bugs (this one, and PR #1215's awk-range/METRICS bugs) surfacing only through manual investigation.

- docs: Replace \s+/\s* with [[:space:]]+/[[:space:]]* in extractor.sh's Pattern 3 open-regex, verified byte-identical output under gawk (no-op) and matching output under mawk (fixes the silent empty-result bug) across affected services
- docs: Add docs/reference/tests/test_helper.bash, a self-contained fixture helper building a fake monorepo root per test (extractor.sh resolves its taxonomy/queuename lookup files relative to CWD), modeled on the existing .circleci/tests/test_helper.bash convention
- docs: Add docs/reference/tests/extractor.bats, 19 tests covering Pattern 1/2/3 subscribeTargets extraction (empty literal, multi-line, raw-string fallback, single-event, gawk/mawk parity), METRICS scoping (real metric captured, unrelated Name field excluded, mixed-file and multi-file cases), lighter smoke coverage of routing/config/dependency extraction and missing_fields class exemptions, and the usage error path

Follow-up to #1215, tracked as VOIP-1411. Verified the fix: byte-identical script output under gawk across all services (pure no-op there), and matching correct output (26 queue symbols for bin-timeline-manager) under mawk where it previously silently returned an empty list. Verified the test suite via mutation testing: swapped in the pre-#1215 and post-#1215/pre-VOIP-1411 versions of extractor.sh and confirmed the suite fails exactly the tests meant to catch each bug, and no others. Passed 3 rounds of independent code review (2 consecutive approvals) for the fix, plus 2 rounds of issue-analysis/design review and 3 rounds of code review (2 consecutive approvals) for the test suite.

Note: these tests aren't wired into any CI job yet - same as the existing (also not CI-wired) .circleci/tests/*.bats convention in this repo. Worth a follow-up if the team wants durable enforcement rather than manual `bats docs/reference/tests/extractor.bats` runs.
