### PR TITLE
NOJIRA-Scale-safe-managers-to-two-replicas

### DIFF
--- a/bin-agent-manager/komodo/docker-compose.yml
+++ b/bin-agent-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-agent-manager
+    # container_name intentionally removed (was voipbin-agent-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-ai-manager/komodo/docker-compose.yml
+++ b/bin-ai-manager/komodo/docker-compose.yml
@@ -10,8 +10,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-ai-manager
+    # container_name intentionally removed (was voipbin-ai-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-billing-manager/komodo/docker-compose.yml
+++ b/bin-billing-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-billing-manager
+    # container_name intentionally removed (was voipbin-billing-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-call-manager/komodo/docker-compose.yml
+++ b/bin-call-manager/komodo/docker-compose.yml
@@ -40,19 +40,15 @@
 #     container - the commented-out line below stays commented, this is
 #     not an open question anymore.
 #
-# container_name is `voipbin-call-manager`, deliberately DIFFERENT from
-# the old container's name `voipbin-call-mgr` (대표님's explicit naming
-# decision, 2026-08-16 - matches GKE's `call-manager` app label rather
-# than install/'s host-wide `-mgr`-abbreviated convention; VOIP-1347 (Tier 1
-# rollout) applied the same `voipbin-<short>-manager` convention to 16 more
-# services, the remaining bin-*-manager services stay on the old convention
-# until they migrate too).
-# Because the names differ, Docker will NOT refuse to run both containers
-# at once the way it would if they shared a name - the mutual-exclusion
-# safety net the original cutover design relied on is gone. §7's ordering
-# (old container removed BEFORE the new one is deployed) still holds, but
-# is no longer enforced by Docker itself - see the design doc's updated
-# §7 for the explicit verification step this requires.
+# container_name history: the Komodo cutover named this container
+# `voipbin-call-manager` (2026-08-16, deliberately different from install/'s
+# `voipbin-call-mgr`; the naming rationale and the mutual-exclusion caveat it
+# carried are preserved in the VOIP-1342 cutover design doc). That fixed name
+# was removed entirely in the P11 2-replica rollout - Docker Compose rejects
+# a fixed container_name together with deploy.replicas > 1 - so replicas now
+# run as Compose-generated names (bin-call-manager-call-manager-N). See
+# docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+# docs/workflows/manager-replica-scaling.md.
 #
 # No healthcheck: bin-call-manager's image is distroless
 # (gcr.io/distroless/static-debian12, no shell, no wget) - the wget-based
@@ -73,8 +69,11 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-call-manager
+    # container_name intentionally removed (was voipbin-call-manager) - see
+    # the container_name history note above the services: block.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-campaign-manager/komodo/docker-compose.yml
+++ b/bin-campaign-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-campaign-manager
+    # container_name intentionally removed (was voipbin-campaign-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-conference-manager/komodo/docker-compose.yml
+++ b/bin-conference-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-conference-manager
+    # container_name intentionally removed (was voipbin-conference-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-conversation-manager/komodo/docker-compose.yml
+++ b/bin-conversation-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-conversation-manager
+    # container_name intentionally removed (was voipbin-conversation-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-customer-manager/komodo/docker-compose.yml
+++ b/bin-customer-manager/komodo/docker-compose.yml
@@ -16,8 +16,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-customer-manager
+    # container_name intentionally removed (was voipbin-customer-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-direct-manager/komodo/docker-compose.yml
+++ b/bin-direct-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-direct-manager
+    # container_name intentionally removed (was voipbin-direct-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-email-manager/komodo/docker-compose.yml
+++ b/bin-email-manager/komodo/docker-compose.yml
@@ -10,8 +10,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-email-manager
+    # container_name intentionally removed (was voipbin-email-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-message-manager/komodo/docker-compose.yml
+++ b/bin-message-manager/komodo/docker-compose.yml
@@ -10,8 +10,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-message-manager
+    # container_name intentionally removed (was voipbin-message-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-number-manager/komodo/docker-compose.yml
+++ b/bin-number-manager/komodo/docker-compose.yml
@@ -10,8 +10,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-number-manager
+    # container_name intentionally removed (was voipbin-number-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-outdial-manager/komodo/docker-compose.yml
+++ b/bin-outdial-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-outdial-manager
+    # container_name intentionally removed (was voipbin-outdial-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-queue-manager/komodo/docker-compose.yml
+++ b/bin-queue-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-queue-manager
+    # container_name intentionally removed (was voipbin-queue-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-registrar-manager/komodo/docker-compose.yml
+++ b/bin-registrar-manager/komodo/docker-compose.yml
@@ -14,8 +14,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-registrar-manager
+    # container_name intentionally removed (was voipbin-registrar-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN_BIN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - DATABASE_DSN_ASTERISK=[[BIN_MANAGER__DATABASE_DSN_ASTERISK]]

--- a/bin-storage-manager/komodo/docker-compose.yml
+++ b/bin-storage-manager/komodo/docker-compose.yml
@@ -36,8 +36,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-storage-manager
+    # container_name intentionally removed (was voipbin-storage-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     secrets:
       - source: gcp_sa_json
         target: google_service_account.json

--- a/bin-tag-manager/komodo/docker-compose.yml
+++ b/bin-tag-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-tag-manager
+    # container_name intentionally removed (was voipbin-tag-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-talk-manager/komodo/docker-compose.yml
+++ b/bin-talk-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-talk-manager
+    # container_name intentionally removed (was voipbin-talk-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-transfer-manager/komodo/docker-compose.yml
+++ b/bin-transfer-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-transfer-manager
+    # container_name intentionally removed (was voipbin-transfer-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-webchat-manager/komodo/docker-compose.yml
+++ b/bin-webchat-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-webchat-manager
+    # container_name intentionally removed (was voipbin-webchat-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/bin-webhook-manager/komodo/docker-compose.yml
+++ b/bin-webhook-manager/komodo/docker-compose.yml
@@ -9,8 +9,14 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    container_name: voipbin-webhook-manager
+    # container_name intentionally removed (was voipbin-webhook-manager) -
+    # Docker Compose rejects a fixed container_name together with
+    # deploy.replicas > 1. Fleet rollout per
+    # docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md and
+    # docs/workflows/manager-replica-scaling.md.
     restart: always
+    deploy:
+      replicas: 2
     environment:
       - DATABASE_DSN=[[BIN_MANAGER__DATABASE_DSN_BIN]]
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]

--- a/docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md
+++ b/docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md
@@ -39,41 +39,46 @@ These gate the **actual replica-scaling PRs** for the remaining
 services. This design document itself, and the doc-only companion edits
 that landed with it, are not gated (no code, no deploy).
 
-1. **BLOCKING — app-side connection-pool caps must be DEPLOYED (not
-   merely merged) before any fleet-wide scale-out.**
-   `bin-common-handler/pkg/databasehandler`'s `Connect()` sets no pool
-   limit (`SetMaxOpenConns` is never called), and `bin-rag-manager`
-   opens its own PostgreSQL pool (`sql.Open("postgres", ...)` in
-   `cmd/rag-manager/main.go`) with the same unbounded default — so
-   every service's connection count is bounded only by load. Doubling
-   replicas doubles the theoretical draw against the shared MariaDB.
-   `max_connections=220` (raised from the 151 default in monorepo-etc,
-   2026-08-27) is headroom, not a fix. Until the pool-cap change is
-   verified deployed — check the running images' commit, not the merge
-   — scale at most a handful of low-traffic services at a time, never
-   the full fleet.
-2. **Advisory — a 1-of-2 degradation alert does not exist yet.** With
-   replicas, `InstanceDown` (`up == 0`) cannot fire for a lost replica
-   (its DNS-SD target simply disappears) and `ManagerServiceGone` fires
-   only when *zero* replicas survive. A service silently running 1-of-2
-   is invisible today. A `count by (service)
-   (up{job="voipbin-managers"}) < 2`-style rule in monorepo-etc's
-   alert-rules.yml closes this; land it as the rollout proceeds. Until
-   then, the post-deploy manual verification in the workflows doc is
-   the only 2-of-2 check.
+1. **RESOLVED by decision (2026-08-28) — app-side pool caps will NOT
+   ship; monitoring is the standing defense line.** The original
+   condition blocked fleet-wide scale-out until an app-side pool cap
+   (`SetMaxOpenConns` in `bin-common-handler/pkg/databasehandler`'s
+   `Connect()`, plus `bin-rag-manager`'s own PostgreSQL pool) was
+   deployed — pools are unbounded, so doubling replicas doubles the
+   theoretical draw on the shared MariaDB. On 2026-08-28 대표님 decided
+   to skip the app-side cap entirely. The replacement gate, measured
+   the same day: `max_connections=220` with a 7-day peak of 61
+   connections (current 39, 24h avg ~37) — a full 2x of the whole
+   fleet's peak lands at ~122/220 (55%), and the deployed
+   `MySQLConnectionsHigh` (>80% warn, 5m) / `MySQLConnectionsCritical`
+   (>90% crit, 2m) → Discord alarm chain catches runaway growth. This
+   unblocks the full-fleet P11 rollout; connection headroom is now a
+   monitored budget, not a code precondition.
+2. **Advisory — a 1-of-2 degradation alert lands WITH the P11 rollout
+   window.** With replicas, `InstanceDown` (`up == 0`) cannot fire for
+   a lost replica (its DNS-SD target simply disappears) and
+   `ManagerServiceGone` fires only when *zero* replicas survive. The
+   `ReplicaDegraded` rule (`count by (service) (up{...}) < 2`, warning,
+   for 10m, enumerating the replica-scaled services) ships in
+   monorepo-etc's alert-rules.yml as P11's companion PR, deployed
+   before the compose changes with a pre-created Alertmanager silence
+   during the rollout. Until that deploy is verified, the post-deploy
+   manual verification in the workflows doc is the only 2-of-2 check.
 
 ## Per-service tracker
 
-32 Komodo stacks. States: **done** (scaled and verified live),
-**ready** (no blocker; still subject to gating condition 1), **blocked**
-(a concrete obstacle must be cleared first), **paced** (safe, but
-deliberately scheduled late as a canary).
+32 Komodo stacks. States: **done** (scaled and verified live; the
+variant "done (P11; deploy verification pending)" means the compose
+change is merged but the live 2-of-2 verification has not been recorded
+yet), **ready** (no blocker), **blocked** (a concrete obstacle must be
+cleared first), **paced** (safe, but deliberately scheduled late as a
+canary).
 
 | Service | State | Blocker / notes |
 |---|---|---|
 | schedule | **done** | PR #1212, live-verified 2026-08-27 |
-| agent, ai, billing, call, campaign, conference, conversation, customer, direct, email, message, number, outdial, queue, registrar, storage, tag, talk, transfer, webchat, webhook | ready | No per-pod queue, no naming dependency, no unguarded global state. Subject to gating condition 1 |
-| flow | ready | Has a global mutex map, but it wraps redsync (Redis distributed locks) — replica-safe. Subject to gating condition 1 |
+| agent, ai, billing, call, campaign, conference, conversation, customer, direct, email, message, number, outdial, queue, registrar, storage, tag, talk, transfer, webchat, webhook | **done (P11; deploy verification pending)** | Scaled in one batch (P11) after gating condition 1 was resolved by the 2026-08-28 no-app-cap decision. No per-pod queue, no naming dependency, no unguarded global state. No resource limits (deliberate: cAdvisor exposes no per-container series to size them from, and measured footprints are 16-69MiB against ~240GB free) |
+| flow | ready | Has a global mutex map, but it wraps redsync (Redis distributed locks) — replica-safe. Excluded from the P11 batch only as a P12 batching choice (paired with hook), not a blocker — gating condition 1 is resolved fleet-wide |
 | hook | **blocked** | Caddy naming: monorepo-etc `infra-caddy/config/Caddyfile:77-82` targets the `voipbin-hook-manager` container name literally as its reverse_proxy upstream. Removing `container_name` breaks it. Needs the Caddy retarget companion work first — do NOT fold into the ready batch |
 | api | **blocked** (two distinct blockers) | (i) Caddy naming: Caddyfile:17-22 targets `voipbin-api-manager` (retargeted from the old install/-era `voipbin-api-mgr` in VOIP-1362 — cite the current name). (ii) Per-pod `streamData` process-local state needs a code redesign; the Caddy fix alone does not make api scalable. The AudioSocket advertise-address defect is already fixed (`internal/nethandler.AdvertiseIP()`, PR #1209) |
 | pipecat | **blocked** | Per-pod queue routing redesign needed; also shares a network namespace 1:1 with its sidecar (`network_mode: service:...`) — the heaviest case in the fleet |
@@ -82,7 +87,7 @@ deliberately scheduled late as a canary).
 | timeline | **blocked** (instrumentation landed — P8a) | The intake channel (`pkg/subscribehandler`, 1000-slot buffered channel) drops events silently when full. P8a added drop/occupancy metrics; re-evaluate when a 24h single-replica baseline shows `increase(timeline_manager_subscribe_event_dropped_total[24h]) == 0` AND `histogram_quantile(0.99, rate(timeline_manager_subscribe_event_channel_usage_bucket[24h])) < 0.5`. Rationale: 24h covers one full daily traffic cycle; zero drops because a drop is permanently lost customer timeline data (no recovery path); p99 < 50% because a rolling restart or unbalanced routing can route the full event stream to one replica — headroom for the worst case must exist at single-replica load |
 | route | **blocked** | Global provider healthcheck loop has no cross-replica lock — 2 replicas would double-probe every SIP provider |
 | contact | **blocked** | In-process lock needs a Redis distributed-lock (or equivalent) decision first |
-| rag | **paced** (not blocked) | Already replica-safe: `DocumentClaimForProcessing` claims work via an atomic CAS UPDATE (same class of safety as schedule's claim machinery). Gating condition 1 applies via rag's own pool-cap fix (it bypasses `databasehandler.Connect()`). Deliberately scheduled as a late canary — this is pacing, not a code defect; do not group it with timeline/route/contact |
+| rag | **paced** (not blocked) | Already replica-safe: `DocumentClaimForProcessing` claims work via an atomic CAS UPDATE (same class of safety as schedule's claim machinery). Its own unbounded PostgreSQL pool (it bypasses `databasehandler.Connect()`) is covered by the same 2026-08-28 no-app-cap decision that resolved gating condition 1 — no pool-cap fix is planned. Deliberately scheduled as a late canary — this is pacing, not a code defect; do not group it with timeline/route/contact |
 
 ## References
 

--- a/docs/workflows/manager-replica-scaling.md
+++ b/docs/workflows/manager-replica-scaling.md
@@ -119,18 +119,30 @@ docker ps --filter name=<service> --format '{{.Names}}\t{{.Status}}'
 count(up{job="voipbin-managers", service="<service>"})
 ```
 
+Also give the service's Grafana dashboard a quick sanity pass:
+per-instance panels now show two series per service (harmless — proven
+by the schedule-manager pilot — but confirm nothing renders wrong).
+
 ## 5. Known fleet-wide gaps (tracked in the rollout design doc — do not re-derive per service)
 
-- **No 1-of-2 degradation alert.** `InstanceDown` can't see a vanished
-  DNS-SD target and `ManagerServiceGone` fires only at zero replicas.
-  Until a `count(...) < 2` rule lands, section 4's manual check is the
-  only 2-of-2 verification.
-- **Runbook naming drift.** monorepo-etc's alert-rules.yml runbooks
-  assume `voipbin-<service>` container names for
-  `docker ps --filter name=` matching. The substring still matches the
-  generated names, so nothing breaks operationally, but each scaled
-  service adds another exception to that convention.
+- **1-of-2 degradation alert: `ReplicaDegraded`** (warning, `for: 10m`,
+  monorepo-etc alert-rules.yml) covers the replica-scaled services —
+  its regex enumerates them, so **scaling a service up or down requires
+  updating that regex and its tests**. Section 4's manual check remains
+  the verification at deploy time (the alert's 10m window deliberately
+  ignores deploy churn).
+- **Runbook naming.** monorepo-etc's alert-rules.yml runbooks describe
+  both container-name regimes (replica-scaled
+  `bin-<svc>-manager-<svc>-manager-N`, single-replica
+  `voipbin-<svc>-manager`); the `docker ps --filter name=` substring
+  match works for both.
 - **Redeploy blip pattern unmeasured** (see section 3).
+- **No resource limits, deliberately** (2026-08-28). cAdvisor on
+  bm-nyc-01 exposes only system cgroup slices — no per-container series
+  exist to size limits from — and one-shot `docker stats` shows
+  16-69MiB per manager against ~240GB free host memory. Inventing
+  limits without data risks OOMKills for no benefit; revisit only after
+  cAdvisor per-container metrics are fixed (tracked separately).
 
 ## 6. Rollback
 


### PR DESCRIPTION
Scale the 21 replica-safe bin-*-manager services from 1 to 2 replicas (P11 fleet rollout), following the pattern proven live by the schedule-manager pilot. Companion monorepo-etc PR adds the ReplicaDegraded alert and must be deployed first (with a pre-created Alertmanager silence, per the rollout procedure in the design doc).

- bin-agent-manager: Remove container_name and set deploy.replicas 2
- bin-ai-manager: Remove container_name and set deploy.replicas 2
- bin-billing-manager: Remove container_name and set deploy.replicas 2
- bin-call-manager: Remove container_name and set deploy.replicas 2; rewrite the historical container_name naming comment so it no longer contradicts the removal
- bin-campaign-manager: Remove container_name and set deploy.replicas 2
- bin-conference-manager: Remove container_name and set deploy.replicas 2
- bin-conversation-manager: Remove container_name and set deploy.replicas 2
- bin-customer-manager: Remove container_name and set deploy.replicas 2
- bin-direct-manager: Remove container_name and set deploy.replicas 2
- bin-email-manager: Remove container_name and set deploy.replicas 2
- bin-message-manager: Remove container_name and set deploy.replicas 2
- bin-number-manager: Remove container_name and set deploy.replicas 2
- bin-outdial-manager: Remove container_name and set deploy.replicas 2
- bin-queue-manager: Remove container_name and set deploy.replicas 2
- bin-registrar-manager: Remove container_name and set deploy.replicas 2
- bin-storage-manager: Remove container_name and set deploy.replicas 2
- bin-tag-manager: Remove container_name and set deploy.replicas 2
- bin-talk-manager: Remove container_name and set deploy.replicas 2
- bin-transfer-manager: Remove container_name and set deploy.replicas 2
- bin-webchat-manager: Remove container_name and set deploy.replicas 2
- bin-webhook-manager: Remove container_name and set deploy.replicas 2
- docs: Revise rollout gating condition 1 (app-side pool cap skipped by 2026-08-28 decision; max_connections 220 plus the MySQL connection alarm chain is the standing defense) and condition 2 (ReplicaDegraded ships as the companion monorepo-etc PR)
- docs: Move the 21 ready services to done (P11; deploy verification pending) in the tracker with the no-resource-limit rationale
- docs: Update manager-replica-scaling workflow (ReplicaDegraded sync duty, mixed naming regimes, deliberate no-limits decision, Grafana sanity pass)