### PR TITLE
VOIP-1409-notifyhandler-housekeeping

### DIFF
--- a/bin-common-handler/docs/architecture.md
+++ b/bin-common-handler/docs/architecture.md
@@ -79,7 +79,7 @@ Per-target circuit breaker. Default tuning: 5 consecutive failures → 30-second
 - Integrated into every `requesthandler.sendRequest()` call
 - Consumer services get CB protection for free; do not add a second CB on top
 
-See [docs/patterns/circuit-breaker.md](../docs/patterns/circuit-breaker.md) for state machine and tuning guidance.
+See [docs/patterns/circuit-breaker.md](../../docs/patterns/circuit-breaker.md) for state machine and tuning guidance.
 
 ### pkg/databasehandler
 DB helper utilities:
@@ -120,4 +120,4 @@ Every change to `bin-common-handler` triggers verification across all 37 consume
 | `<ns>_circuitbreaker_state_transitions_total{target,from,to}` | Counter | CB state transitions |
 | `<ns>_circuitbreaker_rejected_total{target}` | Counter | Open-state rejections |
 
-Consumer services must not register metrics with the same names — `prometheus.MustRegister` panics on duplicates. See [docs/workflows/common-gotchas.md](../docs/workflows/common-gotchas.md).
+Consumer services must not register metrics with the same names — `prometheus.MustRegister` panics on duplicates. See [docs/workflows/common-gotchas.md](../../docs/workflows/common-gotchas.md).

--- a/bin-common-handler/docs/usage.md
+++ b/bin-common-handler/docs/usage.md
@@ -17,6 +17,7 @@ import (
     "monorepo/bin-common-handler/pkg/sockhandler"
     "monorepo/bin-common-handler/models/sock"
     "monorepo/bin-common-handler/models/identity"
+    "monorepo/bin-common-handler/models/outline"
 )
 ```
 
@@ -31,44 +32,50 @@ Before adding a new package to `bin-common-handler`, verify that 3 or more exist
 ### Constructing a RequestHandler
 
 ```go
-rh, err := requesthandler.NewRequestHandler(
-    ctx,
-    sock,                    // sockhandler.SockHandler
-    "my-service-namespace",  // used for Prometheus metric names
+rh := requesthandler.NewRequestHandler(
+    sock,                                  // sockhandler.SockHandler
+    outline.ServiceNameMyService,          // used for Prometheus metric names
 )
-if err != nil {
-    return err
-}
 
 // Call another service
 call, err := rh.CallV1CallGet(ctx, callID)
 ```
 
-All RPC methods go through `sendRequest()` in `pkg/requesthandler/send_request.go`. The circuit breaker is applied here automatically. Do not add another circuit breaker layer in the consumer.
+`NewRequestHandler` takes no `context.Context` and returns a single `RequestHandler` value (no error) — construction cannot fail. All RPC methods go through `sendRequest()` in `pkg/requesthandler/send_request.go`. The circuit breaker is applied here automatically. Do not add another circuit breaker layer in the consumer.
 
 ### Publishing events with NotifyHandler
 
 ```go
-nh, err := notifyhandler.NewNotifyHandler(
-    ctx,
-    sock,
-    "my-service-namespace",
+nh := notifyhandler.NewNotifyHandler(
+    sock,                                  // sockhandler.SockHandler
+    rh,                                    // requesthandler.RequestHandler
+    outline.QueueNameMyServiceEvent,       // this service's own fanout queue (used when the option below is omitted)
+    outline.ServiceNameMyService,
+    notifyhandler.WithGlobalTopicPublish(), // publish to the global topic exchange instead of this service's fanout queue
 )
 
-// Publish a domain event
-err = nh.PublishEvent(ctx, "bin-manager.my-service.event", eventType, data)
+// Typical case: publish the internal event AND deliver the customer webhook
+nh.PublishWebhookEvent(ctx, customerID, eventType, data)
 
-// Send a webhook
-err = nh.PublishWebhook(ctx, customerID, webhookURL, payload)
+// Internal event only, no customer webhook
+nh.PublishEvent(ctx, eventType, data)
+
+// Webhook only, no internal event (rarely used directly -- PublishWebhookEvent covers the common case)
+nh.PublishWebhook(ctx, customerID, eventType, data)
 ```
+
+`NewNotifyHandler` takes no `context.Context` and returns a single `NotifyHandler` value (no error) — the now-mandatory `reqHandler` argument is what `PublishWebhookEvent`/`PublishWebhook` use internally to resolve and deliver the webhook. None of `PublishEvent`, `PublishWebhook`, or `PublishWebhookEvent` return anything, not even an error — they are fire-and-forget.
+
+`data` must satisfy `notifyhandler.WebhookEventMessage` for `PublishWebhookEvent` (a `WebhookMessage` plus `eventtopic.SubscriptionIdentifier`) or plain `eventtopic.SubscriptionIdentifier` for `PublishEvent`. In practice this is free: embedding `identity.Identity` by value and passing the struct as a pointer satisfies `EventSubscriptionID()` via method promotion, so most resource types need no explicit implementation.
+
+**`WithGlobalTopicPublish()`** makes this handler instance publish exclusively to the global topic exchange `bin-manager.event` instead of this service's own per-service fanout queue (VOIP-1404/VOIP-1407) — see [docs/architecture.md](architecture.md#pkgnotifyhandler) for the routing-key scheme. Every production publisher passes this option today except `voip-asterisk-proxy`.
 
 ### Mock generation
 
 All handler interfaces in `bin-common-handler` have generated mocks. In consumer services, generate mocks for the interfaces you import:
 
 ```go
-//go:generate mockgen -package mypackage -destination ./mock_main.go \
-//   -source main.go -build_flags=-mod=mod
+//go:generate mockgen -package mypackage -destination ./mock_main.go -source main.go -build_flags=-mod=mod
 ```
 
 Run `go generate ./...` from the service root.
@@ -87,7 +94,7 @@ type MyResource struct {
 }
 ```
 
-UUID fields on shared models must use the `,uuid` db tag; JSON fields must use the `,json` db tag. See [docs/conventions/models.md](../docs/conventions/models.md).
+UUID fields on shared models must use the `,uuid` db tag; JSON fields must use the `,json` db tag. See [docs/conventions/models.md](../../docs/conventions/models.md).
 
 ### Queue names
 
@@ -109,4 +116,4 @@ When you change an exported function signature, interface method, or model field
 4. Bulk find-and-replace across the monorepo for old call sites — use AST-aware tooling (e.g., `gopls rename`), not plain `sed`, because multi-line call sites will be missed by text replacement.
 5. Run the full verification workflow in each affected service before committing.
 
-See [docs/workflows/common-gotchas.md](../docs/workflows/common-gotchas.md) for the "Updating Shared Library Function Signatures" gotcha.
+See [docs/workflows/common-gotchas.md](../../docs/workflows/common-gotchas.md) for the "Updating Shared Library Function Signatures" gotcha.

--- a/bin-common-handler/pkg/notifyhandler/publish.go
+++ b/bin-common-handler/pkg/notifyhandler/publish.go
@@ -32,7 +32,7 @@ func (h *notifyHandler) PublishWebhook(ctx context.Context, customerID uuid.UUID
 		"func":        "PublishWebhook",
 		"customer_id": customerID,
 		"data":        data,
-		"evnet_type":  eventType,
+		"event_type":  eventType,
 	})
 
 	if customerID == uuid.Nil {
@@ -62,7 +62,7 @@ func (h *notifyHandler) PublishWebhook(ctx context.Context, customerID uuid.UUID
 func (h *notifyHandler) PublishEventRaw(ctx context.Context, eventType string, dataType string, data []byte) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "PublishEventRaw",
-		"evnet_type": eventType,
+		"event_type": eventType,
 		"data_type":  dataType,
 	})
 
@@ -81,7 +81,7 @@ func (h *notifyHandler) PublishEventRaw(ctx context.Context, eventType string, d
 func (h *notifyHandler) PublishEvent(ctx context.Context, eventType string, data eventtopic.SubscriptionIdentifier) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":       "PublishEvent",
-		"evnet_type": eventType,
+		"event_type": eventType,
 	})
 
 	// create event
@@ -220,7 +220,7 @@ func (h *notifyHandler) publishTopicEventOrErr(ctx context.Context, evt *sock.Ev
 func (h *notifyHandler) PublishEventWithRoutingKey(ctx context.Context, eventType string, routingKey string, data interface{}) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "PublishEventWithRoutingKey",
-		"evnet_type":  eventType,
+		"event_type":  eventType,
 		"routing_key": routingKey,
 	})
 


### PR DESCRIPTION
Fix stale bin-common-handler/docs/usage.md snippets and the evnet_type
log field typo found during VOIP-1404 review. No functional change.

- bin-common-handler: Rename the "evnet_type" logrus.Fields key typo to
  "event_type" at all 4 sites in pkg/notifyhandler/publish.go (log field
  only, no behavior change; no test or external log query depends on the
  misspelled key name)
- bin-common-handler: Rewrite docs/usage.md's "Constructing a
  RequestHandler" and "Publishing events with NotifyHandler" examples
  to match the real current signatures (no ctx param on either
  constructor, no error return anywhere in this call chain, the now-
  mandatory reqHandler argument on NewNotifyHandler); lead with
  PublishWebhookEvent as the typical case per docs/conventions/events.md
  section 11.1 instead of the near-unused standalone PublishWebhook;
  document the WebhookEventMessage/SubscriptionIdentifier data
  constraint; add a WithGlobalTopicPublish() example
- bin-common-handler: Fix four relative markdown links in docs/usage.md
  and docs/architecture.md that resolved one directory short of their
  real targets (../docs/... -> ../../docs/...)
- bin-common-handler: Collapse the invalid two-line //go:generate
  example in docs/usage.md (go:generate has no line-continuation syntax)
  to a single line