### PR TITLE
VOIP-1425-remove-api-manager-dead-fanout

### DIFF
--- a/bin-api-manager/cmd/api-manager/main.go
+++ b/bin-api-manager/cmd/api-manager/main.go
@@ -203,23 +203,13 @@ func runSubscribe(
 		"func": "runSubscribe",
 	})
 
-	subscribeTargets := []string{}
 	subHandler := subscribehandler.NewSubscribeHandler(
 		sockHandler,
 		reqHandler,
 		queueNamePod,
-		subscribeTargets,
-
 		pubHandler,
 	)
 
-	// run. NOTE: the VOIP-1258 "#" wildcard binding to the new topic exchange lives INSIDE
-	// subscribeHandler.Run(), sequenced before ConsumeMessage starts -- see that function's
-	// doc comment for why doing it here (after Run() returns) is unsafe: Run() starts
-	// ConsumeMessage on a separate goroutine and returns immediately, so a QueueBind call
-	// here would race the in-flight basic.consume RPC on the same AMQP channel and could
-	// intermittently 503 the channel closed (reproduced in bin-agent-manager production,
-	// 2026-07-14, fixed there in commit ca8c104a9 and here proactively for the same reason).
 	if errRun := subHandler.Run(); errRun != nil {
 		log.Errorf("Could not run the subscribe handler. err: %v", errRun)
 		return

--- a/bin-api-manager/docs/architecture.md
+++ b/bin-api-manager/docs/architecture.md
@@ -31,7 +31,7 @@ graph TD
 | `pkg/servicehandler/` | Business delegation | Auth check + RabbitMQ RPC fan-out; one file per resource type |
 | `pkg/dbhandler/` | Data access | MySQL + Redis cache (customer, accesskey, token data owned by api-manager) |
 | `pkg/cachehandler/` | Redis cache | Session and token caching |
-| `pkg/subscribehandler/` | Event consumption | Subscribes to backend manager event queues |
+| `pkg/subscribehandler/` | Event consumption | Declares this pod's queue and consumes webhook-manager-published events dispatched to it; does not itself bind any exchange |
 | `pkg/websockhandler/` | WebSocket fan-out | Pushes events to authenticated WebSocket clients |
 | `pkg/streamhandler/` | Audio streaming | Audiosocket protocol handler for AI/Pipecat audio path |
 | `pkg/pubsubhandler/` | In-process pub/sub | Broker + per-WebSocket subscribers; prefix-matched event fan-out from subscribehandler to WebSocket connections |
@@ -136,4 +136,4 @@ Each resource group in the REST API maps to one (or occasionally two) backend se
 | `/service_agents/*` | various (agent-scoped proxy) | Agent-facing subset of resources with scoped auth |
 | `/ws` | local (websockhandler) | WebSocket upgrade; real-time event push to clients |
 
-Event re-emission: `pkg/subscribehandler/` consumes events from backend queues (`bin-manager.webhook-manager.event`, `bin-manager.agent-manager.event`, `bin-manager.talk-manager.event`) and pushes them to WebSocket clients and `bin-webhook-manager` for HTTP delivery.
+Event re-emission: `pkg/subscribehandler/` only ever receives events published by `bin-webhook-manager` -- both the legacy fanout-envelope shape (`processEventWebhookManagerWebhookPublished`) and the VOIP-1258 topic-routing-keyed shape (`processEventWebhookManagerRoutingKeyedEvent`), gated on `m.Publisher == ServiceNameWebhookManager`; every other publisher is silently ignored (`default: return`). The actual topic-exchange binding is owned by `pkg/websockhandler/`'s `scopeRefCount` (VOIP-1258 §9), which dynamically `QueueBind`/`QueueUnbind`s this pod's queue against `bin-manager.webhook-manager.event.topic` per active client subscription scope -- not a static list of backend manager event queues.

--- a/bin-api-manager/pkg/subscribehandler/main.go
+++ b/bin-api-manager/pkg/subscribehandler/main.go
@@ -30,7 +30,6 @@ type subscribeHandler struct {
 	reqHandler  requesthandler.RequestHandler
 
 	subscribeQueueNamePod string // subscribe queue name for this pod
-	subscribeTargets      []string
 
 	pubHandler pubsubhandler.PubHandler
 }
@@ -62,7 +61,6 @@ func NewSubscribeHandler(
 	sockHandler sockhandler.SockHandler,
 	reqHandler requesthandler.RequestHandler,
 	subscribeQueueName string,
-	subscribeTargets []string,
 	pubHandler pubsubhandler.PubHandler,
 ) SubscribeHandler {
 	h := &subscribeHandler{
@@ -70,7 +68,6 @@ func NewSubscribeHandler(
 		reqHandler:  reqHandler,
 
 		subscribeQueueNamePod: subscribeQueueName,
-		subscribeTargets:      subscribeTargets,
 
 		pubHandler: pubHandler,
 	}
@@ -90,21 +87,14 @@ func (h *subscribeHandler) Run() error {
 		return fmt.Errorf("could not declare the queue for listenHandler. err: %v", err)
 	}
 
-	// subscribe each targets
-	for _, target := range h.subscribeTargets {
-		if errSubscribe := h.sockHandler.QueueSubscribe(h.subscribeQueueNamePod, target); errSubscribe != nil {
-			log.Errorf("Could not subscribe the target. target: %s, err: %v", target, errSubscribe)
-			return errSubscribe
-		}
-	}
-
-	// NOTE (VOIP-1296 final cutover): the unconditional "#" wildcard baseline bind to the topic
-	// exchange that used to live here has been removed. It was a rollout safety net kept
-	// alongside pkg/websockhandler's scopeRefCount mechanism (VOIP-1258 §9), which already
-	// binds/unbinds this pod's queue per active client subscription scope. Keeping both meant
-	// every event was still delivered to every pod regardless of connected client count --
-	// exactly the problem VOIP-1258 set out to fix. scopeRefCount is the sole binding mechanism
-	// for this pod's queue going forward.
+	// NOTE (VOIP-1296 final cutover, VOIP-1425 cleanup): the unconditional "#" wildcard baseline
+	// bind to the topic exchange that used to live here, and the generic fanout QueueSubscribe
+	// loop that replaced it, have both been removed. The loop's subscribeTargets was populated
+	// with real queue names before VOIP-1258, which emptied it to []string{} when the
+	// topic-exchange/scopeRefCount mechanism took over -- dead ever since, not since inception.
+	// The real event intake is pkg/websockhandler's scopeRefCount (VOIP-1258 §9), which
+	// binds/unbinds this pod's queue per active client subscription scope. scopeRefCount is the
+	// sole binding mechanism for this pod's queue.
 
 	// receive subscribe events
 	go func() {

--- a/bin-api-manager/pkg/subscribehandler/main_test.go
+++ b/bin-api-manager/pkg/subscribehandler/main_test.go
@@ -1,0 +1,120 @@
+package subscribehandler
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+// Test_Run_CallsQueueCreateAndConsume is a functional smoke test: Run() must declare this
+// pod's queue and start consuming from it, with no error, using the arguments the rest of the
+// service (and pkg/websockhandler's scopeRefCount, which binds against the same queue name)
+// depends on.
+func Test_Run_CallsQueueCreateAndConsume(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+
+	queueName := "bin-manager.api-manager.subscribe.test-pod"
+
+	mockSock.EXPECT().QueueCreate(queueName, "volatile").Return(nil)
+	mockSock.EXPECT().ConsumeMessage(gomock.Any(), queueName, string(commonoutline.ServiceNameAPIManager), false, false, false, 10, gomock.Any()).
+		Return(nil).AnyTimes()
+
+	h := NewSubscribeHandler(mockSock, nil, queueName, nil)
+
+	if err := h.Run(); err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+}
+
+// Test_Run_QueueCreateBeforeConsumeGoroutine_golden is a regression test guarding Run()'s
+// synchronous/async ordering after VOIP-1425 removed the dead fanout subscribeTargets
+// machinery.
+//
+// A runtime/mock-based ordering test was tried first and rejected: ConsumeMessage's mock
+// returns instantly, so goroutine-scheduling latency alone dominates any observable timing --
+// mutation testing confirmed that a deliberately-introduced regression (moving the QueueCreate
+// call to after the `go func(){ ... ConsumeMessage(...) }()` statement) still passed a
+// runtime-based ordering assertion 100% of the time, both with a plain channel drain and with
+// gomock.InOrder, because QueueCreate remains synchronous either way and the spawned goroutine
+// essentially never gets scheduled before Run() itself returns in a mocked (zero-latency) test.
+// This is structurally different from the sibling services (bin-agent-manager,
+// bin-call-manager, bin-timeline-manager), whose Run() performs several real synchronous
+// QueueBind/QueueUnbind calls before the goroutine launch -- enough sequential work for a
+// reordering to be runtime-observable. api-manager's Run() has exactly one synchronous op left
+// after VOIP-1425, so the only reliable way to pin its position is structurally, matching the
+// AST-based approach bin-call-manager/pkg/subscribehandler/binding_golden_test.go already uses
+// for this same class of invariant (see Test_fanoutUnbindTargets_golden there).
+//
+// This test parses main.go and asserts, within func (h *subscribeHandler) Run(), that the
+// top-level statement calling QueueCreate appears before the top-level `go func() { ... }()`
+// statement that launches ConsumeMessage.
+func Test_Run_QueueCreateBeforeConsumeGoroutine_golden(t *testing.T) {
+	fset := token.NewFileSet()
+	f, errParse := parser.ParseFile(fset, "main.go", nil, 0)
+	if errParse != nil {
+		t.Fatalf("could not parse main.go. err: %v", errParse)
+	}
+
+	var runFunc *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "Run" && fn.Recv != nil {
+			runFunc = fn
+			break
+		}
+	}
+	if runFunc == nil {
+		t.Fatal("could not find func (h *subscribeHandler) Run() in main.go")
+	}
+
+	queueCreateIdx := -1
+	goStmtIdx := -1
+	for i, stmt := range runFunc.Body.List {
+		if queueCreateIdx == -1 && containsQueueCreateCall(stmt) {
+			queueCreateIdx = i
+		}
+		if goStmtIdx == -1 {
+			if _, ok := stmt.(*ast.GoStmt); ok {
+				goStmtIdx = i
+			}
+		}
+	}
+
+	if queueCreateIdx == -1 {
+		t.Fatal("Run() must contain a top-level statement calling QueueCreate -- the synchronous queue declaration this pod's ConsumeMessage (and pkg/websockhandler's scopeRefCount) depend on existing first.")
+	}
+	if goStmtIdx == -1 {
+		t.Fatal("Run() must contain a top-level `go func() { ... }()` statement launching the ConsumeMessage goroutine.")
+	}
+	if queueCreateIdx >= goStmtIdx {
+		t.Fatalf("QueueCreate must be called BEFORE the ConsumeMessage goroutine is launched (statement index %d), but it appears at index %d -- ordering regression. QueueCreate and the started goroutine share the same AMQP queue; declaring it after starting the consumer risks the consumer racing a not-yet-declared queue.", goStmtIdx, queueCreateIdx)
+	}
+}
+
+// containsQueueCreateCall reports whether stmt is (or directly wraps, e.g. an if-statement's
+// init/cond, matching how Run() actually calls it: `if err := h.sockHandler.QueueCreate(...);
+// err != nil { ... }`) a call to QueueCreate.
+func containsQueueCreateCall(stmt ast.Stmt) bool {
+	found := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if ok && sel.Sel.Name == "QueueCreate" {
+			found = true
+		}
+		return true
+	})
+	return found
+}

--- a/bin-api-manager/pkg/websockhandler/scoperefcount.go
+++ b/bin-api-manager/pkg/websockhandler/scoperefcount.go
@@ -31,6 +31,14 @@ func newScopeRefCount(sock sockhandler.SockHandler, queueName string, exchangeNa
 
 // Acquire increments the refcount for the given binding pattern, binding the queue on the
 // first (0->1) transition.
+//
+// OPEN QUESTION (VOIP-1431): this QueueBind runs at an arbitrary runtime moment (whenever a
+// client subscribes), against the same queue that pkg/subscribehandler's ConsumeMessage is
+// actively consuming from. QueueBind and an in-flight basic.consume share one AMQP channel per
+// queue; a historically-documented (now-removed, VOIP-1425) comment warned that calling
+// QueueBind AFTER a consumer starts on that channel can race the broker and 503 the channel
+// closed (reproduced in bin-agent-manager production, 2026-07-14). Whether that hazard applies
+// here too, or the client library serializes it safely, is unconfirmed -- see VOIP-1431.
 func (r *scopeRefCount) Acquire(pattern string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/docs/plans/2026-08-29-voip-1407-fanout-cutover-plan.md
+++ b/docs/plans/2026-08-29-voip-1407-fanout-cutover-plan.md
@@ -373,7 +373,7 @@ Plus a residue sweep:
 /usr/bin/grep -rn "fanoutUnbindTargets\|subscribesTargets" --include="*.go" .
 # expected survivors: NONE in bin-*/pkg/subscribehandler
 /usr/bin/grep -rn "subscribeTargets" --include="*.go" .
-# expected survivors: bin-api-manager only (see OQ-1)
+# expected survivors: bin-api-manager only (see OQ-1) -- superseded by VOIP-1425, now zero
 ```
 
 ---
@@ -501,7 +501,7 @@ Residue sweeps (R1 finding LOW-7 added the last two, matching §3 E5's full set)
 - [ ] `/usr/bin/grep -rn "publishTopicEvent\b" --include="*.go" .` returns zero.
 - [ ] `/usr/bin/grep -rn "fanoutUnbindTargets" --include="*.go" .` returns zero.
 - [ ] `/usr/bin/grep -rn "subscribesTargets" --include="*.go" .` returns zero (webhook-manager's comma-joined variant).
-- [ ] `/usr/bin/grep -rn "subscribeTargets" --include="*.go" .` returns **exactly one surviving family**: `bin-api-manager` (OQ-1, deliberately left alone, fed an empty slice literal). Any other survivor is a missed deletion.
+- [ ] `/usr/bin/grep -rn "subscribeTargets" --include="*.go" .` returns **exactly one surviving family**: `bin-api-manager` (OQ-1, deliberately left alone, fed an empty slice literal). Any other survivor is a missed deletion. **Superseded by VOIP-1425**: `bin-api-manager` was subsequently removed too, so a post-VOIP-1425 sweep returns zero everywhere except two historical-comment-text hits in `bin-call-manager/pkg/subscribehandler/binding_golden_test.go`.
 
 ---
 
@@ -713,7 +713,7 @@ Three different failure-handling regimes now coexist. Mixing them up is silent a
 
 Per this plan's constraint, these are raised rather than decided.
 
-**OQ-1 -- RESOLVED (대표님 decision):** leave `bin-api-manager`'s residual machinery untouched in this PR; filed as a separate Jira cleanup follow-up, [VOIP-1425](https://voipbin.atlassian.net/browse/VOIP-1425). Matches this section's own recommendation below.
+**OQ-1 -- RESOLVED (대표님 decision):** leave `bin-api-manager`'s residual machinery untouched in this PR; filed as a separate Jira cleanup follow-up, [VOIP-1425](https://voipbin.atlassian.net/browse/VOIP-1425). Matches this section's own recommendation below. **(done in VOIP-1425.)**
 
 **OQ-1 -- `bin-api-manager`'s residual fanout-subscribe machinery.**
 *Verified this plan:* `bin-api-manager/pkg/subscribehandler/main.go` carries a `subscribeTargets []string` struct field (`:33`), constructor parameter (`:65`), and a fanout `QueueSubscribe` loop in `Run()` (`:94-95`) -- structurally identical to what design §3.1 deletes in the 20 services. It is fed an **empty** slice literal at `bin-api-manager/cmd/api-manager/main.go:206` (`subscribeTargets := []string{}`), so it binds zero fanout exchanges and design §5's exchange deletion **cannot** break it. That is presumably why it is correctly absent from the 20-service list. But the design doc does not mention this 21st instance of the same machinery at all, so it is unclear whether leaving it is intentional (genuinely harmless dead code, out of this ticket's stated scope) or an oversight (exactly the code shape this ticket exists to remove). **Recommendation: leave it, and file a separate Jira cleanup follow-up** -- deleting it adds a 21st service to an already 23-module PR for zero functional gain, and it cannot cause the outage design §5 guards against. Needs a ruling either way so a reviewer does not flag it as a miss.


### PR DESCRIPTION
Remove bin-api-manager's dead fanout-subscribe machinery, found during
VOIP-1407's design review. subscribeTargets was populated with real
queue names before VOIP-1258, which emptied it to []string{} when the
topic-exchange/scopeRefCount mechanism took over -- the fanout
QueueSubscribe loop it fed has been dead ever since. No functional
change.

- bin-api-manager: Delete the subscribeTargets struct field,
  constructor parameter, and fanout QueueSubscribe loop from
  pkg/subscribehandler/main.go; leave a NOTE where the loop was,
  matching the sibling-service pattern
- bin-api-manager: Delete the empty-slice wiring at
  cmd/api-manager/main.go's runSubscribe, along with the adjacent
  comment block that incorrectly claimed a topic-exchange wildcard
  bind still lives inside Run() (removed by VOIP-1296) -- the
  underlying AMQP channel-sharing hazard the comment described is
  real but has relocated to pkg/websockhandler's scopeRefCount; added
  an OPEN QUESTION comment on scopeRefCount.Acquire pointing at
  VOIP-1431, which now tracks it, so the hazard isn't silently dropped
- bin-api-manager: Add pkg/subscribehandler/main_test.go with a
  functional Run() smoke test plus an AST-based golden test pinning
  that QueueCreate is called before the ConsumeMessage goroutine is
  launched. A runtime/mock-based ordering test (matching the
  sibling-service pattern) was tried first and rejected after
  mutation testing showed it had near-zero regression-detection power
  here: unlike the siblings' several real synchronous QueueBind calls,
  api-manager's Run() has exactly one synchronous op left post-cleanup,
  too little sequential work for a reordering to be runtime-observable
  against zero-latency mocks. The AST approach matches the pattern
  bin-call-manager/pkg/subscribehandler/binding_golden_test.go already
  uses for the same class of structural invariant, and was confirmed
  via mutation testing to catch the regression deterministically
- bin-api-manager: Correct docs/architecture.md's subscribehandler
  package description and event re-emission section, which described
  a static backend-queue list this service never actually consumed
  from; the real mechanism is pkg/websockhandler's scopeRefCount
  dynamically binding bin-manager.webhook-manager.event.topic per
  client subscription scope
- docs: Annotate the now-superseded VOIP-1407 cutover plan's
  bin-api-manager-survivor assertions (OQ-1, residue sweep checklist)
  as resolved by this ticket