### PR TITLE
VOIP-1431-verify-scoperefcount-amqp-channel-safety

### DIFF
--- a/bin-api-manager/pkg/websockhandler/scoperefcount.go
+++ b/bin-api-manager/pkg/websockhandler/scoperefcount.go
@@ -32,13 +32,20 @@ func newScopeRefCount(sock sockhandler.SockHandler, queueName string, exchangeNa
 // Acquire increments the refcount for the given binding pattern, binding the queue on the
 // first (0->1) transition.
 //
-// OPEN QUESTION (VOIP-1431): this QueueBind runs at an arbitrary runtime moment (whenever a
-// client subscribes), against the same queue that pkg/subscribehandler's ConsumeMessage is
-// actively consuming from. QueueBind and an in-flight basic.consume share one AMQP channel per
-// queue; a historically-documented (now-removed, VOIP-1425) comment warned that calling
-// QueueBind AFTER a consumer starts on that channel can race the broker and 503 the channel
-// closed (reproduced in bin-agent-manager production, 2026-07-14). Whether that hazard applies
-// here too, or the client library serializes it safely, is unconfirmed -- see VOIP-1431.
+// RESOLVED (VOIP-1431): this QueueBind runs at an arbitrary runtime moment (whenever a client
+// subscribes), against the same queue that pkg/subscribehandler's ConsumeMessage is actively
+// consuming from -- the same hazard class as a historically-documented (now-removed, VOIP-1425)
+// comment that warned about a 2026-07-14 bin-agent-manager production incident. Confirmed real:
+// amqp091-go v1.10.0's Channel.QueueBind/QueueUnbind/Consume/Qos all route through an internal,
+// unlocked call() helper sharing one un-correlated reply channel per *amqp.Channel, so two of
+// them running concurrently on the same channel can cross-deliver replies (see
+// docs/plans/2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md for the full
+// investigation, including an open upstream issue confirming this in the library itself).
+// Fixed at the rabbitmqhandler level, not here: QueueBind/QueueUnbind
+// (bin-common-handler/pkg/rabbitmqhandler/queue.go) now issue their AMQP calls on a dedicated,
+// short-lived channel instead of the queue's long-lived consuming channel, so this call no
+// longer shares a channel with anything ConsumeMessage/Qos/Consume is doing. See
+// docs/plans/2026-09-01-voip-1431-amqp-channel-race-design.md for the fix design.
 func (r *scopeRefCount) Acquire(pattern string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/bin-common-handler/pkg/rabbitmqhandler/main.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/main.go
@@ -48,15 +48,48 @@ type amqpChannel interface {
 	QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error)
 	ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
 	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	// PublishWithContext is required by publishExchange/RequestPublish/publishRPCErrorResponse
+	// (consume.go, publish.go), which all open a channel via amqpConnection.Channel() and
+	// publish on it. Added alongside the VOIP-1431 widening of amqpConnection.Channel()'s
+	// return type from *amqp.Channel to amqpChannel -- see realConnection below.
+	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 }
 
 // amqpConnection is an interface for amqp.Connection operations.
 // This interface enables testing by allowing mock implementations.
-// *amqp.Connection implicitly satisfies this interface.
+// *amqp.Connection does NOT implicitly satisfy this interface as of VOIP-1431 -- Channel()
+// returns amqpChannel (not the concrete *amqp.Channel) so that QueueBind/QueueUnbind's
+// dedicated-channel fix (queue.go) can be exercised against a mock connection/channel pair in
+// tests. Go has no return-type covariance, so *amqp.Connection's concrete
+// `Channel() (*amqp.Channel, error)` no longer matches this signature -- realConnection below is
+// the adapter that bridges the two. See docs/plans/2026-09-01-voip-1431-amqp-channel-race-design.md
+// for the full rationale, including why this widening is a deliberate choice (to make the
+// "QueueBind/QueueUnbind don't touch queue.channel" structural property unit-testable) rather
+// than something the underlying race fix strictly requires.
 type amqpConnection interface {
-	Channel() (*amqp.Channel, error)
+	Channel() (amqpChannel, error)
 	Close() error
 	NotifyClose(receiver chan *amqp.Error) chan *amqp.Error
+}
+
+// realConnection adapts *amqp.Connection to amqpConnection's Channel() signature. Close() and
+// NotifyClose() are inherited via embedding since *amqp.Connection's own signatures for those
+// already match amqpConnection unchanged.
+type realConnection struct {
+	*amqp.Connection
+}
+
+// Channel opens a new channel and returns it as the amqpChannel interface. On error, returns an
+// explicit nil interface -- not a typed-nil *amqp.Channel boxed into amqpChannel -- as
+// defensive practice for any future caller that doesn't check err before consulting the channel
+// (amqp091-go's own Connection.Channel() never actually returns a non-nil channel alongside a
+// non-nil error, so this isn't fixing a currently-reachable bug in this package's own callers).
+func (rc *realConnection) Channel() (amqpChannel, error) {
+	ch, err := rc.Connection.Channel()
+	if err != nil {
+		return nil, err
+	}
+	return ch, nil
 }
 
 // rabbit struct for rabbitmq
@@ -218,7 +251,16 @@ func (r *rabbit) connect() {
 			time.Sleep(time.Second * 1)
 			continue
 		}
-		r.connection = conn
+
+		// r.connection is read from arbitrary caller goroutines via connectionGet()
+		// (VOIP-1431's QueueBind/QueueUnbind, in particular, called from scopeRefCount at
+		// arbitrary runtime moments). connect() itself is only ever invoked sequentially
+		// (Connect() calls it once synchronously before spawning reconnector(); reconnector()
+		// calls it one error at a time from its own single goroutine), so this lock protects
+		// the write against those other readers, not against connect() re-entering itself.
+		r.mu.Lock()
+		r.connection = &realConnection{conn}
+		r.mu.Unlock()
 
 		// set error channel
 		r.errorChannel = make(chan *amqp.Error)
@@ -227,6 +269,21 @@ func (r *rabbit) connect() {
 		log.Debug("Connection established to rabbitmq.")
 		return
 	}
+}
+
+// connectionGet returns the current AMQP connection under a read lock. Pairs with connect()'s
+// locked write above -- a read-side-only lock against an unlocked writer provides no
+// synchronization at all. Used by QueueBind/QueueUnbind (queue.go), which read r.connection from
+// arbitrary caller goroutines; this keeps that read from becoming a race in the same goroutine
+// pairing (scopeRefCount vs. the reconnector() goroutine) VOIP-1431 exists to fix. The package's
+// other nine callers of r.connection -- publishExchange, RequestPublish, executeConsumeRPC,
+// publishRPCErrorResponse, ExchangeDeclare, QueueDeclare, checkConnection, Close(), and
+// healthChecker() -- still read the field directly, not through this accessor; that remains a
+// separate, pre-existing, out-of-scope data race (see the design doc).
+func (r *rabbit) connectionGet() amqpConnection {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.connection
 }
 
 // checkConnection probes the RabbitMQ connection by opening and closing a channel.

--- a/bin-common-handler/pkg/rabbitmqhandler/main_test.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/main_test.go
@@ -1,5 +1,14 @@
 package rabbitmqhandler
 
+// Note on realConnection (main.go): its Channel() method has no direct unit test in this file.
+// &realConnection{nil} nil-panics on the embedded *amqp.Connection.Channel() call (traced
+// through amqp091-go's openChannel()/allocateChannel(), which unconditionally locks the
+// receiver), so exercising it requires a real *amqp.Connection -- i.e. a real or fake broker,
+// not something this package's mock-based unit tests can construct. Its explicit-nil-on-error
+// behavior is covered by code review instead (VOIP-1431 design doc §4); the property it exists
+// to protect (checkConnection's `if ch != nil` check) is exercised indirectly by every test that
+// constructs a *rabbit with a mockConnection and calls checkConnection/healthChecker.
+
 import (
 	"context"
 	"errors"
@@ -33,8 +42,9 @@ type mockChannel struct {
 	qosPrefetchSize  int
 	qosGlobal        bool
 
-	mu                 sync.Mutex // guards queueBindCallCount for concurrent-access tests (VOIP-1258)
-	queueBindCallCount int         // VOIP-1258: counts QueueBind invocations, used to verify redeclareAll restores ALL tracked binds
+	mu                   sync.Mutex // guards queueBindCallCount/queueUnbindCallCount for concurrent-access tests (VOIP-1258/VOIP-1431)
+	queueBindCallCount   int        // VOIP-1258: counts QueueBind invocations, used to verify redeclareAll restores ALL tracked binds
+	queueUnbindCallCount int        // VOIP-1431: QueueBind's counter had no QueueUnbind counterpart; added for parity
 
 	// VOIP-1258 Task 1.4: captures ExchangeDeclare's actual call args for assertions.
 	exchangeDeclareName    string
@@ -77,7 +87,14 @@ func (m *mockChannel) QueueBind(name, key, exchange string, noWait bool, args am
 }
 
 func (m *mockChannel) QueueUnbind(name, key, exchange string, args amqp.Table) error {
+	m.mu.Lock()
+	m.queueUnbindCallCount++
+	m.mu.Unlock()
 	return m.queueUnbindErr
+}
+
+func (m *mockChannel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
+	return nil
 }
 
 func (m *mockChannel) QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error) {
@@ -102,11 +119,13 @@ func (m *mockChannel) QueueDeclare(name string, durable, autoDelete, exclusive, 
 
 // mockConnection is a mock implementation of amqpConnection for testing
 type mockConnection struct {
-	channelFunc    func() (*amqp.Channel, error)
-	channelErr     error
-	closeCalled    int
-	closeErr       error
-	notifyCloseCh  chan *amqp.Error
+	channelFunc   func() (amqpChannel, error)
+	channelErr    error
+	closeCalled   int
+	closeErr      error
+	notifyCloseCh chan *amqp.Error
+
+	mu             sync.Mutex // guards channelCallCnt for concurrent-access tests (VOIP-1431)
 	channelCallCnt int
 }
 
@@ -116,16 +135,21 @@ func newMockConnection() *mockConnection {
 	}
 }
 
-func (m *mockConnection) Channel() (*amqp.Channel, error) {
+// Channel returns, in priority order: channelFunc's result if set, channelErr as an error if
+// set, or otherwise a fresh working mock channel (VOIP-1431: this used to default to (nil, nil)
+// -- callers that need that exact "success but no channel" case, or a specific mock channel to
+// assert against, should set channelFunc explicitly rather than relying on this default).
+func (m *mockConnection) Channel() (amqpChannel, error) {
+	m.mu.Lock()
 	m.channelCallCnt++
+	m.mu.Unlock()
 	if m.channelFunc != nil {
 		return m.channelFunc()
 	}
 	if m.channelErr != nil {
 		return nil, m.channelErr
 	}
-	// Return nil channel - tests should use channelMock directly
-	return nil, nil
+	return newMockChannel(), nil
 }
 
 func (m *mockConnection) Close() error {
@@ -169,6 +193,9 @@ func (m *mockChannelWithConsumeCounter) ExchangeDeclare(name, kind string, durab
 }
 func (m *mockChannelWithConsumeCounter) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
 	return amqp.Queue{Name: name}, nil
+}
+func (m *mockChannelWithConsumeCounter) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
+	return nil
 }
 
 // ============================================================================
@@ -608,11 +635,17 @@ func TestQueueBind_ReturnsErrorForNonExistent(t *testing.T) {
 }
 
 func TestQueueBind_Success(t *testing.T) {
+	// VOIP-1431: QueueBind now issues the bind on a dedicated channel obtained from
+	// r.connection, not queue.channel -- mockCh here stands in for queue.channel (still
+	// required for queueGet's existence check) and is deliberately NOT the channel QueueBind
+	// actually calls; mockConn's default Channel() supplies a separate, working mock channel.
 	mockCh := newMockChannel()
+	mockConn := newMockConnection()
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -635,19 +668,61 @@ func TestQueueBind_Success(t *testing.T) {
 	if r.queueBinds["test-queue"][0].exchange != "test-exchange" {
 		t.Errorf("Expected exchange 'test-exchange', got '%s'", r.queueBinds["test-queue"][0].exchange)
 	}
+	// mockCh (queue.channel) must never see this call -- that's the entire point of the fix.
+	if mockCh.queueBindCallCount != 0 {
+		t.Errorf("Expected QueueBind to NOT touch queue.channel, but it was called %d time(s)", mockCh.queueBindCallCount)
+	}
 }
 
-func TestQueueBind_ReturnsChannelError(t *testing.T) {
-	mockCh := newMockChannel()
-	mockCh.queueBindErr = errors.New("bind failed")
+// TestQueueBind_DoesNotUseQueueChannel pins the structural property VOIP-1431's fix relies on:
+// QueueBind must obtain its channel from the connection, never from the queue's own long-lived
+// channel (which startConsumers's Qos/Consume also uses -- sharing it is exactly the race this
+// fix removes). Asserts on the channel identity actually used, not just the end-state map.
+func TestQueueBind_DoesNotUseQueueChannel(t *testing.T) {
+	queueCh := newMockChannel() // stands in for queue.channel -- must stay untouched
+	connCh := newMockChannel()  // the channel QueueBind should actually call
+	mockConn := newMockConnection()
+	mockConn.channelFunc = func() (amqpChannel, error) { return connCh, nil }
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
+	}
+	r.queues["test-queue"] = &queue{name: "test-queue", channel: queueCh}
+
+	if err := r.QueueBind("test-queue", "key", "exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if queueCh.queueBindCallCount != 0 {
+		t.Errorf("Expected queue.channel.QueueBind to never be called, got %d call(s)", queueCh.queueBindCallCount)
+	}
+	if connCh.queueBindCallCount != 1 {
+		t.Errorf("Expected the connection-provided channel's QueueBind to be called exactly once, got %d", connCh.queueBindCallCount)
+	}
+	if connCh.closeCalled != 1 {
+		t.Errorf("Expected the ephemeral channel to be closed exactly once after use, got %d", connCh.closeCalled)
+	}
+}
+
+func TestQueueBind_ReturnsChannelError(t *testing.T) {
+	// VOIP-1431: the error must be injected on the channel the connection provides -- the
+	// channel QueueBind actually calls post-fix -- not on queue.channel, which QueueBind no
+	// longer touches at all.
+	connCh := newMockChannel()
+	connCh.queueBindErr = errors.New("bind failed")
+	mockConn := newMockConnection()
+	mockConn.channelFunc = func() (amqpChannel, error) { return connCh, nil }
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
-		channel: mockCh,
+		channel: newMockChannel(), // queue.channel: irrelevant to this path post-fix
 	}
 
 	err := r.QueueBind("test-queue", "key", "exchange", false, nil)
@@ -657,16 +732,123 @@ func TestQueueBind_ReturnsChannelError(t *testing.T) {
 	}
 }
 
+// TestQueueBind_ReturnsErrorWhenConnectionClosed covers the new conn == nil branch (§3 of the
+// design doc) -- previously unreachable/untested production behavior.
+func TestQueueBind_ReturnsErrorWhenConnectionClosed(t *testing.T) {
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+		connection: nil,
+	}
+	r.queues["test-queue"] = &queue{name: "test-queue", channel: newMockChannel()}
+
+	err := r.QueueBind("test-queue", "key", "exchange", false, nil)
+
+	if !errors.Is(err, amqp.ErrClosed) {
+		t.Errorf("Expected amqp.ErrClosed, got %v", err)
+	}
+}
+
+// TestQueueBind_IdempotentRebind verifies that binding the same (key, exchange) pair twice
+// does not create a duplicate tracked entry (VOIP-1258 round-1 review, code-quality follow-up:
+// this was the single most novel piece of logic in the diff and had no direct test).
+func TestQueueBind_IdempotentRebind(t *testing.T) {
+	mockCh := newMockChannel()
+	mockConn := newMockConnection()
+
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
+	}
+	r.queues["test-queue"] = &queue{
+		name:    "test-queue",
+		channel: mockCh,
+	}
+
+	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error on first bind, got %v", err)
+	}
+	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
+		t.Fatalf("Expected no error on idempotent re-bind, got %v", err)
+	}
+
+	binds := r.queueBinds["test-queue"]
+	if len(binds) != 1 {
+		t.Fatalf("Expected slice to stay at length 1 after idempotent re-bind, got %d", len(binds))
+	}
+}
+
+// ============================================================================
+// connectionGet() Tests
+// ============================================================================
+
+// Test_connectionGet covers connectionGet() directly: returns nil when unset, returns the set
+// value under a read lock otherwise (VOIP-1431 -- previously untested production code).
+func Test_connectionGet(t *testing.T) {
+	r := &rabbit{}
+	if got := r.connectionGet(); got != nil {
+		t.Errorf("Expected nil for unset connection, got %v", got)
+	}
+
+	mockConn := newMockConnection()
+	r.connection = mockConn
+	if got := r.connectionGet(); got != mockConn {
+		t.Errorf("Expected connectionGet to return the set connection, got %v", got)
+	}
+}
+
+// Test_connectionGet_ConcurrentReadWrite exercises connectionGet() (r.mu.RLock-guarded read)
+// against a repeated, r.mu.Lock-guarded write to r.connection from another goroutine -- the
+// exact same field/lock pair connect()'s locked write (main.go) and QueueBind/QueueUnbind's
+// connectionGet() calls use, isolated from connect()'s own real-Dial retry-loop timing (which
+// makes triggering this scenario through connect() itself impractical to do deterministically
+// at unit-test speed -- see the VOIP-1431 design doc §4). Run with -race.
+//
+// Mutation-tested: temporarily removing the r.mu.Lock()/Unlock() pair around this test's write
+// goroutine (mirroring what an unlocked connect() write would look like) makes `go test -race`
+// report a DATA RACE on this exact test, confirming the lock pairing is what's actually being
+// verified here, not merely absence of a panic.
+func Test_connectionGet_ConcurrentReadWrite(t *testing.T) {
+	r := &rabbit{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// writer: repeatedly replaces r.connection under r.mu.Lock(), mirroring connect()'s
+	// locked assignment.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			r.mu.Lock()
+			r.connection = newMockConnection()
+			r.mu.Unlock()
+		}
+	}()
+
+	// reader: repeatedly reads via connectionGet(), mirroring QueueBind/QueueUnbind.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = r.connectionGet()
+		}
+	}()
+
+	wg.Wait()
+}
+
 // ============================================================================
 // QueueUnbind() Tests
 // ============================================================================
 
 func TestQueueUnbind_Success(t *testing.T) {
 	mockCh := newMockChannel()
+	mockConn := newMockConnection()
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -689,10 +871,12 @@ func TestQueueUnbind_Success(t *testing.T) {
 
 func TestQueueUnbind_KeepsOtherBinds(t *testing.T) {
 	mockCh := newMockChannel()
+	mockConn := newMockConnection()
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -733,16 +917,21 @@ func TestQueueUnbind_ReturnsErrorForNonExistent(t *testing.T) {
 }
 
 func TestQueueUnbind_ReturnsChannelError(t *testing.T) {
-	mockCh := newMockChannel()
-	mockCh.queueUnbindErr = errors.New("unbind failed")
+	// VOIP-1431: inject the error on the connection-provided channel -- QueueUnbind no longer
+	// touches queue.channel.
+	connCh := newMockChannel()
+	connCh.queueUnbindErr = errors.New("unbind failed")
+	mockConn := newMockConnection()
+	mockConn.channelFunc = func() (amqpChannel, error) { return connCh, nil }
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
-		channel: mockCh,
+		channel: newMockChannel(), // queue.channel: irrelevant to this path post-fix
 	}
 
 	err := r.QueueUnbind("test-queue", "key", "exchange", nil)
@@ -751,31 +940,49 @@ func TestQueueUnbind_ReturnsChannelError(t *testing.T) {
 	}
 }
 
-// TestQueueBind_IdempotentRebind verifies that binding the same (key, exchange) pair twice
-// does not create a duplicate tracked entry (VOIP-1258 round-1 review, code-quality follow-up:
-// this was the single most novel piece of logic in the diff and had no direct test).
-func TestQueueBind_IdempotentRebind(t *testing.T) {
-	mockCh := newMockChannel()
+// TestQueueUnbind_DoesNotUseQueueChannel is QueueBind's structural test mirrored for QueueUnbind.
+func TestQueueUnbind_DoesNotUseQueueChannel(t *testing.T) {
+	queueCh := newMockChannel()
+	connCh := newMockChannel()
+	mockConn := newMockConnection()
+	mockConn.channelFunc = func() (amqpChannel, error) { return connCh, nil }
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
-	r.queues["test-queue"] = &queue{
-		name:    "test-queue",
-		channel: mockCh,
+	r.queues["test-queue"] = &queue{name: "test-queue", channel: queueCh}
+	r.queueBinds["test-queue"] = []*queueBind{{name: "test-queue", key: "key", exchange: "exchange"}}
+
+	if err := r.QueueUnbind("test-queue", "key", "exchange", nil); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
-		t.Fatalf("Expected no error on first bind, got %v", err)
+	if queueCh.queueUnbindCallCount != 0 {
+		t.Errorf("Expected queue.channel.QueueUnbind to never be called, got %d call(s)", queueCh.queueUnbindCallCount)
 	}
-	if err := r.QueueBind("test-queue", "routing-key", "test-exchange", false, nil); err != nil {
-		t.Fatalf("Expected no error on idempotent re-bind, got %v", err)
+	if connCh.queueUnbindCallCount != 1 {
+		t.Errorf("Expected the connection-provided channel's QueueUnbind to be called exactly once, got %d", connCh.queueUnbindCallCount)
 	}
+	if connCh.closeCalled != 1 {
+		t.Errorf("Expected the ephemeral channel to be closed exactly once after use, got %d", connCh.closeCalled)
+	}
+}
 
-	binds := r.queueBinds["test-queue"]
-	if len(binds) != 1 {
-		t.Fatalf("Expected slice to stay at length 1 after idempotent re-bind, got %d", len(binds))
+// TestQueueUnbind_ReturnsErrorWhenConnectionClosed mirrors the above for QueueUnbind.
+func TestQueueUnbind_ReturnsErrorWhenConnectionClosed(t *testing.T) {
+	r := &rabbit{
+		queues:     make(map[string]*queue),
+		queueBinds: make(map[string][]*queueBind),
+		connection: nil,
+	}
+	r.queues["test-queue"] = &queue{name: "test-queue", channel: newMockChannel()}
+
+	err := r.QueueUnbind("test-queue", "key", "exchange", nil)
+
+	if !errors.Is(err, amqp.ErrClosed) {
+		t.Errorf("Expected amqp.ErrClosed, got %v", err)
 	}
 }
 
@@ -788,11 +995,18 @@ func TestQueueBind_IdempotentRebind(t *testing.T) {
 // via a live amqp connection, out of scope for this unit test).
 func TestRedeclareAll_RestoresAllBindsForSameQueue(t *testing.T) {
 	mockCh := newMockChannel()
+	// VOIP-1431: QueueBind's call count must now be observed on the connection-provided
+	// channel, not queue.channel -- fix channelFunc to a single shared instance so repeated
+	// QueueBind calls in the replay loop below accumulate on the same counter.
+	connCh := newMockChannel()
+	mockConn := newMockConnection()
+	mockConn.channelFunc = func() (amqpChannel, error) { return connCh, nil }
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		exchanges:  make(map[string]*exchange),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -820,27 +1034,36 @@ func TestRedeclareAll_RestoresAllBindsForSameQueue(t *testing.T) {
 		t.Fatalf("Expected the bind snapshot to contain both tracked binds, got %d", len(bindsCopy))
 	}
 
-	mockCh.queueBindCallCount = 0 // reset so we only observe the replay below
+	connCh.queueBindCallCount = 0 // reset so we only observe the replay below
 	for _, qb := range bindsCopy {
 		if err := r.QueueBind(qb.name, qb.key, qb.exchange, qb.noWait, qb.args); err != nil {
 			t.Fatalf("Expected no error replaying bind %+v, got %v", qb, err)
 		}
 	}
 
-	if mockCh.queueBindCallCount != 2 {
-		t.Fatalf("Expected exactly 2 QueueBind calls when replaying all tracked binds (F2 regression), got %d", mockCh.queueBindCallCount)
+	if connCh.queueBindCallCount != 2 {
+		t.Fatalf("Expected exactly 2 QueueBind calls when replaying all tracked binds (F2 regression), got %d", connCh.queueBindCallCount)
+	}
+	if mockCh.queueBindCallCount != 0 {
+		t.Errorf("Expected queue.channel to never see a QueueBind call, got %d", mockCh.queueBindCallCount)
 	}
 }
 
 // TestQueueBindUnbind_ConcurrentAccess exercises QueueBind/QueueUnbind under concurrent access
 // on the same queue name to validate the mutex actually guards the map/slice mutations
-// (run with -race).
+// (run with -race). Deliberately does NOT fix mockConn's channelFunc to a shared instance --
+// mockConnection.Channel()'s default behavior of returning a fresh mockChannel per call means
+// each goroutine's bind/unbind gets its own channel object, so there is no cross-goroutine
+// channel-state sharing to worry about here; mockConnection.channelCallCnt itself is guarded by
+// its own mutex (VOIP-1431).
 func TestQueueBindUnbind_ConcurrentAccess(t *testing.T) {
 	mockCh := newMockChannel()
+	mockConn := newMockConnection()
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -873,10 +1096,12 @@ func TestQueueBindUnbind_ConcurrentAccess(t *testing.T) {
 
 func TestQueueSubscribe_CallsQueueBind(t *testing.T) {
 	mockCh := newMockChannel()
+	mockConn := newMockConnection()
 
 	r := &rabbit{
 		queues:     make(map[string]*queue),
 		queueBinds: make(map[string][]*queueBind),
+		connection: mockConn,
 	}
 	r.queues["test-queue"] = &queue{
 		name:    "test-queue",
@@ -1198,6 +1423,10 @@ func (m *closedCaptureMockChannel) ExchangeDeclare(name, kind string, durable, a
 
 func (m *closedCaptureMockChannel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error) {
 	return amqp.Queue{Name: name}, nil
+}
+
+func (m *closedCaptureMockChannel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
+	return nil
 }
 
 func Test_queueDeclare_storesArgs(t *testing.T) {
@@ -1599,7 +1828,10 @@ func TestHealthChecker_ExitsWhenClosed(t *testing.T) {
 
 func TestHealthChecker_DoesNotCloseHealthyConnection(t *testing.T) {
 	mockConn := newMockConnection()
-	// channelErr is nil — Channel() returns nil, nil (success)
+	// channelErr and channelFunc are both unset, so Channel() falls through to its default:
+	// a fresh working mock channel, nil error (VOIP-1431 changed this default from (nil, nil)
+	// -- checkConnection's Channel() call below now genuinely opens and closes a channel, same
+	// as the real *amqp.Connection.Channel() would on a healthy connection).
 
 	r := &rabbit{
 		uri:                 "amqp://localhost",

--- a/bin-common-handler/pkg/rabbitmqhandler/mock_rabbitmqhandler.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/mock_rabbitmqhandler.go
@@ -302,6 +302,20 @@ func (mr *MockamqpChannelMockRecorder) ExchangeDeclare(name, kind, durable, auto
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeDeclare", reflect.TypeOf((*MockamqpChannel)(nil).ExchangeDeclare), name, kind, durable, autoDelete, internal, noWait, args)
 }
 
+// PublishWithContext mocks base method.
+func (m *MockamqpChannel) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp091.Publishing) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishWithContext", ctx, exchange, key, mandatory, immediate, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishWithContext indicates an expected call of PublishWithContext.
+func (mr *MockamqpChannelMockRecorder) PublishWithContext(ctx, exchange, key, mandatory, immediate, msg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishWithContext", reflect.TypeOf((*MockamqpChannel)(nil).PublishWithContext), ctx, exchange, key, mandatory, immediate, msg)
+}
+
 // Qos mocks base method.
 func (m *MockamqpChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
 	m.ctrl.T.Helper()
@@ -399,10 +413,10 @@ func (m *MockamqpConnection) EXPECT() *MockamqpConnectionMockRecorder {
 }
 
 // Channel mocks base method.
-func (m *MockamqpConnection) Channel() (*amqp091.Channel, error) {
+func (m *MockamqpConnection) Channel() (amqpChannel, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Channel")
-	ret0, _ := ret[0].(*amqp091.Channel)
+	ret0, _ := ret[0].(amqpChannel)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/bin-common-handler/pkg/rabbitmqhandler/queue.go
+++ b/bin-common-handler/pkg/rabbitmqhandler/queue.go
@@ -19,6 +19,12 @@ func (r *rabbit) queueGet(name string) *queue {
 
 // QueueDelete deletes the queue with given args.
 // returns deleted messages in the queue.
+//
+// Currently unreachable from outside this package (absent from both the Rabbit and SockHandler
+// interfaces) -- not fixed as part of VOIP-1431 for that reason, but it uses queue.channel the
+// same way QueueBind/QueueUnbind used to, and shares the same hazard class: if this is ever
+// wired up to a caller that can run at an arbitrary runtime moment (like scopeRefCount), it
+// should get the same dedicated-channel treatment QueueBind/QueueUnbind now have.
 func (r *rabbit) QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error) {
 	queue := r.queueGet(name)
 	if queue == nil {
@@ -141,6 +147,13 @@ func (r *rabbit) QueueDeclare(name string, durable, autoDelete, exclusive, noWai
 	return nil
 }
 
+// QueueQoS sets the queue's channel prefetch settings.
+//
+// Currently unreachable from outside this package (absent from both the Rabbit and SockHandler
+// interfaces) -- not fixed as part of VOIP-1431 for that reason, but it uses queue.channel the
+// same way QueueBind/QueueUnbind used to, and shares the same hazard class: if this is ever
+// wired up to a caller that can run at an arbitrary runtime moment (like scopeRefCount), it
+// should get the same dedicated-channel treatment QueueBind/QueueUnbind now have.
 func (r *rabbit) QueueQoS(name string, prefetchCount, prefetchSize int) error {
 	q := r.queueGet(name)
 	if q == nil {
@@ -163,13 +176,40 @@ func (h *rabbit) QueueSubscribe(name string, topic string) error {
 // queue name (does not overwrite), so redeclareAll() can restore ALL active bindings after a
 // broker reconnect, not just the most recent one (VOIP-1258 round-1 implementation-plan review
 // finding F2).
+//
+// Issues the bind on a dedicated, short-lived channel (VOIP-1431) rather than the queue's own
+// long-lived channel (queue.channel) -- queue.channel is shared with startConsumers's
+// Qos/Consume, and amqp091-go's Channel.QueueBind/Consume/Qos all route through an internal
+// call() helper with no lock and a single un-correlated reply channel (ch.rpc); calling any two
+// of them concurrently on the same *amqp.Channel can cross-deliver replies. See
+// docs/plans/2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md and
+// docs/plans/2026-09-01-voip-1431-amqp-channel-race-design.md for the full analysis.
+// queue.bind is scoped to the queue, not the issuing channel, so this is semantically identical
+// to binding on queue.channel -- except immediately after a reconnect and before redeclareAll
+// has re-declared this queue, where the old code failed fast (ErrClosed on the dead
+// queue.channel) and this instead issues queue.bind against a queue that may not be re-declared
+// yet on the live connection: benign either way. A durable queue survives the reconnect on the
+// broker side, so the bind succeeds and is then harmlessly re-issued (idempotently, via the
+// tracked-bind-set dedup below) when redeclareAll's own replay runs. A volatile queue
+// (x-expires) may have expired, in which case the broker closes this ephemeral channel with a
+// 404 -- harmless precisely because the channel is ephemeral and nothing else is using it; the
+// caller sees the bind fail, same outcome as today's ErrClosed case, just a different error.
 func (r *rabbit) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
-	queue := r.queueGet(name)
-	if queue == nil {
+	if r.queueGet(name) == nil {
 		return fmt.Errorf("no queue found")
 	}
 
-	if err := queue.channel.QueueBind(name, key, exchange, noWait, args); err != nil {
+	conn := r.connectionGet()
+	if conn == nil {
+		return amqp.ErrClosed
+	}
+	channel, err := conn.Channel()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = channel.Close() }()
+
+	if err := channel.QueueBind(name, key, exchange, noWait, args); err != nil {
 		return err
 	}
 
@@ -191,14 +231,25 @@ func (r *rabbit) QueueBind(name, key, exchange string, noWait bool, args amqp.Ta
 }
 
 // QueueUnbind unbinds queue and exchange with a key, removing the matching entry from the
-// tracked bind set (not the whole map key, unless the set becomes empty).
+// tracked bind set (not the whole map key, unless the set becomes empty). Issues the unbind on
+// a dedicated, short-lived channel for the same reason QueueBind does above -- see that doc
+// comment.
 func (r *rabbit) QueueUnbind(name, key, exchange string, args amqp.Table) error {
-	queue := r.queueGet(name)
-	if queue == nil {
+	if r.queueGet(name) == nil {
 		return fmt.Errorf("no queue found")
 	}
 
-	if err := queue.channel.QueueUnbind(name, key, exchange, args); err != nil {
+	conn := r.connectionGet()
+	if conn == nil {
+		return amqp.ErrClosed
+	}
+	channel, err := conn.Channel()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = channel.Close() }()
+
+	if err := channel.QueueUnbind(name, key, exchange, args); err != nil {
 		return err
 	}
 

--- a/docs/plans/2026-09-01-voip-1431-amqp-channel-race-design.md
+++ b/docs/plans/2026-09-01-voip-1431-amqp-channel-race-design.md
@@ -1,0 +1,523 @@
+# VOIP-1431: Fix scopeRefCount vs. consumer-registration AMQP channel race — design
+
+Builds on the approved issue analysis:
+[2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md](2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md)
+(6 review rounds, 2 consecutive approvals). That document establishes: the hazard is real,
+current, and has two independent trigger windows (broker reconnect; pod startup/restart); the
+root cause is `rabbitmqhandler.QueueBind`/`QueueUnbind` and `startConsumers`'s `Qos`/`Consume`
+sharing one long-lived `*amqp.Channel` (`queue.channel`) with no synchronization, on top of an
+unfixed gap in `amqp091-go` v1.10.0 itself (no lock around `call()`, shared un-correlated
+`ch.rpc` reply channel). This document picks a mechanism and specifies the change.
+
+**Revision note:** round 1 of this document's own review loop found the mechanism choice sound
+but the implementation sketch, test plan, and scope section unimplementable as originally
+written. Round 2 found the round-1 fix itself was unimplementable for a different reason (Go
+has no return-type covariance, so naively widening `amqpConnection.Channel()`'s return type
+breaks `*amqp.Connection`'s implicit satisfaction of that interface — a genuine compile error,
+not caught until round 2) and that the proposed race fix only locked the *read* side while the
+*write* site remained unlocked, which provides zero actual synchronization. Round 3 confirmed
+both of those fixes (the `realConnection` adapter, the locked write) are now correct, but caught
+that the "pre-existing unsynchronized readers of `r.connection`" count — introduced to explain
+scope boundaries — had been wrong twice in a row (five, then six; actually nine), and that a
+stale-test-comment pointer named the wrong test. Both corrected below, along with a factual
+cleanup of the `realConnection` nil-handling rationale (the code was already correct; its stated
+justification wasn't). Round 4 confirmed the corrected count and pointer, but found the "nine"
+count wasn't quite exhaustive either — a 10th `r.connection` access exists at `connect()`'s own
+`NotifyClose` call, genuinely race-free (same-goroutine, reads what it just wrote) but
+unmentioned; added with its exclusion reasoning. Round 5 (a whole-document pass, not a
+narrow recheck) found that §4's test plan had never been revisited after §2/§3 grew across
+rounds 2-4: widening `amqpChannel` breaks three hand-written test mocks that were never told to
+implement the new method, and none of the new production code from those rounds
+(`realConnection`, `connectionGet()`, the locked write in `connect()`) had any test coverage or
+even a `-race` mention, despite the locked write's entire justification being "an unlocked
+version is exactly what `-race` would catch." Also flagged, as a documented trade-off rather than
+a defect: the `amqpChannel` widening this ripple stems from isn't required by the race fix
+itself — only by §4's mock-based structural test — and that trade-off wasn't previously stated.
+All addressed in §2 and §4 below. Round 6 (first APPROVE in this loop) independently re-verified
+every fix against source with no remaining findings beyond one cosmetic §5 wording gap (file
+list not naming `main.go` explicitly, unlike §2's convention) and an inaccurate "this project's
+convention" attribution for the round-trip-testing note (traced to personal working-style
+guidance, not an established in-repo precedent) — both corrected below. Round 6 also gave the
+opinion, not as a blocking finding, that the narrower no-widening variant named in §2 might be
+worth adopting outright given this package's admission-rule blast radius (changes here verify
+across 38 services); left as-is per that round's own framing of it as a legitimate,
+already-transparent implementation-time choice rather than something this design document needs
+to pre-decide.
+
+## 1. Chosen approach: dedicated ephemeral channel for QueueBind/QueueUnbind
+
+Of the two options the analysis left open:
+
+- **Option 1 (mutex serializing queue-channel RPCs)** — rejected. Requires a mutex distinct from
+  `r.mu` (reusing `r.mu` deadlocks — see analysis §7), and even done correctly it serializes
+  every `QueueBind`/`QueueUnbind`/`startConsumers` call across the whole rabbit instance,
+  including unrelated queues, for the lifetime of each network round-trip. Ongoing maintenance
+  cost (a lock-ordering rule future contributors must remember) for a problem that has a
+  structural fix available.
+- **Option 2 (dedicated ephemeral channel for QueueBind/QueueUnbind) — chosen.** Matches this
+  package's own dominant convention (`publishExchange`, `RequestPublish`,
+  `publishRPCErrorResponse`, and `executeConsumeRPC`'s reply-publish path all already
+  open-use-close a throwaway `r.connection.Channel()` per call). `queue.bind`/`queue.unbind` are
+  broker-side operations scoped to the *queue*, not to the *issuing channel* — AMQP does not
+  require the binding channel to be the same channel a consumer later reads from. Binding on a
+  fresh channel is semantically identical to binding on `queue.channel`, and removes the race
+  **by construction**: `QueueBind`/`QueueUnbind` no longer touch `queue.channel` at all, so
+  nothing from that path can contend with `startConsumers`'s `Qos`/`Consume` on it. No lock, no
+  lock-ordering rule, no contention with unrelated queues. (Two concurrent `startConsumers`
+  calls on the *same* queue name — e.g. an overlapping initial `ConsumeMessage` registration and
+  a reconnect-triggered `reconsumerAll` — would still contend with each other on `queue.channel`;
+  that pairing is outside this ticket's two identified trigger windows and not addressed here —
+  see the residual noted at the end of this section.)
+
+### Why this closes both trigger windows with one change
+
+Every caller of `QueueBind`/`QueueUnbind` — every service's startup bind, `redeclareAll`'s
+bind-restoration loop, and `scopeRefCount` — goes through the same
+`rabbitmqhandler.QueueBind`/`QueueUnbind` functions. Moving the network call in those two
+functions off `queue.channel` onto a fresh channel means none of those callers touch
+`queue.channel` any more, for either trigger window:
+
+- **Window (a) — reconnect.** The actual racing pair (correcting an earlier draft of this
+  document, which mis-described `redeclareAll`'s own bind-restoration loop and `reconsumerAll`
+  as the two racing parties — they run sequentially on the same `reconnector()` goroutine and
+  can never race each other) is `scopeRefCount`'s arbitrary-timing `QueueBind`/`QueueUnbind`
+  call racing the `reconnector()` goroutine's `startConsumers`-driven `Qos`/`Consume` on the
+  newly-replaced `queue.channel`. Since `scopeRefCount`'s call no longer touches `queue.channel`
+  post-fix, this pairing is closed.
+- **Window (b) — pod startup.** `scopeRefCount`'s call racing the async `ConsumeMessage`
+  goroutine's `Qos`/`Consume` registration in `subscribehandler.Run()`. Same reasoning, same
+  fix. No separate fix is needed for window (b)'s async dispatch itself — the analysis's §7
+  "make `Run()` synchronous" item is superseded by this fix and is **not** implemented (would
+  add a startup-latency cost for no remaining correctness benefit).
+
+**Known residual, not addressed by this fix:** `QueueDeclare` (on reconnect) closes the
+*previous* `queue.channel` while a concurrent `startConsumers` call may still be mid-`Qos`/
+`Consume` on that same object — e.g. the `reconnector()` goroutine's re-declare racing a
+still-in-flight startup `ConsumeMessage` goroutine from before the reconnect. This is a
+`startConsumers`-vs-`startConsumers`/`QueueDeclare` pairing, not a `QueueBind`-vs-anything
+pairing, so it falls outside both of this ticket's identified trigger windows and outside what
+this fix's mechanism (moving `QueueBind`/`QueueUnbind` off the shared channel) can address. Not
+fixed here; flagged so this document doesn't read as "closes the hazard class," only "closes the
+two windows VOIP-1431 identified."
+
+## 2. Scope
+
+**In scope:**
+- `bin-common-handler/pkg/rabbitmqhandler/main.go`: widen `amqpConnection.Channel()` to return
+  `amqpChannel` (the existing test-seam interface) instead of the concrete `*amqp.Channel`, and
+  add `PublishWithContext` to `amqpChannel`. **Why an adapter is required, not just a signature
+  edit:** the package's doc comment states "`*amqp.Connection` implicitly satisfies this
+  interface" (`main.go:53-55`) — true today, but Go has no return-type covariance, so once
+  `Channel()`'s return type changes to the interface, `*amqp.Connection`'s concrete method
+  `func (c *Connection) Channel() (*Channel, error)` no longer has a matching signature and
+  `*amqp.Connection` stops satisfying `amqpConnection` — `r.connection = conn` at `connect()`
+  (`main.go:221`) would fail to compile. This is resolved with a thin adapter, not by editing the
+  interface alone (see §3 for the exact type). `*amqp.Channel` already implements every method
+  `amqpChannel` needs, including `PublishWithContext` (used by `publish.go` and `consume.go`'s
+  RPC-reply path, both of which already call `r.connection.Channel()` and would need the added
+  method) — the *interface* widening is a pure widen; the *production code* needs the adapter to
+  keep compiling, and the adapter's error path must return an explicit nil interface (not a
+  typed-nil `*amqp.Channel` boxed into `amqpChannel`, which would compare `!= nil` and break
+  `checkConnection`'s existing `if ch != nil { ch.Close() }` check at `main.go:239-241`) — see §3.
+  **Ripple this adds to `main_test.go`, not just `main.go`:** widening `amqpChannel` breaks
+  compilation of every existing implementor of that interface until each gets the new method —
+  three hand-written mock types in `main_test.go` (`mockChannel`, line 16;
+  `mockChannelWithConsumeCounter`, line 142; `closedCaptureMockChannel`, line 1165), each needing
+  a `PublishWithContext(...)` stub. See §4 for the exact list and stub content.
+  **Is the widening actually required by the race fix itself? No — stated explicitly, since it's
+  the single largest source of ripple in this design and was the root cause of two of this
+  document's five review rounds' findings.** `QueueBind`/`QueueUnbind` could instead open their
+  ephemeral channel through the *existing*, un-widened `amqpConnection.Channel()` and use the
+  concrete `*amqp.Channel` it already returns — exactly how `ExchangeDeclare`, `QueueDeclare`,
+  `publishExchange`, and `RequestPublish` already do today, none of which needed any interface
+  change. That smaller variant drops the adapter, the `PublishWithContext` addition, and the
+  three-mock ripple entirely. What it costs: without the widening, `mockConnection.Channel()` can
+  never return a working mock channel (only `(nil, nil)` or an error), so §4's structural
+  regression test — "`QueueBind`/`QueueUnbind` open a channel *different* from `queue.channel`,"
+  the one automated check that the actual fix (not touching the shared channel) is doing what it
+  claims — cannot be written as a unit test; only reachable via the real-broker integration test
+  path (§4's regression-test section, option 1). This design accepts the wider interface and its
+  mock-update cost specifically to make that structural property unit-testable, not because the
+  race fix needs it. If unit-testing that property is judged not worth the ripple at
+  implementation time, the narrower variant (skip the widening, rely solely on the integration
+  test for structural coverage) is a legitimate fallback — noted here so that choice is visible
+  and deliberate, not discovered mid-implementation.
+- Add `connectionGet()` — an `r.mu.RLock()`-guarded accessor for `r.connection` — used in
+  `QueueBind`/`QueueUnbind`, **and** change `connect()`'s write of `r.connection`
+  (`main.go:221`) to take `r.mu.Lock()` around the assignment. **Why the write must be locked
+  too, not just the read:** a read-side lock alone provides no synchronization against an
+  unlocked writer — `go test -race` still flags it, and the goal (closing off the exact
+  goroutine pairing this ticket is about, `scopeRefCount` vs. the `reconnector()` goroutine) is
+  not met by locking only one side. Verified `connect()` is safe to lock: neither `Connect()`
+  (`main.go:147-151`) nor `reconnector()` (`main.go:188-203`) holds `r.mu` when calling
+  `connect()`, so there is no re-entrancy hazard. This makes `r.connection` a genuinely
+  race-free field for the two functions this ticket touches. It does **not** retroactively fix
+  the nine *other* pre-existing unsynchronized readers of `r.connection` — grepped every
+  `r.connection.<method>` call site in the package's non-test files to get an exhaustive count
+  (an earlier draft of this document twice undercounted this, first as five, then as six; both
+  counts were wrong): `publishExchange` (`publish.go:16`), `RequestPublish` (`publish.go:55`),
+  `executeConsumeRPC`'s reply-publish path (`consume.go:307`), `publishRPCErrorResponse`
+  (`consume.go:353`), `ExchangeDeclare` (`exchange.go:11`), `QueueDeclare` (`queue.go:103`),
+  `checkConnection` (`main.go:235`), `Close()` (`main.go:177`), and `healthChecker()`
+  (`main.go:259`). All nine read the field directly without going through `connectionGet()`, and
+  remain a separate, pre-existing, out-of-scope issue (see below). (A tenth read exists at
+  `main.go:225`, `r.connection.NotifyClose(r.errorChannel)` — deliberately excluded from this
+  list, not missed: it's inside `connect()` itself, reading the value `connect()` just wrote at
+  `main.go:221` in the same, single invocation. `connect()` is called only from `Connect()` and
+  `reconnector()`, never concurrently with itself, so this read always happens-after its own
+  write in program order on one goroutine and cannot race — unlike the other nine, which are
+  genuinely different goroutines reading a value some other goroutine last wrote.)
+- `bin-common-handler/pkg/rabbitmqhandler/queue.go`: `QueueBind`, `QueueUnbind` — issue the
+  network call on a fresh channel obtained via `connectionGet().Channel()`, closed after the
+  call, instead of `queue.channel`. The queue-existence check (`queueGet(name) == nil` → `"no
+  queue found"`) stays as-is.
+- `bin-common-handler/pkg/rabbitmqhandler/main_test.go`: update `mockConnection.Channel()` (and
+  its `channelFunc` field type) to return a mock `amqpChannel` (not `nil, nil`), and update every
+  existing `QueueBind`/`QueueUnbind` test (success- and error-path alike) that currently
+  constructs `&rabbit{...}` with `connection: nil` to instead provide a `mockConnection` — see
+  §4 for the specific test inventory affected, including the three that need more than adding a
+  `mockConnection` (their assertions currently target `queue.channel`'s mock, which the new code
+  no longer touches).
+- `bin-api-manager/pkg/websockhandler/scoperefcount.go`: remove the `OPEN QUESTION (VOIP-1431)`
+  doc comment on `Acquire` (lines 35-41) now that the question is answered and fixed; replace
+  with a brief note that the underlying channel-sharing hazard is resolved at the
+  `rabbitmqhandler` level (link to this design doc and the analysis doc), so a future reader
+  isn't left staring at a stale "unconfirmed" marker on the exact file this ticket names.
+
+**Explicitly out of scope (checked against actual usage, not assumed):**
+- `QueueDelete` (`queue.go:22-34`) and `QueueQoS` (`queue.go:144-155`) — confirmed dead code by
+  a stronger argument than a repo-wide grep (which can miss a caller and would decay over time):
+  neither method appears in the `Rabbit` interface (`main.go:17-37`) nor the `SockHandler`
+  interface (`bin-common-handler/pkg/sockhandler/main.go:13-33`), and `rabbit` is an unexported
+  struct that only `NewRabbit` constructs, always returned behind one of those two interfaces —
+  so these two methods are unreachable from outside the package *by construction*, not merely
+  uncalled today. (The same-named `QueueDelete` methods in `bin-api-manager/server/queues.go`
+  and `bin-queue-manager/pkg/queuehandler/db.go` are confirmed-unrelated domain methods: the
+  former proxies an RPC to queue-manager, the latter runs a SQL update — neither touches AMQP.)
+  Documentation-only touch: a one-line comment on each noting they share this hazard class and
+  should get the same treatment if ever wired up — this is an in-scope doc edit, not a "leave
+  entirely alone" item.
+- `subscribehandler.Run()`'s async `ConsumeMessage` dispatch (window (b)'s literal trigger) —
+  superseded per §1 above, not touched.
+- `startConsumers`'s `Qos`/`Consume` calls — stay on `queue.channel` as-is; that's correct and
+  necessary (a consumer must read from the channel it registered on).
+- Any other service's `QueueBind` usage — every other caller in the monorepo calls it
+  synchronously at startup before `ConsumeMessage` starts. Spot-checked beyond the issue
+  analysis's own examples: `bin-campaign-manager/pkg/subscribehandler/main.go:117-128`,
+  `bin-conversation-manager/pkg/subscribehandler/main.go:119-130`, and
+  `bin-number-manager/pkg/subscribehandler/main.go:107-118` (which carries an explicit comment,
+  lines 97-102, that this block "MUST run synchronously here, BEFORE the ConsumeMessage
+  goroutine below") — pattern holds broadly, not just in the cases already checked. They were
+  never actually racing anything; this fix changes `rabbitmqhandler`'s shared implementation, so
+  they get the same channel-isolation for free with zero call-site changes.
+- The nine other pre-existing unsynchronized readers of `r.connection` (`publishExchange`,
+  `RequestPublish`, `executeConsumeRPC`, `publishRPCErrorResponse`, `ExchangeDeclare`,
+  `QueueDeclare`, `checkConnection`, `Close()`, `healthChecker()` — see the exhaustive list with
+  line numbers above) — a real latent data race (flagged by `go test -race` if a reconnect
+  happens to overlap any of them), but it predates this ticket, is not part of the hazard this
+  ticket analyzed, and fixing all nine is a separate, broader cleanup better scoped as its own
+  ticket rather than folded into this one. (Locking `connect()`'s write, per the bullet above,
+  does not fix these nine readers — it only makes the *write* safe; each of these nine would
+  still need to be changed to read through `connectionGet()` to actually benefit.)
+
+## 3. Implementation sketch
+
+```go
+// realConnection adapts *amqp.Connection to amqpConnection's widened Channel() signature
+// (returns amqpChannel, not the concrete *amqp.Channel). Go's interface satisfaction has no
+// return-type covariance, so *amqp.Connection stops satisfying amqpConnection the moment
+// Channel()'s return type widens -- this thin wrapper is the reason a wrapper is needed at all,
+// not an optional convenience. Close() and NotifyClose() are inherited via embedding, since
+// *amqp.Connection's signatures for those already match amqpConnection unchanged.
+type realConnection struct {
+	*amqp.Connection
+}
+
+// Channel opens a new channel and returns it as the amqpChannel interface. On error, returns an
+// explicit nil interface -- NOT a typed-nil *amqp.Channel boxed into amqpChannel. This is
+// defensive rather than fixing a currently-reachable bug: amqp091-go's real
+// Connection.allocateChannel never returns a non-nil channel paired with a non-nil error, and
+// checkConnection's own `if ch != nil` check (main.go:239-241) is unreachable on the error path
+// anyway (it returns on `err != nil` first, main.go:236-238). Kept as good defensive practice
+// for this new adapter regardless -- a future caller of Channel() that doesn't happen to check
+// err first should still get a genuinely nil, not typed-nil, channel back.
+func (rc *realConnection) Channel() (amqpChannel, error) {
+	ch, err := rc.Connection.Channel()
+	if err != nil {
+		return nil, err
+	}
+	return ch, nil
+}
+
+// connectionGet returns the current AMQP connection under a read lock. Pairs with the locked
+// write in connect() below -- a read-side-only lock against an unlocked writer provides no
+// synchronization at all (an earlier draft of this document made exactly that mistake).
+// QueueBind/QueueUnbind read it from arbitrary caller goroutines (VOIP-1431's scopeRefCount, in
+// particular), so this accessor+locked-write pair exists specifically to keep that read/write
+// from becoming a second, narrower version of the very race this ticket fixes. (The package's
+// nine other callers of r.connection -- publishExchange, RequestPublish, executeConsumeRPC,
+// publishRPCErrorResponse, ExchangeDeclare, QueueDeclare, checkConnection, Close(),
+// healthChecker() -- still read the field directly, not through this accessor; that's a
+// separate, pre-existing race, out of scope here; see §2.)
+func (r *rabbit) connectionGet() amqpConnection {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.connection
+}
+
+// connect() (existing function, main.go:206-230) changes only at the assignment:
+//   conn, err := amqp.Dial(r.uri)
+//   ...
+//   r.mu.Lock()
+//   r.connection = &realConnection{conn}
+//   r.mu.Unlock()
+// (was: `r.connection = conn`, unlocked). Safe to lock here: neither Connect() (main.go:147-151)
+// nor reconnector() (main.go:188-203) holds r.mu when calling connect(), so there is no
+// re-entrancy hazard.
+
+// QueueBind binds queue and exchange with a key. Issues the bind on a dedicated,
+// short-lived channel (VOIP-1431) rather than the queue's own long-lived channel
+// (queue.channel) -- queue.channel is shared with startConsumers's Qos/Consume, and
+// amqp091-go's Channel.QueueBind/Consume/Qos all route through an internal call()
+// helper with no lock and a single un-correlated reply channel (ch.rpc); calling any
+// two of them concurrently on the same *amqp.Channel can cross-deliver replies. See
+// docs/plans/2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md for the full
+// analysis. queue.bind is scoped to the queue, not the issuing channel, so this is
+// semantically identical to binding on queue.channel -- except immediately after a
+// reconnect and before redeclareAll has re-declared this queue, where the old code
+// failed fast (ErrClosed on the dead queue.channel) and the new code instead issues
+// queue.bind against a queue that may not be re-declared yet on the live connection:
+// benign either way. A durable queue survives the reconnect on the broker side, so the
+// bind succeeds and is then harmlessly re-issued (idempotently, see the existing
+// tracking-map dedup below) when redeclareAll's own replay runs. A volatile queue
+// (x-expires) may have expired, in which case the broker closes THIS ephemeral channel
+// with a 404 -- harmless precisely because the channel is ephemeral and nothing else is
+// using it; the caller sees the bind fail, same outcome as today's ErrClosed case, just
+// with a different error type.
+func (r *rabbit) QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error {
+	if r.queueGet(name) == nil {
+		return fmt.Errorf("no queue found")
+	}
+
+	conn := r.connectionGet()
+	if conn == nil {
+		return amqp.ErrClosed // mirrors the prior behavior's implicit "no connection" failure mode; amqp091-go's own sentinel, already imported in this package
+	}
+	channel, err := conn.Channel()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = channel.Close() }()
+
+	if err := channel.QueueBind(name, key, exchange, noWait, args); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, b := range r.queueBinds[name] {
+		if b.key == key && b.exchange == exchange {
+			return nil
+		}
+	}
+	r.queueBinds[name] = append(r.queueBinds[name], &queueBind{
+		name: name, key: key, exchange: exchange, noWait: noWait, args: args,
+	})
+	return nil
+}
+```
+
+`QueueUnbind` gets the mirror-image change (dedicated channel for `channel.QueueUnbind`, same
+`connectionGet()` use, same tracking-map update as today).
+
+Notes:
+- The existence check now uses `r.queueGet(name) == nil` directly rather than keeping the
+  `*queue` struct around — the old code used `queue.channel` for the network call, so it needed
+  the full struct; the new code only needs to know a queue entry exists, since the bind itself
+  goes on a brand-new channel unrelated to `queue.channel`.
+- The `conn == nil` branch returns an error, not a panic — `queueGet` and `connectionGet` are
+  both plain accessors, and this whole path is a normal early-return, never a nil-pointer
+  dereference. (An earlier draft of this document's own test plan incorrectly described the
+  pre-fix version of the affected tests as panicking under this code; corrected in §4.)
+- In current production usage `r.connection` is never nil by the time any `queueGet(name) !=
+  nil` check passes (a queue entry only exists after `QueueDeclare` succeeded, which requires a
+  connection) — the `conn == nil` branch above is defensive, not a case expected to trigger in
+  practice, and exists to give an explicit, named failure mode (`amqp.ErrClosed`, already
+  imported in this package via `queue.go`'s `amqp` import — no new sentinel needed) rather than
+  a nil-pointer panic if that invariant is ever violated.
+- `amqp091-go`'s channel-ID allocator (`Connection.allocateChannel`/`releaseChannel`) is itself
+  mutex-protected and IDs are released on `Close()`, so opening/closing many short-lived
+  channels concurrently (bounded here by `scopeRefCount`'s own serializing mutex, and by
+  `redeclareAll`'s sequential bind-restoration loop) has no exhaustion or leak risk at this
+  volume.
+
+## 4. Test plan
+
+- **Prerequisite, compile-breaking if skipped: stub `PublishWithContext` on every existing
+  `amqpChannel` implementor.** Widening the interface (§2) breaks compilation of every mock that
+  implements it until each gets the new method. Three in `main_test.go`: `mockChannel` (line 16),
+  `mockChannelWithConsumeCounter` (line 142), `closedCaptureMockChannel` (line 1165). Each needs
+  a `PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg
+  amqp.Publishing) error` method — a plain no-op returning `nil` is sufficient unless a specific
+  test needs to assert on it. Note `mock_rabbitmqhandler.go`'s generated mocks
+  (`MockamqpChannel`/`MockamqpConnection`, from `//go:generate mockgen ... -source ./main.go` at
+  `main.go:3`) are regenerated by `go generate ./...`, not hand-edited — the "full verification
+  workflow" bullet below already runs this, but call it out here since it's the step that
+  resolves this specific ripple for the generated mocks (the three hand-written ones above still
+  need manual stubs).
+- **Enable mocked channel coverage (prerequisite, see §2):** update `mockConnection.Channel()`
+  in `main_test.go` to return a working mock `amqpChannel` (not `nil, nil`) — this requires
+  changing `mockConnection.channelFunc`'s field type from `func() (*amqp.Channel, error)` to
+  `func() (amqpChannel, error)`, not just the return statement, since the field type is exported
+  through the whole mock. **Ripple effect to account for, not just the field itself:** the
+  default `channelFunc` currently returns `(nil, nil)`. `TestCheckConnection_ReturnsNilOnSuccess`
+  (`main_test.go:1517-1532`) only asserts on `mockConn.channelCallCnt`, so it's unaffected. The
+  test that actually depends on and documents the `(nil, nil)` default is
+  `TestHealthChecker_DoesNotCloseHealthyConnection` (`main_test.go:1600-1602`, comment: "//
+  channelErr is nil — Channel() returns nil, nil (success)") — once the default returns a
+  working mock channel instead, this test will actually invoke `Close()` on it; confirm the
+  mock's `Close()` is a safe no-op (it already is, per the existing mock's pattern) and update
+  this test's stale comment. Sweep for any other test relying on the same `(nil, nil)` default
+  before assuming only these two are affected.
+- **Existing-test inventory that breaks under this change, confirmed by name (verified against
+  the current file, not assumed):** every test below constructs `&rabbit{...}` with `connection`
+  left as the zero value and exercises `QueueBind`/`QueueUnbind`. Once those functions call
+  `connectionGet().Channel()`, `connectionGet()` returns a nil `amqpConnection` and `QueueBind`/
+  `QueueUnbind` correctly return `amqp.ErrClosed` per §3 (an early, incorrect draft of this plan
+  said these tests would panic — they fail with an unexpected error instead, which is what
+  needs fixing test-by-test):
+  - `TestQueueBind_Success`, `TestQueueUnbind_Success`, `TestQueueUnbind_KeepsOtherBinds`,
+    `TestQueueBind_IdempotentRebind`, `TestQueueSubscribe_CallsQueueBind` — add a
+    `mockConnection` whose `channelFunc` returns a working mock channel; no other change needed,
+    since these tests only assert on the tracking-map outcome, not on which channel object was
+    used.
+  - `TestQueueBind_ReturnsChannelError` and `TestQueueUnbind_ReturnsChannelError` — need **more
+    than adding a `mockConnection`**: today they inject `queueBindErr`/`queueUnbindErr` on the
+    mock channel stored as `queue.channel`, which the new code never calls. The error must be
+    injected on the mock channel returned by the new `mockConnection`'s `channelFunc` instead, or
+    the test passes vacuously without exercising the intended error path.
+  - `TestRedeclareAll_RestoresAllBindsForSameQueue` (the VOIP-1258 finding-F2 regression test) —
+    same relocation problem: it currently asserts `mockCh.queueBindCallCount == 2` against
+    `queue.channel`'s mock; post-fix that counter stays 0 on the old target. Move the assertion
+    to the new connection-provided channel's call count, or this regression test silently stops
+    testing anything.
+  - `TestQueueBindUnbind_ConcurrentAccess` — add a `mockConnection`. The new concurrency hazard
+    this introduces is in the **connection** mock, not the channel mock: `mockConnection.Channel()`
+    (`main_test.go:119-129`) does an unguarded `m.channelCallCnt++`, and post-fix every one of
+    this test's concurrent goroutines calls it — that counter needs the same kind of guard
+    `mockChannel.queueBindCallCount` already has (`main_test.go:36-37`; note the rest of
+    `mockChannel`, including `mockChannel.Close()`'s `m.closeCalled++`, is *not* guarded either,
+    and matters if a single shared channel instance is returned across calls rather than a fresh
+    one per call — pick whichever matches this file's existing pattern, per the note below, and
+    guard whatever ends up shared).
+- **`mockChannel` gap to fill:** `mockChannel.QueueUnbind` currently has no call counter (unlike
+  `QueueBind`, which does) — add one, since the new "different channel instance" assertion below
+  needs it for `QueueUnbind` parity with `QueueBind`.
+- **New coverage confirming the structural fix:** with the mock now capable of it, add a case
+  asserting `QueueBind`/`QueueUnbind` invoke `Channel()` on the mock **connection** to obtain a
+  **different** mock channel instance than the one already registered as `queue.channel` for
+  that queue — this pins "does not touch `queue.channel`" directly, which is the actual
+  structural property this fix relies on.
+- **Coverage for the new production code itself (§2/§3), not just `QueueBind`/`QueueUnbind`'s use
+  of it** — an earlier draft of this test plan covered the refactored functions but never
+  circled back to test the pieces §2/§3 added along the way:
+  - `connectionGet()` and the new `conn == nil → amqp.ErrClosed` branch in `QueueBind`/
+    `QueueUnbind` — trivially unit-testable: construct `&rabbit{}` with `connection` left nil,
+    call `connectionGet()` directly and assert it returns nil, then call `QueueBind`/`QueueUnbind`
+    and assert `amqp.ErrClosed` specifically (not just "some error") — this is new production
+    behavior with no prior test coverage at all.
+  - `realConnection.Channel()`'s explicit-nil-on-error behavior — genuinely hard to unit test
+    (`&realConnection{nil}` nil-panics on the embedded call, confirmed by tracing
+    `*amqp.Connection.Channel()` → `openChannel()` → `allocateChannel()`, which unconditionally
+    takes a mutex on the receiver; a working test needs a real `*amqp.Connection`, which needs a
+    real or fake broker). State explicitly, in the test file, why round-trip testing wasn't
+    performed here, rather than silently having zero coverage on this exact function — code
+    review is the fallback verification for this one method.
+  - **The locked write in `connect()` — this is the change with the least test coverage relative
+    to how central it is to this ticket's correctness claim, and needs explicit attention, not a
+    silent gap.** Its entire justification (§2/§3) is "a read-only lock alone provides no
+    synchronization; `go test -race` still flags it" — so `-race` coverage of this exact path
+    must appear somewhere in this plan, and as of this revision it didn't. Add `-race` to the
+    verification workflow below. Whether a *targeted* test can be written that fails under
+    `-race` on the pre-fix (unlocked-write) code and passes on the post-fix code — mirroring this
+    project's mutation-testing convention (deliberately revert the lock, confirm the race
+    detector catches it, then restore) — depends on whether a test can reliably force `connect()`
+    and a `QueueBind`/`QueueUnbind` call to overlap in a bounded amount of test time; `connect()`
+    loops on `amqp.Dial` with a 1s retry sleep and blocks until success, which makes deterministic
+    overlap hard to engineer at unit-test speed. If a reliable trigger can't be found within
+    reasonable effort, this is a case for the same real-broker integration test path as the
+    regression test below, not a silent skip — decide and document at implementation time, don't
+    leave `-race` as the only signal.
+- **Regression test for the real AMQP-level race** (the point of this ticket, not just the
+  refactor): a mocked-channel unit test cannot exercise real AMQP RPC-reply cross-delivery —
+  that requires two genuinely concurrent `call()`-style RPCs on one real `*amqp.Channel`, which
+  needs a real (or realistically-behaving fake) broker connection, not a mock. This is
+  necessarily a "prove the bug existed, prove this class of fix prevents it" test, not a
+  mocked-unit-test target. Options, in preference order, to finalize at implementation time:
+  1. A focused integration test against a real RabbitMQ instance (check whether existing test
+     infra in this repo already provides one for `bin-common-handler`, or for another service,
+     before assuming none exists), spawning a goroutine that hammers `QueueBind`/`QueueUnbind`
+     while another goroutine runs `ConsumeMessage`, asserting no error and no missed messages
+     across N iterations — and, if run against the pre-fix code first, confirming it actually
+     fails there (proves the test has real detection power, per this project's mutation-testing
+     convention).
+  2. If no real-broker test infra exists anywhere in the repo, document that gap explicitly
+     rather than silently shipping without it — do not substitute a mocked test and imply it
+     covers the race; a mocked test can only cover the structural refactor (bullet above), never
+     the race itself.
+- **Full verification workflow** (mandatory, root CLAUDE.md): `go mod tidy && go mod vendor &&
+  go generate ./... && go test ./... && golangci-lint run -v --timeout 5m` in
+  `bin-common-handler`, plus a build check (`go build ./...`) in every consumer service to catch
+  any interface-signature drift (the exported `Rabbit`/`SockHandler` interfaces are unchanged;
+  only the unexported `amqpConnection`/`amqpChannel` test seams widen, so no consumer-service
+  build should be affected — verify this holds rather than assuming it). **Additionally run
+  `go test -race ./pkg/rabbitmqhandler/...`** — not covered by the plain `go test ./...` above,
+  and specifically relevant here since the locked write in `connect()` (§2/§3) exists precisely
+  because a race detector would flag its absence; this package's own tests (starting with
+  `TestQueueBindUnbind_ConcurrentAccess`) should run clean under `-race` after this change.
+
+## 5. Risk / rollback
+
+- **Behavior change risk:** low, with one explicitly-analyzed exception. Steady-state
+  bind/unbind semantics on the broker are unchanged (same queue, same key, same exchange); only
+  the AMQP channel used to issue it changes, which is not wire-visible to any consumer. The one
+  analyzed exception is the reconnect-window timing change noted in §3's `QueueBind` doc comment
+  above (old: fails fast with `ErrClosed` on the dead channel; new: attempts the bind on the
+  live connection, which may race `redeclareAll`'s own re-declare of the same queue) — assessed
+  benign in both outcomes, but a real behavior change inside the exact window this ticket
+  targets, not asserted away as "identical."
+- **New-race risk:** addressed directly via `connectionGet()` (§2/§3) rather than left as a gap
+  — without it, this change would trade the ticket's original race for a narrower one on
+  `r.connection` in the same goroutine pairing.
+- **Performance:** two extra synchronous round-trips per `QueueBind`/`QueueUnbind` call (channel
+  open, and channel close — `Channel.Close()` is itself a synchronous RPC waiting for
+  `channel.close-ok`, not fire-and-forget). For `scopeRefCount`, this is per websocket
+  subscribe/unsubscribe transition — already a much heavier operation (HTTP upgrade, auth) than
+  two extra AMQP round-trips, so not expected to be observable. For the reconnect path
+  (`redeclareAll`'s bind-restoration loop), this adds a channel open/close pair per
+  previously-tracked bind being restored — reconnects are rare and this runs once per reconnect,
+  not on any hot path.
+- **Rollback:** the `rabbitmqhandler` package changes — `main.go` (the `realConnection` adapter,
+  `connectionGet()`, the locked write, the widened `amqpConnection`/`amqpChannel` interfaces),
+  `queue.go` (`QueueBind`/`QueueUnbind`), and `main_test.go` (the three mock updates plus new
+  test cases) — are a single, self-contained commit with no schema/API changes to the *exported*
+  `Rabbit`/`SockHandler` interfaces; revert if an issue surfaces. The `scoperefcount.go` comment
+  update is documentation-only and has no functional rollback concern.
+
+## 6. Open items resolved from the analysis's §7
+
+- Mechanism: dedicated channel (Option 2), decided above.
+- `QueueDelete`/`QueueQoS`: confirmed dead code (by interface-absence, not just grep), left out
+  of scope with a comment (§2 above).
+- `subscribehandler.Run()` synchronization: not needed, superseded by this fix (§1 above).
+- Full 2-day production log sweep: not needed to proceed — the fix is a structural elimination
+  of the race, not conditional on how often it has historically fired.
+- (New, surfaced during this document's own review) The `r.connection` unsynchronized-read risk
+  this design would otherwise have introduced: resolved via `connectionGet()` paired with a
+  locked write in `connect()` (a read-only lock alone does not synchronize anything), scoped to
+  the two functions this ticket touches; the nine pre-existing readers (§2 has the exhaustive,
+  line-numbered list — this count was wrong twice before landing on nine) are explicitly left as
+  a separate, out-of-scope, pre-existing issue rather than silently expanded into.
+- (New) The `amqpConnection.Channel()` interface widening requires a `realConnection` adapter
+  around `*amqp.Connection` — Go has no return-type covariance, so the interface change alone
+  does not compile without it. Specified in §3.

--- a/docs/plans/2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md
+++ b/docs/plans/2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md
@@ -1,0 +1,235 @@
+# VOIP-1431: scopeRefCount runtime QueueBind/Unbind vs. AMQP channel safety — issue analysis
+
+**Status:** Issue confirmed valid and current. Root cause identified and verified against
+library source, an authoritative upstream issue, and production logs. Two independent trigger
+windows identified (§4) — round-1 review of this document caught that an earlier draft
+described only one and incorrectly claimed no race exists outside it; corrected. Round-3 review
+caught that an earlier draft's §6/§7 named a specific fix mechanism that actually deadlocks;
+corrected to leave mechanism selection to the design stage, with the deadlock noted as a
+constraint on option 1. Round-4 review caught that §7's precedent for the dedicated-channel
+option mischaracterized `ExchangeDeclare`/`QueueDeclare` as "ephemeral" when they actually open
+a channel and keep it open indefinitely (that kept-open channel *is* `queue.channel`); corrected
+to cite only the genuinely ephemeral precedents and describe Declare separately. No fix
+implemented yet — this document is the analysis stage only, per the mandatory review workflow.
+
+## 1. Issue validity re-check
+
+The ticket's own background (a pre-existing warning comment, deleted by VOIP-1425, describing a
+2026-07-14 production incident on bin-agent-manager) already established that concurrent
+QueueBind against an actively-consuming channel is a real hazard *somewhere* in this codebase.
+The open question was narrower: does it still apply to `scopeRefCount`'s specific usage
+(runtime QueueBind/Unbind driven by websocket subscribe/unsubscribe), and if so, under what
+conditions.
+
+**Re-confirmed as still valid** — see §3 for the verified mechanism and §4 for the precise
+trigger window in this codebase's current state (re-read directly from source, not assumed
+from the ticket description).
+
+## 2. Code re-inspected
+
+- `bin-api-manager/pkg/websockhandler/scoperefcount.go` — `Acquire`/`Release`, both under
+  `scopeRefCount.mu`.
+- `bin-api-manager/pkg/websockhandler/main.go:33-53` — confirms `scopeRefCount` is **one
+  instance shared across all websocket connections on a pod** (explicit comment on the struct
+  field), not per-connection.
+- `bin-common-handler/pkg/rabbitmqhandler/queue.go` — `QueueBind`/`QueueUnbind`: call
+  `queue.channel.QueueBind`/`QueueUnbind` directly; `r.mu` (the rabbit struct's own mutex) is
+  only taken *after* the network call succeeds, to update the Go-level tracking map
+  (`r.queueBinds`) — it does **not** protect the network call itself.
+- `bin-common-handler/pkg/rabbitmqhandler/consume.go` — `startConsumers`: calls
+  `queue.channel.Qos(...)` then `queue.channel.Consume(...)` on the **same** `*amqp.Channel`
+  object, once at initial registration and again on every reconnect via `redeclareAll()` →
+  `reconsumerAll()` → `startConsumers()`.
+- `bin-common-handler/pkg/rabbitmqhandler/main.go` — `redeclareAll()` (runs on the
+  `reconnector()` goroutine after a broker reconnect): re-declares each queue (opens a **new**
+  `*amqp.Channel`, replacing `r.queues[name].channel`), then loops over previously-tracked
+  binds calling `r.QueueBind(...)` for each (restoring prior bindings), then calls
+  `reconsumerAll()` which re-registers `Qos`/`Consume` on that same new channel.
+
+## 3. Root cause, verified against library source (not assumed)
+
+Pinned version: `github.com/rabbitmq/amqp091-go v1.10.0` (`bin-common-handler/go.mod`). Read
+directly from `$(go env GOPATH)/pkg/mod/github.com/rabbitmq/amqp091-go@v1.10.0/channel.go`:
+
+- `Channel.QueueBind`, `QueueUnbind`, `Consume`, `Qos`, `ExchangeDeclare` all route through the
+  internal `ch.call(req, res)` helper, which does `ch.send(req)` then blocks reading **one**
+  message off `ch.rpc` — a single, un-buffered, per-Channel reply channel shared by every
+  in-flight synchronous RPC on that Channel.
+- `ch.dispatch()`'s `default:` case pushes **any** non-content, non-delivery reply frame
+  (`queueBindOk`, `queueUnbindOk`, `basicConsumeOk`, `basicQosOk`, etc.) onto that same
+  `ch.rpc`, with no per-request correlation ID — `call()` matches purely by Go type via
+  `reflect.TypeOf`.
+- Only `Ack`, `Nack`, `Reject`, and `PublishWithDeferredConfirm` take `ch.m.Lock()` before
+  calling `send()`. `QueueBind`/`QueueUnbind`/`Consume`/`Qos` take **no lock at all** — grepped
+  every `ch.m.Lock()` call site in `channel.go` to confirm this is exhaustive, not an
+  oversight in reading.
+- `Connection.send()` **does** hold a write mutex (`c.sendM`) around the raw frame write, so
+  concurrent calls cannot corrupt the wire byte stream itself — but that only serializes the
+  *writes*; it does nothing to prevent two concurrent `call()` invocations from each reading
+  the *other's* reply off the shared `ch.rpc`.
+
+**Net effect:** two goroutines calling any two of {QueueBind, QueueUnbind, Consume, Qos,
+ExchangeDeclare, QueueDeclare} concurrently on the *same* `*amqp.Channel` can cross-deliver
+replies — one goroutine gets a reply of the wrong type (`ErrCommandInvalid`) while the other
+hangs waiting for a reply that already went to the first, until connection-level error/timeout.
+
+### External corroboration
+
+- [rabbitmq/amqp091-go#242](https://github.com/rabbitmq/amqp091-go/issues/242) — "Add mutex
+  guard to Channel methods", filed 2024-01-30, **still open, unresolved**. Reports the exact
+  error `Exception (503) Reason: 'unexpected command received'` from concurrent
+  `Channel.QueueDeclare` calls on one channel, and explicitly notes the same asymmetry found
+  independently above: Ack/Nack/Reject/PublishWithDeferredConfirm are guarded,
+  declare/bind/consume methods are not. This is a confirmed, currently-unfixed gap in the
+  library itself — not speculation, and not unique to VoIPBin's usage.
+- Predecessor library `streadway/amqp` has the same design and the same class of reports
+  (issues #119, #327: "Channel is not thread safe" / "NOT thread safe for concurrent
+  consume/publish").
+
+## 4. Precise trigger windows in this codebase (not "any concurrent use is broken")
+
+Because `scopeRefCount` is a single per-pod instance and `Acquire`/`Release` both hold
+`scopeRefCount.mu` for their entire body including the QueueBind/Unbind call, **scopeRefCount's
+own binds/unbinds cannot race each other** — multiple websocket clients subscribing/unsubscribing
+concurrently are already serialized before reaching the AMQP channel.
+
+There are **two independent** trigger windows where something *other than scopeRefCount itself*
+touches the same channel concurrently with it. (Round-1 review of this document caught that an
+earlier draft claimed only the first of these existed — corrected here.)
+
+**(a) Broker reconnect.** `rabbitmqhandler`'s own reconnection sequence (`redeclareAll` →
+bind-restoration loop → `reconsumerAll` → `startConsumers`'s `Qos`/`Consume`) runs on the
+separate `reconnector()` goroutine, on the newly-replaced channel object, with no coordination
+with scopeRefCount's mutex. A websocket client subscribe/unsubscribe landing inside the window
+between the new channel being installed and `reconsumerAll` finishing races it.
+
+**(b) Pod startup/restart — no reconnect required.** Re-read `bin-api-manager/cmd/api-manager/main.go:190-191`:
+`run()` launches `go runSubscribe(...)` and `go runListenHTTP(...)` as two independent,
+unsynchronized goroutines. Inside `runSubscribe` → `subscribehandler.Run()`
+(`bin-api-manager/pkg/subscribehandler/main.go:78-107`): `QueueCreate` (which opens the
+channel) runs synchronously, but the actual `Qos`+`Consume` registration
+(`ConsumeMessage` → `startConsumers`) is dispatched into **yet another goroutine**
+(`main.go:100-104`) and `Run()` returns immediately without waiting for it. Meanwhile
+`runListenHTTP` stands up the HTTP server that serves the websocket upgrade endpoint with zero
+dependency on that consumer-registration goroutine having completed. So on **every pod
+startup or rolling restart** — not just reconnects — there is a window between the channel
+being created and `Qos`/`Consume` being registered on it, during which a websocket client that
+connects and subscribes fast enough triggers `scopeRefCount.Acquire` → `QueueBind` on that same
+not-yet-fully-registered channel concurrently with the async `startConsumers` call. This is the
+same hazard class as (a), with no reconnect involved at all.
+
+Outside these two windows (steady-state operation with a stable connection, no pod restart in
+progress), there is no race.
+
+## 5. Production evidence check
+
+Queried `bin-api-manager`'s live container (`voipbin-api-manager` on bm-nyc-01, up 2 days) via
+Komodo's `GetContainerLog` (5000-line / ~1.3MB tail, covering roughly 2026-09-01 02:45–04:20
+UTC):
+
+- **No** `unexpected command received`, `503`, `ErrCommandInvalid`, or AMQP channel-closed
+  errors in that window.
+- **No** RabbitMQ reconnect events (`Connecting to rabbitmq` / `Reconnecting after connection
+  closed`) in that window either — meaning the precondition for the race (§4) simply didn't
+  occur in the sampled window.
+- The websocket-subscription code path is actively exercised in production
+  (`subscriptionRunPinger: Sent ping message to client` present repeatedly), so this isn't a
+  dead/unused feature — it's a live feature that hasn't yet had a reconnect coincide with a
+  subscribe/unsubscribe in the sampled log window.
+
+This is consistent with the ticket's own note ("기능 저하 확인된 것은 아님") — **absence of
+observed incidents does not disprove the race; it means the trigger conditions haven't recently
+coincided in the ~2-hour sample.** This check only covered trigger window (a) (reconnect
+events); it did **not** check window (b) (pod startup/restart — the container has been up 2
+days, so its own boot-time window is well outside the sampled tail). A full incident-log sweep
+across the 2-day uptime, and specifically around the most recent deploy/restart timestamp, would
+be needed to check window (b) and to fully rule out past occurrences of window (a); neither was
+performed here (see §7).
+
+## 6. Proceed-or-not analysis
+
+**Proceed.** This is a confirmed, currently-real defect (not a stale/already-fixed concern, not
+a misunderstanding of the code) in a live, actively-used feature (websocket event
+subscriptions), with:
+- A verified mechanism (library source read directly, not inferred).
+- Independent, authoritative external corroboration (open upstream GitHub issue against the
+  exact pinned library version, matching the exact operation family).
+- Two precise, identified trigger conditions (§4) — this is not "rewrite everything," it's "the
+  channel-setup path (startup and reconnect alike) and the runtime-rebind path need to not
+  touch the same channel unsynchronized." Both trigger windows resolve to the same underlying
+  gap — `startConsumers`'s `Qos`/`Consume` registration (called both at initial startup and by
+  `reconsumerAll` on reconnect) racing `QueueBind`/`QueueUnbind` — so a single fix addresses
+  both, not two separate fixes.
+- No evidence of active production impact right now, so this is not an emergency, but it is a
+  legitimate latent correctness bug worth fixing before it manifests as a harder-to-diagnose
+  incident (a repeat of the exact 2026-07-14 bin-agent-manager pattern this ticket's own
+  background cites).
+
+Priority stays Medium (matches Jira) — not escalating, since no active incident. Recommend
+moving to design: the fix belongs in `rabbitmqhandler` (protect the shared per-queue channel's
+`QueueBind`/`QueueUnbind` against concurrent execution with `startConsumers` — both its
+initial-registration call site and its `reconsumerAll`-on-reconnect call site — on the same
+rabbit instance), not in `scopeRefCount` — a rabbitmqhandler-level fix protects every current
+and future caller of `QueueBind`/`QueueUnbind` against reconnect races, not just this one call
+site. The specific mechanism (which mutex, or avoiding the shared channel entirely) is a design
+decision, not resolved here — see §7's options; round-3 review of this document caught that an
+earlier draft named a specific mechanism ("hold `r.mu` for the network-call duration") that is
+not actually viable (see §7 option 1's note), which is exactly the kind of detail this
+analysis-stage document should not have pre-committed to.
+
+## 7. Open items for the design stage (not resolved here)
+
+- **Option 1 — reuse `r.mu` as the serialization point: NOT VIABLE as literally stated.**
+  An earlier draft of this document proposed "hold `r.mu` for the network-call duration of
+  these ops." Round-3 review caught that this deadlocks immediately: `QueueBind`
+  (`queue.go:166-167`) and `startConsumers` (`consume.go:33`) both begin by calling `queueGet`,
+  which takes `r.mu.RLock()` (`queue.go:13-18`) — locking `r.mu.Lock()` at the top of either
+  function and then calling `queueGet` is a write-lock-then-read-lock on the same
+  `sync.RWMutex` from the same goroutine, which Go's `RWMutex` does not support re-entrantly.
+  `r.mu` is currently a *data guard* for the `r.queues`/`r.queueBinds` maps, held only briefly;
+  repurposing it as an *in-flight-network-call guard* held for a whole RPC round-trip is a
+  different invariant with a different hold duration, and mixing the two is what causes the
+  deadlock. If a dedicated mutex is used instead of `r.mu` itself, this option becomes viable,
+  but it still serializes ALL queue/exchange RPCs across the whole rabbit instance, including on
+  unrelated queues — a real contention cost, though narrower than it first appears:
+  `publishExchange`, `RequestPublish`, and `publishRPCErrorResponse` (`publish.go`,
+  `consume.go:307,353`) each open, use, and close their own throwaway channel per call and would
+  not be blocked by this lock. `ExchangeDeclare` (`exchange.go:11-37`) and `QueueDeclare`
+  (`queue.go:102-142`) are a separate case (see Option 2's note below) — they also would not be
+  blocked, but not because they're throwaway; they simply never touch the *pre-existing*
+  `queue.channel` at all. Only `QueueBind`, `QueueUnbind`, `QueueDelete`, `QueueQoS`, and
+  `startConsumers`'s `Qos`/`Consume` share the long-lived `queue.channel` and would contend.
+- **Option 2 — dedicated short-lived channel for `QueueBind`/`QueueUnbind`, matching part of
+  this package's own convention.** `publishExchange`, `RequestPublish`, and
+  `publishRPCErrorResponse` genuinely open-use-close an ephemeral `r.connection.Channel()` per
+  call — a real, directly-applicable precedent for issuing `QueueBind`/`QueueUnbind` the same
+  way. (`ExchangeDeclare`/`QueueDeclare` are a *weaker*, different data point, not the same
+  pattern: verified they open a channel and never close it — they store it into
+  `r.exchanges[name].channel`/`r.queues[name].channel` and keep it open indefinitely, only
+  closing the *previous* one when a future re-declare replaces it. That stored, kept-open
+  channel is `queue.channel` itself — the very channel this whole document is about — so these
+  two functions are the origin of the long-lived shared channel, not an example of avoiding
+  one.) `queue.bind`/`queue.unbind` are broker-side operations scoped to the queue, not to the
+  issuing channel, so binding/unbinding on a fresh ephemeral channel (following the
+  publish/RPC-reply pattern) is semantically identical to doing it on `queue.channel` — and
+  removes the race by construction: no lock, no cross-queue contention, no lock-ordering rules
+  for future maintainers to get wrong. Trade-offs to weigh at design time: one channel
+  open/close per websocket subscribe/unsubscribe transition, and how this interacts with
+  `QueueDeclare`'s channel-replacement on reconnect.
+- Whichever option is chosen, it must cover all five current users of the shared
+  `queue.channel` object — `QueueBind` (`queue.go:172`), `QueueUnbind` (`queue.go:201`),
+  `QueueDelete` (`queue.go:28`), `QueueQoS` (`queue.go:150`), and `startConsumers`'s
+  `Qos`+`Consume` (`consume.go:44,48`, covering both the initial-registration call site in
+  `subscribehandler.Run()` and the `reconsumerAll`-on-reconnect call site) — not just
+  `QueueBind`/`QueueUnbind` vs. `startConsumers` as this document's earlier drafts framed it;
+  `QueueDelete` and `QueueQoS` route through the same unguarded `call()` path and belong to the
+  same hazard class.
+- Whether `subscribehandler.Run()`'s async `go func() { ConsumeMessage(...) }()` (window (b))
+  should instead be synchronous/awaited before `Run()` returns and before `runListenHTTP`
+  starts accepting connections, as a defense-in-depth measure independent of the
+  `rabbitmqhandler`-level mutex fix — would eliminate window (b) entirely rather than just
+  making it safe to race.
+- A full 2-day log sweep (not just the ~2-hour tail sampled here) covering both trigger windows
+  — specifically including the timestamp of the pod's most recent startup/restart (window (b))
+  in addition to any reconnect events (window (a)) — to increase confidence no past incident
+  was already caused by this and mis-attributed to something else.


### PR DESCRIPTION
Investigate and fix the runtime QueueBind/QueueUnbind race scopeRefCount's
Acquire/Release could hit against an already-consuming AMQP channel.
Confirmed via source (amqp091-go v1.10.0's Channel.QueueBind/QueueUnbind/
Consume/Qos all route through an internal call() with no lock and a
single un-correlated reply channel per *amqp.Channel) and an open
upstream issue (rabbitmq/amqp091-go#242) that this is real and current,
with two independent trigger windows in this codebase (broker reconnect;
pod startup/restart, since subscribehandler.Run() dispatches consumer
registration asynchronously while the HTTP/websocket server can already
be accepting connections). Fixed by moving QueueBind/QueueUnbind onto a
dedicated, short-lived AMQP channel instead of the queue's own
long-lived consuming channel, so they structurally never contend with
startConsumers's Qos/Consume for either trigger window.

Both the issue-analysis and design documents went through independent
review loops (6 rounds / 2 consecutive approvals, and 7 rounds / 2
consecutive approvals respectively) that caught and corrected, among
other things: an incomplete trigger-window analysis; a proposed fix
mechanism that would have deadlocked (reusing the package's existing
map-tracking mutex as both a data guard and an in-flight-I/O guard); a
new, narrower data race the fix itself would have introduced by reading
a connection field without synchronization; and a compile-breaking
interface change that doesn't work in Go (no return-type covariance).
The implementation itself then went through a 3-round code-review loop
with 2 consecutive approvals.

- bin-common-handler: Widen amqpConnection.Channel() to return the
  amqpChannel test-seam interface instead of the concrete *amqp.Channel,
  and add PublishWithContext to amqpChannel (needed by the three
  existing callers of that widened method -- publishExchange,
  RequestPublish, publishRPCErrorResponse); add a realConnection adapter
  around *amqp.Connection to keep it compiling, with explicit
  nil-interface handling on the error path
- bin-common-handler: Add connectionGet(), an r.mu.RLock()-guarded
  accessor for r.connection, and lock connect()'s write of that same
  field -- a read-only lock alone would not have synchronized anything
  against the pre-existing unlocked write
- bin-common-handler: QueueBind/QueueUnbind now issue their AMQP calls
  on a channel obtained fresh from the connection, closed after use,
  instead of the queue's own persistent channel; the tracked-bind-set
  bookkeeping (used by redeclareAll's reconnect replay) is unchanged;
  QueueDelete/QueueQoS get a documentation-only note that they share the
  same hazard class (currently unreachable from outside the package, so
  not fixed)
- bin-common-handler: Update the three hand-written amqpChannel test
  mocks for the widened interface; rework the QueueBind/QueueUnbind test
  suite for the new dedicated-channel behavior, including two new tests
  pinning the structural property the fix relies on (the connection-
  provided channel is used, queue.channel never is), two new tests for
  the previously-untested conn == nil path, and a race-detector test for
  connectionGet()'s locked read/write pairing -- mutation-tested by
  temporarily removing the write-side lock and confirming go test -race
  reports the exact data race the lock exists to prevent; test suite
  reorganized so each test sits under the section banner matching what
  it actually tests
- bin-api-manager: Replace scoperefcount.go's now-resolved "OPEN
  QUESTION (VOIP-1431)" doc comment with the actual finding and a
  pointer to the fix, so a future reader isn't left staring at a stale
  unconfirmed marker on the file this ticket was about
- Add docs/plans/2026-09-01-voip-1431-scoperefcount-amqp-safety-analysis.md
  and docs/plans/2026-09-01-voip-1431-amqp-channel-race-design.md,
  the reviewed issue-analysis and design documents this implementation
  follows

Verified: go build/test/vet/-race/golangci-lint all clean in
bin-common-handler; go build clean in bin-api-manager and every other
bin-*-manager/voip-*-proxy service in the monorepo (confirming the
widened amqpConnection/amqpChannel interfaces, being unexported test
seams, do not affect any consumer's build).
