### PR TITLE
VOIP-1444-orphaned-flow-reconciliation

### DIFF
--- a/bin-campaign-manager/docs/architecture.md
+++ b/bin-campaign-manager/docs/architecture.md
@@ -63,6 +63,7 @@ Requests arrive via RabbitMQ queue `bin-manager.campaign-manager.request`. The `
 | `/v1/campaigns/{{UUID}}/actions$` | GET/PUT | Get or update campaign actions (flow actions to run on connect) |
 | `/v1/campaigns/{{UUID}}/resource_info$` | GET | Get resource usage info for a campaign |
 | `/v1/campaigns/{{UUID}}/next_campaign_id$` | PUT | Set the next campaign to run after this one completes |
+| `/v1/campaigns/flows/reconcile$` | POST | (VOIP-1444) Internal-only: scan campaigns deleted within a recent window and delete any still-live backing flow. Dispatched by the `bin-schedule-manager` "campaign-flow-reconcile" schedule (or a manual `/v1/schedules/{id}/execute`) — never exposed through `bin-api-manager`. See [docs/operations.md](operations.md#orphaned-flow-reconciliation-voip-1444). |
 | `/v1/campaigncalls\?` | GET | List campaigncalls with filters/pagination |
 | `/v1/campaigncalls/{{UUID}}$` | GET/DELETE | Get or delete a campaigncall |
 | `/v1/outplans$` | POST | Create a new outplan |

--- a/bin-campaign-manager/docs/domain.md
+++ b/bin-campaign-manager/docs/domain.md
@@ -24,6 +24,32 @@ Dialing configuration shared across one or more campaigns. Defines the dial timi
 
 Key fields: `customer_id`, `name`, `source` (caller ID to use), `dial_timeout` (seconds to wait for answer), `try_interval` (seconds between retries), `max_try_count_0` through `max_try_count_4` (max retries per destination slot), `dials` (list of phone numbers or patterns to dial).
 
+### ReconcileResult (VOIP-1444)
+
+The result of a single orphaned-flow reconciliation pass
+(`pkg/campaignhandler.ReconcileOrphanedFlows`, `models/campaign/reconcile.go`).
+This is a domain type that also serves directly as the wire shape for
+`POST /v1/campaigns/flows/reconcile`'s response (style (A): the
+`listenhandler` marshals it as-is, with no separate `response.*` DTO — see
+the root CLAUDE.md's transport-DTO layering rule).
+
+Key fields: `cleaned` (orphaned flows successfully deleted this pass),
+`skipped` (candidates needing no action: flow already deleted, a typed
+not-found from `bin-flow-manager`, or the defensive nil-`TMDelete` guard),
+`failed` (row-level failures — a non-not-found `FlowV1FlowGet` error or a
+`FlowV1FlowDelete` error on a genuine orphan; both share one counter, see
+[docs/operations.md](operations.md#orphaned-flow-reconciliation-voip-1444)),
+`saturated` (this pass's batch reached the compiled `scanLimit`;
+informational only), `recent_saturated` (the actionable rate-risk signal —
+deletions within the caller-supplied `recent_interval_sec` alone already
+fill `scanLimit`), `partial` (the pass's own self-imposed timeout cut the
+RPC loop short before every candidate was examined).
+
+`err` from `ReconcileOrphanedFlows` is non-nil only when the initial
+`CampaignListDeletedSince` (`pkg/dbhandler/campaign.go`) query itself
+fails; every other outcome is counted in `ReconcileResult`, never
+propagated as an error.
+
 ## Key Business Rules
 
 1. **Campaign status controls dialing**: Only campaigns in `run` status make new call attempts. A campaign in `stop` state will not dial. The `stopping` state is a transitional state while in-progress calls are being wrapped up before the campaign fully stops.

--- a/bin-campaign-manager/docs/operations.md
+++ b/bin-campaign-manager/docs/operations.md
@@ -98,7 +98,138 @@ All metric names are prefixed with `campaign_manager_` at runtime.
 | `campaign_create_total` | Counter | Total campaigns created |
 | `campaign_execute_total` | Counter | Total campaign execute calls (each execution loop trigger) |
 | `campaign_flow_delete_failed_total` | CounterVec | Total failures to delete a campaign's backing flow during campaign delete (labels: `reason` = `not_found` \| `error`). Best-effort cleanup; a failure here does not fail the campaign delete but leaves the flow orphaned, counting against bin-flow-manager's per-customer flow cap. |
+| `campaign_flow_reconcile_cleaned_total` | Counter | (VOIP-1444) Total orphaned flows cleaned up by the reconciliation job. See [Orphaned Flow Reconciliation](#orphaned-flow-reconciliation-voip-1444) below. |
+| `campaign_flow_reconcile_failed_total` | Counter | (VOIP-1444) Total row-level reconciliation failures — a non-not-found `FlowV1FlowGet` error **or** a `FlowV1FlowDelete` error on a genuine orphan. No `reason` label distinguishes which RPC failed; a `bin-flow-manager` outage or open circuit breaker fails every remaining candidate in the pass on the `FlowV1FlowGet` branch, so this counter is the primary outage signal, not an edge case. |
 | `campaign_status_run_total` | Counter | Total campaigns transitioned to `run` status |
 | `campaign_status_stop_total` | Counter | Total campaigns transitioned to `stop` status |
 | `receive_request_process_time` | Histogram | RPC request processing time (labels: `type`, `method`) |
 | `receive_subscribe_event_process_time` | Histogram | Event subscription processing time (labels: `publisher`, `type`) |
+
+## Orphaned Flow Reconciliation (VOIP-1444)
+
+### What it does
+
+`POST /v1/campaigns/flows/reconcile` (internal-only, not exposed through
+`bin-api-manager`) scans campaigns deleted within a recent, bounded time
+window (`window`, `scanLimit` — compiled constants in
+`pkg/campaignhandler/reconcile.go`) and deletes the backing flow of any
+whose owning campaign is deleted but whose flow is still live — closing the
+gap left when `Delete()`'s best-effort `FlowV1FlowDelete` call (VOIP-1443)
+fails silently. It is dispatched by the `bin-schedule-manager`
+`campaign-flow-reconcile` schedule (seeded via a `bin-dbscheme-manager`
+Alembic migration, shipped **disabled** at seed time — see the migration's
+own docstring and the PR's rollout-sequencing note for the manual smoke
+test and enable step) on its `cron` interval, or via a manual
+`POST /v1/schedules/{id}/execute` RPC (there is no `schedule-control
+execute` subcommand — `schedule-control` only supports
+`list`/`get`/`enable`/`disable` for schedules).
+
+Request body: `{"recent_interval_sec": <int64>}` — the schedule's own
+`cron` interval, in seconds, threaded through explicitly because
+`bin-campaign-manager` has no way to read `bin-schedule-manager`'s own
+`cron` field from its database. A missing or non-positive value falls back
+to a conservative 24h default and logs a warning.
+
+The route always returns HTTP 200 for a pass that ran, even with
+`failed > 0` or `partial == true` in the body — those are data about the
+pass, not a pass-level error. A non-2xx response means the initial
+`CampaignListDeletedSince` query itself failed (the pass never ran).
+
+### `saturated` vs `recent_saturated` — two different signals, only one is actionable
+
+- **`saturated`** (`len(candidates) == scanLimit`): purely informational.
+  This fires routinely once the window's total candidate population
+  exceeds `scanLimit` — including when every newly-deleted campaign is
+  still being examined on the very next pass after its own deletion, i.e.
+  when the job is working exactly as intended. Do not alert on this alone.
+- **`recent_saturated`**: the actionable rate-risk signal. True when the
+  count of candidates deleted within `recent_interval_sec` of this pass
+  starting already fills `scanLimit` on its own — meaning the actual
+  safety condition (`scanLimit` > deletions per cron interval) is being
+  violated, not merely approached (the derivation is exact; there is no
+  early-warning margin). **Remedy**: raise `scanLimit` and/or shorten the
+  schedule's `cron` interval. These two remedies are **not equally fast**:
+  raising `scanLimit` is a compiled Go constant and needs a code change
+  plus redeploy; shortening `cron` (and `recent_interval_sec`, see below)
+  is a live data edit via `schedule-control`/`PUT /v1/schedules/{id}`, no
+  redeploy — reach for the live edit first under time pressure.
+- Both `saturated` and `recent_saturated` land in the response body only —
+  there is deliberately no third Prometheus counter for either signal (see
+  "Durability" below for why this is safe despite this service's own logs
+  rotating within hours).
+
+### Changing the schedule's `cron` interval — a two-step operational change
+
+`target_data.recent_interval_sec` is seeded from the same migration row as
+`cron` (kept in sync at seed time only). A later, post-seed edit to `cron`
+(via `schedule-control` or `PUT /v1/schedules/{id}`, including the
+`recent_saturated` remedy above) does **not** automatically update
+`target_data.recent_interval_sec` — they are edited through different
+operational paths once the schedule exists. Any operational change to the
+interval **must**:
+
+1. Update `target_data.recent_interval_sec` to match the new `cron` in the
+   same change.
+2. Re-verify `reconcilePassTimeout` (`pkg/campaignhandler/reconcile.go`) is
+   still well below the new, shorter interval before applying it —
+   `reconcilePassTimeout` is a compiled constant that does not move on its
+   own, and a large-enough interval cut could reintroduce the cadence
+   degradation described below.
+
+### `reconcilePassTimeout` sizing — two independently load-bearing constraints
+
+`ReconcileOrphanedFlows` bounds its own execution with an internal
+`context.WithTimeout(reconcilePassTimeout)` — required because this
+service's RPC listenhandler builds every request's context with
+`context.Background()` (no deadline propagation from
+`bin-schedule-manager`'s `timeout_ms`). `reconcilePassTimeout` must satisfy:
+
+- **Constraint (a) — the actual mutual-exclusion guarantee**:
+  `reconcilePassTimeout` strictly below the schedule's seeded `timeout_ms`,
+  with margin covering real message-delivery delay (not just processing
+  latency — the two timeouts' clocks start at different points).
+  `bin-schedule-manager`'s "Forbid overlap" guard (`ExecutionHasRunning`,
+  checked before the `tm_next_run` CAS on every claim path) keeps an
+  execution row `running` only until `ExecutionComplete` fires, which
+  happens as soon as `SendRequest`'s own `timeout_ms`-bounded wait returns
+  — not when this pass actually finishes. If `reconcilePassTimeout` could
+  exceed `timeout_ms`, there is a real window where `bin-schedule-manager`
+  believes the pass is done while it is still physically executing, and a
+  manual execute fired in that window would genuinely race it. **This
+  violation has no runtime monitor** — it produces an ordinary `success`
+  execution row, indistinguishable from a correctly-serialized one.
+  Correct static sizing is the only defense.
+- **Constraint (b) — a cadence/liveness requirement, not a concurrency
+  guard**: `reconcilePassTimeout` well below the schedule's `cron`
+  interval. Because guard 1 above is checked before the `tm_next_run` CAS,
+  a cron-triggered claim that arrives while the row is still `running` is
+  short-circuited into a dispatch-level overlap skip — it does **not**
+  create a second execution (that's already prevented by constraint (a)
+  holding); it just means the schedule falls behind. **Observable
+  symptom**: the dispatch-level metric
+  `schedule_manager_dispatch_total{result="skipped_overlap"}` climbing for
+  this schedule indicates a constraint-(b) violation (chronic cadence
+  degradation) specifically on the **cron** dispatch path — a manual
+  `/v1/schedules/{id}/execute` hitting the same overlap guard returns a
+  `FailedPrecondition` `EXECUTION_IN_PROGRESS` error instead, with no
+  metric at all (relevant for a rollout smoke test that races a still-
+  running prior pass: just retry). This metric says nothing about a
+  constraint-(a) violation, which has no runtime monitor at all. The
+  counter's granularity is also per-replica, in-memory dedup — a single
+  stuck cron slot can increment it more than once across replicas, so read
+  "climbing" as a health signal, not an exact skip count.
+
+### Durability
+
+`saturated`, `recent_saturated`, and `partial` are not merely logged and
+dropped: they land in the response body, which `bin-schedule-manager`
+persists verbatim as `schedule_executions.result`
+(`models/execution/execution.go`'s `Result string` field) on every pass
+that returns an HTTP response — including `failed > 0` / `partial == true`
+passes (`result` is populated only inside `ExecutionComplete`'s success
+branch; a transport-level failure that never reaches this route leaves
+`result` empty and `error` populated instead, with no `ReconcileResult` to
+persist regardless). This is what makes the decision not to add a third
+Prometheus counter for these signals safe, despite this service's own logs
+rotating within hours (per VOIP-1443's investigation): the durable record
+survives in `bin-schedule-manager`'s own audit trail.

--- a/bin-campaign-manager/models/campaign/reconcile.go
+++ b/bin-campaign-manager/models/campaign/reconcile.go
@@ -1,0 +1,53 @@
+package campaign
+
+// ReconcileResult is the result of a single orphaned-flow reconciliation
+// pass (VOIP-1444: pkg/campaignhandler.ReconcileOrphanedFlows). It is a
+// domain type that also serves as the wire shape for
+// POST /v1/campaigns/flows/reconcile's response — style (A) per the root
+// CLAUDE.md's transport-DTO layering rule: json tags on a domain type are
+// declarative metadata, not a response.* DTO, and listenhandler marshals
+// this type directly with no separate response.* copy.
+type ReconcileResult struct {
+	// Cleaned is the number of genuinely orphaned flows (owning campaign
+	// deleted, flow still live) that were successfully deleted this pass.
+	// Each increment is mirrored in campaign_flow_reconcile_cleaned_total.
+	Cleaned int `json:"cleaned"`
+
+	// Skipped is the number of candidates that needed no action this pass:
+	// the flow was already deleted (TMDelete set by an earlier pass or a
+	// successful Delete() call), FlowV1FlowGet returned a typed not-found
+	// (the flow row does not exist at all — an equally legitimate clean
+	// end state), or the candidate campaign's own TMDelete was
+	// unexpectedly nil (the defensive, second-layer guard against a future
+	// query regression).
+	Skipped int `json:"skipped"`
+
+	// Failed is the number of candidates that could not be resolved this
+	// pass: a non-not-found FlowV1FlowGet error, or a FlowV1FlowDelete
+	// error on a genuine orphan. Both branches increment the single,
+	// shared campaign_flow_reconcile_failed_total counter — there is no
+	// "reason" label distinguishing which RPC failed.
+	Failed int `json:"failed"`
+
+	// Saturated is true when this pass's batch reached scanLimit rows.
+	// Informational only: the window holds more history than a single
+	// pass returns, which is expected at scale and implies no action by
+	// itself. See docs/operations.md for the full runbook.
+	Saturated bool `json:"saturated"`
+
+	// RecentSaturated is true when the count of candidates deleted within
+	// the caller-supplied recentIntervalSec already fills scanLimit on its
+	// own — the actionable rate-risk signal, distinct from Saturated. It
+	// means the actual safety condition (deletions-per-interval <
+	// scanLimit) is being violated. See docs/operations.md for the
+	// documented remedy (raise scanLimit and/or shorten the schedule's
+	// cron interval).
+	RecentSaturated bool `json:"recent_saturated"`
+
+	// Partial is true when the pass's own self-imposed
+	// context.WithTimeout cut the RPC loop short before every candidate
+	// was examined. The counts above reflect only what was processed
+	// before the bail-out; a Partial pass is never silently recorded as a
+	// full success with no trace it was incomplete.
+	Partial bool `json:"partial"`
+}

--- a/bin-campaign-manager/pkg/campaignhandler/main.go
+++ b/bin-campaign-manager/pkg/campaignhandler/main.go
@@ -71,6 +71,36 @@ var (
 		},
 		[]string{"reason"},
 	)
+
+	// promCampaignFlowReconcileCleanedTotal and
+	// promCampaignFlowReconcileFailedTotal are dedicated to the
+	// orphaned-flow reconciliation job (VOIP-1444,
+	// pkg/campaignhandler/reconcile.go). They deliberately do not reuse
+	// promCampaignFlowDeleteFailedTotal above: that metric is documented
+	// as "failures during a live campaign delete", an operationally
+	// distinct signal from "the reconciler couldn't clean up a
+	// known-orphaned flow" — reusing it here would conflate the two into
+	// one series.
+	//
+	// promCampaignFlowReconcileFailedTotal has no "reason" label: both a
+	// non-not-found FlowV1FlowGet error and a FlowV1FlowDelete error on a
+	// genuine orphan increment this one shared counter (see
+	// reconcile.go and docs/operations.md).
+	promCampaignFlowReconcileCleanedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaign_flow_reconcile_cleaned_total",
+			Help:      "Total number of orphaned flows cleaned up by the reconciliation job.",
+		},
+	)
+
+	promCampaignFlowReconcileFailedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "campaign_flow_reconcile_failed_total",
+			Help:      "Total number of row-level failures during flow reconciliation (a non-not-found FlowV1FlowGet error, or a FlowV1FlowDelete error on a genuine orphan; no reason label distinguishes which).",
+		},
+	)
 )
 
 func init() {
@@ -80,6 +110,8 @@ func init() {
 		promCampaignStatusStopTotal,
 		promCampaignExecuteTotal,
 		promCampaignFlowDeleteFailedTotal,
+		promCampaignFlowReconcileCleanedTotal,
+		promCampaignFlowReconcileFailedTotal,
 	)
 
 	// pre-initialize both label series so they read 0 from process start,
@@ -142,6 +174,8 @@ type CampaignHandler interface {
 
 	EventHandleActiveflowDeleted(ctx context.Context, campaignID uuid.UUID) error
 	EventHandleReferenceCallHungup(ctx context.Context, campaignID uuid.UUID) error
+
+	ReconcileOrphanedFlows(ctx context.Context, recentIntervalSec int64) (campaign.ReconcileResult, error)
 }
 
 // NewCampaignHandler return CampaignHandler

--- a/bin-campaign-manager/pkg/campaignhandler/mock_campaignhandler.go
+++ b/bin-campaign-manager/pkg/campaignhandler/mock_campaignhandler.go
@@ -158,6 +158,21 @@ func (mr *MockCampaignHandlerMockRecorder) ListByCustomerID(ctx, customerID, tok
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByCustomerID", reflect.TypeOf((*MockCampaignHandler)(nil).ListByCustomerID), ctx, customerID, token, limit)
 }
 
+// ReconcileOrphanedFlows mocks base method.
+func (m *MockCampaignHandler) ReconcileOrphanedFlows(ctx context.Context, recentIntervalSec int64) (campaign.ReconcileResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileOrphanedFlows", ctx, recentIntervalSec)
+	ret0, _ := ret[0].(campaign.ReconcileResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReconcileOrphanedFlows indicates an expected call of ReconcileOrphanedFlows.
+func (mr *MockCampaignHandlerMockRecorder) ReconcileOrphanedFlows(ctx, recentIntervalSec any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileOrphanedFlows", reflect.TypeOf((*MockCampaignHandler)(nil).ReconcileOrphanedFlows), ctx, recentIntervalSec)
+}
+
 // UpdateActions mocks base method.
 func (m *MockCampaignHandler) UpdateActions(ctx context.Context, id uuid.UUID, actions []action.Action) (*campaign.Campaign, error) {
 	m.ctrl.T.Helper()

--- a/bin-campaign-manager/pkg/campaignhandler/reconcile.go
+++ b/bin-campaign-manager/pkg/campaignhandler/reconcile.go
@@ -1,0 +1,209 @@
+package campaignhandler
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"time"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-campaign-manager/models/campaign"
+)
+
+// Package-level tuning knobs for ReconcileOrphanedFlows (VOIP-1444).
+//
+// These are declared as package-level vars, not true Go constants,
+// specifically so unit tests in this package can override scanLimit and
+// reconcilePassTimeout to small, deterministic values (constructing a
+// scanLimit-sized fixture at the production default of 500 rows, or
+// waiting out a 90s timeout, would make the test suite impractically slow
+// and unwieldy). Production code never mutates these; only tests do,
+// always restoring the original value via defer.
+var (
+	// window bounds how far back CampaignListDeletedSince looks for
+	// deleted-campaign candidates. Anything deleted before this is
+	// explicitly out of scope (see the design doc's "Proposed scope").
+	window = 7 * 24 * time.Hour
+
+	// scanLimit bounds the number of candidates examined in a single
+	// pass, so one scheduled run can never issue an unbounded number of
+	// RPCs. Must exceed the number of campaign deletions per cron
+	// interval (not per window) — see "Scan order and coverage" in the
+	// design/plan docs for the full safety-condition analysis.
+	scanLimit = uint64(500)
+
+	// reconcilePassTimeout bounds this method's own execution via an
+	// internal context.WithTimeout — required because this service's RPC
+	// listenhandler builds every request's context with
+	// context.Background() (no deadline propagation), so nothing else
+	// bounds a pass's duration. Must satisfy two independently
+	// load-bearing constraints against the seeded bin-schedule-manager
+	// schedule (see docs/operations.md and the design/plan docs' "Scan
+	// order and coverage" / "self-imposed pass timeout" sections):
+	//   (a) strictly below the schedule's timeout_ms, with margin for
+	//       real message-delivery delay — the actual mutual-exclusion
+	//       guarantee (keeps bin-schedule-manager's "Forbid overlap"
+	//       guard, ExecutionHasRunning, effective for this pass's entire
+	//       physical duration).
+	//   (b) well below the schedule's cron interval — a cadence/liveness
+	//       requirement, not a concurrency guard (keeps the schedule from
+	//       chronically observing dispatch-level skipped_overlap skips).
+	reconcilePassTimeout = 90 * time.Second
+
+	// defaultRecentInterval is the conservative fallback used when the
+	// caller-supplied recentIntervalSec is missing or non-positive (e.g.
+	// an old/malformed dispatch). Never panics or fails the pass over a
+	// malformed rate-signal input.
+	defaultRecentInterval = 24 * time.Hour
+
+	// windowEdgeMarginFraction defines the "near the window's outer edge"
+	// zone for the per-candidate window-edge warning: a genuine orphan
+	// whose owning campaign was deleted within this fraction of `window`
+	// from the outer cutoff logs a warning, since a bin-flow-manager
+	// outage lasting longer than `window` would let that leak age out of
+	// the scan and silently merge into the out-of-scope historical
+	// backlog.
+	windowEdgeMarginFraction = 0.10
+)
+
+// ReconcileOrphanedFlows scans campaigns deleted within the last `window`
+// (bounded to at most scanLimit rows, most-recently-deleted first) and
+// deletes the backing flow of any campaign whose flow is still live —
+// closing the gap left by Delete()'s best-effort FlowV1FlowDelete call
+// (VOIP-1443) failing silently. See
+// docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-plan.md and
+// its paired design doc for the full analysis and round-by-round review
+// history.
+//
+// recentIntervalSec is the caller-supplied cron interval, in seconds, of
+// the bin-schedule-manager schedule dispatching this pass —
+// bin-campaign-manager has no way to read bin-schedule-manager's own cron
+// field, so it must be threaded through explicitly on every request. A
+// missing or non-positive value falls back to a conservative 24h default
+// (logged as a warning), never panics or fails the pass.
+//
+// err is non-nil only when the initial CampaignListDeletedSince query
+// itself fails — the pass could not run at all. Every other outcome
+// (per-row failures, a self-timeout bail-out) is counted in the returned
+// ReconcileResult, never propagated as err; HTTP status at the
+// listenhandler layer is 200 in all of those cases.
+func (h *campaignHandler) ReconcileOrphanedFlows(ctx context.Context, recentIntervalSec int64) (campaign.ReconcileResult, error) {
+	result := campaign.ReconcileResult{}
+
+	log := logrus.WithFields(logrus.Fields{
+		"func": "ReconcileOrphanedFlows",
+	})
+
+	passStartPtr := h.util.TimeNow()
+	passStart := *passStartPtr
+
+	// Self-imposed pass timeout — see the reconcilePassTimeout doc-comment
+	// above for why this is required and what it must satisfy.
+	pctx, cancel := context.WithTimeout(ctx, reconcilePassTimeout)
+	defer cancel()
+
+	since := passStart.Add(-window)
+	candidates, err := h.db.CampaignListDeletedSince(pctx, since, scanLimit)
+	if err != nil {
+		return result, fmt.Errorf("could not list deleted campaigns. ReconcileOrphanedFlows. err: %v", err)
+	}
+
+	// Compute Saturated and RecentSaturated in a dedicated, RPC-free pass
+	// over the fetched slice, before any FlowV1FlowGet/FlowV1FlowDelete
+	// call — this must not be interleaved with the RPC loop below, since
+	// the self-imposed pass timeout could otherwise cut the count short
+	// of scanLimit on a genuinely saturated batch, producing a false
+	// negative in exactly the overload case this signal exists to catch.
+	result.Saturated = uint64(len(candidates)) == scanLimit
+
+	recentInterval := time.Duration(recentIntervalSec) * time.Second
+	if recentIntervalSec <= 0 {
+		log.Warnf("recentIntervalSec is missing or non-positive (%d); falling back to default %s", recentIntervalSec, defaultRecentInterval)
+		recentInterval = defaultRecentInterval
+	}
+	recentCutoff := passStart.Add(-recentInterval)
+
+	recentCount := 0
+	for _, c := range candidates {
+		if c.TMDelete != nil && !c.TMDelete.Before(recentCutoff) {
+			recentCount++
+		}
+	}
+	result.RecentSaturated = uint64(recentCount) == scanLimit
+
+	windowEdgeThreshold := since.Add(time.Duration(float64(window) * windowEdgeMarginFraction))
+
+	// RPC loop proper.
+	for _, c := range candidates {
+		if pctx.Err() != nil {
+			result.Partial = true
+			log.Warn("self-imposed pass timeout reached mid-pass; returning partial results")
+			return result, nil
+		}
+
+		rowLog := log.WithFields(logrus.Fields{
+			"campaign_id": c.ID,
+			"flow_id":     c.FlowID,
+		})
+
+		// Defensive, second layer of defense: CampaignListDeletedSince
+		// already filters on tm_delete >= since (which excludes live
+		// campaigns via NULL-comparison semantics), but a future query
+		// regression accidentally including live campaigns should be
+		// loud, not silent, given this job mutates data across all
+		// customers.
+		if c.TMDelete == nil {
+			rowLog.Warn("candidate campaign has nil TMDelete; skipping (defensive guard against a query regression)")
+			result.Skipped++
+			continue
+		}
+
+		f, errGet := h.reqHandler.FlowV1FlowGet(pctx, c.FlowID)
+		if errGet != nil {
+			var ve *cerrors.VoipbinError
+			if stderrors.As(errGet, &ve) && ve.Status == cerrors.StatusNotFound {
+				// The flow row genuinely doesn't exist -- a legitimately
+				// clean state, same bucket as an already-deleted flow.
+				result.Skipped++
+				continue
+			}
+
+			// Any other error (RPC timeout, backend error, an open
+			// circuit breaker) is a failure, not a clean state. A
+			// bin-flow-manager outage fails every remaining candidate on
+			// this exact branch, so it must be observable via the shared
+			// counter, not just the in-memory count.
+			rowLog.Errorf("could not get flow. err: %v", errGet)
+			promCampaignFlowReconcileFailedTotal.Inc()
+			result.Failed++
+			continue
+		}
+
+		if f.TMDelete != nil {
+			// Already cleaned up (by an earlier pass, or a successful
+			// Delete() call) -- not an orphan, do not re-delete.
+			result.Skipped++
+			continue
+		}
+
+		// Genuinely orphaned: owning campaign is deleted, flow is live.
+		if c.TMDelete.Before(windowEdgeThreshold) {
+			rowLog.WithField("tm_delete", c.TMDelete).Warn("orphan's owning campaign was deleted near the reconciliation window's outer edge; window may need widening")
+		}
+
+		if _, errDelete := h.reqHandler.FlowV1FlowDelete(pctx, c.FlowID); errDelete != nil {
+			rowLog.Errorf("could not delete orphaned flow. err: %v", errDelete)
+			promCampaignFlowReconcileFailedTotal.Inc()
+			result.Failed++
+			continue
+		}
+
+		result.Cleaned++
+		promCampaignFlowReconcileCleanedTotal.Inc()
+	}
+
+	return result, nil
+}

--- a/bin-campaign-manager/pkg/campaignhandler/reconcile_test.go
+++ b/bin-campaign-manager/pkg/campaignhandler/reconcile_test.go
@@ -1,0 +1,665 @@
+package campaignhandler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	commonoutline "monorepo/bin-common-handler/models/outline"
+	"monorepo/bin-common-handler/pkg/requesthandler"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	fmflow "monorepo/bin-flow-manager/models/flow"
+
+	"github.com/gofrs/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-campaign-manager/models/campaign"
+	"monorepo/bin-campaign-manager/pkg/dbhandler"
+)
+
+// captureWarnLogs installs a local logrus hook on the standard logger
+// (which package-level logrus.WithFields(...) calls in reconcile.go write
+// through) and returns a function that reports whether any warn-level
+// entry was captured. Callers must invoke the returned cleanup themselves
+// via defer.
+func captureWarnLogs() (hadWarn func() bool, cleanup func()) {
+	hook := logrustest.NewLocal(logrus.StandardLogger())
+	origLevel := logrus.GetLevel()
+	logrus.SetLevel(logrus.DebugLevel)
+
+	hadWarn = func() bool {
+		for _, e := range hook.AllEntries() {
+			if e.Level == logrus.WarnLevel {
+				return true
+			}
+		}
+		return false
+	}
+	cleanup = func() {
+		logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
+		logrus.SetLevel(origLevel)
+	}
+	return hadWarn, cleanup
+}
+
+func Test_ReconcileOrphanedFlows_cleansGenuineOrphan(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111101")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222201"),
+		TMDelete: timePtr(now.Add(-time.Hour)),
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: nil}, nil)
+	mockReq.EXPECT().FlowV1FlowDelete(gomock.Any(), c.FlowID).Return(&fmflow.Flow{}, nil)
+
+	beforeCleaned := testutil.ToFloat64(promCampaignFlowReconcileCleanedTotal)
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Cleaned != 1 {
+		t.Errorf("Wrong match. expect Cleaned: 1, got: %d", res.Cleaned)
+	}
+	if res.Skipped != 0 || res.Failed != 0 {
+		t.Errorf("Wrong match. expect Skipped=0 Failed=0, got: %+v", res)
+	}
+
+	afterCleaned := testutil.ToFloat64(promCampaignFlowReconcileCleanedTotal)
+	if afterCleaned != beforeCleaned+1 {
+		t.Errorf("Wrong match. expect cleaned metric delta 1, got: %v", afterCleaned-beforeCleaned)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_alreadyCleanFlow_skipped(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111102")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222202"),
+		TMDelete: timePtr(now.Add(-time.Hour)),
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	// flow already deleted -- FlowV1FlowDelete must NOT be called; no
+	// EXPECT() means gomock fails the test on any unexpected call.
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: timePtr(now)}, nil)
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("Wrong match. expect Skipped: 1, got: %d", res.Skipped)
+	}
+	if res.Cleaned != 0 || res.Failed != 0 {
+		t.Errorf("Wrong match. expect Cleaned=0 Failed=0, got: %+v", res)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_typedNotFound_skipped(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111103")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222203"),
+		TMDelete: timePtr(now.Add(-time.Hour)),
+	}
+
+	notFoundErr := cerrors.NotFound(commonoutline.ServiceNameFlowManager, "FLOW_NOT_FOUND", "flow not found")
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(nil, notFoundErr)
+
+	beforeFailed := testutil.ToFloat64(promCampaignFlowReconcileFailedTotal)
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("Wrong match. expect Skipped: 1, got: %d", res.Skipped)
+	}
+	if res.Failed != 0 {
+		t.Errorf("Wrong match. expect Failed: 0 (typed not-found is a clean state, not a failure), got: %d", res.Failed)
+	}
+
+	afterFailed := testutil.ToFloat64(promCampaignFlowReconcileFailedTotal)
+	if afterFailed != beforeFailed {
+		t.Errorf("Wrong match. expect no failed-metric increment for typed not-found, got delta: %v", afterFailed-beforeFailed)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_transientGetError_failed(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111104")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222204"),
+		TMDelete: timePtr(now.Add(-time.Hour)),
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(nil, fmt.Errorf("rpc timeout"))
+
+	beforeFailed := testutil.ToFloat64(promCampaignFlowReconcileFailedTotal)
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Errorf("Wrong match. expect Failed: 1, got: %d", res.Failed)
+	}
+	if res.Cleaned != 0 || res.Skipped != 0 {
+		t.Errorf("Wrong match. expect Cleaned=0 Skipped=0, got: %+v", res)
+	}
+
+	afterFailed := testutil.ToFloat64(promCampaignFlowReconcileFailedTotal)
+	if afterFailed != beforeFailed+1 {
+		t.Errorf("Wrong match. expect failed metric delta 1, got: %v", afterFailed-beforeFailed)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_deleteError_failed(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111105")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222205"),
+		TMDelete: timePtr(now.Add(-time.Hour)),
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: nil}, nil)
+	mockReq.EXPECT().FlowV1FlowDelete(gomock.Any(), c.FlowID).Return(nil, fmt.Errorf("backend error"))
+
+	beforeFailed := testutil.ToFloat64(promCampaignFlowReconcileFailedTotal)
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Failed != 1 {
+		t.Errorf("Wrong match. expect Failed: 1, got: %d", res.Failed)
+	}
+	if res.Cleaned != 0 {
+		t.Errorf("Wrong match. expect Cleaned: 0, got: %d", res.Cleaned)
+	}
+
+	afterFailed := testutil.ToFloat64(promCampaignFlowReconcileFailedTotal)
+	if afterFailed != beforeFailed+1 {
+		t.Errorf("Wrong match. expect failed metric delta 1 (same shared counter as the FlowV1FlowGet-error case), got: %v", afterFailed-beforeFailed)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_defensiveGuardNilTMDelete_skipped(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111106")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222206"),
+		TMDelete: nil, // should never happen given the query's own filter -- defensive guard
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	// no FlowV1FlowGet/FlowV1FlowDelete EXPECT() -- either call fails the test
+
+	hadWarn, cleanup := captureWarnLogs()
+	defer cleanup()
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("Wrong match. expect Skipped: 1, got: %d", res.Skipped)
+	}
+	if !hadWarn() {
+		t.Errorf("Wrong match. expect a warn log for the defensive guard, got none")
+	}
+}
+
+func Test_ReconcileOrphanedFlows_saturatedSignal(t *testing.T) {
+	origScanLimit := scanLimit
+	scanLimit = 3
+	defer func() { scanLimit = origScanLimit }()
+
+	tests := []struct {
+		name            string
+		candidateCount  int
+		expectSaturated bool
+	}{
+		{"batch reaches scanLimit", 3, true},
+		{"batch below scanLimit", 2, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+			now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+			candidates := make([]*campaign.Campaign, 0, tt.candidateCount)
+			for i := 0; i < tt.candidateCount; i++ {
+				candidates = append(candidates, &campaign.Campaign{
+					Identity: commonidentity.Identity{ID: uuid.Must(uuid.NewV4())},
+					FlowID:   uuid.Must(uuid.NewV4()),
+					// well outside any recentInterval used below
+					TMDelete: timePtr(now.Add(-48 * time.Hour)),
+				})
+			}
+
+			mockUtil.EXPECT().TimeNow().Return(&now)
+			mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return(candidates, nil)
+			mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), gomock.Any()).Return(&fmflow.Flow{TMDelete: timePtr(now)}, nil).Times(tt.candidateCount)
+
+			res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+			if err != nil {
+				t.Fatalf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.Saturated != tt.expectSaturated {
+				t.Errorf("Wrong match. expect Saturated: %v, got: %v", tt.expectSaturated, res.Saturated)
+			}
+		})
+	}
+}
+
+func Test_ReconcileOrphanedFlows_recentSaturatedDistinguishesFromSaturated(t *testing.T) {
+	origScanLimit := scanLimit
+	scanLimit = 3
+	defer func() { scanLimit = origScanLimit }()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	recentIntervalSec := int64(3600) // 1 hour
+
+	tests := []struct {
+		name                  string
+		deletedAgo            []time.Duration
+		expectSaturated       bool
+		expectRecentSaturated bool
+	}{
+		{
+			"all rows within recentInterval -- rate-risk signal fires",
+			[]time.Duration{10 * time.Minute, 20 * time.Minute, 30 * time.Minute},
+			true,
+			true,
+		},
+		{
+			"batch full but rows mostly older than recentInterval -- informational only",
+			[]time.Duration{2 * time.Hour, 3 * time.Hour, 4 * time.Hour},
+			true,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+			candidates := make([]*campaign.Campaign, 0, len(tt.deletedAgo))
+			for _, ago := range tt.deletedAgo {
+				candidates = append(candidates, &campaign.Campaign{
+					Identity: commonidentity.Identity{ID: uuid.Must(uuid.NewV4())},
+					FlowID:   uuid.Must(uuid.NewV4()),
+					TMDelete: timePtr(now.Add(-ago)),
+				})
+			}
+
+			mockUtil.EXPECT().TimeNow().Return(&now)
+			mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return(candidates, nil)
+			mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), gomock.Any()).Return(&fmflow.Flow{TMDelete: timePtr(now)}, nil).Times(len(candidates))
+
+			res, err := h.ReconcileOrphanedFlows(context.Background(), recentIntervalSec)
+			if err != nil {
+				t.Fatalf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.Saturated != tt.expectSaturated {
+				t.Errorf("Wrong match. expect Saturated: %v, got: %v", tt.expectSaturated, res.Saturated)
+			}
+			if res.RecentSaturated != tt.expectRecentSaturated {
+				t.Errorf("Wrong match. expect RecentSaturated: %v, got: %v", tt.expectRecentSaturated, res.RecentSaturated)
+			}
+		})
+	}
+}
+
+// Test_ReconcileOrphanedFlows_saturationComputedBeforeTimeout exercises the
+// design-round-4 fix: Saturated/RecentSaturated must be computed in a
+// dedicated, RPC-free pass before the RPC loop begins, not interleaved with
+// it -- otherwise the self-imposed pass timeout could cut the count short
+// of scanLimit even on a genuinely saturated batch. Uses a
+// reconcilePassTimeout long enough to survive CampaignListDeletedSince (an
+// instant mock call) but short enough to expire partway through the RPC
+// loop -- never a 0-duration timeout, which would fail the query itself
+// before there is any ReconcileResult to assert against.
+func Test_ReconcileOrphanedFlows_saturationComputedBeforeTimeout(t *testing.T) {
+	origScanLimit := scanLimit
+	origTimeout := reconcilePassTimeout
+	scanLimit = 2
+	reconcilePassTimeout = 30 * time.Millisecond
+	defer func() {
+		scanLimit = origScanLimit
+		reconcilePassTimeout = origTimeout
+	}()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	candidates := []*campaign.Campaign{
+		{
+			Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111107")},
+			FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222207"),
+			TMDelete: timePtr(now.Add(-10 * time.Minute)),
+		},
+		{
+			Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111108")},
+			FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222208"),
+			TMDelete: timePtr(now.Add(-20 * time.Minute)),
+		},
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return(candidates, nil)
+	// The first candidate's FlowV1FlowGet sleeps past reconcilePassTimeout,
+	// so the second candidate never gets its RPC issued -- Saturated and
+	// RecentSaturated must already reflect the full 2-row batch, since they
+	// were computed before this call, not during the loop.
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ uuid.UUID) (*fmflow.Flow, error) {
+			time.Sleep(60 * time.Millisecond)
+			return &fmflow.Flow{TMDelete: timePtr(now)}, nil
+		},
+	).Times(1)
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if !res.Saturated {
+		t.Errorf("Wrong match. expect Saturated: true, got: false")
+	}
+	if !res.RecentSaturated {
+		t.Errorf("Wrong match. expect RecentSaturated: true, got: false")
+	}
+	if !res.Partial {
+		t.Errorf("Wrong match. expect Partial: true, got: false")
+	}
+}
+
+func Test_ReconcileOrphanedFlows_recentIntervalFallback(t *testing.T) {
+	tests := []int64{0, -1, -100}
+
+	for _, recentIntervalSec := range tests {
+		t.Run(fmt.Sprintf("recentIntervalSec_%d", recentIntervalSec), func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockUtil := utilhandler.NewMockUtilHandler(mc)
+			mockDB := dbhandler.NewMockDBHandler(mc)
+			mockReq := requesthandler.NewMockRequestHandler(mc)
+			h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+			now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+			c := &campaign.Campaign{
+				Identity: commonidentity.Identity{ID: uuid.Must(uuid.NewV4())},
+				FlowID:   uuid.Must(uuid.NewV4()),
+				TMDelete: timePtr(now.Add(-2 * time.Hour)),
+			}
+
+			mockUtil.EXPECT().TimeNow().Return(&now)
+			mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+			mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: timePtr(now)}, nil)
+
+			hadWarn, cleanup := captureWarnLogs()
+			defer cleanup()
+
+			res, err := h.ReconcileOrphanedFlows(context.Background(), recentIntervalSec)
+			if err != nil {
+				t.Fatalf("Wrong match. expect: ok, got: %v", err)
+			}
+			if res.Skipped != 1 {
+				t.Errorf("Wrong match. expect Skipped: 1, got: %d", res.Skipped)
+			}
+			if !hadWarn() {
+				t.Errorf("Wrong match. expect a warn log for non-positive recentIntervalSec, got none")
+			}
+		})
+	}
+}
+
+func Test_ReconcileOrphanedFlows_partialOnSelfTimeout(t *testing.T) {
+	origTimeout := reconcilePassTimeout
+	reconcilePassTimeout = 30 * time.Millisecond
+	defer func() { reconcilePassTimeout = origTimeout }()
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	candidates := []*campaign.Campaign{
+		{
+			Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111109")},
+			FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222209"),
+			TMDelete: timePtr(now.Add(-time.Hour)),
+		},
+		{
+			Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111110")},
+			FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222210"),
+			TMDelete: timePtr(now.Add(-time.Hour)),
+		},
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return(candidates, nil)
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ uuid.UUID) (*fmflow.Flow, error) {
+			time.Sleep(60 * time.Millisecond)
+			return &fmflow.Flow{TMDelete: timePtr(now)}, nil
+		},
+	).Times(1)
+
+	hadWarn, cleanup := captureWarnLogs()
+	defer cleanup()
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if !res.Partial {
+		t.Errorf("Wrong match. expect Partial: true, got: false")
+	}
+	if res.Skipped != 1 {
+		t.Errorf("Wrong match. expect Skipped: 1 (only the first candidate was processed), got: %d", res.Skipped)
+	}
+	if !hadWarn() {
+		t.Errorf("Wrong match. expect a warn log for the self-imposed timeout bail-out, got none")
+	}
+}
+
+func Test_ReconcileOrphanedFlows_emptySet(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{}, nil)
+	// no FlowV1FlowGet/FlowV1FlowDelete EXPECT() -- zero RPCs expected
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+
+	expect := campaign.ReconcileResult{}
+	if res != expect {
+		t.Errorf("Wrong match. expect: %+v, got: %+v", expect, res)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_idempotentRerun(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222211"),
+		TMDelete: timePtr(now.Add(-time.Hour)),
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now).Times(2)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil).Times(2)
+
+	gomock.InOrder(
+		// first pass: flow is live -> genuinely orphaned, cleaned
+		mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: nil}, nil),
+		mockReq.EXPECT().FlowV1FlowDelete(gomock.Any(), c.FlowID).Return(&fmflow.Flow{}, nil),
+		// second pass: flow is now deleted -> skipped, no second delete call
+		mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: timePtr(now)}, nil),
+	)
+
+	res1, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res1.Cleaned != 1 {
+		t.Errorf("Wrong match. expect first-pass Cleaned: 1, got: %d", res1.Cleaned)
+	}
+
+	res2, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res2.Cleaned != 0 || res2.Skipped != 1 {
+		t.Errorf("Wrong match. expect second-pass Cleaned=0 Skipped=1 (no re-delete), got: %+v", res2)
+	}
+}
+
+func Test_ReconcileOrphanedFlows_windowEdgeWarning(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockReq := requesthandler.NewMockRequestHandler(mc)
+	h := &campaignHandler{util: mockUtil, db: mockDB, reqHandler: mockReq}
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	// deleted just inside the window's outer edge (well within the 10%
+	// margin from the cutoff) -- must trigger the window-edge warning.
+	c := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("11111111-1111-1111-1111-111111111112")},
+		FlowID:   uuid.FromStringOrNil("22222222-2222-2222-2222-222222222212"),
+		TMDelete: timePtr(now.Add(-window + time.Minute)),
+	}
+
+	mockUtil.EXPECT().TimeNow().Return(&now)
+	mockDB.EXPECT().CampaignListDeletedSince(gomock.Any(), gomock.Any(), scanLimit).Return([]*campaign.Campaign{c}, nil)
+	mockReq.EXPECT().FlowV1FlowGet(gomock.Any(), c.FlowID).Return(&fmflow.Flow{TMDelete: nil}, nil)
+	mockReq.EXPECT().FlowV1FlowDelete(gomock.Any(), c.FlowID).Return(&fmflow.Flow{}, nil)
+
+	hadWarn, cleanup := captureWarnLogs()
+	defer cleanup()
+
+	res, err := h.ReconcileOrphanedFlows(context.Background(), 3600)
+	if err != nil {
+		t.Fatalf("Wrong match. expect: ok, got: %v", err)
+	}
+	if res.Cleaned != 1 {
+		t.Errorf("Wrong match. expect Cleaned: 1, got: %d", res.Cleaned)
+	}
+	if !hadWarn() {
+		t.Errorf("Wrong match. expect a window-edge warn log, got none")
+	}
+}

--- a/bin-campaign-manager/pkg/dbhandler/campaign.go
+++ b/bin-campaign-manager/pkg/dbhandler/campaign.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/gofrs/uuid"
@@ -245,6 +246,59 @@ func (h *handler) CampaignList(ctx context.Context, token string, size uint64, f
 	}
 	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows iteration error. CampaignList. err: %v", err)
+	}
+
+	return res, nil
+}
+
+// CampaignListDeletedSince returns campaigns deleted on or after the given
+// time, most-recently-deleted first, bounded by limit. Used by the
+// orphaned-flow reconciliation job (VOIP-1444) to find recently deleted
+// campaigns whose backing flow may still be live.
+//
+// DESC order (not ASC) is deliberate: with no cursor between passes, ASC
+// LIMIT would return the exact same oldest rows forever once in-window
+// candidates exceed limit, permanently starving newer deletions. DESC
+// guarantees every pass covers the most recent deletions first, matching
+// this job's actual purpose (catch a leak shortly after it happens). See
+// docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-plan.md's
+// "Scan order and coverage" section for the full analysis.
+//
+// The comparison against the nullable tm_delete column naturally excludes
+// live campaigns (tm_delete IS NULL) via standard SQL NULL-comparison
+// semantics — no separate IS NOT NULL predicate is needed.
+func (h *handler) CampaignListDeletedSince(ctx context.Context, since time.Time, limit uint64) ([]*campaign.Campaign, error) {
+	fields := commondatabasehandler.GetDBFields(&campaign.Campaign{})
+	query, args, err := squirrel.
+		Select(fields...).
+		From(campaignsTable).
+		Where(squirrel.GtOrEq{string(campaign.FieldTMDelete): since}).
+		OrderBy(string(campaign.FieldTMDelete) + " DESC").
+		Limit(limit).
+		PlaceholderFormat(squirrel.Question).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("could not build query. CampaignListDeletedSince. err: %v", err)
+	}
+
+	rows, err := h.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("could not query. CampaignListDeletedSince. err: %v", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	res := []*campaign.Campaign{}
+	for rows.Next() {
+		u, err := h.campaignGetFromRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("could not get data. CampaignListDeletedSince, err: %v", err)
+		}
+		res = append(res, u)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error. CampaignListDeletedSince. err: %v", err)
 	}
 
 	return res, nil

--- a/bin-campaign-manager/pkg/dbhandler/campaign_reconcile_test.go
+++ b/bin-campaign-manager/pkg/dbhandler/campaign_reconcile_test.go
@@ -1,0 +1,112 @@
+package dbhandler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commonidentity "monorepo/bin-common-handler/models/identity"
+	"monorepo/bin-common-handler/pkg/utilhandler"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-campaign-manager/models/campaign"
+	"monorepo/bin-campaign-manager/pkg/cachehandler"
+)
+
+// Test_CampaignListDeletedSince verifies the date-range filter, the DESC
+// order, and the NULL-comparison exclusion of live campaigns, against the
+// real SQLite test-schema harness (see main_test.go).
+func Test_CampaignListDeletedSince(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockUtil := utilhandler.NewMockUtilHandler(mc)
+	mockCache := cachehandler.NewMockCacheHandler(mc)
+	h := &handler{
+		util:  mockUtil,
+		db:    dbTest,
+		cache: mockCache,
+	}
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	liveCampaign := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000001")},
+		Status:   campaign.StatusStop,
+	}
+	recentlyDeleted := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000002")},
+		Status:   campaign.StatusStop,
+	}
+	olderDeleted := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000003")},
+		Status:   campaign.StatusStop,
+	}
+	outOfWindowDeleted := &campaign.Campaign{
+		Identity: commonidentity.Identity{ID: uuid.FromStringOrNil("aaaaaaaa-0000-0000-0000-000000000004")},
+		Status:   campaign.StatusStop,
+	}
+
+	mockCache.EXPECT().CampaignSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockUtil.EXPECT().TimeNow().Return(&now).AnyTimes()
+
+	for _, c := range []*campaign.Campaign{liveCampaign, recentlyDeleted, olderDeleted, outOfWindowDeleted} {
+		if err := h.CampaignCreate(ctx, c); err != nil {
+			t.Fatalf("Could not create campaign. err: %v", err)
+		}
+	}
+
+	since := now.Add(-24 * time.Hour)
+	tmDeletes := map[uuid.UUID]time.Time{
+		recentlyDeleted.ID:    now.Add(-1 * time.Hour),  // within window, newest
+		olderDeleted.ID:       now.Add(-12 * time.Hour), // within window, older
+		outOfWindowDeleted.ID: now.Add(-48 * time.Hour), // before the cutoff
+	}
+	for id, ts := range tmDeletes {
+		tsCopy := ts
+		if _, err := dbTest.ExecContext(ctx, "UPDATE campaign_campaigns SET tm_delete = ? WHERE id = ?", tsCopy, id.Bytes()); err != nil {
+			t.Fatalf("Could not set tm_delete. err: %v", err)
+		}
+	}
+
+	res, err := h.CampaignListDeletedSince(ctx, since, 10)
+	if err != nil {
+		t.Fatalf("Could not list deleted campaigns. err: %v", err)
+	}
+
+	if len(res) != 2 {
+		t.Fatalf("Wrong match. expect: 2 campaigns (live and out-of-window excluded), got: %d", len(res))
+	}
+
+	// DESC order: most-recently-deleted first.
+	if res[0].ID != recentlyDeleted.ID {
+		t.Errorf("Wrong match. expect first (most recent): %s, got: %s", recentlyDeleted.ID, res[0].ID)
+	}
+	if res[1].ID != olderDeleted.ID {
+		t.Errorf("Wrong match. expect second: %s, got: %s", olderDeleted.ID, res[1].ID)
+	}
+
+	for _, c := range res {
+		if c.ID == liveCampaign.ID {
+			t.Errorf("Wrong match. live campaign (tm_delete IS NULL) must be excluded via NULL-comparison semantics")
+		}
+		if c.ID == outOfWindowDeleted.ID {
+			t.Errorf("Wrong match. campaign deleted before the cutoff must be excluded")
+		}
+	}
+
+	// limit is respected
+	limited, err := h.CampaignListDeletedSince(ctx, since, 1)
+	if err != nil {
+		t.Fatalf("Could not list deleted campaigns with limit. err: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("Wrong match. expect: 1 campaign with limit=1, got: %d", len(limited))
+	}
+	if limited[0].ID != recentlyDeleted.ID {
+		t.Errorf("Wrong match. expect the single most-recently-deleted row, got: %s", limited[0].ID)
+	}
+}

--- a/bin-campaign-manager/pkg/dbhandler/main.go
+++ b/bin-campaign-manager/pkg/dbhandler/main.go
@@ -52,6 +52,7 @@ type DBHandler interface {
 	CampaignGet(ctx context.Context, id uuid.UUID) (*campaign.Campaign, error)
 	CampaignList(ctx context.Context, token string, size uint64, filters map[campaign.Field]any) ([]*campaign.Campaign, error)
 	CampaignListByCustomerID(ctx context.Context, customerID uuid.UUID, token string, limit uint64) ([]*campaign.Campaign, error)
+	CampaignListDeletedSince(ctx context.Context, since time.Time, limit uint64) ([]*campaign.Campaign, error)
 	CampaignUpdate(ctx context.Context, id uuid.UUID, fields map[campaign.Field]any) error
 	CampaignUpdateBasicInfo(
 		ctx context.Context,

--- a/bin-campaign-manager/pkg/dbhandler/mock_dbhandler.go
+++ b/bin-campaign-manager/pkg/dbhandler/mock_dbhandler.go
@@ -17,6 +17,7 @@ import (
 	address "monorepo/bin-common-handler/models/address"
 	action "monorepo/bin-flow-manager/models/action"
 	reflect "reflect"
+	time "time"
 
 	uuid "github.com/gofrs/uuid"
 	gomock "go.uber.org/mock/gomock"
@@ -117,6 +118,21 @@ func (m *MockDBHandler) CampaignListByCustomerID(ctx context.Context, customerID
 func (mr *MockDBHandlerMockRecorder) CampaignListByCustomerID(ctx, customerID, token, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CampaignListByCustomerID", reflect.TypeOf((*MockDBHandler)(nil).CampaignListByCustomerID), ctx, customerID, token, limit)
+}
+
+// CampaignListDeletedSince mocks base method.
+func (m *MockDBHandler) CampaignListDeletedSince(ctx context.Context, since time.Time, limit uint64) ([]*campaign.Campaign, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CampaignListDeletedSince", ctx, since, limit)
+	ret0, _ := ret[0].([]*campaign.Campaign)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CampaignListDeletedSince indicates an expected call of CampaignListDeletedSince.
+func (mr *MockDBHandlerMockRecorder) CampaignListDeletedSince(ctx, since, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CampaignListDeletedSince", reflect.TypeOf((*MockDBHandler)(nil).CampaignListDeletedSince), ctx, since, limit)
 }
 
 // CampaignUpdate mocks base method.

--- a/bin-campaign-manager/pkg/listenhandler/flows.go
+++ b/bin-campaign-manager/pkg/listenhandler/flows.go
@@ -1,0 +1,58 @@
+package listenhandler
+
+import (
+	"context"
+	"encoding/json"
+
+	"monorepo/bin-common-handler/models/sock"
+
+	"github.com/sirupsen/logrus"
+
+	"monorepo/bin-campaign-manager/pkg/listenhandler/models/request"
+)
+
+// v1CampaignsFlowsReconcilePost handles /v1/campaigns/flows/reconcile POST
+// request (VOIP-1444). Internal-only route, dispatched by the
+// bin-schedule-manager "campaign-flow-reconcile" schedule (or a manual
+// POST /v1/schedules/{id}/execute) — not exposed through bin-api-manager.
+//
+// The handler always returns HTTP 200 for a pass that ran, even if
+// Failed > 0 or Partial == true (individual row failures and a self-timeout
+// cutoff are data, not a pass-level error). A non-nil err from the handler
+// (the initial query itself failing) is the only case that produces a
+// non-2xx response, via the default error handling in processRequest.
+func (h *listenHandler) v1CampaignsFlowsReconcilePost(ctx context.Context, m *sock.Request) (*sock.Response, error) {
+	log := logrus.WithFields(logrus.Fields{
+		"func":    "v1CampaignsFlowsReconcilePost",
+		"request": m,
+	})
+	log.Debug("Received request.")
+
+	var req request.V1DataCampaignsFlowsReconcilePost
+	if len(m.Data) > 0 {
+		if err := json.Unmarshal(m.Data, &req); err != nil {
+			log.Errorf("Could not marshal the data. err: %v", err)
+			return nil, err
+		}
+	}
+
+	result, err := h.campaignHandler.ReconcileOrphanedFlows(ctx, req.RecentIntervalSec)
+	if err != nil {
+		log.Errorf("Could not reconcile orphaned flows. err: %v", err)
+		return nil, err
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		log.Errorf("Could not marshal the res. err: %v", err)
+		return nil, err
+	}
+
+	res := &sock.Response{
+		StatusCode: 200,
+		DataType:   "application/json",
+		Data:       data,
+	}
+
+	return res, nil
+}

--- a/bin-campaign-manager/pkg/listenhandler/flows_test.go
+++ b/bin-campaign-manager/pkg/listenhandler/flows_test.go
@@ -1,0 +1,127 @@
+package listenhandler
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"monorepo/bin-common-handler/models/sock"
+	"monorepo/bin-common-handler/pkg/sockhandler"
+
+	"go.uber.org/mock/gomock"
+
+	"monorepo/bin-campaign-manager/models/campaign"
+	"monorepo/bin-campaign-manager/pkg/campaignhandler"
+)
+
+func Test_v1CampaignsFlowsReconcilePost(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		request *sock.Request
+
+		expectRecentIntervalSec int64
+		responseResult          campaign.ReconcileResult
+	}{
+		{
+			"normal, clean pass",
+			&sock.Request{
+				URI:      "/v1/campaigns/flows/reconcile",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"recent_interval_sec":21600}`),
+			},
+
+			21600,
+			campaign.ReconcileResult{
+				Cleaned: 2,
+				Skipped: 3,
+				Failed:  0,
+			},
+		},
+		{
+			"pass with row-level failures still returns 200",
+			&sock.Request{
+				URI:      "/v1/campaigns/flows/reconcile",
+				Method:   sock.RequestMethodPost,
+				DataType: "application/json",
+				Data:     []byte(`{"recent_interval_sec":3600}`),
+			},
+
+			3600,
+			campaign.ReconcileResult{
+				Cleaned: 0,
+				Skipped: 0,
+				Failed:  4,
+				Partial: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := gomock.NewController(t)
+			defer mc.Finish()
+
+			mockSock := sockhandler.NewMockSockHandler(mc)
+			mockCampaign := campaignhandler.NewMockCampaignHandler(mc)
+
+			h := &listenHandler{
+				sockHandler:     mockSock,
+				campaignHandler: mockCampaign,
+			}
+
+			mockCampaign.EXPECT().ReconcileOrphanedFlows(gomock.Any(), tt.expectRecentIntervalSec).Return(tt.responseResult, nil)
+
+			expectData, err := json.Marshal(tt.responseResult)
+			if err != nil {
+				t.Fatalf("Could not marshal expected result. err: %v", err)
+			}
+			expectRes := &sock.Response{
+				StatusCode: 200,
+				DataType:   "application/json",
+				Data:       expectData,
+			}
+
+			res, err := h.processRequest(tt.request)
+			if err != nil {
+				t.Errorf("Wrong match. expect: ok, got: %v", err)
+			}
+
+			if reflect.DeepEqual(res, expectRes) != true {
+				t.Errorf("Wrong match.\nexpect: %s\ngot: %s", expectRes.Data, res.Data)
+			}
+		})
+	}
+}
+
+func Test_v1CampaignsFlowsReconcilePost_queryError(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockCampaign := campaignhandler.NewMockCampaignHandler(mc)
+
+	h := &listenHandler{
+		sockHandler:     mockSock,
+		campaignHandler: mockCampaign,
+	}
+
+	req := &sock.Request{
+		URI:      "/v1/campaigns/flows/reconcile",
+		Method:   sock.RequestMethodPost,
+		DataType: "application/json",
+		Data:     []byte(`{"recent_interval_sec":3600}`),
+	}
+
+	mockCampaign.EXPECT().ReconcileOrphanedFlows(gomock.Any(), int64(3600)).Return(campaign.ReconcileResult{}, fmt.Errorf("could not query the database"))
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Errorf("Wrong match. processRequest itself must not return an error (mapped to a response). got: %v", err)
+	}
+	if res == nil || res.StatusCode == 200 {
+		t.Errorf("Wrong match. expect a non-200 response when the handler itself fails, got: %+v", res)
+	}
+}

--- a/bin-campaign-manager/pkg/listenhandler/main.go
+++ b/bin-campaign-manager/pkg/listenhandler/main.go
@@ -54,6 +54,10 @@ var (
 	regV1CampaignsIDResourceInfo   = regexp.MustCompile("/v1/campaigns/" + regUUID + "/resource_info$")
 	regV1CampaignsIDNextCampaignID = regexp.MustCompile("/v1/campaigns/" + regUUID + "/next_campaign_id$")
 
+	// campaigns/flows -- internal-only, dispatched by bin-schedule-manager
+	// (VOIP-1444), never exposed through bin-api-manager
+	regV1CampaignsFlowsReconcile = regexp.MustCompile("/v1/campaigns/flows/reconcile$")
+
 	// campaigncalls
 	regV1CampaigncallsGet = regexp.MustCompile(`/v1/campaigncalls\?`)
 	regV1CampaigncallsID  = regexp.MustCompile("/v1/campaigncalls/" + regUUID + "$")
@@ -232,6 +236,11 @@ func (h *listenHandler) processRequest(m *sock.Request) (*sock.Response, error) 
 	case regV1CampaignsIDNextCampaignID.MatchString(m.URI) && m.Method == sock.RequestMethodPut:
 		requestType = "/v1/campaigns/<campaign-id>/next_campaign_id"
 		response, err = h.v1CampaignsIDNextCampaignIDPut(ctx, m)
+
+	// /v1/campaigns/flows/reconcile
+	case regV1CampaignsFlowsReconcile.MatchString(m.URI) && m.Method == sock.RequestMethodPost:
+		requestType = "/v1/campaigns/flows/reconcile"
+		response, err = h.v1CampaignsFlowsReconcilePost(ctx, m)
 
 	// campaigncalls
 	// /v1/campaigncalls

--- a/bin-campaign-manager/pkg/listenhandler/models/request/flows.go
+++ b/bin-campaign-manager/pkg/listenhandler/models/request/flows.go
@@ -1,0 +1,13 @@
+package request
+
+// V1DataCampaignsFlowsReconcilePost is
+// v1 data type request struct for
+// /v1/campaigns/flows/reconcile POST
+type V1DataCampaignsFlowsReconcilePost struct {
+	// RecentIntervalSec is the caller's (bin-schedule-manager's) cron
+	// interval, in seconds, for the schedule dispatching this pass. Used
+	// by ReconcileOrphanedFlows to compute the RecentSaturated rate-risk
+	// signal. A missing or non-positive value falls back to a
+	// conservative default inside the handler.
+	RecentIntervalSec int64 `json:"recent_interval_sec"`
+}

--- a/bin-campaign-manager/scripts/database_scripts/table_campaigns.sql
+++ b/bin-campaign-manager/scripts/database_scripts/table_campaigns.sql
@@ -37,3 +37,4 @@ create index idx_campaign_campaigns_flow_id on campaign_campaigns(flow_id);
 create index idx_campaign_campaigns_outplan_id on campaign_campaigns(outplan_id);
 create index idx_campaign_campaigns_outdial_id on campaign_campaigns(outdial_id);
 create index idx_campaign_campaigns_queue_id on campaign_campaigns(queue_id);
+create index idx_campaign_campaigns_tm_delete on campaign_campaigns(tm_delete);

--- a/bin-dbscheme-manager/bin-manager/main/versions/9f7413ad1d07_schedule_schedules_seed_campaign_flow_.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/9f7413ad1d07_schedule_schedules_seed_campaign_flow_.py
@@ -1,0 +1,132 @@
+"""schedule_schedules_seed_campaign_flow_reconcile
+
+Revision ID: 9f7413ad1d07
+Revises: 75bf4fd0682a
+Create Date: 2026-09-02 16:32:50.293038
+
+Seeds the "campaign-flow-reconcile" schedule for bin-schedule-manager
+(VOIP-1444). See
+docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-design.md
+and the paired -plan.md's "Tasks -- bin-dbscheme-manager" / task 8.
+
+Every column both precedent migrations set is set explicitly here,
+never left to a DB default -- most critically timeout_ms, which is
+NOT NULL with no DEFAULT: under a strict sql_mode an INSERT omitting
+it fails loudly at apply time; under a relaxed sql_mode it can
+silently insert 0, which requesthandler.SendRequest turns into an
+already-expired context.WithTimeout on every dispatch, forever.
+
+Primary model: 0c037bf0a362 (schedule_schedules_seed_phase2_ticker_
+jobs) -- the closer precedent for this ticket's cross-service
+dispatch shape (bin-campaign-manager's own /v1/... route) than
+a5e6f559299c's self-RPC housekeeping jobs. Both precedents happen to
+set an identical column list.
+
+target_data carries recent_interval_sec via JSON_OBJECT('recent_
+interval_sec', 21600) -- a bound SQL parameter, not a raw JSON string
+literal like '{"recent_interval_sec": 21600}': op.execute() passes
+raw SQL through sqlalchemy.text(), which would parse the literal's
+bare colon as a bind-parameter marker (the VOIP-1283 hotfix pitfall,
+documented in 0c037bf0a362). recent_interval_sec is seeded here
+alongside cron (both derive from the same 6-hour interval decision)
+so the *initial* values can only drift apart by missing a line in
+this same diff. This protects the initial seed only -- it does NOT
+protect against later drift: a post-seed edit to cron (via
+schedule-control or PUT /v1/schedules/{id}, including the
+RecentSaturated "shorten the interval" remedy documented in
+docs/operations.md) does not automatically update
+target_data.recent_interval_sec, since the two are edited through
+entirely different operational paths once the schedule exists. Any
+future change to the cron interval must update both in the same
+operational change and re-verify reconcilePassTimeout (see below)
+against the new interval -- see bin-campaign-manager/docs/
+operations.md's "Changing the schedule's cron interval" section.
+
+This row ships enabled=0, unlike every row in the 0c037bf0a362
+precedent (which all ship enabled=1). This is deliberate, not an
+oversight: the schedule would otherwise dispatch into a route that
+does not exist yet the moment this migration is applied, ahead of
+the bin-campaign-manager deploy carrying it (the "schedule seeded
+before the route exists" ordering hazard). The rollout sequence
+(apply migration -> deploy the image -> manual
+POST /v1/schedules/{id}/execute smoke test, polled to a terminal
+`success` execution -> `schedule-control schedule enable
+campaign-flow-reconcile`) is documented in the PR description, not
+performed by this migration or by this AI session -- per this
+repo's Alembic AI-authorship boundary, this session creates and
+commits the migration file only, and never runs `alembic upgrade` /
+`alembic downgrade`, nor the post-deploy enable step.
+
+timeout_ms / retry_max / cron sizing (worked example, re-verify
+against real measured RPC latency before the schedule is enabled):
+  - reconcilePassTimeout (pkg/campaignhandler/reconcile.go) = 90s
+  - timeout_ms = 120000 (120s) -- strictly above reconcilePassTimeout,
+    with 30s margin covering real message-delivery delay (not just
+    processing latency; the two timeouts' clocks start at different
+    points -- see bin-campaign-manager/docs/operations.md). This is
+    the actual mutual-exclusion guarantee: it keeps
+    bin-schedule-manager's "Forbid overlap" guard (ExecutionHasRunning,
+    checked before the tm_next_run CAS on every claim path) covering
+    this pass's entire physical duration.
+  - retry_max = 0 -- a failed pass is naturally retried by the next
+    scheduled run; no schedule-level retry needed. Also keeps the
+    reap-deadline formula below simple (no in-execution retry loop).
+  - cron = '0 */6 * * *' (every 6 hours) -- reconcilePassTimeout (90s)
+    is well below this interval (cadence/liveness requirement, not a
+    concurrency guard: keeps the schedule from chronically observing
+    dispatch-level skipped_overlap skips). timeout_ms + 60s (180s,
+    the reap deadline at retry_max=0, bounding how long a
+    bin-schedule-manager dispatch goroutine itself crashing --
+    "abandon-not-drain" -- can leave this schedule's execution row
+    stuck running) is also comfortably below the 6-hour interval.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9f7413ad1d07'
+down_revision = '75bf4fd0682a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO schedule_schedules (
+            id, customer_id, name, detail, type, cron,
+            target_queue, target_uri, target_method, target_data_type, target_data,
+            timeout_ms, retry_max, enabled, tm_next_run, tm_create, tm_update
+        ) VALUES (
+            UNHEX(REPLACE(UUID(), '-', '')),
+            UNHEX('00000000000000000000000000000000'),
+            'campaign-flow-reconcile',
+            'Delete orphaned flows left behind by campaigns deleted within the last 7 days',
+            'rpc',
+            '0 */6 * * *',
+            'bin-manager.campaign-manager.request',
+            '/v1/campaigns/flows/reconcile',
+            'POST',
+            'application/json',
+            JSON_OBJECT('recent_interval_sec', 21600),
+            120000,
+            0,
+            0,
+            NULL,
+            UTC_TIMESTAMP(6),
+            UTC_TIMESTAMP(6)
+        );
+    """)
+
+
+def downgrade():
+    # No executions cleanup needed: there is no FK from
+    # schedule_executions.schedule_id to schedule_schedules.id, so a
+    # plain DELETE leaves at most orphaned audit rows, consistent with
+    # how schedule_executions already outlives soft-deleted schedules
+    # via the app-level DELETE /v1/schedules/<id> API path.
+    op.execute("""
+        DELETE FROM schedule_schedules
+        WHERE name = 'campaign-flow-reconcile'
+          AND customer_id = UNHEX('00000000000000000000000000000000');
+    """)

--- a/bin-dbscheme-manager/bin-manager/main/versions/ab1507b96589_campaign_campaigns_add_index_tm_delete.py
+++ b/bin-dbscheme-manager/bin-manager/main/versions/ab1507b96589_campaign_campaigns_add_index_tm_delete.py
@@ -1,0 +1,45 @@
+"""campaign_campaigns_add_index_tm_delete
+
+Revision ID: ab1507b96589
+Revises: 9f7413ad1d07
+Create Date: 2026-09-02 16:33:11.673388
+
+Adds an index on campaign_campaigns.tm_delete for the orphaned-flow
+reconciliation job (VOIP-1444,
+pkg/dbhandler.CampaignListDeletedSince). Without it, the job's
+`WHERE tm_delete >= ? ORDER BY tm_delete DESC LIMIT ?` query
+full-scans the table on every scheduled run (every 6 hours by
+default -- see the paired schedule seed migration,
+9f7413ad1d07). campaign_campaigns previously had indexes only on
+customer_id, flow_id, outplan_id, outdial_id, and queue_id -- none
+on tm_delete.
+
+Included per the plan's conservative default (add the index
+regardless of measured row count/deletion rate -- small, additive,
+reversible) rather than blocking on production data this session had
+no access to. See
+docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-plan.md's
+"Pre-implementation check".
+
+Per bin-dbscheme-manager/CLAUDE.md's migration+fixture-sync rule, the
+test-schema fixture
+(bin-campaign-manager/scripts/database_scripts/table_campaigns.sql)
+is updated in this same commit to add the matching index.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ab1507b96589'
+down_revision = '9f7413ad1d07'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""CREATE INDEX idx_campaign_campaigns_tm_delete ON campaign_campaigns(tm_delete);""")
+
+
+def downgrade():
+    op.execute("""DROP INDEX idx_campaign_campaigns_tm_delete ON campaign_campaigns;""")

--- a/docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-design.md
+++ b/docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-design.md
@@ -1,0 +1,715 @@
+# Issue Analysis and Design: VOIP-1444 — reconciliation job for orphaned campaign flows
+
+(Title deliberately does not carry a round number — see the repeated staleness this caused,
+flagged at design-review round 3. Round tracking lives entirely in "Revision history" below.
+Design-review-round-9 addition: title updated from "Issue Analysis" alone — the document started
+as issue-analysis-only through round 8, but rounds 3-8 of design review folded substantial design
+content into the same file ("Proposed scope", "Correct placement", "Scheduling mechanism", etc.),
+and the plan document consistently refers to this file as "the design doc".)
+
+## Revision history
+
+- **Round 1** (REQUEST_CHANGES): the proposed self-scheduling mechanism (a self-perpetuating
+  delayed RPC chain, bootstrapped once per pod boot) was unsafe under this service's 2-replica,
+  `restart: always` deployment.
+- **Round 2** (REQUEST_CHANGES): found the original orphan-detection criterion wrong
+  (`FlowV1FlowGet` succeeding does not mean the flow is live) and the "zero new DB code" claim
+  false. Corrected the criterion to check `flow.TMDelete != nil`; added a new DB-layer query for
+  the time-windowed scan.
+- **Round 3 / Round 4** (REQUEST_CHANGES both times): spent trying to design an atomic fix to
+  `bin-flow-manager`'s `Delete()` to close a 2-replica concurrent-race window created by the
+  round-1 fallback mechanism (an in-process `time.Ticker` loop). Each attempt found that fix
+  growing in scope (a shared write-path refactor, a return-contract change, a cache-only-flow edge
+  case). Filed separately as **VOIP-1448**, scope narrowed to exclude it from this ticket, and the
+  residual race disclosed as an accepted trade-off.
+- **Round 5** (REQUEST_CHANGES): found that the accepted-trade-off framing was solving the wrong
+  problem — the race exists **only because** of the round-1 ticker-loop mechanism choice, and this
+  platform already has a purpose-built alternative that eliminates the race entirely:
+  **`bin-schedule-manager`** (VOIP-1283), a platform-internal cron scheduler explicitly documented
+  as existing to "absorb... future ticker migrations" via Redis-lock + DB-CAS at-most-once claim
+  semantics, with an audit trail and an ops kill switch (`schedule-control schedule disable`).
+  Using it instead of a bespoke ticker removes the entire "Concurrency: disclosed residual risk"
+  section this document previously had to carry — there is no residual risk to disclose, because
+  no two replicas can claim the same scheduled run. **This revision replaces the ticker-loop
+  mechanism with a `bin-schedule-manager` schedule entry.** VOIP-1448 remains filed and still
+  valid (the underlying `bin-flow-manager` `Delete()` non-idempotency is real and pre-existing,
+  reachable by any two concurrent `DELETE /v1/flows/{id}` callers in general), but it is now fully
+  orthogonal to this ticket rather than something this ticket's design leans on being "small
+  enough to accept."
+- **Round 6** (REQUEST_CHANGES): the proposed Alembic seed migration for the new schedule row
+  omitted several columns the existing platform-job seed migration sets, most critically
+  `timeout_ms` — that column has no DB default, and a schedule row seeded with it unset scans as
+  Go zero value `0`, which produces an already-expired RPC context on every dispatch, forever
+  (confirmed stronger than initially found: `bin-schedule-manager`'s own CRUD validation rejects
+  `timeout_ms <= 0` at creation time, so a *seeded* row — this ticket's only path — is the one way
+  to introduce this defect). Fixed by explicitly enumerating every column the model migration sets,
+  with sizing guidance for `timeout_ms`/`retry_max` against a worst-case pass and a cross-check
+  against the reaper's abandonment-deadline formula.
+- **Round 7** (APPROVE, first of two required consecutive approvals): independently re-verified
+  the round-6 fix and five other claims spread across the document; all held up. Only editorial
+  gaps found — a stale title/changelog lag behind the body, the seed-migration column list not
+  explicitly covering the cosmetic/loud-failure columns alongside the silent-failure one, and the
+  closing open-questions list not yet listing `timeout_ms`/`retry_max` sizing as still-open.
+  Swept in this revision.
+- **Round 8** (APPROVE, second consecutive — issue-analysis phase closed): independently
+  re-verified the round-7 fix; held up. One non-blocking footnote inaccuracy found (a precedent
+  column mischaracterized as "non-nullable" when it is schema-nullable-but-always-populated in
+  practice) — fixed in this revision. This closed the mandatory 2-consecutive-approval issue-
+  analysis gate; the document then moved into the design/plan review stage below.
+- **Design-review round 1** (REQUEST_CHANGES, on the paired design+plan documents): found the
+  "two PRs" premise wrong (this is one monorepo, not two repos), missing rollout sequencing for
+  the schedule-seeded-before-route-exists ordering hazard, a structural scan-starvation bug in the
+  originally-proposed `ORDER BY tm_delete ASC LIMIT n` query, undefined success/failure semantics
+  on `ReconcileOrphanedFlows`, a punted metric-reuse decision, and an under-sized test plan. All
+  addressed in the plan (see the plan's own revision history for the full fix list).
+- **Design-review round 2** (REQUEST_CHANGES): the round-1 `DESC`-order fix was justified with a
+  mathematically false claim; and the proposed response shape violated the root CLAUDE.md's
+  transport-DTO layering rule (a `response.*` DTO that was a field-for-field copy of the domain
+  `ReconcileResult` struct). Both corrected in the plan.
+- **Design-review round 3** (REQUEST_CHANGES): found six further defects introduced by or
+  surviving the round-1/round-2 fixes, the most significant being that this service's RPC
+  listenhandler builds requests with `context.Background()` (no deadline propagation), which
+  falsified the "structurally impossible race" claim below unless `ReconcileOrphanedFlows` imposes
+  its own internal pass-timeout; and that the saturation signal (`len(candidates) == scanLimit`)
+  is a chronic false alarm across most of the plausible deletion-rate range, with a "shorten the
+  interval" remedy that does not actually clear it. Also found: the "why no cursor" retry-property
+  claim overstated (requires the stronger per-window inequality it explicitly disclaims elsewhere),
+  a missing `docs/domain.md` update for the new `models/` file, an unowned saturation metric
+  mentioned in one section but absent from the metrics task, and an arithmetic error in the
+  **plan's** round-2 revision-history entry (corrected there, not in this document's body).
+- **Design-review round 4** (REQUEST_CHANGES): traced round 3's own fix against actual
+  `bin-schedule-manager` source and found it named the wrong mechanism — the reaper's abandonment
+  deadline does not govern re-dispatch; `bin-schedule-manager`'s `tm_next_run` CAS, which advances
+  at claim time (before the RPC is even sent), is what prevents a second **dispatch** of the same
+  cron slot, independent of pass duration. The real overlap risk is a pass physically outliving the
+  cron interval itself. Also found: the `RecentSaturated` signal (round 3) needed the schedule's
+  cron interval, which `bin-campaign-manager` cannot read from `bin-schedule-manager`'s database —
+  threaded through as an explicit request parameter instead of a compiled constant that would
+  desynchronize the moment the interval changed; `RecentSaturated` was specified to be computed
+  inside the RPC loop, so the self-imposed pass-timeout bail-out could suppress it exactly when the
+  batch was genuinely saturated — moved to a dedicated pre-loop pass; a timed-out partial pass was
+  invisible (recorded as a full `success` with no signal) — added a `Partial` result field; the
+  typed-not-found branch counted neither `Skipped` nor `Failed`, breaking the counter invariant —
+  now counted as `Skipped`; and one more unowned "log/metric" phrase (window-edge warning) survived
+  the round-3 sweep of the same class of defect. All addressed in the plan; see the plan's own
+  revision history for the full fix list.
+- **Design-review round 5** (REQUEST_CHANGES): traced round 4's fix against
+  `bin-schedule-manager`'s claim/dispatch source in full and found round 4 had, for the third
+  consecutive round, named an incomplete safety-mechanism set — this time by affirmatively denying
+  a real guard mattered rather than by omitting it. `ExecutionHasRunning` ("Forbid overlap") is a
+  second, independent concurrency guard neither round 3 nor round 4 accounted for, and it makes
+  `timeout_ms` genuinely load-bearing (round 4 called it merely "cosmetic, for audit accuracy"):
+  the execution row stays `running` — and so blocks a new dispatch — only until
+  `bin-schedule-manager`'s own `SendRequest` wait (bounded by `timeout_ms`) returns, not until this
+  pass physically finishes; if `reconcilePassTimeout` could exceed `timeout_ms`, a manual execute
+  fired in the resulting gap would genuinely race a still-running pass. Fixed: both
+  `reconcilePassTimeout < timeout_ms` and `reconcilePassTimeout << cron interval` are now stated as
+  independently load-bearing; the reaper-abandonment-deadline cross-check round 4 dropped as "an
+  unfalsifiable tautology" was reinstated, correctly framed as bounding crash-recovery time (a real,
+  separate property) rather than as the concurrency-prevention mechanism itself; `skipped_overlap`
+  added as the documented observable symptom. Also found and fixed: the `RecentSaturated` "shorten
+  the interval" remedy could silently violate the cron-interval guard, since `cron` is
+  runtime-mutable while `reconcilePassTimeout` is a compiled constant with no automatic re-check —
+  added an explicit two-step runbook requirement; a genuine self-contradiction between two sections
+  about whether `cron`/`recent_interval_sec` can drift apart (both were right, about different
+  times — seed-time co-location vs. post-seed independent editing — reworded to say so); stale
+  `retry_max`-based reasoning in the "VOIP-1448's relevance" paragraph, left over from before
+  `retry_max: 0` was settled; and a test for the pre-loop signal computation that used a
+  0-duration timeout, testing nothing (it would fail the query itself before producing a
+  `ReconcileResult`). All addressed in the plan; see the plan's own revision history for the full
+  fix list.
+- **Design-review round 6** (REQUEST_CHANGES): traced round 5's two-guard model against
+  `bin-schedule-manager`'s actual source and found two further errors in material round 5 had just
+  added. **`skipped_overlap` is not an execution status and no execution row exists when it
+  fires** — the execution status enum is `running`/`success`/`failed`/`abandoned`; `skipped_overlap`
+  is a dispatch-level metric result label emitted on a path that returns before any execution row
+  is created, and it is the wrong signal besides — it only ever fires for the cadence-degradation
+  case below, never for the actual concurrency-unsafe case, which produces an ordinary `success`
+  row with no distinguishing signal. Fixed everywhere this appeared. **Guard 2 (the `tm_next_run`
+  CAS) is not an independent concurrency guard, contrary to round 5's "both are real, independent
+  concurrency-safety requirements"**: `ExecutionHasRunning` is checked before the CAS on every
+  claim path, so as long as guard 1 holds, a cron claim mid-pass is short-circuited into an
+  overlap skip before the CAS ever runs — no second execution is created either way. Guard 2's
+  real role is cadence/liveness (prevents the schedule from permanently falling behind), not
+  mutual exclusion, which rests on guard 1 alone. Relabeled in several places (design-review-round-7
+  finding: not actually "throughout" — this document's own lead-in bullet and one other paragraph
+  still carried the refuted round-5 framing after this revision; fully swept in round 7). Also
+  fixed: the reap-
+  deadline cross-check (task 8) had been reinstated correctly in round 5 but attributed the crash
+  scenario to a `bin-campaign-manager` replica dying "mid-pass" — wrong; that path is already
+  fully handled by `SendRequest`'s own `timeout_ms` bound and never reaches the reaper, which only
+  matters for `bin-schedule-manager`'s own dispatch goroutine crashing (its "abandon-not-drain"
+  case) — corrected the attribution; the mutual-exclusion closure claim didn't account for the two
+  timeout clocks starting at different points (`timeout_ms` from send, `reconcilePassTimeout` from
+  receive) — added an explicit note that the margin must cover message-delivery delay, not just
+  processing-time variance; this document's own "Proposed scope" item 3 still named the superseded
+  `a5e6f559299c` migration as primary precedent, contradicting its own earlier-corrected paragraph
+  — synced to `0c037bf0a362`; a stale "set `retry_max` consistently with it" phrase, left over from
+  before `retry_max: 0` was settled two sections earlier in the same document — removed; and the
+  plan's Alembic-column acceptance criterion covered `timeout_ms > 0` but not the reap-deadline
+  cross-check condition, which only its verify task covered — added to the acceptance criterion.
+  All addressed in the plan; see the plan's own revision history for the full fix list.
+- **Design-review round 7** (REQUEST_CHANGES): independently re-derived round 6's corrected mental
+  model from `bin-schedule-manager` source and confirmed it holds — `ExecutionHasRunning` genuinely
+  runs before the CAS on both the cron **and** manual claim paths (stronger than round 6 verified:
+  `ScheduleClaimAndCreateExecution` skips the CAS *entirely* for manual triggers, so guard 2/the
+  CAS does not exist at all on that path), and an execution row leaves `running` only via
+  `ExecutionComplete` (success and timeout both funnel through the same call) or the reaper. But
+  round 6's fix was applied incompletely: this document's own "What this buys over the ticker" lead
+  bullet still opened with "provides two independent concurrency guards, not one... Both are real"
+  — the exact framing round 6 refuted, with the correction buried 15 lines below where a skimming
+  reader would miss it — rewritten so the lead itself states the corrected model. The "VOIP-1448's
+  relevance" paragraph still said "the two concurrency guards above" — corrected to name guard 1
+  and correct sizing only. The sentence defining the mutual-exclusion mechanism itself contained a
+  factual error: "lasts exactly `timeout_ms`... regardless of how long the pass actually runs" is
+  the precise inverse of the property being secured (`ExecutionComplete` fires as soon as
+  `SendRequest` returns, whether early on success or at the `timeout_ms` ceiling on timeout, so the
+  row's `running` duration is *at most* `timeout_ms`, tracking real pass duration up to that point)
+  — corrected. Two new findings: the `skipped_overlap` metric is cron-path-only — a manual execute
+  hitting the same overlap guard returns `EXECUTION_IN_PROGRESS` with no metric at all, which
+  matters because task 10's own rollout smoke test is a manual execute and can legitimately hit
+  this if a prior run is in flight — documented the expected behavior there; and the "`timeout_ms`
+  unset silently produces `0`" claim (from the original issue-analysis round 6, carried through
+  every revision since) doesn't account for `timeout_ms` being `NOT NULL` with no `DEFAULT` — under
+  the strict `sql_mode` most modern deployments run, an `INSERT` omitting it is rejected loudly at
+  migration-apply time; the silent-`0` outcome requires a relaxed `sql_mode` some legacy configs
+  still use — hedged the claim without changing the underlying guidance (set every column
+  explicitly regardless). All addressed in the plan; see the plan's own revision history for the
+  full fix list.
+- **Design-review round 8** (REQUEST_CHANGES): spot-checked the now-thrice-confirmed mutual-
+  exclusion model (consistent everywhere it's stated) and did a fresh read of every section
+  unrelated to `bin-schedule-manager` concurrency — this surfaced the round's one substantive
+  defect. **`campaign_flow_reconcile_failed_total` was defined (this section, item 5) to cover
+  both a `FlowV1FlowGet` error and a `FlowV1FlowDelete` error, but the plan only ever wired the
+  metric increment into the `FlowV1FlowDelete` branch** — the `FlowV1FlowGet`-error branch
+  incremented the in-memory `Failed` field only. This is the branch a `bin-flow-manager` outage or
+  an open circuit breaker actually fails on, for every remaining candidate in a pass, so the metric
+  would read zero during exactly the outage it exists to surface. Fixed: both branches now
+  increment the one shared counter (still no `reason` label distinguishing them — documented
+  explicitly rather than silently conflated). Also fixed: this document's own precedent-citation
+  for the mutual-exclusion "at most `timeout_ms`" claim didn't note it's conditioned on
+  `retry_max: 0` (added a qualification, since the general formula loops retries within one
+  execution row); the plan's round-6 revision-history entry still used a since-abandoned "(1)/(2)"
+  numbering with backwards "[now (1)]"-style annotations and two referent-less "constraint (1)"
+  mentions, which round 7's "relabeled throughout" claim missed — corrected to (a)/(b)
+  retroactively in that entry, and this document gained explicit (a)/(b) labels alongside "guard
+  1"/"guard 2" so the round-7 claim that both documents use consistent labels is actually true; the
+  plan's verification checklist named only `go test`/`golangci-lint`, a 2-of-5 subset of the root
+  CLAUDE.md's mandatory workflow, and `go generate` specifically is load-bearing here (task 6's
+  tests mock interfaces tasks 1/3 must also update, which `go generate` regenerates from) — fixed;
+  and task 10's mandatory smoke-test step never said how to actually fire a manual execute (no
+  `schedule-control execute` subcommand exists) — added the RPC-client path and the
+  `schedule get`-first step to resolve the schedule's UUID. All addressed in the plan; see the
+  plan's own revision history for the full fix list.
+- **Design-review round 9** (REQUEST_CHANGES): confirmed the round-8 metric fix landed everywhere
+  it should have in this document (pseudocode, Metrics section) but found the "Not-found detection
+  for `FlowV1FlowGet`" section — separate, normative text an implementer reads to build the actual
+  error branch — still said the non-not-found-error case is "logged and skipped", contradicting the
+  settled `Skipped`-means-legitimately-clean semantics and omitting the metric increment; fixed.
+  Also found: this document's own precedent-citation for the "at most `timeout_ms`" claim didn't
+  carry the same (a)/(b) constraint labels the plan uses, so round 7's "standardized... in both
+  documents" claim only partly held (round 8 already fixed most of this; round 9 confirmed no
+  further gaps here); the plan's acceptance criteria named `schedule-control` as a manual-trigger
+  path for the new route, contradicting task 10's own established fact that it has no `execute`
+  subcommand; the plan's round-6 entry still had one referent-less "Constraint (1)"; the plan's
+  acceptance criteria never pinned `campaign_flow_reconcile_failed_total` explicitly; and the
+  plan's pre-implementation check never actually decided the `cron` interval it's cited elsewhere
+  as producing. All fixed in the plan. Non-blocking: retitled this document "Issue Analysis and
+  Design" to match how the plan refers to it, since design-review rounds folded substantial design
+  content into what started as an issue-analysis-only file.
+- **Design-review round 10** (APPROVE, first of two required consecutive approvals): a fresh,
+  cold read of the plan's full task list, the acceptance-criteria/verify-task mapping, both
+  revision histories, and the layering/DTO split, independently re-verified against source. No
+  defect found. Three non-blocking suggestions were folded into the plan (package constants and
+  the exact DB-query call declared self-containedly in task 3; the redeploy-vs-live-edit
+  distinction between the two `RecentSaturated` remedies; and a note that
+  `bin-schedule-manager/models/execution/execution.go`'s `Result` column durably persists
+  `Saturated`/`RecentSaturated`/`Partial` beyond `bin-campaign-manager`'s own log retention,
+  strengthening the no-third-counter decision's justification).
+
+## Ticket validity check
+
+**VOIP-1444** ("bin-campaign-manager: reconciliation job to clean up orphaned flows from deleted
+campaigns") is a real, still-open follow-up filed during VOIP-1443. Scope was explicitly narrowed
+by 대표님 on 2026-09-02: the per-customer Prometheus alert-rule half of the original proposal is
+dropped; **only** the reconciliation job is in scope. `bin-flow-manager` remains untouched by this
+ticket (VOIP-1448 covers that separately, orthogonally).
+
+**Re-verified against current code**: the underlying defect this job compensates for is still
+present. `bin-campaign-manager/pkg/campaignhandler/campaign.go`'s `Delete()` (post-VOIP-1443)
+still has a best-effort `FlowV1FlowDelete` call that can fail and leave the flow orphaned —
+VOIP-1443 made that failure *observable* (metric + log fields), not impossible. A reconciliation
+job is the correct complementary fix.
+
+## Proceeding-now judgment
+
+- The direct trigger (the shared api-validator customer hitting `bin-flow-manager`'s
+  `maxFlowCount=10000`) is still relevant: VOIP-1443 stops *new* leaks from being silent, but does
+  nothing to prevent the *next* leak from quietly re-accumulating with no automatic cleanup.
+- Contained to `bin-campaign-manager` (the reconciliation logic itself) plus one seeded row in
+  `bin-schedule-manager`'s existing scheduling table — no new service, no new locking
+  infrastructure, no `bin-flow-manager` change.
+- Explicitly separate from, and does **not** retroactively clean up, the existing historical
+  10,000-flow backlog for the shared test customer (out of scope, needs separate authorization per
+  VOIP-1443's design doc) — this job only prevents *future* accumulation.
+
+## Correct placement: bin-campaign-manager, not bin-flow-manager
+
+`bin-flow-manager` has no way to know which of its flows are "owned" by a campaign, let alone
+which owning campaign has since been deleted — flow ownership is one-directional
+(`campaign.FlowID` points at the flow; nothing points back). `bin-campaign-manager` is the only
+service that holds the fact "this flow belongs to campaign X, and campaign X is deleted." The
+reconciliation logic lives in `bin-campaign-manager`, calling out to `bin-flow-manager` only via
+the existing, unmodified `FlowV1FlowGet`/`FlowV1FlowDelete` RPCs. Jira summary already corrected
+to "bin-campaign-manager:" to match.
+
+## How an orphan is identified
+
+- `campaign.go` `Delete()` soft-deletes: `bin-campaign-manager/pkg/dbhandler/campaign.go`'s
+  `CampaignDelete()` (line 141) sets `tm_delete`, does not remove the row. The deleted campaign's
+  `FlowID` remains readable indefinitely.
+- **Criterion**: a flow is orphaned iff its owning campaign is deleted (`tm_delete` set) **and**
+  the flow's own `TMDelete` is still `nil` — not merely "iff `FlowV1FlowGet` succeeds"
+  (`bin-flow-manager`'s `FlowGet` query has no `tm_delete IS NULL` predicate, so it returns
+  already-soft-deleted flows successfully too — confirmed independently: `flowHandler.Delete()`,
+  `pkg/flowhandler/db.go:262-272`, calls `FlowGet` *after* soft-deleting specifically to return the
+  now-deleted record, which would be impossible if `FlowGet` filtered deleted rows).
+  `flow.TMDelete` (`bin-flow-manager/models/flow/flow.go:34`, json tag `tm_delete`, no
+  `omitempty`) crosses the RPC boundary on every `Flow` response (`bin-flow-manager/pkg/listenhandler/v1_flows.go`'s
+  `v1FlowsIDGet` marshals the domain `*flow.Flow` directly, no response-DTO stripping), so the
+  reconciliation job can and must inspect it directly:
+  (pseudocode below sketches the core branching only — see the plan's task 3 for the exact
+  `ReconcileResult` bookkeeping, including the design-review-round-4 fix that counts a typed
+  not-found as `Skipped`, not an uncounted no-op, and the design-review-round-8 fix below):
+  ```go
+  f, err := h.reqHandler.FlowV1FlowGet(ctx, campaign.FlowID)
+  if err != nil {
+      if isTypedNotFound(err) {
+          result.Skipped++ // flow row genuinely doesn't exist -- a legitimately clean state
+      } else {
+          result.Failed++ // + campaign_flow_reconcile_failed_total (design-review-round-8 fix:
+          // an earlier draft counted this only in-memory, leaving the metric silent on exactly
+          // the systemic-outage case it exists to catch -- a bin-flow-manager outage or open
+          // circuit breaker fails every remaining candidate on this branch)
+      }
+      continue
+  }
+  if f.TMDelete != nil {
+      result.Skipped++ // already cleaned up (by an earlier pass, or a successful Delete() call) — not an orphan
+      continue
+  }
+  // flow is live, owning campaign is deleted -> genuinely orphaned
+  if _, err := h.reqHandler.FlowV1FlowDelete(ctx, campaign.FlowID); err != nil {
+      result.Failed++ // log + campaign_flow_reconcile_failed_total (new, dedicated counter -- see "Metrics" below)
+      continue
+  }
+  result.Cleaned++ // + campaign_flow_reconcile_cleaned_total
+  ```
+- Finding the *candidate* deleted campaigns uses `campaignHandler.List()`'s existing filter
+  passthrough (`campaign.go:207`) with the `"deleted": true` special filter key
+  (`bin-common-handler/pkg/databasehandler/main.go:76-85`, maps to `tm_delete IS NOT NULL`) for the
+  boolean predicate — but see "Proposed scope" below for why the *time-windowed* version needs new
+  DB-layer code (this generic filter mechanism has no range-predicate support).
+
+## Not-found detection for `FlowV1FlowGet`
+
+VOIP-1443's `reason` classification on `FlowV1FlowDelete` checks
+`stderrors.Is(err, requesthandler.ErrNotFound)` because `bin-flow-manager`'s `Delete()` path
+returns the flow-delete's `dbhandler.ErrNotFound` **unwrapped**, degrading to a bare 404 at the
+dispatcher. `Get()` is different: `bin-flow-manager/pkg/flowhandler/db.go`'s `Get()` (lines 44-64)
+explicitly wraps not-found in a **typed** error (`cerrors.NotFound(...).Wrap(err)`, lines 53-59).
+So `FlowV1FlowGet`'s not-found case arrives as a typed `*cerrors.VoipbinError` with
+`Status == StatusNotFound`. The reconciliation job's error-branch check must use
+`stderrors.As(err, &ve) && ve.Status == cerrors.StatusNotFound`, not
+`stderrors.Is(err, requesthandler.ErrNotFound)` (that sentinel is for the different, Delete-side,
+untyped-error path). Any other error (RPC timeout, backend error) is counted as **`Failed`**, not
+`Skipped` (design-review-round-9 fix: an earlier draft of this sentence said "logged and skipped",
+which reads as the `Skipped` counter — the settled semantics, per "Metrics" above and the plan's
+task 3, reserve `Skipped` for legitimately-clean end states like a typed not-found; a non-not-found
+error is a failure, counted in `campaign_flow_reconcile_failed_total` (see "Metrics" above), not
+silently treated as "clean").
+
+## Scheduling mechanism: `bin-schedule-manager`, not a bespoke ticker loop (round 5 replacement)
+
+**Rejected**: an in-process `time.Ticker` loop inside `bin-campaign-manager` (rounds 1-4's
+approach). It works, but it re-invents scheduling infrastructure this platform already has, and it
+is what forced rounds 3-4 into designing (and eventually deferring) a `bin-flow-manager`
+concurrency fix that this job wouldn't need at all under a claim-based scheduler.
+
+**Adopted**: `bin-schedule-manager` (VOIP-1283) — this platform's existing DB-driven dispatch
+engine, whose own documentation states its charter as absorbing "future ticker migrations" into
+one engine with Redis-lock + DB-CAS at-most-once claim semantics
+(`bin-schedule-manager/CLAUDE.md`). It already runs in production (`replicas: 2`, same as
+`bin-campaign-manager`) specifically *because* "Redis lock + DB CAS claim make concurrent replicas
+safe." Concretely:
+
+1. A new `schedule_schedules` row (seeded via a new Alembic migration in `bin-dbscheme-manager` —
+   a directory in this same monorepo, not a separate repository; see the implementation plan for
+   why this lands in the same PR as the `bin-campaign-manager` changes, not a separate one).
+   Design-round-1 correction: the closer precedent is
+   `bin-dbscheme-manager/bin-manager/main/versions/0c037bf0a362_schedule_schedules_seed_phase2_ticker_...py`,
+   which already seeds five schedules dispatching into *other* services' request queues —
+   directly answering "is cross-service dispatch via `bin-schedule-manager` sanctioned?" — rather
+   than `a5e6f559299c`'s self-RPC housekeeping jobs, which this analysis originally (and still
+   correctly, just less precisely) cited. Column set:
+   `name: campaign-flow-reconcile`, `type: rpc`, `cron: <interval, e.g. "0 */6 * * *">`,
+   `target_queue: bin-manager.campaign-manager.request` (already in the allowlist —
+   `bin-common-handler/models/outline/queuename.go:53,206`), `target_uri:
+   /v1/campaigns/flows/reconcile`, `target_method: POST`, nil-customer (platform job), plus every
+   other column both precedent migrations set (see the implementation plan for the full list,
+   including the `enabled: 0`-at-seed rollout decision).
+2. A new `bin-campaign-manager` listenhandler route (`POST /v1/campaigns/flows/reconcile`,
+   internal-only — not exposed through `bin-api-manager`), accepting a small request body
+   (`recent_interval_sec` — see the plan's `RecentSaturated` design and design-review-round-4 for
+   why this must be an explicit parameter, not something the handler infers) and calling
+   `campaignHandler.ReconcileOrphanedFlows(ctx, recentIntervalSec)`, returning its result,
+   following the same RPC-route shape every other internal `/v1/*` endpoint in this service
+   already uses.
+
+What this buys over the ticker, concretely:
+- **`bin-schedule-manager` has two dispatch guards, but only one of them provides mutual exclusion
+  (design-review-round-7 correction of a design-review-round-5 over-correction, itself correcting a
+  design-review-round-4 under-correction)** — the two are not co-equal "independent concurrency
+  guards"; one (`ExecutionHasRunning`) is the entire mutual-exclusion mechanism, the other (the
+  `tm_next_run` CAS) is a cadence/liveness mechanism that never gets a chance to matter for safety
+  because the first guard already short-circuits it:
+  1. **"Forbid overlap"** (`ExecutionHasRunning`) — **the actual mutual-exclusion guarantee**: the
+     dispatcher refuses to claim/dispatch a schedule while a `running` execution row already
+     exists for it (on the **cron** path this produces a `skipped_overlap` **dispatch metric**
+     result — not an execution status, since no execution row is ever created for a skipped
+     attempt; the **manual** `/v1/schedules/{id}/execute` path hits the same guard but returns a
+     `FailedPrecondition` `EXECUTION_IN_PROGRESS` error instead, with no metric at all — see the
+     plan's task 10 for the operational implication). That row is marked `running` until
+     `bin-schedule-manager`'s own `SendRequest` wait — bounded by the schedule's `timeout_ms` —
+     returns, **not** until the pass actually finishes
+     inside `bin-campaign-manager`. This guard is only as good as `timeout_ms` tracking real pass
+     duration: if `ReconcileOrphanedFlows`'s own internal timeout could exceed `timeout_ms`, there
+     would be a real window where `bin-schedule-manager` believes the pass is done (guard no longer
+     blocking) while it is still physically executing — a manual `/v1/schedules/{id}/execute`
+     fired in that window would genuinely race the still-running pass.
+  2. **The `tm_next_run` CAS**: the claim transaction (`ScheduleClaimAndCreateExecution`) advances
+     `tm_next_run` to the next cron boundary *before* the RPC to `bin-campaign-manager` is even
+     sent, so the same schedule cannot be re-claimed for a new **cron** dispatch until that
+     boundary.
+  **Design-review-round-6 correction to a design-review-round-5 over-correction**: guard 1 is
+  checked *before* the `tm_next_run` CAS on every claim path (cron and manual alike). This means
+  guard 2 does **not** independently prevent concurrent execution — given guard 1 holds (the
+  execution row stays `running` for the pass's entire physical duration), a cron claim arriving
+  mid-pass is short-circuited into a dispatch-level overlap skip before the CAS ever runs; no
+  second execution is ever created either way. What a chronically-overrunning pass produces via
+  guard 2's absence is **cadence degradation** (the schedule permanently falls behind, observing
+  overlap skips forever), not a race. Round 5 called both guards "independent concurrency-safety
+  requirements" — guard 2 is real and required, but as a cadence/liveness property, not a mutual-
+  exclusion one. Round 4 correctly identified that the schedule-manager reaper's abandonment
+  deadline does not itself govern re-dispatch (it only affects whether a stuck row eventually reads
+  `abandoned` instead of `running` forever, freeing the schedule for guard-1 purposes) — but round
+  4 then over-corrected by treating `timeout_ms` as irrelevant to concurrency, when in fact
+  `timeout_ms` is precisely what determines how long guard 1 stays effective. `bin-campaign-manager`'s
+  RPC listenhandler builds every request's context with `context.Background()`
+  (`pkg/listenhandler/main.go`) — it does **not** propagate the caller's `timeout_ms` as a context
+  deadline, so nothing bounds a pass's duration at the RPC layer by itself. **Mutual exclusion
+  rests on guard 1 alone, and requires `ReconcileOrphanedFlows`'s self-imposed
+  `context.WithTimeout` to stay strictly below `timeout_ms`, with margin covering real
+  message-delivery delay (the two timeouts' clocks start at different points) — not just
+  processing-time variance.** This constraint has no runtime monitor: a violation produces an
+  ordinary `success` row, indistinguishable from a correctly-serialized one. Separately,
+  `ReconcileOrphanedFlows`'s timeout must also stay well below the schedule's cron interval, to
+  avoid the cadence-degradation failure mode above — see the plan's task 3 and task 8's corrected
+  (three-part) cross-check for the concrete sizing, including the reap-deadline bound on how long
+  a *`bin-schedule-manager` dispatch goroutine itself* crashing (its "abandon-not-drain" case, not
+  a `bin-campaign-manager` crash) can leave the schedule stuck under guard 1. No further
+  concurrency section is needed in this design *given the mutual-exclusion bound is implemented*,
+  not on dispatch semantics alone.
+- **A durable audit trail** — every reconciliation pass gets an `execution` row in
+  `bin-schedule-manager`'s own tables, addressing a real gap this session already knows about
+  (`bin-campaign-manager`'s own logs "rotate within hours," per VOIP-1443's investigation).
+- **An ops kill switch without a redeploy** — `schedule-control schedule disable
+  campaign-flow-reconcile` — meaningful for a job that scans and mutates data across all
+  customers.
+- **The reconciliation interval becomes data** (the schedule's `cron` field), not a compiled Go
+  constant — the *mechanism* for changing it later (edit a DB row, no redeploy) is settled by this
+  choice; the *concrete cron value* to seed initially is still an open question, listed below.
+
+Cost is comparable to or lower than the ticker approach: one Alembic seed row plus one
+listenhandler route, versus a `Run(ctx)` goroutine, `main.go` wiring, and (per rounds 1-4) an
+entire concurrency-safety writeup. The one trade-off, already documented and accepted for
+`bin-schedule-manager`'s own housekeeping jobs, is that each pass occupies one of
+`bin-campaign-manager`'s listenhandler workers for its duration
+(`bin-schedule-manager/docs/architecture.md` documents and accepts the identical trade-off for its
+own self-RPC jobs) — negligible for an infrequent (hourly-or-slower) background job.
+
+**VOIP-1448's relevance is now fully orthogonal, not load-bearing for this ticket.** With
+claim-based scheduling and correctly-sized `reconcilePassTimeout` (design-review-round-7 fix: not
+"the two concurrency guards above" — mutual exclusion rests on guard 1 alone, per the correction
+above; per the plan's task 3), this job cannot race itself across replicas. **Design-review-round-5 correction**: an earlier draft of this paragraph
+reasoned from "the schedule's own `retry_max`/timeout settings could still in principle overlap
+with a next scheduled run" — stale, since `retry_max: 0` (no schedule-level retry at all) has been
+settled since round 6 and is restated in the plan's task 8; there is no schedule-level retry path
+left to overlap with anything. VOIP-1448 (making `bin-flow-manager`'s `Delete()` idempotent)
+remains a real, worthwhile fix for the general case (any two concurrent `DELETE /v1/flows/{id}`
+callers system-wide, unrelated to this job's own concurrency model) but is no longer something
+this ticket's correctness depends on.
+
+## Proposed scope
+
+1. **`bin-campaign-manager/pkg/campaignhandler`** (new file, e.g. `reconcile.go`): a
+   `ReconcileOrphanedFlows(ctx context.Context, recentIntervalSec int64) (result
+   campaign.ReconcileResult, err error)` method implementing the detection logic above, with a
+   bounded per-pass scan limit (see point 3). `recentIntervalSec` is a design-review-round-4
+   addition, threaded in from the request body — see "the actual rate-risk signal" below for why
+   the handler cannot infer this itself. `ReconcileResult` is a small domain struct (`Cleaned`,
+   `Skipped`, `Failed` counts, a `Saturated` flag, a design-review-round-3 addition covering the
+   actual rate-risk signal (`RecentSaturated`), and a design-review-round-4 addition (`Partial`,
+   set when the self-imposed pass timeout cuts a pass short) — see the plan's "Tasks —
+   bin-campaign-manager" section for the exact fields and the corrected success/failure semantics;
+   an earlier draft of this document under-specified this as a bare `cleaned int`). The method must
+   bound its own execution with an internal `context.WithTimeout`, sized well below the schedule's
+   *cron interval* — see "self-imposed pass timeout" below; it cannot rely on the caller's RPC
+   context carrying a deadline.
+2. **New DB-layer query**: the generic `ApplyFields` filter mechanism
+   (`bin-common-handler/pkg/databasehandler/main.go:61-110`) supports only equality plus the
+   special boolean `"deleted"` key — no range predicates, so "deleted within the last N days"
+   (`tm_delete >= cutoff`) cannot be expressed through it. Separately, `CampaignList`'s existing
+   time-token pagination is on `tm_create` (`dbhandler/campaign.go:210-211`), the wrong axis for a
+   delete-time window. **New, small, single-consumer method** in
+   `bin-campaign-manager/pkg/dbhandler`, e.g.
+   `CampaignListDeletedSince(ctx, since time.Time, limit uint64) ([]*campaign.Campaign, error)`, a
+   direct squirrel query (`WHERE tm_delete >= ? ORDER BY tm_delete DESC LIMIT ?` — `DESC`, not
+   `ASC`, per the plan's design-round-1 fix: `ASC` with a fixed `LIMIT` and no cursor is a
+   structural scan-starvation bug once in-window candidates exceed the limit, since it returns the
+   same oldest rows forever; `DESC` guarantees every newly-deleted campaign is examined within
+   `scanLimit`/rate passes of its own deletion — see the plan's "Scan order and coverage" section
+   for the full analysis, including the design-review-round-3 correction to the safety condition
+   and the saturation-signal definition. The comparison against the nullable `tm_delete` column
+   naturally excludes live campaigns via standard SQL NULL-comparison semantics, no separate
+   `IS NOT NULL` needed) — self-contained in this service's
+   own dbhandler (no `bin-common-handler` change; a single-consumer query correctly stays local per
+   this repo's `bin-common-handler` admission rule). Range-predicate precedent for this shape
+   exists elsewhere in the monorepo (`bin-call-manager/pkg/dbhandler/channel.go`'s
+   `ChannelGetsForRecovery` uses `squirrel.Gt`/`Lt` on a `*time.Time` column that, while nullable
+   in schema, is always populated by `ChannelCreate` in practice — this query's reliance on
+   NULL-comparison semantics for a column that is *genuinely, routinely* nullable (`tm_delete`,
+   unset for every live campaign) is a step further than that precedent, though the same
+   underlying squirrel/SQL mechanics apply).
+   **Index note**: `campaign_campaigns` currently has indexes on `customer_id`, `flow_id`,
+   `outplan_id`, `outdial_id`, `queue_id` — none on `tm_delete`
+   (`bin-campaign-manager/scripts/database_scripts/table_campaigns.sql`). Without one, this query
+   full-scans the table on every scheduled run. Whether that's acceptable depends on the row-count
+   data point below; if not, an Alembic migration adding an index on `tm_delete` should be included
+   in this PR's scope — and per `bin-dbscheme-manager/CLAUDE.md`, must also update the test schema
+   fixture (`bin-campaign-manager/scripts/database_scripts/table_campaigns.sql`) alongside the
+   migration, not just the migration itself.
+3. **Scheduling** (replaces the rejected ticker-loop design — see above):
+   - New Alembic seed migration in `bin-dbscheme-manager` adding the `campaign-flow-reconcile`
+     schedule row. **Primary model: `0c037bf0a362_schedule_schedules_seed_phase2_ticker_...py`**
+     (design-review-round-6 fix: an earlier draft of this paragraph named
+     `a5e6f559299c_..._seed_platform_jobs.py` here, contradicting this document's own earlier,
+     already-corrected "closer precedent" paragraph above — `0c037bf0a362` is the right reference,
+     since it seeds cross-service dispatches like this one rather than self-RPC housekeeping jobs;
+     the two migrations happen to set an identical column list, so this was a citation
+     inconsistency, not a substantive gap). **Must set every column both precedent migrations
+     set**, not just the ones needed to identify the schedule — `name`, `detail`, `type: 'rpc'`, `cron`,
+     `target_queue`, `target_uri`, `target_method`, `target_data_type: 'application/json'`,
+     **`target_data: JSON_OBJECT('recent_interval_sec', N)` (design-review-round-4 correction: not
+     an empty object — the route does take an input, the cron interval in seconds, since
+     `bin-campaign-manager` has no way to read the schedule's own `cron` field; see the plan's
+     "Scan order and coverage" section. Design-review-round-5 clarification: this seed-time
+     co-location keeps the *initial* values in sync, but a later, post-seed edit to `cron` via
+     `schedule-control`/`PUT /v1/schedules/{id}` does not automatically update `target_data` — see
+     the plan's runbook note for the operational step this requires)**, **`enabled: 0`**
+     (design-round-1 correction: not `1` — see the plan's rollout-sequencing task for why the
+     schedule must ship disabled until the route is deployed), and critically `timeout_ms`: the
+     column is declared `INT NOT NULL` with **no DEFAULT** (design-review-round-7 correction to
+     the original round-6 finding: the failure mode if a migration omits it depends on the
+     database's `sql_mode` — under the strict mode most modern deployments run, MariaDB rejects the
+     `INSERT` outright at migration-apply time (Error 1364), a **loud**, immediate failure, not a
+     silent one; under a relaxed `sql_mode` some legacy configs still use, the omission could
+     instead silently insert `0`, which `requesthandler.SendRequest` would turn into an
+     already-expired `context.WithTimeout` on every dispatch, forever, making the schedule silently
+     non-functional from the moment it's seeded). Either way the fix is identical — set every
+     column explicitly, never rely on a database default for a column this consequential — but the
+     column should not be filed under "guaranteed silent failure" in the taxonomy below; its actual
+     failure mode is environment-dependent. Size `timeout_ms` comfortably above
+     `ReconcileOrphanedFlows`'s own self-imposed
+     `reconcilePassTimeout` (design-review-round-4: this, not a from-scratch RPC-latency estimate,
+     is the actual worst-case pass duration once the handler self-bounds it — and, design-review-
+     round-5: `reconcilePassTimeout` being strictly below `timeout_ms` is not just for a tidy
+     estimate, it's what keeps `bin-schedule-manager`'s own "Forbid overlap" guard effective for
+     the pass's entire physical duration — see "What this buys over the ticker" above; margin must
+     cover real message-delivery delay, not just processing-time variance), `retry_max: 0` — this
+     column is not left open here (design-review-round-6 fix: an earlier draft still said "set
+     `retry_max` consistently with it" at this point, stale — `retry_max: 0` is settled two
+     sections earlier in this same document, and is the value the reap-deadline formula below
+     assumes). **Design-review-round-5 correction to a round-4 over-correction, itself corrected
+     design-review-round-6**: an earlier draft of this paragraph dropped the cross-check against
+     `bin-schedule-manager`'s reaper deadline formula entirely, calling it "an unfalsifiable
+     tautology" — reinstated: with `retry_max: 0` the reap deadline is `timeout_ms + 60s`, a real
+     and useful bound on how long a **`bin-schedule-manager` dispatch goroutine itself crashing**
+     (its documented "abandon-not-drain" shutdown case — not a `bin-campaign-manager` crash, which
+     round 5 wrongly named here and which is already handled by `SendRequest`'s own `timeout_ms`
+     bound without ever reaching the reaper) can leave this schedule's stuck `running` row
+     suppressing it (via the "Forbid overlap" guard) before the reaper frees it — genuinely
+     distinct from, and in addition to, the constraints above. The full set of constraints is now:
+     `reconcilePassTimeout` strictly below `timeout_ms` (the actual mutual-exclusion guarantee —
+     see "What this buys over the ticker" above for why guard 2/the `tm_next_run` CAS is a cadence
+     requirement, not an independent concurrency one), `reconcilePassTimeout` well below the
+     schedule's **cron interval** (cadence/liveness), and `timeout_ms + 60s` comfortably below the
+     cron interval (bounds crash-recovery time for a `bin-schedule-manager`-side crash). (The
+     remaining columns the model migration sets — `id`, `customer_id`
+     (nil-UUID, platform-job convention), `tm_next_run: NULL`, `tm_create`/`tm_update:
+     UTC_TIMESTAMP(6)` — are cosmetic or loud-failure if gotten wrong (design-review-round-7
+     correction: not necessarily contrasted with `timeout_ms` as "silent" — see above,
+     `timeout_ms`'s own failure mode depends on `sql_mode` and can also be loud), but should still
+     be set for consistency with the precedent rows rather than left to be discovered ad hoc during
+     implementation.)
+   - New `bin-campaign-manager` listenhandler route `POST /v1/campaigns/flows/reconcile` calling
+     `ReconcileOrphanedFlows`.
+   - `ReconcileOrphanedFlows` itself queries `CampaignListDeletedSince(ctx, now - window,
+     scanLimit)` — bounded both by a time window (e.g. last 7 days — see sizing note below) and an
+     explicit per-pass row limit (e.g. 500) so one scheduled run can never issue an unbounded
+     number of RPCs.
+4. **Bounded, time-windowed, and per-pass-limited scope, not a full historical backfill** — the
+   load-bearing scope decision:
+   - The entire *historical* backlog beyond the window is explicitly out of scope (separate,
+     authorization-gated data cleanup, per VOIP-1443's design doc).
+   - **Window-sizing — flagged as needing two concrete data points before finalizing, not resolved
+     here**: this analysis could not obtain a live count of `campaign_campaigns` rows with
+     `tm_delete IS NOT NULL`, nor the deletion rate, from this session (no production DB query
+     access available). Check both once before fixing the window/scanLimit constants and the index
+     question above — the safety condition (see the plan's "Scan order and coverage" section, as
+     corrected in design-review-round-3) depends on the **peak** deletions in any single cron
+     interval, not the daily average; the known trigger customer is an automated api-validator
+     loop, i.e. bursty, so a daily average alone could understate the peak.
+   - **Window-edge risk, disclosed**: a leak caused by a `bin-flow-manager` outage lasting longer
+     than the chosen window would age out of the scan and silently merge into the out-of-scope
+     historical backlog. Mitigation to implement regardless of window size: **log** (design-review-
+     round-4 fix: no counter is defined for this, matching the no-third-counter decision for
+     `Saturated`/`RecentSaturated`/`Partial`) a warning when a found orphan's owning campaign's
+     `tm_delete` is close to the window cutoff.
+   - **Scope note**: this job scans and mutates data across **all customers** — a platform-internal
+     hygiene job, not scoped to one customer. `bin-schedule-manager`'s audit trail and kill switch
+     (see above) are a meaningful mitigation for the operational risk of an all-customer background
+     mutator, beyond what the rejected ticker-loop design would have had. Design-review-round-8
+     note (non-blocking): a saturated pass issues up to `scanLimit` sequential
+     `FlowV1FlowGet`/`FlowV1FlowDelete` RPC pairs against `bin-manager.flow-manager.request`,
+     sharing `bin-campaign-manager`'s process-wide circuit breaker with the live campaign
+     create/update/delete paths — acceptable at an hourly-or-slower cadence, but worth keeping in
+     mind if `scanLimit` is later raised substantially.
+5. **Metrics** (resolved in plan, design round 2): two new, dedicated plain `Counter`s —
+   `campaign_flow_reconcile_cleaned_total` (incremented per genuinely-orphaned flow cleaned) and
+   `campaign_flow_reconcile_failed_total` (incremented per row-level failure during reconciliation:
+   **both** a non-not-found `FlowV1FlowGet` error **and** a `FlowV1FlowDelete` failure on a genuine
+   orphan share this one counter, with no `reason` label distinguishing which RPC failed —
+   design-review-round-8 fix: an earlier draft of the plan only wired the metric up for the
+   `FlowV1FlowDelete` branch, leaving the `FlowV1FlowGet`-error branch — the one a
+   `bin-flow-manager` outage or an open circuit breaker actually fails on, for every remaining
+   candidate in the pass — invisible to Prometheus despite this section always having defined the
+   metric to cover both). Neither reuses VOIP-1443's `promCampaignFlowDeleteFailedTotal{reason=...}`
+   — that metric is
+   documented as "failures during a live campaign delete"; reusing it here would conflate two
+   operationally distinct signals ("a delete is failing right now" vs. "the reconciler couldn't
+   clean up a known-orphaned flow") into one series and make VOIP-1443's own doc line inaccurate.
+   No separate counter for `Saturated`/`RecentSaturated`/`Partial` (design-review-round-3/4
+   clarification) — each is surfaced only via a log warning and its own field on the response, kept
+   out of Prometheus to avoid a counter per signal that is informational far more often than it is
+   actionable (see the plan's "Scan order and coverage" section for the corrected framing).
+6. **Tests** (expanded significantly in the plan per design-review-round-3/4 — this is a sketch of
+   the core cases, see the plan's task 6 for the full matrix including `Saturated`/`RecentSaturated`
+   assertions computed correctly independent of the pass-timeout bail-out, the `Partial` field on a
+   self-timed-out pass, the defense-in-depth guard tested in isolation, and an idempotent-rerun
+   case): unit tests for `ReconcileOrphanedFlows` covering: a genuine orphan (flow `TMDelete` nil)
+   found and cleaned; a flow already correctly deleted (`TMDelete` set) correctly skipped and NOT
+   re-deleted; `FlowV1FlowGet` returning typed not-found (flow row doesn't exist at all) counted as
+   `Skipped` (design-review-round-4 fix: not an uncounted no-op); a transient `FlowV1FlowGet` error
+   counted as `Failed` and logged, not counted as cleaned; the per-pass scan limit is respected; a
+   warning fires for an orphan near the window edge. A basic listenhandler-level test for the new
+   `/v1/campaigns/flows/reconcile` route (request parses, calls through to the handler, returns a
+   sane response).
+7. **Docs**: `bin-campaign-manager/docs/operations.md` (new metrics, new route,
+   `Saturated`/`RecentSaturated` runbook note), `bin-campaign-manager/docs/architecture.md`
+   (routing-table entry for the new
+   route), and — added in design-review-round-3, missed in the prior revision —
+   `bin-campaign-manager/docs/domain.md` (the new `ReconcileResult` domain type under `models/`,
+   per the root CLAUDE.md's service-docs-sync table: `models/.../*.go` changes map to
+   `docs/domain.md`).
+8. **Jira housekeeping**: VOIP-1444's summary already corrected to "bin-campaign-manager:"; the
+   `bin-flow-manager` idempotency question filed separately (and now fully orthogonal) as
+   VOIP-1448.
+
+## What this explicitly does not do
+
+- Does not clean up the pre-existing historical backlog beyond the bounded recent window — a full
+  historical sweep is a separate, explicitly-deferred, authorization-gated data operation.
+- Does not add Prometheus alerting (explicitly dropped from VOIP-1444's scope by 대표님's
+  instruction) or any new alerting infrastructure — `bin-schedule-manager`'s existing audit trail
+  and kill switch are operational tooling already in place, not new alerting.
+- Does not touch `bin-flow-manager` at all — the `Delete()` idempotency question is filed as
+  VOIP-1448, fully orthogonal to this ticket's correctness once claim-based scheduling removes the
+  concurrency motivation for touching it.
+- Does not add any new locking infrastructure of its own — `bin-schedule-manager`'s existing claim
+  mechanism is reused as-is, nothing new to build or maintain in `bin-campaign-manager`.
+- Does not change `Delete()`'s existing best-effort semantics from VOIP-1443 in
+  `bin-campaign-manager` (campaign delete still succeeds even if flow cleanup fails) — this job is
+  a downstream safety net, not a change to that contract.
+
+## Confidence and remaining open questions for design/plan phase
+
+High confidence in: the corrected orphan-detection criterion (`TMDelete` check, independently
+re-derived and cross-checked against `Delete()`'s own behavior), the not-found-detection idiom for
+`FlowV1FlowGet`, the `bin-schedule-manager` mechanism choice for *dispatch* (guarantees at most one
+dispatch of a given scheduled slot, eliminating the concurrency question this document spent three
+rounds on for that half of the problem), the service placement, and keeping VOIP-1448 as a
+separate, now-orthogonal ticket.
+
+Design-review-round-3 correction to the above, itself corrected in design-review-round-4, itself
+corrected in design-review-round-5, itself corrected in design-review-round-6: dispatch-uniqueness
+alone does not make overlap "structurally impossible" — that also requires
+`ReconcileOrphanedFlows` to bound its own execution. Round 3 mis-stated the bound as "below
+`timeout_ms`, to finish before the reaper's abandonment deadline" — tracing the actual
+`bin-schedule-manager` dispatch/claim code shows the reaper does not govern re-dispatch at all
+(round 3 was right to move away from it), but round 4 then over-corrected by declaring `timeout_ms`
+cosmetic and the cron interval the *only* real bound; round 5 over-corrected the other way,
+declaring both "independent" mutual-exclusion guards. The accurate picture, per round 6, corrected
+once more in round 7: **guard 1**, "Forbid overlap" (`ExecutionHasRunning`), is checked *before*
+the `tm_next_run` CAS on every claim path and stays effective only as long as the execution row
+remains `running` — which lasts **at most `timeout_ms`** from the moment `bin-schedule-manager`
+sends the RPC, given this schedule's `retry_max: 0` (design-review-round-8 qualification: at
+`retry_max > 0` the window would be up to `(retry_max+1)*timeout_ms + retry_max*backoff`, since
+`bin-schedule-manager` loops retries within one execution row before completing it — not this
+ticket's configuration, but worth noting the bound is conditioned on `retry_max: 0`, not universal)
+(design-review-round-7 correction: not "exactly `timeout_ms`, regardless of how long
+the pass actually runs" — an earlier draft of this sentence stated the precise inverse of the
+property being secured; `ExecutionComplete` fires as soon as `SendRequest` returns, whether that's
+because the pass finished early with a real response or because the `timeout_ms` wait itself
+expired, so the row's `running` duration tracks the pass's actual duration up to that ceiling, not
+a fixed window) — so `reconcilePassTimeout` must stay strictly below `timeout_ms`, with margin for
+real delivery delay (**this is constraint (a)**, using the same label the plan uses —
+design-review-round-8 addition, for cross-document consistency), for this guard to cover the
+pass's real duration. This is the **entire** mutual-exclusion mechanism; it has no runtime monitor
+(a violation reads as an ordinary `success` row). **Guard 2**, the `tm_next_run` CAS, guarantees
+at-most-once **cron** dispatch per boundary, but because guard 1 already short-circuits any claim
+attempt while the row is `running`, guard 2 never gets a chance to matter for mutual exclusion in
+the first place — its role is **cadence/liveness**: `reconcilePassTimeout` well below the cron
+interval (**constraint (b)**) is what keeps an overrunning pass from making every subsequent cron
+tick observe a dispatch-level overlap skip
+(`schedule_manager_dispatch_total{result="skipped_overlap"}`) forever — a cadence failure, not a
+race. The corrected,
+load-bearing requirement is: `ReconcileOrphanedFlows`'s self-imposed `context.WithTimeout` must be
+sized strictly below `timeout_ms` (safety) *and* well below the schedule's cron interval (cadence)
+— see the plan's task 3 and task 8's corrected (three-part, reaper-formula reinstated and
+correctly attributed) cross-check.
+
+Open for design/plan, not resolved here: the concrete window/scanLimit constants and the
+`tm_delete` index decision (both pending the deleted-row-count **and** deletion-rate data points —
+peak per-cron-interval rate, not just a daily average, per the design-review-round-3 correction
+above), and the exact cron interval for the new schedule (which now also fixes
+`recentIntervalSec`'s seeded value and `reconcilePassTimeout`/`timeout_ms`'s sizing against both
+guards above — design-review-round-4/5). Newly open per design-review-round-5: the operational
+runbook must treat any future change to the seeded `cron` interval (including the `RecentSaturated`
+remedy) as a two-step change — update `target_data.recent_interval_sec` to match, and re-verify
+`reconcilePassTimeout` against the new interval — since neither is automatically re-checked once
+the schedule is live; see the plan's "Scan order and coverage" and task 7. The metric-reuse
+question above is no longer open — resolved in the plan (design round 1) as two new dedicated
+counters, no reuse of VOIP-1443's metric, with no third counter added for the
+saturation/rate-risk/partial-pass signals (design-review-round-3/4 clarification — log + response
+fields only).

--- a/docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-plan.md
+++ b/docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-plan.md
@@ -1,0 +1,959 @@
+# Implementation Plan: VOIP-1444 — reconciliation job for orphaned campaign flows
+
+(Title deliberately does not carry a round number — a stale round-number title was flagged
+repeatedly across review rounds. Round tracking lives entirely in "Revision history" below.)
+
+Full technical analysis, all traced source citations, and the extensive round-by-round review
+history that led to the final design (mechanism swaps, corrected orphan-detection criterion, scope
+narrowing — see that document's own "Revision history" for the full, still-growing round count):
+[2026-09-02-voip-1444-orphaned-flow-reconciliation-design.md](2026-09-02-voip-1444-orphaned-flow-reconciliation-design.md).
+This plan translates that analysis into an ordered task list; it does not re-derive it.
+
+## Revision history
+
+- **Design round 1** (REQUEST_CHANGES): found the "two PRs" premise wrong (this is one monorepo,
+  not two repos — corrected to one PR), no rollout sequencing for the schedule-seed-before-route-
+  exists ordering hazard (fixed: seed disabled, enable post-deploy), a structural scan-starvation
+  bug in the bounded query (`ORDER BY tm_delete ASC LIMIT n` never advances past the oldest `n`
+  candidates once the window holds more than `scanLimit` rows — fixed: `DESC` order, converting
+  this into the already-accepted "ages out of window" risk instead of a permanent blind spot, plus
+  an explicit saturation signal), undefined success/failure semantics on `ReconcileOrphanedFlows`,
+  a punted metric-reuse decision, and a test plan under-sized for an all-customer data mutator. All
+  addressed below.
+
+- **Design round 2** (REQUEST_CHANGES): the round-1 `DESC`-order fix was justified with a
+  mathematically false claim ("candidates rise toward the front as newer rows age past the
+  window") — under `DESC` order a row's rank only ever increases as more deletions accumulate, so
+  a row that falls past `scanLimit` never re-enters range; this is a permanent, in-scope coverage
+  gap, not the deliberately-accepted window-edge boundary. Corrected: the real safety condition is
+  `scanLimit` exceeding deletions-per-cron-interval (not per-window), the saturation signal is now
+  documented as actionable (raise `scanLimit` / shorten interval), and a new "Why no cursor/
+  watermark instead" section records the deliberate retry-vs-saturation trade-off. Also: the
+  proposed `response.*` DTO for the reconcile route was a field-for-field identical-json-tag copy
+  of the `ReconcileResult` domain struct — exactly the layering violation the root CLAUDE.md
+  forbids (style (A) wearing a DTO costume). Corrected: `ReconcileResult` is now defined as the
+  domain type itself (with json tags) under `bin-campaign-manager/models/`, and the listenhandler
+  marshals it directly — no `response.*` DTO introduced. Task list renumbered (`bin-campaign-
+  manager` 6→7 tasks, `bin-dbscheme-manager` 3→4 tasks under the new numbering — design-round-3
+  correction: an earlier version of this entry mis-stated these as "6→9" and "unchanged at 3") to
+  reflect splitting the old task 2 into a dedicated `ReconcileResult`-definition task, and the
+  rollout-sequencing task now inserts a pre-enable manual smoke-test step
+  (`POST /v1/schedules/{id}/execute`) before `schedule-control schedule enable`.
+
+- **Design round 3** (REQUEST_CHANGES): six defects found in round 1/2's own fixes.
+  (1) **Unbounded execution, breaking the "structurally impossible race" claim**: this service's
+  RPC listenhandler builds every request's context with `context.Background()` — it does not
+  propagate the caller's `timeout_ms` as a deadline, so the `ctx.Err()` guard in
+  `ReconcileOrphanedFlows` was dead code and a pass could run past the schedule's abandonment
+  deadline, letting the reaper release the slot for a second dispatch while the first pass was
+  still in flight — exactly the race the design doc claimed was impossible. Fixed: task 3 now
+  wraps the pass in its own `context.WithTimeout`, sized strictly below the schedule's
+  `timeout_ms` with margin. (2) **Saturation signal is a chronic false alarm across most of the
+  plausible rate range**: `len(candidates) == scanLimit` fires whenever in-window candidates
+  exceed `scanLimit` — which happens routinely even when every *newly-deleted* campaign is still
+  being examined promptly, because old, already-`Skipped` (clean) rows keep re-occupying batch
+  slots until they age out of the window. "Shorten the interval" does not clear this (it reduces
+  per-interval arrivals, not the per-window population that drives batch fullness). Fixed: kept
+  `Saturated` as an honest "batch reached its cap" fact (informational, expected at scale, no
+  action implied by itself), and added a second, precisely-actionable signal —
+  `RecentSaturated` — computed for free from the already-fetched batch (no extra query, no
+  persisted cursor): true when the count of returned rows with `tm_delete` within the most recent
+  cron interval itself reaches `scanLimit`, i.e. the actual safety condition
+  (deletions-per-interval < `scanLimit`) is being approached or violated. Runbook: `Saturated`
+  alone → no action; `RecentSaturated` → raise `scanLimit` and/or shorten the interval (both now
+  genuinely help this signal). (3) **"Why no cursor" retry-property overclaim**: the full-window
+  retry claim silently required the *stronger*, per-window inequality (`scanLimit` > deletions per
+  *window*) that the safety-condition section explicitly disclaims in favor of the weaker
+  per-interval one — corrected to state retry holds "for as long as the candidate's rank stays
+  within `scanLimit`", not unconditionally for the whole window; the pre-implementation check's
+  "full window coverage" phrasing corrected to "at-least-once examination shortly after deletion";
+  the "safe-by-construction" claim softened to "the failure mode is visible via `RecentSaturated`",
+  since deletion rate is unmeasured at plan time. Also: the rate check now asks for the **peak**
+  per-cron-interval deletion rate, not just a daily average (the known trigger customer is a
+  bursty automated loop). (4) The design doc still specified the rejected `ASC` order and a stale
+  `(cleaned int, err error)` handler signature, and its own revision history lagged the body by a
+  full round (missing a Round 8 entry) — both synced. (5) Task 7 omitted `docs/domain.md`, which
+  the root CLAUDE.md's service-docs-sync table requires for the new `models/` file introduced in
+  task 2 — added. (6) The saturation signal was written to require "increment a `saturated`
+  counter" in one section but task 5 defined only two counters — resolved by keeping the
+  saturation/rate-risk signal out of Prometheus entirely (log + response field only), removing the
+  inconsistency rather than adding a third counter for a mostly-informational signal. All
+  addressed below; see the design doc's own revision history for its mirrored entries.
+
+- **Design round 4** (REQUEST_CHANGES): traced round 3's own headline fix against actual
+  `bin-schedule-manager` source and found it named the wrong mechanism. (1) **The race-prevention
+  argument was still wrong, differently**: round 3 claimed the race was prevented because a
+  bounded pass finishes "before the reaper's abandonment deadline", implying the reaper releasing
+  a stuck slot was the risk. Tracing `pkg/dispatchhandler/dispatch.go` and
+  `pkg/dbhandler/execution.go` shows the reaper never enters into it: `ScheduleClaimAndCreateExecution`
+  advances `tm_next_run` to the *next* cron boundary in the same atomic claim transaction, before
+  the RPC to `bin-campaign-manager` is even sent — so the same schedule cannot be re-claimed for a
+  new **cron** dispatch until that next boundary arrives, regardless of how long (or whether) the
+  current pass finishes. The real overlap condition is **pass duration exceeding the cron
+  interval itself** (the previous pass still physically running in `bin-campaign-manager` when
+  the next cron-triggered RPC arrives) — not a reaper-driven slot release. Fixed: reworded every
+  claim below to name the `tm_next_run` CAS as the dispatch-uniqueness guarantee, and
+  `reconcilePassTimeout` as bounding pass duration **well below the cron interval** (the true
+  concurrency-prevention lever) rather than primarily below `timeout_ms` (`timeout_ms` still
+  matters, but for audit-row accuracy — see (5) below — not for preventing overlap). Task 8's
+  "cross-check against the reaper's abandonment-deadline formula" is dropped as the safety
+  argument (it reduced to an unfalsifiable tautology with `retry_max: 0` and a fixed reap margin)
+  and replaced with the actual two constraints: `reconcilePassTimeout` << cron interval, and
+  `reconcilePassTimeout` < `timeout_ms` with margin.
+  (2) **`RecentSaturated` needed the cron interval, which `bin-campaign-manager` cannot read from
+  `bin-schedule-manager`'s database, and a hardcoded Go constant would desynchronize the moment
+  someone applied this very section's "shorten the interval" remedy**: fixed by threading
+  `recentInterval` through as an explicit request parameter (seeded in the same `target_data` row
+  as `cron`, so both live in one migration, one diff, one review) rather than a compiled constant.
+  (3) **`RecentSaturated` was specified to be computed inside the RPC loop**, so the self-imposed
+  pass-timeout bail-out (fix (1) above) could stop the count short of `scanLimit` even on a
+  genuinely saturated batch — a false negative in exactly the overload case the signal exists to
+  catch. Fixed: `RecentSaturated` (and `Saturated`) must now be computed in a dedicated,
+  RPC-free pass over the fetched slice immediately after the query returns, before any
+  `FlowV1FlowGet`/`FlowV1FlowDelete` call. (4) Dropped the "or approached" half of
+  `RecentSaturated`'s stated meaning — the derivation is exact (`count == scanLimit` iff true
+  interval deletions `>= scanLimit`; `scanLimit - 1` reads as clean, no early-warning margin
+  exists) — and disclosed a real, accepted limitation: the signal assumes the previous pass ran
+  exactly `recentInterval` ago, so a skipped/delayed/failed prior pass (schedule-manager's own
+  single-fire, no-catch-up semantics) can make it under-report. (5) **A pass that hits its own
+  timeout returns `err == nil` with partial counts and is recorded as a `success` execution, with
+  no signal anywhere that it was cut short**: added a `Partial bool` field to `ReconcileResult`,
+  set true on the self-timeout bail-out and logged at `warn` — not a new counter, following the
+  same informational-signal pattern as `Saturated`. (6) The typed-not-found `FlowV1FlowGet` branch
+  incremented neither `Skipped` nor `Failed`, so the three counters didn't sum to candidates
+  examined and the case had nothing to assert in a test — fixed by counting it as `Skipped` (it is
+  a legitimately clean end state, same bucket as an already-deleted flow). (7) One more unowned
+  "log/metric" phrase survived for the window-edge warning (the same class of defect round 3 fixed
+  for the saturation signal) — corrected to "log" only. (8) Misattributed which document's
+  revision history contained the task-count arithmetic error round 3 fixed — it was this plan's
+  round-2 entry, not the design doc's own body; corrected in the design doc. All addressed below.
+
+- **Design round 5** (REQUEST_CHANGES): traced round 4's fix against `bin-schedule-manager`'s
+  claim/dispatch source in full and found round 4 had, for the third consecutive round, named an
+  incomplete safety-mechanism set — this time not by omitting a guard but by affirmatively denying
+  that a real one mattered. (1) **`ExecutionHasRunning` ("Forbid overlap") is a second, independent
+  concurrency guard round 4 never mentioned, and `timeout_ms` is genuinely load-bearing for it, not
+  merely "cosmetic for audit accuracy" as round 4 claimed**: the execution row stays `running`
+  until `bin-schedule-manager`'s own `SendRequest` wait (bounded by `timeout_ms`) returns — not
+  until this pass actually finishes. If `reconcilePassTimeout` were allowed to exceed `timeout_ms`,
+  there would be a real window where `bin-schedule-manager` believes the pass is done (so
+  `ExecutionHasRunning` no longer blocks a new dispatch) while `bin-campaign-manager` is still
+  physically executing it — a manual `/v1/schedules/{id}/execute` fired in that window would
+  genuinely race the still-running pass. Fixed: task 3 and task 8 now state both
+  `reconcilePassTimeout < timeout_ms` (guard 1: keeps "Forbid overlap" effective) and
+  `reconcilePassTimeout << cron interval` (guard 2: keeps the `tm_next_run` CAS's next cron claim
+  from arriving mid-pass) as independently load-bearing, with neither cosmetic; reinstated the
+  reaper-abandonment-deadline cross-check round 4 dropped as "tautological" — it is not: it bounds
+  how long a *crashed* replica's stuck `running` row can suppress the schedule via the overlap
+  guard before the reaper frees it, a real and distinct property from guards 1 and 2. Added
+  `skipped_overlap` as the documented observable symptom if any of the three constraints is ever
+  violated (previously absent from every doc). (2) **The `RecentSaturated` remedy ("shorten the
+  interval") can silently violate guard 2**, since `cron` is runtime-mutable (no redeploy) while
+  `reconcilePassTimeout` is a compiled constant with no automatic re-check on a live interval
+  change — fixed by adding an explicit runbook step (task 7): any interval change must update
+  `target_data.recent_interval_sec` in the same change *and* re-verify `reconcilePassTimeout`
+  against the new interval. (3) The `Partial` bullet in task 3 had a parenthesis left unclosed by
+  round 4's edit, burying the normative instruction inside a justification clause — reformatted.
+  (4) The defense-in-depth guard (`if c.TMDelete == nil`) reproduced the exact counter-invariant
+  gap round 4 had just fixed for the typed-not-found branch (incremented nothing, logged nothing)
+  — fixed to count `Skipped` and log at `warn`. (5) A genuine contradiction from round 4's own
+  edits: task 8's docstring claimed `cron`/`recent_interval_sec` "can only be edited apart by
+  missing a line in the same diff" while the "Scan order and coverage" section said the opposite
+  ("no automated check can catch a mismatch... different systems' config surfaces") — both are
+  true at different times (seed-time co-location vs. post-seed independent editing); reworded both
+  passages to say so explicitly instead of contradicting each other. (6) Design doc's "VOIP-1448's
+  relevance" paragraph still reasoned from schedule-level retries ("the schedule's own
+  `retry_max`/timeout settings could still in principle overlap with a next scheduled run") after
+  `retry_max: 0` had long since been settled elsewhere — corrected. (7) A test for the pre-loop
+  signal computation specified a 0-duration `reconcilePassTimeout`, which would fail the initiating
+  query itself before there was any `ReconcileResult` to assert against, testing nothing about the
+  property it claimed to cover — corrected to use a timeout that survives the query but expires
+  during the RPC loop; also defined `passStart` in task 3, used previously but never declared. (8)
+  Softened this document's own "8-round review history" reference to the design doc, now stale
+  after four additional design-review rounds, to avoid re-staling on every future round. All
+  addressed above and in the design doc.
+
+- **Design round 6** (REQUEST_CHANGES): traced round 5's two-guard model against
+  `bin-schedule-manager`'s actual claim/dispatch source and found two further errors, both in
+  material round 5 had just added. (1) **`skipped_overlap` is not an execution status, and no
+  execution row is ever created when it fires** — the execution status enum is
+  `running`/`success`/`failed`/`abandoned`; `skipped_overlap` is a **dispatch-level metric result
+  label** (`schedule_manager_dispatch_total{result="skipped_overlap"}`), emitted on a code path
+  that returns *before* an execution row would ever be inserted. Worse, it is the wrong signal for
+  the constraint it was attached to: a constraint-(a) violation (the actual concurrency-unsafe
+  case, at the time of this round labeled the mutual-exclusion constraint) produces an ordinary
+  `success` row with no distinguishing signal at all — `skipped_overlap` only ever fires for the
+  cadence-degradation case. Fixed everywhere this appeared (task 3, task 7, acceptance criteria,
+  verify tasks) to correctly name it a metric label, attach it only to the constraint it actually
+  indicates, and state plainly that the real concurrency constraint has no runtime monitor at all —
+  only correct static sizing. (2) **Constraint (b) is not an independent concurrency guard —
+  round 5's "both are real, independent concurrency-safety requirements" over-corrected round 4's
+  opposite mistake**: `ExecutionHasRunning` is checked *before* the `tm_next_run` CAS on every claim
+  path, so as long as constraint (a) holds (the execution row stays `running` for the pass's whole
+  physical duration), a cron claim arriving mid-pass is short-circuited into an overlap skip — no
+  CAS runs, no second execution is ever created. Constraint (b) is therefore a cadence/liveness
+  requirement (prevents the schedule from permanently falling behind), not a mutual-exclusion
+  mechanism; mutual exclusion rests on guard 1 (`ExecutionHasRunning`) plus constraint (a) alone.
+  (Design-round-8 correction to this entry's own historical record: an earlier revision of this
+  paragraph used a since-abandoned "(1)/(2)" numbering scheme in place of the "(a)/(b)" labels used
+  everywhere else — including two bare, referent-less mentions of "constraint (1)" — round 7's own
+  standardization pass missed this entry when relabeling; this paragraph now uses (a)/(b)
+  throughout, consistent with the rest of both documents.) Relabeled in several places (not fully
+  "throughout", per the design-review-round-7 finding above) to stop implying dropping (b) reopens
+  a race. Also fixed in this pass: (3) the reap-
+  deadline cross-check (task 8, item 3) had been reinstated in round 5 but attributed the crash
+  scenario to a `bin-campaign-manager` replica dying "mid-pass" — wrong; that path is already fully
+  handled by `SendRequest`'s own `timeout_ms` bound and never reaches the reaper. The reaper only
+  matters for `bin-schedule-manager`'s own dispatch goroutine crashing (its documented
+  "abandon-not-drain" case) — corrected the attribution. (4) Constraint (a)'s closure claim
+  ("always finishes... before `bin-schedule-manager` ever considers the row non-`running`") did
+  not account for the two timeout clocks starting at different points (`timeout_ms` from when
+  `bin-schedule-manager` sends the RPC; `reconcilePassTimeout` from when `bin-campaign-manager`
+  starts processing it) — added an explicit note that the required margin must cover real
+  message-delivery delay, not just processing-time variance. (5) Design doc's "Proposed scope"
+  item 3 still named the superseded `a5e6f559299c` migration as the primary precedent, contradicting
+  its own earlier-corrected paragraph naming `0c037bf0a362` — synced (no practical column
+  difference between the two precedents, but the normative reference was self-contradictory). (6)
+  A stale "set `retry_max` consistently with it" phrase in the design doc, left over from before
+  `retry_max: 0` was settled two sections earlier in the same document — removed. (7) The
+  Alembic-column acceptance criterion covered `timeout_ms > 0` but not the reap-deadline
+  cross-check's `timeout_ms + 60s < cron` condition, which only the verify task covered — added to
+  the acceptance criterion too. All addressed above and in the design doc.
+
+- **Design round 7** (REQUEST_CHANGES): independently re-derived round 6's model from
+  `bin-schedule-manager` source — confirmed correct, and confirmed *stronger* than round 6 itself
+  verified (the manual claim path skips the `tm_next_run` CAS entirely, not just deprioritizes it,
+  so guard 2 doesn't exist there at all). But round 6's fix was applied incompletely, leaving four
+  places carrying the refuted round-5 "two independent concurrency guards" framing, one factual
+  error in the sentence defining the mechanism itself, and one live contradiction between this
+  document's own acceptance criteria/verify-task section (using labels "(1)"/"(2)") and task 3
+  (using "(a)"/"(b)") that left a verify-task line with no literal referent in the task it was
+  meant to verify. Fixed: standardized on constraint labels (a)/(b) everywhere, removed the
+  (1)/(2) scheme entirely; corrected the acceptance-criteria bullet's "concurrency-safety
+  condition" back to "cadence/liveness condition" for constraint (b) in the "Scan order and
+  coverage" section, matching task 3; swept the design doc's lead bullet and VOIP-1448 paragraph
+  (see the design doc's own revision history). Also found and fixed: the `skipped_overlap` metric
+  fires only on the **cron** claim path — a manual execute hitting the same overlap guard returns
+  `EXECUTION_IN_PROGRESS` instead, with no metric — added this to task 10's rollout smoke-test step
+  (which is itself a manual execute and can legitimately hit this) and to the acceptance criteria;
+  the `skipped_overlap` counter's granularity is per-replica, in-memory dedup, so a single stuck
+  slot can increment it more than once across replicas — added a one-line caveat to task 7's
+  runbook text; and the "`timeout_ms` unset silently produces `0`" claim (present in the design doc
+  since its original issue-analysis round 6) doesn't account for `timeout_ms` being `NOT NULL`
+  with no `DEFAULT` — under strict `sql_mode`, omitting it fails the migration loudly at
+  apply-time; the silent-`0` outcome needs a relaxed `sql_mode`. This claim never made it into this
+  plan document directly (only the design doc), so no plan-side fix was needed beyond noting it
+  here. All addressed above and in the design doc.
+
+- **Design round 8** (REQUEST_CHANGES): a fresh read of the sections unrelated to
+  `bin-schedule-manager` concurrency (explicitly requested after seven straight rounds focused
+  there) found one substantive defect: **`campaign_flow_reconcile_failed_total` was defined (task
+  5, and the design doc) to cover both the `FlowV1FlowGet`-error branch and the
+  `FlowV1FlowDelete`-error branch of task 3, but only the latter branch actually incremented the
+  metric** — the former incremented `Failed` in-memory only. Since a `bin-flow-manager` outage or
+  an open circuit breaker fails every remaining candidate on exactly the unmetriced branch, the
+  counter would read zero during the outage it exists to catch. Fixed: both branches now increment
+  the shared counter (task 3, task 6's test list, task 5, and the design doc's Metrics section and
+  pseudocode all updated to agree); documented explicitly that the one counter conflates both RPCs
+  with no `reason` label. Also found and fixed: this document's own round-6 entry above still used
+  a since-abandoned "(1)/(2)" numbering with backwards "[now (1)]"-style annotations and two
+  referent-less bare "constraint (1)" mentions — corrected retroactively to (a)/(b), and the
+  design doc gained explicit (a)/(b) labels so round 7's "standardized... in both documents" claim
+  is now actually true (it previously only held for this plan); the verification checklist named
+  only `go test`/`golangci-lint`, a 2-of-5 subset of root CLAUDE.md's mandatory 5-step workflow —
+  `go generate` specifically is required here, since tasks 1 and 3 add methods to the
+  `DBHandler`/`CampaignHandler` interfaces that `mockgen` must regenerate mocks from before task
+  6's tests compile — added the interface-declaration step to tasks 1/3 and the full workflow to
+  the acceptance criteria/verify tasks; and task 10's smoke-test step never said how to actually
+  fire a manual execute (`schedule-control` has no `execute` subcommand) — added the RPC-client
+  path and the prerequisite `schedule get` step to resolve the schedule's UUID. Two non-blocking
+  notes also folded in: the "at most `timeout_ms`" mutual-exclusion bound is conditioned on
+  `retry_max: 0` (noted in the design doc), and a saturated pass's RPC volume shares
+  `bin-campaign-manager`'s process-wide circuit breaker with live traffic (noted as a scope
+  caveat). All addressed above and in the design doc.
+
+- **Design round 9** (REQUEST_CHANGES): verified the round-8 metric fix landed in all five places
+  it should have, plus found one more place it hadn't reached and four smaller issues from a fresh
+  read of sections outside the concurrency-model discussion. The design doc's "Not-found detection
+  for `FlowV1FlowGet`" section — the normative text an implementer would actually build the
+  error-branch logic from — still described the non-not-found-error case as "logged and skipped",
+  which reads as the `Skipped` counter even though the settled semantics reserve `Skipped` for
+  legitimately-clean states and this case is `Failed`; also omitted the metric increment entirely.
+  Fixed to say `Failed`, with the metric. Also found: the acceptance criteria still named
+  `schedule-control` as a way to manually trigger the new route, when task 10 (a round-8 fix)
+  already established `schedule-control` has no `execute` subcommand and cannot reach this route
+  at all — fixed to name only the `/v1/schedules/{id}/execute` RPC; one referent-less "Constraint
+  (1)" survived in this document's own round-6 entry, undercutting round 8's claim to have fixed
+  "two" such mentions — relabeled to "Constraint (a)"; the acceptance criteria never mentioned
+  `campaign_flow_reconcile_failed_total` at all despite it being the exact thing round 8 fixed —
+  added a criterion pinning it explicitly; and the pre-implementation check's "This decides" list
+  omitted the `cron` interval, even though task 8 says to seed `cron` "from the pre-implementation
+  check" — added it to the list and to the conservative default (`'0 */6 * * *'` /
+  `recent_interval_sec = 21600`, matching task 8's own worked example). Non-blocking: retitled the
+  design doc from "Issue Analysis" to "Issue Analysis and Design", since design-review rounds 3-8
+  folded substantial design content into the same file and the plan already refers to it as "the
+  design doc". All addressed above and in the design doc.
+
+- **Design round 10** (APPROVE, first of two required consecutive approvals): a fresh,
+  from-scratch read of the full task list as an implementer, the acceptance-criteria-to-task
+  mapping, both revision histories for orphaned staleness, and the layering/DTO compliance —
+  independently re-verified against `bin-campaign-manager`, `bin-schedule-manager`, and
+  `bin-common-handler` source (route-regex collision, `tm_delete` NULL-sentinel convention, the
+  two-directory PR scope, the metric registration pattern) — found no defect that would cause an
+  implementer to build the wrong thing. Three non-blocking suggestions folded in anyway: task 3
+  now declares its package constants (`window`, `scanLimit`, `reconcilePassTimeout`) and the exact
+  `CampaignListDeletedSince` call, making it self-contained without cross-referencing the design
+  doc; task 7 now states explicitly that `scanLimit` (a compiled constant, needs redeploy) and
+  `cron`/`recent_interval_sec` (a live data edit) are not equally fast remedies for
+  `RecentSaturated`; and task 7 now notes that `Saturated`/`RecentSaturated`/`Partial` survive in
+  `bin-schedule-manager`'s own `schedule_executions.result` column even after
+  `bin-campaign-manager`'s local logs rotate, which is what makes the no-third-counter decision
+  safe.
+
+## Scope
+
+A periodic, `bin-schedule-manager`-triggered job in `bin-campaign-manager` that finds campaigns
+deleted within a recent, bounded time window whose backing flow is still live (not soft-deleted)
+and deletes that flow, closing the gap VOIP-1443 made observable but did not close.
+
+**One PR, both directories touched**: `bin-campaign-manager` (the job itself) and
+`bin-dbscheme-manager` (the Alembic seed migration registering the schedule, plus the `tm_delete`
+index migration). Both are directories inside this single monorepo, not separate repositories —
+the "one PR per repo" structural exception does not apply here (corrected from an earlier draft
+that wrongly claimed it did). One PR, commit body with both `bin-campaign-manager:` and
+`bin-dbscheme-manager:` prefixed bullets, per the standard convention.
+
+Explicitly out of scope (all already filed as separate tickets or explicitly deferred):
+- The existing historical flow backlog beyond the window (VOIP-1443's design doc, needs separate
+  authorization).
+- Prometheus alerting (dropped from VOIP-1444 by 대표님's explicit instruction).
+- `bin-flow-manager`'s `Delete()` non-idempotency (VOIP-1448, orthogonal — `bin-schedule-manager`'s
+  claim semantics make concurrent duplicate dispatch structurally impossible, so this job's
+  correctness never depends on VOIP-1448 landing).
+
+## Pre-implementation check (do this first, before fixing constants)
+
+Get, from production, both: (a) the current count of `campaign_campaigns` rows with
+`tm_delete IS NOT NULL`, and (b) the **peak** rate of new campaign deletions within a single
+prospective cron interval, not just a daily average (design-round-3 correction: a daily average
+can understate the peak — the known trigger customer is a bursty, automated api-validator loop;
+rate is what determines whether `scanLimit` and the scan-order fix below actually give
+at-least-once examination shortly after each deletion, not "full window coverage" in the sense of
+every in-window row being re-examined every pass). This decides:
+- The window size and `scanLimit`.
+- Whether the `tm_delete` index migration is needed now or can be deferred.
+- **The `cron` interval to seed (design-round-9 addition — an earlier draft left this
+  undetermined: task 8 says to seed `cron` "from the pre-implementation check", but this list
+  didn't actually include it)**: pick an interval such that the peak-rate data point above keeps
+  `scanLimit` comfortably above deletions-per-interval (the safety condition in "Scan order and
+  coverage" below), and such that `reconcilePassTimeout`/`timeout_ms` (task 3/task 8) fit
+  comfortably beneath it. This same value also becomes `target_data.recent_interval_sec` (task 8)
+  — the two are seeded together from this one decision.
+
+Default to proceeding with a conservative, safe choice if this data cannot be obtained before
+implementation: **window = 7 days, scanLimit = 500, cron = `'0 */6 * * *'` (every 6 hours,
+`recent_interval_sec = 21600`), add the index anyway** (small, additive, reversible) rather than
+blocking implementation indefinitely — see "Scan order and coverage" below; this default's safety
+is not assumed blind, but it is also not "by construction" in the strong sense (design-round-3
+correction) — deletion rate is unmeasured at plan time, so what the design actually guarantees is
+that a rate violation becomes **visible** via the `RecentSaturated` signal, not that it cannot
+happen.
+
+## Scan order and coverage (design-round-1 correction)
+
+**Rejected**: `ORDER BY tm_delete ASC LIMIT scanLimit` (oldest-deleted-first). With no cursor
+carried between passes, this query returns the *exact same* oldest `scanLimit` rows on every
+single scheduled run once the window holds more candidates than `scanLimit` — rows beyond position
+`scanLimit` are never reached until enough of the oldest rows age out of the window on their own.
+This is a structural blind spot, not a matter of degree: campaigns deleted while the window is
+"full" from this job's perspective can go unprocessed for the rest of their time in the window,
+however long that is.
+
+**Adopted**: `ORDER BY tm_delete DESC LIMIT scanLimit` (most-recently-deleted-first). This
+guarantees every pass always covers the most recent deletions — matching this job's actual
+purpose (catch a leak shortly after it happens).
+
+**Design-round-2 correction — the residual risk is real and permanent, not equivalent to the
+window-edge risk**: under `DESC`, a candidate's rank at any later pass is the count of deletions
+strictly newer than it, which is monotonically non-decreasing — a row that once falls past
+position `scanLimit` **never re-enters range**. It does not "rise toward the front as newer rows
+age past the window" (an earlier draft of this section claimed this, incorrectly — every row
+newer than it ages out *after* it does, never before). So a burst of churn that pushes a
+still-in-window candidate past `scanLimit` makes that specific candidate permanently unreachable
+by this job for the rest of its time in the window; it is only rescued by aging out into the
+out-of-scope historical backlog, the same *outcome* as the window-edge risk but via a genuinely
+different, in-scope trigger (a coverage failure on a row this job was supposed to reach, not a
+deliberate scope boundary). Do not conflate the two when reasoning about correctness.
+
+**The actual safety condition, to size against real data**: `scanLimit` must exceed the number of
+campaign deletions per cron interval (not per window), with margin — e.g. at a 6-hour interval and
+`scanLimit = 500`, this design is safe as long as fewer than ~500 campaigns are deleted platform-
+wide per 6 hours. The pre-implementation rate check above exists specifically to confirm this
+inequality holds; if it doesn't, raise `scanLimit`, shorten the interval, or both.
+
+**Two distinct signals, not one — design-round-3 correction**: a naive `Saturated =
+len(candidates) == scanLimit` conflates two very different situations. Once steady-state in-window
+candidates exceed `scanLimit` (which happens routinely at scale, since already-`Skipped`
+correctly-clean rows keep re-appearing as candidates every pass until they age out of the window),
+`Saturated` is true on **every single pass forever**, even when every newly-deleted campaign is
+still being examined on the first pass after its own deletion — i.e. even when the job is working
+exactly as intended. Treating that as an actionable alarm produces a chronic false positive with
+no real remedy (see below), which is worse than no signal at all.
+
+- **`Saturated`** (`len(candidates) == scanLimit`): kept, but reframed as purely **informational** —
+  "this pass's batch reached its cap; the window holds more history than one pass returns, which is
+  normal and expected at scale." No action implied by itself. No independent counter — see task 5.
+- **`RecentSaturated`** (new in design-round-3, corrected in design-round-4; the actual actionable
+  signal): computed from the batch already fetched for `Saturated` — no extra query, no persisted
+  cursor. **Design-round-4 correction — must be computed in a dedicated pass over the fetched
+  slice, before the RPC loop begins, not interleaved with it**: an earlier draft computed this
+  "while iterating the batch" in the same loop that issues `FlowV1FlowGet`/`FlowV1FlowDelete`
+  calls, which meant the self-imposed pass-timeout bail-out (task 3) could stop the count short of
+  `scanLimit` even when the batch itself was genuinely full — producing a false negative exactly
+  in the overload case this signal exists to catch. Since the batch is already `DESC`-ordered by
+  `tm_delete` and fully in memory, computing this is a pure O(n) timestamp scan requiring no RPCs —
+  do it immediately after the query returns, before touching `bin-flow-manager` at all.
+
+  Count how many returned rows have `tm_delete >= passStart - recentInterval` (see
+  **`recentInterval`, a request parameter, design-round-4 fix** below for why this cannot be a
+  compiled Go constant). If that count reaches `scanLimit` — meaning even restricting to just this
+  interval's own new deletions already fills the entire batch — the actual safety condition
+  (deletions-per-interval < `scanLimit`) **is being violated** (design-round-4 correction: drop
+  "or approached" from the original wording — the derivation is exact: with `R = min(scanLimit,
+  D)` where `D` is true deletions in the interval, `R == scanLimit` if and only if `D >=
+  scanLimit`; there is no early-warning margin, `D = scanLimit - 1` reads as clean). This is the
+  signal to act on: log a **warning** (not `info`/`debug`) and raise `scanLimit` and/or shorten the
+  interval — unlike the plain-`Saturated` case, shortening the interval genuinely helps here,
+  because it lowers deletions-per-interval directly (see the `recentInterval` note below for what
+  else must change together with the interval). Document this response explicitly in the log
+  message and in `docs/operations.md` (task 7).
+
+  **Known limitation, disclosed rather than solved**: this signal assumes the previous pass ran
+  exactly `recentInterval` ago. If a pass was skipped, delayed, or failed (per
+  `bin-schedule-manager`'s own single-fire catch-up semantics — missed slots are not replayed), the
+  true gap since the last successful pass can exceed `recentInterval`, and `RecentSaturated` can
+  under-report in that scenario (it measures the wrong, too-short interval and may read `false`
+  when the actual gap-since-last-pass already exceeds the safety condition). This is an accepted
+  gap, not a claimed guarantee — `Saturated` and the audit trail in `bin-schedule-manager` remain
+  the backstop for detecting an unhealthy cadence.
+
+  **`recentInterval` must be a request parameter, not a hardcoded Go constant (design-round-4
+  fix)**: `bin-campaign-manager` has no way to read the schedule's `cron` field from
+  `bin-schedule-manager`'s own database — a compiled constant would silently drift from the real
+  cron interval the moment someone changes it. Fixed: the seed migration's `target_data` carries
+  `recent_interval_sec` alongside `cron` (task 8, same migration row **at seed time**), the new
+  route accepts it as a request body field, and `ReconcileOrphanedFlows` takes it as an explicit
+  parameter (task 3). If the field is missing or non-positive (e.g. an old/malformed dispatch),
+  fall back to a conservative default (24 h) and log a warning — never panic or fail the pass over
+  a malformed rate-signal input.
+
+  **Design-round-5 correction — this does not eliminate post-seed drift, and the runbook must say
+  so**: co-locating the two values in one migration row only protects the *initial* seed. A later
+  operational change to `cron` (via `schedule-control` or `PUT /v1/schedules/{id}` — including the
+  "shorten the interval" remedy this section itself recommends for a `RecentSaturated` alert) edits
+  `schedule_schedules.cron` directly and does **not** touch `target_data.recent_interval_sec`,
+  since they're edited through different operational paths once the schedule exists. **The runbook
+  for both remedies (raising `scanLimit` and/or shortening the interval) must therefore
+  explicitly instruct**: (1) update `target_data.recent_interval_sec` to match the new `cron` in
+  the same operational change, and (2) re-verify `reconcilePassTimeout` (task 3) is still well
+  below the *new*, shorter interval — `reconcilePassTimeout` is a compiled constant that does not
+  move on its own, and a large-enough interval cut could violate the **cadence/liveness condition**
+  in task 3's "self-imposed pass timeout" section (constraint (b) — design-round-7 correction: not
+  a concurrency-safety condition; violating (b) alone causes chronic `skipped_overlap` cadence
+  degradation, not a race, since mutual exclusion rests on constraint (a) alone) without either
+  document's own checks catching it, since those checks only run once, at migration-review time.
+  Document this as an explicit pre-flight step in `docs/operations.md` (task 7), not just a passing
+  mention here.
+
+**Why no cursor/watermark instead** (deliberate trade-off, stated explicitly so a future
+maintainer doesn't "optimize" it away — design-round-3 correction to the retry-property claim
+below): a cursor-based design (remember the last-processed `tm_delete` per pass, only fetch newer)
+would eliminate the plain `Saturated` case entirely (no more re-fetching already-`Skipped` history),
+but at a real cost — it would also permanently skip any candidate whose `FlowV1FlowDelete` call
+failed on a past pass, since the cursor would have already advanced past it. The current no-cursor,
+re-scan-the-whole-window-every-time design instead gives a failed cleanup automatic retry on every
+subsequent pass **for as long as the candidate's rank stays within `scanLimit`** — not
+unconditionally for its entire time in the window; full-window retry would require the stronger
+per-window inequality (`scanLimit` > deletions per *window*) that the safety-condition section
+above explicitly does not rely on. In practice, under the per-interval safety condition, a
+newly-deleted or newly-failed candidate is retried on every pass for multiple intervals before its
+rank could plausibly exceed `scanLimit`, which is worth the re-scan cost at this job's expected
+scale (a background hygiene job, not a high-throughput queue) — and is why the
+DESC-order-plus-two-signal fix was chosen over a cursor, not because a cursor wasn't considered.
+
+## Tasks — `bin-campaign-manager`
+
+1. **`pkg/dbhandler/campaign.go`**: add `CampaignListDeletedSince(ctx, since time.Time, limit
+   uint64) ([]*campaign.Campaign, error)` — direct squirrel query,
+   `WHERE tm_delete >= ? ORDER BY tm_delete DESC LIMIT ?`, mirroring this file's existing
+   `CampaignList`'s error-wrapping style (no cache interaction, consistent with `CampaignList`
+   itself being a fresh scan, not a single-entity cache-backed lookup). **Also add the method to
+   the `DBHandler` interface declaration in `pkg/dbhandler/main.go`** (design-round-8 addition: an
+   earlier draft only specified the concrete implementation — the interface is what task 6's tests
+   mock, and what `//go:generate mockgen ... -source main.go` regenerates
+   `mock_dbhandler.go` from; without this, task 3 won't compile against the interface and `go
+   generate` won't produce a mock exposing the new method).
+2. **`bin-campaign-manager/models/campaign`** (or a new small `models/reconcile` package, matching
+   how `bin-timeline-manager`'s analogous multi-field result, `EventListResponse`, lives in a
+   *domain* package under `models/`, not under `pkg/listenhandler/models`): add
+   `ReconcileResult{Cleaned, Skipped, Failed int; Saturated, RecentSaturated, Partial bool}` (
+   `RecentSaturated` is a design-round-3 addition, corrected in design-round-4 — see "Scan order
+   and coverage" above for its exact meaning and the `recentInterval` request-parameter fix;
+   `Partial` is a design-round-4 addition, set true when the self-imposed pass timeout cuts a pass
+   short — see task 3) **with json tags** — this is a
+   domain type that also serves as the wire shape (style A per this repo's layering rule), not a
+   `response.*` DTO. Design-round-2 correction: an earlier draft proposed a separate
+   `pkg/listenhandler/models/response.*` copy of this exact same shape, which the root CLAUDE.md's
+   layering rule explicitly forbids ("Do NOT introduce a `response.*` DTO that is a field-for-field,
+   identical-json-tag copy of a domain type — that is style (A) wearing a DTO costume"). Since no
+   single existing domain type already equals this wire shape, `ReconcileResult` itself becomes
+   that domain type (carrying json tags is allowed and is not the same as being a `response.*`
+   DTO) — there is nothing to map into a separate struct.
+3. **`pkg/campaignhandler`** (new file `reconcile.go`): add
+   `ReconcileOrphanedFlows(ctx context.Context, recentIntervalSec int64) (result
+   campaign.ReconcileResult, err error)` (or the equivalent type from wherever task 2 places it) —
+   `recentIntervalSec` is a design-round-4 addition, threaded in from the request body by task 4.
+   **Also add the method to the `CampaignHandler` interface declaration in
+   `pkg/campaignhandler/main.go`** (design-round-8 addition, same reasoning as task 1: task 4's
+   listenhandler calls this through the interface, and `//go:generate mockgen ... -source main.go`
+   must regenerate `mock_campaignhandler.go` with the new method before task 6's listenhandler test
+   can mock it). **Package-level constants (design-round-10 addition, for self-containment)**:
+   declare `window time.Duration`, `scanLimit uint64`, and `reconcilePassTimeout time.Duration` as
+   package constants in this file, sized per the pre-implementation check above; the body calls
+   `CampaignListDeletedSince(ctx, passStart.Add(-window), scanLimit)` (task 1) as its first
+   statement after the timeout wrap:
+   - **Self-imposed pass timeout, required (design-round-3, corrected rounds 4/5, corrected again
+     design-round-6)**: `ReconcileOrphanedFlows` must wrap its own body in `passStart := <time this
+     call began>; ctx, cancel := context.WithTimeout(ctx, reconcilePassTimeout); defer cancel()`.
+     **`reconcilePassTimeout` must satisfy two constraints that play genuinely different roles —
+     design-round-6 correction: round 5 wrongly promoted both to co-equal "independent concurrency
+     guards"; only (a) actually prevents concurrent execution, (b) is a cadence/liveness
+     requirement**:
+     - **(a) — the actual mutual-exclusion guarantee: `reconcilePassTimeout` strictly below the
+       schedule's seeded `timeout_ms` (task 8), with margin that also absorbs message-delivery
+       delay (design-round-6 addition — see below).** Tracing `bin-schedule-manager` source:
+       `ExecutionHasRunning` ("Forbid overlap") is checked *before* the `tm_next_run` CAS on every
+       claim path (cron and manual alike) and refuses to dispatch while a `running` row exists for
+       this schedule. That row is marked `running` until `ExecutionComplete` fires, which happens
+       as soon as `SendRequest`'s own `timeout_ms`-bounded wait returns (success or timeout) — **not**
+       when this pass actually finishes in `bin-campaign-manager`. If `reconcilePassTimeout` (as
+       measured from when `bin-campaign-manager` actually starts processing, not from when
+       `bin-schedule-manager` sends the RPC — the two clocks do not start together; the margin
+       below `timeout_ms` must absorb whatever message-delivery delay sits between them, not just
+       clock skew) could exceed `timeout_ms`, there would be a real window — from `timeout_ms`
+       until this pass's own timeout — where `bin-schedule-manager` believes the execution is no
+       longer `running` (so `ExecutionHasRunning` no longer blocks anything) while this pass is
+       still physically executing. A manual `/v1/schedules/{id}/execute` fired in that window would
+       genuinely race a second RPC against the still-running first one. This is the only condition
+       under which two calls to this route could ever execute concurrently, and it produces **no
+       distinct alert** — the raced execution reads as an ordinary `success` row, exactly like a
+       correctly-serialized one (design-round-6 finding: there is no monitorable signal for an
+       (a)-violation; correct static sizing, with margin for delivery delay, is the only defense).
+     - **(b) — a cadence/liveness requirement, not a concurrency guard (design-round-6
+       correction)**: `reconcilePassTimeout` well below the schedule's `cron` interval. Because
+       `ExecutionHasRunning` is checked *before* the `tm_next_run` CAS, a cron-triggered claim that
+       arrives while the row is still `running` is short-circuited into an overlap skip — the CAS
+       never runs, so `tm_next_run` is never advanced ("the slot is late, not lost", per
+       `bin-schedule-manager`'s own documentation) — it does **not** create concurrent execution;
+       given (a) holds, guard 1 alone already prevents that. What a chronically-overrunning pass
+       actually produces is **cadence degradation**: every cron tick after the first observes the
+       overlap skip, so the job effectively stops running on schedule at all. Constraint (b) exists
+       to keep the schedule's cadence meaningful, not to prevent a race.
+     **Runbook implication**: because `cron` is runtime-mutable data (edited via
+     `schedule-control`/`PUT /v1/schedules/{id}`, no redeploy) while `reconcilePassTimeout` is a
+     compiled Go constant, *any* operational change to the interval — including the
+     `RecentSaturated` remedy below — must be checked against constraint (b) before applying it, to
+     avoid reintroducing cadence degradation; see "Scan order and coverage" above. Constraint (a)
+     is load-bearing independent of both, for a further reason: this service's
+     `pkg/listenhandler/main.go` builds every RPC request's context with `context.Background()` —
+     it does **not** propagate `timeout_ms` as a deadline — so without this internal bound, nothing
+     stops a pass from running arbitrarily long in the first place. The `ctx.Err()` check below is
+     only meaningful because of this self-imposed deadline. **Observable symptom, design-round-6
+     correction — this is NOT an execution row or status; there is no `skipped_overlap` execution
+     status (the enum is `running`/`success`/`failed`/`abandoned`)**: `skipped_overlap` is a
+     **dispatch-level metric result label** (`schedule_manager_dispatch_total{result=
+     "skipped_overlap"}`, emitted and counted *before* any execution row is ever created for that
+     attempt — the claim path returns early on an overlap skip). This metric climbing is the
+     observable symptom of a **constraint-(b)** violation (chronic cadence degradation) — it tells
+     you nothing about an (a) violation, which produces a normal `success` row with no distinct
+     signal at all. Document both facts explicitly in `docs/operations.md` (task 7): watch
+     `schedule_manager_dispatch_total{result="skipped_overlap"}` for (b) health, and treat (a) as a
+     static-sizing correctness property with no runtime monitor.
+   - `err` is non-nil **only** when the initial `CampaignListDeletedSince` query itself fails (the
+     pass could not run at all) — never for per-row outcomes, which are counted, not propagated.
+   - **Compute `Saturated` and `RecentSaturated` in a dedicated, RPC-free pass over the fetched
+     slice immediately after the query returns — design-round-4 fix, before any
+     `FlowV1FlowGet`/`FlowV1FlowDelete` call, not interleaved with the RPC loop below.** An earlier
+     draft computed `RecentSaturated` "while iterating the batch" in the same loop that issues
+     RPCs, which meant the self-imposed pass-timeout bail-out could stop the count short of
+     `scanLimit` even on a genuinely saturated batch — a false negative in exactly the overload
+     case this signal exists to catch. Since the batch is already `DESC`-ordered and fully in
+     memory, this is a pure O(n) timestamp scan, no RPCs involved:
+     - `Saturated = uint64(len(candidates)) == scanLimit` — informational only (see "Scan order
+       and coverage" above): the window holds more history than one pass returns, normal and
+       expected at scale, not itself actionable. (Implementation nit, design-round-11: `len()`
+       returns `int`; keep `scanLimit`'s declared type (task 3's package constants) in mind and
+       cast explicitly rather than comparing mixed integer types, which doesn't compile in Go.)
+     - `RecentSaturated`: count how many candidates have `tm_delete >= passStart -
+       recentInterval` (`passStart` is the wall-clock time this call began, captured before the
+       query runs; `recentInterval = time.Duration(recentIntervalSec) * time.Second`, falling back
+       to a conservative 24h default with a logged warning if `recentIntervalSec <= 0`);
+       `RecentSaturated = (uint64(thatCount) == scanLimit)`. See "Scan order and coverage" above
+       for the exact meaning, the disclosed under-reporting limitation, and the runbook response.
+   - For each candidate campaign (now iterating for the RPC loop proper), check `ctx.Err()` at the
+     top of the loop iteration and bail out early if the context is done: set `Partial = true`
+     (design-round-4 addition) and log at `warn` — a partial pass with `err == nil` would otherwise
+     be silently indistinguishable from a complete one, which is what previously made a timed-out
+     pass look like a full `success` in the audit trail — then return `(result, nil)` with the
+     accumulated counts so far; the self-imposed pass timeout will cut a slow pass mid-iteration,
+     so don't keep issuing RPCs against a dead context.
+   - Defensive guard: `if c.TMDelete == nil { Skipped++; continue }` (design-round-5 fix: an
+     earlier draft incremented no counter and logged nothing here, reproducing the exact
+     counter-invariant gap design-round-4 fixed for the typed-not-found branch — corrected to log
+     at `warn` and count it as `Skipped`, same reasoning: nothing needed doing for this row) even
+     though the query already filters on `tm_delete >= since` (which excludes live campaigns via
+     NULL-comparison semantics) — this is a second, cheap layer of defense against a future query
+     change accidentally including live campaigns, given this job mutates data across all
+     customers. The warn log (not just a silent `continue`) is what makes a future query regression
+     visible instead of merely harmless.
+   - `FlowV1FlowGet(campaign.FlowID)`. On typed not-found
+     (`stderrors.As(err, &ve) && ve.Status == cerrors.StatusNotFound`), **`Skipped++`**
+     (design-round-4 fix: an earlier draft incremented neither counter here, which meant
+     `Cleaned+Skipped+Failed` didn't sum to candidates examined and this case had nothing
+     assertable in a test — corrected to count it as `Skipped`, the same bucket as an
+     already-cleaned flow, since a genuinely absent flow row is an equally legitimate clean end
+     state). On any other error, log + increment `campaign_flow_reconcile_failed_total` (task 5) +
+     `Failed++` (design-round-8 fix: an earlier draft incremented `Failed` here but **not** the
+     metric, leaving the metric defined — task 5 and the design doc — to cover this branch while
+     no instruction actually wired it up; this is the systemically important branch to alert on,
+     since a `bin-flow-manager` outage or an open circuit breaker on the shared RPC client makes
+     every remaining candidate in the pass fail here, and under the previous, unmetriced version
+     the counter would read zero while the pass failed on every single row). On success: if
+     `f.TMDelete != nil`, `Skipped++` (already clean, not an error). Otherwise, it's a genuine
+     orphan: call `FlowV1FlowDelete(campaign.FlowID)`; on error, log + increment
+     `campaign_flow_reconcile_failed_total` (task 5) + `Failed++`; on success, `Cleaned++` +
+     increment `campaign_flow_reconcile_cleaned_total`. **Both error branches share the same
+     `campaign_flow_reconcile_failed_total` counter** (no `reason` label distinguishing
+     `FlowV1FlowGet` failures from `FlowV1FlowDelete` failures) — call this out explicitly in
+     `docs/operations.md` (task 7) so a reader of the metric knows it conflates the two RPCs.
+   - Window-edge warning (per-candidate, orthogonal to the saturation signals): for each orphan
+     found whose owning campaign's `tm_delete` is within [some margin, e.g. 10%] of the window's
+     outer edge, **log** a warning noting the window may need widening (design-round-4 fix: an
+     earlier draft said "log/metric" here — no counter is defined for this, matching the
+     no-third-counter decision for `Saturated`/`RecentSaturated`).
+4. **`pkg/listenhandler`**: add route `POST /v1/campaigns/flows/reconcile` (new regex + dispatch
+   case in `main.go`, new handler file e.g. `flows.go`). Request body: `{"recent_interval_sec":
+   int64}` — a new, small `request.*` DTO under this service's existing
+   `pkg/listenhandler/models/request` subpackage (this is the transport-DTO-for-inputs case the
+   layering rule expects listenhandler to own — not a violation of the task-2 domain-type
+   decision, which is about the *response* shape). The handler unmarshals it, calls
+   `campaignHandler.ReconcileOrphanedFlows(ctx, req.RecentIntervalSec)` with the unwrapped scalar
+   (not the request struct itself, per this repo's "unwrapped parameters, not a wrapped request
+   struct" convention), and `json.Marshal`s the returned `ReconcileResult` **directly** — style
+   (A), per the correction in task 2, matching every other route in this service (this service's
+   `pkg/listenhandler/models/` gains only this one small `request.*` addition; still no
+   `response/` subpackage). HTTP status: 200 even if `Failed > 0` or `Partial == true` (the pass
+   ran; individual row failures and a self-timeout cutoff are data, not a pass-level error) — a
+   non-nil `err` from the handler (query-level failure) is the only case that should produce a
+   non-2xx response. Internal-only route, not exposed through `bin-api-manager` (no OpenAPI spec
+   change).
+5. **`pkg/campaignhandler/main.go`**: add two new plain `Counter`s (not a reuse of VOIP-1443's
+   `promCampaignFlowDeleteFailedTotal` — that metric is documented as "failures during campaign
+   delete" and reusing it here would collapse two operationally distinct signals: "a live delete
+   is failing right now" vs. "the reconciler couldn't clean up a known-orphaned flow" — into one
+   series and make that existing doc line inaccurate):
+   `campaign_flow_reconcile_cleaned_total` and `campaign_flow_reconcile_failed_total`, following
+   the existing `init()` pattern. No third counter for `Saturated`/`RecentSaturated`
+   (design-round-3 clarification): that signal is surfaced only via the log warning and the
+   `ReconcileResult` response field, kept out of Prometheus since it is informational far more
+   often than actionable (see "Scan order and coverage" above).
+6. **Tests**: `reconcile_test.go` covering:
+   - Genuine orphan (flow `TMDelete` nil) found and cleaned — `Cleaned` increments, metric fires.
+   - Already-clean flow (`TMDelete` set) skipped — `Skipped` increments, no `FlowV1FlowDelete`
+     call, no metric.
+   - `FlowV1FlowGet` typed not-found — **`Skipped` increments** (design-round-4 fix: an earlier
+     draft counted this case nowhere, so `Cleaned+Skipped+Failed` didn't sum to candidates
+     examined; now the same bucket as an already-clean flow), not counted as `Failed`.
+   - A transient `FlowV1FlowGet` error — `Failed` increments, logged, not counted as `Cleaned`,
+     **and `campaign_flow_reconcile_failed_total` fires** (design-round-8 fix: an earlier draft
+     asserted only the in-memory `Failed` counter here, matching a task-3 draft that incremented
+     `Failed` without the metric — corrected so this, the systemically important failure branch, is
+     actually observable via Prometheus, not just in the response body and logs).
+   - `FlowV1FlowDelete` failure on a genuine orphan — `Failed` increments (not `Cleaned`), and
+     `campaign_flow_reconcile_failed_total` fires (same counter as the `FlowV1FlowGet`-error case
+     above — no `reason` label distinguishes them).
+   - A campaign with `TMDelete == nil` fed directly into the handler (bypassing the query) —
+     assert `Skipped` increments (design-round-5 fix: an earlier draft asserted only "no RPCs
+     called", which is not assertable as a positive outcome — now the same counter-invariant fix
+     applied to the typed-not-found case above) and `FlowV1FlowDelete`/`FlowV1FlowGet` are never
+     called (the defense-in-depth guard, tested in isolation from the query's own filtering), and
+     that a `warn`-level log line fires (this guard existing at all means a future query regression
+     should be loud, not silent).
+   - `scanLimit`-sized result set — assert `Saturated == true`; a smaller result set — assert
+     `Saturated == false`.
+   - `scanLimit`-sized result set where all rows fall within `recentInterval` — assert
+     `RecentSaturated == true`; a `scanLimit`-sized result set where most rows are older than
+     `recentInterval` — assert `Saturated == true` but `RecentSaturated == false` (this is the case
+     that distinguishes the two signals).
+   - **Design-round-4 addition, corrected design-round-5**: `Saturated`/`RecentSaturated` are
+     computed correctly even when the self-imposed pass timeout fires during the RPC loop (a slow
+     fake RPC client on, say, the second candidate) — asserts the two-signal computation genuinely
+     happened in its own pre-loop pass over the fetched slice before any RPC was issued, not
+     interleaved with the RPC loop (the exact false-negative this task's earlier draft would have
+     produced). Design-round-5 correction: do not test this via a 0-duration `reconcilePassTimeout`
+     — that would expire before `CampaignListDeletedSince` itself returns, so the pass would fail
+     at `err != nil` with no `ReconcileResult` to assert against, testing nothing about the
+     ordering property; use a `reconcilePassTimeout` long enough for the query to return but short
+     enough to expire partway through the RPC loop.
+   - **Design-round-4 addition**: `recentIntervalSec <= 0` (missing/malformed request field) falls
+     back to the conservative default and logs a warning, does not panic or fail the pass.
+   - Self-imposed pass timeout fires mid-pass (inject a short `reconcilePassTimeout` or a slow fake
+     RPC client) — assert early return with the partial counts accumulated so far, `Partial ==
+     true` (design-round-4 addition), `err == nil` (this exercises the handler's own
+     `context.WithTimeout`, not the RPC-layer context, since the RPC layer does not propagate a
+     deadline).
+   - Empty candidate set — `{0,0,0,false,false,false}, nil` (design-round-4: now six `ReconcileResult`
+     fields including `Partial`), zero RPCs issued.
+   - Idempotent re-run: running the same pass twice against the same fixture data cleans nothing
+     and deletes nothing the second time.
+   - Window-edge warning fires for a near-cutoff candidate.
+   - A `dbhandler` test for `CampaignListDeletedSince` against this package's real SQLite
+     test-schema harness, confirming the date-range filter, the `DESC` order, and the
+     NULL-comparison exclusion of live campaigns.
+   - A basic listenhandler test for the new route (request parses, calls through, the marshaled
+     `ReconcileResult` shape is correct, 200 status even with `Failed > 0`).
+7. **Docs**: `docs/operations.md` — two new metrics, new route, the `Saturated`/`RecentSaturated`
+   runbook note from "Scan order and coverage" above, **and**: (i) design-round-6 correction of a
+   design-round-5 addition — there is no `skipped_overlap` execution status (the execution status
+   enum is `running`/`success`/`failed`/`abandoned`); the real observable signal is the
+   **dispatch-level metric** `schedule_manager_dispatch_total{result="skipped_overlap"}` climbing
+   for this schedule, which indicates a **constraint-(b)** violation (cadence degradation — see
+   task 3) and calls for re-tuning `reconcilePassTimeout` against real pass durations; explicitly
+   document that this metric does **not** detect a constraint-(a) violation (the actual
+   concurrency-safety condition), which produces an indistinguishable, ordinary `success` row —
+   (a) is a static-sizing correctness property with no runtime monitor, not something to watch a
+   dashboard for; (ii) any operational change to the schedule's `cron` interval (including the
+   `RecentSaturated` remedy) MUST update `target_data.recent_interval_sec` to match in the same
+   change, and must re-verify `reconcilePassTimeout` is still well below the new interval before
+   applying it (constraint (b), to avoid reintroducing cadence degradation); (iii) design-round-10
+   addition — the `RecentSaturated` remedy's two options are not equally fast: raising `scanLimit`
+   is a compiled constant and needs a code change + redeploy, while shortening `cron`/updating
+   `recent_interval_sec` is a live data edit with no redeploy — state this explicitly so an
+   operator under saturation pressure reaches for the immediate remedy first; (iv) design-round-10
+   addition — `Saturated`/`RecentSaturated`/`Partial` are not merely logged and dropped: they land
+   in the response body, which `bin-schedule-manager` persists verbatim as
+   `schedule_executions.result` (`models/execution/execution.go`'s `Result string` field) on every
+   pass that returns a response (design-round-11 precision fix: every HTTP 200, including
+   `Failed > 0`/`Partial == true` — `result` is populated only inside `ExecutionComplete`'s success
+   branch, so a transport-level failure that never reaches this route leaves `result` empty and
+   `error` populated instead; that case has no `ReconcileResult` to persist regardless) — this is
+   what makes the no-third-counter decision safe despite
+   `bin-campaign-manager`'s own logs "rotating within hours" (per VOIP-1443's investigation): the
+   durable record survives in `bin-schedule-manager`'s own audit trail even after local logs
+   rotate. `docs/architecture.md` (routing-table entry for the new route), and — design-round-3
+   addition, missed in the prior revision — `docs/domain.md` (the new `ReconcileResult` type added
+   under `models/` in task 2), per this service's own service-docs-sync convention and the root
+   CLAUDE.md's `models/.../*.go` → `docs/domain.md` mapping.
+
+## Tasks — `bin-dbscheme-manager` (same PR, different directory — not a separate PR)
+
+8. **New Alembic migration**: seed the `campaign-flow-reconcile` schedule row into
+   `schedule_schedules`. Primary model: `0c037bf0a362_schedule_schedules_seed_phase2_ticker_...py`
+   (seeds five schedules dispatching into *other* services' request queues — the closer precedent
+   for this ticket's cross-service dispatch shape than the self-RPC housekeeping jobs in
+   `a5e6f559299c`). Set every column both precedent migrations set: `id` (fresh UUID),
+   `customer_id` (nil-UUID platform-job convention), `name: 'campaign-flow-reconcile'`, `detail`,
+   `type: 'rpc'`, `cron` (from the pre-implementation check, e.g. `'0 */6 * * *'` — every 6 hours,
+   adjust per the rate finding), `target_queue: 'bin-manager.campaign-manager.request'`,
+   `target_uri: '/v1/campaigns/flows/reconcile'`, `target_method: 'POST'`, `target_data_type:
+   'application/json'`, **`target_data: JSON_OBJECT('recent_interval_sec', N)` where `N` is the
+   `cron` field's interval in seconds (design-round-4 addition — e.g. `21600` for the `'0 */6 * *
+   *'` example above)** — not an empty `JSON_OBJECT()`: `bin-campaign-manager` has no way to read
+   `cron` from `bin-schedule-manager`'s own database, so the interval must be handed to it
+   explicitly per request; seeding both in this same migration row means the *initial* values can
+   only be edited apart by missing a line in the same diff (design-round-5 clarification: this
+   applies at seed time only — see the docstring note below and "Scan order and coverage" above for
+   the post-seed runtime-drift risk this does *not* eliminate), `timeout_ms` (design-round-6
+   correction of a design-round-5 over-correction: `reconcilePassTimeout` (task 3) strictly below
+   `timeout_ms` is the actual mutual-exclusion guarantee — it keeps `bin-schedule-manager`'s "Forbid
+   overlap" guard (`ExecutionHasRunning`, checked before the `tm_next_run` CAS on every claim path)
+   effective for this pass's entire physical duration; being well below `cron`'s interval is a
+   separate, secondary cadence requirement (task 3), not an independent concurrency guard — see
+   task 3's full reasoning for why. Size with margin that covers real message-delivery delay
+   between `bin-schedule-manager` sending the RPC and `bin-campaign-manager` starting to process
+   it, not just RPC latency — e.g. `reconcilePassTimeout = 90s` → `timeout_ms: 120000` as a
+   starting estimate, both values confirmed against real per-row
+   `FlowV1FlowGet`/`FlowV1FlowDelete` latency, real queue delivery delay, and comfortably below the
+   6-hour `cron` interval), `retry_max: 0` (a failed pass is naturally retried by the next
+   scheduled run — no need for schedule-level retry), **`enabled: 0`** (rollout ordering, see task
+   10 — not `1`, correcting an earlier draft), `tm_next_run: NULL`, `tm_create`/`tm_update:
+   UTC_TIMESTAMP(6)`. Include, in the migration's docstring: (a) why `target_data` carries
+   `recent_interval_sec` as a bound SQL parameter via `JSON_OBJECT(...)` rather than a raw JSON
+   string literal like `'{"recent_interval_sec": 21600}'` — `op.execute()` passes raw SQL through
+   `sqlalchemy.text()`, which would parse the literal's bare colon as a bind-parameter marker, per
+   `0c037bf0a362`'s own documented reasoning; and that `recent_interval_sec` must be kept in sync
+   with `cron` by hand whenever either changes **after** this migration is applied — a post-seed
+   edit to `cron` (via `schedule-control` or `PUT /v1/schedules/{id}`) does **not** automatically
+   update `target_data`, since the two are edited through entirely different operational paths once
+   the schedule exists (design-round-5 correction: an earlier draft of this note contradicted
+   itself by also implying they're safely co-located forever because they started in one migration
+   row — that co-location protects only the initial seed, not later edits); (b) why this row ships
+   `enabled: 0` unlike all five rows in the `0c037bf0a362` precedent (which ship `enabled: 1`) —
+   the rollout-ordering reason in task 10 — so a future reader doesn't "fix" it back to `1`.
+   - Cross-check (design-round-6 correction of design-round-5's framing — round 4 wrongly dropped
+     the reaper-abandonment-deadline comparison as "an unfalsifiable tautology"; round 5 reinstated
+     it correctly but attributed the crash scenario to the wrong service; both fixed below):
+     1. `reconcilePassTimeout` (task 3) strictly below `timeout_ms`, with margin covering real
+        message-delivery delay (not just processing latency) — the actual mutual-exclusion
+        guarantee: keeps `bin-schedule-manager`'s "Forbid overlap" (`ExecutionHasRunning`) guard
+        covering this pass's entire actual execution. This has no runtime monitor — get the sizing
+        right, since a violation produces an ordinary `success` row with no distinguishing signal.
+     2. `reconcilePassTimeout` well below the `cron` interval above — a cadence/liveness
+        requirement (task 3), not a concurrency guard: keeps the schedule from chronically
+        observing dispatch-level `skipped_overlap` skips (see task 3) rather than actually running
+        on its intended cadence.
+     3. `timeout_ms + 60s` (the reap deadline at `retry_max: 0`) comfortably below the `cron`
+        interval — bounds how long a **`bin-schedule-manager` dispatch goroutine itself crashing
+        mid-wait** (its documented "abandon-not-drain" shutdown case, not a
+        `bin-campaign-manager` crash — design-round-6 correction: an earlier draft of this
+        cross-check attributed the crash to the wrong service) can leave this schedule's execution
+        row stuck `running` — and hence the schedule stuck observing overlap skips — before the
+        reaper reclaims it; at `timeout_ms: 120000` vs. a 6-hour `cron`, this holds with wide
+        margin, but re-verify it whenever either constant changes.
+9. **`tm_delete` index migration** (include per the plan's conservative default, or confirmed
+   necessary by the pre-implementation check): add an index on `campaign_campaigns.tm_delete`, and
+   update the corresponding test-schema fixture
+   (`bin-campaign-manager/scripts/database_scripts/table_campaigns.sql`) in the same commit, per
+   `bin-dbscheme-manager/CLAUDE.md`'s migration+fixture-sync rule.
+10. **Rollout sequencing (closes the dispatch-before-route-exists ordering hazard)**: the seed
+    migration ships with **`enabled: 0`**. After this PR merges and both the migration is applied
+    (by 대표님/ops, per the Alembic AI-authorship boundary below) and the `bin-campaign-manager`
+    image carrying the new route is deployed: (a) fire a manual smoke test via
+    `POST /v1/schedules/{id}/execute` — **design-round-8 addition, how to actually issue this
+    call**: `bin-schedule-manager/cmd/schedule-control` has no `execute` subcommand (only
+    `list`/`get`/`enable`/`disable` for schedules); the only path is
+    `requesthandler.ScheduleV1ScheduleExecute` (a Go RPC client call) or publishing the equivalent
+    RPC directly onto `bin-manager.schedule-manager.request` — the same idiom
+    `bin-schedule-manager/docs/operations.md` already documents for its own backup runbook, not a
+    new invention. First resolve the schedule's `{id}` (a generated UUID, unknown at
+    migration-authoring time) via `schedule-control schedule get campaign-flow-reconcile`. This
+    call (works on disabled schedules, per `bin-schedule-manager`'s own documentation, and never
+    consumes the cron slot; it dispatches asynchronously and returns the execution row in
+    `running` status — design-round-4 fix: poll the execution row rather than expecting a terminal
+    status in the response) — confirm the resulting execution row settles
+    to status **`success`** (design-round-4 correction: the status enum value is `success`, not
+    `succeeded` — an earlier draft used the event name instead of the status value) and the new
+    counters moved. **Design-round-7 addition**: if this call instead returns a
+    `FailedPrecondition` `EXECUTION_IN_PROGRESS` error, it means a prior execution for this
+    schedule is still `running` (the manual path's own overlap guard — distinct from cron's
+    `skipped_overlap` metric, and not itself a metric event) — simply wait for it to finish and
+    retry, not a failure of this rollout step; (b) only then enable the schedule via
+    `schedule-control schedule enable campaign-flow-reconcile` (no redeploy, no second migration
+    needed for either step). This is a post-deploy operational sequence, not part of the PR's
+    code — call it out explicitly in the PR description so it isn't missed. Symmetric rollback:
+    `schedule-control schedule disable campaign-flow-reconcile` if the job needs to be paused for
+    any reason, no redeploy needed either direction.
+11. **AI-authorship boundary**: create and commit the migration file(s) via `alembic revision`; do
+    **not** run `alembic upgrade`/`downgrade` — that requires human authorization per this repo's
+    Alembic rule. The enable step in task 10 is likewise a human/ops action, not something this
+    session performs.
+
+## Acceptance criteria
+
+- A campaign deleted more than `window` days ago is never touched by this job (out of scope by
+  design, not a bug).
+- A campaign deleted within the window whose flow was already correctly cleaned up (by
+  VOIP-1443's `Delete()` best-effort path succeeding) is left alone — no re-delete, counted as
+  `Skipped` in the response only (no dedicated Prometheus counter exists for skips — see task 5).
+- A campaign deleted within the window whose flow is still live gets that flow deleted, and
+  `campaign_flow_reconcile_cleaned_total` increments.
+- A row-level failure on *either* `FlowV1FlowGet` (non-not-found) or `FlowV1FlowDelete` increments
+  `campaign_flow_reconcile_failed_total` (design-round-9 addition, pinning the round-8 lesson here
+  explicitly: an earlier draft only wired this metric to the `FlowV1FlowDelete` branch, leaving it
+  silent during exactly the `bin-flow-manager`-outage scenario it exists to catch) — the one
+  counter conflates both RPCs, with no `reason` label distinguishing which one failed.
+- A pass that reaches its `scanLimit` is visibly flagged (`Saturated` in the response, log +
+  response `RecentSaturated` when the more precise rate-risk condition is met), not silently
+  truncated — but plain `Saturated` alone is informational, not itself a defect (see "Scan order
+  and coverage").
+- A reconciliation pass's own execution is bounded by `ReconcileOrphanedFlows`'s self-imposed
+  `context.WithTimeout` (task 3), satisfying two constraints that play different roles —
+  design-round-6 correction of design-round-5's framing (design-round-7 fix: standardizing on
+  constraint labels (a)/(b) throughout both documents, not a second, conflicting (1)/(2) scheme):
+  they are not co-equal "independent concurrency guards"; only one of them prevents concurrent
+  execution: **(a)** strictly below the schedule's `timeout_ms`, with margin covering real
+  message-delivery delay — this is the actual mutual-exclusion guarantee, keeping
+  `bin-schedule-manager`'s "Forbid overlap" (`ExecutionHasRunning`) guard effective for the pass's
+  entire physical duration; without it, a manual execute could race a genuinely still-running pass
+  once `bin-schedule-manager`'s own RPC wait gives up, and this violation produces an ordinary
+  `success` row with **no distinguishing signal** — correct sizing is the only defense; and **(b)**
+  well below the schedule's `cron` interval — a cadence/liveness requirement, not a concurrency
+  guard, since `ExecutionHasRunning` is checked before the `tm_next_run` CAS on the **cron** claim
+  path and a cron claim arriving mid-pass is short-circuited into a dispatch-level
+  `skipped_overlap` metric result, not a second execution (design-round-7 correction: this applies
+  to the cron path only — a **manual** `/v1/schedules/{id}/execute` that hits the same overlap
+  guard does not increment this metric at all; it returns a `FailedPrecondition`
+  `EXECUTION_IN_PROGRESS` error instead, since `ScheduleClaimAndCreateExecution` skips the CAS
+  entirely for manual triggers). The `schedule_manager_dispatch_total{result="skipped_overlap"}`
+  metric climbing is the observable symptom of a constraint-(b) violation (chronic cadence
+  degradation) specifically, on the cron path — it says nothing about constraint (a).
+- A pass cut short by its own self-imposed timeout sets `Partial = true` in the response and logs
+  a warning — it is never silently recorded as a full `success` with no trace it was incomplete.
+- The new route can only ever be reached via the seeded schedule (once enabled) or a manual
+  `/v1/schedules/{id}/execute` RPC (design-review-round-9 fix: not `schedule-control`, which per
+  task 10 has no `execute` subcommand and cannot fire this route at all — only
+  `list`/`get`/`enable`/`disable`) — no `bin-api-manager` exposure.
+- The schedule ships disabled; enabling it is an explicit, documented post-deploy step, not
+  automatic on merge or on migration apply.
+- Before the schedule is ever enabled, a manual `POST /v1/schedules/{id}/execute` smoke test has
+  been fired and its execution row polled to a terminal **`success`** status with the new counters
+  moved — enabling the cron trigger is not the first time this route is exercised in production.
+- The full repo-mandated verification workflow (`go mod tidy && go mod vendor && go generate ./...
+  && go test ./... && golangci-lint run`, per root CLAUDE.md's "CRITICAL: Verification before
+  commit" — design-round-8 fix: an earlier draft of this criterion and the verify tasks below
+  named only `go test`/`golangci-lint run`, a 2-of-5 subset; `go generate` in particular is
+  load-bearing here, not boilerplate — see tasks 1/3) passes in `bin-campaign-manager`; the new
+  Alembic migration is created (not applied) and reviewed for column completeness (all columns
+  explicitly set, `timeout_ms > 0`, `enabled: 0`, `target_data.recent_interval_sec` matching
+  `cron`, and — design-round-6 addition, previously covered only by the verify task, not this
+  criterion — `timeout_ms + 60s` comfortably below `cron`) against this plan's task 8's full
+  three-part cross-check.
+
+## Verify tasks
+
+- [ ] `go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v
+      --timeout 5m` passes in `bin-campaign-manager`, in that order, per root CLAUDE.md's mandatory
+      5-step workflow (design-round-8 fix: an earlier draft of this checklist covered only
+      `go test`/`golangci-lint`, skipping `go mod tidy`/`vendor` — go.sum drift risk for any new
+      import — and `go generate`, which is required here specifically: `mockgen` regenerates
+      `mock_dbhandler.go`/`mock_campaignhandler.go` from the `//go:generate` directives in
+      `pkg/dbhandler/main.go`/`pkg/campaignhandler/main.go`, and task 6's tests cannot compile
+      against the new `CampaignListDeletedSince`/`ReconcileOrphanedFlows` interface methods until
+      the mocks are regenerated), including all reconciliation-specific cases in task 6
+- [ ] Manual review of the seed migration's column list against task 8's checklist, specifically
+      confirming all three constraints in task 8's cross-check: `reconcilePassTimeout` (task 3) is
+      strictly below `timeout_ms` with margin for delivery delay, well below the seeded `cron`
+      interval, and that `timeout_ms + 60s` (the reap deadline at `retry_max: 0`) is comfortably
+      below `cron`; and that `target_data.recent_interval_sec` matches `cron` (design-round-6: the
+      reaper-formula comparison was dropped in round 4, reinstated in round 5, and correctly
+      re-attributed in round 6 to a `bin-schedule-manager` — not `bin-campaign-manager` — crash
+      scenario; it is not the tautology round 4 believed it was)
+- [ ] Confirm `docs/operations.md` documents (design-round-6 correction: there is no
+      `skipped_overlap` execution status) the `schedule_manager_dispatch_total{result=
+      "skipped_overlap"}` **metric** as the observable symptom of a constraint-(b)
+      (cadence/liveness) violation only, **on the cron path** (design-round-7: a manual execute
+      hitting the same overlap guard returns `EXECUTION_IN_PROGRESS` instead and increments no
+      metric — call this out for task 10's smoke-test step, which is itself a manual execute and
+      can legitimately hit this if a prior run is still in flight) — explicitly noting the metric
+      does NOT detect a constraint-(a) (mutual-exclusion) violation, which is a static-sizing
+      property with no runtime monitor — and that the counter's granularity is per-replica,
+      in-memory dedup (design-round-7 addition: a single stuck cron slot can increment it more than
+      once across replicas, so "climbing" should be read as a health signal, not an exact skip
+      count) — and the recent-interval-change runbook step (update `target_data.recent_interval_sec`
+      and re-verify `reconcilePassTimeout` together whenever `cron` changes)
+- [ ] `git diff` review confirms no unrelated changes, and that both `bin-campaign-manager` and
+      `bin-dbscheme-manager` changes are in the same PR
+- [ ] Confirm the new route does not appear in any `bin-api-manager`/OpenAPI surface
+- [ ] Confirm the PR description explicitly calls out the post-merge, post-deploy sequence: apply
+      migration → deploy → manual `/v1/schedules/{id}/execute` smoke test → poll the execution row
+      to `success` → `schedule-control schedule enable campaign-flow-reconcile`


### PR DESCRIPTION
Add a bin-schedule-manager-triggered reconciliation job that finds campaigns deleted within a recent window whose backing flow is still live and deletes it, closing the leak-detection gap VOIP-1443 made observable but did not close.

- bin-campaign-manager: Add CampaignListDeletedSince(ctx, since, limit) to pkg/dbhandler -- DESC-ordered, NULL-comparison excludes live campaigns, bounded by an explicit row limit.
- bin-campaign-manager: Add ReconcileResult domain type (models/campaign) with json tags, marshaled directly by the listenhandler (style A, no response.* DTO) -- Cleaned/Skipped/Failed counts plus Saturated/RecentSaturated/Partial signal flags.
- bin-campaign-manager: Add ReconcileOrphanedFlows to pkg/campaignhandler. Self-imposed context.WithTimeout (reconcilePassTimeout) bounds each pass independent of the RPC layer's context.Background(); sized against two distinct constraints -- strictly below the schedule's timeout_ms (keeps bin-schedule-manager's ExecutionHasRunning overlap guard effective for the pass's full duration) and well below the cron interval (cadence/liveness, avoids chronic skipped_overlap). Saturated/RecentSaturated are computed in a dedicated pre-loop pass over the fetched batch, before any RPC, so a mid-pass timeout can't produce a false negative. A context-timeout bail-out sets Partial=true rather than silently completing.
- bin-campaign-manager: Add POST /v1/campaigns/flows/reconcile (internal-only, not exposed via bin-api-manager) taking recent_interval_sec as a request.* DTO input.
- bin-campaign-manager: Add campaign_flow_reconcile_cleaned_total and campaign_flow_reconcile_failed_total counters (the latter fires on both the FlowV1FlowGet-error and FlowV1FlowDelete-error branches, not VOIP-1443's promCampaignFlowDeleteFailedTotal, to avoid conflating campaign-delete failures with reconciliation failures).
- bin-campaign-manager: Add an index on campaign_campaigns.tm_delete to the test-schema fixture, and extensive test coverage across dbhandler/campaignhandler/listenhandler.
- bin-campaign-manager: Update docs/architecture.md, docs/domain.md, docs/operations.md (metrics, route, and the operational runbook for skipped_overlap, the RecentSaturated remedy's redeploy-vs-live-edit distinction, and the execution.Result durability note).
- bin-dbscheme-manager: Add an Alembic migration seeding the campaign-flow-reconcile schedule row into schedule_schedules (enabled: 0 pending rollout, retry_max: 0, target_data carries recent_interval_sec alongside cron in the same row).
- bin-dbscheme-manager: Add an Alembic migration for the campaign_campaigns.tm_delete index.

Design and implementation plan, including the review history (11 design/plan rounds, 3 code-review rounds) that led to the final design (mechanism swaps, corrected orphan-detection criterion, the two-guard concurrency analysis against bin-schedule-manager, scope narrowing):
docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-design.md
docs/plans/2026-09-02-voip-1444-orphaned-flow-reconciliation-plan.md

Post-merge rollout (not part of this PR's code, must be run in order after merge):
1. Apply the Alembic migrations (human/ops, per this repo's Alembic-only rule).
2. Deploy the bin-campaign-manager image carrying the new route.
3. Fire a manual smoke test via POST /v1/schedules/{id}/execute and confirm the execution settles to status success with the new counters moved.
4. Only then: schedule-control schedule enable campaign-flow-reconcile.

Verification: go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run all pass in bin-campaign-manager. Alembic migrations created via alembic revision only -- alembic upgrade/downgrade were never run.

Follow-ups filed separately, not included here:
- VOIP-1445: admin console delete-UX for VOIP-1443's 409 response.
- VOIP-1448: bin-flow-manager Delete() idempotency (orthogonal -- this job's concurrency safety does not depend on it).