### PR TITLE
NOJIRA-Redeploy-pipecat-manager-tool-whitelist

### DIFF
--- a/bin-pipecat-manager/README.md
+++ b/bin-pipecat-manager/README.md
@@ -6,8 +6,14 @@ poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 # Deploy
 
-`bin-pipecat-manager-build` pushes the image, and a single `build-approval` gate covers
-the test -> build pipeline. The CircleCI `bin-pipecat-manager-deploy` job (direct SSH
-deploy to bm-nyc-01) has been removed. Deploys to bm-nyc-01 are manual until
-this service migrates to the Komodo-managed deploy path (see bin-call-manager
-for the pattern).
+Komodo-managed (VOIP-1350), same as the other `bin-*-manager` services. CI runs
+`bin-pipecat-manager-build` (pushes the image) then `bin-pipecat-manager-deploy`
+(renders the image tag into `komodo/docker-compose.yml` and deploys via the
+Komodo API), gated behind a single `build-approval` step. No manual deploy
+step. See [docs/operations.md](docs/operations.md#deployment-komodo) for
+details, including three intentional deviations from the standard Tier 1/2
+template.
+
+Redeploying (even with no source change here) is sometimes required to pick
+up a `bin-ai-manager` change — see
+[docs/dependencies.md](docs/dependencies.md) for why.

--- a/bin-pipecat-manager/docs/dependencies.md
+++ b/bin-pipecat-manager/docs/dependencies.md
@@ -7,7 +7,7 @@ All resolved via `replace` directives in `go.mod`.
 | Module | Purpose |
 |--------|---------|
 | `bin-common-handler` | Shared transport (sockhandler, requesthandler, notifyhandler, circuit breaker) |
-| `bin-ai-manager` | AI call models; target service for tool execution RPCs |
+| `bin-ai-manager` | AI call models; target service for tool execution RPCs; also the source of the Insight-tool whitelist (see note below) |
 | `bin-call-manager` | External media models; RPC to create Asterisk WebSocket endpoint |
 | `bin-agent-manager` | Agent models |
 | `bin-billing-manager` | Billing events |
@@ -35,6 +35,26 @@ All resolved via `replace` directives in `go.mod`.
 | `bin-transfer-manager` | Transfer models |
 | `bin-tts-manager` | TTS models |
 | `bin-webhook-manager` | Webhook models |
+
+**Redeploy trigger, no source change required:** `pkg/toolhandler/main.go`'s
+`GetByNames` filters every tool through `amai.AllowedToolNames(aiType)`
+(`bin-ai-manager/models/ai/tool_validation.go`, which derives from
+`bin-ai-manager/models/tool`'s `AllInsightToolNames`/`AllToolNames`). Because
+that whitelist is a Go value compiled into this service's binary via the
+local module `replace` above (not fetched at runtime), **adding or removing a
+tool from those lists in `bin-ai-manager` has no effect here until this
+service is rebuilt and redeployed** -- even though this service's own source
+is untouched. (Tool *definitions* -- name/description/parameters/`run_llm`
+-- are different: those are fetched at runtime via `AIV1ToolList` RPC on a
+5-minute ticker, so they propagate without a redeploy. Only the whitelist
+membership is compile-time.) There is no ordering requirement between the
+two services' deploys -- whichever lags simply filters the new tool out
+(or doesn't yet know its definition), with no error either way -- but until
+both have deployed, the tool is not usable by an Insight AI. See VOIP-1455 (`docs/plans/2026-09-04-insight-assistant-emit-info-card-design.md`
+at the monorepo root, §1.1) for the incident that surfaced this: `bin-ai-manager`
+deployed a new whitelist entry (`emit_info_card`) and this service was never
+redeployed to pick it up, so the new tool silently had no effect for roughly
+a day until someone noticed and triggered a manual redeploy.
 
 ## External Dependencies
 


### PR DESCRIPTION
Doc-only change to bin-pipecat-manager, opened primarily to trigger a redeploy: VOIP-1455 (PR #1264, merged) added emit_info_card to bin-ai-manager's Insight-tool whitelist, but that whitelist is compiled into bin-pipecat-manager via a local go.mod replace, not fetched at runtime -- so this service needs to be rebuilt and redeployed (no source change of its own required) before the new tool is actually usable by an Insight AI. While tracking that down, found and fixed a stale README claim about the deploy mechanism.

- bin-pipecat-manager: Correct README.md's stale claim that the CircleCI deploy job was removed -- bin-pipecat-manager-deploy still runs via the Komodo API and is the current, correct mechanism (matches docs/operations.md, which was already accurate)
- bin-pipecat-manager: Document in docs/dependencies.md that the bin-ai-manager Insight-tool whitelist is compiled in via the local module replace, so this service needs a redeploy (no source change required) whenever that whitelist changes in bin-ai-manager -- tool definitions propagate automatically via a 5-minute RPC poll, but whitelist membership does not