### PR TITLE
VOIP-1460-Fix-orphaned-tool-messages-insight-multiturn

### DIFF
--- a/bin-ai-manager/pkg/aicallhandler/start.go
+++ b/bin-ai-manager/pkg/aicallhandler/start.go
@@ -676,10 +676,13 @@ func (h *aicallHandler) getPipecatcallMessages(ctx context.Context, c *aicall.AI
 				// replaying it on a later turn. Build a COPIED slice rather than
 				// mutating m.ToolCalls in place; the tool_calls entry itself
 				// (id/type/name) is preserved, only Arguments is replaced. No-op for
-				// every other tool. Defense-in-depth (see VOIP-1460): not currently
-				// load-bearing since bin-pipecat-manager's Python filter already
-				// drops this entry today regardless of Arguments, but keeping the
-				// entry neutered here is what stays safe once that changes.
+				// every other tool. As of VOIP-1460 this is LOAD-BEARING: the
+				// bin-pipecat-manager filter no longer drops the tool-call request
+				// message (filter_valid_messages keeps a paired one), so this
+				// entry really is replayed to the LLM and the neutered Arguments
+				// are the only thing keeping the card content out of the prompt.
+				// Keep the placeholder valid JSON -- pipecat's Gemini adapter runs
+				// json.loads on Function.Arguments.
 				toolCalls := make([]message.ToolCall, len(m.ToolCalls))
 				for i, tc := range m.ToolCalls {
 					toolCalls[i] = tc

--- a/bin-ai-manager/pkg/aicallhandler/tool.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool.go
@@ -83,7 +83,17 @@ func (h *aicallHandler) ToolHandle(ctx context.Context, id uuid.UUID, toolID str
 		tmpMessageContent = fn(ctx, c, tool)
 	} else {
 		log.Debugf("unknown tool call: %s", tool.Function.Name)
-		return nil, fmt.Errorf("unknown tool call: %s", tool.Function.Name)
+		// Record a failure result message before returning. Without this the
+		// tool-call request message created above stays permanently unpaired,
+		// which breaks every later turn of this aicall once the pipecat-side
+		// filter stops dropping unpaired tool-call messages (VOIP-1460).
+		errMsg := fmt.Sprintf("unknown tool call: %s", tool.Function.Name)
+		failContent := newToolResult(tool.ID)
+		fillFailed(failContent, stderrors.New(errMsg))
+		if _, errRecord := h.toolCreateResultMessage(ctx, c, tool, failContent, toolCallActiveAIID); errRecord != nil {
+			log.WithError(errRecord).Error("could not record the failure result message for the unknown tool call")
+		}
+		return nil, stderrors.New(errMsg)
 	}
 
 	msg, err := h.toolCreateResultMessage(ctx, c, tool, tmpMessageContent, toolCallActiveAIID)

--- a/bin-ai-manager/pkg/aicallhandler/tool_unknown_test.go
+++ b/bin-ai-manager/pkg/aicallhandler/tool_unknown_test.go
@@ -1,0 +1,106 @@
+package aicallhandler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	gomock "go.uber.org/mock/gomock"
+
+	"monorepo/bin-ai-manager/models/aicall"
+	"monorepo/bin-ai-manager/models/message"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
+	"monorepo/bin-ai-manager/pkg/messagehandler"
+	commonidentity "monorepo/bin-common-handler/models/identity"
+)
+
+// Test_ToolHandle_unknownToolNameRecordsFailureResult pins the VOIP-1460
+// second line of defense: ToolHandle stores the tool-call REQUEST message
+// before dispatching, so the unknown-tool-name branch must record a paired
+// failure RESULT message before returning the error. Without it the request
+// message stays permanently unpaired, and once bin-pipecat-manager's filter
+// stops dropping unpaired tool-call messages (the first line of defense in
+// the same ticket) every later turn of that aicall would be rejected by an
+// OpenAI-shaped provider.
+func Test_ToolHandle_unknownToolNameRecordsFailureResult(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockDB := dbhandler.NewMockDBHandler(mc)
+	mockMsg := messagehandler.NewMockMessageHandler(mc)
+	h := &aicallHandler{db: mockDB, messageHandler: mockMsg}
+
+	ctx := context.Background()
+	aicallID := uuid.FromStringOrNil("9a01c1a0-c900-11f0-8a00-000000000001")
+	customerID := uuid.FromStringOrNil("9a01c1a0-c900-11f0-8a00-000000000002")
+	activeflowID := uuid.FromStringOrNil("9a01c1a0-c900-11f0-8a00-000000000003")
+	toolCallID := "9a01c1a0-c900-11f0-8a00-000000000004"
+
+	responseAIcall := &aicall.AIcall{
+		Identity: commonidentity.Identity{
+			ID:         aicallID,
+			CustomerID: customerID,
+		},
+		ActiveflowID: activeflowID,
+	}
+
+	function := message.FunctionCall{
+		Name:      message.FunctionCallName("no_such_tool"),
+		Arguments: "{}",
+	}
+	expectTool := message.ToolCall{
+		ID:       toolCallID,
+		Type:     message.ToolTypeFunction,
+		Function: function,
+	}
+
+	mockDB.EXPECT().AIcallGet(ctx, aicallID).Return(responseAIcall, nil)
+
+	// The tool-call REQUEST message (role=assistant, empty content, tool_calls
+	// populated) is created before dispatch -- this is what makes the missing
+	// result message an orphan.
+	mockMsg.EXPECT().Create(
+		ctx, uuid.Nil, customerID, aicallID, activeflowID,
+		message.DirectionIncoming, message.RoleAssistant, "",
+		[]message.ToolCall{expectTool}, "", gomock.Any(),
+	).Return(&message.Message{}, nil)
+
+	// The failure RESULT message must be recorded for the SAME tool_call_id,
+	// with the standard Result: "failed" shape (never a novel value).
+	var gotContent string
+	mockMsg.EXPECT().Create(
+		ctx, uuid.Nil, customerID, aicallID, activeflowID,
+		message.DirectionOutgoing, message.RoleTool, gomock.Any(),
+		nil, toolCallID, gomock.Any(),
+	).DoAndReturn(func(
+		_ context.Context, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID, _ uuid.UUID,
+		_ message.Direction, _ message.Role, content string,
+		_ []message.ToolCall, _ string, _ ...messagehandler.CreateOption,
+	) (*message.Message, error) {
+		gotContent = content
+		return &message.Message{}, nil
+	})
+
+	res, err := h.ToolHandle(ctx, aicallID, toolCallID, message.ToolTypeFunction, function)
+
+	if err == nil {
+		t.Fatalf("expected an error for an unknown tool name, got nil")
+	}
+	if res != nil {
+		t.Errorf("expected a nil result for an unknown tool name, got: %v", res)
+	}
+	if !strings.Contains(err.Error(), "unknown tool call: no_such_tool") {
+		t.Errorf("unexpected error message. got: %s", err.Error())
+	}
+
+	if !strings.Contains(gotContent, `"result":"failed"`) {
+		t.Errorf("failure result message must carry result=failed. got: %s", gotContent)
+	}
+	if !strings.Contains(gotContent, toolCallID) {
+		t.Errorf("failure result message must carry the tool_call_id %s. got: %s", toolCallID, gotContent)
+	}
+	if !strings.Contains(gotContent, "unknown tool call: no_such_tool") {
+		t.Errorf("failure result message must explain the failure. got: %s", gotContent)
+	}
+}

--- a/bin-pipecat-manager/scripts/pipecat/message_filters.py
+++ b/bin-pipecat-manager/scripts/pipecat/message_filters.py
@@ -6,7 +6,7 @@ imported and unit-tested in isolation. See VOIP-1460 design doc
 """
 
 
-def filter_valid_messages(messages):
+def filter_valid_messages(messages: list[dict]) -> list[dict]:
     """Keep role+content-or-tool_calls messages, then drop any tool_calls /
     tool-result that isn't actually paired. A tool-call-request message
     survives only if EVERY one of its tool_calls has a matching role="tool"
@@ -21,13 +21,12 @@ def filter_valid_messages(messages):
     truncation cut, or anything else not yet discovered) -- see VOIP-1460
     design doc section 2-1.
 
-    (This function went through two broken drafts in design review before
-    reaching this shape -- both broke by emitting output from more than one
-    loop/list, which let a message dropped in one place resurface via a
-    stray `else: append` in another. The fix is structural: compute
-    `kept_assistant_call_ids` first with NO side effect on the output, then
-    emit the final list from a SINGLE loop that is the only place `append`
-    is ever called.)
+    Structural invariant: `kept_assistant_call_ids` is computed with NO side
+    effect on the output (pass 1), then the final list is emitted from a
+    SINGLE loop that is the only place `append` is ever called (pass 2) --
+    this is what keeps the two halves of a pair from being judged by
+    different criteria (see design doc section 2-1 for the two earlier
+    drafts that broke by emitting output from more than one place).
     """
     candidates = [m for m in messages if m.get("role") and (m.get("content") or m.get("tool_calls"))]
     result_ids = {m.get("tool_call_id") for m in candidates if m.get("role") == "tool"}

--- a/bin-pipecat-manager/scripts/pipecat/message_filters.py
+++ b/bin-pipecat-manager/scripts/pipecat/message_filters.py
@@ -1,0 +1,69 @@
+"""Shared LLM message-list filtering for run.py and team_flow.py.
+
+Kept deliberately dependency-free (no pipecat, no loguru) so it can be
+imported and unit-tested in isolation. See VOIP-1460 design doc
+(docs/plans/2026-09-04-fix-orphaned-tool-messages-design.md).
+"""
+
+
+def filter_valid_messages(messages):
+    """Keep role+content-or-tool_calls messages, then drop any tool_calls /
+    tool-result that isn't actually paired. A tool-call-request message
+    survives only if EVERY one of its tool_calls has a matching role="tool"
+    result somewhere in the candidates; a role="tool" message survives only
+    if its tool_call_id belongs to a tool-call-request message that ALSO
+    survives that same check. Both directions are decided against the same
+    `kept_assistant_call_ids` set -- there is exactly one place (the loop
+    below) where a message is appended to the output, so there is no way
+    for the two halves of a pair to be judged by different criteria. This is
+    what makes the fix safe regardless of WHY a pair might be incomplete (an
+    unknown-tool-name error that never got recorded, an old-side window
+    truncation cut, or anything else not yet discovered) -- see VOIP-1460
+    design doc section 2-1.
+
+    (This function went through two broken drafts in design review before
+    reaching this shape -- both broke by emitting output from more than one
+    loop/list, which let a message dropped in one place resurface via a
+    stray `else: append` in another. The fix is structural: compute
+    `kept_assistant_call_ids` first with NO side effect on the output, then
+    emit the final list from a SINGLE loop that is the only place `append`
+    is ever called.)
+    """
+    candidates = [m for m in messages if m.get("role") and (m.get("content") or m.get("tool_calls"))]
+    result_ids = {m.get("tool_call_id") for m in candidates if m.get("role") == "tool"}
+
+    # Pass 1: compute-only, no emission. Which assistant tool_calls entries
+    # are answerable (every one of that message's ids has a matching
+    # candidate result)? Conservative: if ANY tool_call in a message lacks a
+    # matching result, none of that message's ids are added -- a provider
+    # that requires every tool_calls entry to be answered would 400 on a
+    # partial match anyway, and partial-answer messages are not something
+    # this codebase currently produces (each ToolHandle call carries exactly
+    # one ToolCall -- tool.go:39-47).
+    kept_assistant_call_ids = set()
+    for m in candidates:
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            ids = [tc.get("id") for tc in m["tool_calls"]]
+            if all(cid in result_ids for cid in ids):
+                kept_assistant_call_ids.update(ids)
+
+    # Pass 2: the ONLY place output is emitted. Re-applies the same
+    # completeness check to assistant tool_calls messages (against the now-
+    # final `kept_assistant_call_ids`, not the provisional `result_ids`),
+    # and checks role="tool" messages against that identical set -- so both
+    # halves of a pair are always judged by the same criterion, in the same
+    # loop, with no append site outside this loop.
+    final_messages = []
+    for m in candidates:
+        role = m.get("role")
+        if role == "assistant" and m.get("tool_calls"):
+            if all(tc.get("id") in kept_assistant_call_ids for tc in m["tool_calls"]):
+                final_messages.append(m)
+            # else: drop -- unpaired tool-call request, would 400 downstream
+        elif role == "tool":
+            if m.get("tool_call_id") in kept_assistant_call_ids:
+                final_messages.append(m)
+            # else: drop -- orphaned tool result, its call was never kept
+        else:
+            final_messages.append(m)
+    return final_messages

--- a/bin-pipecat-manager/scripts/pipecat/run.py
+++ b/bin-pipecat-manager/scripts/pipecat/run.py
@@ -41,6 +41,7 @@ from pipecat.transports.websocket.client import (
     WebsocketClientTransport,
 )
 
+from message_filters import filter_valid_messages
 from tools import tool_register, tool_unregister, convert_to_openai_format, get_tool_names
 from task import task_manager
 from routing_llm import RoutingLLMService
@@ -447,7 +448,7 @@ def _openai_tools_to_standard(openai_tools: list[dict]) -> list[FunctionSchema]:
 
 
 def create_llm_service(type: str, key: str, messages: list[dict], tools: list[dict], **options):
-    valid_messages = [m for m in messages if m.get("role") and m.get("content")]
+    valid_messages = filter_valid_messages(messages)
 
     if "." in type:
         service_name, model_name = type.split(".", 1)
@@ -634,7 +635,7 @@ async def init_team_pipeline(
     start_messages = []
     if start_member["ai"].get("init_prompt"):
         start_messages.append({"role": "system", "content": start_member["ai"]["init_prompt"]})
-    start_messages.extend([m for m in llm_messages if m.get("role") and m.get("content")])
+    start_messages.extend(filter_valid_messages(llm_messages))
 
     # Use universal LLMContext + LLMContextAggregatorPair so FlowManager's
     # create_adapter() returns UniversalLLMAdapter. This ensures tools are

--- a/bin-pipecat-manager/scripts/pipecat/team_flow.py
+++ b/bin-pipecat-manager/scripts/pipecat/team_flow.py
@@ -7,6 +7,8 @@ import common
 from loguru import logger
 from pipecat_flows import FlowManager, FlowArgs, FlowsFunctionSchema, NodeConfig
 
+from message_filters import filter_valid_messages
+
 # Google Gemini requires function names: start with letter/underscore,
 # alphanumeric + _.-: only, max 64 chars.
 _MAX_FUNCTION_NAME_LENGTH = 64
@@ -115,9 +117,7 @@ def build_team_flow(
     # the shared LLMContext with only role_messages (system prompt), losing all
     # prior conversation history.
     if llm_messages:
-        start_node["task_messages"] = [
-            m for m in llm_messages if m.get("role") and m.get("content")
-        ]
+        start_node["task_messages"] = filter_valid_messages(llm_messages)
 
     return member_nodes, start_node
 

--- a/bin-pipecat-manager/scripts/pipecat/test_init_pipeline.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_init_pipeline.py
@@ -291,3 +291,113 @@ async def test_init_team_pipeline_swaps_flowmanager_llm_to_router():
         )
 
     assert flow_manager_stub._llm is mock_routing
+
+
+@pytest.mark.asyncio
+async def test_init_team_pipeline_preserves_paired_tool_call_messages():
+    """init_team_pipeline routes llm_messages through filter_valid_messages.
+
+    VOIP-1460: reuses the working success-path harness from
+    test_init_team_pipeline_swaps_flowmanager_llm_to_router and adds
+    patch("run.LLMContext") so the message list the shared LLMContext is
+    built with can be asserted. The production shape (assistant message with
+    content="" + tool_calls, followed by its role="tool" result) must survive
+    intact; an unpaired tool-call request must still be dropped.
+    """
+    mock_llm = MagicMock()
+
+    mock_routing = MagicMock()
+    mock_routing.active_service = mock_llm
+    mock_routing.cleanup = AsyncMock()
+
+    resolved_team = {
+        "id": "team-7",
+        "start_member_id": "member-1",
+        "members": [
+            {
+                "id": "member-1",
+                "name": "Agent A",
+                "ai": {
+                    "engine_model": "openai.gpt-4o",
+                    "engine_key": "fake-key",
+                    "init_prompt": "You are helpful.",
+                },
+                "tools": [],
+                "transitions": [],
+            }
+        ],
+    }
+
+    tool_call_request = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_abc",
+                "type": "function",
+                "function": {"name": "get_resource", "arguments": "{}"},
+            }
+        ],
+    }
+    tool_call_result = {
+        "role": "tool",
+        "content": '{"tool_call_id": "call_abc", "result": "success"}',
+        "tool_call_id": "call_abc",
+    }
+    unpaired_request = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_orphan",
+                "type": "function",
+                "function": {"name": "unknown_tool", "arguments": "{}"},
+            }
+        ],
+    }
+
+    llm_messages = [
+        {"role": "user", "content": "What is the status?"},
+        tool_call_request,
+        tool_call_result,
+        unpaired_request,
+        {"role": "user", "content": "and now?"},
+    ]
+
+    mock_task = MagicMock()
+    mock_task.cancel = AsyncMock()
+    mock_task.queue_frames = AsyncMock()
+    mock_transport = MagicMock()
+    mock_transport.cleanup = AsyncMock()
+
+    flow_manager_stub = MagicMock()
+    flow_manager_stub._llm = MagicMock()
+    flow_manager_stub.initialize = AsyncMock()
+
+    with patch("run.create_llm_service", return_value=(mock_llm, MagicMock())), \
+         patch("run.RoutingLLMService", return_value=mock_routing), \
+         patch("run.create_websocket_transport", return_value=mock_transport), \
+         patch("run.Pipeline"), \
+         patch("run.PipelineTask", return_value=mock_task), \
+         patch("run.build_team_flow", return_value=({}, MagicMock())), \
+         patch("run.FlowManager", return_value=flow_manager_stub), \
+         patch("run.LLMContext") as mock_context, \
+         patch("run.task_manager") as mock_task_mgr:
+        mock_task_mgr.add = AsyncMock()
+        mock_task_mgr.remove = AsyncMock()
+
+        await init_team_pipeline(
+            id="test-11",
+            resolved_team=resolved_team,
+            llm_messages=llm_messages,
+        )
+
+    mock_context.assert_called_once()
+    passed_messages = mock_context.call_args[1]["messages"]
+    assert passed_messages == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is the status?"},
+        tool_call_request,
+        tool_call_result,
+        {"role": "user", "content": "and now?"},
+    ]

--- a/bin-pipecat-manager/scripts/pipecat/test_message_filters.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_message_filters.py
@@ -1,0 +1,165 @@
+"""Pure unit tests for filter_valid_messages() (VOIP-1460).
+
+message_filters.py has no dependencies (no pipecat, no loguru), so these
+tests import it directly with no mocking.
+"""
+
+from message_filters import filter_valid_messages
+
+
+def _assistant_call(call_id, name="get_resource", content=""):
+    """Production shape: content="" + tool_calls (tool.go creates it this way)."""
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+        ],
+    }
+
+
+def _tool_result(call_id, content='{"result": "success"}'):
+    return {"role": "tool", "content": content, "tool_call_id": call_id}
+
+
+def test_preserves_paired_tool_call():
+    """content=""+tool_calls assistant + its role=tool pair both survive, in order."""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is the status?"},
+        _assistant_call("call_1"),
+        _tool_result("call_1"),
+        {"role": "assistant", "content": "The status is fine."},
+    ]
+
+    result = filter_valid_messages(messages)
+
+    assert result == messages, "a complete pair plus plain messages must pass through untouched"
+    # order is load-bearing: the tool result must follow its call request
+    assert result[2]["tool_calls"][0]["id"] == "call_1"
+    assert result[3]["tool_call_id"] == "call_1"
+
+
+def test_drops_unpaired_tool_call():
+    """Design doc 2-1 case 1: unknown-tool-name early return left no result message."""
+    orphan_call = _assistant_call("call_missing")
+    messages = [
+        {"role": "user", "content": "Do the thing"},
+        orphan_call,
+        {"role": "user", "content": "Hello?"},
+    ]
+
+    result = filter_valid_messages(messages)
+
+    assert orphan_call not in result
+    assert result == [
+        {"role": "user", "content": "Do the thing"},
+        {"role": "user", "content": "Hello?"},
+    ]
+
+
+def test_drops_orphaned_tool_result():
+    """Design doc 2-1 case 2: window truncation cut the call request away."""
+    orphan_result = _tool_result("call_truncated")
+    messages = [
+        orphan_result,
+        {"role": "assistant", "content": "Here is what I found."},
+        {"role": "user", "content": "Thanks"},
+    ]
+
+    result = filter_valid_messages(messages)
+
+    assert orphan_result not in result
+    assert result == [
+        {"role": "assistant", "content": "Here is what I found."},
+        {"role": "user", "content": "Thanks"},
+    ]
+
+
+def test_existing_fixtures_unaffected():
+    """Existing fixtures with NO role="tool" message keep their old behavior.
+
+    These are the three fixtures from the design doc section 3 table that
+    contain no role="tool" message, so pass 2 cannot change their outcome.
+    (test_tool_role_messages_preserved is deliberately excluded -- its
+    fixture carries an orphaned role="tool" message and correctly loses it,
+    see design doc section 3 correction / section 5-9.)
+    """
+    # test_openai_filters_invalid_messages
+    fixture_1 = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "", "content": "no role"},
+        {"content": "missing role key"},
+        {"role": "user"},
+        {"role": "user", "content": ""},
+        {"role": "user", "content": "valid message"},
+    ]
+    assert filter_valid_messages(fixture_1) == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "valid message"},
+    ]
+
+    # test_malformed_messages_filtered_out
+    fixture_2 = [
+        {"role": "user", "content": "valid message"},
+        {"role": "assistant"},
+        {"content": "orphaned content"},
+        {},
+        {"role": "", "content": "empty role"},
+        {"role": "user", "content": ""},
+        {"role": "assistant", "content": "also valid"},
+    ]
+    assert filter_valid_messages(fixture_2) == [
+        {"role": "user", "content": "valid message"},
+        {"role": "assistant", "content": "also valid"},
+    ]
+
+    # test_none_values_in_messages_filtered_out
+    fixture_3 = [
+        {"role": None, "content": "text"},
+        {"role": "user", "content": None},
+        {"role": "user", "content": "valid"},
+    ]
+    assert filter_valid_messages(fixture_3) == [
+        {"role": "user", "content": "valid"},
+    ]
+
+    # each of the three matches the old predicate-only result exactly
+    for fixture in (fixture_1, fixture_2, fixture_3):
+        predicate_only = [m for m in fixture if m.get("role") and m.get("content")]
+        assert filter_valid_messages(fixture) == predicate_only
+
+
+def test_partial_pairing_drops_both():
+    """Both halves are judged against the SAME surviving set, never candidates.
+
+    An assistant message with two tool_calls (c1, c2) where only c1 has a
+    result: nothing survives. If pass 2 re-checked role="tool" messages
+    against the provisional `result_ids` instead of the final
+    `kept_assistant_call_ids`, the c1 result would survive alone as an
+    orphan -- which is exactly the bug found in design review round 2.
+    """
+    partial_call = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+            {"id": "c2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+        ],
+    }
+    messages = [
+        {"role": "user", "content": "Do two things"},
+        partial_call,
+        _tool_result("c1"),
+    ]
+
+    result = filter_valid_messages(messages)
+
+    assert result == [{"role": "user", "content": "Do two things"}], (
+        "an assistant message with a partially answered tool_calls list, and "
+        "the lone result that answered it, must BOTH be dropped"
+    )

--- a/bin-pipecat-manager/scripts/pipecat/test_run.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_run.py
@@ -208,6 +208,76 @@ class TestCreateLLMService:
         assert passed_messages[0] == {"role": "system", "content": "You are helpful."}
         assert passed_messages[1] == {"role": "user", "content": "valid message"}
 
+    @patch("run.LLMContextAggregatorPair")
+    @patch("run.LLMContext")
+    @patch("run.OpenAILLMService")
+    def test_openai_preserves_paired_tool_call_messages(self, mock_service, mock_context, mock_pair):
+        """create_llm_service must route messages through filter_valid_messages.
+
+        Production shape (VOIP-1460): the tool-call request message has
+        content="" and a populated tool_calls list, followed by its
+        role="tool" result. The old predicate dropped the request and
+        orphaned the result. Both halves must now survive, in order, while an
+        unpaired tool-call request is still dropped.
+        """
+        from run import create_llm_service
+
+        mock_service.return_value = MagicMock()
+
+        tool_call_request = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {"name": "get_resource", "arguments": "{}"},
+                }
+            ],
+        }
+        tool_call_result = {
+            "role": "tool",
+            "content": '{"tool_call_id": "call_abc", "result": "success"}',
+            "tool_call_id": "call_abc",
+        }
+        unpaired_request = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_orphan",
+                    "type": "function",
+                    "function": {"name": "unknown_tool", "arguments": "{}"},
+                }
+            ],
+        }
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "What is the status?"},
+            tool_call_request,
+            tool_call_result,
+            unpaired_request,
+            {"role": "user", "content": "and now?"},
+        ]
+
+        create_llm_service(
+            type="openai.gpt-4o",
+            key="test-key",
+            messages=messages,
+            tools=[]
+        )
+
+        mock_context.assert_called_once()
+        passed_messages = mock_context.call_args[1]["messages"]
+        assert passed_messages == [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "What is the status?"},
+            tool_call_request,
+            tool_call_result,
+            {"role": "user", "content": "and now?"},
+        ]
+
     @patch("run.ToolsSchema")
     @patch("run._openai_tools_to_standard")
     @patch("run.LLMContextAggregatorPair")

--- a/bin-pipecat-manager/scripts/pipecat/test_team_flow.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_team_flow.py
@@ -170,13 +170,31 @@ class TestBuildTeamFlowConversationHistory:
             {"role": "user", "content": "valid"},
         ]
 
-    def test_tool_role_messages_preserved(self):
-        """Tool call results (role=tool) should pass through the filter."""
+    def test_tool_role_messages_preserved_with_content(self):
+        """Tool call results (role=tool) should pass through the filter.
+
+        VOIP-1460: the original fixture carried a role="tool" message whose
+        tool_call_id ("call_123") had no matching assistant tool_calls entry,
+        i.e. an orphaned tool result. The pairing re-check in
+        filter_valid_messages correctly drops such a message, so the fixture
+        is repaired into a complete pair here to preserve the test's original
+        intent (a tool result WITH content survives).
+        """
         member = _make_member("m1")
         team = _make_team([member], "m1")
         llm_messages = [
             {"role": "user", "content": "Transfer me to sales"},
-            {"role": "assistant", "content": "Transferring now."},
+            {
+                "role": "assistant",
+                "content": "Transferring now.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "transfer", "arguments": "{}"},
+                    }
+                ],
+            },
             {"role": "tool", "content": '{"status": "ok"}', "tool_call_id": "call_123"},
         ]
 
@@ -186,6 +204,64 @@ class TestBuildTeamFlowConversationHistory:
         )
 
         assert start_node["task_messages"] == llm_messages
+
+    def test_tool_role_messages_preserved_with_empty_content_and_tool_calls(self):
+        """Production shape: content="" + tool_calls survives with its result.
+
+        VOIP-1460: bin-ai-manager stores the tool-call request message as
+        role="assistant", content="", tool_calls=[...] (tool.go:47). The old
+        `m.get("content")` predicate dropped it and orphaned the following
+        role="tool" result. Both halves must now survive in order, while an
+        unpaired tool-call request is still dropped.
+        """
+        member = _make_member("m1")
+        team = _make_team([member], "m1")
+        tool_call_request = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "function": {"name": "get_resource", "arguments": "{}"},
+                }
+            ],
+        }
+        tool_call_result = {
+            "role": "tool",
+            "content": '{"tool_call_id": "call_abc", "result": "success"}',
+            "tool_call_id": "call_abc",
+        }
+        unpaired_request = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_orphan",
+                    "type": "function",
+                    "function": {"name": "unknown_tool", "arguments": "{}"},
+                }
+            ],
+        }
+        llm_messages = [
+            {"role": "user", "content": "What is the status?"},
+            tool_call_request,
+            tool_call_result,
+            unpaired_request,
+            {"role": "user", "content": "and now?"},
+        ]
+
+        _, start_node = build_team_flow(
+            team, "pc-1", MagicMock(), None, None,
+            llm_messages=llm_messages,
+        )
+
+        assert start_node["task_messages"] == [
+            {"role": "user", "content": "What is the status?"},
+            tool_call_request,
+            tool_call_result,
+            {"role": "user", "content": "and now?"},
+        ]
 
     def test_extra_keys_in_messages_preserved(self):
         """Extra keys in message dicts should pass through unmodified."""

--- a/docs/plans/2026-09-04-fix-orphaned-tool-messages-design.md
+++ b/docs/plans/2026-09-04-fix-orphaned-tool-messages-design.md
@@ -1,0 +1,232 @@
+# VOIP-1460: Fix orphaned tool-result messages in Insight multi-turn conversations
+
+**상태:** 설계 초안 (리뷰 대기)
+**티켓:** VOIP-1460 (Highest)
+**이슈 분석:** 3라운드 (REQUEST CHANGES → APPROVE → APPROVE), 2연속 승인으로 종료. 근본 원인/수정 사이트/회귀 무영향(당시 검증 대상은 1단계 predicate 변경뿐 — 2단계 페어링 재검사는 이후 설계 단계에서 추가됨, §3 정정 참고) 모두 코드 재검증 및 픽스처 실행으로 확인됨.
+
+## 1. 문제
+
+Insight AI가 tool을 한 번이라도 호출한 세션에서 사용자가 다음 메시지를 보내면(`SendReferenceTypeOthers`가 매 턴마다 `startPipecatcall`을 새로 호출해 `getPipecatcallMessages`로 히스토리를 재구성), 아래 3곳의 동일한 필터가:
+
+```python
+valid_messages = [m for m in messages if m.get("role") and m.get("content")]
+```
+
+tool-call 요청 메시지(`role="assistant"`, `content=""`, `tool_calls` 있음 — `bin-ai-manager/pkg/aicallhandler/tool.go:47`에서 이 형태로 저장됨)를 제거하고, 대응하는 tool-result 메시지(`role="tool"`, content 비어있지 않음)만 고아 상태로 LLM에 전달된다.
+
+## 2. 수정 대상 (3곳, 전부 동일 패턴)
+
+| 파일 | 위치 | 함수 |
+|---|---|---|
+| `bin-pipecat-manager/scripts/pipecat/run.py` | 450행 | `create_llm_service` (단일 AI 경로) |
+| `bin-pipecat-manager/scripts/pipecat/run.py` | 637행 | `init_team_pipeline` (team 경로 1) |
+| `bin-pipecat-manager/scripts/pipecat/team_flow.py` | 118-120행 | `build_team_flow` (team 경로 2) |
+
+세 곳 모두 동일하게 수정:
+
+```python
+# before
+valid_messages = [m for m in messages if m.get("role") and m.get("content")]
+# after
+valid_messages = [m for m in messages if m.get("role") and (m.get("content") or m.get("tool_calls"))]
+```
+
+세 곳 다 고쳐야 하는 이유: 단일 AI 경로(`run.py:450`)와 team 경로(`run.py:637` + `team_flow.py:119`, 둘 다 team 세션에서 실행됨)가 독립적인 필터를 갖고 있어, 두 곳만 고치면 team 기반 Insight 세션은 여전히 깨진 채로 남는다.
+
+## 2-1. 핵심 위험: 단순히 "넓히기만" 하면 새로운 하드 실패가 생긴다 (설계 리뷰 1라운드 REQUEST CHANGES 반영)
+
+위 predicate 변경은 "content 비어있는 assistant tool_calls 메시지를 살린다"는 한쪽 방향으로만 넓힌다. 이게 안전하려면 **살아난 assistant tool_calls 메시지에는 항상 짝이 되는 role="tool" 결과 메시지가 존재해야 한다.** 그런데 그렇지 않은 경로가 실제로 존재한다:
+
+1. **`bin-ai-manager/pkg/aicallhandler/tool.go:47`가 tool 실행 *전에* 먼저 tool-call 요청 메시지를 저장한다.** 이후 `tool.go:84-87`(`mapFunctions`에 없는 unknown tool name → `return nil, fmt.Errorf(...)`)로 조기 반환되면, 그 tool-call 메시지는 **영구히 짝 없는 상태**로 남는다. 지금까지는 이 메시지가 항상 필터에 의해 드롭됐기 때문에 조용히 넘어갔지만, 수정 후에는 이 메시지가 살아나 그 aicall의 **이후 모든 턴이 OpenAI-shaped provider에서 400으로 실패**하게 된다.
+2. **`getPipecatcallMessages`(`bin-ai-manager/pkg/aicallhandler/start.go:624` 부근)는 최신 100건만 조회해 역순 정렬한다.** 오래된 쪽에서 절단이 일어나므로, 아주 긴 대화에서 pair가 윈도우 경계에 걸리면(호출 메시지가 잘려나가고 결과 메시지만 남는 경우) 동일한 고아 문제가 **Python 필터와 무관하게** 재발할 수 있다.
+
+반대 방향(role="tool" 메시지가 비어서 필터에 드롭되는 경우)은 발생하지 않는다 — `tool.go:154-159`(`toolCreateResultMessage`)가 항상 `messageContent`를 `json.Marshal`하므로 결과 메시지의 content는 최소 `{"tool_call_id":"..."}`를 포함해 절대 비지 않는다. 이 불변식이 "tool 결과 쪽은 그대로 둬도 된다"는 판단의 근거다.
+
+### 대응: Python 쪽 페어링 정합성 재검사(1차 방어선) + Go 쪽 소스 수정(2차 방어선)
+
+**1차 방어선 (Python, 3개 필터 사이트 전부에 적용, 신규 공유 헬퍼):** predicate로 살릴 메시지를 고른 뒤, 페어링이 실제로 완결된 것만 최종적으로 남기는 정합성 재검사를 추가한다. 새 파일 `bin-pipecat-manager/scripts/pipecat/message_filters.py`(기존 `common.py`처럼 `run.py`/`team_flow.py` 양쪽이 import하는 얕은 유틸 모듈 — `common.py`는 순수 설정값만 담고 있어 로직을 넣기에 맞지 않음):
+
+```python
+def filter_valid_messages(messages):
+    """Keep role+content-or-tool_calls messages, then drop any tool_calls /
+    tool-result that isn't actually paired. A tool-call-request message
+    survives only if EVERY one of its tool_calls has a matching role="tool"
+    result somewhere in the candidates; a role="tool" message survives only
+    if its tool_call_id belongs to a tool-call-request message that ALSO
+    survives that same check. Both directions are decided against the same
+    `kept_assistant_call_ids` set -- there is exactly one place (the loop
+    below) where a message is appended to the output, so there is no way
+    for the two halves of a pair to be judged by different criteria. This is
+    what makes the fix safe regardless of WHY a pair might be incomplete (an
+    unknown-tool-name error that never got recorded, an old-side window
+    truncation cut, or anything else not yet discovered) -- see VOIP-1460
+    design doc section 2-1.
+
+    (This function went through two broken drafts in design review before
+    reaching this shape -- both broke by emitting output from more than one
+    loop/list, which let a message dropped in one place resurface via a
+    stray `else: append` in another. The fix is structural: compute
+    `kept_assistant_call_ids` first with NO side effect on the output, then
+    emit the final list from a SINGLE loop that is the only place `append`
+    is ever called.)
+    """
+    candidates = [m for m in messages if m.get("role") and (m.get("content") or m.get("tool_calls"))]
+    result_ids = {m.get("tool_call_id") for m in candidates if m.get("role") == "tool"}
+
+    # Pass 1: compute-only, no emission. Which assistant tool_calls entries
+    # are answerable (every one of that message's ids has a matching
+    # candidate result)? Conservative: if ANY tool_call in a message lacks a
+    # matching result, none of that message's ids are added -- a provider
+    # that requires every tool_calls entry to be answered would 400 on a
+    # partial match anyway, and partial-answer messages are not something
+    # this codebase currently produces (each ToolHandle call carries exactly
+    # one ToolCall -- tool.go:39-47).
+    kept_assistant_call_ids = set()
+    for m in candidates:
+        if m.get("role") == "assistant" and m.get("tool_calls"):
+            ids = [tc.get("id") for tc in m["tool_calls"]]
+            if all(cid in result_ids for cid in ids):
+                kept_assistant_call_ids.update(ids)
+
+    # Pass 2: the ONLY place output is emitted. Re-applies the same
+    # completeness check to assistant tool_calls messages (against the now-
+    # final `kept_assistant_call_ids`, not the provisional `result_ids`),
+    # and checks role="tool" messages against that identical set -- so both
+    # halves of a pair are always judged by the same criterion, in the same
+    # loop, with no append site outside this loop.
+    final_messages = []
+    for m in candidates:
+        role = m.get("role")
+        if role == "assistant" and m.get("tool_calls"):
+            if all(tc.get("id") in kept_assistant_call_ids for tc in m["tool_calls"]):
+                final_messages.append(m)
+            # else: drop -- unpaired tool-call request, would 400 downstream
+        elif role == "tool":
+            if m.get("tool_call_id") in kept_assistant_call_ids:
+                final_messages.append(m)
+            # else: drop -- orphaned tool result, its call was never kept
+        else:
+            final_messages.append(m)
+    return final_messages
+```
+
+순서는 `candidates`를 그대로 한 번 순회해 만들어지므로 원래 순서가 유지된다. (설계 리뷰 3라운드에서 재확인: 반례 `[A(tool_calls=[c1,c2]), T1(c1)]`을 추적하면 `result_ids={c1}` → pass 1에서 `all(["c1","c2"] in {c1})`가 거짓이라 `kept_assistant_call_ids`는 빈 집합으로 남고, pass 2에서 A는 같은 조건으로 다시 드롭, T1은 `"c1" not in set()`으로 드롭 — 결과 `[]`, 둘 다 제거됨을 확인.)
+
+세 사이트 모두 이 함수를 호출하도록 교체:
+
+```python
+# run.py:450, run.py:637, team_flow.py:119 -- 전부 동일하게
+valid_messages = filter_valid_messages(messages)  # (또는 llm_messages)
+```
+
+**정정(설계 리뷰 6라운드): 아래 문장은 5라운드에서 §3/§5에 반영한 정정과 모순되므로 폐기.** `filter_valid_messages`의 1단계(predicate)만은 원래 predicate의 상위집합이라 §3 표의 predicate-only 결과와 일치하지만, **2단계(페어링 재검사)까지 포함한 전체 함수는 원래 predicate의 상위집합이 아니다** — `role="tool"` 메시지가 있지만 짝이 되는 `tool_calls`가 없는 기존 픽스처(`test_tool_role_messages_preserved`)가 실제로 있고, 그 메시지는 2단계에서 드롭된다(§3 정정, §5-9 참고). 즉 "기존 픽스처 중 `tool_calls`를 가진 것이 없다"는 관찰은 맞지만 거기서 "2단계가 기존 픽스처에 영향 없다"는 결론은 틀렸다 — 영향을 받는 조건은 `tool_calls`의 존재가 아니라 `role="tool"` 메시지의 존재이기 때문이다. `role="tool"` 메시지가 전혀 없는 나머지 3개 픽스처는 실제로 영향이 없다(§5-4 참고).
+
+**2차 방어선 (Go, 근본에서 차단):** `tool.go:84-87`(83이 아니라 84행)의 unknown-tool-name 분기를 수정해, 조기 반환 전에 실패 결과 메시지를 반드시 기록한다. 기존 헬퍼 `newToolResult`/`fillFailed`(`tool.go:167-174`)를 재사용해 다른 모든 tool 실패와 동일한 `Result: "failed"` 값(신조어 "failure" 금지 — LLM에 그대로 전달되는 필드라 기존에 없던 값을 새로 만들면 안 됨)을 쓰고, `fmt.Errorf(errMsg)`(비-상수 포맷 문자열은 `go vet`의 printf 체크에 걸림, 이 저장소에 그런 패턴이 0건)가 아니라 이미 import된 `stderrors`(`tool.go:6`)의 `stderrors.New`를 쓴다:
+
+```go
+} else {
+    log.Debugf("unknown tool call: %s", tool.Function.Name)
+    errMsg := fmt.Sprintf("unknown tool call: %s", tool.Function.Name)
+    failContent := newToolResult(tool.ID)
+    fillFailed(failContent, stderrors.New(errMsg))
+    if _, errRecord := h.toolCreateResultMessage(ctx, c, tool, failContent, toolCallActiveAIID); errRecord != nil {
+        log.WithError(errRecord).Error("could not record the failure result message for the unknown tool call")
+    }
+    return nil, stderrors.New(errMsg)
+}
+```
+
+이렇게 하면 "unknown tool name" 경로에서도 tool-call 요청과 결과가 항상 페어를 이뤄 저장되므로, 애초에 고아가 생기지 않는다. (`toolCreateResultMessage` 자체가 실패하는 이중 실패 케이스는 원천적으로 방어 불가능하지만, Python 쪽 1차 방어선이 그 경우에도 해당 tool-call 메시지를 드롭해 안전하게 처리한다.)
+
+**중요 — `conftest.py`의 모듈 스텁 목록에 `message_filters`를 절대 추가하지 않는다.** `conftest.py:90-97`은 `run.py`/`team_flow.py`가 import하는 로컬 모듈들(`common`, `tools`, `task`, `routing_llm/tts/stt`, `team_flow`)을 `_make_mock_module(...)`로 전부 MagicMock 스텁 처리한다. `message_filters`를 신규 로컬 import로 추가하면서 이 관례를 그대로 따라 스텁 목록에 넣으면, §5-7/8/9의 통합 테스트에서 `filter_valid_messages`가 실제 로직이 아니라 MagicMock이 되어 `call_args[1]["messages"]` 검증이 겉보기엔 통과하지만 실제로는 아무것도 검증하지 못하는 상태가 된다. 구현 시 이 함정을 명시적으로 피할 것 — `message_filters`는 스텁 대상이 아니다.
+
+두 방어선의 관계: Go 수정은 "새로운 고아를 만들지 않는다", Python 수정은 "어떤 이유로든 이미 고아가 됐다면 안전하게 제거한다" — 후자가 최종 안전망이므로 Go 수정이 누락되거나 다른 미지의 경로로 고아가 생겨도 프로덕션이 깨지지 않는다.
+
+## 3. 회귀 안전성
+
+이슈 분석 3라운드에서 기존 픽스처 전체를 **1단계 predicate만**(2-1의 페어링 재검사 없이) 실행해 확인한 결과:
+
+| 테스트 | old kept | new kept (predicate만) | 동일 여부 |
+|---|---|---|---|
+| `test_openai_filters_invalid_messages` | 2 | 2 | 동일 |
+| `test_malformed_messages_filtered_out` | 2 | 2 | 동일 |
+| `test_none_values_in_messages_filtered_out` | 1 | 1 | 동일 |
+| `test_tool_role_messages_preserved` | 3 | 3 | 동일 (predicate 단계까지만) |
+
+`{"role":"user","content":""}` 같은 기존 "빈 content는 버려야 하는" 픽스처는 `tool_calls`가 없으므로 새 predicate에서도 그대로 제거된다. 1단계(predicate)는 순수하게 넓히기만 하며(`content`가 falsy이고 `tool_calls`가 truthy인 경우만 추가로 살림), 기존 픽스처 중 그런 조합은 하나도 없다.
+
+**정정(설계 리뷰 5라운드): 위 표는 `filter_valid_messages` 전체(2단계 페어링 재검사 포함)가 아니라 1단계 predicate만 실행한 결과다. `test_tool_role_messages_preserved`는 전체 함수를 통과시키면 결과가 달라진다** — 이 테스트의 픽스처는 `role="tool", tool_call_id="call_123"` 메시지가 있지만 그 짝이 되는 `role="assistant", tool_calls=[{"id":"call_123",...}]` 메시지가 **없다**(원래 assistant 메시지는 `content: "Transferring now."`뿐, `tool_calls` 없음). 2단계에서 `result_ids={"call_123"}`이지만 `kept_assistant_call_ids`는 빈 집합(assistant tool_calls 메시지 자체가 없으므로)이라, 이 tool 메시지는 **고아로 드롭된다** — old 3 kept, 전체 함수로는 **new 2 kept**, "동일" 아님.
+
+이건 버그가 아니라 §5 테스트 3(`test_drops_orphaned_tool_result`)이 정확히 검증하는 그 동작이 이 기존 픽스처에도 똑같이 적용된 것뿐이다(고아 tool 결과는 항상 드롭돼야 한다는 게 이 함수의 핵심 목적). 즉 §4의 "거짓 안전망" 정정과 별개로, 이 픽스처 자체가 **애초에 불완전한 페어(고아 tool 메시지)를 담고 있었다** — 원래 테스트 작성자의 의도("content 있는 tool 결과가 보존된다")를 살리려면 픽스처를 완전한 페어로 고쳐야 한다. §5-9에서 이를 반영.
+
+## 4. 기존 테스트의 오귀속 정정
+
+`test_team_flow.py::test_tool_role_messages_preserved`는 `run.py`가 아니라 `team_flow.py`의 필터를 검증하는 테스트이며(`build_team_flow`를 호출), 그마저도 assistant 메시지의 content를 `"Transferring now."`(비어있지 않음)로 채워서 테스트하기 때문에 프로덕션에서 실제로 나오는 `content=""` 모양을 전혀 재현하지 못하는 거짓 안전망이다. 저장소 전체(`test_run.py`, `test_team_flow.py` 등 7개 테스트 파일)에 `tool_calls` 키를 가진 메시지를 만드는 테스트가 **0건** — 이 경로는 지금 전혀 커버되지 않는다.
+
+## 5. 신규/수정 테스트 계획 (파일/패치 대상/어서션 대상까지 확정)
+
+프로덕션 shape(`content=""` + `tool_calls` 채워진 assistant 메시지 + 그 뒤를 잇는 `role="tool"` 결과 메시지, `tool_call_id`로 페어링)과, 페어링이 깨진 케이스(2-1의 정합성 재검사) 양쪽을 커버한다.
+
+### `message_filters.py`용 순수 단위 테스트 (신규 파일 `test_message_filters.py`)
+
+의존성 없는 순수 함수이므로 mock 없이 직접 테스트:
+
+1. `test_preserves_paired_tool_call` — `content=""`+`tool_calls` assistant + 페어인 `role="tool"` 메시지 → 둘 다 남고 순서 유지.
+2. `test_drops_unpaired_tool_call` — `tool_calls`는 있지만 매칭되는 `role="tool"` 결과가 리스트에 없는 assistant 메시지 → 드롭됨 (2-1의 케이스 1: unknown-tool-name 조기 반환).
+3. `test_drops_orphaned_tool_result` — `role="tool"` 메시지는 있지만 매칭되는 **살아남은(surviving)** assistant tool_calls가 없음(윈도우 절단 시뮬레이션) → 드롭됨 (2-1의 케이스 2).
+4. `test_existing_fixtures_unaffected` — §3 표의 4개 기존 픽스처 중 **`role="tool"` 메시지가 없는 3개**(`test_openai_filters_invalid_messages`, `test_malformed_messages_filtered_out`, `test_none_values_in_messages_filtered_out`)만 그대로 넣어 `filter_valid_messages` 전체 실행 결과가 predicate-only 결과와 동일한지 확인. `test_tool_role_messages_preserved`의 픽스처는 여기서 **제외** — 그 픽스처는 애초에 불완전한 페어(고아 `role="tool"` 메시지)를 담고 있어 전체 함수에서는 다른 결과가 나오는 게 맞는 동작이다(§3 정정, §5-9 참고).
+5. **`test_partial_pairing_drops_both`(설계 리뷰 2라운드에서 추가 — 두 pass가 candidate 기준이 아니라 surviving 기준으로 일관되게 동작하는지 확인하는 핵심 회귀 테스트)** — `tool_calls`가 2개(`c1`, `c2`)인 assistant 메시지 + `c1`만 응답하는 `role="tool"` 메시지 하나를 입력. 기대 결과: **둘 다 드롭됨** — pass 1은 계산 전용이라 아무것도 드롭하지 않지만, `c2`가 미응답이라 `c1`/`c2` 모두 `kept_assistant_call_ids`에 들어가지 못한다. pass 2에서 assistant 메시지는 `all(tc.id in kept)`가 거짓이라 드롭되고, `c1`의 tool 결과도 `"c1" not in kept`라 함께 드롭된다. (초안에서 실제로 이 케이스가 깨져 있었음 — pass 2가 `candidates`/`result_ids` 기준으로 재검사해 `c1` 결과가 혼자 살아남는 버그가 리뷰에서 발견됨. 이 테스트가 그 버그의 mutation-check 역할을 한다.)
+6. mutation-check: pass 1의 `all(cid in result_ids for cid in ids)` 조건을 무조건 `True`로 바꿔보고 테스트 2/5가 실패하는지 확인. 그리고 설계 리뷰에서 실제로 발생했던 두 버그를 각각 재현하는 mutation도 반드시 포함: (a) pass 2의 assistant 분기 조건을 제거하고 `else: final_messages.append(m)`으로 무조건 추가하도록 바꿔보고(2라운드에서 실제로 있었던 버그 형태) 테스트 5가 실패하는지, (b) pass 2를 `for m in candidates: ... else: final_messages.append(m)` 형태로 바꿔 tool_calls 분기를 아예 놓치게 해보고(3라운드에서 실제로 있었던 버그 형태) 테스트 5가 실패하는지. 세 mutation 모두 확인 후 복원.
+
+### 각 호출 사이트가 `filter_valid_messages`를 실제로 쓰는지 확인하는 통합 테스트
+
+7. **`create_llm_service` (run.py:450)** — `test_run.py`에 추가. 기존 `test_openai_filters_invalid_messages`(183행)와 동일한 패턴(`@patch("run.LLMContext")`, `mock_context.call_args[1]["messages"]` 검증)을 미러링 — 이 패턴이 이미 검증된 하네스이므로 새로 고민할 필요 없음. 프로덕션 shape 페어를 입력에 포함시켜 결과에 둘 다 남는지 확인.
+8. **`init_team_pipeline` (run.py:637)** — `test_run.py`가 아니라 **`test_init_pipeline.py`에 추가**. `test_init_pipeline.py:238-293`의 `test_init_team_pipeline_swaps_flowmanager_llm_to_router`가 이미 `init_team_pipeline`의 성공 경로를 끝까지 통과시키는 동작하는 async 하네스(`RoutingLLMService`/`Pipeline`/`PipelineTask`/`build_team_flow`/`task_manager` patch 포함)를 갖고 있으므로, 그 하네스에 `patch("run.LLMContext")`를 추가해 `mock_context.call_args[1]["messages"]`를 검증하는 신규 테스트를 그 파일에 둔다. `test_run.py`에 두면 안 됨(하네스 부재).
+9. **`build_team_flow` (team_flow.py:119)** — `test_team_flow.py`에 위치. `conftest.py:97`이 `team_flow` 모듈 자체를 MagicMock으로 스텁하고 `test_team_flow.py:9`가 `sys.modules`에서 이를 pop해 실제 모듈을 로드하는 구조를 그대로 따른다(새 테스트를 다른 파일에 두면 stub이 적용돼 실제 코드가 실행되지 않음). 기존 `test_tool_role_messages_preserved`(173행)의 픽스처가 §3 정정에서 밝혀진 대로 애초에 불완전한 페어(고아 `role="tool"` 메시지, 짝이 되는 assistant `tool_calls` 메시지가 없음)였으므로, **픽스처를 완전한 페어로 고쳐서** 원래 검증 의도("content가 있는 tool 결과가 보존된다")를 살린다 — assistant 메시지를 `{"role":"assistant","content":"Transferring now.","tool_calls":[{"id":"call_123","type":"function","function":{"name":"transfer","arguments":"{}"}}]}`로 바꿔 `tool_calls`를 추가하고(이름은 그대로 두거나 `test_tool_role_messages_preserved_with_content`로 개명), `task_messages == llm_messages`(3개 전부 유지, 순서 포함) 어서션은 그대로 유지한다. 그리고 프로덕션 shape(`content=""`+`tool_calls`)을 검증하는 `test_tool_role_messages_preserved_with_empty_content_and_tool_calls`를 신규로 추가한다. 둘 다 `start_node["task_messages"]`에 대해 순서 포함 어서션.
+
+### mutation-check (3개 통합 테스트 전부)
+
+10. 각 사이트에서 `filter_valid_messages(...)` 호출을 원래의 `[m for m in messages if m.get("role") and m.get("content")]`로 되돌리고, 해당 사이트의 신규 통합 테스트(7/8/9)가 실제로 실패하는지 확인한 뒤 복원. PR 본문에 실패 출력(assert 메시지)을 붙인다 — "확인했다"는 서술만으로는 불충분(§7에서 재강조).
+
+## 6. 스코프 밖 (별도 티켓/후속) 및 미검증 리스크
+
+- **Anthropic 어댑터 분기 누락** (`create_llm_service`의 `else: raise ValueError`): 이 티켓과는 독립적인 사전 결함. 별도 확인 후 필요 시 하위 티켓 분리 (VOIP-1460 원문의 "해야 할 일 4"). 이번 PR에서는 손대지 않음.
+- **DB 조회로 실사용 영향 범위 확인**(`engine_model LIKE 'openai.%' OR 'grok.%'` AND `type='insight'`): 이 세션에서 프로덕션 DB 접근 권한이 없어 수행 불가. 코드 수정 자체는 provider 무관하게 안전하므로(모든 provider가 이득을 보거나 최소한 손해는 없음) 이 조사가 수정 자체를 막지는 않음. 참고용으로 후속 확인 필요성만 기록.
+- **VOIP-1455(`emit_info_card`)와의 상호작용**: `bin-ai-manager/pkg/aicallhandler/start.go:679`의 "defense-in-depth, not currently load-bearing" 주석이 가리키는 tool_calls Arguments 뉴트럴화 로직은, 이번 수정으로 Python 필터가 더 이상 해당 메시지를 드롭하지 않게 되면 **실제로 load-bearing이 됨**. 즉 이 수정이 배포된 후에는 VOIP-1455의 `emit_info_card` 호출의 tool-call 메시지가 실제로 LLM에 재주입되고, 그때 start.go의 뉴트럴화(Arguments를 placeholder로 치환)가 처음으로 실질적 방어선이 된다. 이 상호작용을 구현 단계에서 회귀 테스트로 확인(뉴트럴화가 여전히 동작하는지 — VOIP-1455 PR #1264가 이미 이 로직을 구현해 두었으므로, 새 필터 배포 후에도 해당 로직이 그대로 유효한지 재확인만 필요, 로직 자체를 변경하지 않음).
+- **Gemini의 "크래시 없이 폴백" 근거는 미검증 리스크로 재분류한다.** 이 판단은 프로덕션 로그(pipecatcall `965e27bf-...`)로만 확인됐고, `pipecat` 어댑터 코드 자체는 이 환경에 라이브러리가 설치돼 있지 않아 검사하지 못했다. 이번 수정 후 Gemini 세션은 **이전에 한 번도 받아본 적 없는** `tool_calls`가 채워진 assistant 메시지를 처음 받게 된다 — universal `LLMContext` + `GeminiLLMAdapter`가 OpenAI shape의 `tool_calls`/`role="tool"`을 Gemini의 functionCall/functionResponse로 정확히 변환해준다는 전제가 이번 수정으로 처음 실제 트래픽에서 검증받는 것이다. 구현 단계에서 pipecat 어댑터 소스(`pipecat/adapters/services/gemini_adapter.py`)를 최소한 한 번 읽어 이 변환 경로가 실제로 존재하는지 확인하고, 가능하면 배포 후 Gemini insight 세션에 대한 스모크 확인(로그 관찰)을 수행한다. 코드 수정 자체를 막는 조건은 아니나, "provider 무관하게 안전"이라는 §6의 기존 서술을 "OpenAI/Grok/team 경로는 코드로 확정, Gemini는 어댑터 변환 경로 확인 후 확정, Anthropic은 스코프 밖"으로 정정한다.
+- **와이어 경로 근거(load-bearing, 명시 확인됨)**: 이 수정이 의미가 있으려면 Go에서 저장된 `tool_calls`가 실제로 Python `run.py`/`team_flow.py`까지 도달해야 한다. `scripts/pipecat/main.py:17-29`의 pydantic `Message`/`ToolCall` 모델이 `tool_calls: Optional[List[ToolCall]]`/`tool_call_id`를 선언하고 있고, `main.py:128`이 `[m.model_dump() for m in req.llm_messages]`로 매핑하므로 `tool_calls` 키는 값이 없을 때도 `None`(falsy)으로, 있을 때는 채워져서 항상 dict에 존재한다. Go `message.ToolCall`(`id`/`type`/`function{name,arguments}`)과 필드 shape이 일치함도 확인됨(`bin-ai-manager/pkg/aicallhandler/start.go:621-701`의 `getPipecatcallMessages`가 이 매핑을 수행). 이 경로가 끊겨 있었다면 이번 수정 전체가 no-op이 됐을 것 — 이미 확인됐으므로 리스크 아님, 근거로만 남김.
+
+## 7. 구현 순서
+
+1. `bin-pipecat-manager/scripts/pipecat/message_filters.py` 신규 작성 (§2-1), `test_message_filters.py` 순수 단위 테스트 5종 + mutation-check
+2. `run.py:450` 교체 + 통합 테스트(§5-7) 추가, mutation-check
+3. `run.py:637` 교체 + 통합 테스트(§5-8, `test_init_pipeline.py`) 추가, mutation-check
+4. `team_flow.py:119` 교체 + 통합 테스트(§5-9, `test_team_flow.py`) 추가, mutation-check
+5. `bin-ai-manager/pkg/aicallhandler/tool.go`의 unknown-tool-name 분기 수정(§2-1 2차 방어선) — Go 쪽 verification workflow(`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run`) 전체 실행
+6. Python 쪽 전체 테스트 스위트 로컬 실행 (아래 §7-1 참고) — `role="tool"` 메시지가 없는 3개 픽스처는 무변화인지, `test_tool_role_messages_preserved`는 §5-9의 페어 보정을 거친 뒤 3개 유지로 통과하는지 재확인
+7. `start.go:679` 주변 VOIP-1455 뉴트럴화 로직에 대한 기존 Go 테스트가 여전히 통과하는지 확인(회귀 없음 재확인, 로직 변경 없음)
+8. Gemini 어댑터 변환 경로 소스 확인(§6)
+9. PR 생성 — mutation-check 실패 출력 스크린샷/로그를 PR 본문에 첨부
+
+### 7-1. Python 테스트는 CI에 포함되지 않음 — 로컬 실행 필수, PR 본문에 결과 명시
+
+`.circleci/config_work.yml:539`의 `bin-pipecat-manager-test` job은 주석 처리돼 있고, 살아있더라도 그 job은 Go 테스트(`go-test-pipecat-manager`)만 돈다. `scripts/pipecat/pyproject.toml`에 `pytest`/`pytest-asyncio`가 dependency로 등록돼 있지 않다. 즉 **이번에 추가하는 Python 회귀 테스트는 CI가 자동으로 잡아주지 않는다.**
+
+로컬 실행 명령(정확한 형태는 구현 시 `pyproject.toml`/`requirements*.txt`를 확인해 확정하되, 현재 파악된 기본형):
+
+```bash
+cd bin-pipecat-manager/scripts/pipecat
+python -m pytest -q test_message_filters.py test_run.py test_init_pipeline.py test_team_flow.py
+```
+
+PR 본문에 이 실행의 전체 출력(pass 개수)과, §5-10 mutation-check의 실패 출력을 반드시 포함한다 — "확인했다"는 서술만으로는 이 저장소의 테스트 표준(코드 리뷰 루프가 실제로 검증 가능한 형태)을 충족하지 못한다.
+
+## 8. 완료 기준
+
+- `message_filters.py` 신규 작성, 3개 필터 사이트 전부 이를 사용하도록 수정
+- `tool.go` unknown-tool-name 분기 수정(2차 방어선)
+- 순수 단위 테스트 5종 + 사이트별 통합 테스트(run.py:450/637, team_flow.py:119 사이트당 각 1개 신규 + team_flow.py 사이트는 기존 픽스처 페어 보정 1개 추가) — mutation-check는 신규 프로덕션-shape 테스트에만 의미 있음(페어 보정만 한 기존 테스트는 원래 predicate로 되돌려도 통과하므로 mutation-check 대상 아님), 전부 실패 출력 PR에 첨부
+- 기존 pipecat 테스트 스위트 전체 통과(회귀 없음), 로컬 실행 결과 PR 본문에 명시(§7-1)
+- bin-ai-manager 쪽 verification workflow 전체 통과(go test/vet/lint), VOIP-1455 관련 테스트 회귀 없음 확인
+- Gemini 어댑터 변환 경로 소스 확인 완료(§6)
+- 코드 리뷰 루프 3라운드, 2연속 승인


### PR DESCRIPTION
Fix orphaned tool-result messages that broke every turn after the first tool call in an Insight session. The shared `role and content` message filter dropped the tool-call request message (role=assistant, content="", tool_calls populated) and left its role=tool result behind as an orphan, which OpenAI-shaped providers reject with a 400.

Design doc: `docs/plans/2026-09-04-fix-orphaned-tool-messages-design.md` (issue analysis 3 rounds, design review 8 rounds).

- bin-pipecat-manager: Add message_filters.filter_valid_messages() shared helper that keeps role+content-or-tool_calls messages, then drops any tool-call request or tool result whose pairing is not actually complete
- bin-pipecat-manager: Replace the filter in run.py create_llm_service, run.py init_team_pipeline and team_flow.py build_team_flow with filter_valid_messages()
- bin-pipecat-manager: Add test_message_filters.py with 5 pure unit tests covering paired preservation, unpaired call drop, orphaned result drop, existing-fixture parity and partial-pairing drop-both
- bin-pipecat-manager: Add per-site integration tests in test_run.py, test_init_pipeline.py and test_team_flow.py asserting the production message shape survives at each of the three call sites
- bin-pipecat-manager: Repair the test_team_flow.py tool-result fixture into a complete pair (it carried an orphaned role=tool message)
- bin-ai-manager: Record a paired failure result message in the unknown-tool-name branch of ToolHandle so that path can no longer leave a permanently unpaired tool-call request message
- bin-ai-manager: Add Test_ToolHandle_unknownToolNameRecordsFailureResult regression test for the new pairing guarantee
- bin-ai-manager: Update the emit_info_card Arguments neutralization comment in start.go, which this change makes load-bearing

## Go verification (bin-ai-manager)

`go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-lint run -v --timeout 5m`

```
=== GO TEST ===
Go test: 1411 passed in 38 packages
=== GO LINT ===
golangci-lint: No issues found
```

(1410 before this change, 1411 after — the one new test is `Test_ToolHandle_unknownToolNameRecordsFailureResult`.)

## Python tests — NOT run by CI, executed locally (design doc §7-1)

`.circleci/config_work.yml:539`'s `bin-pipecat-manager-test` job is commented out, and `scripts/pipecat/pyproject.toml` does not declare `pytest`/`pytest-asyncio`, so these regression tests are not picked up automatically. Run locally in a venv with `pytest` + `pytest-asyncio` + `loguru`:

```
$ cd bin-pipecat-manager/scripts/pipecat
$ python -m pytest -q --asyncio-mode=auto test_message_filters.py test_run.py test_init_pipeline.py test_team_flow.py
2 failed, 71 passed in 0.20s

$ python -m pytest -q --asyncio-mode=auto
2 failed, 140 passed in 0.32s
```

Baseline on `main` in the identical venv was **2 failed, 132 passed** — the same 2 failures, and +8 passing tests from this PR (5 pure unit + 3 integration). The 2 failures are pre-existing and unrelated to this change:

```
FAILED test_run.py::TestCreateTTSService::test_google_tts_service_creation
FAILED test_run.py::TestCreateTTSService::test_google_tts_default_voice
E   AssertionError: expected call not found.
E   Expected: GoogleTTSService(voice_id='default_voice_id')
E     Actual: GoogleTTSService(voice_id='en-US-Chirp3-HD-Charon', params=<MagicMock ...>)
```

`conftest.py`'s module-stub dict deliberately does **not** include `message_filters` (design doc §2-1) — stubbing it would turn the three integration tests into MagicMock no-ops that assert nothing.

## Mutation-check evidence

Every check below was actually executed: the code was temporarily broken, the test was confirmed to fail with the shown output, then the code was restored and the test confirmed to pass again.

### §5-6 (a) pass 1 completeness check forced to `True`

```
###### MUTATION A: pass 1 completeness check forced to True ######
>       assert orphan_call not in result
E       AssertionError: assert {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_missing', ...}]} not in [{'role': 'user', 'content': 'Do the thing'}, {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_missing', ...}]}, {'role': 'user', 'content': 'Hello?'}]
E       AssertionError: an assistant message with a partially answered tool_calls list, and the lone result that answered it, must BOTH be dropped
E       assert [{'role': 'us...ll_id': 'c1'}] == [{'role': 'us... two things'}]
E         Left contains 2 more items, first extra item: {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'c1', ...}, {'id': 'c2', ...}]}
FAILED test_message_filters.py::test_drops_unpaired_tool_call
FAILED test_message_filters.py::test_partial_pairing_drops_both
2 failed, 3 passed in 0.01s
--- restored, reverify ---
5 passed in 0.00s
```

### §5-6 (b) pass 2 assistant branch appends unconditionally (design review round-2 bug shape)

```
###### MUTATION B ######
E       AssertionError: assert {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_missing', ...}]} not in [...]
E       AssertionError: assert {'role': 'tool', 'content': '{"result": "success"}', 'tool_call_id': 'call_truncated'} not in [...]
E       AssertionError: an assistant message with a partially answered tool_calls list, and the lone result that answered it, must BOTH be dropped
FAILED test_message_filters.py::test_drops_unpaired_tool_call
FAILED test_message_filters.py::test_drops_orphaned_tool_result
FAILED test_message_filters.py::test_partial_pairing_drops_both
3 failed, 2 passed in 0.01s
```

### §5-6 (c) pass 2 loses the tool_calls branch entirely (design review round-3 bug shape)

```
###### MUTATION C ######
E       AssertionError: assert {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_missing', ...}]} not in [...]
E       AssertionError: an assistant message with a partially answered tool_calls list, and the lone result that answered it, must BOTH be dropped
E         Left contains one more item: {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'c1', ...}, {'id': 'c2', ...}]}
FAILED test_message_filters.py::test_drops_unpaired_tool_call
FAILED test_message_filters.py::test_partial_pairing_drops_both
2 failed, 3 passed in 0.01s

--- restored, full reverify ---
5 passed in 0.00s
```

### §5-10 site 1 — run.py:450 `create_llm_service` reverted to the old predicate

```
E       assert [{'role': 'sy...: 'and now?'}] == [{'role': 'sy...: 'and now?'}]
E         At index 2 diff: {'role': 'tool', 'content': '{"tool_call_id": "call_abc", "result": "success"}', 'tool_call_id': 'call_abc'} != {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_abc', ...}]}
E         Right contains one more item: {'role': 'user', 'content': 'and now?'}
FAILED test_run.py::TestCreateLLMService::test_openai_preserves_paired_tool_call_messages
1 failed in 0.04s
```

### §5-10 site 2 — run.py:638 `init_team_pipeline` reverted to the old predicate

```
E       assert [{'role': 'sy...: 'and now?'}] == [{'role': 'sy...: 'and now?'}]
E         At index 2 diff: {'role': 'tool', 'content': '{"tool_call_id": "call_abc", "result": "success"}', 'tool_call_id': 'call_abc'} != {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_abc', ...}]}
E         Right contains one more item: {'role': 'user', 'content': 'and now?'}
FAILED test_init_pipeline.py::test_init_team_pipeline_preserves_paired_tool_call_messages
1 failed in 0.03s
```

### §5-10 site 3 — team_flow.py:119 `build_team_flow` reverted to the old predicate

```
E       assert [{'role': 'us...: 'and now?'}] == [{'role': 'us...: 'and now?'}]
E         At index 1 diff: {'role': 'tool', 'content': '{"tool_call_id": "call_abc", "result": "success"}', 'tool_call_id': 'call_abc'} != {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'call_abc', ...}]}
E         Right contains one more item: {'role': 'user', 'content': 'and now?'}
FAILED test_team_flow.py::TestBuildTeamFlowConversationHistory::test_tool_role_messages_preserved_with_empty_content_and_tool_calls
1 failed, 10 passed in 0.02s
```

Note that only the new production-shape test fails here. `test_tool_role_messages_preserved_with_content` (the repaired fixture) passes under the old predicate too, exactly as design doc §8 anticipated — that fixture is not a mutation-check target.

### Go — unknown-tool-name branch reverted to the bare `return nil, fmt.Errorf(...)`

```
--- FAIL: Test_ToolHandle_unknownToolNameRecordsFailureResult (0.00s)
    tool_unknown_test.go:98: failure result message must carry result=failed. got:
    tool_unknown_test.go:101: failure result message must carry the tool_call_id 9a01c1a0-c900-11f0-8a00-000000000004. got:
    tool_unknown_test.go:104: failure result message must explain the failure. got:
    controller.go:251: missing call(s) to *messagehandler.MockMessageHandler.Create(..., is equal to outgoing (message.Direction), is equal to tool (message.Role), ...)
    controller.go:251: aborting test due to missing call(s)
FAIL	monorepo/bin-ai-manager/pkg/aicallhandler	0.009s

--- restored ---
ok  	monorepo/bin-ai-manager/pkg/aicallhandler	0.010s
```

## §6 Gemini adapter transformation path — confirmed

The design doc flagged this as an unverified risk because `pipecat` is not installed in the dev environment. Resolved by fetching the pinned wheel (`pipecat_ai-1.8.1`) and reading `pipecat/adapters/services/gemini_adapter.py`. `_from_standard_message` handles both halves of the OpenAI shape explicitly:

- `if msg.get("tool_calls"):` → `Part(function_call=FunctionCall(id=..., name=..., args=json.loads(tc["function"]["arguments"])))`, recording `tool_call_id_to_name_mapping[id] = name`
- `elif role == "tool":` → role rewritten to `user`, `Part(function_response=FunctionResponse(id=tool_call_id, name=<looked up from tool_call_id_to_name_mapping>, response=...))`

Two consequences worth recording:

1. The mapping is populated by the assistant message and consumed by the following tool result, so **message order is load-bearing** on the Gemini path. `filter_valid_messages` emits from a single pass over `candidates` and therefore preserves the original order.
2. `args=json.loads(tc["function"]["arguments"])` means `Function.Arguments` must be valid JSON. The VOIP-1455 `emit_info_card` neutralization in `start.go` substitutes `"{}"`, which is valid — so that path is safe. The stale "not currently load-bearing" comment there is updated in this PR, since this change is exactly what makes it load-bearing.

Anthropic remains out of scope (design doc §6); it still hits the `else: raise ValueError` branch in `create_llm_service`, unchanged by this PR.

## Follow-up left open (design doc §6)

- DB query to size the real-world impact (`engine_model LIKE 'openai.%' OR 'grok.%'` AND `type='insight'`) — no production DB access from this session.
- Post-deploy smoke observation of a Gemini insight session, now that the adapter path is exercised by real traffic for the first time.


## Round-1 code review follow-up

- Added type annotations + trimmed the docstring's design-review narration in `message_filters.py` (commit after initial push).
- Filed [VOIP-1465](https://voipbin.atlassian.net/browse/VOIP-1465) for the Gemini `Arguments` JSON-validity hardening gap noted during review (non-blocking, no production repro available from this session).

[VOIP-1465]: https://voipbin.atlassian.net/browse/VOIP-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ