### PR TITLE
VOIP-1481-Gate-team-pipeline-tts-stt-on-text-sessions

### DIFF
--- a/bin-pipecat-manager/docs/domain.md
+++ b/bin-pipecat-manager/docs/domain.md
@@ -70,6 +70,8 @@ LLM providers supported (configured by bin-ai-manager at session start):
 STT providers: Deepgram, Whisper
 TTS providers: Cartesia, ElevenLabs, Google
 
+Audio mode is selected by the request-level `stt_type`/`tts_type` that bin-ai-manager sends: both empty means a text-only session (conversation, task, contact_case listen turn) and no STT/TTS or audio input is built; non-empty means a voice call. Both the single-AI and the team pipeline honour this. In team mode each member's TTS/STT is built from that member's own configuration, and only in voice mode (VOIP-1481).
+
 ## Tool Execution
 
 When the LLM emits a function call:

--- a/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-gate-design.md
+++ b/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-gate-design.md
@@ -1,0 +1,116 @@
+# Design: gate team-pipeline TTS/STT on the session's audio mode (VOIP-1481)
+
+Date: 2026-09-07
+Status: approved; implemented in VOIP-1481
+Analysis: `2026-09-07-team-pipeline-text-mode-issue-analysis.md` (same directory)
+
+## 1. Problem (from the analysis)
+
+`init_team_pipeline` in `bin-pipecat-manager/scripts/pipecat/run.py` builds per-member TTS/STT services from each member AI's voice configuration regardless of whether the pipecatcall is a voice call or a text-only session (webchat/conversation, task, contact_case listen turn). For a text session the request-level `stt_type`/`tts_type` are empty (ai-manager blanks them for every non-call AIcall reference), but `init_pipeline` does not forward them to the team branch, so the team path has no mode signal at all. When a member uses Google TTS/STT the constructor fails on the missing Application Default Credentials and the whole pipeline is rejected; ai-manager's backstop then sends the fallback sentence. For any other vendor the text session still needlessly constructs TTS/STT services and the audio input transport.
+
+## 2. Goal / non-goals
+
+Goal
+- A text-only team session (request-level `stt_type` and `tts_type` both empty) builds exactly what the single-AI text path builds: per-member LLM services, the routing LLM, the context aggregator, the output transport, the FlowManager. No TTS, no STT, no input transport.
+- A voice team session (request-level types non-empty) behaves exactly as today: per-member TTS/STT from each member's own configuration, routing TTS/STT, input transport with VAD.
+
+Parity caveat: no team pipeline of any kind has completed in production since the containers started (analysis 3.4: 17/17 failed at init), so "builds what the single-AI text path builds" is a structural argument from the code, not an observed one. The only proof is the production verification in section 7 (steps 2-3).
+
+Non-goals
+- Provisioning Google ADC in the runner (VOIP-1482). Consequence: after this change a **voice** team call whose members use Google TTS/STT still fails identically until VOIP-1482 lands; matrix row 4 below describes the intended, not the currently reachable, behaviour.
+- Validating unsupported TTS/STT vendors in ai-manager (VOIP-1482 scope note).
+- Shortening the 18 s gap between a runner 400 and `terminate` (possible follow-up).
+- Any Go-side change to the `/run` payload.
+
+## 3. Mode signal
+
+Use the request-level `stt_type` / `tts_type` **presence**, exactly like `init_single_ai_pipeline` does. Facts that make this correct today (all verified in the analysis):
+
+- Only three producers of pipecatcall start requests exist, all in ai-manager. The voice-call path always sends non-empty types (defaults `deepgram`/`elevenlabs` fill any empty AI value); the task, listen and conversation paths send empty types.
+- pipecat-manager's own transport dispatch agrees: only `aicall.ReferenceType == call` gets an Asterisk media leg.
+- The Go request struct marks both fields `omitempty`, so empty arrives in Python as `None`; the gate is the same `if tts_type:` shape as the single-AI path.
+- The `/run` request already carries these fields alongside `resolved_team`; nothing new crosses the Go/Python boundary.
+
+Gate TTS and STT **separately** on their own request-level field (as the single-AI path does), not on a combined "voice" boolean. In practice a voice call sets both, but separate gating keeps the two paths symmetric and costs nothing.
+
+The request-level **values** are never used for members. They are a snapshot of the start member's AI; each member keeps building its service from its own `tts_type` / `tts_voice_id` / `stt_type`.
+
+Rejected alternatives
+- Derive mode from a reference type in pipecat-manager or the runner: `pipecatcall.ReferenceType` is always `ai_call` here; the AIcall reference type is not in the payload; re-deriving duplicates a policy ai-manager already applied and would drift.
+- Strip member TTS/STT on the Go side when request-level types are empty: works, but moves the decision away from the place that already makes it for single-AI sessions, and leaves the Python function unable to defend itself when called with a team payload directly (7 test call sites do that).
+- Add an explicit `mode` field to the request: cleaner in the long run but touches Go + pydantic + tests for no behavioural gain today. Can be revisited if a future producer needs an audio session with empty types.
+
+## 4. Changes
+
+### 4.1 `run.py`
+
+`init_pipeline` (team branch): forward `stt_type=stt_type, tts_type=tts_type` to `init_team_pipeline`. Nothing else changes in the dispatch.
+
+`init_team_pipeline`: add keyword parameters `stt_type: str = None, tts_type: str = None`. Defaults keep the 7 existing test call sites valid and mean "text-only", mirroring `init_single_ai_pipeline`'s defaults. Trade-off acknowledged: a future caller that forgets to forward the types gets a silent text-only pipeline rather than a loud failure; the docstring must state that `None` means text-only, and test 4 pins the one production caller's forwarding. In the member loop:
+
+```python
+if tts_type and ai.get("tts_type"):
+    tts_services[mid] = create_tts_service(ai["tts_type"], voice_id=ai.get("tts_voice_id"), language=tts_language)
+if stt_type and ai.get("stt_type"):
+    stt_services[mid] = create_stt_service(ai["stt_type"], language=stt_language)
+```
+
+Everything downstream is already conditional on `tts_services` / `stt_services` being empty (`routing_tts`/`routing_stt` None at `run.py:621-629`, input transport gated on `routing_stt` at `run.py:650-657`, stage list, `build_team_flow`, transition handler guards `team_flow.py:155-158`, cleanup). One INFO log line `[TEAM][INIT] Text-only session; skipping per-member TTS/STT`, emitted once per pipeline (not per member) and only when **both** request-level `stt_type` and `tts_type` are falsy, so the partial-types shape (test 3) does not log a misleading "text-only" line.
+
+Update the docstring of `init_team_pipeline` to state the gate and the invariant it relies on.
+
+### 4.2 Go side
+
+No change. `resolveTeamForPython` keeps sending full member configuration; the payload stays a complete description of the team, and the runner decides what to instantiate for the session, as it does for single AIs.
+
+### 4.3 Docs
+
+- Add the analysis and this design under `bin-pipecat-manager/docs/plans/`.
+- One or two sentences in `bin-pipecat-manager/docs/domain.md` under `## Pipecat Pipeline` (the section that describes what `run.py` constructs; `architecture.md` does not mention teams at all) stating that request-level `stt_type`/`tts_type` presence selects voice vs text-only, that the single-AI and team paths both honour it, and that team members' TTS/STT are built from member config only in voice mode.
+
+## 5. Behaviour matrix
+
+| session | request-level stt/tts | members | TTS/STT built | input transport | output transport |
+|---|---|---|---|---|---|
+| conversation (webchat) | empty/empty | google, google | none | no | yes |
+| task | empty/empty | mixed vendors | none | no | yes |
+| contact_case listen turn | empty/empty | any | none | no | yes |
+| voice call | deepgram/elevenlabs (defaults or snapshot) | google, google | per member, google | yes | yes |
+| voice call | deepgram/elevenlabs | start member without TTS, other member with TTS | only for the member that has one (unchanged from today) | yes | yes |
+| voice call | deepgram/elevenlabs | mixed vendors | per member, each with its own vendor | yes | yes |
+
+Rows 1-3 are the new behaviour; rows 4-6 must be byte-for-byte today's behaviour. Pre-existing and out of scope: in voice mode a team whose members all lack `stt_type` gets no input transport (deaf call), and one whose members all lack `tts_type` gets no TTS (`run.py:621-629,650-657` today); the gate does not change that. Rows 1-3 collapse into a single unit test (test 1): `init_team_pipeline` has no notion of the AIcall reference type, and all three sessions arrive as empty request-level types, so one text-mode test covers them.
+
+## 6. Tests (pytest, `scripts/pipecat/test_init_pipeline.py`)
+
+Run with `uv run --project . --with pytest --with pytest-asyncio python -m pytest -q` from `scripts/pipecat` (verified: 11 existing tests pass at b41b11ea4).
+
+New tests (tests 1-4 must fail before the change and pass after; test 6 is coverage for a newly reachable path and passes both before and after):
+
+1. `test_init_team_pipeline_text_mode_skips_member_tts_stt`: two members both `tts_type="google"`, `stt_type="google"`; call with no `stt_type`/`tts_type`. Patch `run.create_tts_service` and `run.create_stt_service` and assert neither was called; assert `create_websocket_transport` was called only for `"output"`; assert returned `routing_tts` and `routing_stt` are `None` and `transport_input` is `None`.
+2. `test_init_team_pipeline_voice_mode_builds_member_tts_stt_from_member_config`: request-level `stt_type="deepgram"`, `tts_type="elevenlabs"`; member A `tts_type="google"`, `tts_voice_id="v-a"`, `stt_type="google"`; member B no `tts_type`, `stt_type="whisper"` (distinct from A's vendor and from the request-level `deepgram`). Assert `create_tts_service` called once with `("google", voice_id="v-a", language=...)`, `create_stt_service` called twice with the members' own vendors in member order, and the request-level values never appear in those calls.
+3. `test_init_team_pipeline_partial_request_types_gate_independently`: `stt_type="deepgram"`, `tts_type=None` → STT services created, TTS not (mirrors single-AI). Plus the mirror case (added in code review) `test_init_team_pipeline_partial_request_types_tts_only_builds_no_stt`: `tts_type="elevenlabs"`, `stt_type=None` → TTS created, no STT, no input transport.
+4. `test_init_pipeline_forwards_request_types_to_team_branch`: patch `run.init_team_pipeline` and assert `init_pipeline(..., stt_type="deepgram", tts_type="elevenlabs", resolved_team=...)` forwards both as kwargs; and with both `None` forwards `None`.
+5. Existing 11 tests keep passing unchanged (they call `init_team_pipeline` without types; those members have no TTS/STT so behaviour is identical).
+6. `test_team_flow.py`: the handler returned by `_create_transition_handler` invoked with `routing_tts=None, routing_stt=None` switches only the LLM router, updates `current_state`, and does not raise. This path (`team_flow.py:145-169`, guards at 155-158) becomes reachable in production for the first time with this change and is currently untested: every team test in `test_init_pipeline.py` patches `build_team_flow` away and `test_team_flow.py` never awaits a handler. Mechanics: needs `@pytest.mark.asyncio` (strict mode, no `asyncio_mode` in pyproject) and a patch of `team_flow._notify_member_switched` (the handler fires it with `asyncio.create_task`, `team_flow.py:163`) so no pending task is destroyed at test end.
+
+Test 4 detail: production calls `init_pipeline` with positional arguments (`main.py:124-138`), so the test asserts on what the patched `init_team_pipeline` receives (`stt_type`/`tts_type` kwargs), not on how `init_pipeline` itself was called.
+
+What the tests cannot show: `conftest.py` stubs the whole `pipecat` package tree (including `pipecat.services.google.tts/stt`), so `create_tts_service("google")` returns a MagicMock in tests and never touches ADC. The tests pin the gate; only section 7 proves the production effect.
+
+CI: `.circleci/config_work.yml` currently runs no tests at all for this service (the Go test job is commented out since 2026-03, tracked as VOIP-1356) and has never run the pytest suite. Both the Go verification and the pytest run are local-only for this PR; the PR must state both runs and their results. Adding the Python step to CI belongs with VOIP-1356, out of scope here.
+
+Mutation check: revert the gate and confirm test 1 fails on the `create_tts_service` assertion and test 4 fails on the missing kwargs.
+
+## 7. Verification plan (production)
+
+1. Merge → CI image → Komodo deploy of `bin-pipecat-manager` stack (both manager+runner pairs). Confirm the two runner containers restarted and `md5sum run.py` in the container matches the merged commit.
+2. Send a visitor message through the voipbin.net webchat widget (public widget boot → session → inbound message). Expect an AI answer, not the backstop sentence. Check `script-runner` logs: `run_request ... has_resolved_team: true` followed by `[TEAM][INIT] Text-only session; skipping per-member TTS/STT` and `[TEAM][INIT][total]`, no `Pipeline validation failed`.
+3. In the same session, send a message that should make the start member hand off to the other member (for this team: a sales question). Expect a `member_switched` event / reply from the other member with no error, since the text-mode transition path (`team_flow.py:145-169` with both routers `None`) has never run in production. Also ask something that triggers a member tool, so team-mode tool execution (`team_flow.py` `_call_go_tool_endpoint`) runs once in production, and confirm `[TEAM][CLEANUP]` appears in the runner log after the turn ends (normal team teardown, `run.py:779-794`, has also never run in production).
+4. Check ai-manager logs: no new `Backstop reply sent` for the new AIcall.
+5. Re-test VOIP-1457 on the square-main widget; close it if it no longer reproduces.
+6. Voice regression: production has had zero voice run_requests since 2026-09-05, and a voice team call with these (google) members would fail on VOIP-1482 regardless, so the voice rows are protected by tests 2, 3 and 6 plus the unchanged code path. A zero-cost live check is possible (call to a virtual number with a throwaway team whose members use elevenlabs/deepgram, allowed by the repo's API testing guidelines); do it if time permits, otherwise state the omission in the PR.
+
+## 8. Rollback
+
+One Python source file plus tests and docs; revert the PR and redeploy. No schema, no payload, no Go change.

--- a/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-gate-plan.md
+++ b/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-gate-plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: gate team-pipeline TTS/STT on session audio mode (VOIP-1481)
+
+Date: 2026-09-07
+Status: executed (rev 4; test 2 vendor and mirror test 3b amended during code review)
+Design: `2026-09-07-team-pipeline-text-mode-gate-design.md` (approved). Analysis: `2026-09-07-team-pipeline-text-mode-issue-analysis.md` (approved).
+Branch/worktree: `VOIP-1481-Gate-team-pipeline-tts-stt-on-text-sessions` at `.worktrees/` of `~/gitvoipbin/monorepo`, based on `origin/main` `b41b11ea4`.
+
+All paths below are relative to `bin-pipecat-manager/`. Only Python and docs change; no Go, no payload, no schema.
+
+## 0. Acceptance criteria
+
+- A1. `init_team_pipeline(..., stt_type=None, tts_type=None)` with members that declare `tts_type`/`stt_type` creates no TTS/STT services, no input transport, returns `routing_tts is None`, `routing_stt is None`, `transport_input is None`; output transport and FlowManager path unchanged.
+- A2. `init_team_pipeline(..., stt_type="deepgram", tts_type="elevenlabs")` creates per-member TTS/STT from each member's own config exactly as today (members without a type are skipped as today; request-level values never reach `create_tts_service`/`create_stt_service`).
+- A3. TTS and STT are gated independently by their own request-level field.
+- A4. `init_pipeline` forwards request-level `stt_type`/`tts_type` to `init_team_pipeline`.
+- A5. The transition handler works with both routers `None`.
+- A6. All pre-existing tests keep their baseline result: 140 pass; the 2 pre-existing failures in `test_run.py::TestCreateTTSService` (`test_google_tts_service_creation`, `test_google_tts_default_voice`: stale assertions from before the Chirp3 default-voice change, unrelated to this work, never caught because CI runs no pytest) remain exactly 2 and are not touched by this PR (recorded on VOIP-1356).
+- A7. Docs: analysis, design, plan in `docs/plans/` with README index rows; `docs/domain.md` Pipecat Pipeline section states the mode rule.
+- A8. Manual mutation check recorded: with the signature kept but the two guards and the forwarding reverted, tests 1, 3, 3b and 4 fail (test 2 keeps passing because the voice path is unchanged). Final suite: `2 failed, 146 passed` = 140 baseline + 6 new tests (tests 1-4, 3b, and the transition-handler test).
+
+## 1. Test environment
+
+```bash
+cd bin-pipecat-manager/scripts/pipecat
+uv run --project . --with pytest --with pytest-asyncio python -m pytest -q
+```
+
+Baseline at b41b11ea4 (worktree, untouched code): `2 failed, 140 passed in 0.42s`. The 2 failures are `test_run.py::TestCreateTTSService::test_google_tts_default_voice` (expects `voice_id='default_voice_id'`; code now defaults to `en-US-Chirp3-HD-Charon` at `run.py:365-367`) and `::test_google_tts_service_creation` (asserts `assert_called_once_with(voice_id=...)` only; code now also passes `params=GoogleTTSService.InputParams(language=lang)` at `run.py:377-380`); both pre-existing stale assertions, out of scope, recorded on VOIP-1356 as a precondition for wiring pytest into CI. `uv run --project .` (re)creates `.venv` from `uv.lock` (python 3.11); `.venv`/`venv` are gitignored.
+
+Note: `conftest.py` stubs the whole `pipecat` tree, `routing_tts`/`routing_stt`/`team_flow`, `aiohttp`, so tests observe the gate, not the Google ADC failure (design 6). `test_team_flow.py` pops the `team_flow` stub to import the real module (`test_team_flow.py:9`).
+
+## 2. Steps (TDD, one commit at the end)
+
+### Step 1. Baseline
+
+Done: `2 failed, 140 passed` (see section 1). Every later run must show the same 2 failures and only them, plus the new tests passing.
+
+### Step 2. RED: add tests 1-4 to `scripts/pipecat/test_init_pipeline.py`
+
+Reuse the success-path harness from `test_init_team_pipeline_swaps_flowmanager_llm_to_router` (`test_init_pipeline.py:238-293`): patches for `run.create_llm_service`, `run.RoutingLLMService`, `run.create_websocket_transport`, `run.Pipeline`, `run.PipelineTask`, `run.build_team_flow`, `run.FlowManager`, `run.task_manager`, with `mock_routing.active_service = mock_llm`, `flow_manager_stub._llm = MagicMock()`, `flow_manager_stub.initialize = AsyncMock()`. Extract a small module-level helper `_run_team_init(resolved_team, **kwargs)` that builds those mocks, additionally patches `run.create_tts_service`, `run.create_stt_service`, `run.RoutingTTSService`, `run.RoutingSTTService`, `run.SileroVADAnalyzer`, `run.build_vad_params`, awaits `init_team_pipeline(id=..., resolved_team=resolved_team, **kwargs)`, and returns `(ctx, mocks)` where `mocks` exposes the TTS/STT/transport mocks. Existing tests are left untouched (no refactor of the 11 existing tests).
+
+Fixture: `_two_google_members()` → members `member-1` (start) `{engine_model: "gemini.gemini-2.5-flash", engine_key: "", tts_type: "google", tts_voice_id: "en-US-Chirp3-HD-Gacrux", stt_type: "google"}` and `member-2` `{..., tts_type: "google", tts_voice_id: "", stt_type: "google"}` (mirrors the production team). Every `resolved_team` used by tests 1-3 must set `start_member_id` to a member present in `members` (`member-1`), otherwise `run.py:632-634` raises `ValueError("start_member_id ... not found")` and masks the intended RED/GREEN outcome.
+
+All four new tests are `async def` and MUST carry `@pytest.mark.asyncio` (pytest-asyncio strict mode: no `asyncio_mode` in `pyproject.toml`; all 11 existing tests are marked). An unmarked async test is skipped with a warning instead of failing, which would silently break RED.
+
+1. `test_init_team_pipeline_text_mode_skips_member_tts_stt` (A1): call with no `stt_type`/`tts_type`. Assert `create_tts_service.assert_not_called()`, `create_stt_service.assert_not_called()`, `RoutingTTSService`/`RoutingSTTService` not called, `create_websocket_transport` called exactly once with first positional `"output"`, `ctx["routing_tts"] is None`, `ctx["routing_stt"] is None`, `ctx["transport_input"] is None`, `create_llm_service.call_count == 2`.
+2. `test_init_team_pipeline_voice_mode_builds_member_tts_stt_from_member_config` (A2): call with `stt_type="deepgram"`, `tts_type="elevenlabs"`, `tts_language="en-US"`, `stt_language="en-US"`; members: A `tts_type="google"`, `tts_voice_id="v-a"`, `stt_type="google"`; B no `tts_type`, `stt_type="whisper"` (a third vendor, distinct from both A's and the request-level `deepgram`, so mixed-vendor routing and request-level leaks are both detectable). Assert `create_tts_service.assert_called_once_with("google", voice_id="v-a", language="en-US")`; `create_stt_service` call args list `== [call("google", language="en-US"), call("whisper", language="en-US")]`; `"elevenlabs"` does not appear in any `create_tts_service` call and `"deepgram"` in no `create_stt_service` call; `RoutingTTSService`/`RoutingSTTService` each constructed once; `create_websocket_transport` called twice (`"input"` then `"output"`); `ctx["transport_input"] is not None`.
+3. `test_init_team_pipeline_partial_request_types_gate_independently` (A3): `stt_type="deepgram"`, `tts_type=None`, members both with google TTS+STT. Assert `create_stt_service.call_count == 2`, `create_tts_service.assert_not_called()`, `ctx["routing_stt"] is not None`, `ctx["routing_tts"] is None`, `ctx["transport_input"] is not None`.
+3b. `test_init_team_pipeline_partial_request_types_tts_only_builds_no_stt` (A3, mirror, added during code review): `stt_type=None`, `tts_type="elevenlabs"`. Assert `create_tts_service.call_count == 2`, `create_stt_service.assert_not_called()`, `ctx["routing_tts"] is not None`, `ctx["routing_stt"] is None`, `ctx["transport_input"] is None`, exactly one `create_websocket_transport` call for `"output"`. Together with test 3 it fails a combined `(tts_type or stt_type)` gate.
+4. `test_init_pipeline_forwards_request_types_to_team_branch` (A4): `patch("run.init_team_pipeline", new=AsyncMock(side_effect=lambda *a, **k: {}))` (fresh dict per call, since `init_pipeline` mutates the returned ctx at `run.py:106`); call `init_pipeline("id", "openai.gpt-4o", "k", [], "deepgram", "en-US", "elevenlabs", "en-US", "voice", [], resolved_team={"id": "t", "start_member_id": "m", "members": []})` positionally, mirroring `main.py:124-138`. Assert the mock was awaited once and `call_args.kwargs["stt_type"] == "deepgram"`, `call_args.kwargs["tts_type"] == "elevenlabs"`; second call with `None`/`None` asserts both kwargs are `None` (present, not missing).
+
+Run: all four must FAIL at RED. Test 1 fails on `create_tts_service.assert_not_called()` (the current code builds member TTS). Tests 2 and 3 fail with `TypeError: init_team_pipeline() got an unexpected keyword argument ...` (whichever of `stt_type`/`tts_type` CPython reports first) because the parameters do not exist yet (`run.py:566-574`); the pass criterion for RED is the `TypeError`, not the exact keyword name. Test 4 fails with `KeyError` on the missing kwargs. Record the four failure modes.
+
+### Step 3. Coverage test 6 in `scripts/pipecat/test_team_flow.py` (A5)
+
+The file currently imports only `sys` and `MagicMock` (`test_team_flow.py:3-4`); add `import asyncio`, `import pytest`, `from unittest.mock import AsyncMock, patch`, and extend the `team_flow` import with `_create_transition_handler`.
+
+`test_transition_handler_with_no_tts_stt_routers`: `routing_llm = MagicMock()`; `member_nodes = {"m2": {"name": "m2"}}`; `current_state = {"active_member_id": "m1"}`; `resolved_team = _make_team([...], "m1")`; build the handler with `next_member_id="m2"`, `routing_tts=None, routing_stt=None`, `pipecatcall_id="pc-1"`, `function_name="transfer_to_m2"`; `with patch("team_flow._notify_member_switched", new=AsyncMock())`; await `handler({}, MagicMock())`. Assert result `== ({"status": "transferred"}, member_nodes["m2"])`, `routing_llm.set_active_member.assert_called_once_with("m2")`, `current_state["active_member_id"] == "m2"`, and the notify mock awaited once with `("pc-1", "m1", "m2", "transfer_to_m2", resolved_team)`. Mark `@pytest.mark.asyncio`; let the event loop settle (`await asyncio.sleep(0)`) before asserting the notify call. Expected to PASS before and after the change (documented as coverage, not RED).
+
+### Step 4. GREEN: `scripts/pipecat/run.py`
+
+- `init_pipeline` (lines 97-105): add `stt_type=stt_type, tts_type=tts_type,` to the `init_team_pipeline` call.
+- `init_team_pipeline` signature (lines 566-574): add `stt_type: str = None, tts_type: str = None,` after `tts_language`. Docstring: "`stt_type`/`tts_type` are the request-level types from bin-ai-manager. Their presence selects the session's audio mode: both `None` (the default) means a text-only session (conversation, task, contact_case listen turn) and no per-member TTS/STT or input transport is built; non-empty means a voice call and each member's TTS/STT is built from that member's own config. The values themselves are never used for members."
+- Member loop (lines 602-611): change the two guards to `if tts_type and ai.get("tts_type"):` and `if stt_type and ai.get("stt_type"):`.
+- After the loop's summary log (line 615), add: `if not stt_type and not tts_type: logger.info(f"[TEAM][INIT] Text-only session; skipping per-member TTS/STT. pipeline id={id}")`. Emitted once, only when both are falsy.
+
+Run the full suite: everything passes.
+
+### Step 5. Mutation check (A8)
+
+Temporarily revert the two guards and the forwarding (git stash of `run.py` or manual), run tests 1-4: tests 1, 3, 4 fail; restore. Record the failing assertion names in the PR body.
+
+### Step 6. Docs (A7)
+
+- `docs/domain.md`, `## Pipecat Pipeline`: after the STT/TTS provider lines add a short paragraph: "Audio mode is selected by the request-level `stt_type`/`tts_type` that bin-ai-manager sends: both empty means a text-only session (conversation, task, contact_case listen turn) and no STT/TTS or audio input is built; non-empty means a voice call. Both the single-AI and the team pipeline honour this. In team mode each member's TTS/STT is built from that member's own configuration, and only in voice mode (VOIP-1481)."
+- `docs/plans/README.md`: add index rows for the three 2026-09-07 documents.
+- Design doc status line → "approved; implemented in VOIP-1481" (status metadata only, no content change to the signed-off text); plan doc status → "executed".
+
+### Step 7. Verification before commit
+
+```bash
+cd bin-pipecat-manager/scripts/pipecat && uv run --project . --with pytest --with pytest-asyncio python -m pytest -q
+cd ../.. && git status --short && git diff --stat
+```
+
+No Go files touched → the full Go verification chain (`go mod tidy && go mod vendor && go generate ./... && golangci-lint run`) is not required, but run `go build ./... && go test ./...` in `bin-pipecat-manager` once as a sanity check that nothing else in the worktree changed. RST docs (`bin-api-manager/docsdev/source/`) are not affected: no API, webhook or billing surface changes; state this in the PR body.
+
+### Step 8. Commit, push, PR
+
+- Pull-main/conflict check from the worktree: `git fetch origin main`, `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | grep -E "^(CONFLICT|changed in both)"`, `git log --oneline HEAD..origin/main`.
+- One commit. Per the monorepo `CLAUDE.md` the commit title MUST match the branch name exactly; body bullets carry the project prefix:
+  ```
+  VOIP-1481-Gate-team-pipeline-tts-stt-on-text-sessions
+
+  - bin-pipecat-manager: skip per-member TTS/STT and the input transport in init_team_pipeline when the request-level stt_type/tts_type are empty (text-only session)
+  - bin-pipecat-manager: forward request-level stt_type/tts_type from init_pipeline to the team branch
+  - bin-pipecat-manager: add pytest coverage for text-mode/voice-mode/partial gating, init_pipeline forwarding, and the transition handler with no TTS/STT routers
+  - bin-pipecat-manager: document the audio-mode rule in docs/domain.md and add the VOIP-1481 analysis/design/plan docs
+  ```
+- Push branch, open PR titled `VOIP-1481-Gate-team-pipeline-tts-stt-on-text-sessions`. Body per the monorepo/global format: a narrative paragraph first (which also states, in prose, the pytest run result, that Go is untouched, that CI runs no tests for this service (VOIP-1356), that voice regression is covered by tests only, the VOIP-1482 caveat for Google voice teams, and that RST docs are unaffected), then the `bin-pipecat-manager:` bullets. No markdown headers, no "Test plan" section, no AI attribution.
+- Do not merge; wait for 대표님's explicit instruction.
+
+### Step 9. After merge (separate approval)
+
+Follow design section 7: confirm runner containers picked up the image (`md5sum run.py` vs merged commit), send a visitor message on the voipbin.net widget, drive a member transition and a tool call, check runner/ai-manager logs, re-test VOIP-1457, then transition VOIP-1481 to Done.
+
+## 3. Risks and rollback
+
+- Risk: a hidden consumer expects `routing_tts`/`routing_stt` non-None in team mode. Mitigation: design review enumerated every consumer (`run.py:621-629,650-657,661-670,753-763,779-794`, `team_flow.py:46-47,155-158`); test 1 exercises the return path; test 6 the transition path.
+- Risk: voice regression. Mitigation: tests 2 and 3 pin per-member creation with the members' own values; the guards only add a conjunct that is always true in voice mode.
+- Rollback: revert the PR; no data or payload change.
+
+## 4. Out of scope (tickets)
+
+- VOIP-1482: Google ADC missing in the runner; unsupported vendor cast in ai-manager.
+- VOIP-1356: CI test step for this service.
+- Follow-up candidate (no ticket yet): fail-fast on runner 400 in `RunnerStart` to cut the ~18 s wait before the backstop.

--- a/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-gate-plan.md
+++ b/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-gate-plan.md
@@ -68,7 +68,7 @@ Run the full suite: everything passes.
 
 ### Step 5. Mutation check (A8)
 
-Temporarily revert the two guards and the forwarding (git stash of `run.py` or manual), run tests 1-4: tests 1, 3, 4 fail; restore. Record the failing assertion names in the PR body.
+Temporarily revert the two guards and the forwarding (git stash of `run.py` or manual), run the new tests: tests 1, 3, 3b and 4 fail while test 2 passes; restore. Record the failing assertion names in the PR body.
 
 ### Step 6. Docs (A7)
 

--- a/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-issue-analysis.md
+++ b/bin-pipecat-manager/docs/plans/2026-09-07-team-pipeline-text-mode-issue-analysis.md
@@ -1,0 +1,116 @@
+# Issue Analysis: webchat AI Talk (Team) always replies with backstop text
+
+Date: 2026-09-07 (rev 5, after review rounds 1-4; round 4 approved, non-blocking notes folded in)
+Reporter: 대표님 (CEO/CTO), observed on voipbin.net webchat widget ("voipbin main webchat", widget 8d566129)
+Related AIcall: a9b2c39b-85c3-40db-8fa0-647276f93c2f, pipecatcall 9770d769-1c2a-463e-abc1-521751add341
+Observed message: 871c1af6-9d03-4015-aca1-58317833113f, text "Sorry, I'm having trouble responding right now. Please try again." (sender_id nil, direction outbound)
+
+## 1. Symptom
+
+The webchat widget's Message Flow ("webchat message voipbin main") routes every inbound visitor message straight to an `ai_talk` action whose assistance is the Team `voipbin admin helper` (d414dc93). Every visitor message produces the fixed fallback sentence instead of an AI answer. Screenshot shows two visitor messages and two identical fallback bubbles.
+
+## 2. Issue validity (still valid: YES)
+
+Reproduced in production on 2026-09-06 21:12-21:13 UTC. The deployed Python runner scripts are byte-identical to `origin/main` (md5 of `run.py`, `team_flow.py`, `main.py`, `routing_llm.py` match between `voipbin-pipecat-script-runner-1` and monorepo `b41b11ea4`). Nothing on main fixes this yet.
+
+Jira: no ticket describes this defect (searched VOIP, 90 days, for team / credentials / backstop / webchat AI). VOIP-1457 ("square-main public webchat: AI reply hangs indefinitely on Thinking state", Backlog, 2026-09-04) reports a different symptom (hang, no fallback bubble) on the same widget two days earlier. It may share this root cause (the team pipeline never started, so no reply), but the missing fallback bubble is unexplained by this analysis. Decision: create a new ticket for this defect and link VOIP-1457 as "relates to"; do not mark VOIP-1457 as a duplicate. Re-test VOIP-1457 after this fix is deployed and close it only if it no longer reproduces.
+
+## 3. Evidence chain (production logs, bm-nyc-01)
+
+All timestamps UTC, 2026-09-06.
+
+| t | component | fact | source |
+|---|---|---|---|
+| 21:12:36.42 | bin-ai-manager-1 | `startAIcallByMessaging` created AIcall a9b2c39b: `assistance_type=team`, `assistance_id=d414dc93`, `reference_type=conversation`, `ai_engine_model=gemini.gemini-2.5-flash`, `current_member_id=30cef188` | ai-manager log |
+| 21:12:36.43 | bin-ai-manager-1 | `startPipecatcall`: "Determined variables. sttType: , ttsType: , ttsVoiceID: " (empty by design for non-call references, `bin-ai-manager/pkg/aicallhandler/start.go:807-816`) | ai-manager log |
+| 21:12:36.45 | pipecat-manager-1 | `runnerStartScript` → `resolveTeamForPython` → "Resolved team for python runner" → "Sending request to python runner" | pipecat-manager log |
+| 21:12:36.458 | script-runner-1 | `run_request`: `llm_type=gemini.gemini-2.5-flash`, `stt_type=null`, `tts_type=null`, `has_resolved_team=true` → `[TEAM][INIT] Starting team pipeline` | script-runner log |
+| 21:12:48.522 | script-runner-1 | `Pipeline validation failed (id=9770d769): No valid credentials provided.` → HTTP 400. No `[TEAM][INIT] Member ... services created` line was logged, so the first member's service construction failed (see 3.1 for which constructor) | script-runner log |
+| 21:12:48.523 | pipecat-manager-1 | `RunnerStart`: "Could not start the pipecat runner script: ... 400 Bad Request, body: {"detail":"No valid credentials provided."}" | pipecat-manager log |
+| 21:13:06.45 | pipecat-manager-1 | `terminate` → publishes `pipecatcall_terminated`; python `/stop` returns 404 (no pipeline was ever registered) | pipecat-manager + script-runner log |
+| 21:13:09.46 | bin-ai-manager-1 | `EventPMPipecatcallTerminated`: grace 3s, no assistant reply row → "Backstop reply sent" (message 0606d0ed) → `ConversationV1MessageSend` with `backstopReplyText` (`bin-ai-manager/pkg/messagehandler/event.go:35,436-499`) | ai-manager log |
+
+The observed webchat message 871c1af6 (tm_create 21:13:09.461) is that backstop send.
+
+### 3.1 Where "No valid credentials provided." comes from, and which constructor raised it
+
+The string exists only in pipecat's Google service constructors (pipecat-ai 1.4.x as vendored in `scripts/pipecat/venv`; line numbers differ between the two local venvs so functions are cited instead): `pipecat/services/google/tts.py` (`GoogleTTSService._create_client`, called from `GoogleTTSService.__init__`; the sibling class `GoogleHttpTTSService` has its own identical check but is not used by `run.py`, which imports and returns `GoogleTTSService` at `run.py:13,375`), `stt.py` (`GoogleSTTService.__init__`, inline), and the Vertex LLM variants (`llm_vertex.py`, `gemini_live/llm_vertex.py`). In all of them the check is `google.auth.default()` → on failure `raise ValueError("No valid credentials provided.")`, so the ADC lookup happens at construction time.
+
+Constructors ruled out for this run:
+- LLM: `run.py:493` builds the non-Vertex `GoogleLLMService(api_key=key or os.getenv("GOOGLE_API_KEY"))`, which only calls `genai.Client(api_key=...)` (`pipecat/services/google/llm.py`, `GoogleLLMService._create_client`) and never `google.auth.default()`. `GOOGLE_API_KEY` is present in the runner env. The empty `engine_key` on both member AIs (3.3) is therefore not the cause: the code falls back to the env key, and single-AI Gemini sessions with the same empty key succeed (3.4).
+- Vertex: not referenced by `run.py`.
+
+So the raise came from `create_tts_service("google")` or `create_stt_service("google")` inside the member loop (`run.py:602-611`); the loop creates LLM first (line 599), then TTS, then STT, so TTS is the first to fail for a member with `tts_type=google`.
+
+The ~12 s between run_request and the failure is `google.auth.default()` probing the (absent) GCE metadata server before giving up.
+
+Verified in the container:
+
+```
+$ docker exec voipbin-pipecat-script-runner-1 python -c "import google.auth; google.auth.default()"
+DefaultCredentialsError: Your default credentials were not found.
+```
+
+Env in the runner: `DEEPGRAM_API_KEY XAI_API_KEY GOOGLE_API_KEY CARTESIA_API_KEY ELEVENLABS_API_KEY OPENAI_API_KEY` only. No `GOOGLE_APPLICATION_CREDENTIALS`, no mounts, no `~/.config/gcloud`.
+
+### 3.2 Why the team path builds Google TTS/STT in a text-only session
+
+`bin-pipecat-manager/scripts/pipecat/run.py`:
+
+- `init_pipeline` (line 81): when `resolved_team` is present it calls `init_team_pipeline(id, resolved_team, stt_language, tts_language, llm_messages, vad_config, smart_turn_enabled)` and **drops the request-level `stt_type` / `tts_type` / `tts_voice_id`** (lines 97-107).
+- `init_team_pipeline` (line 566): for every member it does `if ai.get("tts_type"): create_tts_service(...)` and `if ai.get("stt_type"): create_stt_service(...)` (lines 594-613) using the member AI's own voice config. There is no session-mode input to this function at all.
+- `init_single_ai_pipeline` (line 128), by contrast, only creates STT/TTS when the request-level `stt_type` / `tts_type` is set (lines 157, 175). ai-manager sends none for conversation/task references, so single-AI text sessions never touch Google TTS/STT.
+
+`bin-pipecat-manager/pkg/pipecatcallhandler/run.go:135-213` (`resolveTeamForPython`) copies each member AI's `TTSType`, `TTSVoiceID`, `STTType` into the payload (`run.go:196-206`) regardless of the pipecatcall's mode. `runner.go:173-188` sends both the request-level `pc.STTType`/`pc.TTSType` and `resolvedTeam` in the same `/run` request, so the runner already receives the mode signal it needs for the team branch; it just does not forward it.
+
+Blast radius of `init_team_pipeline`: exactly one production caller (`run.py:98`) and 7 direct call sites in `test_init_pipeline.py` (lines 78, 104, 120, 176, 232, 288, 389). Downstream already tolerates a TTS-less/STT-less team pipeline: `run.py:621-670` builds the stage list conditionally and `team_flow.py:46-47,155-158` handles `routing_tts`/`routing_stt` being `None`.
+
+### 3.3 Team configuration (production DB, read-only)
+
+`ai_ais` for the two members of team d414dc93 (`voipbin admin helper`):
+
+| AI | engine_model | tts_type | tts_voice_id | stt_type | engine_key set |
+|---|---|---|---|---|---|
+| voipbin Sales Assistant (74b3d982) | gemini.gemini-2.5-flash | google | en-US-Chirp3-HD-Gacrux | google | no (falls back to env `GOOGLE_API_KEY`, not a cause) |
+| voipbin General Assistant (dfeb9e05) | gemini.gemini-2.5-flash | google | (empty) | google | no (same) |
+
+The first member iterated triggers `create_tts_service("google")` → `GoogleTTSService()` → ADC lookup → `ValueError`.
+
+### 3.4 Correlation across all recent runs (40 h window, both runners)
+
+- 17 run_requests with `has_resolved_team=true`: **17/17** failed with `No valid credentials provided.` (all with `stt_type=null`, i.e. text mode).
+- ~20 run_requests with `has_resolved_team=false` (Gemini and OpenAI, text mode): **0** validation failures.
+- 0 voice run_requests (non-null `stt_type`/`tts_type`) since the containers started on 2026-09-05 04:31 UTC.
+
+What this evidence supports: the team path, which constructs the members' Google TTS/STT services, fails 100% of the time in this environment, while the single-AI text path, which constructs no TTS/STT, succeeds with the same Gemini model, same env and same empty `engine_key`. The evidence does **not** separate "team + text" from "team, any mode": with zero voice samples, a voice team call with these members would fail identically today because the ADC lookup fails regardless of mode (secondary finding, section 4). That the text session should never have built TTS/STT is a code-based design argument (3.2), not an empirical one.
+
+## 4. Root cause
+
+**Primary (this ticket):** `init_team_pipeline` has no notion of session mode and instantiates per-member TTS/STT services from the member AI's voice configuration even when the pipecatcall is text-only. Because the team's members are configured with Google TTS/STT, construction fails at ADC lookup and the whole pipeline is rejected (HTTP 400) before any LLM turn runs; ai-manager's backstop then delivers the fallback sentence. Any team whose members use Google TTS/STT is unusable for webchat/SMS/conversation AI Talk in the current environment; teams whose members use other vendors still needlessly build TTS/STT services and the audio input transport for text sessions.
+
+**Secondary (separate ticket):** the pipecat script runner on bm-nyc-01 has no Google Application Default Credentials, so `GoogleTTSService`/`GoogleSTTService` cannot be constructed for **any** pipeline, single-AI or team, voice or text. This affects voice AI calls whose AI has `tts_type=google` or `stt_type=google`, independent of this ticket. Not proven from logs (no voice run in the retained log window), but the ADC probe is conclusive about the container state. Open question for that ticket: whether Google TTS/STT ever worked on GKE (k8s `deployment.yml` sets only `GOOGLE_API_KEY`, no `serviceAccountName`/volume; credentials could have come from the node service account via the metadata server, or the feature may never have worked). That answer decides whether it is a migration regression or a never-supported configuration. Reach confirmation from code: `pipecatcall.TTSType`/`STTType` define no `google` constant (`models/pipecatcall/main.go:46-59`) while `ai.TTSType`/`STTType` do, and `getPipecatcallTTSInfo`/`getPipecatcallSTTType` cast the AI value unchecked (`start.go:759-777`), so a voice single-AI call whose AI has `tts_type=google` sends `tts_type="google"` at request level and hits the identical ADC failure in `create_tts_service`. The same unchecked cast also lets every other `ai.TTSType`/`STTType` vendor (`models/ai/main.go:247-268,303-307` define 21 non-empty TTS and 4 non-empty STT vendors; the runner implements only cartesia/elevenlabs/google TTS and deepgram/google STT at `run.py:346-407`, leaving 18 TTS and 2 STT vendors unsupported), failing with `Unsupported TTS/STT service`; the secondary ticket should scope that too. Suggested priority: High, because it silently breaks voice AI for any Google-TTS/STT AI, and VOIP-1351 covered credential materialisation only for api/storage/rag/transcribe-manager.
+
+## 5. Why now / should we proceed (YES, high priority)
+
+- Impact: voipbin.net's own public webchat AI (the product demo surface) answers every visitor with an apology. Same for any customer using a Team in a Message Flow.
+- Fix shape: local to the pipecat runner request path; the design must give the team path an explicit session-mode signal and skip per-member TTS/STT (and the input transport) when the session is text-only, mirroring what the single-AI path already does. Existing pytest harnesses for the team pipeline exist to extend.
+- Mode signal available today (verified across all three `PipecatV1PipecatcallStart` call sites in ai-manager, the only producers of pipecatcall requests):
+  - voice AI call, `startPipecatcall` (`start.go:807-816`): request-level STT/TTS types are filled from the AIcall snapshot with **non-empty defaults** when the snapshot is empty (`getPipecatcallSTTType` → `defaultPipecatcallSTTType` = `deepgram`, `getPipecatcallTTSInfo` → `defaultPipecatcallTTSType` = `elevenlabs`; `start.go:759-777`, `main.go:95,99`). So for a voice call they are always non-empty.
+  - AI task, `startPipecatcallTask` (`start.go:856-869`): `STTTypeNone`/`TTSTypeNone`.
+  - listen turn, `startListenPipecatcall` (`listen.go:412-427`): `STTTypeNone`/`TTSTypeNone`, documented as "a listen turn has no audio legs at all". Listen turns run only on `contact_case` AIcalls (`listen.go:270-276`, `listen_trigger.go:219`, `listen_kind.go:58-66`); the underlying Case may point at a call, but the AIcall itself is never `ReferenceTypeCall`.
+  - every non-call AIcall reference (`conversation` as in this bug, `task`, `contact_case`, empty): the gate at `start.go:811` is `c.ReferenceType == aicall.ReferenceTypeCall`, so `startPipecatcall` leaves both `None` for all of them.
+  Invariant on main: **request-level `stt_type`/`tts_type` non-empty ⟺ the pipeline needs audio; both empty ⟺ text-only.** The single-AI path already relies on exactly this (`run.py:157,175`). pipecat-manager's own transport decision agrees on every path: only `aicall.ReferenceType == call` gets an Asterisk external-media leg (`pkg/pipecatcallhandler/start.go:197` vs the audio-less `default` branch at `:276`). Because the request struct uses `omitempty` (`pythonrunner.go:89,91`), empty types arrive in Python as `None`, so a team gate would be literally the same `if stt_type:` shape as the single-AI path. The invariant is implicit and unenforced, so the design may choose to make it explicit, but a presence gate is correct today.
+- Two things the design must NOT do:
+  - Do not use the request-level type **values** as the per-member TTS/STT type. For a team AIcall they are a create-time snapshot of the **start member's** AI (`start.go:67-77` `resolveAI`; `db.go:52-54`), while members are heterogeneous (3.3). Presence is the mode flag; per-member values stay per-member.
+  - Do not re-derive the mode from a reference type inside pipecat-manager or the runner. `pipecatcall.ReferenceType` is always `ai_call` for AI-driven sessions (`models/pipecatcall/main.go:34-39`; all three call sites pass it), so it carries no mode. The AIcall's `ReferenceType` does correlate with mode today (`call` ⟺ audio, identical to the presence gate on every current path), but it is not part of the `/run` payload, and re-deriving it in a second service duplicates a policy ai-manager already computed when it filled or blanked the request-level types; the two would drift the next time ai-manager adds an audio-less start path. Consume the signal ai-manager already sends.
+- Behaviour matrix for design: {text session (conversation / task / contact_case listen turn: request-level types empty), voice call (request-level types non-empty)} × {members with google TTS/STT, members mixed vendors, start member without TTS but another member with TTS}. Every text-session row must build no TTS/STT and no input transport, while the output transport stays unconditional on both paths (`run.py:194-201,235` single; `run.py:658,670` team) because text sessions deliver the LLM reply through it; every voice row must keep today's per-member TTS/STT from member config.
+- Dependencies/risks: none on other in-flight work. Voice team calls must keep creating per-member TTS/STT in voice mode.
+- Alternatives considered: (a) configure Google ADC in the runner only. Unblocks this case but leaves TTS/STT being built for text sessions and is an infra-level change (secondary ticket). (b) the Go side already blanks the request-level types for non-audio sessions; the remaining gap is the per-member payload in `resolveTeamForPython` (`run.go:196-205`) plus the absent Python-side gate. Design phase decides between: Python presence gate in `init_team_pipeline` (mirrors the single-AI path, smallest change), Go-side stripping of member TTS/STT when the request-level types are empty, an explicit mode field on the `/run` request, or a combination.
+- Latency note (not a blocker): between the runner's 400 (21:12:48) and `terminate` (21:13:06) ~18 s pass, so the user waits ~33 s for the fallback. `RunnerStart` only logs and returns on script-start failure (`runner.go:86-89`). Possible follow-up ticket, not in scope.
+
+## 6. Next steps
+
+1. Create Jira ticket (VOIP, Bug): summary in English, body in Korean; link VOIP-1457 (relates to); create the secondary ticket (Google ADC missing in pipecat runner) with the open question recorded.
+2. Design: choose where the mode signal is computed and how it is transported; write the behaviour matrix above; confirm the voice team path is unchanged.
+3. Plan → TDD in `scripts/pipecat` (failing tests: team text session (request-level types empty) with google-TTS/STT members must not call `create_tts_service`/`create_stt_service` and must build no input transport; voice team session (request-level types non-empty) still builds per-member TTS/STT from member config, including when the start member lacks TTS but another member has it; a contact_case listen turn on a team (request-level types empty) behaves like the text row).
+4. Deploy, verify on voipbin.net webchat (visitor inbound via widget token), re-test VOIP-1457, close tickets.

--- a/bin-pipecat-manager/docs/plans/README.md
+++ b/bin-pipecat-manager/docs/plans/README.md
@@ -8,3 +8,6 @@ Design documents and implementation plans for non-trivial changes.
 |------|------|-------|
 | [2026-01-22-audio-resampling-design.md](2026-01-22-audio-resampling-design.md) | 2026-01-22 | Audio sample rate handling and resampling strategy |
 | [2026-01-22-performance-optimization.md](2026-01-22-performance-optimization.md) | 2026-01-22 | Performance optimization analysis and recommendations |
+| [2026-09-07-team-pipeline-text-mode-issue-analysis.md](2026-09-07-team-pipeline-text-mode-issue-analysis.md) | 2026-09-07 | Issue analysis: webchat AI Talk (Team) always replies with backstop text |
+| [2026-09-07-team-pipeline-text-mode-gate-design.md](2026-09-07-team-pipeline-text-mode-gate-design.md) | 2026-09-07 | Design: gate team-pipeline TTS/STT on the session's audio mode |
+| [2026-09-07-team-pipeline-text-mode-gate-plan.md](2026-09-07-team-pipeline-text-mode-gate-plan.md) | 2026-09-07 | Implementation plan: gate team-pipeline TTS/STT on session audio mode |

--- a/bin-pipecat-manager/scripts/pipecat/run.py
+++ b/bin-pipecat-manager/scripts/pipecat/run.py
@@ -99,6 +99,8 @@ async def init_pipeline(
             id, resolved_team,
             stt_language=stt_language,
             tts_language=tts_language,
+            stt_type=stt_type,
+            tts_type=tts_type,
             llm_messages=llm_messages,
             vad_config=vad_config,
             smart_turn_enabled=smart_turn_enabled,
@@ -568,11 +570,23 @@ async def init_team_pipeline(
     resolved_team: dict,
     stt_language: str = None,
     tts_language: str = None,
+    stt_type: str = None,
+    tts_type: str = None,
     llm_messages: list = None,
     vad_config: dict = None,
     smart_turn_enabled: bool = False,
 ) -> dict:
-    """Initialize team pipeline. Returns context dict. Raises on failure."""
+    """Initialize team pipeline. Returns context dict. Raises on failure.
+
+    `stt_type`/`tts_type` are the request-level types from bin-ai-manager. Their
+    presence selects the session's audio mode: both `None` (the default) means a
+    text-only session (conversation, task, contact_case listen turn) and no
+    per-member TTS/STT or input transport is built; non-empty means a voice call
+    and each member's TTS/STT is built from that member's own config. The two
+    fields gate independently (`tts_type` gates member TTS, `stt_type` gates
+    member STT), mirroring init_single_ai_pipeline. The values themselves are
+    never used for members.
+    """
     total_start = time.monotonic()
     logger.info(f"[TEAM][INIT] Starting team pipeline. pipeline id={id}")
 
@@ -599,13 +613,13 @@ async def init_team_pipeline(
         llm_svc, _ = create_llm_service(ai["engine_model"], ai["engine_key"], [], [])
         llm_services[mid] = llm_svc
 
-        if ai.get("tts_type"):
+        if tts_type and ai.get("tts_type"):
             tts_services[mid] = create_tts_service(
                 ai["tts_type"],
                 voice_id=ai.get("tts_voice_id"), language=tts_language,
             )
 
-        if ai.get("stt_type"):
+        if stt_type and ai.get("stt_type"):
             stt_services[mid] = create_stt_service(
                 ai["stt_type"], language=stt_language,
             )
@@ -613,6 +627,8 @@ async def init_team_pipeline(
         logger.info(f"[TEAM][INIT] Member {mid} services created in {time.monotonic() - start:.3f}s")
 
     logger.info(f"[TEAM][INIT] Created {len(llm_services)} LLM, {len(tts_services)} TTS, {len(stt_services)} STT services. pipeline id={id}")
+    if not stt_type and not tts_type:
+        logger.info(f"[TEAM][INIT] Text-only session; skipping per-member TTS/STT. pipeline id={id}")
 
     # --- Step 2: Create routing services ---
     routing_llm = RoutingLLMService(llm_services)

--- a/bin-pipecat-manager/scripts/pipecat/test_init_pipeline.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_init_pipeline.py
@@ -559,6 +559,10 @@ async def test_init_team_pipeline_voice_mode_builds_member_tts_stt_from_member_c
                 "ai": {
                     "engine_model": "openai.gpt-4o",
                     "engine_key": "fake-key",
+                    # "whisper" is deliberately an unimplemented-but-distinct
+                    # vendor string: create_stt_service is mocked here, and the
+                    # test needs three mutually distinct STT values (member-1
+                    # "google", request-level "deepgram", member-2 this one).
                     "stt_type": "whisper",
                 },
                 "tools": [],

--- a/bin-pipecat-manager/scripts/pipecat/test_init_pipeline.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_init_pipeline.py
@@ -4,9 +4,102 @@ Verifies that init_pipeline raises exceptions for invalid configurations
 instead of silently failing in a background task.
 """
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from types import SimpleNamespace
+from unittest.mock import call, patch, MagicMock, AsyncMock
 
 from run import init_pipeline, init_team_pipeline, init_single_ai_pipeline
+
+
+def _two_google_members():
+    """Two members with Google TTS/STT, mirroring the production team d414dc93."""
+    return [
+        {
+            "id": "member-1",
+            "name": "Sales Assistant",
+            "ai": {
+                "engine_model": "gemini.gemini-2.5-flash",
+                "engine_key": "",
+                "tts_type": "google",
+                "tts_voice_id": "en-US-Chirp3-HD-Gacrux",
+                "stt_type": "google",
+            },
+            "tools": [],
+            "transitions": [],
+        },
+        {
+            "id": "member-2",
+            "name": "General Assistant",
+            "ai": {
+                "engine_model": "gemini.gemini-2.5-flash",
+                "engine_key": "",
+                "tts_type": "google",
+                "tts_voice_id": "",
+                "stt_type": "google",
+            },
+            "tools": [],
+            "transitions": [],
+        },
+    ]
+
+
+async def _run_team_init(resolved_team, pipeline_id="test-gate", **kwargs):
+    """Await init_team_pipeline on the success-path mock harness.
+
+    Reuses the mock set from test_init_team_pipeline_swaps_flowmanager_llm_to_router
+    and additionally patches the TTS/STT factories, the routing TTS/STT services and
+    the VAD/transport factories so the audio-mode gate can be observed.
+
+    Returns (ctx, mocks) where mocks exposes the patched factories.
+    """
+    mock_llm = MagicMock()
+
+    mock_routing = MagicMock()
+    mock_routing.active_service = mock_llm
+    mock_routing.cleanup = AsyncMock()
+
+    mock_task = MagicMock()
+    mock_task.cancel = AsyncMock()
+    mock_task.queue_frames = AsyncMock()
+
+    mock_transport = MagicMock()
+    mock_transport.cleanup = AsyncMock()
+
+    flow_manager_stub = MagicMock()
+    flow_manager_stub._llm = MagicMock()
+    flow_manager_stub.initialize = AsyncMock()
+
+    with patch("run.create_llm_service", return_value=(mock_llm, MagicMock())) as mock_create_llm, \
+         patch("run.RoutingLLMService", return_value=mock_routing), \
+         patch("run.create_tts_service") as mock_create_tts, \
+         patch("run.create_stt_service") as mock_create_stt, \
+         patch("run.RoutingTTSService") as mock_routing_tts, \
+         patch("run.RoutingSTTService") as mock_routing_stt, \
+         patch("run.SileroVADAnalyzer"), \
+         patch("run.build_vad_params"), \
+         patch("run.create_websocket_transport", return_value=mock_transport) as mock_create_transport, \
+         patch("run.Pipeline"), \
+         patch("run.PipelineTask", return_value=mock_task), \
+         patch("run.build_team_flow", return_value=({}, MagicMock())), \
+         patch("run.FlowManager", return_value=flow_manager_stub), \
+         patch("run.task_manager") as mock_task_mgr:
+        mock_task_mgr.add = AsyncMock()
+        mock_task_mgr.remove = AsyncMock()
+
+        ctx = await init_team_pipeline(
+            id=pipeline_id,
+            resolved_team=resolved_team,
+            **kwargs,
+        )
+
+    mocks = SimpleNamespace(
+        create_llm_service=mock_create_llm,
+        create_tts_service=mock_create_tts,
+        create_stt_service=mock_create_stt,
+        RoutingTTSService=mock_routing_tts,
+        RoutingSTTService=mock_routing_stt,
+        create_websocket_transport=mock_create_transport,
+    )
+    return ctx, mocks
 
 
 @pytest.mark.asyncio
@@ -401,3 +494,200 @@ async def test_init_team_pipeline_preserves_paired_tool_call_messages():
         tool_call_result,
         {"role": "user", "content": "and now?"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_init_team_pipeline_text_mode_skips_member_tts_stt():
+    """VOIP-1481 (A1): text-only session builds no per-member TTS/STT.
+
+    Both request-level stt_type/tts_type are absent (the shape ai-manager sends
+    for conversation / task / contact_case listen turns), so the members' own
+    Google TTS/STT configuration must be ignored: no service construction, no
+    routing TTS/STT, no audio input transport. The output transport is still
+    built because a text session delivers the LLM reply through it.
+    """
+    resolved_team = {
+        "id": "team-text",
+        "start_member_id": "member-1",
+        "members": _two_google_members(),
+    }
+
+    ctx, mocks = await _run_team_init(resolved_team)
+
+    mocks.create_tts_service.assert_not_called()
+    mocks.create_stt_service.assert_not_called()
+    mocks.RoutingTTSService.assert_not_called()
+    mocks.RoutingSTTService.assert_not_called()
+
+    assert mocks.create_llm_service.call_count == 2
+    assert mocks.create_websocket_transport.call_count == 1
+    assert mocks.create_websocket_transport.call_args[0][0] == "output"
+
+    assert ctx["routing_tts"] is None
+    assert ctx["routing_stt"] is None
+    assert ctx["transport_input"] is None
+
+
+@pytest.mark.asyncio
+async def test_init_team_pipeline_voice_mode_builds_member_tts_stt_from_member_config():
+    """VOIP-1481 (A2): voice session keeps today's per-member construction.
+
+    The request-level values ("elevenlabs"/"deepgram") only signal the mode; each
+    member's service is still built from that member's own vendor and voice id,
+    and a member without a tts_type is skipped exactly as before.
+    """
+    resolved_team = {
+        "id": "team-voice",
+        "start_member_id": "member-1",
+        "members": [
+            {
+                "id": "member-1",
+                "name": "Agent A",
+                "ai": {
+                    "engine_model": "openai.gpt-4o",
+                    "engine_key": "fake-key",
+                    "tts_type": "google",
+                    "tts_voice_id": "v-a",
+                    "stt_type": "google",
+                },
+                "tools": [],
+                "transitions": [],
+            },
+            {
+                "id": "member-2",
+                "name": "Agent B",
+                "ai": {
+                    "engine_model": "openai.gpt-4o",
+                    "engine_key": "fake-key",
+                    "stt_type": "whisper",
+                },
+                "tools": [],
+                "transitions": [],
+            },
+        ],
+    }
+
+    # Members use different vendors from each other (mixed-vendor team) and the
+    # request-level types are deliberately different from every member's own
+    # vendor, so that both "wrong member's vendor" and "request-level value
+    # leaked into a member factory call" are visible.
+    ctx, mocks = await _run_team_init(
+        resolved_team,
+        stt_type="deepgram",
+        tts_type="elevenlabs",
+        stt_language="en-US",
+        tts_language="en-US",
+    )
+
+    mocks.create_tts_service.assert_called_once_with(
+        "google", voice_id="v-a", language="en-US",
+    )
+    assert mocks.create_stt_service.call_args_list == [
+        call("google", language="en-US"),
+        call("whisper", language="en-US"),
+    ]
+    # The request-level TTS/STT types must never reach a member's service factory.
+    for tts_call in mocks.create_tts_service.call_args_list:
+        assert "elevenlabs" not in tts_call.args
+        assert "elevenlabs" not in tts_call.kwargs.values()
+    for stt_call in mocks.create_stt_service.call_args_list:
+        assert "deepgram" not in stt_call.args
+        assert "deepgram" not in stt_call.kwargs.values()
+
+    mocks.RoutingTTSService.assert_called_once()
+    mocks.RoutingSTTService.assert_called_once()
+
+    assert mocks.create_websocket_transport.call_count == 2
+    assert [c.args[0] for c in mocks.create_websocket_transport.call_args_list] == [
+        "input", "output",
+    ]
+    assert ctx["transport_input"] is not None
+
+
+@pytest.mark.asyncio
+async def test_init_team_pipeline_partial_request_types_gate_independently():
+    """VOIP-1481 (A3): TTS and STT are gated by their own request-level field."""
+    resolved_team = {
+        "id": "team-partial",
+        "start_member_id": "member-1",
+        "members": _two_google_members(),
+    }
+
+    ctx, mocks = await _run_team_init(
+        resolved_team,
+        stt_type="deepgram",
+        tts_type=None,
+        stt_language="en-US",
+        tts_language="en-US",
+    )
+
+    assert mocks.create_stt_service.call_count == 2
+    mocks.create_tts_service.assert_not_called()
+
+    assert ctx["routing_stt"] is not None
+    assert ctx["routing_tts"] is None
+    assert ctx["transport_input"] is not None
+
+
+@pytest.mark.asyncio
+async def test_init_team_pipeline_partial_request_types_tts_only_builds_no_stt():
+    """VOIP-1481 (A3, mirror case): tts_type alone builds member TTS but no STT.
+
+    With no request-level stt_type there is no STT router and therefore no
+    input transport; only the output transport is created.
+    """
+    resolved_team = {
+        "id": "team-partial-tts",
+        "start_member_id": "member-1",
+        "members": _two_google_members(),
+    }
+
+    ctx, mocks = await _run_team_init(
+        resolved_team,
+        stt_type=None,
+        tts_type="elevenlabs",
+        stt_language="en-US",
+        tts_language="en-US",
+    )
+
+    assert mocks.create_tts_service.call_count == 2
+    mocks.create_stt_service.assert_not_called()
+
+    assert ctx["routing_tts"] is not None
+    assert ctx["routing_stt"] is None
+    assert ctx["transport_input"] is None
+    assert mocks.create_websocket_transport.call_count == 1
+    assert mocks.create_websocket_transport.call_args_list[0].args[0] == "output"
+
+
+@pytest.mark.asyncio
+async def test_init_pipeline_forwards_request_types_to_team_branch():
+    """VOIP-1481 (A4): init_pipeline forwards the request-level types to the team branch.
+
+    Production calls init_pipeline positionally (main.py), so the assertion is on
+    what the team branch receives. A fresh dict is returned per call because
+    init_pipeline mutates the returned ctx.
+    """
+    resolved_team = {"id": "t", "start_member_id": "m", "members": []}
+
+    with patch("run.init_team_pipeline", new=AsyncMock(side_effect=lambda *a, **k: {})) as mock_team:
+        await init_pipeline(
+            "id", "openai.gpt-4o", "k", [],
+            "deepgram", "en-US", "elevenlabs", "en-US", "voice", [],
+            resolved_team=resolved_team,
+        )
+
+        mock_team.assert_awaited_once()
+        assert mock_team.call_args.kwargs["stt_type"] == "deepgram"
+        assert mock_team.call_args.kwargs["tts_type"] == "elevenlabs"
+
+    with patch("run.init_team_pipeline", new=AsyncMock(side_effect=lambda *a, **k: {})) as mock_team_text:
+        await init_pipeline(
+            "id", "openai.gpt-4o", "k", [],
+            None, None, None, None, None, [],
+            resolved_team=resolved_team,
+        )
+
+        mock_team_text.assert_awaited_once()
+        assert mock_team_text.call_args.kwargs["stt_type"] is None
+        assert mock_team_text.call_args.kwargs["tts_type"] is None

--- a/bin-pipecat-manager/scripts/pipecat/test_team_flow.py
+++ b/bin-pipecat-manager/scripts/pipecat/test_team_flow.py
@@ -1,14 +1,17 @@
 """Tests for build_team_flow() conversation history injection."""
 
+import asyncio
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 # conftest.py mocks team_flow itself (for run.py tests). Remove it so we
 # can import the real module. conftest already stubs pipecat_flows, common,
 # aiohttp, etc., which team_flow.py needs.
 sys.modules.pop("team_flow", None)
 
-from team_flow import build_team_flow  # noqa: E402
+from team_flow import build_team_flow, _create_transition_handler  # noqa: E402
 
 
 def _make_team(members, start_member_id):
@@ -279,3 +282,42 @@ class TestBuildTeamFlowConversationHistory:
         assert start_node["task_messages"] == llm_messages
         assert start_node["task_messages"][0]["name"] == "Alice"
         assert start_node["task_messages"][0]["timestamp"] == 12345
+
+
+@pytest.mark.asyncio
+async def test_transition_handler_with_no_tts_stt_routers():
+    """VOIP-1481: a member transition works when both audio routers are None.
+
+    In a text-only team session there is no routing TTS/STT, so the transition
+    handler must switch only the LLM router, update the shared state and still
+    notify Go. This path becomes reachable in production with the audio-mode
+    gate and was previously untested.
+    """
+    routing_llm = MagicMock()
+    member_nodes = {"m2": {"name": "m2"}}
+    current_state = {"active_member_id": "m1"}
+    resolved_team = _make_team([_make_member("m1"), _make_member("m2")], "m1")
+
+    handler = _create_transition_handler(
+        next_member_id="m2",
+        member_nodes=member_nodes,
+        routing_llm=routing_llm,
+        routing_tts=None,
+        routing_stt=None,
+        current_state=current_state,
+        pipecatcall_id="pc-1",
+        resolved_team=resolved_team,
+        function_name="transfer_to_m2",
+    )
+
+    with patch("team_flow._notify_member_switched", new=AsyncMock()) as mock_notify:
+        result = await handler({}, MagicMock())
+        # Let the fire-and-forget notification task run before asserting.
+        await asyncio.sleep(0)
+
+    assert result == ({"status": "transferred"}, member_nodes["m2"])
+    routing_llm.set_active_member.assert_called_once_with("m2")
+    assert current_state["active_member_id"] == "m2"
+    mock_notify.assert_awaited_once_with(
+        "pc-1", "m1", "m2", "transfer_to_m2", resolved_team,
+    )


### PR DESCRIPTION
Fix the webchat/conversation AI Talk failure for Team assistances. Every visitor message on the voipbin.net webchat (Message Flow → ai_talk with Team "voipbin admin helper") was answered with the fixed backstop sentence "Sorry, I'm having trouble responding right now. Please try again." because the Python team pipeline built each member AI's Google TTS/STT services even for a text-only session, the runner has no Google Application Default Credentials, construction failed with "No valid credentials provided." (HTTP 400), the pipecatcall terminated, and bin-ai-manager's backstop sent the fallback. The single-AI path already gates STT/TTS on the request-level stt_type/tts_type that bin-ai-manager blanks for every non-call reference (conversation, task, contact_case listen turn) and always fills for voice calls; init_pipeline now forwards those two fields to the team branch and init_team_pipeline builds per-member TTS/STT (and the audio input transport) only when they are present. Voice team calls are unchanged: each member's TTS/STT is still built from that member's own configuration. Production evidence, root cause and design constraints are recorded in the three docs/plans documents added here (VOIP-1481). Verification: pytest in scripts/pipecat runs 2 failed, 146 passed; the 2 failures are pre-existing stale assertions in test_run.py::TestCreateTTSService unrelated to this change and recorded on VOIP-1356 (CI currently runs neither the Go nor the Python tests for this service). No Go files change, so the Go verification chain was not needed; go build and go test pass. RST docs are not affected (no API, webhook or billing surface change). Voice-team regression is covered by unit tests only; production has had no voice pipecat run in the retained log window. A voice team whose members use Google TTS/STT still fails until VOIP-1482 (missing Google ADC in the runner) is resolved.

- bin-pipecat-manager: forward request-level stt_type/tts_type from init_pipeline to init_team_pipeline
- bin-pipecat-manager: gate per-member TTS/STT creation in init_team_pipeline on the request-level types so text-only team sessions build no TTS/STT or input transport; log the text-only skip once per pipeline
- bin-pipecat-manager: add pytest coverage for text-mode skip, voice-mode per-member construction with mixed vendors, both partial-gating directions, init_pipeline forwarding, and the transition handler with no TTS/STT routers
- bin-pipecat-manager: document the audio-mode rule in docs/domain.md and add the VOIP-1481 issue analysis, design and implementation plan under docs/plans
