### PR TITLE
VOIP-1486-Deploy-kamailio-proxy-komodo-stack

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -844,6 +844,10 @@ workflows:
           <<: *context_production
           requires:
             - voip-kamailio-proxy-test
+      - voip-kamailio-proxy-deploy:
+          <<: *context_production
+          requires:
+            - voip-kamailio-proxy-build
 
   ############################################
   # namespace: tooling
@@ -2157,6 +2161,21 @@ jobs:
           project-id: voipbin
           project-repository: voip-kamailio-proxy
           source-directory: voip-kamailio-proxy
+
+  voip-kamailio-proxy-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh voip-kamailio-proxy/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy voip-kamailio-proxy via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh voip-kamailio-proxy voip-kamailio-proxy/komodo/docker-compose.yml
 
   ############################################
   # namespace: tooling

--- a/.circleci/tests/voip-kamailio-proxy-komodo.bats
+++ b/.circleci/tests/voip-kamailio-proxy-komodo.bats
@@ -4,8 +4,9 @@
 # (VOIP-1486). See voip-kamailio-proxy/docs/plans/2026-09-07-kamailio-proxy-
 # komodo-stack-design.md.
 #
-# CONSTRAINT: the shell-tests job installs only bats and mawk
-# (config_work.yml:2176-2183), so there is no PyYAML and no yq here. Every
+# CONSTRAINT: the shell-tests job in config_work.yml installs only bats and
+# mawk, so there is no PyYAML and no yq here. (Cited by job name on purpose:
+# line numbers in that file move, including from this very change.) Every
 # assertion below is grep/awk over the raw text. Assertions anchor on YAML key
 # shapes rather than bare substrings, because both files carry comments that
 # mention the very names some assertions require to be ABSENT.

--- a/.circleci/tests/voip-kamailio-proxy-komodo.bats
+++ b/.circleci/tests/voip-kamailio-proxy-komodo.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+#
+# Pins the voip-kamailio-proxy Komodo stack definition and its CI wiring
+# (VOIP-1486). See voip-kamailio-proxy/docs/plans/2026-09-07-kamailio-proxy-
+# komodo-stack-design.md.
+#
+# CONSTRAINT: the shell-tests job installs only bats and mawk
+# (config_work.yml:2176-2183), so there is no PyYAML and no yq here. Every
+# assertion below is grep/awk over the raw text. Assertions anchor on YAML key
+# shapes rather than bare substrings, because both files carry comments that
+# mention the very names some assertions require to be ABSENT.
+#
+# KNOWN TRIGGER GAP: this suite is armed by .circleci/tests/.* (config.yml:59-62),
+# not by voip-kamailio-proxy/.*, so editing the compose file alone does not
+# re-run it. Accepted: the highest-value property (the __IMAGE_TAG__
+# placeholder) is independently enforced at deploy time by
+# render-image-tag.sh, which exits 1 when the placeholder is missing.
+
+load test_helper
+
+REPO_ROOT="$(dirname "$CIRCLECI_DIR")"
+COMPOSE="voip-kamailio-proxy/komodo/docker-compose.yml"
+CONFIG_WORK=".circleci/config_work.yml"
+
+setup() {
+    cd "$REPO_ROOT"
+}
+
+@test "compose: file exists and declares exactly one service, kamailio-proxy" {
+    [ -f "$COMPOSE" ]
+    [ "$(grep -c '^  kamailio-proxy:$' "$COMPOSE")" -eq 1 ]
+    # Any second service key under services: would break the single-target
+    # assumption the Prometheus scrape job and the replica count rest on.
+    run bash -c "awk '/^services:/{f=1;next} /^networks:/{f=0} f' '$COMPOSE' | grep -cE '^  [a-z][a-z0-9-]*:\$'"
+    [ "$output" -eq 1 ]
+}
+
+@test "compose: image carries the __IMAGE_TAG__ placeholder, not a literal tag" {
+    [ "$(grep -cF 'image: voipbin/voip-kamailio-proxy:__IMAGE_TAG__' "$COMPOSE")" -eq 1 ]
+    run grep -cE 'image: voipbin/voip-kamailio-proxy:[0-9a-f]{7,}' "$COMPOSE"
+    [ "$output" -eq 0 ]
+}
+
+@test "compose: render-image-tag.sh substitutes the placeholder" {
+    setup_test_env
+    local copy="$TEST_TEMP_DIR/docker-compose.yml"
+    cp "$COMPOSE" "$copy"
+
+    run "$SCRIPTS_DIR/render-image-tag.sh" "$copy" deadbeefcafe1234
+    [ "$status" -eq 0 ]
+    [ "$(grep -c '__IMAGE_TAG__' "$copy")" -eq 0 ]
+    [ "$(grep -c ':deadbeefcafe1234' "$copy")" -eq 1 ]
+
+    teardown_test_env
+}
+
+@test "compose: restart always, two replicas, no container_name" {
+    # restart: always (not on-failure) because a failed getKamailioID exits 0.
+    [ "$(grep -c '^    restart: always$' "$COMPOSE")" -eq 1 ]
+    [ "$(grep -c '^      replicas: 2$' "$COMPOSE")" -eq 1 ]
+    # Compose rejects container_name together with replicas > 1.
+    run grep -c '^[[:space:]]*container_name:' "$COMPOSE"
+    [ "$output" -eq 0 ]
+}
+
+@test "compose: environment sets exactly the four intended variables" {
+    [ "$(grep -cE '^[[:space:]]*-[[:space:]]*RABBITMQ_ADDRESS=\[\[BIN_MANAGER__RABBITMQ_ADDRESS\]\]$' "$COMPOSE")" -eq 1 ]
+    [ "$(grep -cE '^[[:space:]]*-[[:space:]]*PROMETHEUS_LISTEN_ADDRESS=:2112$' "$COMPOSE")" -eq 1 ]
+    [ "$(grep -cE '^[[:space:]]*-[[:space:]]*PROMETHEUS_ENDPOINT=/metrics$' "$COMPOSE")" -eq 1 ]
+    [ "$(grep -cE '^[[:space:]]*-[[:space:]]*SIP_TIMEOUT=' "$COMPOSE")" -eq 1 ]
+
+    # Deliberately omitted: their defaults are already correct, and writing
+    # them is the only way to get them wrong. Pinned in Go by
+    # cmd/kamailio-proxy/main_test.go Test_defaults. The env-entry anchor
+    # matters: both names appear in this file's comments.
+    run grep -cE '^[[:space:]]*-[[:space:]]*RABBITMQ_QUEUE_LISTEN=' "$COMPOSE"
+    [ "$output" -eq 0 ]
+    run grep -cE '^[[:space:]]*-[[:space:]]*INTERFACE_NAME=' "$COMPOSE"
+    [ "$output" -eq 0 ]
+}
+
+@test "compose: no cap_add, depends_on, or resource limits" {
+    # The SIP OPTIONS probe uses net.DialUDP, not a raw socket, so the
+    # Ansible definition's NET_RAW is not needed.
+    for key in cap_add depends_on mem_limit cpus; do
+        run grep -cE "^[[:space:]]*${key}:" "$COMPOSE"
+        [ "$output" -eq 0 ]
+    done
+}
+
+@test "compose: attaches to the external production network" {
+    [ "$(grep -c '^    name: production$' "$COMPOSE")" -eq 1 ]
+    [ "$(grep -c '^    external: true$' "$COMPOSE")" -eq 1 ]
+}
+
+@test "ci: deploy job exists and calls both deployment scripts on this compose file" {
+    [ "$(grep -c '^  voip-kamailio-proxy-deploy:$' "$CONFIG_WORK")" -eq 1 ]
+    [ "$(grep -cF "render-image-tag.sh voip-kamailio-proxy/komodo/docker-compose.yml" "$CONFIG_WORK")" -eq 1 ]
+    [ "$(grep -cF "komodo-api-deploy.sh voip-kamailio-proxy voip-kamailio-proxy/komodo/docker-compose.yml" "$CONFIG_WORK")" -eq 1 ]
+}
+
+@test "ci: deploy workflow entry has the production context and requires the build job" {
+    # Range ends at the next workflow-entry bullet OR at any dedent. Ending on
+    # the bullet alone is not enough: this entry is the last one in its
+    # workflow, so the range would run on into the following workflow block.
+    local entry
+    entry="$(awk '/^      - voip-kamailio-proxy-deploy:$/{f=1;next} /^      - /||/^  [^ ]/{f=0} f' "$CONFIG_WORK")"
+
+    # Without the production context the Komodo credentials are not injected.
+    [ "$(printf '%s\n' "$entry" | grep -c '<<: \*context_production')" -eq 1 ]
+
+    # Positive assertion, deliberately. Asserting "no mismatching line" would
+    # pass silently against the flow-sequence form
+    # (requires: [voip-kamailio-proxy-build]), because then the standalone
+    # requires: line disappears and there is nothing left to mismatch.
+    [ "$(printf '%s\n' "$entry" | grep -A1 '^[[:space:]]*requires:$' | grep -cE '^[[:space:]]*- voip-kamailio-proxy-build$')" -eq 1 ]
+}

--- a/.circleci/tests/voip-kamailio-proxy-komodo.bats
+++ b/.circleci/tests/voip-kamailio-proxy-komodo.bats
@@ -10,11 +10,17 @@
 # shapes rather than bare substrings, because both files carry comments that
 # mention the very names some assertions require to be ABSENT.
 #
-# KNOWN TRIGGER GAP: this suite is armed by .circleci/tests/.* (config.yml:59-62),
-# not by voip-kamailio-proxy/.*, so editing the compose file alone does not
-# re-run it. Accepted: the highest-value property (the __IMAGE_TAG__
-# placeholder) is independently enforced at deploy time by
-# render-image-tag.sh, which exits 1 when the placeholder is missing.
+# KNOWN TRIGGER GAP: shell-tests is armed only by .circleci/scripts/.*,
+# .circleci/tests/.*, docs/reference/extractor.sh and docs/reference/tests/.*
+# (config.yml:59-62). Neither voip-kamailio-proxy/.* nor .circleci/config_work.yml
+# is on that list, so editing the compose file or the deploy wiring does not
+# re-run this suite; only editing a file under .circleci/tests/ does.
+#
+# Partial mitigation, and only for the compose file: the single highest-value
+# property, the __IMAGE_TAG__ placeholder, is independently enforced at deploy
+# time by render-image-tag.sh, which exits 1 when it is missing. The two
+# CI-wiring assertions at the end have no such backstop - they are a guard for
+# a reviewer to run, not a gate CI will apply on their behalf.
 
 load test_helper
 
@@ -24,6 +30,12 @@ CONFIG_WORK=".circleci/config_work.yml"
 
 setup() {
     cd "$REPO_ROOT"
+}
+
+# bats aborts a test body on the first failed assertion, so an inline
+# teardown_test_env would leak the mktemp -d whenever a test actually fails.
+teardown() {
+    teardown_test_env
 }
 
 @test "compose: file exists and declares exactly one service, kamailio-proxy" {
@@ -50,8 +62,6 @@ setup() {
     [ "$status" -eq 0 ]
     [ "$(grep -c '__IMAGE_TAG__' "$copy")" -eq 0 ]
     [ "$(grep -c ':deadbeefcafe1234' "$copy")" -eq 1 ]
-
-    teardown_test_env
 }
 
 @test "compose: restart always, two replicas, no container_name" {
@@ -64,6 +74,11 @@ setup() {
 }
 
 @test "compose: environment sets exactly the four intended variables" {
+    # Count first, so a fifth variable cannot slip in alongside the four
+    # asserted below.
+    run bash -c "awk '/^    environment:/{f=1;next} /^    [a-z]/{f=0} f' '$COMPOSE' | grep -cE '^      - [A-Z_]+='"
+    [ "$output" -eq 4 ]
+
     [ "$(grep -cE '^[[:space:]]*-[[:space:]]*RABBITMQ_ADDRESS=\[\[BIN_MANAGER__RABBITMQ_ADDRESS\]\]$' "$COMPOSE")" -eq 1 ]
     [ "$(grep -cE '^[[:space:]]*-[[:space:]]*PROMETHEUS_LISTEN_ADDRESS=:2112$' "$COMPOSE")" -eq 1 ]
     [ "$(grep -cE '^[[:space:]]*-[[:space:]]*PROMETHEUS_ENDPOINT=/metrics$' "$COMPOSE")" -eq 1 ]

--- a/bin-route-manager/docs/operations.md
+++ b/bin-route-manager/docs/operations.md
@@ -78,26 +78,29 @@ VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
   [docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md](../../docs/plans/2026-08-18-bin-manager-komodo-rollout-tier1-design.md)
   (in the monorepo root, not this service's own `docs/`).
 - **Route-manager-specific deviation:** this service runs a background
-  health-check ticker (`pkg/healthcheckhandler`) that probes every
-  configured carrier via outbound SIP OPTIONS on an interval. During
-  old/new container overlap this doubles outbound probe traffic to
-  carriers, so — unlike the other Tier 1 services — cut over **promptly**
-  once the new container is confirmed healthy at the log level; do not
-  leave both containers running for an extended soak. See the design doc's
-  cutover section for the full rationale.
+  health-check ticker (`pkg/healthcheckhandler`) that, for every configured
+  carrier, calls `voip-kamailio-proxy` over RPC on an interval; it is
+  `voip-kamailio-proxy`, not route-manager, that sends the outbound SIP
+  OPTIONS probe. During old/new container overlap this doubles the RPC
+  probe requests sent to `voip-kamailio-proxy`, so — unlike the other Tier
+  1 services — cut over **promptly** once the new container is confirmed
+  healthy at the log level; do not leave both containers running for an
+  extended soak. See the design doc's cutover section for the full
+  rationale.
 - **P23b — standing 2-replica operation:** since the fleet rollout
   (docs/plans/2026-08-28-bin-manager-two-replica-rollout-design.md), this
   service normally runs 2 replicas, guarded by a redsync cross-replica
   lock around the healthcheck cycle (`pkg/healthcheckhandler/health.go`)
-  so only one replica probes carriers per tick. The lock fails **open** on
-  a Redis error (proceeds unlocked rather than skipping the cycle) — this
-  is a deliberate tradeoff, since `ProviderUpdateHealthStatus` is a blind
-  UPDATE with no CAS, so a concurrent unlocked write is harmless and the
-  only cost is the same transient doubled-probe traffic already accepted
-  above for cutover overlaps. An **extended** Redis outage would make that
-  doubled probing persist for the outage's duration rather than a brief
-  window — watch for `WARN`-level "healthcheck lock" log lines during a
-  Redis incident, which is the passive signal this is happening.
+  so only one replica issues the RPC health-check calls per tick. The lock
+  fails **open** on a Redis error (proceeds unlocked rather than skipping
+  the cycle) — this is a deliberate tradeoff, since
+  `ProviderUpdateHealthStatus` is a blind UPDATE with no CAS, so a
+  concurrent unlocked write is harmless and the only cost is the same
+  transient doubled RPC-call traffic already accepted above for cutover
+  overlaps. An **extended** Redis outage would make that doubled RPC-call
+  traffic persist for the outage's duration rather than a brief window —
+  watch for `WARN`-level "healthcheck lock" log lines during a Redis
+  incident, which is the passive signal this is happening.
 
 ## Configuration
 
@@ -108,6 +111,7 @@ VOIP-1342/bin-call-manager pilot pattern) instead of the older SSH +
 | `--redis_address` | `REDIS_ADDRESS` | required | Redis cache |
 | `--redis_password` | `REDIS_PASSWORD` | `` | Redis auth password |
 | `--redis_database` | `REDIS_DATABASE` | `` | Redis DB index |
+| `--health_check_interval` | `HEALTH_CHECK_INTERVAL` | `30s` | Provider health check ticker interval |
 | `--external_sip_gateway_fqdn_for_pstn` | `EXTERNAL_SIP_GATEWAY_FQDN_FOR_PSTN` | `` | Public SIP gateway FQDN:port (e.g. `pstn.voipbin.net:5060`) registered on Telnyx as an FQDN connection for provider setup |
 | `--prometheus_endpoint` | `PROMETHEUS_ENDPOINT` | `/metrics` | Metrics path |
 | `--prometheus_listen_address` | `PROMETHEUS_LISTEN_ADDRESS` | `:2112` | Metrics listen address |

--- a/bin-route-manager/pkg/healthcheckhandler/health.go
+++ b/bin-route-manager/pkg/healthcheckhandler/health.go
@@ -146,7 +146,9 @@ func (h *healthCheckHandler) acquireLock(ctx context.Context, log *logrus.Entry)
 	return nil, false, false
 }
 
-// checkProvider sends a SIP OPTIONS probe and updates the provider's health status.
+// checkProvider asks voip-kamailio-proxy to probe the provider over RPC and
+// updates the provider's health status with the verdict. The SIP OPTIONS packet
+// itself is sent by voip-kamailio-proxy, not here.
 func (h *healthCheckHandler) checkProvider(ctx context.Context, p *provider.Provider) {
 	log := logrus.WithFields(logrus.Fields{
 		"func":        "checkProvider",

--- a/voip-kamailio-proxy/CLAUDE.md
+++ b/voip-kamailio-proxy/CLAUDE.md
@@ -13,6 +13,7 @@ The `+sub` is a filesystem heuristic in `docs/reference/service-taxonomy-gen.sh`
 - [docs/dependencies.md](docs/dependencies.md) — monorepo and external dependencies
 - [docs/operations.md](docs/operations.md) — failure modes, debugging guide, configuration, Prometheus metrics
 - [docs/subsystems.md](docs/subsystems.md) — relationship to the Kamailio daemon (none at runtime), deployment notes
+- [komodo/README.md](komodo/README.md) — how the service is deployed: stack definition, queue contract, environment variables, post-deploy verification
 
 ## Common commands
 

--- a/voip-kamailio-proxy/CLAUDE.md
+++ b/voip-kamailio-proxy/CLAUDE.md
@@ -1,6 +1,8 @@
 # voip-kamailio-proxy
 
-Service class: **A** - standalone Go RPC service. Exposes SIP OPTIONS health check endpoints over RabbitMQ.
+Service class: **A+sub** - standalone Go RPC service. Exposes SIP OPTIONS health check endpoints over RabbitMQ.
+
+The `+sub` is a filesystem heuristic in `docs/reference/service-taxonomy-gen.sh` (a `voip-*` name with a `pkg/listenhandler/`), not a fact about this service: it has no embedded native daemon and is not deployed alongside one. The label is kept so this file agrees with the generated `docs/reference/service-taxonomy.md`; reconciling the two is VOIP-1488.
 
 > Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md).
 

--- a/voip-kamailio-proxy/CLAUDE.md
+++ b/voip-kamailio-proxy/CLAUDE.md
@@ -1,6 +1,6 @@
 # voip-kamailio-proxy
 
-Service class: **A+sub** — Go RPC proxy co-located with a Kamailio SIP proxy daemon. Exposes SIP OPTIONS health check endpoints over RabbitMQ.
+Service class: **A** - standalone Go RPC service. Exposes SIP OPTIONS health check endpoints over RabbitMQ.
 
 > Cross-cutting rules (verification workflow, branch/commit format, worktree usage, Alembic, RST sync) live in the root [CLAUDE.md](../CLAUDE.md).
 
@@ -10,7 +10,7 @@ Service class: **A+sub** — Go RPC proxy co-located with a Kamailio SIP proxy d
 - [docs/domain.md](docs/domain.md) — domain entities, key business rules
 - [docs/dependencies.md](docs/dependencies.md) — monorepo and external dependencies
 - [docs/operations.md](docs/operations.md) — failure modes, debugging guide, configuration, Prometheus metrics
-- [docs/subsystems.md](docs/subsystems.md) — Kamailio daemon overview, configuration, deployment notes
+- [docs/subsystems.md](docs/subsystems.md) — relationship to the Kamailio daemon (none at runtime), deployment notes
 
 ## Common commands
 
@@ -28,7 +28,7 @@ go mod tidy && go mod vendor && go generate ./... && go test ./... && golangci-l
 ## Key implementation facts
 
 - Entry point: `cmd/kamailio-proxy/main.go`; configuration in `cmd/kamailio-proxy/init.go`
-- Instance identity: MAC address of `--interface_name` (default `eth0`); used to name the volatile queue `voip.kamailio.<mac>.request`
+- Instance identity: MAC address of `--interface_name` (default `eth0`); names a volatile queue `voip.kamailio.<mac>.request` that is declared and consumed but never addressed. The real route is the shared permanent queue `voip.kamailio.request`
 - Single RPC endpoint: `POST /v1/providers/health` — sends raw UDP SIP OPTIONS to `hostname:5060`
 - SIP OPTIONS logic: `pkg/siphandler/health.go` — always returns a `HealthCheckResult`, never a Go error
 - Any SIP response (any code) = healthy; timeout/network error = unhealthy

--- a/voip-kamailio-proxy/cmd/kamailio-proxy/main_test.go
+++ b/voip-kamailio-proxy/cmd/kamailio-proxy/main_test.go
@@ -61,3 +61,38 @@ func Test_getKamailioID(t *testing.T) {
 		})
 	}
 }
+
+// Test_defaults pins the three configuration defaults that the Komodo stack
+// definition (komodo/docker-compose.yml, VOIP-1486) relies on rather than
+// setting explicitly.
+//
+//   - defaultRabbitMQQueueListen must stay voip.kamailio.request, the only
+//     queue bin-route-manager publishes health-check RPCs to. The compose file
+//     omits RABBITMQ_QUEUE_LISTEN entirely, so a change here would silently
+//     move the service off the queue it serves.
+//   - defaultInterfaceName must stay eth0, the interface a container on the
+//     Docker production bridge actually has. The compose file omits
+//     INTERFACE_NAME; getKamailioID fails on a wrong name and main() then
+//     returns with exit code 0, leaving a container that is up but deaf.
+//   - defaultPrometheusListenAddress must stay :2112, which the Prometheus
+//     dns_sd job scrapes by port number. The earlier Ansible deployment used
+//     :9102; that value would never be scraped.
+func Test_defaults(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"rabbitmq queue listen", defaultRabbitMQQueueListen, "voip.kamailio.request"},
+		{"interface name", defaultInterfaceName, "eth0"},
+		{"prometheus listen address", defaultPrometheusListenAddress, ":2112"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("default = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/voip-kamailio-proxy/docs/architecture.md
+++ b/voip-kamailio-proxy/docs/architecture.md
@@ -1,6 +1,6 @@
 # voip-kamailio-proxy — Architecture
 
-Service class: **A** (standalone Go RPC service).
+Service class: **A+sub** by the generated taxonomy, though the `sub` is a naming heuristic: this is a standalone Go RPC service with no embedded daemon. See `CLAUDE.md`.
 
 ## Component Overview
 
@@ -24,7 +24,7 @@ Service class: **A** (standalone Go RPC service).
                                                                   (carrier)
 ```
 
-The SIP OPTIONS health check is performed by the Go service itself (not forwarded to Kamailio). Kamailio handles all actual SIP routing; the Go proxy only handles health checks and RabbitMQ routing.
+The SIP OPTIONS health check is performed by the Go service itself. It opens its own UDP socket to the carrier; no SIP proxy is involved on the way out.
 
 ## Layer Responsibilities
 

--- a/voip-kamailio-proxy/docs/architecture.md
+++ b/voip-kamailio-proxy/docs/architecture.md
@@ -1,10 +1,10 @@
 # voip-kamailio-proxy — Architecture
 
-Service class: **A+sub** (Go RPC manager + embedded Kamailio SIP proxy daemon).
+Service class: **A** (standalone Go RPC service).
 
 ## Component Overview
 
-`voip-kamailio-proxy` is a lightweight RabbitMQ-to-Kamailio bridge. It exposes a single RPC endpoint that accepts SIP provider health check requests from the platform and dispatches SIP OPTIONS packets directly over UDP — without going through Kamailio. The Go service runs co-located with a Kamailio daemon (same pod) and registers its identity on the message bus using the MAC address of its primary network interface.
+`voip-kamailio-proxy` is a lightweight RabbitMQ-to-carrier health check bridge. It exposes a single RPC endpoint that accepts SIP provider health check requests from the platform and dispatches SIP OPTIONS packets directly over UDP to the carrier, without going through Kamailio. The Go service runs as its own standalone deployment (no Kamailio co-location) and registers its identity on the message bus using the MAC address of its primary network interface.
 
 ```
                     ┌──────────────────────────────────────┐
@@ -18,13 +18,10 @@ Service class: **A+sub** (Go RPC manager + embedded Kamailio SIP proxy daemon).
                     │    processRequest()                   │
                     │    POST /v1/providers/health          │──► UDP SIP OPTIONS
                     │         │                             │    (port 5060)
-                    │         ▼                             │
-                    │    SIPChecker (siphandler pkg)        │
-                    └──────────────────────────────────────┘
-                              │
-                              ▼
-                         Kamailio SIP Proxy
-                         (co-located daemon)
+                    │         ▼                             │         │
+                    │    SIPChecker (siphandler pkg)        │         ▼
+                    └──────────────────────────────────────┘    SIP Provider
+                                                                  (carrier)
 ```
 
 The SIP OPTIONS health check is performed by the Go service itself (not forwarded to Kamailio). Kamailio handles all actual SIP routing; the Go proxy only handles health checks and RabbitMQ routing.
@@ -52,7 +49,7 @@ Unmatched URIs return status 404. Pattern matching runs in `processRequest()` in
 
 | Queue type | Name format | Purpose |
 |------------|------------|---------|
-| Permanent | `voip.kamailio.request` | Shared; any proxy instance can handle the request |
-| Volatile | `voip.kamailio.<mac-address>.request` | Instance-specific; routes requests to one specific Kamailio pod |
+| Permanent | `voip.kamailio.request` | Shared; any proxy instance can handle the request. This is the only queue actually addressed by RPC callers |
+| Volatile | `voip.kamailio.<mac-address>.request` | Instance-specific; declared and consumed, but never addressed by any publisher |
 
 Both queues are consumed concurrently. The volatile queue format uses the MAC address of `--interface_name` (default `eth0`).

--- a/voip-kamailio-proxy/docs/dependencies.md
+++ b/voip-kamailio-proxy/docs/dependencies.md
@@ -55,6 +55,5 @@ The large transitive replace list is inherited from `bin-common-handler`'s own m
 | Dependency | Purpose |
 |-----------|---------|
 | RabbitMQ | Message bus for RPC request/response |
-| Kamailio daemon | Co-located SIP proxy (not communicated with by Go; shares the pod) |
 
 The service does not depend on MySQL, Redis, or any other storage system. All state is transient.

--- a/voip-kamailio-proxy/docs/domain.md
+++ b/voip-kamailio-proxy/docs/domain.md
@@ -16,8 +16,7 @@ A health check verifies that a named SIP provider is reachable and responding to
 
 Each proxy instance is uniquely identified by the MAC address of its network interface (`--interface_name`, default `eth0`). This identity drives:
 
-- The volatile RabbitMQ queue name: `voip.kamailio.<mac-address>.request`
-- Targeted routing from upstream services to a specific Kamailio pod
+- The volatile RabbitMQ queue name: `voip.kamailio.<mac-address>.request`, which is declared and consumed but never addressed by any publisher; the shared permanent queue `voip.kamailio.request` is the queue actually routed to
 
 ### SIP OPTIONS Message
 

--- a/voip-kamailio-proxy/docs/operations.md
+++ b/voip-kamailio-proxy/docs/operations.md
@@ -4,7 +4,7 @@
 
 ### RabbitMQ connection refused
 
-**Symptom:** Container keeps running, but logs repeat `Could not connect to rabbitmq. Will retry again after 1 sec` and no queue consumer is ever registered. The RabbitMQ handler retries the connection forever at 1s intervals (`bin-common-handler/pkg/rabbitmqhandler/main.go:244`); the service never exits over this.
+**Symptom:** Container keeps running, but logs repeat `Could not connect to rabbitmq. Will retry again after 1 sec` and no queue consumer is ever registered. The RabbitMQ handler retries the connection forever at 1s intervals (`bin-common-handler/pkg/rabbitmqhandler/main.go:250`); the service never exits over this.
 
 **Cause:** RabbitMQ is not reachable at `RABBITMQ_ADDRESS`.
 
@@ -35,7 +35,7 @@
 
 **Resolution:**
 1. Test manually: `nc -u <hostname> 5060` or `tcpdump -i eth0 udp port 5060`
-2. Increase timeout: `SIP_TIMEOUT=10s`
+2. Increase timeout, but keep it below the caller's RPC deadline: `SIP_TIMEOUT=8s`. bin-route-manager gives the RPC 10s (`bin-common-handler/pkg/requesthandler/main.go:152`), so a probe budget of 10s or more turns a slow provider into an RPC timeout at the caller instead of an unhealthy verdict.
 3. Verify DNS: `nslookup <hostname>` from within the container.
 
 ### Queue not being consumed

--- a/voip-kamailio-proxy/docs/operations.md
+++ b/voip-kamailio-proxy/docs/operations.md
@@ -4,13 +4,13 @@
 
 ### RabbitMQ connection refused
 
-**Symptom:** Service exits immediately after startup with a connection error.
+**Symptom:** Container keeps running, but logs repeat `Could not connect to rabbitmq. Will retry again after 1 sec` and no queue consumer is ever registered. The RabbitMQ handler retries the connection forever at 1s intervals (`bin-common-handler/pkg/rabbitmqhandler/main.go:244`); the service never exits over this.
 
 **Cause:** RabbitMQ is not reachable at `RABBITMQ_ADDRESS`.
 
 **Resolution:**
 1. Verify the address: `echo $RABBITMQ_ADDRESS`
-2. Confirm RabbitMQ is running and the AMQP port (5672) is reachable from the pod.
+2. Confirm RabbitMQ is running and the AMQP port (5672) is reachable from the container.
 3. Check for credential mismatch (default: `amqp://guest:guest@localhost:5672`).
 
 ### Interface not found / no MAC address
@@ -21,7 +21,7 @@
 
 **Resolution:**
 1. Check available interfaces: `ip link show`
-2. Confirm the pod's primary interface is `eth0` (or set `INTERFACE_NAME` appropriately).
+2. Confirm the container's primary interface is `eth0` (or set `INTERFACE_NAME` appropriately).
 3. In test environments, virtual interfaces (e.g., `lo`) have no MAC address — use a real interface.
 
 ### SIP health check always returns unhealthy
@@ -36,7 +36,7 @@
 **Resolution:**
 1. Test manually: `nc -u <hostname> 5060` or `tcpdump -i eth0 udp port 5060`
 2. Increase timeout: `SIP_TIMEOUT=10s`
-3. Verify DNS: `nslookup <hostname>` from within the pod.
+3. Verify DNS: `nslookup <hostname>` from within the container.
 
 ### Queue not being consumed
 
@@ -53,7 +53,8 @@
 ### View live logs
 
 ```bash
-kubectl logs -f <pod-name> -c kamailio-proxy
+docker ps --filter name=kamailio-proxy
+docker logs -f <container-name>
 ```
 
 The service logs at DEBUG level by default (joonix/fluentd JSON format).
@@ -83,7 +84,7 @@ Using `rabbitmqadmin` or any AMQP client, publish to `voip.kamailio.request`:
 ### Check Prometheus metrics
 
 ```bash
-curl http://<pod-ip>:2112/metrics
+curl http://<container-ip>:2112/metrics
 ```
 
 Default endpoint: `:2112/metrics`.

--- a/voip-kamailio-proxy/docs/operations.md
+++ b/voip-kamailio-proxy/docs/operations.md
@@ -34,9 +34,15 @@
 - SIP_TIMEOUT too short; the provider responds slowly.
 
 **Resolution:**
-1. Test manually: `nc -u <hostname> 5060` or `tcpdump -i eth0 udp port 5060`
+1. Test manually from somewhere that has tooling. The service image is
+   `gcr.io/distroless/static-debian12` (`Dockerfile:12`): no shell, no `nc`, no
+   `nslookup`, so `docker exec` into it is not an option. Use a throwaway
+   container on the same network instead:
+   `docker run --rm --network production nicolaka/netshoot nc -u <hostname> 5060`
+   Or capture on the host: `tcpdump -i any udp port 5060`
 2. Increase timeout, but keep it below the caller's RPC deadline: `SIP_TIMEOUT=8s`. bin-route-manager gives the RPC 10s (`bin-common-handler/pkg/requesthandler/main.go:152`), so a probe budget of 10s or more turns a slow provider into an RPC timeout at the caller instead of an unhealthy verdict.
-3. Verify DNS: `nslookup <hostname>` from within the container.
+3. Verify DNS the same way:
+   `docker run --rm --network production nicolaka/netshoot nslookup <hostname>`
 
 ### Queue not being consumed
 
@@ -62,8 +68,12 @@ The service logs at DEBUG level by default (joonix/fluentd JSON format).
 ### Check which queues are active
 
 ```bash
-rabbitmqctl list_queues name messages consumers | grep kamailio
+docker exec infra-rabbitmq rabbitmqctl list_queues name messages consumers \
+  | grep kamailio
 ```
+
+`rabbitmqctl` is not installed on the host; the broker runs in the
+`infra-rabbitmq` container.
 
 Look for:
 - `voip.kamailio.request` — permanent queue

--- a/voip-kamailio-proxy/docs/plans/2026-09-07-kamailio-proxy-komodo-stack-design.md
+++ b/voip-kamailio-proxy/docs/plans/2026-09-07-kamailio-proxy-komodo-stack-design.md
@@ -1,0 +1,522 @@
+# Deploy voip-kamailio-proxy as a standalone Komodo stack — Design
+
+Date: 2026-09-07 (v6 — design review rounds 1-5 applied, approved)
+Jira: VOIP-1486
+Branch: `VOIP-1486-Deploy-kamailio-proxy-komodo-stack`
+Repos touched: `voipbin/monorepo` (this), `voipbin/monorepo-etc` (`infra-prometheus`)
+
+## Problem (issue analysis)
+
+`bin-route-manager` runs an unconditional health-check ticker every 30 s
+(`cmd/route-manager/main.go:152-153`, `internal/config/config.go:47`) that RPCs
+`voip.kamailio.request` for every active provider. **Nothing consumes that queue.**
+`voip-kamailio-proxy` ran on the GCP VM fleet via Ansible
+(`monorepo-voip/voip-kamailio-ansible/…/docker-compose.yml:84-102`, PRs #78/#79/#80) but was
+never ported to Komodo when that fleet was cut over to bm-nyc-01 on 2026-08-13.
+
+Live on bm-nyc-01 (2026-09-07): no proxy container, no `voip.kamailio.request` queue, both
+route-manager replicas logging `circuit breaker … half-open -> open` and
+`context deadline exceeded` every 30 s, and `route_providers.health_checked_at` frozen at
+2026-08-12 for both active providers (26 days). Calls are unaffected —
+`bin-route-manager/pkg/routehandler/` never reads `health_status` — but the field ships to
+customers over REST (`openapi.yaml:6761`) and provider webhooks
+(`models/provider/webhook.go:30-31`), so it is publishing a 26-day-old claim.
+
+The full analysis (9 revisions, 8 review rounds, two consecutive approvals) is the source for
+every constraint below.
+
+## Decision
+
+**A standalone Komodo stack on the `production` network, deployed from monorepo** — not a
+sidecar on the Kamailio stack.
+
+The sidecar model existed for one reason: the SIP OPTIONS probe's source IP should match the
+SIP proxy's so carrier ACLs would not drop it. Measured on bm-nyc-01, that premise fails twice:
+
+1. **Host networking would not deliver it anyway.** Kamailio's SIP public IP is
+   `199.127.61.42` (the `kamailio-ext` veth); the host's default egress is `104.243.38.39`
+   (`enp7s0`). `SendOptionsCheck` dials with a nil local address
+   (`pkg/siphandler/health.go:40`), so the kernel picks the route's source — never Kamailio's.
+2. **The carrier does not filter on it.** Probing `sip.telnyx.com` bound to `104.243.38.39`,
+   `199.127.61.42`, `172.24.0.246`, and from **inside a `production`-network container**
+   (`172.24.128.85`) all returned `SIP/2.0 200 Keepalive P20` in ~40 ms. Our Telnyx
+   integration authenticates by FQDN connection with credentials, not source IP
+   (`bin-route-manager/pkg/telnyxclient/main.go:31-46`).
+
+Dropping host networking removes the constraints that made a sidecar expensive:
+
+| | Sidecar (rejected) | **Standalone stack (chosen)** |
+|---|---|---|
+| SIP interruption | Certain — the kamailio deploy job rewrites that service's image tag every commit (`monorepo-voip/.circleci/config_work.yml:1057`), so `up -d` recreates it | **None.** The Kamailio stack is untouched |
+| Image reference | Manual digest pin. `IMAGE_TAG_PLACEHOLDER` is rejected by the deploy guard (`:1059-1062`, regression-pinned at `voip-kamailio-docker/tests/komodo-config.bats:556-585`) because its sed only matches `voipbin/voip-kamailio:` | `__IMAGE_TAG__` + `render-image-tag.sh`; `$CIRCLE_SHA1` is meaningful because the image is built in this repo |
+| Stale image | Last deployed tag `bac8645d` is 7 commits behind HEAD, spanning the distroless migration (`ac066fd2c`) and the toolchain upgrade (`e15975e58`) | Pipeline builds and deploys the current commit |
+| Existing tests | `komodo-config.bats`'s position-dependent `sed` ranges (`:84`, `:599`, `:611`, `:618`, `:625`) would need rework | Untouched |
+| RabbitMQ | Host netns has no Docker DNS → `127.0.0.1:5672` | `[[BIN_MANAGER__RABBITMQ_ADDRESS]]`, same as 34 peers |
+| Metrics | Docker SD cannot compute an address for a host-network container | Standard dns_sd path |
+
+The cost accepted: the probe's source IP is now a container address SNAT'd to
+`104.243.38.39`, permanently different from Kamailio's `199.127.61.42`. With the only active
+real carrier authenticating by FQDN this is free today; see "Known limitation".
+
+## Change 1 — `monorepo/voip-kamailio-proxy` (this repo)
+
+### `komodo/docker-compose.yml` (new)
+
+Modelled on `bin-route-manager/komodo/docker-compose.yml`, which is the pattern 33 services
+already use.
+
+```yaml
+services:
+  kamailio-proxy:
+    image: voipbin/voip-kamailio-proxy:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: always
+    deploy:
+      replicas: 2
+    environment:
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - SIP_TIMEOUT=5s
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true
+```
+
+Decisions this file encodes, each load-bearing:
+
+- **Service key `kamailio-proxy`.** It is the container's DNS name on the `production`
+  network and therefore the scrape target name. Not `-manager`-suffixed, which is why the
+  Prometheus choice below must be (b) — see Change 2.
+- **`RABBITMQ_QUEUE_LISTEN` deliberately omitted.** The binary defaults to
+  `QueueNameKamailioRequest` = `voip.kamailio.request` (`cmd/kamailio-proxy/init.go:20`),
+  which is the only queue route-manager publishes to. Setting it explicitly adds a way to get
+  it wrong.
+- **`INTERFACE_NAME` deliberately omitted.** The default is `eth0` (`init.go:22`), and a
+  `production`-network container has exactly `lo` and `eth0`, with a MAC (verified with
+  `docker run --network production busybox ip -o link show`). The Ansible value `ens4` was a
+  GCP artifact; `enp7s0` would have been needed only under host networking.
+- **`restart: always`**, matching all 38 bin-*-manager service blocks. This matters more than
+  it looks: a failed `getKamailioID` returns from `main()` with **exit code 0**
+  (`main.go:34-38`), so `on-failure` would never restart it.
+- **`replicas: 2`**, matching 31 of 33 peers, and run through the repo's own eligibility gate
+  (`docs/workflows/manager-replica-scaling.md:14-37`) rather than assumed:
+  1. *No per-pod queue* — this service **does** declare one (`main.go:41`,
+     `voip.kamailio.<mac>.request`), which item 1 flags as disqualifying. **Exempt, verified**:
+     the only publisher path is `bin-common-handler/pkg/requesthandler/send_request.go:343-344`
+     → `QueueNameKamailioRequest`, and a repo-wide grep finds nothing publishing to a per-MAC
+     kamailio queue. The volatile queue is declared and consumed but never addressed, and it is
+     `autoDelete` with `x-expires: 1800000` (`rabbitmqhandler/queue.go:70-78`), so redeploys
+     leave no orphans. This exemption goes in the compose comment, not just here.
+  2. *No container-name-dependent env/DNS* — none; nothing resolves its own container name.
+  3-6. *External naming / ordering / state / singleton work* — the permanent queue is a
+     competing consumer (RPC replies go to the caller's reply-to, not a shared queue), the
+     service holds no state between checks (`docs/domain.md`: "Health checks are stateless"),
+     and the once-per-cycle guarantee lives in route-manager's redsync lock, not here.
+- **`PROMETHEUS_LISTEN_ADDRESS=:2112`**, the binary default, stated explicitly because the
+  Ansible precedent's `:9102` would never be scraped by a `port: 2112` dns_sd job.
+- **The env rule, stated plainly** (it is not "always omit defaults"): the Prometheus pair is
+  written out to match all 33 bin-*-manager peers; `SIP_TIMEOUT` is carried forward from the
+  Ansible precedent so the probe budget is visible next to the RPC's 10 s timeout;
+  `RABBITMQ_QUEUE_LISTEN` and `INTERFACE_NAME` are omitted because writing them is the only
+  way to get them wrong, and both defaults are pinned by a Go test (see Tests).
+- **No `container_name`** (Compose rejects it with `replicas > 1`) and **no resource limits**
+  (all 38 bin-*-manager blocks omit them; `mem_limit`/`cpus` is a monorepo-voip convention).
+- **No `command:`**, unlike 37 of the 38 peer service blocks (e.g.
+  `bin-route-manager/komodo/docker-compose.yml:38`; the one exception is
+  `bin-sentinel-manager`'s third-party `sentinel-docker-socket-proxy`): this image sets
+  `ENTRYPOINT ["/app/bin/kamailio-proxy"]` (`Dockerfile:17`), so the binary already runs.
+- **No `cap_add: NET_RAW`.** The Ansible definition had it, but `SendOptionsCheck` uses an
+  ordinary `net.DialUDP` socket.
+- **No `depends_on`.** Cross-project references are impossible, and the RabbitMQ handler
+  retries connection forever at 1 s intervals (`rabbitmqhandler/main.go:244`), which absorbs
+  any ordering concern.
+
+### `.circleci/config_work.yml`
+
+Add a deploy job mirroring `bin-route-manager-deploy` (`config_work.yml:1708-1721`, workflow entry `:610-613`; `:1038-1051` is the byte-identical `bin-campaign-manager-deploy`):
+
+```yaml
+  voip-kamailio-proxy-deploy:
+    docker:
+      - image: cimg/base:2024.02
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Render image tag into Komodo compose fragment
+          command: .circleci/scripts/render-image-tag.sh voip-kamailio-proxy/komodo/docker-compose.yml "$CIRCLE_SHA1"
+      - run:
+          name: Deploy voip-kamailio-proxy via Komodo API
+          command: |
+            CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
+              .circleci/scripts/komodo-api-deploy.sh voip-kamailio-proxy voip-kamailio-proxy/komodo/docker-compose.yml
+```
+
+and extend the workflow (`:834-846`) so `-deploy` requires `-build`, **with
+`<<: *context_production`** on the deploy entry — without it the Komodo credentials are not
+injected. The path filter already exists (`.circleci/config.yml:56`), so adding files under
+`voip-kamailio-proxy/` triggers the pipeline. Komodo stack name = `voip-kamailio-proxy`;
+`komodo-api-deploy.sh` creates the stack if it does not exist. This is monorepo's first
+`voip-*` Komodo deploy target.
+
+### Tests — `.circleci/tests/voip-kamailio-proxy-komodo.bats` (new)
+
+The `shell-tests` job globs `.circleci/tests/*.bats` (`config_work.yml:2183`), so a new file is
+picked up automatically and no existing suite enumerates services.
+
+**Known trigger gap**: `shell-tests` is armed by `.circleci/tests/.*` (`config.yml:59-62`), not
+by `voip-kamailio-proxy/.*` (`:56`), so a later edit to the compose file alone would not re-run
+this suite. This would also be the first suite in that directory to assert on files outside
+`.circleci/` (the three existing ones are script-unit suites). Accepted rather than solved: the
+single highest-value assertion — the `__IMAGE_TAG__` placeholder being present — is
+independently enforced at deploy time by `render-image-tag.sh:64-67`, which `exit 1`s when it is
+missing.
+
+**No PyYAML.** That job installs only `bats` and `mawk` on `cimg/base:2024.02`
+(`config_work.yml:2176-2180`), no existing suite under `.circleci/tests/` imports `yaml`, and
+the sibling repo has already taken a CI failure from exactly this assumption
+(`monorepo-etc/.circleci/config_work.yml:643-658`: "ubuntu-2204:current has no PyYAML
+preinstalled, unlike every local dev machine this branch was reviewed on"). Assertions are
+therefore `grep`/`awk` only. Where an assertion needs structure (the workflow entry's context),
+pin the literal lines instead of parsing YAML.
+
+Assertions:
+
+1. the compose declares the service key `kamailio-proxy` (`grep -c '^  kamailio-proxy:' == 1`)
+   and no second top-level service key (`grep -c '^  [a-z].*:$'` under `services:` == 1, via an
+   `awk` range from `^services:` to `^networks:`). YAML validity is not asserted here — the
+   deploy job's own `render-image-tag.sh` + Komodo push is what would reject a malformed file,
+   and asserting it would need a parser this job has no dependency for.
+2. image is `voipbin/voip-kamailio-proxy:__IMAGE_TAG__` (placeholder present, no literal tag).
+3. `render-image-tag.sh` on a temp copy substitutes it and leaves no `__IMAGE_TAG__`.
+4. `restart: always`; `deploy.replicas == 2`; no `container_name`.
+5. env: `RABBITMQ_ADDRESS` is exactly `[[BIN_MANAGER__RABBITMQ_ADDRESS]]`;
+   `PROMETHEUS_LISTEN_ADDRESS` is `:2112`; `SIP_TIMEOUT` present; **`RABBITMQ_QUEUE_LISTEN` and
+   `INTERFACE_NAME` are absent as env entries**. The absence assertion must anchor on the env
+   form — `grep -cE '^\s*-\s*RABBITMQ_QUEUE_LISTEN=' == 0` — **not** a bare name grep, because
+   the compose comments deliberately mention both names to explain the omission — write those
+   comments, the same way the replica exemption is required to be commented. A bare grep would fail against the file this design
+   specifies.
+6. no `cap_add`, no `depends_on`, no `mem_limit`/`cpus` — anchored on the key form
+   (`^\s*cap_add:`, `^\s*depends_on:`, `^\s*mem_limit:`, `^\s*cpus:`), not bare names, for the
+   same reason as assertion 5: the compose comments will mention these keys while explaining
+   why they are absent.
+7. network is external `production`.
+8. `config_work.yml`: `voip-kamailio-proxy-deploy` exists as a job key, its command lines
+   reference `render-image-tag.sh` and `komodo-api-deploy.sh` with the stack name
+   `voip-kamailio-proxy`, and **its workflow entry carries the context**. Assert the literal the
+   design actually writes — `<<: *context_production` — not `context: [production]`: every entry
+   in this file uses the merge-key alias (`config_work.yml:3-5` defines the anchor, `:610-613`
+   is bin-route-manager's deploy entry), and resolving the alias needs a YAML parser this job
+   does not have. Pin the alias line plus the dependency by extracting the workflow entry's
+   line range with `awk` and asserting **two lines**: `requires:` followed by
+   `^ *- voip-kamailio-proxy-build$`. `requires:` is a **block sequence** everywhere in this
+   file — `grep -c 'requires: \['` over `.circleci/` returns 0 — so a flow-sequence literal
+   like `requires: [voip-kamailio-proxy-build]` would fail against a correct implementation,
+   the same trap as `context: [production]` above.
+
+**A Go test pins the other half of the omission contract.** Asserting only that the compose
+file lacks `RABBITMQ_QUEUE_LISTEN`/`INTERFACE_NAME` pins the decision, not the thing it rests
+on: if someone edits `init.go:20` or `:22`, the compose stays "correct" while the service
+listens on the wrong queue or fails `getKamailioID` with exit 0. Add to
+`cmd/kamailio-proxy/main_test.go`:
+
+```go
+// The Komodo compose deliberately omits RABBITMQ_QUEUE_LISTEN, INTERFACE_NAME
+// and relies on PROMETHEUS_LISTEN_ADDRESS's default matching the dns_sd port.
+// See voip-kamailio-proxy/komodo/docker-compose.yml and
+// monorepo-etc infra-prometheus's kamailio-proxy job.
+defaultRabbitMQQueueListen == "voip.kamailio.request"  // the literal, not the const
+defaultInterfaceName        == "eth0"
+defaultPrometheusListenAddress == ":2112"
+```
+
+### Docs
+
+- `komodo/README.md` (new): what the stack is, the queue contract, why
+  `RABBITMQ_QUEUE_LISTEN`/`INTERFACE_NAME` are omitted, the deploy path, the verification
+  commands from §Rollout, and the known limitation.
+- Correct the co-location claims this change invalidates: `CLAUDE.md:3`
+  ("co-located with a Kamailio SIP proxy daemon"), `docs/architecture.md` ("same pod"),
+  `docs/subsystems.md` ("Sidecar pattern … the pod's network namespace is shared"),
+  `docs/dependencies.md:58` ("Co-located SIP proxy … shares the pod").
+- `docs/operations.md` is the on-call doc for a service that is now a Docker/Komodo stack and
+  is wrong throughout, not only at line 7: `:7` (claims the service exits immediately when
+  RabbitMQ is unreachable; it retries forever), `:13` "reachable from the pod", `:24` "the
+  pod's primary interface", `:39` "from within the pod", `:56`
+  `kubectl logs -f <pod-name> -c kamailio-proxy` (the actual command is `docker logs`), `:86`
+  `<pod-ip>`. Fix all of them in this pass. (`docs/domain.md:38`'s "exits immediately" refers
+  to the interface-lookup path and is correct — leave it.)
+- `CLAUDE.md`'s "Instance identity: MAC address of `--interface_name` … used to name the
+  volatile queue" is now semantically empty (a random container MAC, no Kamailio to identify).
+  Reword alongside line 3.
+- The same vacated claim appears in three more files and must go with them:
+  `docs/domain.md:20` ("routing … to a specific Kamailio pod"), `docs/architecture.md:7`
+  ("same pod") and `:56` ("routes requests to one specific Kamailio pod"),
+  `docs/subsystems.md:3` ("the same container or pod"), `:63-66` (the whole "Sidecar pattern"
+  / shared-namespace passage), `:70` ("targeted routing … to a specific pod") and `:74-76` (the
+  "Startup order" passage, which assumes Kamailio is listening on the proxy's own `:5060`). Note
+  `docs/subsystems.md:80`'s egress warning stays — it is still true and the issue analysis
+  used it — but "proxy pod" becomes "proxy container".
+- **`docs/architecture.md:26-27`**, the ASCII diagram, terminates the proxy's arrow at
+  "Kamailio SIP Proxy / (co-located daemon)". This is the most misleading surviving instance —
+  it already contradicts `:30` ("not forwarded to Kamailio") — and must be redrawn so the
+  probe arrow goes to the SIP provider, not to Kamailio.
+- `bin-route-manager/docs/operations.md` describes the health check as route-manager probing
+  carriers directly — i.e. a topology in which this outage is impossible. The wrong mechanism
+  recurs past the first mention and the follow-on text gives operational instructions derived
+  from it, so fix the block as a whole: `:81-82` (the mechanism), `:83-84` ("this doubles
+  outbound probe traffic to carriers, so … cut over promptly"), and `:88-100` (the P23b
+  paragraph's "only one replica probes carriers per tick" / "doubled probing"). The redsync
+  lock and its fail-open tradeoff are still real; what changes is that the probe is issued by
+  `voip-kamailio-proxy` over RPC, so the doubling is of RPC requests, not of direct SIP
+  traffic from route-manager. Also add `health_check_interval` to its Configuration table.
+
+## Change 2 — `monorepo-etc/infra-prometheus`
+
+**A dedicated `kamailio-proxy` scrape job, not membership in `voipbin-managers`.**
+
+Joining `voipbin-managers` is the tempting option because it inherits `ManagerServiceGone`'s
+zero-target coverage. It is rejected because `infra-prometheus/tests/config.bats:399-420`
+asserts the `ManagerServiceGone` literal set equals the dns_sd `names:` set, extracting with
+`r'"service",\s*"([a-z0-9-]+-manager)"'` (`:415`, asserted at `:417`) — and that test runs in
+CI (`monorepo-etc/.circleci/config_work.yml:663`). Adding `kamailio-proxy` puts it in
+`configured` but not `alerted`, so **infra-prometheus CI goes red**. Making it fit would mean
+either renaming the service to end in `-manager` (wrong for a `voip-*` service, and that name
+becomes the container and DNS name) or changing a regex 32 services share. The dedicated job
+avoids all five sync points at the cost of one guard alert.
+
+```yaml
+  - job_name: kamailio-proxy
+    metrics_path: /metrics
+    dns_sd_configs:
+      - names: [kamailio-proxy]
+        type: A
+        port: 2112
+    relabel_configs:
+      - source_labels: [__meta_dns_name]
+        regex: (.+)
+        target_label: service
+        action: replace
+```
+
+dns_sd, not `static_configs`: with `replicas: 2` a single fixed hostname resolves to whichever
+replica DNS round-robin picks per scrape (`prometheus.yml:297-305` records exactly this
+reasoning). The `service` relabel mirrors `:374-378` so `InstanceDown`'s
+`{{ $labels.service }}` renders.
+
+`alert-rules.yml` gains a zero-target guard shaped like `AsteriskTargetsMissing`
+(`:223-224`), since `InstanceDown` cannot fire for a target discovery never produced:
+
+```yaml
+      # zero-target guard: InstanceDown cannot fire for a target discovery
+      # never produced. SYNC POINTS for the literal 2 below: deploy.replicas
+      # in monorepo/voip-kamailio-proxy/komodo/docker-compose.yml, the
+      # ReplicaDegraded variant, alert-rules_test.yml, tests/config.bats.
+      - alert: KamailioProxyTargetsMissing
+        expr: (count(up{job="kamailio-proxy"}) or vector(0)) < 1
+        for: 10m
+        labels:
+          severity: critical
+
+      # 1-of-2 only. NO `or vector(0)` - deliberately, mirroring
+      # ReplicaDegraded (alert-rules.yml:183-188). At zero targets the count
+      # series disappears and this rule cannot fire; that boundary belongs to
+      # the zero-target guard above (alert-rules.yml:155-161 states the same
+      # three-way split for the manager fleet). Adding `or vector(0)` here would put
+      # this rule and the zero-target guard on the same state, which is the
+      # ownership split the fleet comment above forbids. (It would NOT make
+      # the guard fire during a redeploy - that rule's `for: 10m` absorbs a
+      # rollout, exactly as its AsteriskTargetsMissing model states at
+      # alert-rules.yml:221-222.)
+      # `for: 0s` matches the fleet's 2026-08-29 decision: a redeploy is
+      # EXPECTED to produce this warning; that is how you know the replica
+      # was actually recreated.
+      - alert: KamailioProxyReplicaDegraded
+        expr: count(up{job="kamailio-proxy"}) < 2
+        for: 0s
+        labels:
+          severity: warning
+```
+
+**The alert that actually detects this ticket's outage is a third one, and it is nearly free.**
+Neither rule above can catch the failure mode that produced this ticket: `initProm` runs in
+`init()` before `main()`, so `/metrics` answers — and `up == 1` — even when `listenRun` died
+silently and no consumer exists (`pkg/listenhandler/main.go:58-68`). The signal that
+distinguishes "running" from "actually consuming" is already scraped: the `rabbitmq` job
+(`prometheus.yml:96-98`, kbudde exporter with `RABBIT_EXPORTERS=exchange,node,queue`, no
+`metric_relabel_configs`) exposes `rabbitmq_queue_consumers` — 91 series live on bm-nyc-01
+today, e.g. `asterisk.call.request = 2`.
+
+```yaml
+      # THE detector for this ticket's failure mode, and it belongs in the
+      # `rabbitmq` group (not instance-health) because it is sourced from
+      # rabbitmq_* series, like its neighbour RabbitMQNoConsumers.
+      # `< 1`, not `< 2`: one consumer is a fully working health-check
+      # pipeline (the permanent queue is competing-consumer, and ConsumeRPC
+      # registers exactly one AMQP consumer per replica -
+      # bin-common-handler/pkg/rabbitmqhandler/consume.go:48-68), so 1-of-2
+      # is redundancy loss and belongs to KamailioProxyReplicaDegraded.
+      # `or vector(0)` is required here and means something different from
+      # the target rules: it covers the queue not existing at all, which is
+      # exactly what the 26-day outage looked like.
+      # `and on() (up{job="rabbitmq"} == 1)` keeps a broker/exporter outage
+      # from being reported as a proxy fault; RabbitMQDown covers that case.
+      # `on()` is MANDATORY here, not stylistic: the left side is label-free
+      # (max()/vector(0)) and the right side is labelled, so a bare `and`
+      # (as at alert-rules.yml:254, where both sides share labels) would
+      # never match and the alert would be permanently silent.
+      - alert: KamailioProxyHealthCheckStalled
+        expr: |
+          ((max(rabbitmq_queue_consumers{queue="voip.kamailio.request"}) or vector(0)) < 1)
+          and on() (up{job="rabbitmq"} == 1)
+        for: 10m
+        labels:
+          severity: critical
+```
+
+**Overlap with the existing `RabbitMQNoConsumers`** (`alert-rules.yml:499-510`,
+`rabbitmq_queue_messages_ready > 0 and rabbitmq_queue_consumers == 0`, unlabelled so it already
+applies to this queue): that rule would catch a dead consumer on an **existing** queue that has
+**pending messages**. It missed this outage on both counts — the queue never existed, and RPC
+publishes to a nonexistent queue leave nothing ready. The new rule covers the queue-absent case
+and the idle case (`messages_ready == 0` between 30 s cycles). Post-deploy, a dead proxy with
+pending RPCs fires both; that is acceptable duplication for a critical path, and the new rule's
+summary must be specific enough to tell them apart.
+
+**Annotations for all three are label-free.** `count(...)` and `max(...)` strip every label, so
+no `{{ $labels.* }}` renders — `alert-rules_test.yml:842` pins exactly that empty-string outcome
+for a neighbouring rule. Do not copy a `{{ $labels.service }}` line from an adjacent rule — it
+would render empty. `{{ $value }}` is unaffected by label stripping and **is** available: the
+model rule uses it (`alert-rules.yml:229`, "only {{ $value }} of 6 targets discovered"), and it
+is the only dynamic context these rules can carry (0-of-2 vs 1-of-2), so use it in `summary`.
+The CI assertion bans templates in the **runbook** only (`tests/config.bats:622`,
+`assert '{{' not in ann['runbook']`), not in `summary`/`impact`.
+
+All three rules carry the three-annotation schema (`alert-rules.yml:53`) with no Go templates in
+the runbook.
+
+**`InstanceDown`'s runbook is deliberately NOT touched.** Adding a `kamailio-proxy` step there
+would break monorepo-etc CI in four pinned places — `tests/config.bats:273-286` asserts
+literally `'5. kamailio job:' in rb`, `'6. Logs:' in rb` and `'5. Logs:' not in rb`, and
+`alert-rules_test.yml:842,864` pin the entire rendered runbook verbatim for the kamailio-job
+and asterisk-job cases — which is the exact failure class used above to reject option (a). It
+is also unnecessary: the runbook's existing **step 2** (`docker ps --filter name={{ $labels.job }}`)
+works for this target, because the job name, the compose service key and the container-name
+substring are all `kamailio-proxy`. (Step 3 does *not* cover it — it is textually scoped to the
+`voipbin-managers` job and routes the reader to bin-*-manager projects. The residual gap is that
+no step names this service explicitly.) The triage detail specific to this service lives
+in `komodo/README.md` and in the new alert's own runbook.
+
+Two prose registries enumerate the covered alerts and must be updated alongside the new cases,
+though neither is CI-asserted: `alert-rules_test.yml:6-9` and the step comment in
+`monorepo-etc/.circleci/config_work.yml:578-584`.
+
+Tests, following the `AsteriskTargetsMissing` precedent: promtool cases in
+`alert-rules_test.yml` covering (1) zero targets → `KamailioProxyTargetsMissing` fires,
+(2) zero targets → `KamailioProxyReplicaDegraded` **silent** (this is what pins the missing
+`or vector(0)`, and it is the case the fleet's own comment says belongs to the other rule),
+(3) both up → both silent, (4) both down (`up == 0`, two series) → both silent, that is
+`InstanceDown`'s job, (5) one of two → `KamailioProxyReplicaDegraded` fires and
+`KamailioProxyTargetsMissing` silent, (6) `rabbitmq_queue_consumers` absent with
+`up{job="rabbitmq"} == 1` → `KamailioProxyHealthCheckStalled` fires, (7) same but
+`up{job="rabbitmq"} == 0` → silent (pins the exporter-outage guard), (8) consumers == 1 **with
+`up{job="rabbitmq"} == 1` present in the input series** → silent. That series is what makes the
+case discriminating: without it the `and on()` guard silences the rule regardless of threshold,
+so a `< 2` mutation would pass.
+
+Each case carries explicit `eval_time`s, and the two `for:` values are pinned behaviourally the
+way this file already does it (`alert-rules_test.yml:739-746`: "The 9m probe … pins `for: 10m`
+behaviourally for this rule too (a `for: 5m` or `for: 0m` mutation would fire here)"): for the
+two `for: 10m` rules, a 9m probe asserting still-pending plus a 12m probe asserting fired; for
+`KamailioProxyReplicaDegraded`'s `for: 0s`, a probe at the first evaluation asserting it has
+already fired (a `for: 10m` mutation would be silent there). Cases (1) and (2) also need the
+filler-series trick the zero-target precedent uses (`alert-rules_test.yml:782-787`: "The
+unrelated asterisk-proxy series is present only so the test has some input"), since a case with
+no input series at all evaluates nothing.
+
+Alongside those promtool cases, `tests/config.bats` gets assertions for the job shape (dns_sd
+not static_configs, port 2112, the `service` relabel) and for each new alert's three-annotation
+shape.
+
+Naming and placement: `alert-rules.yml:306` already has `KamailioTargetMissing` for the SIP
+proxy's own xhttp_prom target (VOIP-1474), so the three new rules must lead their
+`summary`/`impact` with "provider health-check RPC worker", never a bare "Kamailio", and the two
+`up`-based rules go in the `instance-health` group (the precedent tests assert
+`grp['instance-health']`) and the `rabbitmq_queue_consumers` rule goes in the **`rabbitmq`**
+group (`alert-rules.yml:459`), next to `RabbitMQNoConsumers`, because the file segregates rules
+by metric source.
+
+While editing `prometheus.yml`, add the missing `dns_sd_configs` bullet to the header's target-style list
+(`:5-29` enumerates the other styles but not this one; `config.bats:314-326` only pins the
+docker_sd bullet, so this edit is free).
+
+Docs: add the dashboard-free service to `docker-compose_monitoring/README.md`'s job list and
+record in `docs/follow-ups.md` that this target's only signal is liveness — the service
+registers no custom metrics (`promhttp.Handler()` only, `docs/operations.md:108,110`), and
+the health check's real health is observable from `route_providers.health_checked_at`.
+
+## Known limitation
+
+The probe's source IP is now permanently different from Kamailio's SIP IP. Today every active
+carrier authenticates by FQDN, so this costs nothing. If a source-IP-ACL carrier is ever
+added, calls would work while its health check reported `unhealthy`. Routing does not consult
+`health_status`, so this is a reporting defect, not an outage. Record it in
+`komodo/README.md`; the fix would be an egress rule or a carrier-side ACL entry for
+`104.243.38.39`.
+
+## Rollout
+
+No SIP interruption: the Kamailio stack is not touched.
+
+1. Merge Change 1, then click `build-approval` **on the `voip-kamailio-proxy` workflow**.
+   **Order matters in both directions**: merging alone does not deploy, and approving on an
+   unmerged branch runs test → build → deploy straight to production with no further gate.
+   **There will be more than one approval button.** Change 1 edits
+   `bin-route-manager/docs/operations.md`, which matches `bin-route-manager/.*`
+   (`.circleci/config.yml:41`) and arms that service's workflow — whose approval performs a
+   live Komodo redeploy of both route-manager replicas. Leave it untouched. (If that risk is
+   judged not worth carrying, the alternative is to drop the route-manager doc fix from this PR
+   and land it separately; the design keeps it here so the on-call doc stops describing a
+   topology in which this outage is impossible.)
+2. Verify on bm-nyc-01 — **not by whether the container is running**. `listenhandler.Run()`
+   spawns a goroutine and returns `nil` unconditionally (`pkg/listenhandler/main.go:58-68`),
+   so a failed `QueueCreate`/`ConsumeRPC` leaves the container `Up` with no consumer, which
+   looks exactly like today's outage. Also note the CI gate cannot prove 2-of-2:
+   `check_stack_running` reads `.container.state` per compose service, not per container
+   (`docs/workflows/manager-replica-scaling.md:106-123`), so a green deploy proves at most
+   1-of-2. Required checks:
+   - `docker ps --filter name=kamailio-proxy` → **exactly 2** running containers
+   - `docker exec infra-rabbitmq rabbitmqctl list_queues name consumers | grep voip.kamailio.request`
+     → **consumers == 2** (one `ConsumeRPC` registration per replica). `>= 1` would pass a
+     half-failed deploy
+   - route-manager logs: no `circuit breaker` or `context deadline exceeded` for that queue
+   - `route_providers.health_checked_at` advancing on a ~30 s cadence
+   - `sip.telnyx.com` → `healthy`, `pchero21.com` → `unhealthy`
+3. Merge Change 2, approve `infra-prometheus`. Then `count(up{job="kamailio-proxy"}) == 2`,
+   and all three new alerts silent.
+
+**Rollback.** This is the stack's first deploy, so there is no previous pipeline run to
+re-approve; the only rollback is stopping or deleting the stack in Komodo. Before Change 2 is
+merged, that returns the system to today's state — failing health checks and a stale
+`health_status`, degraded but not an outage. **After Change 2 is merged, stopping the stack leaves two alerts firing**:
+`KamailioProxyTargetsMissing` and `KamailioProxyHealthCheckStalled`, both after 10 minutes. It
+does **not** leave `KamailioProxyReplicaDegraded` firing — at zero targets
+`count(up{job="kamailio-proxy"})` returns empty and, with no `or vector(0)`, that rule cannot
+match; it fires for at most one evaluation window during teardown and then resolves on its own.
+So a rollback at that point must revert Change 2 or silence those two.
+
+## Out of scope
+
+- Making routing consult `health_status` (a product decision).
+- Cleaning up the 8 soft-deleted dummy providers.
+- Removing the dead `voip-kamailio-ansible` proxy definition — worth doing to prevent drift,
+  but it is a different repo and a different concern; track separately if wanted.

--- a/voip-kamailio-proxy/docs/subsystems.md
+++ b/voip-kamailio-proxy/docs/subsystems.md
@@ -1,8 +1,11 @@
 # voip-kamailio-proxy — Subsystems
 
-This service is class **A**: a standalone Go service, deployed on its own and not co-located with any SIP daemon.
+This service is registered as class **A+sub**, but the `sub` is a naming heuristic: it is a standalone Go service, deployed on its own and not co-located with any SIP daemon. See `CLAUDE.md`.
 
-## Relationship to the Kamailio SIP daemon
+## Native Daemon Overview
+
+There is no native daemon in this service's deployment. The section below explains
+why the name suggests otherwise.
 
 Despite the name, this service does not start, stop, configure, or communicate
 with the Kamailio SIP daemon. It never did at runtime; it used to be deployed
@@ -18,6 +21,13 @@ whitelist and TLS transport are owned by a separate repository
 documented there. Sections describing them used to live in this file, which
 made this service look like it managed the daemon.
 
+## Configuration
+
+All configuration is environment variables, read in `cmd/kamailio-proxy/init.go`.
+The values used in production, and which defaults are deliberately left unset,
+are documented in [../komodo/README.md](../komodo/README.md); the full table with
+failure modes is in [operations.md](operations.md).
+
 ## Deployment Notes
 
 ### Container model
@@ -28,16 +38,13 @@ The Dockerfile (`voip-kamailio-proxy/Dockerfile`) builds only the Go binary. The
 
 On startup, the proxy reads the MAC address from `--interface_name` (default `eth0`) to derive a unique instance ID. This ID is used to name the volatile RabbitMQ queue `voip.kamailio.<mac>.request`, but the queue is declared and consumed without ever being addressed by any publisher; the queue that is actually addressed is the shared permanent queue `voip.kamailio.request`.
 
-Unlike `voip-asterisk-proxy`, `voip-kamailio-proxy` does **not** register its address in Redis or patch Kubernetes annotations. Identity is purely through RabbitMQ queue naming.
+Unlike `voip-asterisk-proxy`, `voip-kamailio-proxy` does **not** register its address anywhere. Identity is purely through RabbitMQ queue naming.
 
-### Network policy considerations
+### Egress
 
-Outbound UDP on port 5060 must be permitted from the proxy container to the SIP provider IPs. If network policies are restrictive, health checks will always time out, and every provider will be marked unhealthy.
-
-```yaml
-# Example: allow egress to SIP providers on UDP 5060
-egress:
-  - ports:
-      - port: 5060
-        protocol: UDP
-```
+Outbound UDP on port 5060 must reach the SIP provider IPs. The container sits on
+the `production` Docker bridge, which SNATs outbound traffic to the host's
+default egress address; there is no policy object to configure. If egress is
+blocked upstream, every health check times out and every provider is marked
+unhealthy, regardless of whether the providers are actually reachable from
+elsewhere.

--- a/voip-kamailio-proxy/docs/subsystems.md
+++ b/voip-kamailio-proxy/docs/subsystems.md
@@ -1,83 +1,38 @@
 # voip-kamailio-proxy — Subsystems
 
-This service is class **A+sub**: the Go proxy runs co-located with a Kamailio SIP proxy daemon in the same container or pod.
+This service is class **A**: a standalone Go service, deployed on its own and not co-located with any SIP daemon.
 
-## Native Daemon Overview
+## Relationship to the Kamailio SIP daemon
 
-### Kamailio SIP Proxy
+Despite the name, this service does not start, stop, configure, or communicate
+with the Kamailio SIP daemon. It never did at runtime; it used to be deployed
+onto the same hosts, and that co-location is now gone.
 
-[Kamailio](https://www.kamailio.org/) is an open-source SIP server that handles SIP routing, registration, authentication, and load balancing. In VoIPbin, each Kamailio instance acts as the SIP signaling front-door for inbound and outbound calls.
+The SIP OPTIONS health check goes straight to the carrier hostname carried in
+the RPC request, over an ordinary UDP socket. Kamailio is not in the path, so
+Kamailio's own state has no bearing on whether a health check succeeds.
 
-The Go proxy does **not** start, stop, or communicate directly with Kamailio at runtime. The two processes are co-deployed and serve complementary roles:
-
-| Component | Responsibility |
-|-----------|---------------|
-| Kamailio daemon | SIP signaling (REGISTER, INVITE, BYE, ACK), routing, authentication |
-| Go proxy | RabbitMQ bridge, SIP OPTIONS health checks on behalf of platform services |
-
-The Go proxy performs SIP OPTIONS health checks itself (raw UDP to port 5060) without routing through Kamailio. Kamailio is not involved in health check processing.
-
-### Kamailio control interfaces
-
-Kamailio exposes management interfaces that may be used by operators, though the Go proxy does not use them at runtime:
-
-| Interface | Protocol | Default | Purpose |
-|-----------|----------|---------|---------|
-| XMLRPC | HTTP | `localhost:5060` (or `/RPC`) | Remote procedure calls (reload config, list dialogs, etc.) |
-| Binrpc (`kamctl`) | TCP | `localhost:9998` | Native binary RPC used by `kamctl` CLI |
-| SIP port | UDP/TCP | `0.0.0.0:5060` | SIP signaling |
-
-## Configuration
-
-### Kamailio main configuration (`kamailio.cfg`)
-
-Kamailio is configured via its own `kamailio.cfg` file. The Go proxy does not modify or read this file. Key parameters relevant to the combined deployment:
-
-```
-# Listen on all interfaces for SIP
-listen=udp:0.0.0.0:5060
-
-# Enable XMLRPC for management (optional)
-loadmodule "xmlrpc.so"
-
-# Route to RTPEngine for media proxying (if integrated)
-loadmodule "rtpengine.so"
-```
-
-The Ansible role `voip-kamailio-ansible` manages Kamailio configuration in production.
-
-### PSTN whitelist
-
-Kamailio supports a PSTN IP whitelist via the `PSTN_WHITELIST_IPS` environment variable (injected by the Ansible deployment). Whitelisted IPs bypass SIP authentication for inbound PSTN calls.
-
-### TLS / SRTP
-
-If TLS SIP transport is required, configure `tls.cfg` and load `tls.so` in `kamailio.cfg`. The Go proxy has no TLS configuration — it uses plain UDP for OPTIONS health checks.
+The Kamailio daemon, its `kamailio.cfg`, its control interfaces, the PSTN
+whitelist and TLS transport are owned by a separate repository
+(`monorepo-voip`, `voip-kamailio-docker` and `voip-kamailio-ansible`) and are
+documented there. Sections describing them used to live in this file, which
+made this service look like it managed the daemon.
 
 ## Deployment Notes
 
 ### Container model
 
-The Dockerfile (`voip-kamailio-proxy/Dockerfile`) builds only the Go binary. Kamailio is expected to be installed in the runtime environment separately:
-
-1. **Sidecar pattern**: Kamailio runs as a separate container in the same Kubernetes pod, sharing the network namespace. The Go proxy and Kamailio both see `localhost:5060`.
-2. **Single container**: Kamailio and the proxy binary are installed in the same image.
-
-In either case, the pod's network namespace is shared so that SIP OPTIONS probes sent by the Go proxy reach Kamailio on `localhost:5060`.
+The Dockerfile (`voip-kamailio-proxy/Dockerfile`) builds only the Go binary. The service runs as its own standalone container (a Komodo stack, 2 replicas, on the `production` Docker network); no Kamailio daemon is installed in the runtime image or co-located in the same container.
 
 ### Instance identity
 
-On startup, the proxy reads the MAC address from `--interface_name` (default `eth0`) to derive a unique instance ID. This ID is used to name the volatile RabbitMQ queue `voip.kamailio.<mac>.request`, enabling targeted routing from upstream services to a specific pod.
+On startup, the proxy reads the MAC address from `--interface_name` (default `eth0`) to derive a unique instance ID. This ID is used to name the volatile RabbitMQ queue `voip.kamailio.<mac>.request`, but the queue is declared and consumed without ever being addressed by any publisher; the queue that is actually addressed is the shared permanent queue `voip.kamailio.request`.
 
 Unlike `voip-asterisk-proxy`, `voip-kamailio-proxy` does **not** register its address in Redis or patch Kubernetes annotations. Identity is purely through RabbitMQ queue naming.
 
-### Startup order
-
-Kamailio and the Go proxy start independently. If Kamailio is not ready when a health check arrives, the OPTIONS packet will be answered (or not) by whatever is listening on port 5060. The Go proxy handles this gracefully — any response is healthy, no response is unhealthy.
-
 ### Network policy considerations
 
-Outbound UDP on port 5060 must be permitted from the proxy pod to the SIP provider IPs. If network policies are restrictive, health checks will always time out even if Kamailio is running correctly.
+Outbound UDP on port 5060 must be permitted from the proxy container to the SIP provider IPs. If network policies are restrictive, health checks will always time out, and every provider will be marked unhealthy.
 
 ```yaml
 # Example: allow egress to SIP providers on UDP 5060

--- a/voip-kamailio-proxy/komodo/README.md
+++ b/voip-kamailio-proxy/komodo/README.md
@@ -1,0 +1,97 @@
+# Komodo stack: voip-kamailio-proxy
+
+Deployment definition for the provider health-check RPC worker. VOIP-1486.
+
+## What this stack runs
+
+`voip-kamailio-proxy` answers exactly one RabbitMQ RPC, `POST /v1/providers/health`,
+by sending a raw UDP SIP OPTIONS packet to the carrier named in the request and
+reporting whether anything answered. Any SIP response code counts as healthy; a
+timeout or network error counts as unhealthy.
+
+`bin-route-manager` calls it once every 30 seconds from a background ticker
+(`bin-route-manager/pkg/healthcheckhandler`) and writes the verdict to each
+provider's `health_status`. Without this stack running, that ticker's RPCs go
+unanswered and provider health stops being updated.
+
+## Why it is a standalone stack, not a sidecar
+
+The service was previously deployed by `voip-kamailio-ansible` onto the GCP
+Kamailio VMs, alongside the Kamailio SIP daemon, on the premise that the probe
+had to originate from Kamailio's own SIP source address. That premise was
+measured and does not hold: Kamailio's SIP address and the host's default egress
+address already differ, and the carrier answers OPTIONS from every source
+address tested. The probe needs egress to the carrier and nothing else, so the
+service runs on its own on the `production` bridge network.
+
+One consequence is worth stating plainly: the probe leaves from the container's
+egress address, not from the SIP proxy's public address. A carrier that
+whitelists by source IP could answer the probe while rejecting real SIP traffic,
+or the reverse.
+
+## Queue contract
+
+| Queue | Role |
+|---|---|
+| `voip.kamailio.request` | The shared RPC queue. Every replica is a competing consumer, so exactly one replica handles each request. This is the only queue anything publishes to. |
+| `voip.kamailio.<mac>.request` | Declared and consumed per replica, derived from the MAC of `eth0`. Nothing in the monorepo publishes to it. It is `autoDelete` with `x-expires` of 30 minutes, so redeploys leave no orphans. |
+
+Because the per-instance queue is never addressed, the usual bar on running
+multiple replicas of a service that declares one does not apply here. See
+`docs/workflows/manager-replica-scaling.md`.
+
+## Environment variables
+
+Set explicitly:
+
+| Variable | Value | Why |
+|---|---|---|
+| `RABBITMQ_ADDRESS` | Komodo variable | Broker address. |
+| `SIP_TIMEOUT` | `5s` | The per-probe budget. Visible next to route-manager's 10 second RPC timeout, so the relationship between the two is legible. |
+| `PROMETHEUS_ENDPOINT` | `/metrics` | Matches the bin-*-manager peers. |
+| `PROMETHEUS_LISTEN_ADDRESS` | `:2112` | The default, written out on purpose: the Ansible precedent used `:9102`, which the Prometheus scrape job would never reach. |
+
+Deliberately omitted, because their defaults are already the values needed and
+writing them out is the only way to get them wrong:
+
+| Variable | Default | Source |
+|---|---|---|
+| `RABBITMQ_QUEUE_LISTEN` | `voip.kamailio.request` | `cmd/kamailio-proxy/init.go` |
+| `INTERFACE_NAME` | `eth0` | `cmd/kamailio-proxy/init.go` |
+
+All three defaults are pinned by `Test_defaults` in
+`cmd/kamailio-proxy/main_test.go`.
+
+## Deployment
+
+CircleCI workflow `voip-kamailio-proxy`: test, then build (behind the
+`build-approval` gate), then `voip-kamailio-proxy-deploy`, which renders the
+image tag into this compose file and pushes it to Komodo as the stack
+`voip-kamailio-proxy`. Approving `build-approval` deploys to production.
+
+## Verification
+
+```bash
+bats .circleci/tests/voip-kamailio-proxy-komodo.bats
+python3 -c "import yaml; yaml.safe_load(open('voip-kamailio-proxy/komodo/docker-compose.yml'))"
+cd voip-kamailio-proxy && go test ./...
+```
+
+After deploying, on the host:
+
+```bash
+docker ps --filter name=kamailio-proxy          # expect 2 containers
+rabbitmqctl list_queues name consumers | grep voip.kamailio.request   # expect 2
+```
+
+Provider health updating is the real signal: `health_checked_at` should advance
+every 30 seconds, and route-manager's log should stop reporting health-check
+failures.
+
+## Known limits
+
+- `restart: always` is required, not stylistic. A failed `getKamailioID` returns
+  from `main()` with exit code 0, so `on-failure` would never restart it.
+- A failure to declare or consume the queue leaves the container `Up` with no
+  consumer registered. Container liveness alone does not prove the service is
+  working; the consumer count and `health_checked_at` do.

--- a/voip-kamailio-proxy/komodo/README.md
+++ b/voip-kamailio-proxy/komodo/README.md
@@ -49,7 +49,7 @@ Set explicitly:
 | `RABBITMQ_ADDRESS` | Komodo variable | Broker address. |
 | `SIP_TIMEOUT` | `5s` | The per-probe budget. Visible next to route-manager's 10 second RPC timeout, so the relationship between the two is legible. |
 | `PROMETHEUS_ENDPOINT` | `/metrics` | Matches the bin-*-manager peers. |
-| `PROMETHEUS_LISTEN_ADDRESS` | `:2112` | The default, written out on purpose: the Ansible precedent used `:9102`, which the Prometheus scrape job would never reach. |
+| `PROMETHEUS_LISTEN_ADDRESS` | `:2112` | The default, written out on purpose: the Ansible precedent used `:9102`, which the planned scrape job will not reach. See Monitoring below. |
 
 Deliberately omitted, because their defaults are already the values needed and
 writing them out is the only way to get them wrong:
@@ -69,6 +69,21 @@ CircleCI workflow `voip-kamailio-proxy`: test, then build (behind the
 image tag into this compose file and pushes it to Komodo as the stack
 `voip-kamailio-proxy`. Approving `build-approval` deploys to production.
 
+## Monitoring
+
+The stack exposes metrics on `:2112`, but **nothing scrapes it yet.** Prometheus
+discovers the `bin-*-manager` fleet from a static list of service names, and
+`kamailio-proxy` is not on it. Until a scrape job is added in `monorepo-etc`
+(`infra-prometheus`, the second half of VOIP-1486):
+
+- there is no alert if this stack disappears or drops to one replica, and
+- the post-deploy check in `docs/workflows/manager-replica-scaling.md`,
+  `count(up{job="voipbin-managers", service="kamailio-proxy"}) == 2`, returns
+  empty rather than 2. That is the expected result right now, not a failed
+  deploy.
+
+Until then, verify by hand as below.
+
 ## Verification
 
 ```bash
@@ -81,8 +96,12 @@ After deploying, on the host:
 
 ```bash
 docker ps --filter name=kamailio-proxy          # expect 2 containers
-rabbitmqctl list_queues name consumers | grep voip.kamailio.request   # expect 2
+docker exec infra-rabbitmq rabbitmqctl list_queues name consumers \
+  | grep voip.kamailio.request                  # expect 2
 ```
+
+`rabbitmqctl` is not installed on the host; the broker runs in the
+`infra-rabbitmq` container.
 
 Provider health updating is the real signal: `health_checked_at` should advance
 every 30 seconds, and route-manager's log should stop reporting health-check

--- a/voip-kamailio-proxy/komodo/README.md
+++ b/voip-kamailio-proxy/komodo/README.md
@@ -76,11 +76,18 @@ discovers the `bin-*-manager` fleet from a static list of service names, and
 `kamailio-proxy` is not on it. Until a scrape job is added in `monorepo-etc`
 (`infra-prometheus`, the second half of VOIP-1486):
 
-- there is no alert if this stack disappears or drops to one replica, and
-- the post-deploy check in `docs/workflows/manager-replica-scaling.md`,
-  `count(up{job="voipbin-managers", service="kamailio-proxy"}) == 2`, returns
-  empty rather than 2. That is the expected result right now, not a failed
-  deploy.
+there is no alert if this stack disappears or drops to one replica.
+
+Note that the post-deploy check in `docs/workflows/manager-replica-scaling.md`,
+`count(up{job="voipbin-managers", service="kamailio-proxy"}) == 2`, will return
+empty **permanently**, not just until the job lands. That check assumes
+membership in the `voipbin-managers` job, whose target list is a static
+enumeration of `bin-*-manager` names. This service gets its own job instead, so
+once the scrape job exists the query to use is:
+
+```
+count(up{job="kamailio-proxy"}) == 2
+```
 
 Until then, verify by hand as below.
 

--- a/voip-kamailio-proxy/komodo/docker-compose.yml
+++ b/voip-kamailio-proxy/komodo/docker-compose.yml
@@ -1,0 +1,59 @@
+# Komodo Stack definition for voip-kamailio-proxy (VOIP-1486).
+# See voip-kamailio-proxy/docs/plans/2026-09-07-kamailio-proxy-komodo-stack-design.md
+# for the design and its evidence.
+#
+# This is a STANDALONE stack, not a sidecar. The service was originally
+# deployed by voip-kamailio-ansible onto the GCP Kamailio VMs, co-located with
+# the Kamailio SIP daemon, on the premise that the SIP OPTIONS probe had to
+# leave from Kamailio's own source address. That premise was measured and
+# refuted: Kamailio's SIP address and the host's default egress address are
+# already different, and the carrier answers OPTIONS from every source address
+# tested. The probe only needs egress to the carrier, which any container on
+# the production bridge has, so the service runs on its own.
+services:
+  kamailio-proxy:
+    image: voipbin/voip-kamailio-proxy:__IMAGE_TAG__
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    # restart: always (not on-failure) is load-bearing: a failed getKamailioID
+    # returns from main() with exit code 0 (cmd/kamailio-proxy/main.go:34-38),
+    # so on-failure would never restart the container.
+    restart: always
+    # 2 replicas per docs/workflows/manager-replica-scaling.md. Item 1 of that
+    # gate (no per-pod queue) does not disqualify this service even though it
+    # declares one: the volatile voip.kamailio.<mac>.request queue
+    # (main.go:41) has no publisher anywhere in the monorepo - the only path is
+    # requesthandler/send_request.go:343-344 -> the shared
+    # voip.kamailio.request - and the queue is autoDelete with
+    # x-expires 1800000 (rabbitmqhandler/queue.go:70-78), so redeploys leave no
+    # orphans. The RPC's permanent queue is a competing consumer, and the
+    # once-per-cycle guarantee lives in bin-route-manager's redsync lock.
+    deploy:
+      replicas: 2
+    # RABBITMQ_QUEUE_LISTEN and INTERFACE_NAME are deliberately omitted: their
+    # defaults (voip.kamailio.request and eth0, cmd/kamailio-proxy/init.go:20,22)
+    # are exactly the values needed here, and writing them out is the only way
+    # to get them wrong. Both defaults are pinned by cmd/kamailio-proxy/main_test.go.
+    # PROMETHEUS_LISTEN_ADDRESS is written out even though :2112 is the default,
+    # matching all 33 bin-*-manager peers: the Ansible precedent used :9102,
+    # which a port-2112 dns_sd scrape job would never reach.
+    environment:
+      - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
+      - SIP_TIMEOUT=5s
+      - PROMETHEUS_ENDPOINT=/metrics
+      - PROMETHEUS_LISTEN_ADDRESS=:2112
+    # No command: this image sets ENTRYPOINT ["/app/bin/kamailio-proxy"]
+    # (Dockerfile:17), unlike the bin-*-manager images. No container_name
+    # (Compose rejects it with replicas > 1), no cap_add: NET_RAW (the probe
+    # uses an ordinary net.DialUDP socket, not a raw socket), and no
+    # depends_on (the RabbitMQ handler retries connection forever at 1s
+    # intervals, rabbitmqhandler/main.go:244).
+    networks:
+      default: {}
+networks:
+  default:
+    name: production
+    external: true

--- a/voip-kamailio-proxy/komodo/docker-compose.yml
+++ b/voip-kamailio-proxy/komodo/docker-compose.yml
@@ -39,7 +39,9 @@ services:
     # to get them wrong. Both defaults are pinned by cmd/kamailio-proxy/main_test.go.
     # PROMETHEUS_LISTEN_ADDRESS is written out even though :2112 is the default,
     # matching all 33 bin-*-manager peers: the Ansible precedent used :9102,
-    # which a port-2112 dns_sd scrape job would never reach.
+    # which the planned port-2112 scrape job would not reach. Nothing scrapes
+    # this stack yet - the job is the monorepo-etc half of VOIP-1486. See
+    # komodo/README.md, Monitoring.
     environment:
       - RABBITMQ_ADDRESS=[[BIN_MANAGER__RABBITMQ_ADDRESS]]
       - SIP_TIMEOUT=5s


### PR DESCRIPTION
Deploy voip-kamailio-proxy as its own Komodo stack on bm-nyc-01. The service answers bin-route-manager's carrier health-check RPC by sending SIP OPTIONS to the carrier and reporting whether anything answered. It has had no running instance since the GCP VM fleet was decommissioned, so every provider health check has been failing continuously.

It is deployed standalone rather than alongside the Kamailio SIP daemon. The co-location premise was that the probe had to leave from Kamailio's own SIP source address; measurement showed that address already differs from the host's egress address, and the carrier answers OPTIONS from every source address tested. The probe needs egress to the carrier and nothing else.

- voip-kamailio-proxy: Add komodo/docker-compose.yml, 2 replicas on the production network, with the reasoning behind each omitted setting inline
- voip-kamailio-proxy: Add komodo/README.md covering the queue contract, the environment variables and their defaults, monitoring status, and post-deploy verification
- voip-kamailio-proxy: Pin the three defaults the compose file relies on (queue name, interface name, metrics listen address) in main_test.go
- voip-kamailio-proxy: Correct docs that described a Kubernetes sidecar deployment; drop the Kamailio daemon reference sections from subsystems.md, which belong to voip-kamailio-docker and voip-kamailio-ansible
- .circleci: Add voip-kamailio-proxy-deploy job and wire it into the workflow
- .circleci: Add tests/voip-kamailio-proxy-komodo.bats pinning the stack definition and its CI wiring
- bin-route-manager: Correct operations.md and a handler comment that credited the SIP probe to route-manager; add health_check_interval to the config table

Two things to know before approving.

Approving this workflow's build-approval gate deploys straight to production; there is no staging. Because this PR also touches bin-route-manager/docs/operations.md and a comment in that service, the bin-route-manager workflow is armed too and a second approval button appears. Approving that one live-redeploys both route-manager replicas. Only the voip-kamailio-proxy button is needed here.

Nothing scrapes this stack yet. Prometheus discovers the manager fleet from a static list of bin-*-manager names, and this service is not on it. The scrape job and its three alerts are the monorepo-etc half of VOIP-1486 and land separately, since they are a different repository. Until then there is no alerting, and in particular the failure mode this ticket exists to fix stays undetectable: the metrics server starts before the queue consumer registers, so a container that never consumed anything still reports up. That half must land before VOIP-1486 is closed.

Verification: bats 108 passed across all suites, 17 mutations of the compose file and CI wiring each caught by the assertion that targets them, all three Go defaults caught when mutated, go test 18 passed in voip-kamailio-proxy and 11 in bin-route-manager/pkg/healthcheckhandler, golangci-lint clean in both, both YAML files parse. A real SIP OPTIONS sent from a container on the production network to the carrier returned SIP/2.0 200, confirming the standalone deployment premise.

Follow-up: VOIP-1488, the generated service taxonomy classifies this service as A+sub although it has no embedded daemon.