### PR TITLE
VOIP-1482-Add-google-credentials-to-pipecat-runner

### DIFF
--- a/.circleci/config_work.yml
+++ b/.circleci/config_work.yml
@@ -1586,7 +1586,7 @@ jobs:
           name: Deploy bin-pipecat-manager via Komodo API
           command: |
             CC_KOMODO_POLL_ATTEMPTS=60 CC_KOMODO_POLL_INTERVAL_S=3 \
-              .circleci/scripts/komodo-api-deploy.sh bin-pipecat-manager bin-pipecat-manager/komodo/docker-compose.yml
+              .circleci/scripts/komodo-api-deploy.sh bin-pipecat-manager bin-pipecat-manager/komodo/docker-compose.yml bin-pipecat-manager/komodo/environment.env
 
   # bin-queue-manager
   bin-queue-manager-test:

--- a/bin-pipecat-manager/docs/operations.md
+++ b/bin-pipecat-manager/docs/operations.md
@@ -21,11 +21,12 @@ Python environment variables (set in `.env` or exported):
 |-----|---------|
 | `OPENAI_API_KEY` | OpenAI LLM |
 | `XAI_API_KEY` | Grok (xAI) LLM |
-| `GOOGLE_API_KEY` | Gemini LLM + Google TTS |
-| `ANTHROPIC_API_KEY` | Anthropic Claude |
+| `GOOGLE_API_KEY` | Gemini LLM only (passed explicitly to `GoogleLLMService`) |
+| `ANTHROPIC_API_KEY` | Not used today. The runner's LLM dispatch (`run.py`) handles only OpenAI, Grok and Gemini, and no deployment provisions this key. |
 | `DEEPGRAM_API_KEY` | Deepgram STT |
 | `CARTESIA_API_KEY` | Cartesia TTS |
 | `ELEVENLABS_API_KEY` | ElevenLabs TTS |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Google Cloud TTS/STT. `GoogleTTSService`/`GoogleSTTService` take no api_key and fall back to Application Default Credentials, so they need a service account key file, not `GOOGLE_API_KEY`. On GKE this came implicitly from the node metadata server; on bare metal the Komodo stack mounts the shared `bin-manager` service account at `/run/secrets/google_service_account.json` (VOIP-1482). |
 
 ## Prometheus Metrics
 
@@ -87,7 +88,7 @@ cd scripts/pipecat && uvicorn main:app --host 0.0.0.0 --port 8000
 ## Deployment Notes
 
 - Both Go (port 8080) and Python (port 8000) components must be running in the same network namespace — the Go side drives the Python runner at `http://localhost:8000/run`.
-- The Dockerfile builds one image carrying both the Go binary and the Python pipeline (deps preinstalled); each deployment runs it twice — once as the Go service, once as the Python runner. On GKE these were two containers in one pod (`k8s/deployment.yml`); on Komodo/Compose they are the `pipecat-manager` and `pipecat-script-runner` services, the latter joined via `network_mode: "service:pipecat-manager"`.
+- The Dockerfile builds one image carrying both the Go binary and the Python pipeline (deps preinstalled); each deployment runs it twice — once as the Go service, once as the Python runner. On GKE these were two containers in one pod (`k8s/deployment.yml`); on Komodo/Compose they are the `pipecat-manager-1`/`-2` and `pipecat-script-runner-1`/`-2` services, each runner joined to its own manager via `network_mode: "service:pipecat-manager-N"`.
 - Per-pod queues are declared **volatile** — they auto-delete when the pod terminates, preventing dead-letter buildup.
 
 ## Deployment (Komodo)
@@ -95,7 +96,22 @@ cd scripts/pipecat && uvicorn main:app --host 0.0.0.0 --port 8000
 Komodo-managed (VOIP-1350), same mechanism as the other `bin-*-manager` services
 (see bin-call-manager for the original pattern). Deployed via
 `.circleci/scripts/render-image-tag.sh` + `.circleci/scripts/komodo-api-deploy.sh`
-from `komodo/docker-compose.yml`.
+from `komodo/docker-compose.yml`, with `komodo/environment.env` passed as the
+deploy script's optional third argument and PATCHed into the Stack's own
+`environment` field.
+
+That environment file carries `GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]`,
+the Komodo Variable holding the shared `bin-manager` Google service account key.
+Compose materializes it as the `gcp_sa_json` secret at
+`/run/secrets/google_service_account.json` in both runners (VOIP-1482).
+
+**If that Variable is missing, the deploy fails and takes the runners down.**
+Compose refuses to start a service whose secret has no source, so `docker compose up`
+exits non-zero and the deploy goes red, but the runner containers have already been
+recreated and are left in `Created`. `restart: always` never applies to a container
+that never reached Running, so both runners stay down and every `ai_talk` fails,
+which is worse than the Google-only breakage this change fixes. Treat a failed
+deploy here as a live outage: set the Variable and redeploy.
 
 Three deviations from the Tier 1/2 template, all intentional:
 - **Non-distroless runtime** (`python:3.12-slim`, needed to run the Python
@@ -115,8 +131,10 @@ Three deviations from the Tier 1/2 template, all intentional:
   NOJIRA-Fix-pipecat-runner-sidecar): the Python Pipecat pipeline runs as
   a second service from the same image (`python /app/scripts/pipecat/main.py`,
   uvicorn on 0.0.0.0:8000), sharing the Go container's network namespace
-  via `network_mode: "service:pipecat-manager"` so localhost:8000 works
+  via `network_mode: "service:pipecat-manager-N"` so localhost:8000 works
   exactly as it did in the GKE pod. It was dropped in the original Komodo
   cutover, which made every `ai_talk` action fail with connection-refused
-  on localhost:8000 and tear the call down. It receives the same six
-  STT/LLM/TTS API-key env vars the GKE runner container had.
+  on localhost:8000 and tear the call down. It receives the
+  STT/LLM/TTS API-key env vars the GKE runner container had, plus the
+  Google service account key GKE used to supply implicitly through the
+  node metadata server (mounted as a Compose secret, VOIP-1482).

--- a/bin-pipecat-manager/komodo/docker-compose.yml
+++ b/bin-pipecat-manager/komodo/docker-compose.yml
@@ -18,7 +18,8 @@
 # "connection refused" on localhost:8000 and the flow tore the call
 # down (2026-08-22 incident, NOJIRA-Fix-pipecat-runner-sidecar). Same
 # image (all Python deps are baked in), network_mode
-# "service:pipecat-manager" reproduces the GKE pod's shared localhost.
+# "service:pipecat-manager" reproduces the GKE pod's shared localhost
+# (now "service:pipecat-manager-N" after the 2-replica split below).
 #
 # P15+16 (NOJIRA-Scale-pipecat-manager-to-two-replicas): the single-pod
 # reproduction above is scaled to 2 replicas by hand-duplicating the
@@ -54,6 +55,30 @@
 # `docker rm -f` them if present. The same check applies when rolling
 # back this PR (reverting to the 2-service form leaves the new 4-service
 # names as orphans instead).
+#
+# VOIP-1482: the Google service account for Cloud TTS/STT. GKE handed the
+# runner Application Default Credentials from the NODE's service account,
+# so k8s/deployment.yml mounted no key and the Komodo migration carried
+# none - every Google TTS/STT call has failed since the bare-metal cutover.
+# This injects the shared bin-manager service account instead, the same one
+# storage/rag/transcribe/tts already use. Note it is a DIFFERENT principal
+# than the GKE node account, so verify one Google TTS and one Google STT
+# call after the first deploy.
+#
+# DEPLOY PRECONDITION: GCP_SA_JSON comes from komodo/environment.env, which
+# komodo-api-deploy.sh PATCHes into the Stack's `environment` field. If that
+# variable is unset at deploy time, Compose refuses to start the secret's
+# consumers and they stay in Created forever (restart: always never applies
+# to a container that never reached Running - see the sidecar note below).
+# That would take BOTH runners down and fail every ai_talk, which is worse
+# than today's Google-only breakage. The deploy itself goes red (compose up
+# exits non-zero), but only AFTER the runners have been recreated - so a
+# failed deploy here is a live outage, not a safe no-op. Set the Variable
+# and redeploy.
+secrets:
+  gcp_sa_json:
+    environment: "GCP_SA_JSON"
+
 services:
   pipecat-manager-1:
     image: voipbin/bin-pipecat-manager:__IMAGE_TAG__
@@ -112,9 +137,18 @@ services:
     depends_on:
       pipecat-manager-1:
         condition: service_healthy
-    # Same env set the GKE pipecat-script-runner container received
+    # The env the GKE pipecat-script-runner container received
     # (k8s/deployment.yml) - the Python side calls the STT/LLM/TTS APIs
-    # directly.
+    # directly - PLUS the Google service account GKE supplied implicitly.
+    #
+    # VOIP-1482: GOOGLE_API_KEY is the Gemini LLM key and is read only by
+    # GoogleLLMService (run.py passes it explicitly). Cloud TTS/STT take no
+    # api_key: GoogleTTSService/GoogleSTTService fall back to Application
+    # Default Credentials, which on GKE came from the node metadata server
+    # and on bare metal must come from this mounted service account key.
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
     environment:
       - CARTESIA_API_KEY=[[BIN_MANAGER__CARTESIA_API_KEY]]
       - ELEVENLABS_API_KEY=[[BIN_MANAGER__ELEVENLABS_API_KEY]]
@@ -122,6 +156,7 @@ services:
       - DEEPGRAM_API_KEY=[[BIN_MANAGER__DEEPGRAM_API_KEY]]
       - XAI_API_KEY=[[BIN_MANAGER__XAI_API_KEY]]
       - GOOGLE_API_KEY=[[BIN_MANAGER__GOOGLE_API_KEY]]
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
     command: ["python", "/app/scripts/pipecat/main.py"]
 
   pipecat-manager-2:
@@ -175,9 +210,18 @@ services:
     depends_on:
       pipecat-manager-2:
         condition: service_healthy
-    # Same env set the GKE pipecat-script-runner container received
+    # The env the GKE pipecat-script-runner container received
     # (k8s/deployment.yml) - the Python side calls the STT/LLM/TTS APIs
-    # directly.
+    # directly - PLUS the Google service account GKE supplied implicitly.
+    #
+    # VOIP-1482: GOOGLE_API_KEY is the Gemini LLM key and is read only by
+    # GoogleLLMService (run.py passes it explicitly). Cloud TTS/STT take no
+    # api_key: GoogleTTSService/GoogleSTTService fall back to Application
+    # Default Credentials, which on GKE came from the node metadata server
+    # and on bare metal must come from this mounted service account key.
+    secrets:
+      - source: gcp_sa_json
+        target: google_service_account.json
     environment:
       - CARTESIA_API_KEY=[[BIN_MANAGER__CARTESIA_API_KEY]]
       - ELEVENLABS_API_KEY=[[BIN_MANAGER__ELEVENLABS_API_KEY]]
@@ -185,6 +229,7 @@ services:
       - DEEPGRAM_API_KEY=[[BIN_MANAGER__DEEPGRAM_API_KEY]]
       - XAI_API_KEY=[[BIN_MANAGER__XAI_API_KEY]]
       - GOOGLE_API_KEY=[[BIN_MANAGER__GOOGLE_API_KEY]]
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/google_service_account.json
     command: ["python", "/app/scripts/pipecat/main.py"]
 networks:
   default:

--- a/bin-pipecat-manager/komodo/environment.env
+++ b/bin-pipecat-manager/komodo/environment.env
@@ -1,0 +1,11 @@
+# Komodo Stack-level environment (VOIP-1351/VOIP-1358 pattern, reused
+# here). See bin-storage-manager/komodo/environment.env for the full
+# explanation - this file is passed as komodo-api-deploy.sh's optional 3rd
+# argument and PATCHed into the Stack's own `environment` config field.
+#
+# VOIP-1482: the pipecat script runner needs a Google service account for
+# Cloud TTS/STT. On GKE it got Application Default Credentials implicitly
+# from the node metadata server, so k8s/deployment.yml never mounted a
+# key - the Komodo migration therefore carried none, and every Google
+# TTS/STT call has failed since the bare-metal cutover.
+GCP_SA_JSON=[[BIN_MANAGER__GOOGLE_APPLICATION_CREDENTIALS_JSON]]


### PR DESCRIPTION
Give the pipecat script runner the Google service account it needs for Cloud TTS and STT. On GKE the runner received Application Default Credentials implicitly from the node's service account, so the Kubernetes manifest mounted no key and the Komodo migration carried none. Since the bare metal cutover every Google TTS and STT call has failed: the AI produces an answer but nothing is spoken, and the call ends silently. Measured on production, calls using Google TTS answered 212 of 262 times before the cutover and 0 of 5 after, while ElevenLabs calls in the same window kept working.

- bin-pipecat-manager: Mount the shared bin-manager Google service account into both pipecat script runners as a Compose secret and point GOOGLE_APPLICATION_CREDENTIALS at it, matching the pattern bin-transcribe-manager already uses
- bin-pipecat-manager: Add komodo/environment.env so the deploy script PATCHes GCP_SA_JSON into the Komodo stack environment, and pass it as the deploy call's third argument
- bin-pipecat-manager: Correct docs/operations.md, which claimed GOOGLE_API_KEY covers Google TTS; that key is read only by the Gemini LLM path, and the Cloud TTS and STT services take no api_key at all
- bin-pipecat-manager: Document the deploy precondition, since an unset Komodo variable leaves both runners in Created and fails every ai_talk rather than failing safe

The Go side is unchanged, no default changes, and GOOGLE_API_KEY stays for Gemini. The service account was verified against production Cloud TTS before this change: it minted a token for voipbin-production and synthesized audio with the default voice.

Verification after deploy: confirm both runners reach Running, then place one Google TTS call and one Google STT call to a virtual number and confirm the AI answers, plus one Deepgram or Cartesia call to confirm no regression.
