### PR TITLE
NOJIRA-Fix-mcp-secret-encryption-keys-env-var

### DIFF
--- a/bin-ai-manager/komodo/docker-compose.yml
+++ b/bin-ai-manager/komodo/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - PROMETHEUS_ENDPOINT=/metrics
       - PROMETHEUS_LISTEN_ADDRESS=:2112
       - ENGINE_KEY_CHATGPT=[[BIN_MANAGER__ENGINE_KEY_CHATGPT]]
+      - MCP_SECRET_ENCRYPTION_KEYS=[[BIN_MANAGER__MCP_SECRET_ENCRYPTION_KEYS]]
     command: ./ai-manager
     networks:
       default: {}


### PR DESCRIPTION
Adds the MCP_SECRET_ENCRYPTION_KEYS env var wiring to bin-ai-manager's Komodo compose fragment, closing a gap found via a live production smoke test after PR #1285 merged.

- bin-ai-manager: add MCP_SECRET_ENCRYPTION_KEYS=[[BIN_MANAGER__MCP_SECRET_ENCRYPTION_KEYS]] to komodo/docker-compose.yml. This env var was required by pkg/mcpserverhandler/secret.go (design doc §6/§13) but was never wired into the Komodo Stack's deploy manifest -- 5 rounds of PR #1285 code review checked the Go source extensively but never checked the deploy manifest itself.

Verified live in production (disposable smoke test, resource created and deleted immediately): POST /mcpservers with a secret returned 500 INTERNAL; the identical request with no secret returned 200. Root cause: SecretCrypto.currentVersion==0 when MCP_SECRET_ENCRYPTION_KEYS is unset, so Encrypt() errors out.

This PR alone does not fix the bug -- it only wires the env var reference. A matching Komodo Variable BIN_MANAGER__MCP_SECRET_ENCRYPTION_KEYS must also be registered via infra-secret's secrets-source/bin-manager/secrets.enc.yml (SOPS+age encrypted, key held only by 대표님) before this takes effect.