### PR TITLE
NOJIRA-Fix-mcp-server-ids-validation-error-status

### DIFF
--- a/bin-ai-manager/pkg/aihandler/mcpserver_validation.go
+++ b/bin-ai-manager/pkg/aihandler/mcpserver_validation.go
@@ -2,17 +2,23 @@ package aihandler
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
 	"monorepo/bin-ai-manager/models/ai"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 // ValidateMcpServerIDs checks that every id in ids refers to an existing
-// McpServer row owned by customerID. Returns an error naming the first
-// non-existent or cross-customer id it finds.
+// McpServer row owned by customerID. Returns a *cerrors.VoipbinError
+// (InvalidArgument, surfaced as HTTP 400) naming the first non-existent or
+// cross-customer id it finds -- listenhandler's errorResponse() only maps
+// *cerrors.VoipbinError to a non-500 status, so a plain error here would
+// otherwise reach the customer as an opaque 500 for a client-input mistake
+// (mirrors the existing ai.ValidateToolNames -> cerrors.InvalidArgument
+// pattern in chatbot.go).
 //
 // Lives in pkg/aihandler (has db access), not models/ai, mirroring why
 // ai.ValidateToolNames itself takes no ctx/db today -- see
@@ -21,7 +27,11 @@ func (h *aiHandler) ValidateMcpServerIDs(ctx context.Context, customerID uuid.UU
 	for _, id := range ids {
 		srv, err := h.db.McpServerGet(ctx, id)
 		if err != nil || srv == nil || srv.CustomerID != customerID {
-			return fmt.Errorf("mcp_server_id %s is not accessible", id)
+			return cerrors.InvalidArgument(
+				commonoutline.ServiceNameAIManager,
+				"INVALID_MCP_SERVER_ID",
+				"mcp_server_id "+id.String()+" is not accessible",
+			)
 		}
 	}
 

--- a/bin-ai-manager/pkg/aihandler/mcpserver_validation.go
+++ b/bin-ai-manager/pkg/aihandler/mcpserver_validation.go
@@ -2,11 +2,13 @@ package aihandler
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
 
 	"monorepo/bin-ai-manager/models/ai"
+	"monorepo/bin-ai-manager/pkg/dbhandler"
 	cerrors "monorepo/bin-common-handler/models/errors"
 	commonoutline "monorepo/bin-common-handler/models/outline"
 )
@@ -20,13 +22,32 @@ import (
 // (mirrors the existing ai.ValidateToolNames -> cerrors.InvalidArgument
 // pattern in chatbot.go).
 //
+// A genuine infra failure from McpServerGet (query build/exec/scan error,
+// as opposed to dbhandler.ErrNotFound) is deliberately NOT mapped to 400
+// here -- it is returned as-is so errorResponse() falls through to 500,
+// matching the dbhandler.ErrNotFound-vs-other-error split ActivateInsight
+// already established in db.go. Collapsing both into 400 would mislabel
+// real DB outages as client mistakes and hide them from 5xx alerting.
+//
 // Lives in pkg/aihandler (has db access), not models/ai, mirroring why
 // ai.ValidateToolNames itself takes no ctx/db today -- see
 // docs/plans/2026-09-11-mcp-tool-integration-design.md §5.
 func (h *aiHandler) ValidateMcpServerIDs(ctx context.Context, customerID uuid.UUID, ids []uuid.UUID) error {
 	for _, id := range ids {
 		srv, err := h.db.McpServerGet(ctx, id)
-		if err != nil || srv == nil || srv.CustomerID != customerID {
+		if err != nil {
+			if stderrors.Is(err, dbhandler.ErrNotFound) {
+				return cerrors.InvalidArgument(
+					commonoutline.ServiceNameAIManager,
+					"INVALID_MCP_SERVER_ID",
+					"mcp_server_id "+id.String()+" is not accessible",
+				).Wrap(err)
+			}
+
+			return errors.Wrapf(err, "could not get mcp server %s", id)
+		}
+
+		if srv == nil || srv.CustomerID != customerID {
 			return cerrors.InvalidArgument(
 				commonoutline.ServiceNameAIManager,
 				"INVALID_MCP_SERVER_ID",

--- a/bin-ai-manager/pkg/aihandler/mcpserver_validation_test.go
+++ b/bin-ai-manager/pkg/aihandler/mcpserver_validation_test.go
@@ -2,6 +2,7 @@ package aihandler
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -9,6 +10,7 @@ import (
 
 	"monorepo/bin-ai-manager/models/mcpserver"
 	"monorepo/bin-ai-manager/pkg/dbhandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
 	"monorepo/bin-common-handler/models/identity"
 	"monorepo/bin-common-handler/pkg/notifyhandler"
 	"monorepo/bin-common-handler/pkg/requesthandler"
@@ -90,6 +92,19 @@ func Test_ValidateMcpServerIDs(t *testing.T) {
 			}
 			if !tt.wantError && err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantError {
+				// Must be a typed *cerrors.VoipbinError so listenhandler's
+				// errorResponse() maps it to HTTP 400, not an opaque 500 for
+				// what is a client-input mistake (invalid/cross-customer
+				// mcp_server_id).
+				var ve *cerrors.VoipbinError
+				if !errors.As(err, &ve) {
+					t.Fatalf("expected a *cerrors.VoipbinError, got %T: %v", err, err)
+				}
+				if ve.Status != cerrors.StatusInvalidArgument {
+					t.Fatalf("expected StatusInvalidArgument, got %v", ve.Status)
+				}
 			}
 		})
 	}

--- a/bin-ai-manager/pkg/aihandler/mcpserver_validation_test.go
+++ b/bin-ai-manager/pkg/aihandler/mcpserver_validation_test.go
@@ -30,6 +30,11 @@ func Test_ValidateMcpServerIDs(t *testing.T) {
 		ids       []uuid.UUID
 		setupMock func(*dbhandler.MockDBHandler)
 		wantError bool
+		// wantTyped asserts the error is a *cerrors.VoipbinError with
+		// StatusInvalidArgument (-> HTTP 400). false for a case where an
+		// error is expected but it must NOT be typed as InvalidArgument
+		// (a genuine DB infra failure, which must fall through to 500).
+		wantTyped bool
 	}{
 		{
 			name: "valid same-customer id accepts",
@@ -50,6 +55,7 @@ func Test_ValidateMcpServerIDs(t *testing.T) {
 				}, nil)
 			},
 			wantError: true,
+			wantTyped: true,
 		},
 		{
 			name: "nonexistent id rejects",
@@ -58,6 +64,22 @@ func Test_ValidateMcpServerIDs(t *testing.T) {
 				mockDB.EXPECT().McpServerGet(gomock.Any(), nonexistentServerID).Return(nil, dbhandler.ErrNotFound)
 			},
 			wantError: true,
+			wantTyped: true,
+		},
+		{
+			// Pins the code review fix: a genuine DB infra failure (query
+			// build/exec/scan error, NOT dbhandler.ErrNotFound) must NOT be
+			// collapsed into a 400 InvalidArgument alongside not-found and
+			// cross-customer -- it must remain untyped so errorResponse()
+			// falls through to 500, matching the dbhandler.ErrNotFound-vs-
+			// other-error split ActivateInsight already uses in db.go.
+			name: "db infra failure is not mislabeled as invalid argument",
+			ids:  []uuid.UUID{sameCustomerServerID},
+			setupMock: func(mockDB *dbhandler.MockDBHandler) {
+				mockDB.EXPECT().McpServerGet(gomock.Any(), sameCustomerServerID).Return(nil, errors.New("mcpserverGetFromDB: could not query. err: connection refused"))
+			},
+			wantError: true,
+			wantTyped: false,
 		},
 		{
 			name:      "empty ids accepts trivially",
@@ -94,16 +116,21 @@ func Test_ValidateMcpServerIDs(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if tt.wantError {
-				// Must be a typed *cerrors.VoipbinError so listenhandler's
-				// errorResponse() maps it to HTTP 400, not an opaque 500 for
-				// what is a client-input mistake (invalid/cross-customer
-				// mcp_server_id).
 				var ve *cerrors.VoipbinError
-				if !errors.As(err, &ve) {
-					t.Fatalf("expected a *cerrors.VoipbinError, got %T: %v", err, err)
-				}
-				if ve.Status != cerrors.StatusInvalidArgument {
-					t.Fatalf("expected StatusInvalidArgument, got %v", ve.Status)
+				isTyped := errors.As(err, &ve)
+				if tt.wantTyped {
+					// Must be a typed *cerrors.VoipbinError so listenhandler's
+					// errorResponse() maps it to HTTP 400, not an opaque 500
+					// for what is a client-input mistake (invalid/cross-
+					// customer mcp_server_id).
+					if !isTyped {
+						t.Fatalf("expected a *cerrors.VoipbinError, got %T: %v", err, err)
+					}
+					if ve.Status != cerrors.StatusInvalidArgument {
+						t.Fatalf("expected StatusInvalidArgument, got %v", ve.Status)
+					}
+				} else if isTyped {
+					t.Fatalf("expected a plain (untyped) error for a DB infra failure so it falls through to 500, got *cerrors.VoipbinError: %v", ve)
 				}
 			}
 		})

--- a/bin-ai-manager/pkg/listenhandler/v1_ais_test.go
+++ b/bin-ai-manager/pkg/listenhandler/v1_ais_test.go
@@ -19,6 +19,8 @@ import (
 	"monorepo/bin-ai-manager/pkg/aihandler"
 	"monorepo/bin-ai-manager/pkg/dbhandler"
 	"monorepo/bin-ai-manager/pkg/participanthandler"
+	cerrors "monorepo/bin-common-handler/models/errors"
+	commonoutline "monorepo/bin-common-handler/models/outline"
 )
 
 func Test_processV1AIsGet(t *testing.T) {
@@ -614,5 +616,58 @@ func Test_processV1AIsIDPut_McpServerIDsOmittedLeavesUntouched(t *testing.T) {
 	}
 	if res.StatusCode != 200 {
 		t.Fatalf("expected status 200, got %d (body: %s)", res.StatusCode, res.Data)
+	}
+}
+
+// Test_processV1AIsIDPut_McpServerIDsInvalidReturns400 pins the fix for a
+// bug found during CPO review: ValidateMcpServerIDs used to return a plain
+// fmt.Errorf, which errorResponse() (only maps *cerrors.VoipbinError to a
+// non-500 status) turned into an opaque 500 for what is a client-input
+// mistake (an invalid or cross-customer mcp_server_id). It must now surface
+// as 400.
+func Test_processV1AIsIDPut_McpServerIDsInvalidReturns400(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	mockSock := sockhandler.NewMockSockHandler(mc)
+	mockAI := aihandler.NewMockAIHandler(mc)
+
+	h := &listenHandler{
+		sockHandler: mockSock,
+		aiHandler:   mockAI,
+	}
+
+	id := uuid.FromStringOrNil("de99e522-a770-11ed-a0ab-5b39ee2db203")
+	customerID := uuid.FromStringOrNil("24676972-7f49-11ec-bc89-b7d33e9d3ea8")
+	invalidServerID := uuid.FromStringOrNil("11111111-1111-1111-1111-111111111111")
+
+	req := &sock.Request{
+		URI:    "/v1/ais/" + id.String(),
+		Method: sock.RequestMethodPut,
+		Data:   []byte(`{"mcp_server_ids":["` + invalidServerID.String() + `"]}`),
+	}
+
+	preUpdate := &ai.AI{
+		Identity: identity.Identity{
+			ID:         id,
+			CustomerID: customerID,
+		},
+	}
+
+	mockAI.EXPECT().Update(
+		gomock.Any(), id, "", "", ai.Type(""), ai.EngineModel(""), map[string]any(nil), "",
+		uuid.Nil, "", ai.TTSType(""), "", ai.STTType(""), "", []tool.ToolName(nil), (*ai.VADConfig)(nil), false, false,
+	).Return(preUpdate, nil)
+
+	mockAI.EXPECT().ValidateMcpServerIDs(gomock.Any(), customerID, []uuid.UUID{invalidServerID}).Return(
+		cerrors.InvalidArgument(commonoutline.ServiceNameAIManager, "INVALID_MCP_SERVER_ID", "mcp_server_id "+invalidServerID.String()+" is not accessible"),
+	)
+
+	res, err := h.processRequest(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if res.StatusCode != 400 {
+		t.Fatalf("expected status 400, got %d (body: %s)", res.StatusCode, res.Data)
 	}
 }


### PR DESCRIPTION
Fixes a 500-instead-of-400 bug flagged during CPO-level review of the MCP tool integration feature (VOIP-1513 / PR #1285).

- bin-ai-manager: ValidateMcpServerIDs used a plain fmt.Errorf for an invalid/cross-customer mcp_server_id -- a client-input mistake. listenhandler's errorResponse() only maps *cerrors.VoipbinError to a non-500 status (mirrors the existing ai.ValidateToolNames -> cerrors.InvalidArgument pattern already in chatbot.go), so this reached the customer as an opaque 500 instead of 400. Now returns cerrors.InvalidArgument(..., "INVALID_MCP_SERVER_ID", ...).
- bin-ai-manager: extend Test_ValidateMcpServerIDs to assert the returned error is a *cerrors.VoipbinError with StatusInvalidArgument, not just err != nil -- confirmed via revert-and-rerun that this genuinely fails against the pre-fix code.
- bin-ai-manager: add Test_processV1AIsIDPut_McpServerIDsInvalidReturns400 pinning the end-to-end 400 status at the listenhandler layer.

go build/vet/test/golangci-lint all clean.